### PR TITLE
Fix NullPointerException in EventMapper when Event rawData field is null

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/EventMapper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/EventMapper.java
@@ -398,15 +398,17 @@ public class EventMapper<K1,V1 extends RawRecordContainer,K2,V2> extends StatsDE
         boolean reprocessedNDCPush = false;
         
         byte[] rawData = value.getRawData();
-        long rawDataBytes = rawData.length;
-        getCounter(context, IngestInput.LINE_BYTES.toString(), "TOTAL").increment(rawDataBytes);
-        long minBytes = getCounter(context, IngestInput.LINE_BYTES.toString(), "MIN").getValue();
-        if (rawDataBytes < minBytes) {
-            getCounter(context, IngestInput.LINE_BYTES.toString(), "MIN").setValue(rawDataBytes);
-        }
-        long maxBytes = getCounter(context, IngestInput.LINE_BYTES.toString(), "MAX").getValue();
-        if (rawDataBytes > maxBytes) {
-            getCounter(context, IngestInput.LINE_BYTES.toString(), "MAX").setValue(rawDataBytes);
+        if (rawData != null) {
+            long rawDataBytes = rawData.length;
+            getCounter(context, IngestInput.LINE_BYTES.toString(), "TOTAL").increment(rawDataBytes);
+            long minBytes = getCounter(context, IngestInput.LINE_BYTES.toString(), "MIN").getValue();
+            if (rawDataBytes < minBytes) {
+                getCounter(context, IngestInput.LINE_BYTES.toString(), "MIN").setValue(rawDataBytes);
+            }
+            long maxBytes = getCounter(context, IngestInput.LINE_BYTES.toString(), "MAX").getValue();
+            if (rawDataBytes > maxBytes) {
+                getCounter(context, IngestInput.LINE_BYTES.toString(), "MAX").setValue(rawDataBytes);
+            }
         }
         
         // First lets clear this event from the error table if we are reprocessing a previously errored event

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
@@ -58,6 +58,21 @@ public class EventMapperTest {
     }
     
     @Test
+    public void shouldHandleNullRawData() throws IOException {
+        // some RecordReaders may null out raw data entirely because they pass data to their
+        // handlers in other ways. Verify that the EventMapper can handle this case.
+        record.setRawData(null);
+        
+        driver.setInput(new LongWritable(1), record);
+        driver.run();
+        
+        Multimap<BulkIngestKey,Value> written = TestContextWriter.getWritten();
+        
+        // two fields mutations + LOAD_DATE + ORIG_FILE + RAW_FILE
+        assertEquals(5, written.size());
+    }
+    
+    @Test
     public void shouldNotWriteMetricsByDefault() throws IOException {
         driver.setInput(new LongWritable(1), record);
         driver.run();

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
@@ -30,7 +30,7 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
     private String rawFileName = "";
     private long rawRecordNumber = 0;
     private long rawRecordTimestamp = 0;
-    private byte[] rawData = new byte[0];
+    private byte[] rawData = null;
     private Object auxData;
     private ColumnVisibility visibility;
     
@@ -224,8 +224,12 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
         dataOutput.writeLong(rawRecordNumber);
         dataOutput.writeLong(rawRecordTimestamp);
         
-        dataOutput.writeInt(rawData.length);
-        dataOutput.write(rawData);
+        if (rawData == null) {
+            dataOutput.writeInt(0);
+        } else {
+            dataOutput.writeInt(rawData.length);
+            dataOutput.write(rawData);
+        }
         
         // skipping auxData and visibility for now
     }
@@ -248,8 +252,13 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
         rawRecordTimestamp = dataInput.readLong();
         
         int len = dataInput.readInt();
-        rawData = new byte[len];
-        dataInput.readFully(rawData);
+        if (len > 0) {
+            rawData = new byte[len];
+            dataInput.readFully(rawData);
+        }
+        else {
+            rawData = null;
+        }
     }
     
     @Override


### PR DESCRIPTION
Some RecordReaders may generate Events with null raw data fields because they pass data to their handlers in other ways. Fix the EventMapper so that it can properly handle the case where an Event's raw data field is null.