### PR TITLE
Fixed edge query range encoding

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/edge/DefaultExtendedEdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/edge/DefaultExtendedEdgeQueryLogic.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import datawave.audit.SelectorExtractor;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.Type;
+import datawave.edge.util.EdgeKeyUtil;
 import datawave.query.config.EdgeExtendedSummaryConfiguration;
 import datawave.query.config.EdgeQueryConfiguration;
 import datawave.query.iterator.filter.EdgeFilterIterator;
@@ -204,24 +205,7 @@ public class DefaultExtendedEdgeQueryLogic extends EdgeQueryLogic {
         String[] sources = StringUtils.split(query, configuration.getDelimiter());
         for (String source : sources) {
             for (String normalizedSource : normalizeQualifiedSource(source)) {
-                Text startRow;
-                Text endRow;
-                
-                // Stats rows start at SourceA (inclusive) and run through SourceA\0SourceB (exclusive)
-                // Relationship rows start at SourceA\0SourceB (inclusive) and run through SourceA\1 (exclusive)
-                
-                if (configuration.includeStats() == false)
-                    startRow = new Text((normalizedSource + "\0").getBytes(Charset.forName("UTF-8")));
-                else
-                    startRow = new Text(normalizedSource.getBytes(Charset.forName("UTF-8")));
-                
-                if (configuration.isIncludeRelationships() == false)
-                    endRow = new Text((normalizedSource + "\0").getBytes(Charset.forName("UTF-8")));
-                else
-                    endRow = new Text((normalizedSource + "\1").getBytes(Charset.forName("UTF-8")));
-                
-                Range range = new Range(startRow, true, endRow, false);
-                ranges.add(range);
+                ranges.add(EdgeKeyUtil.createEscapedRange(normalizedSource, false, configuration.includeStats(), configuration.isIncludeRelationships()));
             }
         }
         return ranges;


### PR DESCRIPTION
Changes to Edge Utility code to correctly escape search terms when building ranges. This is needed to match the same encoding scheme that is used on ingest for the edge table. Without this change search terms that include special characters may result in invalid search ranges. 