### PR TITLE
audit-service was pulling in some dependencies from audit-api version…

### DIFF
--- a/services/audit-service/pom.xml
+++ b/services/audit-service/pom.xml
@@ -11,8 +11,8 @@
     <version>1.5-SNAPSHOT</version>
     <description>DATAWAVE Auditing Microservice</description>
     <properties>
-        <version.in-memory-accumulo>1.8.1</version.in-memory-accumulo>
-        <version.microservice.audit-api>1.3</version.microservice.audit-api>
+        <version.in-memory-accumulo>1.9.2</version.in-memory-accumulo>
+        <version.microservice.audit-api>1.4-SNAPSHOT</version.microservice.audit-api>
         <version.microservice.starter>1.2</version.microservice.starter>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
audit-api version 1.3 caused audit-service to include Accumulo 1.8.1 jars that failed some tests