### PR TITLE
File rule watcher load path fix

### DIFF
--- a/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
+++ b/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
@@ -252,11 +252,10 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
     private Collection<? extends RuleConfig> loadParentRuleConfigs(Node parent) throws IOException {
         Collection<RuleConfig> rules = new ArrayList<>();
         String parentPathStr = parent.getTextContent();
-        URL resource = this.getClass().getResource(parentPathStr);
-        if (resource == null) {
-            throw new IllegalArgumentException("Invalid parent config path specified, resource " + parentPathStr + " not found!");
+        if (null == parentPathStr || parentPathStr.isEmpty()) {
+            throw new IllegalArgumentException("Invalid parent config path, none specified!");
         }
-        Path parentPath = new Path(resource.toString());
+        Path parentPath = new Path(parentPathStr);
         if (!fs.exists(parentPath)) {
             throw new IllegalArgumentException("Invalid parent config path specified, " + parentPathStr + " does not exist!");
         }

--- a/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
+++ b/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileRuleWatcher.java
@@ -252,8 +252,16 @@ public class FileRuleWatcher extends FileSystemWatcher<Collection<FilterRule>> {
     private Collection<? extends RuleConfig> loadParentRuleConfigs(Node parent) throws IOException {
         Collection<RuleConfig> rules = new ArrayList<>();
         String parentPathStr = parent.getTextContent();
+        
         if (null == parentPathStr || parentPathStr.isEmpty()) {
             throw new IllegalArgumentException("Invalid parent config path, none specified!");
+        }
+        // look for file on classpath first
+        URL resource = this.getClass().getResource(parentPathStr);
+        // if found, update path to fully qualified version, other wise try to use the provided path
+        // as it may be resolvable outside of the class path i.e. hdfs:///path/to/the/parent.xml
+        if (null != resource) {
+            parentPathStr = resource.toString();
         }
         Path parentPath = new Path(parentPathStr);
         if (!fs.exists(parentPath)) {

--- a/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleFieldMergeTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleFieldMergeTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -42,6 +44,18 @@ public class FileRuleFieldMergeTest {
         assertThat(isIndexTable(parentFilter), is(false));
         
         assertThat(isIndexTable(childFilter), is(true));
+    }
+    
+    @Test
+    public void verifyInheritedParentConfigs() throws IOException {
+        // parent config fields
+        // <fields>alpha,beta,gamma,delta</fields>
+        // since child is index config, field should be in the column family
+        Key key = new Key("row", "alpha", "cq", "vis", 0);
+        assertThat(childFilter.accept(key, new Value()), is(false));
+        
+        key = new Key("row", "beta", "cq", "vis", Long.MAX_VALUE);
+        assertThat(childFilter.accept(key, new Value()), is(true));
     }
     
     private Boolean isIndexTable(TestFieldFilter filter) {

--- a/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleLoadContentsMergeFiltersTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/FileRuleLoadContentsMergeFiltersTest.java
@@ -116,8 +116,10 @@ public class FileRuleLoadContentsMergeFiltersTest {
         // the time check is ts > cutoffTimestamp, so + 1 will let exact offsetInDays to pass this
         long timestamp = anchorTime - (offsetInDays * MILLIS_IN_DAY) + 1;
         Key key = TestTrieFilter.create(data, timestamp);
-        assertThat(failedExpectationMessage(data, offsetInDays, expectation), filter.accept(filterOptions.getAgeOffPeriod(anchorTime), key, value),
-                        is(expectation));
+        // @formatter:off
+        assertThat(failedExpectationMessage(data, offsetInDays, expectation),
+            filter.accept(filterOptions.getAgeOffPeriod(anchorTime), key, value), is(expectation));
+        // @formatter:on
     }
     
     private String failedExpectationMessage(String data, long offsetInDays, boolean expectation) {

--- a/warehouse/core/src/test/resources/test-customized-data-type.xml
+++ b/warehouse/core/src/test/resources/test-customized-data-type.xml
@@ -1,5 +1,5 @@
 <ageoffConfiguration>
-	<parent>/test-root-data-type.xml</parent>
+	<parent>test-root-data-type.xml</parent>
 	<rules>
 		<rule label="test" mode="merge">
 			<filterClass>datawave.ingest.util.cache.watch.TestDataTypeFilter</filterClass>

--- a/warehouse/core/src/test/resources/test-customized-field.xml
+++ b/warehouse/core/src/test/resources/test-customized-field.xml
@@ -1,6 +1,8 @@
 <ageoffConfiguration>
+    <parent>test-root-field.xml</parent>
     <rules>
-        <rule label="test">
+        <!-- we want to inherit all of the extended options so we need mode="merge" -->
+        <rule label="test" mode="merge">
             <filterClass>datawave.ingest.util.cache.watch.TestFieldFilter</filterClass>
             <isindextable>true</isindextable>
         </rule>

--- a/warehouse/core/src/test/resources/test-customized-rules.xml
+++ b/warehouse/core/src/test/resources/test-customized-rules.xml
@@ -1,5 +1,5 @@
 <ageoffConfiguration>
-    <parent>/test-root-rules.xml</parent>
+    <parent>test-root-rules.xml</parent>
     <rules>
     	<!-- by specifying merge mode the match patterns of any rules with the 
     		same labels will be concatenated -->

--- a/warehouse/core/src/test/resources/test-root-field.xml
+++ b/warehouse/core/src/test/resources/test-root-field.xml
@@ -3,7 +3,7 @@
         <rule label="test">
             <filterClass>datawave.ingest.util.cache.watch.TestFieldFilter</filterClass>
             <ttl units="ms">90</ttl>
-            <matchPattern>greek</matchPattern>
+            <matchPattern>vis</matchPattern>
             <fields>alpha,beta,gamma,delta</fields>
         </rule>
     </rules>


### PR DESCRIPTION
Fix now works with hdfs:/// and classpath based URLs.  Verified unit tests are passing once again.