### PR TITLE
Added PasswordConverter to allow passwords from environment

### DIFF
--- a/warehouse/core/src/main/java/datawave/util/AccumuloCounterSource.java
+++ b/warehouse/core/src/main/java/datawave/util/AccumuloCounterSource.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 
 import datawave.util.CounterDump.CounterSource;
+import datawave.util.cli.PasswordConverter;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -108,7 +109,7 @@ public class AccumuloCounterSource extends CounterSource {
         String instance = args[0];
         String zookeepers = args[1];
         String username = args[2];
-        String password = args[3];
+        String password = PasswordConverter.parseArg(args[3]);
         String table = args[4];
         String startRow = args[5];
         String endRow = args[6];

--- a/warehouse/core/src/main/java/datawave/util/cli/PasswordConverter.java
+++ b/warehouse/core/src/main/java/datawave/util/cli/PasswordConverter.java
@@ -28,8 +28,7 @@ public class PasswordConverter implements IStringConverter<String> {
     };
     
     /**
-     * Static method to parse args that may contain env: prefix indicating that
-     * an environment variable should be looked up to obtain the value
+     * Static method to parse args that may contain env: prefix indicating that an environment variable should be looked up to obtain the value
      * 
      * @param arg
      *            to parse
@@ -40,8 +39,7 @@ public class PasswordConverter implements IStringConverter<String> {
     }
     
     /**
-     * Static method to parse args that may contain env: prefix indicating that
-     * an environment variable should be looked up to obtain the value
+     * Static method to parse args that may contain env: prefix indicating that an environment variable should be looked up to obtain the value
      * 
      * @param arg
      *            to parse

--- a/warehouse/core/src/main/java/datawave/util/cli/PasswordConverter.java
+++ b/warehouse/core/src/main/java/datawave/util/cli/PasswordConverter.java
@@ -1,0 +1,44 @@
+package datawave.util.cli;
+
+import com.beust.jcommander.IStringConverter;
+
+/**
+ * Custom converter for parsing passwords from the command line. Inspired from Accumulo's ShellOptionsJC.PasswordConverter Allows password to be specified as an
+ * environment variable using the form: env:PASSWORD_ENV_VAR, where PASSWORD_ENV_VAR is an environment variable that is accessible to the JVM
+ * 
+ * <pre>
+ * To us as a jcommander parameter:
+ * </pre>
+ * 
+ * <pre>
+ * &#064;Parameter(names = {&quot;-p&quot;, &quot;--password&quot;}, description = &quot;password (if prefixed with env:NAME, NAME will be used to get from the environment)&quot;,
+ *                 converter = PasswordConverter.class)
+ * private String password;
+ * </pre>
+ * 
+ * Otherwise call {@code PasswordConverter.parseArg(passwordArgString)} to get same functionality
+ */
+public class PasswordConverter implements IStringConverter<String> {
+    
+    private static final String ENV_PREFIX = "env:";
+    
+    @Override
+    public String convert(String value) {
+        return parseArg(value);
+    };
+    
+    /**
+     * Static method to parse password args that may contain env: prefix
+     * 
+     * @param arg
+     *            to parse
+     * @return the parsed password
+     */
+    public static String parseArg(String arg) {
+        if (arg.startsWith(ENV_PREFIX)) {
+            return System.getenv(arg.substring(ENV_PREFIX.length()));
+        } else {
+            return arg;
+        }
+    }
+}

--- a/warehouse/core/src/main/java/datawave/util/cli/PasswordConverter.java
+++ b/warehouse/core/src/main/java/datawave/util/cli/PasswordConverter.java
@@ -28,15 +28,35 @@ public class PasswordConverter implements IStringConverter<String> {
     };
     
     /**
-     * Static method to parse password args that may contain env: prefix
+     * Static method to parse args that may contain env: prefix indicating that
+     * an environment variable should be looked up to obtain the value
      * 
      * @param arg
      *            to parse
-     * @return the parsed password
+     * @return the parsed password or null if env var not defined
      */
     public static String parseArg(String arg) {
+        return parseArg(arg, null);
+    }
+    
+    /**
+     * Static method to parse args that may contain env: prefix indicating that
+     * an environment variable should be looked up to obtain the value
+     * 
+     * @param arg
+     *            to parse
+     * @param defaultValue
+     *            if env var not present
+     * @return the parsed password or default if env var not defined
+     */
+    public static String parseArg(String arg, String defaultValue) {
         if (arg.startsWith(ENV_PREFIX)) {
-            return System.getenv(arg.substring(ENV_PREFIX.length()));
+            String value = System.getenv(arg.substring(ENV_PREFIX.length()));
+            if (null == value) {
+                return defaultValue;
+            } else {
+                return value;
+            }
         } else {
             return arg;
         }

--- a/warehouse/core/src/test/java/datawave/util/cli/PasswordConverterTest.java
+++ b/warehouse/core/src/test/java/datawave/util/cli/PasswordConverterTest.java
@@ -5,8 +5,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-import java.util.Random;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +47,12 @@ public class PasswordConverterTest {
     @Test
     public void testConvertEnvPrefixedUndefinedEnvironmentVar() {
         // prefix with env var not defined should return null
-        argv[1] = "env:HighlyUnlikelyThisWillBeDefined" + new Random().nextInt();
+        String name = "HighlyUnlikelyThisWillBeDefined";
+        // make sure it is not defined
+        assertThat("Expected " + name + " to not be defined but it was!", System.getenv(name), is(nullValue()));
+        
+        argv[1] = "env:" + name;
+        
         new JCommander(password).parse(argv);
         assertThat(password.password, is(nullValue()));
     }

--- a/warehouse/core/src/test/java/datawave/util/cli/PasswordConverterTest.java
+++ b/warehouse/core/src/test/java/datawave/util/cli/PasswordConverterTest.java
@@ -1,0 +1,65 @@
+package datawave.util.cli;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+
+public class PasswordConverterTest {
+    
+    private String[] argv;
+    private Password password;
+    
+    private class Password {
+        @Parameter(names = "--password", converter = PasswordConverter.class)
+        String password;
+    }
+    
+    @Before
+    public void setup() {
+        argv = new String[] {"--password", ""};
+        password = new Password();
+    }
+    
+    @Test
+    public void testConvertEnvPrefixed() {
+        // just use the first thing that shows up in the environment
+        String name = System.getenv().keySet().iterator().next();
+        argv[1] = "env:" + name;
+        new JCommander(password).parse(argv);
+        assertThat(password.password, is(equalTo(System.getenv(name))));
+    }
+    
+    @Test
+    public void testConvertEnvPrefixedEmpty() {
+        // prefix with no var defined should return null
+        argv[1] = "env:";
+        new JCommander(password).parse(argv);
+        assertThat(password.password, is(nullValue()));
+    }
+    
+    @Test
+    public void testConvertEnvPrefixedUndefinedEnvironmentVar() {
+        // prefix with env var not defined should return null
+        argv[1] = "env:HighlyUnlikelyThisWillBeDefined" + new Random().nextInt();
+        new JCommander(password).parse(argv);
+        assertThat(password.password, is(nullValue()));
+    }
+    
+    @Test
+    public void testConvertNonEnvPrefixed() {
+        String expected = "behavior";
+        argv[1] = expected;
+        new JCommander(password).parse(argv);
+        assertThat(password.password, is(equalTo(expected)));
+    }
+    
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/BulkIngestMapFileLoader.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/BulkIngestMapFileLoader.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Future;
 
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.mapreduce.StandaloneStatusReporter;
+import datawave.util.cli.PasswordConverter;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -329,7 +330,7 @@ public final class BulkIngestMapFileLoader implements Runnable {
         String jobDirPattern = args[1].replaceAll("'", "");
         String instanceName = args[2];
         String zooKeepers = args[3];
-        String passwordStr = args[5];
+        String passwordStr = PasswordConverter.parseArg(args[5]);
         
         Credentials credentials = new Credentials(args[4], new PasswordToken(passwordStr));
         BulkIngestMapFileLoader processor = new BulkIngestMapFileLoader(workDir, jobDirPattern, instanceName, zooKeepers, credentials, seqFileHdfs, srcHdfs,

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
@@ -31,6 +31,8 @@ import datawave.ingest.table.config.TableConfigHelper;
 import datawave.iterators.PropogatingIterator;
 import datawave.marking.MarkingFunctions;
 import datawave.util.StringUtils;
+import datawave.util.cli.PasswordConverter;
+
 import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -54,7 +56,6 @@ import org.apache.commons.io.comparator.LastModifiedFileComparator;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -564,7 +565,7 @@ public class IngestJob implements Tool {
                 userName = args[++i];
                 AccumuloHelper.setUsername(conf, userName);
             } else if (args[i].equals("-pass")) {
-                password = args[++i].getBytes();
+                password = PasswordConverter.parseArg(args[++i]).getBytes();
                 AccumuloHelper.setPassword(conf, password);
             } else if (args[i].equals("-flagFile")) {
                 flagFile = args[++i];

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/AccumuloCliOptions.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/AccumuloCliOptions.java
@@ -1,6 +1,8 @@
 package datawave.ingest.util;
 
 import datawave.ingest.data.config.ingest.AccumuloHelper;
+import datawave.util.cli.PasswordConverter;
+
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.OptionBuilder;
@@ -17,6 +19,7 @@ public class AccumuloCliOptions {
     private final Options options = new Options();
     private CommandLine cl = null;
     
+    @SuppressWarnings("static-access")
     public AccumuloCliOptions() {
         options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Accumulo username").create("u"));
         options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Accumulo password").create("p"));
@@ -75,7 +78,7 @@ public class AccumuloCliOptions {
     
     public void setAccumuloConfiguration(Configuration conf) {
         AccumuloHelper.setUsername(conf, cl.getOptionValue("u"));
-        AccumuloHelper.setPassword(conf, cl.getOptionValue("p").getBytes());
+        AccumuloHelper.setPassword(conf, PasswordConverter.parseArg(cl.getOptionValue("p")).getBytes());
         AccumuloHelper.setInstanceName(conf, cl.getOptionValue("i"));
         AccumuloHelper.setZooKeepers(conf, cl.getOptionValue("zk"));
         

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateEdgeKeyVersionCache.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateEdgeKeyVersionCache.java
@@ -3,6 +3,8 @@ package datawave.ingest.util;
 import datawave.ingest.data.config.ingest.AccumuloHelper;
 import datawave.ingest.mapreduce.handler.edge.EdgeKeyVersioningCache;
 import datawave.ingest.time.Now;
+import datawave.util.cli.PasswordConverter;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -54,7 +56,7 @@ public class GenerateEdgeKeyVersionCache {
                         printUsageAndExit();
                     } else {
                         username = toolArgs[i];
-                        password = toolArgs[i + 1].getBytes();
+                        password = PasswordConverter.parseArg(toolArgs[i + 1]).getBytes();
                         tableName = toolArgs[i + 2];
                         // skip over args
                         i += 3;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
@@ -24,6 +24,7 @@ public class GenerateMultipleNumShardsCacheFile {
     public static final String CONFIG_DIRECTORY_LOCATION_OVERRIDE = "cd";
     public static final String CONFIG_SUFFIEX_OVERRIDE = "cs";
     
+    @SuppressWarnings("static-access")
     public static void main(String[] args) throws ParseException, AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException {
         AccumuloCliOptions accumuloOptions = new AccumuloCliOptions();
         Options options = accumuloOptions.getOptions();

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateShardSplits.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateShardSplits.java
@@ -1,6 +1,7 @@
 package datawave.ingest.util;
 
 import datawave.util.StringUtils;
+import datawave.util.cli.PasswordConverter;
 import datawave.util.time.DateHelper;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
@@ -92,7 +93,7 @@ public class GenerateShardSplits {
                     printUsageAndExit();
                 } else {
                     username = args[i];
-                    password = args[i + 1].getBytes();
+                    password = PasswordConverter.parseArg(args[i + 1]).getBytes();
                     tableName = args[i + 2];
                     // skip over args
                     i += 3;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateSplitsFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateSplitsFile.java
@@ -17,6 +17,7 @@ public class GenerateSplitsFile {
     
     private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(GenerateSplitsFile.class);
     
+    @SuppressWarnings("static-access")
     public static void main(String[] args) {
         AccumuloCliOptions accumuloOptions = new AccumuloCliOptions();
         Options options = accumuloOptions.getOptions();

--- a/warehouse/query-core/src/main/java/datawave/query/cardinality/CardinalityScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/cardinality/CardinalityScanner.java
@@ -14,6 +14,8 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import datawave.common.cl.OptionBuilder;
 import datawave.security.util.ScannerHelper;
+import datawave.util.cli.PasswordConverter;
+
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
@@ -162,7 +164,7 @@ public class CardinalityScanner {
         config.setZookeepers(cl.getOptionValue(ZOOKEEPERS));
         config.setInstanceName(cl.getOptionValue(INSTANCE));
         config.setUsername(cl.getOptionValue(USERNAME));
-        config.setPassword(cl.getOptionValue(PASSWORD));
+        config.setPassword(PasswordConverter.parseArg(cl.getOptionValue(PASSWORD)));
         config.setTableName(cl.getOptionValue(TABLE));
         config.setAuths(cl.getOptionValue(AUTHS));
         try {


### PR DESCRIPTION
Created PasswordConverter class to allow users to specify passwords
using an env: prefix.  This will indicate that an ENVIRONMENT variable
should be used to obtain the password.

This is useful in order to prevent passwords from showing up in the process list

Updated some core classes to make use of this convention.