### PR TITLE
use builder pattern for IndexIterator and Ivarator classes

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -59,6 +59,121 @@ import java.util.concurrent.atomic.AtomicLong;
  * 
  */
 public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIterator implements CompositePredicateFilterer {
+    
+    public static abstract class Builder<B extends Builder<B>> {
+        private Text fieldName;
+        protected Text fieldValue;
+        private Predicate<Key> datatypeFilter;
+        private TimeFilter timeFilter;
+        private boolean negated;
+        private PartialKey returnKeyType = DEFAULT_RETURN_KEY_TYPE;
+        private int maxRangeSplit = 11;
+        private FileSystem fs;
+        private Path uniqueDir;
+        private QueryLock queryLock;
+        private boolean allowDirReuse;
+        private long scanThreshold = 10000;
+        private int hdfsBackedSetBufferSize = 10000;
+        private int maxOpenFiles = 100;
+        private boolean sortedUIDs = true;
+        protected QuerySpanCollector querySpanCollector = null;
+        protected volatile boolean collectTimingDetails = false;
+        private volatile long scanTimeout = 1000L * 60 * 60;
+        private Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters;
+        
+        @SuppressWarnings("unchecked")
+        protected B self() {
+            return (B) this;
+        }
+        
+        public B withFieldName(Text fieldName) {
+            this.fieldName = fieldName;
+            return self();
+        }
+        
+        public B withFieldValue(Text fieldValue) {
+            this.fieldValue = fieldValue;
+            return self();
+        }
+        
+        public B withTimeFilter(TimeFilter timeFilter) {
+            this.timeFilter = timeFilter;
+            return self();
+        }
+        
+        public B withDatatypeFilter(Predicate datatypeFilter) {
+            this.datatypeFilter = datatypeFilter;
+            return self();
+        }
+        
+        public B negated(boolean negated) {
+            this.negated = negated;
+            return self();
+        }
+        
+        public B withScanThreshold(long scanThreshold) {
+            this.scanThreshold = scanThreshold;
+            return self();
+        }
+        
+        public B withScanTimeout(long scanTimeout) {
+            this.scanTimeout = scanTimeout;
+            return self();
+        }
+        
+        public B withHdfsBackedSetBufferSize(int hdfsBackedSetBufferSize) {
+            this.hdfsBackedSetBufferSize = hdfsBackedSetBufferSize;
+            return self();
+        }
+        
+        public B withMaxRangeSplit(int maxRangeSplit) {
+            this.maxRangeSplit = maxRangeSplit;
+            return self();
+        }
+        
+        public B withMaxOpenFiles(int maxOpenFiles) {
+            this.maxOpenFiles = maxOpenFiles;
+            return self();
+        }
+        
+        public B withFileSystem(FileSystem fs) {
+            this.fs = fs;
+            return self();
+        }
+        
+        public B withUniqueDir(Path uniqueDir) {
+            this.uniqueDir = uniqueDir;
+            return self();
+        }
+        
+        public B withQueryLock(QueryLock queryLock) {
+            this.queryLock = queryLock;
+            return self();
+        }
+        
+        public B allowDirResuse(boolean allowDirReuse) {
+            this.allowDirReuse = allowDirReuse;
+            return self();
+        }
+        
+        public B withReturnKeyType(PartialKey returnKeyType) {
+            this.returnKeyType = returnKeyType;
+            return self();
+        }
+        
+        public B withSortedUUIDs(boolean sortedUUIDs) {
+            this.sortedUIDs = sortedUUIDs;
+            return self();
+        }
+        
+        public B withCompositePredicateFilters(Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters) {
+            this.compositePredicateFilters = compositePredicateFilters;
+            return self();
+        }
+        
+        public abstract DatawaveFieldIndexCachingIteratorJexl build();
+    }
+    
     public static final Collection<ByteSequence> EMPTY_COL_FAMS = new ArrayList<>();
     public static final Logger log = Logger.getLogger(DatawaveFieldIndexCachingIteratorJexl.class);
     public static final String NULL_BYTE = Constants.NULL_BYTE_STRING;
@@ -168,6 +283,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
     
     // -------------------------------------------------------------------------
     // ------------- Constructors
+    
     public DatawaveFieldIndexCachingIteratorJexl() {
         super();
         this.fieldName = null;
@@ -191,24 +307,14 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         this.sortedUIDs = true;
     }
     
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexCachingIteratorJexl(Text fieldName, Text fieldValue, TimeFilter timeFilter, Predicate<Key> datatypeFilter, long scanThreshold,
-                    long scanTimeout, int bufferSize, int maxRangeSplit, int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock,
-                    boolean allowDirReuse) {
-        this(fieldName, fieldValue, timeFilter, datatypeFilter, false, scanThreshold, scanTimeout, bufferSize, maxRangeSplit, maxOpenFiles, fs, uniqueDir,
-                        queryLock, allowDirReuse);
+    protected DatawaveFieldIndexCachingIteratorJexl(Builder builder) {
+        this(builder.fieldName, builder.fieldValue, builder.timeFilter, builder.datatypeFilter, builder.negated, builder.scanThreshold, builder.scanTimeout,
+                        builder.hdfsBackedSetBufferSize, builder.maxRangeSplit, builder.maxOpenFiles, builder.fs, builder.uniqueDir, builder.queryLock,
+                        builder.allowDirReuse, builder.returnKeyType, builder.sortedUIDs, builder.compositePredicateFilters);
     }
     
     @SuppressWarnings("hiding")
-    public DatawaveFieldIndexCachingIteratorJexl(Text fieldName, Text fieldValue, TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg,
-                    long scanThreshold, long scanTimeout, int bufferSize, int maxRangeSplit, int maxOpenFiles, FileSystem fs, Path uniqueDir,
-                    QueryLock queryLock, boolean allowDirReuse) {
-        this(fieldName, fieldValue, timeFilter, datatypeFilter, neg, scanThreshold, scanTimeout, bufferSize, maxRangeSplit, maxOpenFiles, fs, uniqueDir,
-                        queryLock, allowDirReuse, DEFAULT_RETURN_KEY_TYPE, true, null);
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexCachingIteratorJexl(Text fieldName, Text fieldValue, TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg,
+    private DatawaveFieldIndexCachingIteratorJexl(Text fieldName, Text fieldValue, TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg,
                     long scanThreshold, long scanTimeout, int bufferSize, int maxRangeSplit, int maxOpenFiles, FileSystem fs, Path uniqueDir,
                     QueryLock queryLock, boolean allowDirReuse, PartialKey returnKeyType, boolean sortedUIDs,
                     Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters) {

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexFilterIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexFilterIteratorJexl.java
@@ -34,36 +34,33 @@ import java.util.Map;
 public class DatawaveFieldIndexFilterIteratorJexl extends DatawaveFieldIndexRangeIteratorJexl {
     private Filter filter;
     
+    public static class Builder<B extends Builder<B>> extends DatawaveFieldIndexRangeIteratorJexl.Builder<B> {
+        private Filter filter;
+        
+        public B withFilter(Filter filter) {
+            this.filter = filter;
+            return self();
+        }
+        
+        public DatawaveFieldIndexFilterIteratorJexl build() {
+            return new DatawaveFieldIndexFilterIteratorJexl(this);
+        }
+        
+    }
+    
+    public static Builder<?> builder() {
+        return new Builder();
+    }
+    
+    protected DatawaveFieldIndexFilterIteratorJexl(Builder builder) {
+        super(builder);
+        this.filter = builder.filter;
+    }
+    
     // -------------------------------------------------------------------------
     // ------------- Constructors
     public DatawaveFieldIndexFilterIteratorJexl() {
         super();
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexFilterIteratorJexl(Text fieldName, Filter filter, Text lowerBound, boolean lowerInclusive, Text upperBound,
-                    boolean upperInclusive, TimeFilter timeFilter, Predicate<Key> datatypeFilter, long scanThreshold, long scanTimeout, int bufferSize,
-                    int maxRangeSplit, int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock, boolean allowDirReuse) {
-        this(fieldName, filter, lowerBound, lowerInclusive, upperBound, upperInclusive, timeFilter, datatypeFilter, false, scanThreshold, scanTimeout,
-                        bufferSize, maxRangeSplit, maxOpenFiles, fs, uniqueDir, queryLock, allowDirReuse);
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexFilterIteratorJexl(Text fieldName, Filter filter, Text lowerBound, boolean lowerInclusive, Text upperBound,
-                    boolean upperInclusive, TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg, long scanThreshold, long scanTimeout,
-                    int bufferSize, int maxRangeSplit, int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock, boolean allowDirReuse) {
-        this(fieldName, filter, lowerBound, lowerInclusive, upperBound, upperInclusive, timeFilter, datatypeFilter, neg, scanThreshold, scanTimeout,
-                        bufferSize, maxRangeSplit, maxOpenFiles, fs, uniqueDir, queryLock, allowDirReuse, DEFAULT_RETURN_KEY_TYPE, true, null);
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexFilterIteratorJexl(Text fieldName, Filter filter, Text lowerBound, boolean lowerInclusive, Text upperBound,
-                    boolean upperInclusive, TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg, long scanThreshold, long scanTimeout,
-                    int bufferSize, int maxRangeSplit, int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock, boolean allowDirReuse,
-                    PartialKey returnKeyType, boolean sortedUIDs, Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters) {
-        super(fieldName, lowerBound, lowerInclusive, upperBound, upperInclusive, timeFilter, datatypeFilter, neg, scanThreshold, scanTimeout, bufferSize,
-                        maxRangeSplit, maxOpenFiles, fs, uniqueDir, queryLock, allowDirReuse, returnKeyType, sortedUIDs, compositePredicateFilters);
-        this.filter = filter;
     }
     
     public DatawaveFieldIndexFilterIteratorJexl(DatawaveFieldIndexFilterIteratorJexl other, IteratorEnvironment env) {

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRangeIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRangeIteratorJexl.java
@@ -32,6 +32,43 @@ import java.util.Map;
  * 
  */
 public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachingIteratorJexl {
+    
+    public static class Builder<B extends Builder<B>> extends DatawaveFieldIndexCachingIteratorJexl.Builder<B> {
+        protected Text upperBound = null;
+        protected boolean upperInclusive = true;
+        protected boolean lowerInclusive = true;
+        
+        public B withUpperBound(Text upperBound) {
+            this.upperBound = upperBound;
+            return self();
+        }
+        
+        public B upperInclusive(boolean upperInclusive) {
+            this.upperInclusive = upperInclusive;
+            return self();
+        }
+        
+        public B lowerInclusive(boolean lowerInclusive) {
+            this.lowerInclusive = lowerInclusive;
+            return self();
+        }
+        
+        public DatawaveFieldIndexRangeIteratorJexl build() {
+            return new DatawaveFieldIndexRangeIteratorJexl(this);
+        }
+    }
+    
+    public static Builder<?> builder() {
+        return new Builder();
+    }
+    
+    protected DatawaveFieldIndexRangeIteratorJexl(Builder builder) {
+        super(builder);
+        this.upperBound = builder.upperBound;
+        this.upperInclusive = builder.upperInclusive;
+        this.lowerInclusive = builder.lowerInclusive;
+    }
+    
     protected Text upperBound = null;
     protected boolean upperInclusive = true;
     protected boolean lowerInclusive = true;
@@ -40,34 +77,6 @@ public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachi
     // ------------- Constructors
     public DatawaveFieldIndexRangeIteratorJexl() {
         super();
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexRangeIteratorJexl(Text fieldName, Text lowerBound, boolean lowerInclusive, Text upperBound, boolean upperInclusive,
-                    TimeFilter timeFilter, Predicate<Key> datatypeFilter, long scanThreshold, long scanTimeout, int bufferSize, int maxRangeSplit,
-                    int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock, boolean allowDirReuse) {
-        this(fieldName, lowerBound, lowerInclusive, upperBound, upperInclusive, timeFilter, datatypeFilter, false, scanThreshold, scanTimeout, bufferSize,
-                        maxRangeSplit, maxOpenFiles, fs, uniqueDir, queryLock, allowDirReuse);
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexRangeIteratorJexl(Text fieldName, Text lowerBound, boolean lowerInclusive, Text upperBound, boolean upperInclusive,
-                    TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg, long scanThreshold, long scanTimeout, int bufferSize, int maxRangeSplit,
-                    int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock, boolean allowDirReuse) {
-        this(fieldName, lowerBound, lowerInclusive, upperBound, upperInclusive, timeFilter, datatypeFilter, neg, scanThreshold, scanTimeout, bufferSize,
-                        maxRangeSplit, maxOpenFiles, fs, uniqueDir, queryLock, allowDirReuse, DEFAULT_RETURN_KEY_TYPE, true, null);
-    }
-    
-    @SuppressWarnings("hiding")
-    public DatawaveFieldIndexRangeIteratorJexl(Text fieldName, Text lowerBound, boolean lowerInclusive, Text upperBound, boolean upperInclusive,
-                    TimeFilter timeFilter, Predicate<Key> datatypeFilter, boolean neg, long scanThreshold, long scanTimeout, int bufferSize, int maxRangeSplit,
-                    int maxOpenFiles, FileSystem fs, Path uniqueDir, QueryLock queryLock, boolean allowDirReuse, PartialKey returnKeyType, boolean sortedUIDs,
-                    Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters) {
-        super(fieldName, lowerBound, timeFilter, datatypeFilter, neg, scanThreshold, scanTimeout, bufferSize, maxRangeSplit, maxOpenFiles, fs, uniqueDir,
-                        queryLock, allowDirReuse, returnKeyType, sortedUIDs, compositePredicateFilters);
-        this.lowerInclusive = lowerInclusive;
-        this.upperBound = upperBound;
-        this.upperInclusive = upperInclusive;
     }
     
     public DatawaveFieldIndexRangeIteratorJexl(DatawaveFieldIndexRangeIteratorJexl other, IteratorEnvironment env) {

--- a/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorIndexIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorIndexIterator.java
@@ -1,32 +1,33 @@
 package datawave.query.ancestor;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import datawave.query.iterator.filter.composite.CompositePredicateFilter;
 import datawave.query.iterator.logic.IndexIterator;
-import datawave.query.jexl.functions.FieldIndexAggregator;
-import datawave.query.jexl.functions.IdentityAggregator;
 import datawave.query.predicate.TimeFilter;
 import datawave.query.tld.TLD;
-import datawave.query.util.TypeMetadata;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.hadoop.io.Text;
 
-import java.util.Map;
-
 public class AncestorIndexIterator extends IndexIterator {
     
-    public AncestorIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter) {
-        this(field, value, source, timeFilter, null, false, Predicates.<Key> alwaysTrue(), new IdentityAggregator(null, null), null);
+    public static class Builder<B extends Builder<B>> extends IndexIterator.Builder<B> {
+        
+        Builder(Text field, Text value, SortedKeyValueIterator<Key,Value> source) {
+            super(field, value, source);
+        }
+        
+        public AncestorIndexIterator build() {
+            return new AncestorIndexIterator(this);
+        }
     }
     
-    public AncestorIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter, TypeMetadata typeMetadata,
-                    boolean buildDocument, Predicate<Key> datatypeFilter, FieldIndexAggregator aggregator,
-                    Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters) {
-        super(field, value, source, timeFilter, typeMetadata, buildDocument, datatypeFilter, aggregator, compositePredicateFilters);
+    public static Builder<?> builder(Text field, Text value, SortedKeyValueIterator<Key,Value> source) {
+        return new Builder(field, value, source);
+    }
+    
+    protected AncestorIndexIterator(Builder builder) {
+        super(builder);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorIndexIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorIndexIteratorBuilder.java
@@ -5,7 +5,6 @@ import datawave.query.iterator.builder.IndexIteratorBuilder;
 import datawave.query.iterator.logic.IndexIterator;
 import datawave.query.jexl.functions.FieldIndexAggregator;
 import datawave.query.predicate.TimeFilter;
-
 import datawave.query.util.TypeMetadata;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -17,8 +16,8 @@ public class AncestorIndexIteratorBuilder extends IndexIteratorBuilder {
     @Override
     public IndexIterator newIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter, TypeMetadata typeMetadata,
                     boolean buildDocument, Predicate<Key> datatypeFilter, FieldIndexAggregator aggregator) {
-        return new AncestorIndexIterator(field, value, source, timeFilter, typeMetadata, buildDocument, datatypeFilter, aggregator,
-                        createCompositePredicateFilters(field.toString()));
+        
+        return AncestorIndexIterator.builder(field, value, source).withTimeFilter(timeFilter).withTypeMetadata(typeMetadata).shouldBuildDocument(buildDocument)
+                        .withDatatypeFilter(datatypeFilter).withAggregation(aggregator).build();
     }
-    
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/CardinalityIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/CardinalityIteratorBuilder.java
@@ -9,9 +9,11 @@ public class CardinalityIteratorBuilder extends IndexIteratorBuilder {
     @SuppressWarnings("unchecked")
     public IndexIteratorBridge build() {
         if (notNull(field, value, source, datatypeFilter, keyTform, timeFilter)) {
-            IndexIteratorBridge itr = new IndexIteratorBridge(new IndexIterator(new Text(field), new Text(value), source, this.timeFilter, this.typeMetadata,
-                            this.fieldsToAggregate == null ? false : this.fieldsToAggregate.contains(field), this.datatypeFilter, this.keyTform,
-                            createCompositePredicateFilters(field)));
+            IndexIteratorBridge itr = new IndexIteratorBridge(IndexIterator.builder(new Text(field), new Text(value), source).withTimeFilter(timeFilter)
+                            .withTypeMetadata(typeMetadata)
+                            .shouldBuildDocument(this.fieldsToAggregate == null ? false : this.fieldsToAggregate.contains(field))
+                            .withDatatypeFilter(datatypeFilter).withAggregation(this.keyTform)
+                            .withCompositePredicateFilters(createCompositePredicateFilters(field)).build());
             field = null;
             value = null;
             source = null;

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexFilterIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexFilterIteratorBuilder.java
@@ -70,11 +70,15 @@ public class IndexFilterIteratorBuilder extends IvaratorBuilder implements Itera
             DocumentIterator docIterator = null;
             try {
                 // create a field index caching ivarator
-                DatawaveFieldIndexFilterIteratorJexl rangeIterator = new DatawaveFieldIndexFilterIteratorJexl(new Text(range.getFieldName()), filter, new Text(
-                                range.getLower().toString()), range.isLowerInclusive(), new Text(range.getUpper().toString()), range.isUpperInclusive(),
-                                this.timeFilter, this.datatypeFilter, false, ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout,
-                                ivaratorCacheBufferSize, maxRangeSplit, ivaratorMaxOpenFiles, hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true,
-                                PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs, createCompositePredicateFilters(range.getFieldName()));
+                DatawaveFieldIndexFilterIteratorJexl rangeIterator = DatawaveFieldIndexFilterIteratorJexl.builder()
+                                .withFieldName(new Text(range.getFieldName())).withFilter(filter).withUpperBound(new Text(range.getUpper().toString()))
+                                .upperInclusive(range.isUpperInclusive()).withTimeFilter(timeFilter).withDatatypeFilter(datatypeFilter).negated(false)
+                                .withScanThreshold(ivaratorCacheScanPersistThreshold).withScanTimeout(ivaratorCacheScanTimeout)
+                                .withHdfsBackedSetBufferSize(ivaratorCacheBufferSize).withMaxRangeSplit(maxRangeSplit).withMaxOpenFiles(ivaratorMaxOpenFiles)
+                                .withFileSystem(hdfsFileSystem).withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
+                                .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
+                                .withCompositePredicateFilters(createCompositePredicateFilters(range.getFieldName())).build();
+                
                 if (collectTimingDetails) {
                     rangeIterator.setCollectTimingDetails(true);
                     rangeIterator.setQuerySpanCollector(this.querySpanCollector);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexIteratorBuilder.java
@@ -91,8 +91,9 @@ public class IndexIteratorBuilder extends AbstractIteratorBuilder {
     
     public IndexIterator newIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter, TypeMetadata typeMetadata,
                     boolean buildDocument, Predicate<Key> datatypeFilter, FieldIndexAggregator aggregator) {
-        return new IndexIterator(field, value, source, timeFilter, typeMetadata, buildDocument, datatypeFilter, aggregator,
-                        createCompositePredicateFilters(field.toString()));
+        return IndexIterator.builder(field, value, source).withTimeFilter(timeFilter).withTypeMetadata(typeMetadata).shouldBuildDocument(buildDocument)
+                        .withDatatypeFilter(datatypeFilter).withAggregation(aggregator)
+                        .withCompositePredicateFilters(createCompositePredicateFilters(field.toString())).build();
     }
     
     protected Map<String,Map<String,CompositePredicateFilter>> createCompositePredicateFilters(String fieldName) {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexListIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexListIteratorBuilder.java
@@ -96,16 +96,32 @@ public class IndexListIteratorBuilder extends IvaratorBuilder implements Iterato
                 // create a field index caching ivarator
                 DatawaveFieldIndexListIteratorJexl listIterator = null;
                 if (values != null) {
-                    listIterator = new DatawaveFieldIndexListIteratorJexl(new Text(field), values, this.timeFilter, this.datatypeFilter, negated,
-                                    ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout, ivaratorCacheBufferSize, maxRangeSplit, ivaratorMaxOpenFiles,
-                                    hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true, PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs,
-                                    createCompositePredicateFilters(field));
+                    listIterator = DatawaveFieldIndexListIteratorJexl.builder().withFieldName(new Text(field)).withValues(values).withTimeFilter(timeFilter)
+                                    .withDatatypeFilter(datatypeFilter).negated(negated).withScanThreshold(ivaratorCacheScanPersistThreshold)
+                                    .withScanTimeout(ivaratorCacheScanTimeout).withHdfsBackedSetBufferSize(ivaratorCacheBufferSize)
+                                    .withMaxRangeSplit(maxRangeSplit).withMaxOpenFiles(ivaratorMaxOpenFiles).withFileSystem(hdfsFileSystem)
+                                    .withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
+                                    .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
+                                    .withCompositePredicateFilters(createCompositePredicateFilters(field)).build();
+                    
+                    // new DatawaveFieldIndexListIteratorJexl(new Text(field), values, this.timeFilter, this.datatypeFilter, negated,
+                    // ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout, ivaratorCacheBufferSize, maxRangeSplit, ivaratorMaxOpenFiles,
+                    // hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true, PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs,
+                    // createCompositePredicateFilters(field));
                 } else {
                     FST fst = DatawaveFieldIndexListIteratorJexl.FSTManager.get(new Path(fstURI), hdfsFileCompressionCodec, fstHdfsFileSystem);
-                    listIterator = new DatawaveFieldIndexListIteratorJexl(new Text(field), fst, this.timeFilter, this.datatypeFilter, negated,
-                                    ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout, ivaratorCacheBufferSize, maxRangeSplit, ivaratorMaxOpenFiles,
-                                    hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true, PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs,
-                                    createCompositePredicateFilters(field));
+                    listIterator = DatawaveFieldIndexListIteratorJexl.builder().withFieldName(new Text(field)).withFST(fst).withTimeFilter(timeFilter)
+                                    .withDatatypeFilter(datatypeFilter).negated(negated).withScanThreshold(ivaratorCacheScanPersistThreshold)
+                                    .withScanTimeout(ivaratorCacheScanTimeout).withHdfsBackedSetBufferSize(ivaratorCacheBufferSize)
+                                    .withMaxRangeSplit(maxRangeSplit).withMaxOpenFiles(ivaratorMaxOpenFiles).withFileSystem(hdfsFileSystem)
+                                    .withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
+                                    .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
+                                    .withCompositePredicateFilters(createCompositePredicateFilters(field)).build();
+                    
+                    // listIterator = new DatawaveFieldIndexListIteratorJexl(new Text(field), fst, this.timeFilter, this.datatypeFilter, negated,
+                    // ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout, ivaratorCacheBufferSize, maxRangeSplit, ivaratorMaxOpenFiles,
+                    // hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true, PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs,
+                    // createCompositePredicateFilters(field));
                 }
                 if (collectTimingDetails) {
                     listIterator.setCollectTimingDetails(true);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRangeIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRangeIteratorBuilder.java
@@ -62,11 +62,16 @@ public class IndexRangeIteratorBuilder extends IvaratorBuilder implements Iterat
             DocumentIterator docIterator = null;
             try {
                 // create a field index caching ivarator
-                DatawaveFieldIndexRangeIteratorJexl rangeIterator = new DatawaveFieldIndexRangeIteratorJexl(new Text(range.getFieldName()), new Text(range
-                                .getLower().toString()), range.isLowerInclusive(), new Text(range.getUpper().toString()), range.isUpperInclusive(),
-                                this.timeFilter, this.datatypeFilter, false, ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout,
-                                ivaratorCacheBufferSize, maxRangeSplit, ivaratorMaxOpenFiles, hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true,
-                                PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs, createCompositePredicateFilters(range.getFieldName()));
+                DatawaveFieldIndexRangeIteratorJexl rangeIterator = DatawaveFieldIndexRangeIteratorJexl.builder().withFieldName(new Text(range.getFieldName()))
+                                .withFieldValue(new Text(range.getLower().toString())).lowerInclusive(range.isLowerInclusive())
+                                .withUpperBound(new Text(range.getUpper().toString())).upperInclusive(range.isUpperInclusive()).withTimeFilter(this.timeFilter)
+                                .withDatatypeFilter(this.datatypeFilter).negated(false).withScanThreshold(ivaratorCacheScanPersistThreshold)
+                                .withScanTimeout(ivaratorCacheScanTimeout).withHdfsBackedSetBufferSize(ivaratorCacheBufferSize)
+                                .withMaxRangeSplit(maxRangeSplit).withMaxOpenFiles(ivaratorMaxOpenFiles).withFileSystem(hdfsFileSystem)
+                                .withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
+                                .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
+                                .withCompositePredicateFilters(createCompositePredicateFilters(range.getFieldName())).build();
+                
                 if (collectTimingDetails) {
                     rangeIterator.setCollectTimingDetails(true);
                     rangeIterator.setQuerySpanCollector(this.querySpanCollector);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRegexIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRegexIteratorBuilder.java
@@ -58,10 +58,14 @@ public class IndexRegexIteratorBuilder extends IvaratorBuilder implements Iterat
             DocumentIterator docIterator = null;
             try {
                 // create a field index caching ivarator
-                DatawaveFieldIndexRegexIteratorJexl regexIterator = new DatawaveFieldIndexRegexIteratorJexl(new Text(field), new Text(value), this.timeFilter,
-                                this.datatypeFilter, negated, ivaratorCacheScanPersistThreshold, ivaratorCacheScanTimeout, ivaratorCacheBufferSize,
-                                maxRangeSplit, ivaratorMaxOpenFiles, hdfsFileSystem, new Path(hdfsCacheURI), queryLock, true,
-                                PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME, sortedUIDs, createCompositePredicateFilters(field));
+                DatawaveFieldIndexRegexIteratorJexl regexIterator = DatawaveFieldIndexRegexIteratorJexl.builder().withFieldName(new Text(field))
+                                .withFieldValue(new Text(value)).withTimeFilter(timeFilter).withDatatypeFilter(datatypeFilter).negated(negated)
+                                .withScanThreshold(ivaratorCacheScanPersistThreshold).withScanTimeout(ivaratorCacheScanTimeout)
+                                .withHdfsBackedSetBufferSize(ivaratorCacheBufferSize).withMaxRangeSplit(maxRangeSplit).withMaxOpenFiles(ivaratorMaxOpenFiles)
+                                .withFileSystem(hdfsFileSystem).withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
+                                .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
+                                .withCompositePredicateFilters(createCompositePredicateFilters(field)).build();
+                
                 if (collectTimingDetails) {
                     regexIterator.setCollectTimingDetails(true);
                     regexIterator.setQuerySpanCollector(this.querySpanCollector);
@@ -81,8 +85,8 @@ public class IndexRegexIteratorBuilder extends IvaratorBuilder implements Iterat
                 
             } catch (IOException e) {
                 throw new IllegalStateException("Unable to initialize regex iterator stack", e);
-            } catch (JavaRegexParseException e) {
-                throw new IllegalStateException("Unable to parse regex " + value, e);
+                // } catch (JavaRegexParseException e) {
+                // throw new IllegalStateException("Unable to parse regex " + value, e);
             }
             
             IndexIteratorBridge itr = new IndexIteratorBridge(docIterator);

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexIterator.java
@@ -1,12 +1,7 @@
 package datawave.query.tld;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import datawave.query.iterator.filter.composite.CompositePredicateFilter;
 import datawave.query.iterator.logic.IndexIterator;
-import datawave.query.jexl.functions.FieldIndexAggregator;
 import datawave.query.predicate.TimeFilter;
-import datawave.query.util.TypeMetadata;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
@@ -14,18 +9,25 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.hadoop.io.Text;
 
-import java.util.Map;
-
 public class TLDIndexIterator extends IndexIterator {
     
-    public TLDIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter) {
-        this(field, value, source, timeFilter, null, false, Predicates.<Key> alwaysTrue(), new TLDFieldIndexAggregator(null, null), null);
+    public static class Builder<B extends Builder<B>> extends IndexIterator.Builder<B> {
+        
+        Builder(Text field, Text value, SortedKeyValueIterator<Key,Value> source) {
+            super(field, value, source);
+        }
+        
+        public TLDIndexIterator build() {
+            return new TLDIndexIterator(this);
+        }
     }
     
-    public TLDIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter, TypeMetadata typeMetadata,
-                    boolean buildDocument, Predicate<Key> datatypeFilter, FieldIndexAggregator aggregator,
-                    Map<String,Map<String,CompositePredicateFilter>> compositePredicateFilters) {
-        super(field, value, source, timeFilter, typeMetadata, buildDocument, datatypeFilter, aggregator, compositePredicateFilters);
+    public static Builder<?> builder(Text field, Text value, SortedKeyValueIterator<Key,Value> source) {
+        return new Builder(field, value, source);
+    }
+    
+    protected TLDIndexIterator(Builder builder) {
+        super(builder);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexIteratorBuilder.java
@@ -12,11 +12,12 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.hadoop.io.Text;
 
 public class TLDIndexIteratorBuilder extends IndexIteratorBuilder {
+    
     @Override
     public IndexIterator newIndexIterator(Text field, Text value, SortedKeyValueIterator<Key,Value> source, TimeFilter timeFilter, TypeMetadata typeMetadata,
                     boolean buildDocument, Predicate<Key> datatypeFilter, FieldIndexAggregator aggregator) {
-        return new TLDIndexIterator(field, value, source, timeFilter, typeMetadata, buildDocument, datatypeFilter, aggregator,
-                        createCompositePredicateFilters(field.toString()));
+        
+        return TLDIndexIterator.builder(field, value, source).withTimeFilter(timeFilter).withTypeMetadata(typeMetadata).shouldBuildDocument(buildDocument)
+                        .withDatatypeFilter(datatypeFilter).withAggregation(aggregator).build();
     }
-    
 }


### PR DESCRIPTION
 Changes to be committed:
	modified:   warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorIndexIterator.java
	modified:   warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorIndexIteratorBuilder.java
	modified:   warehouse/query-core/src/main/java/datawave/query/iterator/builder/CardinalityIteratorBuilder.java
	modified:   warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexIteratorBuilder.java
	modified:   warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIterator.java
	modified:   warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexIterator.java
	modified:   warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexIteratorBuilder.java