### PR TITLE
Updates to allow age off configs to inherit from common file

### DIFF
--- a/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
+++ b/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
@@ -7,13 +7,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
-import datawave.iterators.filter.AgeOffConfigParams;
-import datawave.iterators.filter.ageoff.FilterOptions;
-import datawave.iterators.filter.ageoff.FilterRule;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -26,13 +25,17 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import datawave.iterators.filter.AgeOffConfigParams;
+import datawave.iterators.filter.ageoff.FilterOptions;
+import datawave.iterators.filter.ageoff.FilterRule;
+
 /**
  * 
  */
 public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
-    
+
     private static final Logger log = Logger.getLogger(FileRuleWatcher.class);
-    
+
     /**
      * @param fs
      * @param filePath
@@ -42,7 +45,7 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
     public FileRuleWatcher(FileSystem fs, Path filePath, long configuredDiff) throws IOException {
         super(fs, filePath, configuredDiff);
     }
-    
+
     /**
      * @param filePath
      * @param configuredDiff
@@ -51,7 +54,7 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
     public FileRuleWatcher(Path filePath, long configuredDiff) throws IOException {
         super(filePath.getFileSystem(new Configuration()), filePath, configuredDiff);
     }
-    
+
     /*
      * (non-Javadoc)
      * 
@@ -60,95 +63,30 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
     @Override
     protected Collection<FilterRule> loadContents(InputStream in) throws IOException {
         
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder docBuilder;
-        
-        Document doc;
         try {
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            docBuilder = factory.newDocumentBuilder();
-            doc = docBuilder.parse(in);
-            
+            Collection<RuleConfig> mergedRuleConfigs = loadRuleConfigs(in);
             Collection<FilterRule> filterRules = new ArrayList<>();
-            Element docElement = doc.getDocumentElement();
-            NodeList rules = docElement.getElementsByTagName("rule");
-            
-            Map<String,String> extendedOptions = new HashMap<>();
             /**
              * This has been changed to support extended options.
              */
-            for (int i = 0; i < rules.getLength(); i++) {
-                String ttlValue = null;
-                String ttlUnits = null;
-                String matchPattern = null;
-                String filterClassName = null;
-                extendedOptions.clear();
-                
-                Element ruleElem = (Element) rules.item(i);
-                
-                NodeList ruleElementList = ruleElem.getChildNodes();
-                for (int j = 0; j < ruleElementList.getLength(); j++) {
-                    Node nodeItem = ruleElementList.item(j);
-                    
-                    String nodeName = nodeItem.getNodeName();
-                    log.debug("getting " + nodeName);
-                    if ("filterClass".equals(nodeName)) {
-                        filterClassName = nodeItem.getTextContent().trim();
-                    } else if ("ttl".equals(nodeName)) {
-                        ttlValue = nodeItem.getTextContent().trim();
-                        ttlUnits = ((Element) nodeItem).getAttribute("units").trim();
-                    } else if ("ttlValue".equals(nodeName)) {
-                        ttlValue = nodeItem.getTextContent().trim();
-                    } else if ("ttlUnits".equals(nodeName)) {
-                        ttlUnits = nodeItem.getTextContent().trim();
-                    } else if ("matchPattern".equals(nodeName)) {
-                        matchPattern = nodeItem.getTextContent().trim();
-                    } else {
-                        /*
-                         * gives us the ability to add arbitrary configuration items along with adding XML attributes as sub tags.
-                         * 
-                         * The sub tags are sent as name . attributename
-                         */
-                        
-                        extendedOptions.put(nodeName, nodeItem.getTextContent().trim());
-                        if (nodeItem.hasAttributes()) {
-                            NamedNodeMap attributeMap = nodeItem.getAttributes();
-                            // if an xml tag exists with the attribute "name" then use the modified prefix
-                            String prefix = extractNewPrefix(nodeName, attributeMap);
-                            if (null == prefix) {
-                                // to maintain backwards compatibility, continue to produce the legacy option name
-                                prefix = nodeName;
-                            }
-                            for (int k = 0; k < attributeMap.getLength(); k++) {
-                                Node attItem = attributeMap.item(k);
-                                extendedOptions.put(prefix + "." + attItem.getNodeName(), attItem.getTextContent().trim());
-                            }
-                        }
-                    }
-                    
-                }
+            for (RuleConfig ruleConfig : mergedRuleConfigs) {
                 
                 try {
-                    FilterRule filter = (FilterRule) Class.forName(filterClassName).newInstance();
+                    FilterRule filter = (FilterRule) Class.forName(ruleConfig.filterClassName).newInstance();
                     
                     FilterOptions option = new FilterOptions();
                     
-                    if (ttlValue != null) {
-                        option.setTTL(Long.valueOf(ttlValue));
+                    if (ruleConfig.ttlValue != null) {
+                        option.setTTL(Long.valueOf(ruleConfig.ttlValue));
                     }
-                    if (ttlUnits != null) {
-                        option.setTTLUnits(ttlUnits);
+                    if (ruleConfig.ttlUnits != null) {
+                        option.setTTLUnits(ruleConfig.ttlUnits);
                     }
-                    option.setOption(AgeOffConfigParams.MATCHPATTERN, matchPattern);
+                    option.setOption(AgeOffConfigParams.MATCHPATTERN, ruleConfig.matchPattern);
                     
                     StringBuilder extOptions = new StringBuilder();
                     
-                    for (Entry<String,String> myOption : extendedOptions.entrySet()) {
+                    for (Entry<String,String> myOption : ruleConfig.extendedOptions.entrySet()) {
                         option.setOption(myOption.getKey(), myOption.getValue());
                         extOptions.append(myOption.getKey()).append(",");
                     }
@@ -175,16 +113,161 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
         }
         
     }
+
+    protected Collection<RuleConfig> loadRuleConfigs(InputStream in) throws IOException {
+        
+        Collection<RuleConfig> ruleConfigs = new ArrayList<>();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder docBuilder;
+        
+        Document doc;
+        try {
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            docBuilder = factory.newDocumentBuilder();
+            doc = docBuilder.parse(in);
+            
+            Element docElement = doc.getDocumentElement();
+            NodeList parents = docElement.getElementsByTagName("parent");
+            if (null != parents) {
+                ruleConfigs.addAll(loadParentRuleConfigs(parents));
+            }
+            NodeList rules = docElement.getElementsByTagName("rule");
+            // parse each node in rules and create a rule config
+            ruleConfigs.addAll(IntStream.range(0, rules.getLength())
+                .mapToObj(i -> getRuleConfigForNode(rules, i))
+                .collect(Collectors.toList()));
+            
+            // merge configs that map to the same filter class name
+            Collection<RuleConfig> mergedRuleConfigs = ruleConfigs.stream().collect(Collectors.toMap(
+                    RuleConfig::getFilterClassName, 
+                    Function.identity(),
+                    (rule1, rule2) -> mergeRules(rule1, rule2)))
+                .values();
+            return mergedRuleConfigs;
+        } catch (Exception ex) {
+            log.error("uh oh: " + ex);
+            throw new IOException(ex);
+        } finally {
+            IOUtils.closeStream(in);
+        }
+    }
     
+    RuleConfig mergeRules(RuleConfig rule1, RuleConfig rule2) {
+        // the rule that is a merge should have its values override the original rule
+        if (rule1.isMerge) {
+            rule2.ttlValue = rule1.ttlValue;
+            rule2.ttlUnits = rule1.ttlUnits;
+            rule2.extendedOptions.putAll(rule1.extendedOptions);
+            rule2.matchPattern += rule1.matchPattern;
+            return rule2;
+        } else if (rule2.isMerge) {
+            rule1.ttlValue = rule2.ttlValue;
+            rule1.ttlUnits = rule2.ttlUnits;
+            rule1.extendedOptions.putAll(rule2.extendedOptions);
+            rule1.matchPattern += rule2.matchPattern;
+            return rule1;
+        }
+        // neither is a merge rule, so just pick highest priority?
+        if (rule1.priority > rule2.priority) {
+            return rule1;
+        } else {
+            return rule2;
+        }
+    }
+
+    private RuleConfig getRuleConfigForNode(NodeList rules, int index) {
+        Map<String,String> extendedOptions = new HashMap<>();
+        String ttlValue = null;
+        String ttlUnits = null;
+        String matchPattern = null;
+        String filterClassName = null;
+        extendedOptions.clear();
+
+        Element ruleElem = (Element) rules.item(index);
+        boolean isMerge = isMergeRule(ruleElem);
+
+        NodeList ruleElementList = ruleElem.getChildNodes();
+        for (int j = 0; j < ruleElementList.getLength(); j++) {
+            Node nodeItem = ruleElementList.item(j);
+
+            String nodeName = nodeItem.getNodeName();
+
+            log.debug("getting " + nodeName);
+            if ("filterClass".equals(nodeName)) {
+                filterClassName = nodeItem.getTextContent().trim();
+            } else if ("ttl".equals(nodeName)) {
+                ttlValue = nodeItem.getTextContent().trim();
+                ttlUnits = ((Element) nodeItem).getAttribute("units").trim();
+            } else if ("ttlValue".equals(nodeName)) {
+                ttlValue = nodeItem.getTextContent().trim();
+            } else if ("ttlUnits".equals(nodeName)) {
+                ttlUnits = nodeItem.getTextContent().trim();
+            } else if ("matchPattern".equals(nodeName)) {
+                matchPattern = nodeItem.getTextContent().trim();
+            } else {
+                /*
+                 * gives us the ability to add arbitrary configuration items along with adding XML
+                 * attributes as sub tags.
+                 * 
+                 * The sub tags are sent as name . attributename
+                 */
+
+                extendedOptions.put(nodeName, nodeItem.getTextContent().trim());
+                if (nodeItem.hasAttributes()) {
+                    NamedNodeMap attributeMap = nodeItem.getAttributes();
+                    // if an xml tag exists with the attribute "name" then use the modified prefix
+                    String prefix = extractNewPrefix(nodeName, attributeMap);
+                    if (null == prefix) {
+                        // to maintain backwards compatibility, continue to produce the legacy
+                        // option name
+                        prefix = nodeName;
+                    }
+                    for (int k = 0; k < attributeMap.getLength(); k++) {
+                        Node attItem = attributeMap.item(k);
+                        extendedOptions.put(prefix + "." + attItem.getNodeName(),
+                                attItem.getTextContent().trim());
+                    }
+                }
+            }
+
+        }
+        extendedOptions.put(AgeOffConfigParams.IS_MERGE, Boolean.toString(isMerge));
+        return new RuleConfig(filterClassName, index)
+                .ttlValue(ttlValue)
+                .ttlUnits(ttlUnits)
+                .matchPattern(matchPattern)
+                .isMerge(isMerge)
+                .extendedOptions(extendedOptions);
+    }
+
+    private Collection<? extends RuleConfig> loadParentRuleConfigs(NodeList parents) throws IOException {
+        Collection<RuleConfig> rules = new ArrayList<>();
+        for (int i = 0; i < parents.getLength(); i++) {
+            Node parent = parents.item(i);
+            String parentPathStr = parent.getTextContent();
+            Path parentPath = new Path(this.getClass().getResource(parentPathStr).toString());
+            rules.addAll(loadRuleConfigs(fs.open(parentPath)));
+        }
+        return rules;
+    }
+
     /**
-     * Xml tag names cannot start with a number, so it was not previously possible to include extended options for items that begin with a number. The new
-     * prefix, provided by this method, provides a mechanism for doing this. Check if attribute "name" exists, e.g. &lt;field name='abc'&gt;value&lt;/field&gt;
+     * Xml tag names cannot start with a number, so it was not previously possible to include
+     * extended options for items that begin with a number. The new prefix, provided by this method,
+     * provides a mechanism for doing this. Check if attribute "name" exists, e.g. &lt;field
+     * name='abc'&gt;value&lt;/field&gt;
      * 
      * @param nodeName
      *            xml tag name, e.g. field using the above example
      * @param attributeMap
      *            attributes for current node
-     * @return null if the name attribute does not exist in the attribute map, or a prefix, e.g. field.abc using the above example
+     * @return null if the name attribute does not exist in the attribute map, or a prefix, e.g.
+     *         field.abc using the above example
      */
     private String extractNewPrefix(String nodeName, NamedNodeMap attributeMap) {
         String newPrefix = null;
@@ -193,5 +276,71 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
             newPrefix = nodeName + "." + nameAttribute.getNodeValue();
         }
         return newPrefix;
+    }
+
+    /**
+     * does the rule specify mode="merge"
+     * 
+     * @param nodeItem
+     *            to inspect
+     * @return if mode attribute is set to merge
+     */
+    private boolean isMergeRule(Node nodeItem) {
+        if (null != nodeItem.getAttributes()) {
+            Node namedItem = nodeItem.getAttributes().getNamedItem("mode");
+            if (null == namedItem) {
+                return false;
+            }
+            return namedItem.getNodeValue().equalsIgnoreCase("merge");
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Temporary holding class for rule configs to allow merges of rules;
+     */
+    private static class RuleConfig {
+        String ttlValue = null;
+        String ttlUnits = null;
+        String matchPattern = null;
+        String filterClassName = null;
+        boolean isMerge = false;
+        Map<String,String> extendedOptions = new HashMap<>();
+        int priority = -1;
+
+        public RuleConfig(String filterClassName, int priority) {
+            this.filterClassName = filterClassName;
+            this.priority = priority;
+        }
+
+        public String getFilterClassName() {
+            return filterClassName;
+        }
+
+        public RuleConfig ttlValue(String ttlValue) {
+            this.ttlValue = ttlValue;
+            return this;
+        }
+
+        public RuleConfig ttlUnits(String ttlUnits) {
+            this.ttlUnits = ttlUnits;
+            return this;
+        }
+
+        public RuleConfig matchPattern(String matchPattern) {
+            this.matchPattern = matchPattern;
+            return this;
+        }
+
+        public RuleConfig isMerge(boolean isMerge) {
+            this.isMerge = isMerge;
+            return this;
+        }
+
+        public RuleConfig extendedOptions(Map<String,String> extendedOptions) {
+            this.extendedOptions = extendedOptions;
+            return this;
+        }
     }
 }

--- a/warehouse/core/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
@@ -43,4 +43,9 @@ public class AgeOffConfigParams {
      * A flag denoting whether the age off should be disabled on system initialized major compactions (non-full majc)
      */
     public static final String DISABLE_ON_NON_FULL_MAJC = "disableOnNonFullMajc";
+
+    /**
+     * A flag indicating that the ageoff parameters are from the merging of two or more config files.  Some filter parsing need special handling for this case.
+     */
+    public static final String IS_MERGE = "ismerge";
 }

--- a/warehouse/core/src/main/java/datawave/iterators/filter/TokenTtlTrie.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/TokenTtlTrie.java
@@ -87,11 +87,19 @@ public final class TokenTtlTrie {
         private final List<Long> stateTtlList = new ArrayList<>();
         private final List<Integer> statePriorityList = new ArrayList<>();
         private final Set<Byte> delimiters = new HashSet<>();
+        private boolean isMerge;
+        
+        public enum MERGE_MODE { ON, OFF };
         
         Builder() {
+            this(MERGE_MODE.OFF);
+        }
+
+        Builder(MERGE_MODE mergeMode) {
             transitionMaps.add(new HashMap<Byte,Integer>());
             stateTtlList.add(null);
             statePriorityList.add(null);
+            this.isMerge = mergeMode.equals(MERGE_MODE.ON);
         }
         
         public int size() {
@@ -128,9 +136,13 @@ public final class TokenTtlTrie {
                 }
             }
             int myPriority = ++entryCount;
+            // if this is a merge of two configs, override ttl with latest seen
             if (stateTtlList.get(curState) == null) {
                 stateTtlList.set(curState, ttl);
                 statePriorityList.set(curState, myPriority);
+            } else if (isMerge) {
+                // maintain original priority just update the ttl
+                stateTtlList.set(curState, ttl);
             } else {
                 throw new IllegalArgumentException(String.format("Token '%s'(#%d) already specified at index %d", new String(token),
                                 statePriorityList.get(curState), myPriority));

--- a/warehouse/core/src/main/java/datawave/iterators/filter/TokenizingFilterBase.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/TokenizingFilterBase.java
@@ -1,6 +1,8 @@
 package datawave.iterators.filter;
 
 import java.util.Objects;
+
+import datawave.iterators.filter.TokenTtlTrie.Builder.MERGE_MODE;
 import datawave.iterators.filter.ageoff.AgeOffPeriod;
 import datawave.iterators.filter.ageoff.AppliedRule;
 import datawave.iterators.filter.ageoff.FilterOptions;
@@ -46,8 +48,7 @@ import org.apache.accumulo.core.data.Value;
  *
  */
 public abstract class TokenizingFilterBase extends AppliedRule {
-    public final static String DELIMITERS_TAG = "delimiters";
-    
+    public static final String DELIMITERS_TAG = "delimiters";
     private String matchPattern = null;
     private TokenTtlTrie scanTrie = null;
     private boolean ruleApplied;
@@ -75,12 +76,13 @@ public abstract class TokenizingFilterBase extends AppliedRule {
         super.init(options);
         ruleApplied = false;
         String confPattern = options.getOption(AgeOffConfigParams.MATCHPATTERN);
+        MERGE_MODE mode = getMergeMode(options);
         if (!Objects.equals(matchPattern, confPattern)) {
-            this.scanTrie = new TokenTtlTrie.Builder().setDelimiters(getDelimiters(options)).parse(confPattern).build();
+            this.scanTrie = new TokenTtlTrie.Builder(mode).setDelimiters(getDelimiters(options)).parse(confPattern).build();
             this.matchPattern = confPattern;
         }
     }
-    
+
     @Override
     public void deepCopyInit(FilterOptions newOptions, AppliedRule parentCopy) {
         TokenizingFilterBase parent = (TokenizingFilterBase) parentCopy;
@@ -109,6 +111,16 @@ public abstract class TokenizingFilterBase extends AppliedRule {
         return ruleApplied;
     }
     
+    private MERGE_MODE getMergeMode(FilterOptions options) {
+        String isMergeStr = options.getOption(AgeOffConfigParams.IS_MERGE);
+        if (null == isMergeStr) {
+            return MERGE_MODE.OFF;
+        } else {
+            boolean isMerge = Boolean.parseBoolean(isMergeStr);
+            return isMerge ? MERGE_MODE.ON : MERGE_MODE.OFF;
+        }
+    }
+
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "[size=" + (scanTrie == null ? null : scanTrie.size()) + "]";

--- a/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleLoadContentsMergeFiltersTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleLoadContentsMergeFiltersTest.java
@@ -1,0 +1,159 @@
+package datawave.ingest.util.cache.watch;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+import datawave.iterators.filter.AgeOffConfigParams;
+import datawave.iterators.filter.AgeOffTtlUnits;
+import datawave.iterators.filter.ageoff.AgeOffPeriod;
+import datawave.iterators.filter.ageoff.AppliedRule;
+import datawave.iterators.filter.ageoff.FilterOptions;
+import datawave.iterators.filter.ageoff.FilterRule;
+
+/**
+ * Tests to verify capability of merging configs that use filters that inherit from {@code TokenizingFilterBase}
+ */
+public class FileRuleLoadContentsMergeFiltersTest {
+    private static final String ROOT_FILTER_CONFIGURATION_FILE = "/test-root-rules.xml";
+    private static final String CHILD_FILTER_CONFIGURATION_FILE = "/test-customized-rules.xml";
+    private static final long MILLIS_IN_DAY = 24 * 60 * 60 * 1000;
+    private static final int MILLIS_IN_ONE_SEC = 60 * 1000;
+
+    private FileRuleWatcher watcher;
+    private TestTrieFilter parentFilter;
+    // this on inherits defaults from parentFilter
+    private TestTrieFilter childFilter;
+    // reference used by multiple tests, contents not used
+    private Value value = new Value();
+    // fixes the root time
+    private long anchorTime;
+    private FilterOptions filterOptions;
+
+    @Before
+    public void before() throws IOException {
+        Path childPath = new Path(
+                this.getClass().getResource(CHILD_FILTER_CONFIGURATION_FILE).toString());
+        Path rootPath = new Path(
+                this.getClass().getResource(ROOT_FILTER_CONFIGURATION_FILE).toString());
+        FileSystem fs = childPath.getFileSystem(new Configuration());
+        watcher = new FileRuleWatcher(fs, childPath, 1);
+        parentFilter = (TestTrieFilter) loadRulesFromFile(watcher, fs, rootPath);
+        childFilter = (TestTrieFilter) loadRulesFromFile(watcher, fs, childPath);
+        anchorTime = System.currentTimeMillis();
+        // use this to configure the age off evaluation, all units expected to be in days
+        filterOptions = new FilterOptions();
+        filterOptions.setTTL(365);
+        filterOptions.setTTLUnits(AgeOffTtlUnits.DAYS);
+    }
+
+    @Test
+    public void verifyOverridenValues() throws IOException {
+        // there are 6 rules, three are overridden
+
+        // original mappings should be
+        // "baking powder" : 365d
+        // "dried beans" : 548d
+        // "baking soda" : 720d
+        // "coffee grounds" : 90d
+        // "coffee whole bean" : 183d
+        // "coffee instant" : 730d
+
+        // we are using the definitions from the customized rules file which should override
+        // "coffee grounds" : 30d
+        // "coffee whole bean" : 150d
+        // "coffee instant" : 1080d
+
+        // verify original mappings
+        verifyParentRule("baking powder", 365L);
+        verifyParentRule("dried beans", 548L);
+        verifyParentRule("baking soda", 720L);
+        verifyParentRule("coffee ground", 90L);
+        verifyParentRule("coffee whole bean", 183L);
+        verifyParentRule("coffee instant", 730L);
+
+        // verify overridden mappings, which should include original and new values
+        verifyChildRule("baking powder", 365L);
+        verifyChildRule("dried beans", 548L);
+        verifyChildRule("baking soda", 720L);
+        verifyChildRule("coffee ground", 30L);
+        verifyChildRule("coffee whole bean", 150L);
+        verifyChildRule("coffee instant", 1080L);
+    }
+
+    private void verifyParentRule(String data, long offsetInDays) {
+        // should accept if timestamp is exact
+        verifyAppliedRule(parentFilter, data, offsetInDays, true);
+        // should accept if timestamp is less than configured age off
+        verifyAppliedRule(parentFilter, data, offsetInDays - 1, true);
+        // should NOT accept if timestamp is more than configured age off
+        verifyAppliedRule(parentFilter, data, offsetInDays + 1, false);
+    }
+
+    private void verifyChildRule(String data, long offsetInDays) {
+        // should accept if timestamp is exact
+        verifyAppliedRule(childFilter, data, offsetInDays, true);
+        // should accept if timestamp is less than configured age off
+        verifyAppliedRule(childFilter, data, offsetInDays - 1, true);
+        // should NOT accept if timestamp is more than configured age off
+        verifyAppliedRule(childFilter, data, offsetInDays + 1, false);
+    }
+
+    private void verifyAppliedRule(AppliedRule filter, String data, long offsetInDays, boolean expectation) {
+        // need time stamp that is N days ago, use anchorTime to anchor time
+        // that way only need one call to System.currentTimeInMillis()
+        // the time check is ts > cutoffTimestamp, so + 1 will let exact offsetInDays to pass this
+        long timestamp = anchorTime - (offsetInDays * MILLIS_IN_DAY) + 1;
+        Key key = TestTrieFilter.create(data, timestamp);
+        assertThat(failedExpectationMessage(data, offsetInDays, expectation),
+                filter.accept(filterOptions.getAgeOffPeriod(anchorTime), key, value),
+                is(expectation));
+    }
+
+    private String failedExpectationMessage(String data, long offsetInDays, boolean expectation) {
+        return "Expected " + data + " with offset of " + offsetInDays + " days to be " + expectation
+                + " but was " + !expectation;
+    }
+
+    @Test
+    public void testTtl() {
+        FilterOptions filterOpts = new FilterOptions();
+        filterOpts.setOption(AgeOffConfigParams.MATCHPATTERN, "\"1234\":5s");
+        long tenSecondsAgo = System.currentTimeMillis() - (10 * MILLIS_IN_ONE_SEC);
+
+        TestTrieFilter filter = new TestTrieFilter();
+        // set the default to 5 seconds
+        filterOpts.setTTL(5);
+        filterOpts.setTTLUnits(AgeOffTtlUnits.SECONDS);
+        filter.init(filterOpts);
+
+        Key key = new Key("1234".getBytes(), tenSecondsAgo);
+        AgeOffPeriod ageOffPeriod = filterOpts.getAgeOffPeriod(System.currentTimeMillis());
+        assertFalse(filter.accept(ageOffPeriod, key, new Value()));
+        assertTrue(filter.isFilterRuleApplied());
+    }
+
+    private static FilterRule loadRulesFromFile(FileRuleWatcher watcher, FileSystem fs,
+            Path filePath) throws IOException {
+        Collection<FilterRule> rules = watcher.loadContents(fs.open(filePath));
+        // should only have the single rule
+        assertThat(rules.size(), is(1));
+        for (FilterRule rule : rules) {
+            assertEquals(TestTrieFilter.class, rule.getClass());
+        }
+        return rules.iterator().next();
+    }
+}

--- a/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleWatcherTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleWatcherTest.java
@@ -1,19 +1,19 @@
 package datawave.ingest.util.cache.watch;
 
-import datawave.iterators.filter.AgeOffConfigParams;
-import datawave.iterators.filter.ageoff.FilterRule;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import datawave.iterators.filter.AgeOffConfigParams;
+import datawave.iterators.filter.ageoff.FilterRule;
 
 public class FileRuleWatcherTest {
     private static final String FILTER_CONFIGURATION_FILE = "/test-filter-rules.xml";
@@ -30,7 +30,6 @@ public class FileRuleWatcherTest {
         rulesByMatchPattern = new HashMap<>();
         filePath = new Path(this.getClass().getResource(FILTER_CONFIGURATION_FILE).toString());
         fs = filePath.getFileSystem(new Configuration());
-        FSDataInputStream inputStream = fs.open(filePath);
         watcher = new FileRuleWatcher(fs, filePath, 1);
         rules = watcher.loadContents(fs.open(filePath));
         Assert.assertEquals(5, rules.size());

--- a/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/TestTrieFilter.java
+++ b/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/TestTrieFilter.java
@@ -1,0 +1,37 @@
+package datawave.ingest.util.cache.watch;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import datawave.iterators.filter.TokenizingFilterBase;
+import datawave.iterators.filter.ageoff.FilterOptions;
+
+/**
+ * Class to assist in the testing of TokeninzingFilters
+ */
+public class TestTrieFilter extends TokenizingFilterBase {
+    private static final byte[] DELIM_BYTES = "/".getBytes();
+
+    // public so that the tests can inspect the options
+    public FilterOptions options;
+    
+    @Override
+    public void init(FilterOptions options) {
+        super.init(options);
+        this.options = options;
+    }
+
+    @Override
+    public byte[] getKeyField(Key k, Value V) {
+        return k.getRow().getBytes();
+    }
+
+    @Override
+    public byte[] getDelimiters(FilterOptions options) {
+        return DELIM_BYTES;
+    }
+    
+    public static Key create(String data, long ts) {
+        return new Key(data.getBytes(), ts);
+    }
+}

--- a/warehouse/core/src/test/java/datawave/iterators/filter/TokenTtlTrieTest.java
+++ b/warehouse/core/src/test/java/datawave/iterators/filter/TokenTtlTrieTest.java
@@ -1,14 +1,19 @@
 package datawave.iterators.filter;
 
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import datawave.iterators.filter.TokenTtlTrie.Builder.MERGE_MODE;
 import datawave.iterators.filter.ageoff.AgeOffPeriod;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Assert;
 
 public class TokenTtlTrieTest {
     public static Logger log = Logger.getLogger(TokenTtlTrieTest.class);
@@ -31,15 +36,15 @@ public class TokenTtlTrieTest {
         Assert.assertEquals((Long) 4L, trie.scan("buffer,baz".getBytes()));
         Assert.assertNull(trie.scan("b;ba,banana,bread,apple,pie".getBytes()));
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void tokensMayNotContainDelimiters() {
-        TokenTtlTrie trie = new TokenTtlTrie.Builder().setDelimiters(",".getBytes()).addToken("foo,".getBytes(), 1).build();
+        new TokenTtlTrie.Builder().setDelimiters(",".getBytes()).addToken("foo,".getBytes(), 1).build();
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void tokensMustBeUnique() {
-        TokenTtlTrie trie = new TokenTtlTrie.Builder().setDelimiters(",".getBytes()).addToken("foo".getBytes(), 1).addToken("foo".getBytes(), 2).build();
+        new TokenTtlTrie.Builder().setDelimiters(",".getBytes()).addToken("foo".getBytes(), 1).addToken("foo".getBytes(), 2).build();
     }
     
     @Test
@@ -81,8 +86,50 @@ public class TokenTtlTrieTest {
         Assert.assertNull(trie.scan("b;ba,banana,bread,apple,pie".getBytes()));
     }
     
+    @Test
+    public void testParseAndMerge() {
+        String initial = "\"foo\" : 1ms\n" +
+                         "\"bar\" : 3ms\n" +
+                         "\"baz\" : 5ms\n" +
+                         "\"zip\" : 7ms\n";
+
+        String override = "\"bar\" : 5ms\n" +
+                          "\"zip\" : 9ms\n";
+
+        TokenTtlTrie trie = new TokenTtlTrie.Builder(MERGE_MODE.ON)
+                .setDelimiters("/".getBytes())
+                .parse(initial + override)
+                .build();
+        // original values
+        assertThat(trie.scan("foo".getBytes()), is(equalTo(1L)));
+        assertThat(trie.scan("baz".getBytes()), is(equalTo(5L)));
+        // overridden values
+        assertThat(trie.scan("bar".getBytes()), is(equalTo(5L)));
+        assertThat(trie.scan("zip".getBytes()), is(equalTo(9L)));
+    }
+    
+    @Test
+    public void testParseWithWhiteSpaces() {
+        String initial = "\"baking powder\" : 1d\n\t\t\t\t"
+                + "\"dried beans\" : 2d\n\t\t\t\t"
+                + "\"baking soda\" : 3d\n\t\t\t\t"
+                + "\"coffee grounds\" : 4d\n\t\t\t\t"
+                + "\"coffee whole bean\" : 5d\n\t\t\t\t"
+                + "\"coffee instant\" : 6d";
+
+        TokenTtlTrie trie = new TokenTtlTrie.Builder()
+                .setDelimiters("/".getBytes())
+                .parse(initial)
+                .build();
+        assertThat(trie.scan("baking powder".getBytes()), is(notNullValue()));
+        assertThat(trie.scan("dried beans".getBytes()), is(notNullValue()));
+        assertThat(trie.scan("baking soda".getBytes()), is(notNullValue()));
+        // not one of the ones we configured the tree with
+        assertThat(trie.scan("zip foo".getBytes()), is(nullValue()));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void parsedTokensMayNotContainDelimiters() {
-        TokenTtlTrie trie = new TokenTtlTrie.Builder().setDelimiters(",".getBytes()).parse("\"foo,\":10s").build();
+        new TokenTtlTrie.Builder().setDelimiters(",".getBytes()).parse("\"foo,\":10s").build();
     }
 }

--- a/warehouse/core/src/test/resources/test-customized-rules.xml
+++ b/warehouse/core/src/test/resources/test-customized-rules.xml
@@ -1,0 +1,16 @@
+<ageoffConfiguration>
+    <parent>/test-root-rules.xml</parent>
+    <rules>
+    	<!-- by specifying merge mode the match patterns of any rules for the 
+    		identical filter classes will be concatenated -->
+        <rule mode="merge">
+            <filterClass>datawave.ingest.util.cache.watch.TestTrieFilter</filterClass>
+            <ismerge>true</ismerge>
+            <matchPattern> <!-- override parent definitions -->
+				"coffee ground" : 30d
+				"coffee whole bean" : 150d
+				"coffee instant" : 1080d
+			</matchPattern>
+        </rule>
+    </rules>
+</ageoffConfiguration>

--- a/warehouse/core/src/test/resources/test-root-rules.xml
+++ b/warehouse/core/src/test/resources/test-root-rules.xml
@@ -1,0 +1,16 @@
+<ageoffConfiguration>
+	<rules>
+		<rule>
+			<filterClass>datawave.ingest.util.cache.watch.TestTrieFilter
+			</filterClass>
+			<matchPattern>
+				"baking powder" : 365d
+				"dried beans" : 548d
+				"baking soda" : 720d
+				"coffee ground" : 90d
+				"coffee whole bean" : 183d
+				"coffee instant" : 730d
+			</matchPattern>
+		</rule>
+	</rules>
+</ageoffConfiguration>


### PR DESCRIPTION
Updated FileRuleWatcher to allow the inheritance and merging of rules

Updated TokenizingFilterBase to include a merge mode that allows ttl values
later in the config to overwrite the ones earlier one, while maintaining the
priority

Added FileRuleLoadContentsMergeFiltersTest to fully test merge of configs and
the application of the rules against data.