### PR TITLE
Fix for FileRuleWatcher where path to file in hdfs not loaded correctly

### DIFF
--- a/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
+++ b/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
@@ -252,11 +252,10 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
     private Collection<? extends RuleConfig> loadParentRuleConfigs(Node parent) throws IOException {
         Collection<RuleConfig> rules = new ArrayList<>();
         String parentPathStr = parent.getTextContent();
-        URL resource = this.getClass().getResource(parentPathStr);
-        if (resource == null) {
-            throw new IllegalArgumentException("Invalid parent config path specified, resource " + parentPathStr + " not found!");
+        if (null == parentPathStr || parentPathStr.isEmpty()) {
+            throw new IllegalArgumentException("Invalid parent config path, none specified!");
         }
-        Path parentPath = new Path(resource.toString());
+        Path parentPath = new Path(parentPathStr);
         if (!fs.exists(parentPath)) {
             throw new IllegalArgumentException("Invalid parent config path specified, " + parentPathStr + " does not exist!");
         }


### PR DESCRIPTION
Previously used this.getClass.getResource() to look up file.  This will
not necessarily resolve files with hdfs:// prefixes, which results in an
unintended IllegalArgumentException