### PR TITLE
fixed #41 Redundant UID generation

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/config/RawRecordContainerImpl.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/config/RawRecordContainerImpl.java
@@ -141,13 +141,18 @@ public class RawRecordContainerImpl implements Writable, Configurable, RawRecord
         setUid(id);
     }
     
+    @Override
+    public void generateId(String uidExtra) {
+        this.uid = uidBuilder.newId(rawData, getTimeForUID(), uidExtra);
+    }
+    
     public UID getUid() {
         return uid;
     }
     
     /**
      * This method is used by the "reverse ingest" process to set the UID object correctly. It is to be used by the "reverse ingest" process" only, because in
-     * the course of the normal ingest process it is set when one calls the validate() method.
+     * the course of the normal ingest process it is set via generateId.
      * 
      * @param uid
      *            {@code UID} object
@@ -262,7 +267,7 @@ public class RawRecordContainerImpl implements Writable, Configurable, RawRecord
     }
     
     /**
-     * This method is used by the "reverse ingest" process to clear the error values that are set by the validate() method. This is due to the fact that the
+     * This method is used by the "reverse ingest" process to clear the error values that are set by the generateId() method. This is due to the fact that the
      * Event object is not fully populated in "reverse ingest" process.
      */
     @Override
@@ -374,42 +379,12 @@ public class RawRecordContainerImpl implements Writable, Configurable, RawRecord
         this.auxData = auxData;
     }
     
-    @Override
-    public void setRawDataAndGenerateId(byte[] rawData) {
-        this.setRawDataAndGenerateUid(rawData);
-    }
-    
-    @Override
-    public void setRawDataAndGenerateId(byte[] rawData, String extra) {
-        this.setRawDataAndGenerateUid(rawData, extra);
-    }
-    
-    public void setRawDataAndGenerateUid(byte[] rawData) {
-        setRawDataAndGenerateUid(rawData, null);
-    }
-    
-    public void setRawDataAndGenerateUid(byte[] rawData, String uidExtra) {
-        this.rawData = rawData;
-        this.uid = uidBuilder.newId(rawData, getTimeForUID(), uidExtra);
-    }
-    
     /**
      * @return Copy of this RwaRecordContainerImpl object.
      */
     @Override
     public RawRecordContainerImpl copy() {
         return copyInto(new RawRecordContainerImpl());
-    }
-    
-    /**
-     * This method should not normally be used. Use with caution
-     * 
-     * @param uid
-     *            - new UID value
-     */
-    
-    public void overrideUid(UID uid) {
-        this.uid = uid;
     }
     
     /*

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/RawRecordContainer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/RawRecordContainer.java
@@ -28,6 +28,14 @@ public interface RawRecordContainer {
     
     void setId(UID id);
     
+    /**
+     * This method will generate the uid given the current state of the event
+     * 
+     * @param uidExtra
+     *            If not null, this is added into the uid
+     */
+    void generateId(String uidExtra);
+    
     Type getDataType();
     
     void setDataType(Type dataType);
@@ -97,10 +105,6 @@ public interface RawRecordContainer {
     Object getAuxData();
     
     void setAuxData(Object auxData);
-    
-    void setRawDataAndGenerateId(byte[] rawData);
-    
-    void setRawDataAndGenerateId(byte[] rawData, String extra);
     
     RawRecordContainer copy();
     

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/AbstractEventRecordReader.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/AbstractEventRecordReader.java
@@ -163,6 +163,9 @@ public abstract class AbstractEventRecordReader<K> extends RecordReader<LongWrit
         this.inputDate = time;
     }
     
+    /**
+     * This implementation of getEvent is not complete. This only creates an initial event that should be modified futher and validated.
+     */
     @Override
     public RawRecordContainer getEvent() {
         event.clear();

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/RawRecordContainerImplTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/RawRecordContainerImplTest.java
@@ -72,31 +72,43 @@ public class RawRecordContainerImplTest {
     @Test
     public void testPopulateAll() {
         ValidatingRawRecordContainerImpl event = create();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertTrue(event.getErrors().size() == 0);
         
         event = create();
         event.setVisibility("TESTVIS1&TESTVIS2");
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertTrue(event.getErrors().size() == 0);
     }
     
     @Test
     public void testEquals() {
         ValidatingRawRecordContainerImpl e1 = create();
-        e1.validate(csv.getBytes());
+        e1.setRawData(csv.getBytes());
+        e1.generateId(null);
+        e1.validate();
         
         ValidatingRawRecordContainerImpl e2 = create();
-        e2.validate(csv.getBytes());
+        e2.setRawData(csv.getBytes());
+        e2.generateId(null);
+        e2.validate();
         
         assertTrue(e1.equals(e2));
         assertTrue(e2.equals(e1));
         
         e1 = create();
-        e1.validate(csv.getBytes());
+        e1.setRawData(csv.getBytes());
+        e1.generateId(null);
+        e1.validate();
         
         e2 = create();
-        e2.validate(csv.getBytes());
+        e2.setRawData(csv.getBytes());
+        e2.generateId(null);
+        e2.validate();
         
         assertTrue(e1.equals(e2));
         assertTrue(e2.equals(e1));
@@ -105,18 +117,22 @@ public class RawRecordContainerImplTest {
     @Test
     public void testNotEquals() {
         ValidatingRawRecordContainerImpl e1 = create();
-        e1.validate(csv.getBytes());
-        e1.setUid(UID.builder().newId(e1.getRawData(), e1.getTimeForUID(), field1));
+        e1.setRawData(csv.getBytes());
+        e1.generateId(field1);
+        e1.validate();
         
         ValidatingRawRecordContainerImpl e2 = create();
-        e2.validate(csv.getBytes());
-        e2.setUid(UID.builder().newId(e2.getRawData(), e2.getTimeForUID(), field2));
+        e2.setRawData(csv.getBytes());
+        e2.generateId(field2);
+        e2.validate();
         
         assertTrue(!e1.equals(e2));
         assertTrue(!e2.equals(e1));
         
         e2 = create();
-        e2.validate(csv.getBytes());
+        e2.setRawData(csv.getBytes());
+        e2.generateId(null);
+        e2.validate();
         
         assertTrue(!e1.equals(e2));
         assertTrue(!e2.equals(e1));
@@ -129,7 +145,9 @@ public class RawRecordContainerImplTest {
         
         // Write out the event
         ValidatingRawRecordContainerImpl e1 = create();
-        e1.validate(csv.getBytes());
+        e1.setRawData(csv.getBytes());
+        e1.generateId(null);
+        e1.validate();
         e1.write(out);
         
         out.close();
@@ -152,7 +170,9 @@ public class RawRecordContainerImplTest {
         
         // Write out the event
         e1 = create();
-        e1.validate(csv.getBytes());
+        e1.setRawData(csv.getBytes());
+        e1.generateId(null);
+        e1.validate();
         e1.write(out);
         
         out.close();
@@ -180,7 +200,9 @@ public class RawRecordContainerImplTest {
         event.setDataType(dataType);
         event.setRawFileName(rawFileName);
         event.getIds().add(uuid);
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertFalse(event.fatalError());
         assertTrue(event.ignorableError());
         Collection<String> errors = event.getErrors();
@@ -192,13 +214,17 @@ public class RawRecordContainerImplTest {
     public void testMissingUuids() {
         ValidatingRawRecordContainerImpl event = create();
         event.getIds().clear();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertTrue(event.fatalError());
         assertFalse(event.ignorableError());
         Collection<String> errors = event.getErrors();
         assertTrue(errors.contains(RawDataErrorNames.UUID_MISSING));
         
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertTrue(event.fatalError());
         errors = event.getErrors();
         assertFalse(errors.isEmpty());
@@ -208,7 +234,9 @@ public class RawRecordContainerImplTest {
     @Test
     public void testCopy() {
         ValidatingRawRecordContainerImpl event = create();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         RawRecordContainerImpl copy = event.copy();
         assertTrue(event.equals(copy));
     }
@@ -216,31 +244,41 @@ public class RawRecordContainerImplTest {
     @Test
     public void testUID() {
         ValidatingRawRecordContainerImpl event = create();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         UID uid = event.getUid();
         assertEquals(-1, uid.getTime());
         
         conf.set(RawRecordContainerImpl.USE_TIME_IN_UID, "true");
         event.reloadConfiguration();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         uid = event.getUid();
         assertNotSame(-1, uid.getTime());
         
         conf.set(RawRecordContainerImpl.USE_TIME_IN_UID, "false");
         event.reloadConfiguration();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         uid = event.getUid();
         assertEquals(-1, uid.getTime());
         
         conf.set(event.getDataType().typeName() + '.' + RawRecordContainerImpl.USE_TIME_IN_UID, "false");
         event.reloadConfiguration();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         uid = event.getUid();
         assertEquals(-1, uid.getTime());
         
         conf.set(event.getDataType().typeName() + '.' + RawRecordContainerImpl.USE_TIME_IN_UID, "true");
         event.reloadConfiguration();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         uid = event.getUid();
         assertNotSame(-1, uid.getTime());
     }
@@ -249,7 +287,9 @@ public class RawRecordContainerImplTest {
     public void testCopiedObjectAfterClear() {
         // Create original
         RawRecordContainerImpl event = create();
-        ((ValidatingRawRecordContainerImpl) event).validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        ((ValidatingRawRecordContainerImpl) event).validate();
         // Create copy
         RawRecordContainerImpl copy = event.copy();
         assertTrue(event.equals(copy));
@@ -273,7 +313,9 @@ public class RawRecordContainerImplTest {
         event.setRawFileName(rawFileName);
         event.setRawRecordNumber(rawRecordNumber);
         event.getIds().add(uuid);
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertTrue(event.fatalError());
         assertFalse(event.ignorableError());
         
@@ -284,25 +326,33 @@ public class RawRecordContainerImplTest {
         event.setRawFileName(rawFileName);
         event.setRawRecordNumber(rawRecordNumber);
         event.getIds().add(uuid);
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertFalse(event.fatalError());
         assertTrue(event.ignorableError());
         
         event.clearErrors();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertFalse(event.fatalError());
         assertTrue(event.ignorableError());
         
         event.clearErrors();
         // Need to create the type directly as we cannot generate this type from the registry
         event.setDataType(TypeRegistry.getType("samplecsv"));
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertFalse(event.fatalError());
         assertTrue(event.ignorableError());
         
         event.reloadConfiguration();
         event.getIds().clear();
-        event.validate(csv.getBytes());
+        event.setRawData(csv.getBytes());
+        event.generateId(null);
+        event.validate();
         assertTrue(event.ignorableError());
     }
     
@@ -318,11 +368,7 @@ public class RawRecordContainerImplTest {
             }
         }
         
-        public void validate(byte[] rawData) {
-            validate(rawData, null);
-        }
-        
-        public void validate(byte[] rawData, String uidExtra) {
+        public void validate() {
             if (getAltIds() == null || getAltIds().size() == 0) {
                 addError(RawDataErrorNames.UUID_MISSING);
             }
@@ -352,9 +398,6 @@ public class RawRecordContainerImplTest {
             if (getSecurityMarkings() == null) {
                 addError(RawDataErrorNames.MISSING_DATA_ERROR);
             }
-            
-            // Set rawData & Calculate the UID
-            setRawDataAndGenerateUid(rawData, uidExtra);
         }
         
         @Override

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
@@ -52,7 +52,8 @@ public class EventMapperTest {
         record.setRawFileTimestamp(eventTime);
         record.setDataType(type);
         record.setDate(eventTime);
-        record.setRawDataAndGenerateId("some data".getBytes());
+        record.setRawData("some data".getBytes());
+        record.generateId(null);
     }
     
     @Test

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
@@ -65,6 +65,11 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
     }
     
     @Override
+    public void generateId(String extra) {
+        setId(uidBuilder.newId(rawData, getTimeForUID(), extra));
+    }
+    
+    @Override
     public Type getDataType() {
         return dataType;
     }
@@ -192,18 +197,6 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
     @Override
     public void setAuxData(Object auxData) {
         this.auxData = auxData;
-    }
-    
-    @Override
-    public void setRawDataAndGenerateId(byte[] rawData) {
-        setRawData(rawData);
-        setId(uidBuilder.newId(rawData, getTimeForUID()));
-    }
-    
-    @Override
-    public void setRawDataAndGenerateId(byte[] rawData, String extra) {
-        setRawData(rawData);
-        setId(uidBuilder.newId(rawData, getTimeForUID(), extra));
     }
     
     @Override

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexDataTypeHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexDataTypeHandlerTest.java
@@ -196,7 +196,9 @@ public class DateIndexDataTypeHandlerTest {
         event.setDate(getTime(data));
         event.setRawFileName("DateIndexDataTypeHandlerTest.data");
         event.setRawRecordNumber(1l);
-        event.validate(data.getBytes());
+        event.setRawData(data.getBytes());
+        event.generateId(null);
+        event.validate();
         return event;
     }
     

--- a/warehouse/ingest-csv/src/main/java/datawave/ingest/csv/mr/input/CSVReaderBase.java
+++ b/warehouse/ingest-csv/src/main/java/datawave/ingest/csv/mr/input/CSVReaderBase.java
@@ -157,14 +157,18 @@ public class CSVReaderBase extends LongLineEventRecordReader implements EventRec
         // decorate with additional data (used by overriding classes)
         decorateEvent();
         
-        event.setRawDataAndGenerateId(rawEventRecordStr.getBytes());
-        enforcePolicy(event);
+        event.setRawData(rawEventRecordStr.getBytes());
         
         // Check to see if we need to override the UID. The use case for this is that some of the hashes are "enrichment" and the same
         // values will be loaded over and over again. By default, the UID is calculated on the raw byte[]
         final UID newUID = uidOverride(event);
-        if (newUID != null)
+        if (newUID != null) {
             event.setId(newUID);
+        } else {
+            event.generateId(null);
+        }
+        
+        enforcePolicy(event);
         
         if (header.length > rawEventFields.length) {
             event.addError(RawDataErrorNames.NOT_ENOUGH_FIELDS);

--- a/warehouse/ingest-json/src/main/java/datawave/ingest/json/mr/input/JsonRecordReader.java
+++ b/warehouse/ingest-json/src/main/java/datawave/ingest/json/mr/input/JsonRecordReader.java
@@ -227,19 +227,21 @@ public class JsonRecordReader extends AbstractEventRecordReader<BytesWritable> {
         
         decorateEvent();
         
-        event.setRawDataAndGenerateId(currentJsonObj.toString().getBytes());
-        
-        UID newUID = uidOverride(event);
-        if (null != newUID) {
-            event.setId(newUID);
-        }
-        
-        checkSecurityMarkings();
-        enforcePolicy(event);
+        event.setRawData(currentJsonObj.toString().getBytes());
         
         if (0 == event.getDate()) {
             event.setDate(System.currentTimeMillis());
         }
+        
+        UID newUID = uidOverride(event);
+        if (null != newUID) {
+            event.setId(newUID);
+        } else {
+            event.generateId(null);
+        }
+        
+        checkSecurityMarkings();
+        enforcePolicy(event);
         
         return event;
     }

--- a/warehouse/ingest-json/src/test/java/datawave/ingest/json/config/helper/JsonIngestHelperTest.java
+++ b/warehouse/ingest-json/src/test/java/datawave/ingest/json/config/helper/JsonIngestHelperTest.java
@@ -58,7 +58,8 @@ public class JsonIngestHelperTest {
         
         RawRecordContainer event = new RawRecordContainerImpl();
         event.setDate((new Date()).getTime());
-        event.setRawDataAndGenerateId(testRecord);
+        event.setRawData(testRecord);
+        event.generateId(null);
         Assert.assertNotNull(ingestHelper.getEmbeddedHelper());
         
         Multimap<String,NormalizedContentInterface> fieldMap = ingestHelper.getEventFields(event);
@@ -79,7 +80,8 @@ public class JsonIngestHelperTest {
         
         RawRecordContainer event = new RawRecordContainerImpl();
         event.setDate((new Date()).getTime());
-        event.setRawDataAndGenerateId(testRecord);
+        event.setRawData(testRecord);
+        event.generateId(null);
         Assert.assertNotNull(ingestHelper.getEmbeddedHelper());
         
         Multimap<String,NormalizedContentInterface> fieldMap = ingestHelper.getEventFields(event);
@@ -100,7 +102,8 @@ public class JsonIngestHelperTest {
         
         RawRecordContainer event = new RawRecordContainerImpl();
         event.setDate((new Date()).getTime());
-        event.setRawDataAndGenerateId(testRecord);
+        event.setRawData(testRecord);
+        event.generateId(null);
         Assert.assertNotNull(ingestHelper.getEmbeddedHelper());
         
         Multimap<String,NormalizedContentInterface> fieldMap = ingestHelper.getEventFields(event);

--- a/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaRecordReader.java
+++ b/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaRecordReader.java
@@ -261,14 +261,14 @@ public class WikipediaRecordReader extends AggregatingRecordReader {
                 event.addError(RawDataErrorNames.INVALID_XML);
             }
             
-            if (event instanceof Configurable) {
-                event.setId(UID.builder(((Configurable) event).getConf()).newId(data.getBytes(), new Date()));
-            } else {
-                event.setId(UID.builder().newId(data.getBytes(), new Date()));
-            }
-            
             updateEventTypeInformation(event);
             updateEventDate(event);
+            
+            if (event instanceof Configurable) {
+                event.setId(UID.builder(((Configurable) event).getConf()).newId(data.getBytes(), event.getTimeForUID()));
+            } else {
+                event.generateId(null);
+            }
             
             if (eventFixer != null) {
                 if (event instanceof Configurable) {

--- a/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
@@ -183,7 +183,8 @@ public class GeoSortedQueryDataTest {
             record.setRawFileName("geodata_" + recNum + ".dat");
             record.setRawRecordNumber(recNum++);
             record.setDate(formatter.parse(BEGIN_DATE).getTime() + dates[i]);
-            record.setRawDataAndGenerateId(wktData[i].getBytes("UTF8"));
+            record.setRawData(wktData[i].getBytes("UTF8"));
+            record.generateId(null);
             record.setVisibility(new ColumnVisibility(AUTHS));
             
             final Multimap<String,NormalizedContentInterface> fields = ingestHelper.getEventFields(record);


### PR DESCRIPTION
  Avoid multiple UID generation
  Remove setRawDataAndGenerateId in lieu of setRawData() and generateId()
  Allow for alternate UID implementations