### PR TITLE
Case independent token field

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
@@ -148,7 +148,7 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
             String field = fieldNode.getFieldAsString();
             
             // treat these fields as unfielded and skip tokenization if enabled.
-            if (skipTokenizeUnfieldedFields.contains(field)) {
+            if (skipTokenizeUnfieldedFields.contains(field.toUpperCase())) {
                 fieldNode.setField("");
                 
                 if (logger.isDebugEnabled()) {
@@ -158,7 +158,7 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                 return fieldNode;
             }
             
-            if ((tokenizedFields.contains(field) || (unfieldedTokenized && field.isEmpty()))) {
+            if ((tokenizedFields.contains(field.toUpperCase()) || (unfieldedTokenized && field.isEmpty()))) {
                 node = tokenizeNode(node, text, field);
             }
             

--- a/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
@@ -96,12 +96,12 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
         }
         
         if (getQueryConfigHandler().has(LuceneToJexlQueryParser.TOKENIZED_FIELDS)) {
-            tokenizedFields.addAll(getQueryConfigHandler().get(LuceneToJexlQueryParser.TOKENIZED_FIELDS));
+            getQueryConfigHandler().get(LuceneToJexlQueryParser.TOKENIZED_FIELDS).stream().forEach(s -> tokenizedFields.add(s.toUpperCase()));
         }
         
         if (getQueryConfigHandler().has(LuceneToJexlQueryParser.SKIP_TOKENIZE_UNFIELDED_FIELDS)) {
             skipTokenizeUnfieldedFields.clear();
-            skipTokenizeUnfieldedFields.addAll(getQueryConfigHandler().get(LuceneToJexlQueryParser.SKIP_TOKENIZE_UNFIELDED_FIELDS));
+            getQueryConfigHandler().get(LuceneToJexlQueryParser.SKIP_TOKENIZE_UNFIELDED_FIELDS).stream().forEach(s -> skipTokenizeUnfieldedFields.add(s.toUpperCase()));
         }
         
         if (getQueryConfigHandler().has(LuceneToJexlQueryParser.TOKENIZE_UNFIELDED_QUERIES)) {

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -18,6 +18,7 @@ public class TestLuceneToJexlQueryParser {
     @Before
     public void setUp() {
         parser = new LuceneToJexlQueryParser();
+        parser.setSkipTokenizeUnfieldedFields(Sets.newHashSet("NOTOKEN"));
         parser.setTokenizedFields(Sets.newHashSet("TOKFIELD"));
     }
     
@@ -212,6 +213,8 @@ public class TestLuceneToJexlQueryParser {
     public void testSkipTokenizedFields() throws ParseException {
         parser.setTokenizeUnfieldedQueries(false);
         Assert.assertEquals(Constants.ANY_FIELD + " == '5678 1234 to bird'", parseQuery("NOTOKEN:5678\\ 1234\\ to\\ bird"));
+        // test for case independence of field name
+        Assert.assertEquals(Constants.ANY_FIELD + " == '5678 1234 to bird'", parseQuery("notoken:5678\\ 1234\\ to\\ bird"));
     }
     
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -251,11 +251,12 @@ public class TestLuceneToJexlQueryParser {
     public void testPhrases() throws ParseException {
         Assert.assertEquals("content:phrase(termOffsetMap, 'quick', 'brown', 'fox')", parseQuery("\"quick brown fox\""));
         Assert.assertEquals("content:within(TOKFIELD, 3, termOffsetMap, 'quick', 'brown', 'fox')", parseQuery("TOKFIELD:\"quick brown fox\""));
-
-        // testing case independence of "TOKFIELD"  This would return content:phrase if it were not case independent
+        
+        // testing case independence of "TOKFIELD" This would return content:phrase if it were not case independent
         Assert.assertEquals("content:within(tokfield, 3, termOffsetMap, 'quick', 'brown', 'fox')", parseQuery("tokfield:\"quick brown fox\""));
-
-        Assert.assertEquals("TOKFIELD == 'value' && content:phrase(termOffsetMap, 'quick', 'brown', 'fox')", parseQuery("TOKFIELD:value AND \"quick brown fox\""));
+        
+        Assert.assertEquals("TOKFIELD == 'value' && content:phrase(termOffsetMap, 'quick', 'brown', 'fox')",
+                        parseQuery("TOKFIELD:value AND \"quick brown fox\""));
         Assert.assertEquals(anyField + " == 'quick'", parseQuery("\"quick\""));
         Assert.assertEquals("content:phrase(termOffsetMap, 'qui.ck', 'brown', 'fox')", parseQuery("\"qui\\.ck brown fox\""));
         
@@ -519,6 +520,5 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo\\ Foo.*'", parser.parse("FOO:bar BAZ:/Foo\\/Foo\\ Foo.*/").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo Foo.*?'", parser.parse("FOO:bar BAZ:/Foo\\/Foo Foo.*?/").getOriginalQuery());
     }
-
-
+    
 }

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -18,8 +18,8 @@ public class TestLuceneToJexlQueryParser {
     @Before
     public void setUp() {
         parser = new LuceneToJexlQueryParser();
-        parser.setSkipTokenizeUnfieldedFields(Sets.newHashSet("NOTOKEN"));
-        parser.setTokenizedFields(Sets.newHashSet("TOKFIELD"));
+        parser.setSkipTokenizeUnfieldedFields(Sets.newHashSet("noToken"));
+        parser.setTokenizedFields(Sets.newHashSet("tokField"));
     }
     
     private static final String anyField = Constants.ANY_FIELD;


### PR DESCRIPTION
This change is to ensure we can handle lower case field names for tokenized and non-tokenized fields.