### PR TITLE
Update ingest scripts to use pssh instead of pdsh commands.

### DIFF
--- a/warehouse/ingest-scripts/src/main/resources/bin/system/list-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/list-ingest.sh
@@ -26,7 +26,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pssh -p 1 -i -h ${ingestHost} "$INGEST_BIN/ingest/listIngest.sh" < /dev/null | grep -v 'SUCCESS'
+  pdsh -f 1 -d -w ^${ingestHost} "$INGEST_BIN/ingest/listIngest.sh" < /dev/null | grep -v 'SUCCESS'
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/list-metrics-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/list-metrics-ingest.sh
@@ -26,7 +26,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pssh -p 1 -i -h ${ingestHost} "$METRICS_BIN/metrics/listMetricsIngest.sh" < /dev/null | grep -v 'SUCCESS'
+  pdsh -f 1 -d -w ^${ingestHost} "$METRICS_BIN/metrics/listMetricsIngest.sh" < /dev/null | grep -v 'SUCCESS'
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/start-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/start-ingest.sh
@@ -29,7 +29,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${ingestHost} "$INGEST_BIN/ingest/start-ingesters.sh $FORCE" < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$INGEST_BIN/ingest/start-ingesters.sh $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/start-metrics-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/start-metrics-ingest.sh
@@ -32,9 +32,9 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh ingest $FORCE" < /dev/null
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh loader $FORCE" < /dev/null
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh flagmaker $FORCE" < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh ingest $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh loader $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh flagmaker $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/stop-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/stop-ingest.sh
@@ -25,7 +25,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${ingestHost} "$INGEST_BIN/ingest/stop-ingesters.sh $@" < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$INGEST_BIN/ingest/stop-ingesters.sh $@" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/stop-metrics-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/stop-metrics-ingest.sh
@@ -25,7 +25,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${ingestHost} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT
@@ -45,7 +45,7 @@ else
       echo $host >> $stagingHosts
   done
 
-  pssh -p 25 -o /tmp/stdout -e /tmp/stderr -h ${stagingHosts} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" < /dev/null
+  pdsh -f 25 -w ^${stagingHosts} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
 
   rm $stagingHosts
   trap - INT TERM EXIT


### PR DESCRIPTION
Listed are the alternate options I used and why during the refactor:

| pssh | pdsh | Use |
|--------|--------|-------|
| `-h <host_file>` | `-w ^<host_file>` (must be prepended with `^` if reading from file) | Specify list of hosts to connect to |
| `-v -i` | `-d` | Output error messages |
| `-p <concurrent_sessions>` | `-f <simultaneous_commands>` | Number of concurrent commands/sessions to run |
| `-o <filename>` | `1>> <filename>` | Redirect stdout to file |
| `-e <filename>` | `2>> <filename>` | Redirect stderr to file |
