### PR TITLE
add unit tests for limit fields. Fix LimitFields regex so that all as…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
@@ -32,7 +32,7 @@ public class LimitFields implements Function<Entry<Key,Document>,Entry<Key,Docum
     
     public final static String ORIGINAL_COUNT_SUFFIX = "ORIGINAL_COUNT";
     
-    public final static Pattern PREFIX_SUFFIX_PATTERN = Pattern.compile("([A-Za-z0-9]+[\\._])[A-Za-z0-9\\.]*\\.([A-Za-z0-9]+)");
+    public final static Pattern PREFIX_SUFFIX_PATTERN = Pattern.compile("([A-Za-z0-9]+[\\._])[A-Za-z0-9\\._]*\\.([A-Za-z0-9]+)");
     
     private Map<String,Integer> limitFieldsMap;
     

--- a/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedTest.java
@@ -1,0 +1,302 @@
+package datawave.query;
+
+import com.google.common.collect.Sets;
+import datawave.configuration.spring.SpringBean;
+import datawave.helpers.PrintUtility;
+import datawave.ingest.data.TypeRegistry;
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.Attributes;
+import datawave.query.attributes.Content;
+import datawave.query.attributes.Document;
+import datawave.query.function.LimitFields;
+import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.util.LimitFieldsTestingIngest;
+import datawave.webservice.edgedictionary.TestDatawaveEdgeDictionaryImpl;
+import datawave.webservice.query.QueryImpl;
+import datawave.webservice.query.configuration.GenericQueryConfiguration;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.log4j.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static datawave.query.QueryTestTableHelper.*;
+
+/**
+ * Tests the limit.fields feature to ensure that hit terms are always included and that
+ * associated fields at the same grouping context are included along with the field that
+ * hit on the query
+ * 
+ */
+public abstract class HitsAreAlwaysIncludedTest {
+    
+    @RunWith(Arquillian.class)
+    public static class ShardRange extends HitsAreAlwaysIncludedTest {
+        protected static Connector connector = null;
+        
+        @BeforeClass
+        public static void setUp() throws Exception {
+            
+            QueryTestTableHelper qtth = new QueryTestTableHelper(ShardRange.class.toString(), log);
+            connector = qtth.connector;
+            
+            LimitFieldsTestingIngest.writeItAll(connector, LimitFieldsTestingIngest.WhatKindaRange.SHARD);
+            Authorizations auths = new Authorizations("ALL");
+            PrintUtility.printTable(connector, auths, SHARD_TABLE_NAME);
+            PrintUtility.printTable(connector, auths, SHARD_INDEX_TABLE_NAME);
+            PrintUtility.printTable(connector, auths, MODEL_TABLE_NAME);
+        }
+        
+        @Override
+        protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
+                        throws Exception {
+            super.runTestQuery(connector, queryString, startDate, endDate, extraParms, goodResults);
+        }
+    }
+    
+    @RunWith(Arquillian.class)
+    public static class DocumentRange extends HitsAreAlwaysIncludedTest {
+        protected static Connector connector = null;
+        
+        @BeforeClass
+        public static void setUp() throws Exception {
+            
+            QueryTestTableHelper qtth = new QueryTestTableHelper(DocumentRange.class.toString(), log);
+            connector = qtth.connector;
+            
+            LimitFieldsTestingIngest.writeItAll(connector, LimitFieldsTestingIngest.WhatKindaRange.DOCUMENT);
+            Authorizations auths = new Authorizations("ALL");
+            PrintUtility.printTable(connector, auths, SHARD_TABLE_NAME);
+            PrintUtility.printTable(connector, auths, SHARD_INDEX_TABLE_NAME);
+            PrintUtility.printTable(connector, auths, MODEL_TABLE_NAME);
+        }
+        
+        @Override
+        protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
+                        throws Exception {
+            super.runTestQuery(connector, queryString, startDate, endDate, extraParms, goodResults);
+        }
+    }
+    
+    private static final Logger log = Logger.getLogger(HitsAreAlwaysIncludedTest.class);
+    
+    protected Authorizations auths = new Authorizations("ALL");
+    
+    protected Set<Authorizations> authSet = Collections.singleton(auths);
+    
+    @Inject
+    @SpringBean(name = "EventQuery")
+    protected ShardQueryLogic logic;
+    
+    protected KryoDocumentDeserializer deserializer;
+    
+    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
+    
+    @Deployment
+    public static JavaArchive createDeployment() throws Exception {
+        
+        return ShrinkWrap
+                        .create(JavaArchive.class)
+                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
+                                        "datawave.webservice.query.result.event")
+                        .addClass(TestDatawaveEdgeDictionaryImpl.class)
+                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
+                        .deleteClass(datawave.query.metrics.ShardTableQueryMetricHandler.class)
+                        .addAsManifestResource(
+                                        new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
+                                                        + "</alternatives>"), "beans.xml");
+    }
+    
+    @AfterClass
+    public static void teardown() {
+        TypeRegistry.reset();
+    }
+    
+    @Before
+    public void setup() {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        
+        logic.setFullTableScanEnabled(true);
+        deserializer = new KryoDocumentDeserializer();
+    }
+    
+    protected abstract void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
+                    throws Exception;
+    
+    protected void runTestQuery(Connector connector, String queryString, Date startDate, Date endDate, Map<String,String> extraParms,
+                    Collection<String> goodResults) throws Exception {
+        
+        QueryImpl settings = new QueryImpl();
+        settings.setBeginDate(startDate);
+        settings.setEndDate(endDate);
+        settings.setPagesize(Integer.MAX_VALUE);
+        settings.setQueryAuthorizations(auths.serialize());
+        settings.setQuery(queryString);
+        settings.setParameters(extraParms);
+        settings.setId(UUID.randomUUID());
+        
+        log.debug("query: " + settings.getQuery());
+        log.debug("logic: " + settings.getQueryLogicName());
+        
+        GenericQueryConfiguration config = logic.initialize(connector, settings, authSet);
+        logic.setupQuery(config);
+        
+        Set<Document> docs = new HashSet<>();
+        for (Entry<Key,Value> entry : logic) {
+            Document d = deserializer.apply(entry).getValue();
+            log.trace(entry.getKey() + " => " + d);
+            docs.add(d);
+            
+            Attribute hitAttribute = d.get("HIT_TERM");
+            
+            if (hitAttribute instanceof Attributes) {
+                Attributes attributes = (Attributes) hitAttribute;
+                for (Attribute attr : attributes.getAttributes()) {
+                    if (attr instanceof Content) {
+                        Content content = (Content) attr;
+                        Assert.assertTrue(goodResults.contains(content.getContent()));
+                    }
+                }
+            } else if (hitAttribute instanceof Content) {
+                Content content = (Content) hitAttribute;
+                Assert.assertTrue(goodResults.contains(content.getContent()));
+            }
+            
+            // remove from goodResults as we find the expected return fields
+            log.debug("goodResults: " + goodResults);
+            Map<String,Attribute<? extends Comparable<?>>> dictionary = d.getDictionary();
+            log.debug("dictionary:" + dictionary);
+            for (Entry<String,Attribute<? extends Comparable<?>>> dictionaryEntry : dictionary.entrySet()) {
+                
+                Attribute<? extends Comparable<?>> attribute = dictionaryEntry.getValue();
+                if (attribute instanceof Attributes) {
+                    for (Attribute attr : ((Attributes) attribute).getAttributes()) {
+                        String toFind = dictionaryEntry.getKey() + ":" + attr;
+                        boolean found = goodResults.remove(toFind);
+                        if (found)
+                            log.debug("removed " + toFind);
+                        else
+                            log.debug("Did not remove " + toFind);
+                    }
+                } else {
+                    
+                    String toFind = dictionaryEntry.getKey() + ":" + dictionaryEntry.getValue();
+                    
+                    boolean found = goodResults.remove(toFind);
+                    if (found)
+                        log.debug("removed " + toFind);
+                    else
+                        log.debug("Did not remove " + toFind);
+                }
+                
+            }
+            
+            Assert.assertTrue(goodResults + " was not empty", goodResults.isEmpty());
+        }
+        Assert.assertTrue("No docs were returned!", docs.size() > 0);
+    }
+    
+    @Test
+    public void checkThePattern() throws Exception {
+        Pattern pattern = LimitFields.PREFIX_SUFFIX_PATTERN;
+        Matcher matcher = pattern.matcher("FOO_3.FOO.3.3");
+        Assert.assertTrue(matcher.matches());
+        Assert.assertEquals(matcher.group(1), "FOO_");
+        Assert.assertEquals(matcher.group(2), "3");
+        matcher = pattern.matcher("FOO_3");
+        Assert.assertFalse(matcher.matches());
+        matcher = pattern.matcher("FOO_3_BAR.FOO.3");
+        Assert.assertTrue(matcher.matches());
+        Assert.assertEquals(matcher.group(1), "FOO_");
+        Assert.assertEquals(matcher.group(2), "3");
+    }
+    
+    @Test
+    public void testHitForIndexedQueryTerm() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        
+        String queryString = "FOO_3_BAR == 'defg<cat>'";
+        
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
+                        "FOO_1.FOO.1.3:good");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+    @Test
+    public void testHitForIndexedQueryOnUnrealmed() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        
+        String queryString = "FOO_3 == 'defg'";
+        
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
+                        "FOO_1.FOO.1.3:good");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+    @Test
+    public void testHitForIndexedQueryAndAnyfieldLimit() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "_ANYFIELD_=2");
+        
+        String queryString = "FOO_3_BAR == 'defg<cat>'";
+        
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
+                        "FOO_1.FOO.1.3:good");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+    @Test
+    public void testHitForIndexedAndUnindexedQueryAndAnyfieldLimit() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        
+        String queryString = "FOO_3_BAR == 'defg<cat>' and FOO_1 == 'good'";
+        
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
+                        "FOO_1.FOO.1.3:good");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+}

--- a/warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java
@@ -1,0 +1,258 @@
+package datawave.query.util;
+
+import datawave.data.ColumnFamilyConstants;
+import datawave.data.hash.UID;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.Type;
+import datawave.ingest.protobuf.Uid;
+import datawave.query.QueryTestTableHelper;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.SummingCombiner;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * write data in accumulo for testing of the limit.fields function
+ */
+public class LimitFieldsTestingIngest {
+    
+    public static enum WhatKindaRange {
+        SHARD, DOCUMENT;
+    }
+    
+    private static final Type<?> lcNoDiacriticsType = new LcNoDiacriticsType();
+    
+    protected static final String datatype = "test";
+    protected static final String date = "20130101";
+    protected static final String shard = date + "_0";
+    protected static final ColumnVisibility columnVisibility = new ColumnVisibility("ALL");
+    protected static final Value emptyValue = new Value(new byte[0]);
+    protected static final long timeStamp = 1356998400000l;
+    
+    /**
+     *
+     * 
+     * @return
+     */
+    public static void writeItAll(Connector con, WhatKindaRange range) throws Exception {
+        
+        BatchWriter bw = null;
+        BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(1000L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
+        Mutation mutation = null;
+        
+        String myUID = UID.builder().newId("MyUid".getBytes(), (Date) null).toString();
+        
+        try {
+            // write the shard table :
+            bw = con.createBatchWriter(QueryTestTableHelper.SHARD_TABLE_NAME, bwConfig);
+            mutation = new Mutation(shard);
+            
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1.FOO.1.0" + "\u0000" + "yawn", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_4.FOO.4.0" + "\u0000" + "purr", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3.FOO.3.0" + "\u0000" + "abcd", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3_BAR.FOO.0" + "\u0000" + "abcd<cat>", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1_BAR.FOO.0" + "\u0000" + "yawn<cat>", columnVisibility, timeStamp, emptyValue);
+            
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1.FOO.1.1" + "\u0000" + "yawn", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_4.FOO.4.1" + "\u0000" + "purr", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3.FOO.3.1" + "\u0000" + "bcde", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3_BAR.FOO.1" + "\u0000" + "bcde<cat>", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1_BAR.FOO.1" + "\u0000" + "yawn<cat>", columnVisibility, timeStamp, emptyValue);
+            
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1.FOO.1.2" + "\u0000" + "yawn", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_4.FOO.4.2" + "\u0000" + "purr", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3.FOO.3.2" + "\u0000" + "cdef", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3_BAR.FOO.2" + "\u0000" + "cdef<cat>", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1_BAR.FOO.2" + "\u0000" + "yawn<cat>", columnVisibility, timeStamp, emptyValue);
+            
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1.FOO.1.3" + "\u0000" + "good", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_4.FOO.4.3" + "\u0000" + "yes", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3.FOO.3.3" + "\u0000" + "defg", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_3_BAR.FOO.3" + "\u0000" + "defg<cat>", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1_BAR.FOO.3" + "\u0000" + "good<cat>", columnVisibility, timeStamp, emptyValue);
+            
+            bw.addMutation(mutation);
+            
+        } finally {
+            if (null != bw) {
+                bw.close();
+            }
+        }
+        
+        try {
+            // write shard index table:
+            bw = con.createBatchWriter(QueryTestTableHelper.SHARD_INDEX_TABLE_NAME, bwConfig);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("abcd"));
+            mutation.put("FOO_3".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("bcde"));
+            mutation.put("FOO_3".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("cdef"));
+            mutation.put("FOO_3".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("defg"));
+            mutation.put("FOO_3".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("abcd<cat>"));
+            mutation.put("FOO_3_BAR".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("bcde<cat>"));
+            mutation.put("FOO_3_BAR".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("cdef<cat>"));
+            mutation.put("FOO_3_BAR".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("defg<cat>"));
+            mutation.put("FOO_3_BAR".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("yawn<cat>"));
+            mutation.put("FOO_1_BAR".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation(lcNoDiacriticsType.normalize("good<cat>"));
+            mutation.put("FOO_1_BAR".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
+            bw.addMutation(mutation);
+            
+        } finally {
+            if (null != bw) {
+                bw.close();
+            }
+        }
+        
+        try {
+            
+            // write the field index table:
+            
+            bw = con.createBatchWriter(QueryTestTableHelper.SHARD_TABLE_NAME, bwConfig);
+            
+            mutation = new Mutation(shard);
+            
+            mutation.put("fi\u0000" + "FOO_3", lcNoDiacriticsType.normalize("abcd") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility, timeStamp,
+                            emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3", lcNoDiacriticsType.normalize("bcde") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility, timeStamp,
+                            emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3", lcNoDiacriticsType.normalize("cdef") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility, timeStamp,
+                            emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3", lcNoDiacriticsType.normalize("defg") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility, timeStamp,
+                            emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3_BAR", lcNoDiacriticsType.normalize("abcd<cat>") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility,
+                            timeStamp, emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3_BAR", lcNoDiacriticsType.normalize("bcde<cat>") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility,
+                            timeStamp, emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3_BAR", lcNoDiacriticsType.normalize("cdef<cat>") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility,
+                            timeStamp, emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_3_BAR", lcNoDiacriticsType.normalize("defg<cat>") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility,
+                            timeStamp, emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_1_BAR", lcNoDiacriticsType.normalize("yawn<cat>") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility,
+                            timeStamp, emptyValue);
+            
+            mutation.put("fi\u0000" + "FOO_1_BAR", lcNoDiacriticsType.normalize("good<cat>") + "\u0000" + datatype + "\u0000" + myUID, columnVisibility,
+                            timeStamp, emptyValue);
+            
+            bw.addMutation(mutation);
+            
+        } finally {
+            if (null != bw) {
+                bw.close();
+            }
+        }
+        
+        try {
+            // write metadata table:
+            bw = con.createBatchWriter(QueryTestTableHelper.MODEL_TABLE_NAME, bwConfig);
+            
+            mutation = new Mutation("FOO_3");
+            mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
+            mutation.put(ColumnFamilyConstants.COLF_I, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\u0000" + lcNoDiacriticsType.getClass().getName()), emptyValue);
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation("FOO_4");
+            mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation("FOO_1");
+            mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation("FOO_3_BAR");
+            mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
+            mutation.put(ColumnFamilyConstants.COLF_I, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\u0000" + lcNoDiacriticsType.getClass().getName()), emptyValue);
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation("FOO_1_BAR");
+            mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
+            mutation.put(ColumnFamilyConstants.COLF_I, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\u0000" + lcNoDiacriticsType.getClass().getName()), emptyValue);
+            bw.addMutation(mutation);
+            
+        } finally {
+            if (null != bw) {
+                bw.close();
+            }
+        }
+    }
+    
+    private static Value getValueForBuilderFor(String... in) {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        for (String s : in) {
+            builder.addUID(s);
+        }
+        builder.setCOUNT(in.length);
+        builder.setIGNORE(false);
+        return new Value(builder.build().toByteArray());
+    }
+    
+    /**
+     * forces a shard range
+     * 
+     * @return
+     */
+    private static Value getValueForNuthinAndYourHitsForFree() {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.setCOUNT(50); // better not be zero!!!!
+        builder.setIGNORE(true); // better be true!!!
+        return new Value(builder.build().toByteArray());
+    }
+}


### PR DESCRIPTION
…sociated fields are included (even if limited) when one of them has a hit from the query

 Changes to be committed:
	modified:   warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
	new file:   warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedTest.java
	new file:   warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java