### PR TITLE
add function to carry queryOptions into the ShardQueryConfiguration

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -1185,6 +1185,18 @@ public class EvaluationPhaseFilterFunctions {
     }
     
     /**
+     * This is the query function to pass query option pairs to the ShardQueryConfiguration. It always evaluates to 'true' so that it does not need to be
+     * removed from the query after the args are parsed to the ShardQueryConfiguration
+     * 
+     * @param args
+     *            ignored here. used to pass key/value pairs to the query options
+     * @return true
+     */
+    public static boolean options(String[] args) {
+        return true;
+    }
+    
+    /**
      * A special format denoting the time since epoch format
      */
     public static final String TIME_SINCE_EPOCH_FORMAT = "e";

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -1185,18 +1185,6 @@ public class EvaluationPhaseFilterFunctions {
     }
     
     /**
-     * This is the query function to pass query option pairs to the ShardQueryConfiguration. It always evaluates to 'true' so that it does not need to be
-     * removed from the query after the args are parsed to the ShardQueryConfiguration
-     * 
-     * @param args
-     *            ignored here. used to pass key/value pairs to the query options
-     * @return true
-     */
-    public static boolean options(String[] args) {
-        return true;
-    }
-    
-    /**
      * A special format denoting the time since epoch format
      */
     public static final String TIME_SINCE_EPOCH_FORMAT = "e";

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
@@ -41,7 +41,7 @@ public class EvaluationPhaseFilterFunctionsDescriptor implements JexlFunctionArg
         private static final ImmutableSet<String> dateBetweenFunctions = ImmutableSet.of("betweenDates", "betweenLoadDates");
         private static final String MATCHCOUNTOF = "matchesAtLeastCountOf";
         private static final String TIMEFUNCTION = "timeFunction";
-        
+        private static final String OPTIONS_FUNCTION = "options";
         private final ASTFunctionNode node;
         
         public EvaluationPhaseFilterJexlArgumentDescriptor(ASTFunctionNode node) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
@@ -1,6 +1,8 @@
 package datawave.query.jexl.visitors;
 
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
+import org.apache.commons.jexl2.parser.ASTReference;
+import org.apache.commons.jexl2.parser.ASTReferenceExpression;
 import org.apache.commons.jexl2.parser.ASTStringLiteral;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.log4j.Logger;
@@ -55,7 +57,7 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
                 String value = optionsList.get(i);
                 optionsMap.put(key, value);
             }
-            return ret;
+            return null;
         }
         return super.visit(node, optionsMap);
     }
@@ -89,6 +91,39 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
     private Object visit(ASTStringLiteral node, List<String> list) {
         list.add(node.image);
         return super.visit(node, list);
+    }
+    
+    /**
+     * If the visit to the ASTFunction node returned null (because it was the options function) then there could be an empty ASTReference node. This would
+     * generate a parseException in the jexl Parser unless the empty ASTReference node is also removed by returning null here.
+     * 
+     * @param node
+     * @param data
+     * @return
+     */
+    @Override
+    public Object visit(ASTReference node, Object data) {
+        JexlNode n = (JexlNode) super.visit(node, data);
+        if (n.jjtGetNumChildren() == 0)
+            return null;
+        return n;
+    }
+    
+    /**
+     * If the visit to the ASTFunction node returned null (because it was the options function) then there could be an empty ASTReferenceExpression node. This
+     * would generate a parseException in the jexl Parser unless the empty ASTReferenceExpression node is also removed by returning null here.
+     *
+     * @param node
+     * @param data
+     * @return
+     */
+    @Override
+    public Object visit(ASTReferenceExpression node, Object data) {
+        JexlNode n = (JexlNode) super.visit(node, data);
+        if (n.jjtGetNumChildren() == 0)
+            return null;
+        return n;
+        
     }
     
     @SuppressWarnings("unchecked")

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/jexl/JexlTreeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/jexl/JexlTreeBuilder.java
@@ -24,6 +24,7 @@ import datawave.query.language.functions.jexl.MatchesAtLeastCountOf;
 import datawave.query.language.functions.jexl.MatchesInGroupFunction;
 import datawave.query.language.functions.jexl.MatchesInGroupLeft;
 import datawave.query.language.functions.jexl.OccurrenceFunction;
+import datawave.query.language.functions.jexl.Options;
 import datawave.query.language.functions.jexl.TimeFunction;
 import datawave.query.language.parser.jexl.JexlNode;
 
@@ -47,7 +48,7 @@ public class JexlTreeBuilder extends QueryTreeBuilder {
     public static final JexlQueryFunction[] DEFAULT_ALLOWED_FUNCTIONS = {new IsNull(), new IsNotNull(), new Include(), new Exclude(), new GeoFunction(),
             new Contains(), new CoveredBy(), new Covers(), new Crosses(), new Intersects(), new Overlaps(), new Within(), new Loaded(), new DateFunction(),
             new OccurrenceFunction(), new MatchesInGroupFunction(), new MatchesInGroupLeft(), new GetAllMatches(), new MatchesAtLeastCountOf(), new Jexl(),
-            new TimeFunction(), new AtomValuesMatchFunction()};
+            new TimeFunction(), new AtomValuesMatchFunction(), new Options()};
     
     public static final List<JexlQueryFunction> DEFAULT_ALLOWED_FUNCTION_LIST;
     

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Options.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Options.java
@@ -1,0 +1,48 @@
+package datawave.query.language.functions.jexl;
+
+import datawave.query.language.functions.QueryFunction;
+import datawave.webservice.query.exception.BadRequestQueryException;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+
+public class Options extends JexlQueryFunction {
+    
+    public Options() {
+        super("options", new ArrayList<String>());
+    }
+    
+    /**
+     * query options are pairs of key/value. Ensure that the number of args is even
+     * 
+     * @throws IllegalArgumentException
+     */
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (this.parameterList.size() % 2 != 0) {
+            BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+            throw new IllegalArgumentException(qe);
+        }
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        
+        sb.append("(");
+        int x = 0;
+        while (x < parameterList.size()) {
+            String key = parameterList.get(x++);
+            String value = parameterList.get(x++);
+            sb.append("filter:options(").append(escapeString(key)).append(", ").append(escapeString(value)).append(")");
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+    
+    @Override
+    public QueryFunction duplicate() {
+        return new Options();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Options.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Options.java
@@ -1,0 +1,50 @@
+package datawave.query.language.functions.lucene;
+
+import datawave.query.language.functions.QueryFunction;
+import datawave.query.search.WildcardFieldedFilter;
+import datawave.webservice.query.exception.BadRequestQueryException;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.BooleanQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Options extends LuceneQueryFunction {
+    public Options() {
+        super("options", new ArrayList<String>());
+    }
+    
+    @Override
+    public void initialize(List<String> parameterList, int depth, QueryNode parent) throws IllegalArgumentException {
+        super.initialize(parameterList, depth, parent);
+        this.fieldedFilter = new WildcardFieldedFilter(false, WildcardFieldedFilter.BooleanType.AND);
+        this.fieldedFilter.addCondition(parameterList.get(0), ".+");
+    }
+    
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (this.parameterList.size() % 2 != 0) { // must have even number of args
+            BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+            throw new IllegalArgumentException(qe);
+        }
+        if (this.depth != 1) {
+            throw new IllegalArgumentException("function: " + this.name + " must be at the top level of the query");
+        }
+        if (!(this.parent instanceof AndQueryNode || this.parent instanceof BooleanQueryNode)) {
+            throw new IllegalArgumentException("function: " + this.name + " must be part of an AND expression");
+        }
+    }
+    
+    @Override
+    public String toString() {
+        return this.fieldedFilter.toString();
+    }
+    
+    @Override
+    public QueryFunction duplicate() {
+        return new Options();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
@@ -28,9 +28,6 @@ public class QueryOptionsSwitch {
                 case QueryOptions.TYPE_METADATA_IN_HDFS:
                     config.setTypeMetadataInHdfs(Boolean.parseBoolean(value));
                     break;
-                case QueryOptions.DISABLE_EVALUATION:
-                    config.setDisableEvaluation(Boolean.parseBoolean(value));
-                    break;
                 case QueryOptions.GROUP_FIELDS:
                     String[] groups = StringUtils.split(value, Constants.PARAM_VALUE_SEP);
                     config.setLimitFields(Sets.newHashSet(groups));

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
@@ -1,0 +1,41 @@
+package datawave.query.planner;
+
+import com.google.common.collect.Sets;
+import datawave.query.Constants;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.iterator.QueryOptions;
+import datawave.util.StringUtils;
+
+import java.util.Map;
+
+public class QueryOptionsSwitch {
+    
+    public static void apply(Map<String,String> optionsMap, ShardQueryConfiguration config) {
+        for (Map.Entry<String,String> entry : optionsMap.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            switch (key) {
+                case QueryOptions.INCLUDE_GROUPING_CONTEXT:
+                    config.setIncludeGroupingContext(Boolean.parseBoolean(value));
+                    break;
+                case QueryOptions.HIT_LIST:
+                    config.setHitList(Boolean.parseBoolean(value));
+                    break;
+                case QueryOptions.LIMIT_FIELDS:
+                    String[] lf = StringUtils.split(value, Constants.PARAM_VALUE_SEP);
+                    config.setLimitFields(Sets.newHashSet(lf));
+                    break;
+                case QueryOptions.TYPE_METADATA_IN_HDFS:
+                    config.setTypeMetadataInHdfs(Boolean.parseBoolean(value));
+                    break;
+                case QueryOptions.DISABLE_EVALUATION:
+                    config.setDisableEvaluation(Boolean.parseBoolean(value));
+                    break;
+                case QueryOptions.GROUP_FIELDS:
+                    String[] groups = StringUtils.split(value, Constants.PARAM_VALUE_SEP);
+                    config.setLimitFields(Sets.newHashSet(groups));
+                    break;
+            }
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -879,7 +879,6 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     
     protected void loadQueryParameters(ShardQueryConfiguration config, Query settings) throws QueryException {
         TraceStopwatch stopwatch = config.getTimers().newStartedStopwatch("ShardQueryLogic - Parse query parameters");
-        
         boolean rawDataOnly = false;
         String rawDataOnlyStr = settings.findParameter(QueryParameters.RAW_DATA_ONLY).getParameterValue().trim();
         if (org.apache.commons.lang.StringUtils.isNotBlank(rawDataOnlyStr)) {

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
@@ -3,7 +3,6 @@ package datawave.query;
 import datawave.configuration.spring.SpringBean;
 import datawave.helpers.PrintUtility;
 import datawave.ingest.data.TypeRegistry;
-import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.PreNormalizedAttribute;
@@ -11,7 +10,11 @@ import datawave.query.attributes.TypeAttribute;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.jexl.functions.EvaluationPhaseFilterFunctions;
+import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
 import datawave.query.tables.ShardQueryLogic;
+import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataHelper;
+import datawave.query.util.TypeMetadataWriter;
 import datawave.query.util.WiseGuysIngest;
 import datawave.webservice.edgedictionary.TestDatawaveEdgeDictionaryImpl;
 import datawave.webservice.query.QueryImpl;
@@ -20,6 +23,7 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -34,8 +38,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,10 +54,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
-import static datawave.query.QueryTestTableHelper.METADATA_TABLE_NAME;
-import static datawave.query.QueryTestTableHelper.MODEL_TABLE_NAME;
-import static datawave.query.QueryTestTableHelper.SHARD_INDEX_TABLE_NAME;
-import static datawave.query.QueryTestTableHelper.SHARD_TABLE_NAME;
+import static datawave.query.QueryTestTableHelper.*;
 
 /**
  * Tests the composite functions, the #JEXL lucene function, and the matchesAtLeastCountOf function
@@ -79,8 +81,7 @@ public abstract class CompositeFunctionsTest {
         }
         
         @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws ParseException,
-                        Exception {
+        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
             super.runTestQuery(expected, querystr, startDate, endDate, extraParms, connector);
         }
     }
@@ -104,8 +105,7 @@ public abstract class CompositeFunctionsTest {
         }
         
         @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws ParseException,
-                        Exception {
+        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
             super.runTestQuery(expected, querystr, startDate, endDate, extraParms, connector);
         }
     }
@@ -114,18 +114,41 @@ public abstract class CompositeFunctionsTest {
     
     protected Authorizations auths = new Authorizations("ALL");
     
-    protected Set<Authorizations> authSet = Collections.singleton(auths);
+    private Set<Authorizations> authSet = Collections.singleton(auths);
     
     @Inject
     @SpringBean(name = "EventQuery")
     protected ShardQueryLogic logic;
     
-    protected KryoDocumentDeserializer deserializer;
+    private static final String tempDirForCompositeFunctionsTest = "/tmp/TempDirForCompositeFunctionsTest";
+    
+    @BeforeClass
+    public static void beforeClass() {
+        // this will get property substituted into the TypeMetadataBridgeContext.xml file
+        // for the injection test (when this unit test is first created)
+        System.setProperty("type.metadata.dir", tempDirForCompositeFunctionsTest);
+    }
+    
+    @AfterClass
+    public static void teardown() {
+        // maybe delete the temp folder here
+        File tempFolder = new File(tempDirForCompositeFunctionsTest);
+        if (tempFolder.exists()) {
+            try {
+                FileUtils.forceDelete(tempFolder);
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        }
+        TypeRegistry.reset();
+    }
+    
+    private KryoDocumentDeserializer deserializer;
     
     private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
     
     @Deployment
-    public static JavaArchive createDeployment() throws Exception {
+    public static JavaArchive createDeployment() {
         
         return ShrinkWrap
                         .create(JavaArchive.class)
@@ -139,11 +162,6 @@ public abstract class CompositeFunctionsTest {
                                                         + "</alternatives>"), "beans.xml");
     }
     
-    @AfterClass
-    public static void teardown() {
-        TypeRegistry.reset();
-    }
-    
     @Before
     public void setup() {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
@@ -152,11 +170,10 @@ public abstract class CompositeFunctionsTest {
         deserializer = new KryoDocumentDeserializer();
     }
     
-    protected abstract void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
-                    throws ParseException, Exception;
+    protected abstract void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception;
     
     protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms, Connector connector)
-                    throws ParseException, Exception {
+                    throws Exception {
         log.debug("runTestQuery");
         log.trace("Creating QueryImpl");
         QueryImpl settings = new QueryImpl();
@@ -174,10 +191,16 @@ public abstract class CompositeFunctionsTest {
         GenericQueryConfiguration config = logic.initialize(connector, settings, authSet);
         logic.setupQuery(config);
         
-        HashSet<String> expectedSet = new HashSet<String>(expected);
+        TypeMetadataWriter typeMetadataWriter = TypeMetadataWriter.Factory.createTypeMetadataWriter();
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper();
+        typeMetadataHelper.initialize(connector, MODEL_TABLE_NAME, authSet);
+        Map<Set<String>,TypeMetadata> typeMetadataMap = typeMetadataHelper.getTypeMetadataMap(authSet);
+        typeMetadataWriter.writeTypeMetadataMap(typeMetadataMap, MODEL_TABLE_NAME);
+        
+        HashSet<String> expectedSet = new HashSet<>(expected);
         HashSet<String> resultSet;
-        resultSet = new HashSet<String>();
-        Set<Document> docs = new HashSet<Document>();
+        resultSet = new HashSet<>();
+        Set<Document> docs = new HashSet<>();
         for (Entry<Key,Value> entry : logic) {
             Document d = deserializer.apply(entry).getValue();
             
@@ -228,7 +251,7 @@ public abstract class CompositeFunctionsTest {
         String[] queryStrings = {"UUID =~ '^[CS].*' AND filter:matchesAtLeastCountOf(3,NAM,'MICHAEL','VINCENT','FREDO','TONY')",
                 "UUID =~ '^[CS].*' AND filter:matchesAtLeastCountOf(3,NAME,'MICHAEL','VINCENT','FRED','TONY')"};
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE"), Arrays.asList()};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CORLEONE"), Collections.emptyList()};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -244,15 +267,15 @@ public abstract class CompositeFunctionsTest {
         // @formatter:off
         String[] queryStrings = {
                 "UUID =~ '^[CS].*' AND filter:matchesAtLeastCountOf(3,NAM,'MICHAEL','VINCENT','FREDO','TONY') "+
-                        "AND filter:options('include.grouping.context','true','hit.list','true')",
+                        "AND filter:options('type.metadata.in.hdfs','true','include.grouping.context','true','hit.list','true')",
 
                 "UUID =~ '^[CS].*' AND filter:matchesAtLeastCountOf(3,NAME,'MICHAEL','VINCENT','FRED','TONY') "+
-                        "AND filter:options('include.grouping.context','true','hit.list','true')"
+                        "AND filter:options('type.metadata.in.hdfs','true','include.grouping.context','true','hit.list','true')"
         };
         // @formatter:on
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE"), Arrays.asList()};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CORLEONE"), Collections.emptyList()};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -273,8 +296,8 @@ public abstract class CompositeFunctionsTest {
                 "(UUID:C* OR UUID:S*) AND #TIME_FUNCTION(DEATH_DATE,BIRTH_DATE,'-','>','2522880000000L')",};
         // timeFunction(Object time1, Object time2, String operatorString, String equalityString, long goal)
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CAPONE"), Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("CAPONE"),
-                Arrays.asList("CAPONE"),};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CAPONE"), Arrays.asList("CORLEONE", "CAPONE"),
+                Collections.singletonList("CAPONE"), Collections.singletonList("CAPONE"),};
         for (int i = 0; i < queryStrings.length; i++) {
             if (i == 3) {
                 logic.setParser(new LuceneToJexlQueryParser());
@@ -284,7 +307,7 @@ public abstract class CompositeFunctionsTest {
     }
     
     @Test
-    public void makeSureTheyCannotDoAnythingCrazy() throws Exception {
+    public void testAgainstUnsupportedCompositeStructures() {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
@@ -296,7 +319,7 @@ public abstract class CompositeFunctionsTest {
                 "UUID == 'CORLEONE' AND  filter:getAllMatches(NAME,'SANTINO').clear() == false",};
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList(), Arrays.asList()};
+        List<String>[] expectedLists = new List[] {Collections.emptyList(), Collections.emptyList()};
         for (int i = 0; i < queryStrings.length; i++) {
             try {
                 runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
@@ -308,7 +331,7 @@ public abstract class CompositeFunctionsTest {
     }
     
     @Test
-    public void testWithIndexOnlyFieldsAndModelExpansion() throws Exception {
+    public void testWithIndexOnlyFieldsAndModelExpansion() {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
@@ -326,8 +349,8 @@ public abstract class CompositeFunctionsTest {
         };
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CAPONE"), Arrays.asList("CORLEONE"), Arrays.asList("CORLEONE", "SOPRANO"),
-                Arrays.asList("CAPONE"), Arrays.asList("CORLEONE"),};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CAPONE"), Collections.singletonList("CORLEONE"),
+                Arrays.asList("CORLEONE", "SOPRANO"), Collections.singletonList("CAPONE"), Collections.singletonList("CORLEONE"),};
         for (int i = 0; i < queryStrings.length; i++) {
             try {
                 runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
@@ -353,8 +376,9 @@ public abstract class CompositeFunctionsTest {
                 "UUID == 'CORLEONE' AND filter:getAllMatches(NAM,'hubert').size() == 0",};
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE"), Arrays.asList("CORLEONE"), Arrays.asList("CORLEONE"), Arrays.asList(),
-                Arrays.asList(), Arrays.asList(), Arrays.asList("CORLEONE"), Arrays.asList("CORLEONE"),};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CORLEONE"), Collections.singletonList("CORLEONE"),
+                Collections.singletonList("CORLEONE"), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                Collections.singletonList("CORLEONE"), Collections.singletonList("CORLEONE"),};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -382,12 +406,12 @@ public abstract class CompositeFunctionsTest {
                 "UUID =~ '^[CS].*' AND filter:isNull(UUID) && filter:isNull(NULL1)"};
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList(),
+        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Collections.emptyList(),
                 Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"),
-                Arrays.asList(), Arrays.asList(),
+                Collections.emptyList(), Collections.emptyList(),
                 
-                Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList(), Arrays.asList(),
-                Arrays.asList(),};
+                Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyList(),};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -416,11 +440,11 @@ public abstract class CompositeFunctionsTest {
                 "UUID =~ '^[CS].*' AND filter:isNotNull(UUID||NULL1)", "UUID =~ '^[CS].*' AND filter:isNotNull(ONE_NULL)",};
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList(), Arrays.asList(), Arrays.asList(),
-                Arrays.asList(), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"),
-                Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"),
+        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyList(), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"),
+                Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"),
                 
-                Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList(), Arrays.asList(), Arrays.asList(),
+                Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                 Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"), Arrays.asList("CORLEONE", "CAPONE", "SOPRANO"),};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
@@ -441,7 +465,7 @@ public abstract class CompositeFunctionsTest {
                 "UUID =~ '^[CS].*' AND filter:includeRegex(NAM,'MICHAEL').size() + filter:includeRegex(NAM,'VINCENT').size() + filter:includeRegex(NAM,'FRED').size() + filter:includeRegex(NAM,'TONY').size() >= 3"};
         
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE"), Arrays.asList()};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CORLEONE"), Collections.emptyList()};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -467,10 +491,11 @@ public abstract class CompositeFunctionsTest {
         
         @SuppressWarnings("unchecked")
         List<String>[] expectedLists = new List[] {
-                Arrays.asList("SOPRANO"), // family name starts with C or S
-                Arrays.asList("SOPRANO"), // family name starts with C or S
-                Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("CORLEONE"),
-                Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("SOPRANO"), Arrays.asList("SOPRANO"), Arrays.asList("CORLEONE")};
+                Collections.singletonList("SOPRANO"), // family name starts with C or S
+                Collections.singletonList("SOPRANO"), // family name starts with C or S
+                Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("CORLEONE", "CAPONE"), Arrays.asList("CORLEONE", "CAPONE"),
+                Collections.singletonList("CORLEONE"), Arrays.asList("CORLEONE", "CAPONE"), Collections.singletonList("SOPRANO"),
+                Collections.singletonList("SOPRANO"), Collections.singletonList("CORLEONE")};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -487,7 +512,7 @@ public abstract class CompositeFunctionsTest {
         }
         String[] queryStrings = {"(UUID:C* OR UUID:S*) AND #MATCHES_AT_LEAST_COUNT_OF('3',NAM,'MICHAEL','VINCENT','FREDO','TONY')",};
         @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Arrays.asList("CORLEONE"),};
+        List<String>[] expectedLists = new List[] {Collections.singletonList("CORLEONE"),};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -511,11 +536,11 @@ public abstract class CompositeFunctionsTest {
                 "UUID:CORLEONE AND #JEXL(\"filter:getAllMatches(NAM,'SANTINO').size() == 1\")"};
         @SuppressWarnings("unchecked")
         List<String>[] expectedLists = new List[] {Arrays.asList("CAPONE", "CORLEONE"), // family name starts with 'C'
-                Arrays.asList("SOPRANO"), // family name is SOPRANO
+                Collections.singletonList("SOPRANO"), // family name is SOPRANO
                 Arrays.asList("SOPRANO", "CORLEONE", "CAPONE"), // family name starts with C or S
-                Arrays.asList("CORLEONE"), // family has child CONSTANZIA
+                Collections.singletonList("CORLEONE"), // family has child CONSTANZIA
                 Arrays.asList("CORLEONE", "CAPONE"), // family has child MICHAEL
-                Arrays.asList("CORLEONE"), Arrays.asList("CORLEONE")};
+                Collections.singletonList("CORLEONE"), Collections.singletonList("CORLEONE")};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -542,12 +567,12 @@ public abstract class CompositeFunctionsTest {
         @SuppressWarnings("unchecked")
         List<String>[] expectedLists = new List[] {
                 Arrays.asList("CAPONE", "CORLEONE"), // family name starts with 'C'
-                Arrays.asList("SOPRANO"), // family name is SOPRANO
+                Collections.singletonList("SOPRANO"), // family name is SOPRANO
                 Arrays.asList("SOPRANO", "CORLEONE", "CAPONE"), // family name starts with C or S
-                Arrays.asList("CORLEONE"), // family has child CONSTANZIA
+                Collections.singletonList("CORLEONE"), // family has child CONSTANZIA
                 Arrays.asList("CORLEONE", "CAPONE"), // family has child MICHAEL
-                Arrays.asList("CORLEONE"),
-                Arrays.asList("CORLEONE")
+                Collections.singletonList("CORLEONE"),
+                Collections.singletonList("CORLEONE")
         };
         // @formatter:on
         for (int i = 0; i < queryStrings.length; i++) {
@@ -556,7 +581,7 @@ public abstract class CompositeFunctionsTest {
     }
     
     @Test
-    public void testRightOf() throws Exception {
+    public void testRightOf() {
         String[] inputs = {"NAME.grandparent_0.parent_0.child_0", "NAME.grandparent_0.parent_0.child_0",
                 "NAME.gggparent.ggparent.grandparent_0.parent_0.child_0",};
         String[] expected = {"child_0", "parent_0.child_0", "ggparent.grandparent_0.parent_0.child_0",};

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
@@ -270,12 +270,16 @@ public abstract class CompositeFunctionsTest {
                         "AND filter:options('type.metadata.in.hdfs','true','include.grouping.context','true','hit.list','true')",
 
                 "UUID =~ '^[CS].*' AND filter:matchesAtLeastCountOf(3,NAME,'MICHAEL','VINCENT','FRED','TONY') "+
-                        "AND filter:options('type.metadata.in.hdfs','true','include.grouping.context','true','hit.list','true')"
+                        "OR filter:options('type.metadata.in.hdfs','true','include.grouping.context','true','hit.list','true')"
+        };
+
+        @SuppressWarnings("unchecked")
+        List<String>[] expectedLists = new List[] {
+                Collections.singletonList("CORLEONE"),
+                Collections.emptyList()
         };
         // @formatter:on
         
-        @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {Collections.singletonList("CORLEONE"), Collections.emptyList()};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
@@ -253,6 +253,19 @@ public abstract class HitsAreAlwaysIncludedTest {
     }
     
     @Test
+    public void testHitForIndexedQueryTermWithOptionsInQueryFunction() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        String queryString = "FOO_3_BAR == 'defg<cat>' and filter:options('include.grouping.context', 'true', "
+                        + "'hit.list', 'true', 'limit.fields', 'FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3')";
+        
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
+                        "FOO_1.FOO.1.3:good");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+    @Test
     public void testHitForIndexedQueryOnUnrealmed() throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");


### PR DESCRIPTION
 Changes to be committed:
	modified:   warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
	modified:   warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
	new file:   warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
	modified:   warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
	new file:   warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
	modified:   warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
	modified:   warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
	modified:   warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java