### PR TITLE
Added updates to help validate shard splits

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
@@ -787,8 +787,10 @@ public class IngestJob implements Tool {
             conf.set("split.work.dir", conf.get("ingest.work.dir.qualified"));
         }
         conf.setInt("splits.num.reduce", this.reduceTasks);
+        // want validation turned off by default
+        boolean validateShardTableMapFiles = conf.getBoolean(ShardedTableMapFile.SHARD_VALIDATION_ENABLED, false);
         // used by the output formatter and the sharded partitioner
-        ShardedTableMapFile.setupFile(conf);
+        ShardedTableMapFile.setupFile(conf, validateShardTableMapFiles);
         
         conf.setInt(MultiRFileOutputFormatter.EVENT_PARTITION_COUNT, this.reduceTasks * 2);
         configureMultiRFileOutputFormatter(conf, compressionType, compressionTableBlackList, maxRFileEntries, maxRFileSize, generateMapFileRowKeys);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/ShardedTableMapFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/ShardedTableMapFile.java
@@ -3,7 +3,9 @@ package datawave.ingest.mapreduce.job;
 import datawave.ingest.data.config.ConfigurationHelper;
 import datawave.ingest.data.config.ingest.AccumuloHelper;
 import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
+import datawave.ingest.mapreduce.handler.shard.ShardIdFactory;
 import datawave.util.StringUtils;
+import datawave.util.time.DateHelper;
 import org.apache.accumulo.core.client.*;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -11,6 +13,7 @@ import org.apache.accumulo.core.data.impl.KeyExtent;
 import org.apache.accumulo.core.metadata.MetadataServicer;
 import org.apache.accumulo.core.client.impl.Credentials;
 import org.apache.accumulo.fate.util.UtilWaitThread;
+import org.apache.commons.lang.time.DateUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.io.*;
@@ -19,22 +22,28 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Extracted from IngestJob
  */
 public class ShardedTableMapFile {
+    public static final String SHARDS_BALANCED_DAYS_TO_VERIFY = "shards.balanced.days.to.verify";
     private static final String PREFIX = ShardedTableMapFile.class.getName();
+    private static final int MAX_RETRY_ATTEMPTS = 10;
+    
+    private static final Logger log = Logger.getLogger(ShardedTableMapFile.class);
+    
     public static final String TABLE_NAMES = "job.table.names";
     public static final String SHARD_TSERVER_MAP_FILE = PREFIX + ".shardTServerMapFile";
     public static final String SPLIT_WORK_DIR = "split.work.dir";
     
     public static final String CONFIGURED_SHARDED_TABLE_NAMES = ShardedDataTypeHandler.SHARDED_TNAMES + ".configured";
-    private static final Logger log = Logger.getLogger(ShardedTableMapFile.class);
     public static final String SHARDED_MAP_FILE_PATHS_RAW = "shardedMap.file.paths.raw";
+    public static final String SHARD_VALIDATION_ENABLED = "shardedMap.validation.enabled";
     
-    public static void setupFile(Configuration conf) throws IOException, URISyntaxException, AccumuloSecurityException, AccumuloException {
-        Map<String,Path> map = loadMap(conf);
+    public static void setupFile(Configuration conf, boolean doValidation) throws IOException, URISyntaxException, AccumuloSecurityException, AccumuloException {
+        Map<String,Path> map = loadMap(conf, doValidation);
         if (null == map) {
             log.fatal("Receieved a null mapping of sharded tables to split files, exiting...");
             throw new RuntimeException("Receieved a null mapping of sharded tables to split files, exiting...");
@@ -58,6 +67,7 @@ public class ShardedTableMapFile {
         
         Text shardID = new Text();
         Text location = new Text();
+        
         try {
             while (reader.next(shardID, location)) {
                 locations.put(new Text(shardID), location.toString());
@@ -66,6 +76,102 @@ public class ShardedTableMapFile {
             reader.close();
         }
         return locations;
+    }
+    
+    public static void validateShardIdLocations(Configuration conf, String tableName, int daysToVerify, Map<Text,String> shardIdToLocation) {
+        ShardIdFactory shardIdFactory = new ShardIdFactory(conf);
+        // assume true unless proven otherwise
+        boolean isValid = true;
+        for (int daysAgo = 0; daysAgo <= daysToVerify; daysAgo++) {
+            long inMillis = System.currentTimeMillis() - (daysAgo * DateUtils.MILLIS_PER_DAY);
+            String datePrefix = DateHelper.format(inMillis);
+            int expectedNumberOfShards = shardIdFactory.getNumShards(datePrefix);
+            boolean shardsExist = shardsExistForDate(shardIdToLocation, datePrefix, expectedNumberOfShards);
+            if (!shardsExist) {
+                log.warn("Shards for " + datePrefix + " for table " + tableName + " do not exist!");
+                isValid = false;
+                continue;
+            }
+            boolean shardsAreBalanced = shardsAreBalanced(shardIdToLocation, datePrefix);
+            if (!shardsAreBalanced) {
+                log.warn("Shards for " + datePrefix + " for table " + tableName + " are not balanced!");
+                isValid = false;
+            }
+        }
+        if (!isValid) {
+            throw new IllegalStateException("All of today's shards have not been created.  Run bin/ingest/create_shards_since.sh "
+                            + "yyyymmdd, substitute yyyymmdd with today's date.  Ensure that the normal mechanism "
+                            + "for creating shards is running - e.g, crontab");
+        }
+    }
+    
+    /**
+     * Existence check for the shard splits for the specified date
+     * 
+     * @param locations
+     *            mapping of shard to tablet
+     * @param datePrefix
+     *            to check
+     * @param expectedNumberOfShards
+     *            that should exist
+     * @return if the number of shards for the given date are as expected
+     */
+    private static boolean shardsExistForDate(Map<Text,String> locations, String datePrefix, int expectedNumberOfShards) {
+        int count = 0;
+        byte[] prefixBytes = datePrefix.getBytes();
+        for (Text key : locations.keySet()) {
+            if (prefixMatches(prefixBytes, key.getBytes(), key.getLength())) {
+                count++;
+            }
+        }
+        return count == expectedNumberOfShards;
+    }
+    
+    /**
+     * Checks that the shard splits for the given date have been assigned to unique tablets.
+     * 
+     * @param locations
+     *            mapping of shard to tablet
+     * @param datePrefix
+     *            to check
+     * @return if the shards are distributed in a balanced fashion
+     */
+    private static boolean shardsAreBalanced(Map<Text,String> locations, String datePrefix) {
+        // assume true unless proven wrong
+        boolean dateIsBalanced = true;
+        
+        Set<String> tabletsSeenForDate = new HashSet<>();
+        byte[] prefixBytes = datePrefix.getBytes();
+        
+        for (Entry<Text,String> entry : locations.entrySet()) {
+            Text key = entry.getKey();
+            // only check entries for specified date
+            if (prefixMatches(prefixBytes, key.getBytes(), key.getLength())) {
+                String value = entry.getValue();
+                // if we have already seen this tablet assignment, then the shards are not balanced
+                if (tabletsSeenForDate.contains(value)) {
+                    log.warn("Multiple Shards for " + datePrefix + " assigned to tablet " + value);
+                    dateIsBalanced = false;
+                }
+                tabletsSeenForDate.add(value);
+            }
+        }
+        
+        return dateIsBalanced;
+    }
+    
+    private static boolean prefixMatches(byte[] prefixBytes, byte[] keyBytes, int keyLen) {
+        // if key length is less than prefix size, no use comparing
+        if (prefixBytes.length > keyLen) {
+            return false;
+        }
+        for (int i = 0; i < prefixBytes.length; i++) {
+            if (prefixBytes[i] != keyBytes[i]) {
+                return false;
+            }
+        }
+        // at this point didn't fail match, so should be good
+        return true;
     }
     
     public static void addToConf(Configuration conf, Map<String,Path> map) {
@@ -77,7 +183,8 @@ public class ShardedTableMapFile {
         conf.setStrings(CONFIGURED_SHARDED_TABLE_NAMES, var.toArray(new String[var.size()]));
     }
     
-    private static Map<String,Path> loadMap(Configuration conf) throws IOException, URISyntaxException, AccumuloSecurityException, AccumuloException {
+    private static Map<String,Path> loadMap(Configuration conf, boolean doValidation) throws IOException, URISyntaxException, AccumuloSecurityException,
+                    AccumuloException {
         AccumuloHelper accumuloHelper = null;
         Path workDir = new Path(conf.get(SPLIT_WORK_DIR));// todo make sure this is set in ingest job
         String[] tableNames = StringUtils.split(conf.get(TABLE_NAMES), ",");// todo make sure this is set in ingest job
@@ -108,7 +215,7 @@ public class ShardedTableMapFile {
                 }
                 Connector conn = accumuloHelper.getConnector();
                 Credentials credentials = accumuloHelper.getCredentials();
-                shardedMapFile = createShardedMapFile(log, conf, workDir, conn.getInstance(), credentials, shardedTableName);
+                shardedMapFile = createShardedMapFile(log, conf, workDir, conn.getInstance(), credentials, shardedTableName, doValidation);
             }
             
             // Ensure that we either computed, or were given, a valid path to the shard mappings
@@ -162,26 +269,34 @@ public class ShardedTableMapFile {
      *            Accumulo access credentials for querying shard locations
      * @param shardedTableName
      *            name of the shard table--the table whose locations we are querying
+     * @param validateShardLocations
+     *            if validation of shards mappings should be performed
      * @return the path to the sharded table map file
      * @throws IOException
      * @throws URISyntaxException
      */
-    public static Path createShardedMapFile(Logger log, Configuration conf, Path workDir, Instance instance, Credentials credentials, String shardedTableName)
-                    throws IOException, URISyntaxException {
+    public static Path createShardedMapFile(Logger log, Configuration conf, Path workDir, Instance instance, Credentials credentials, String shardedTableName,
+                    boolean validateShardLocations) throws IOException, URISyntaxException {
         Path shardedMapFile = null;
+        // minus one to make zero based indexed
+        int daysToVerify = conf.getInt(SHARDS_BALANCED_DAYS_TO_VERIFY, 2) - 1;
         
         if (null != shardedTableName) {
             // Read all the metadata entries for the sharded table so that we can
             // get the mapping of shard IDs to tablet locations.
             log.info("Reading metadata entries for " + shardedTableName);
             
-            SortedMap<KeyExtent,String> locations = getLocations(log, instance, credentials, shardedTableName);
+            Map<KeyExtent,String> rawLocations = getLocations(log, instance, credentials, shardedTableName);
+            Map<Text,String> convertedLocations = convertToTextStringMap(rawLocations);
+            if (validateShardLocations) {
+                validateShardIdLocations(conf, shardedTableName, daysToVerify, convertedLocations);
+            }
             
             // Now write all of the assignments out to a file stored in HDFS
             // we're ok with putting the sharded table file in the hdfs workdir. why is that not good enough for the non sharded splits?
             shardedMapFile = new Path(workDir, shardedTableName + "_shards.lst");
             log.info("Writing shard assignments to " + shardedMapFile);
-            long count = writeSplitsFile(locations, shardedMapFile, conf);
+            long count = writeSplitsFile(convertedLocations, shardedMapFile, conf);
             log.info("Wrote " + count + " shard assignments to " + shardedMapFile);
         }
         
@@ -204,14 +319,26 @@ public class ShardedTableMapFile {
     public static SortedMap<KeyExtent,String> getLocations(Logger log, Instance instance, Credentials credentials, String shardedTableName) {
         
         TreeMap<KeyExtent,String> locations = new TreeMap<>();
-        while (true) {
+        boolean keepRetrying = true;
+        int attempts = 0;
+        while (keepRetrying && attempts < MAX_RETRY_ATTEMPTS) {
             try {
+                attempts++;
                 // re-create the locations so that we don't re-use stale metadata information.
                 locations.clear();
-                MetadataServicer servicer = MetadataServicer.forTableName(
-                                new ClientContext(instance, credentials, AccumuloConfiguration.getDefaultConfiguration()), shardedTableName);
-                servicer.getTabletLocations(locations);
-                break;
+                ClientContext context = new ClientContext(instance, credentials, AccumuloConfiguration.getDefaultConfiguration());
+                // if table does not exist don't want to catch the errors and end up in infinite loop
+                Map<String,String> tableIdMap = context.getConnector().tableOperations().tableIdMap();
+                boolean tableExists = tableIdMap.containsKey(shardedTableName);
+                if (!tableExists) {
+                    log.error("Table " + shardedTableName + " not found, skipping split locations for missing table");
+                } else {
+                    MetadataServicer servicer = MetadataServicer.forTableName(context, shardedTableName);
+                    servicer.getTabletLocations(locations);
+                }
+                // made it here, no errors so break out
+                keepRetrying = false;
+                ;
             } catch (Exception e) {
                 log.warn(e.getMessage() + " ... retrying ...");
                 UtilWaitThread.sleep(3000);
@@ -233,24 +360,59 @@ public class ShardedTableMapFile {
      * @throws IOException
      *             if file system interaction fails
      */
-    public static long writeSplitsFile(Map<KeyExtent,String> splits, Path file, Configuration conf) throws IOException {
+    public static long writeSplitsFile(Map<Text,String> splits, Path file, Configuration conf) throws IOException {
         FileSystem fs = file.getFileSystem(conf);
         if (fs.exists(file))
             fs.delete(file, false);
         
         long count = 0;
+        // reusable value for writing
+        Text value = new Text();
         SequenceFile.Writer writer = SequenceFile.createWriter(conf, SequenceFile.Writer.file(file), SequenceFile.Writer.keyClass(Text.class),
                         SequenceFile.Writer.valueClass(Text.class));
-        for (Map.Entry<KeyExtent,String> entry : splits.entrySet()) {
-            KeyExtent extent = entry.getKey();
-            if (extent.getEndRow() != null && entry.getValue() != null) {
-                count++;
-                Text location = new Text(entry.getValue().replaceAll("[\\.:]", "_"));
-                writer.append(extent.getEndRow(), location);
-            }
+        for (Entry<Text,String> entry : splits.entrySet()) {
+            count++;
+            value.set(entry.getValue());
+            writer.append(entry.getKey(), value);
         }
         writer.close();
         return count;
+    }
+    
+    /**
+     * Writes the contents of splits out to a sequence file on the given FileSystem.
+     *
+     * @param splits
+     *            map of split points for a table
+     * @param file
+     *            the file to which the splits should be written
+     * @param conf
+     *            hadoop configuration
+     * @return the number of entries written to the splits file
+     * @throws IOException
+     *             if file system interaction fails
+     */
+    public static long writeSplitsFileLegacy(Map<KeyExtent,String> splits, Path file, Configuration conf) throws IOException {
+        return writeSplitsFile(convertToTextStringMap(splits), file, conf);
+    }
+    
+    /**
+     * Formats KeyExtent end row to tablet server for consumption by other methods.
+     * 
+     * @param splits
+     *            raw splits read from accumulo
+     * @return converted to end row to location mapping
+     */
+    private static Map<Text,String> convertToTextStringMap(Map<KeyExtent,String> splits) {
+        Map<Text,String> converted = new TreeMap<>();
+        for (Map.Entry<KeyExtent,String> entry : splits.entrySet()) {
+            KeyExtent extent = entry.getKey();
+            if (extent.getEndRow() != null && entry.getValue() != null) {
+                String location = entry.getValue().replaceAll("[\\.:]", "_");
+                converted.put(extent.getEndRow(), location);
+            }
+        }
+        return converted;
     }
     
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/ShardedTableMapFileTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/ShardedTableMapFileTest.java
@@ -1,30 +1,61 @@
 package datawave.ingest.mapreduce.job;
 
-import com.google.common.io.Files;
-import datawave.ingest.data.config.ingest.AccumuloHelper;
-import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
-import org.apache.accumulo.core.client.*;
-import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.accumulo.core.data.impl.KeyExtent;
-import org.apache.accumulo.minicluster.MiniAccumuloCluster;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
-import org.apache.hadoop.io.*;
-import org.apache.hadoop.util.StringUtils;
-import org.junit.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.URI;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.commons.lang.time.DateUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.util.StringUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.io.Files;
+
+import datawave.ingest.data.config.ingest.AccumuloHelper;
+import datawave.ingest.mapreduce.handler.shard.ShardIdFactory;
+import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
+import datawave.util.time.DateHelper;
 
 public class ShardedTableMapFileTest {
     public static final String PASSWORD = "123";
     public static final String USERNAME = "root";
     private static final String TABLE_NAME = "unitTestTable";
+    private static final int SHARDS_PER_DAY = 10;
+    private static Configuration conf;
+    
+    @BeforeClass
+    public static void defineShardLocationsFile() throws IOException {
+        conf = new Configuration();
+        conf.setInt(ShardIdFactory.NUM_SHARDS, SHARDS_PER_DAY);
+        conf.set(ShardedDataTypeHandler.SHARDED_TNAMES, "shard");
+    }
     
     @Test
     public void testWriteSplitsToFileAndReadThem() throws Exception {
         Configuration conf = new Configuration();
+        conf.setInt(ShardIdFactory.NUM_SHARDS, SHARDS_PER_DAY);
         
         conf.set(ShardedDataTypeHandler.SHARDED_TNAMES, TABLE_NAME
                         + ",shard_ingest_unit_test_table_1,shard_ingest_unit_test_table_2,shard_ingest_unit_test_table_3");
@@ -32,13 +63,12 @@ public class ShardedTableMapFileTest {
         String[] tableNames = new String[] {TABLE_NAME};
         conf.set(ShardedTableMapFile.TABLE_NAMES, StringUtils.join(",", tableNames));
         
-        Map<KeyExtent,String> splits = new HashMap<>();
-        splits.put(new KeyExtent(TABLE_NAME, null, null), "location1:1234"); // won't be written to splits file
-        splits.put(new KeyExtent(TABLE_NAME, new Text("zEndRow"), new Text("prevEndRow")), "location2:1234");
+        Map<Text,String> splits = new HashMap<>();
+        splits.put(new Text("zEndRow"), "location2_1234");
         
         Path file = createSplitsFile(splits, conf, 1);
         conf.set(ShardedTableMapFile.SHARDED_MAP_FILE_PATHS_RAW, TABLE_NAME + "=" + file.toString());
-        ShardedTableMapFile.setupFile(conf);
+        ShardedTableMapFile.setupFile(conf, true);
         TreeMap<Text,String> result = ShardedTableMapFile.getShardIdToLocations(conf, TABLE_NAME);
         Assert.assertEquals("location2_1234", result.get(new Text("zEndRow")).toString());
         Assert.assertEquals(1, result.size());
@@ -47,12 +77,14 @@ public class ShardedTableMapFileTest {
     @Test
     public void testWriteSplitsToAccumuloAndReadThem() throws Exception {
         Configuration conf = new Configuration();
+        conf.setInt(ShardIdFactory.NUM_SHARDS, 1);
+        conf.setInt(ShardedTableMapFile.SHARDS_BALANCED_DAYS_TO_VERIFY, 1);
+        String today = formatDay(0) + "_1";
         
-        AccumuloHelper helper = new AccumuloHelper();
         MiniAccumuloCluster accumuloCluster = null;
         try {
-            SortedSet sortedSet = new TreeSet();
-            sortedSet.add(new Text("zEndRow"));
+            SortedSet<Text> sortedSet = new TreeSet<>();
+            sortedSet.add(new Text(today));
             accumuloCluster = createMiniAccumuloWithTestTableAndSplits(sortedSet);
             
             configureAccumuloHelper(conf, accumuloCluster);
@@ -60,8 +92,8 @@ public class ShardedTableMapFileTest {
             conf.set(ShardedDataTypeHandler.SHARDED_TNAMES, TABLE_NAME
                             + ",shard_ingest_unit_test_table_1,shard_ingest_unit_test_table_2,shard_ingest_unit_test_table_3");
             conf.set(ShardedTableMapFile.TABLE_NAMES, TABLE_NAME);
-            FileSystem fs = setWorkingDirectory(conf);
-            ShardedTableMapFile.setupFile(conf);
+            setWorkingDirectory(conf);
+            ShardedTableMapFile.setupFile(conf, true);
         } finally {
             if (null != accumuloCluster) {
                 accumuloCluster.stop();
@@ -69,7 +101,7 @@ public class ShardedTableMapFileTest {
         }
         
         TreeMap<Text,String> result = ShardedTableMapFile.getShardIdToLocations(conf, TABLE_NAME);
-        Assert.assertNotNull(result.get(new Text("zEndRow")).toString());
+        Assert.assertNotNull(result.get(new Text(today)).toString());
         Assert.assertEquals(1, result.size());
     }
     
@@ -94,14 +126,21 @@ public class ShardedTableMapFileTest {
         AccumuloHelper.setZooKeepers(conf, accumuloCluster.getZooKeepers());
     }
     
-    private Path createSplitsFile(Map<KeyExtent,String> splits, Configuration conf, int expectedNumRows) throws IOException {
+    private Path createSplitsFile(Map<Text,String> splits, Configuration conf, int expectedNumRows) throws IOException {
+        return createSplitsFile(splits, conf, expectedNumRows, "test");
+    }
+    
+    private Path createSplitsFile(Map<Text,String> splits, Configuration conf, int expectedNumRows, String tableName) throws IOException {
         conf.set(FileSystem.FS_DEFAULT_NAME_KEY, URI.create("file:///").toString());
         conf.setLong("fs.local.block.size", 32 * 1024 * 1024);
         FileSystem fs = setWorkingDirectory(conf);
         
-        Path file = fs.makeQualified(new Path("splits.seq"));
+        Path path = new Path("splits" + tableName + ".seq");
+        Path file = fs.makeQualified(path);
         long actualCount = ShardedTableMapFile.writeSplitsFile(splits, file, conf);
-        
+        Map<String,Path> shardedTableMapFiles = new HashMap<>();
+        shardedTableMapFiles.put(tableName, path);
+        ShardedTableMapFile.addToConf(conf, shardedTableMapFiles);
         Assert.assertEquals("IngestJob#writeSplitsFile failed to create the expected number of rows", expectedNumRows, actualCount);
         
         Assert.assertTrue(fs.exists(file));
@@ -130,28 +169,28 @@ public class ShardedTableMapFileTest {
         
         String[] tableNames = new String[] {TABLE_NAME};
         conf.set(ShardedTableMapFile.TABLE_NAMES, StringUtils.join(",", tableNames));
-        Map<String,String> shardedTableMapFilePaths = new HashMap<>();
-        ShardedTableMapFile.setupFile(conf);
+        ShardedTableMapFile.setupFile(conf, true);
         ShardedTableMapFile.getShardIdToLocations(conf, TABLE_NAME);
     }
     
     @Test
     public void testWriteSplitsFileNewPath() throws Exception {
         Configuration conf = new Configuration();
-        Path file = createSplitsFile(new HashMap<KeyExtent,String>(), conf, 0);
+        Path file = createSplitsFile(new HashMap<Text,String>(), conf, 0);
         
         SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(file));
         Text key = new Text();
         Text val = new Text();
         boolean valid = reader.next(key, val);
         Assert.assertFalse(valid);
+        reader.close();
     }
     
     @Test
     public void testWriteSplitsFileExistingPath() throws Exception {
-        Map<KeyExtent,String> splits = new HashMap<>();
+        Map<Text,String> splits = new HashMap<>();
         Configuration conf = new Configuration();
-        splits.put(new KeyExtent(), "hello, world!");
+        splits.put(new Text(), "hello, world!");
         
         Path file = createSplitsFile(splits, conf, 1);
         SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(file));
@@ -165,14 +204,13 @@ public class ShardedTableMapFileTest {
         Assert.assertEquals("hello, world!", val.toString());
         valid = reader.next(key, val);
         Assert.assertFalse(valid);
-        
+        reader.close();
     }
     
     @Test
     public void testWriteSplitsFileExistingPathMultipleKeyExtents() throws Exception {
-        Map<KeyExtent,String> splits = new HashMap<>();
-        splits.put(new KeyExtent(TABLE_NAME, null, null), "location1:1234"); // won't be written to splits file
-        splits.put(new KeyExtent(TABLE_NAME, new Text("zEndRow"), new Text("prevEndRow")), "location2:1234");
+        Map<Text,String> splits = new HashMap<>();
+        splits.put(new Text("zEndRow"), "location2_1234");
         Configuration conf = new Configuration();
         
         Path file = createSplitsFile(splits, conf, 1);
@@ -188,5 +226,109 @@ public class ShardedTableMapFileTest {
         Assert.assertEquals("location2_1234", val.toString());
         valid = reader.next(key, val);
         Assert.assertFalse(valid);
+        reader.close();
+    }
+    
+    @Test
+    public void testSingleDaySplitsCreated_AndValid() throws Exception {
+        String tableName = "validSplits";
+        SortedMap<Text,String> splits = createDistributedLocations(tableName);
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        // three days of splits, all should be good, none of these should error
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 1, locations);
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 2, locations);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testMissingAllOfTodaysSplits() throws Exception {
+        String tableName = "missingTodaysSplits";
+        SortedMap<Text,String> splits = simulateMissingSplitsForDay(0, tableName);
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        // three days of splits, today should be invalid, which makes the rest bad too
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 1, locations);
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 2, locations);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testUnbalancedTodaysSplits() throws Exception {
+        String tableName = "unbalancedTodaysSplits";
+        SortedMap<Text,String> splits = simulateUnbalancedSplitsForDay(0, tableName);
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        // three days of splits, today should be invalid, which makes the rest bad too
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testMissingAllOfYesterdaysSplits() throws Exception {
+        String tableName = "missingYesterdaysSplits";
+        SortedMap<Text,String> splits = simulateMissingSplitsForDay(1, tableName);
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        assertThat(splits.size(), is(equalTo(locations.size())));
+        // three days of splits, today should be valid
+        // yesterday and all other days invalid
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+        // this should cause the exception
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 1, locations);
+    }
+    
+    @Test(expected = IllegalStateException.class)
+    public void testUnbalancedYesterdaysSplits() throws Exception {
+        String tableName = "unbalancedYesterdaysSplits";
+        SortedMap<Text,String> splits = simulateUnbalancedSplitsForDay(1, tableName);
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        // three days of splits, today should be valid
+        // yesterday and all other days invalid
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+        // this should cause the exception
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 1, locations);
+    }
+    
+    private SortedMap<Text,String> simulateUnbalancedSplitsForDay(int daysAgo, String tableName) throws IOException {
+        // start with a well distributed set of shards per day for 3 days
+        SortedMap<Text,String> locations = createDistributedLocations(tableName);
+        // for shards from "daysAgo", peg them to first shard
+        String tserverId = "1";
+        String date = DateHelper.format(System.currentTimeMillis() - (daysAgo * DateUtils.MILLIS_PER_DAY));
+        for (int currShard = 0; currShard < SHARDS_PER_DAY; currShard++) {
+            locations.put(new Text(date + "_" + currShard), tserverId);
+        }
+        
+        return locations;
+    }
+    
+    private SortedMap<Text,String> simulateMissingSplitsForDay(int daysAgo, String tableName) throws IOException {
+        // start with a well distributed set of shards per day for 3 days
+        SortedMap<Text,String> locations = createDistributedLocations(tableName);
+        // for shards from "daysAgo", remove them
+        String day = DateHelper.format(System.currentTimeMillis() - (daysAgo * DateUtils.MILLIS_PER_DAY));
+        for (int currShard = 0; currShard < SHARDS_PER_DAY; currShard++) {
+            locations.remove(new Text(day + "_" + currShard));
+        }
+        
+        return locations;
+    }
+    
+    private SortedMap<Text,String> createDistributedLocations(String tableName) {
+        SortedMap<Text,String> locations = new TreeMap<>();
+        long now = System.currentTimeMillis();
+        int tserverId = 1;
+        for (int daysAgo = 0; daysAgo <= 2; daysAgo++) {
+            String day = DateHelper.format(now - (daysAgo * DateUtils.MILLIS_PER_DAY));
+            for (int currShard = 0; currShard < SHARDS_PER_DAY; currShard++) {
+                locations.put(new Text(day + "_" + currShard), Integer.toString(tserverId++));
+            }
+        }
+        return locations;
+    }
+    
+    private static String formatDay(int daysBack) {
+        return DateHelper.format(System.currentTimeMillis() - (daysBack * DateUtils.MILLIS_PER_DAY));
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/BalancedShardPartitionerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/BalancedShardPartitionerTest.java
@@ -252,16 +252,16 @@ public class BalancedShardPartitionerTest {
             partitionsUsed.add(partition);
         }
         // 9 is what we get by hashing the shardId
-        Assert.assertTrue("For " + daysBack + " days ago, we had a different number of collisions: " + collisions, expectedCollisions >= collisions); // this
-                                                                                                                                                      // has
-                                                                                                                                                      // more to
-                                                                                                                                                      // do with
-                                                                                                                                                      // the
-                                                                                                                                                      // random
-                                                                                                                                                      // assignment
-                                                                                                                                                      // of the
-                                                                                                                                                      // tablets
-        
+        Assert.assertTrue("For " + daysBack + " days ago, we had a different number of collisions: " + collisions, expectedCollisions >= collisions);
+        // this
+        // has
+        // more to
+        // do with
+        // the
+        // random
+        // assignment
+        // of the
+        // tablets
     }
     
     private static String formatDay(int daysBack) {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/TestShardGenerator.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/TestShardGenerator.java
@@ -84,7 +84,7 @@ public class TestShardGenerator {
     
     private void writeSplits(Map<KeyExtent,String> locations, String directory, String fileName) throws IOException {
         Path shardedMapFile = new Path(directory, fileName);
-        ShardedTableMapFile.writeSplitsFile(locations, shardedMapFile, conf);
+        ShardedTableMapFile.writeSplitsFileLegacy(locations, shardedMapFile, conf);
     }
     
     private void registerSplitsFileForShardTable(String directory, String fileName, String... tableNames) {


### PR DESCRIPTION
I am not a fan of the ShardedTableMapFile class.  It is overly complicated and should be refactored and simplified.  In spite of that, these changes should help mitigate problems when shards have not be created or balanced before the ingest jobs launch.

Note: Not sure if unbalanced shard splits is an easily recoverable situation.  It may be necessary to split up the existence and balance checks for the shard splits.

Credit to @smonaem and @matthpetterson for reference implementations that were borrowed from

Updated ShardedTableMapFile.setupFile method to take an additional boolean
argument specifying whether validation of the generated shard to tablet mappings
should be validated for a given date range

Validation is turned off by default in IngestJob unless the:
- shardedMap.validation.enabled
property is set to true

Default is to validate the last two days of shard table splits.  The range can be
overridden using the:
- shards.balanced.days.to.verify
property, where 1 would mean only validate today, 2 yeterday and today, etc.

Validation is dependent on the ShardIdFactory class to inform us of the number
of shards that should exist for a given day.  Any deviation from this number,
when validation is turned on, will result in an IllegalStateException

Validation that the shards are balanced, i.e. have been spread out to unique
tservers via custom balancer, is also performed when validation is on. An
unbalanced mapping of shard splits will also result in an IllegalStateException.