### PR TITLE
Remove redirects to /tmp/stdout and /tmp/stderr

### DIFF
--- a/warehouse/ingest-scripts/src/main/resources/bin/system/start-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/start-ingest.sh
@@ -29,7 +29,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pdsh -f 25 -w ^${ingestHost} "$INGEST_BIN/ingest/start-ingesters.sh $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$INGEST_BIN/ingest/start-ingesters.sh $FORCE" < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/start-metrics-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/start-metrics-ingest.sh
@@ -32,9 +32,9 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh ingest $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
-  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh loader $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
-  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh flagmaker $FORCE" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh ingest $FORCE" < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh loader $FORCE" < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/startMetricsIngest.sh flagmaker $FORCE" < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/stop-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/stop-ingest.sh
@@ -25,7 +25,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pdsh -f 25 -w ^${ingestHost} "$INGEST_BIN/ingest/stop-ingesters.sh $@" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$INGEST_BIN/ingest/stop-ingesters.sh $@" < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT

--- a/warehouse/ingest-scripts/src/main/resources/bin/system/stop-metrics-ingest.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/system/stop-metrics-ingest.sh
@@ -25,7 +25,7 @@ else
   trap 'rm -f "$ingestHost"; exit $?' INT TERM EXIT
   echo $INGEST_HOST > $ingestHost
 
-  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${ingestHost} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" < /dev/null
 
   rm $ingestHost
   trap - INT TERM EXIT
@@ -45,7 +45,7 @@ else
       echo $host >> $stagingHosts
   done
 
-  pdsh -f 25 -w ^${stagingHosts} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" 1>> /tmp/stdout 2>> /tmp/stderr < /dev/null
+  pdsh -f 25 -w ^${stagingHosts} "$METRICS_BIN/metrics/stopMetricsIngest.sh $@" < /dev/null
 
   rm $stagingHosts
   trap - INT TERM EXIT


### PR DESCRIPTION
Previous version of these scripts used the redirection arguments `-o /tmp/stdout` and `-e /tmp/stderr` for `pssh` when executing these commands. In moving to `pdsh` this was immitated by redirecting to `/tmp/stderr` and `/tmp/stdout`. However, since the previous command version actually created `/tmp/stdout` and `/tmp/stderr` as folders containing the `stdout` and `stderr` of each node contacted, the `pdsh` version of the command fails since it tries to write to a folder instead of a file.

This is a temporary fix that will be made better in the future by utilizing [`dshbak`](https://linux.die.net/man/1/dshbak) to write out results by node for debugging purposes.