### PR TITLE
Fixes issue introduced in #257 and test that would have caught it

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
@@ -200,7 +200,7 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                 return node;
             } else if (FuzzyQueryNode.class.isAssignableFrom(nodeClazz)) {
                 return node;
-            } else if (node.getParent() != null && TermRangeQueryNode.class.isAssignableFrom(nodeClazz)) {
+            } else if (node.getParent() != null && TermRangeQueryNode.class.isAssignableFrom(node.getParent().getClass())) {
                 // Ignore children of TermReangeQueryNodes (for now)
                 return node;
             }
@@ -342,6 +342,8 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
                 }
                 
                 // Only add slop if the original had slop, or the original was not a phrase and slop is enabled.
+                // Using slop for non-quoted terms is a workaround until the phrase function will accept multiple
+                // terms in the same position as a valid match.
                 boolean originalWasQuoted = QuotedFieldQueryNode.class.isAssignableFrom(node.getClass());
                 if ((useSlopForTokenizedTerms && !originalWasQuoted) || originalSlop > 0) {
                     n = new SlopQueryNode(n, slopRange);

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -8,7 +8,6 @@ import datawave.query.Constants;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestLuceneToJexlQueryParser {
@@ -344,15 +343,12 @@ public class TestLuceneToJexlQueryParser {
     }
     
     @Test
-    @Ignore
     public void testMiscEscapeTokenization() throws ParseException {
         // apostrophe escapes
-        Assert.assertEquals("(TOKFIELD == 'johnny\\'s' || TOKFIELD == 'johnny')", parseQuery("TOKFIELD:johnny's"));
-        Assert.assertEquals("(TOKFIELD == 'johnny\\'s' || TOKFIELD == 'johnny')", parseQuery("TOKFIELD:johnny\\'s")); // lucene drops single slash
-        Assert.assertEquals("(TOKFIELD == 'johnny\\'s' || TOKFIELD == 'johnny')", parseQuery("TOKFIELD:\"johnny's\""));
-        Assert.assertEquals(
-                        "(content:phrase(TOKFIELD, termOffsetMap, 'johnny\\'s', 'chicken') || content:within(TOKFIELD, 2, termOffsetMap, 'johnny', 'chicken'))",
-                        parseQuery("TOKFIELD:\"johnny's chicken\""));
+        Assert.assertEquals("TOKFIELD == 'johnny\\'s'", parseQuery("TOKFIELD:johnny's"));
+        Assert.assertEquals("TOKFIELD == 'johnny\\'s'", parseQuery("TOKFIELD:johnny\\'s")); // lucene drops single slash
+        Assert.assertEquals("TOKFIELD == 'johnny\\'s'", parseQuery("TOKFIELD:\"johnny's\""));
+        Assert.assertEquals("content:phrase(TOKFIELD, termOffsetMap, 'johnny\\'s', 'chicken')", parseQuery("TOKFIELD:\"johnny's chicken\""));
         Assert.assertEquals("TOKFIELD =~ '11\\'22.*?'", parseQuery("TOKFIELD:11'22*"));
         Assert.assertEquals("(TOKFIELD >= 'A\\'\\u005c*' && TOKFIELD <= 'B\\'')", parseQuery("TOKFIELD:[A'\\\\\\* TO B']"));
         
@@ -360,19 +356,19 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("(TOKFIELD == 'joh.nny chicken' || content:within(TOKFIELD, 2, termOffsetMap, 'joh.nny', 'chicken'))",
                         parseQuery("TOKFIELD:joh.nny\\ chicken"));
         Assert.assertEquals("TOKFIELD =~ 'joh\\u005c.nny chick.*?'", parseQuery("TOKFIELD:joh.nny\\ chick*"));
-        Assert.assertEquals("(TOKFIELD == 'joh.nny chicken' || content:within(TOKFIELD, 2, termOffsetMap, 'joh.nny', 'chicken'))",
+        Assert.assertEquals("(TOKFIELD == 'joh.nny chicken' || content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chicken'))",
                         parseQuery("TOKFIELD:\"joh.nny\\ chicken\""));
         
         Assert.assertEquals(
-                        "(content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chic ken') || content:within(TOKFIELD, 3, termOffsetMap, 'joh.nny', 'chic', 'ken'))",
+                        "(content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chic ken') || content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chic', 'ken'))",
                         parseQuery("TOKFIELD:\"joh.nny chic\\ ken\""));
         Assert.assertEquals(
-                        "(content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chic k*') || content:within(TOKFIELD, 3, termOffsetMap, 'joh.nny', 'chic', 'k'))",
+                        "(content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chic k*') || content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chic', 'k'))",
                         parseQuery("TOKFIELD:\"joh.nny chic\\ k*\""));
         
         // quote escapes
         Assert.assertEquals(
-                        "(content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', '\"chicken\"') || content:within(TOKFIELD, 2, termOffsetMap, 'joh.nny', 'chicken'))",
+                        "(content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', '\"chicken\"') || content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chicken'))",
                         parseQuery("TOKFIELD:\"joh.nny \\\"chicken\\\"\""));
         
         // unicode escapes.
@@ -383,7 +379,7 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("(TOKFIELD == 'someone\\u005c234someplace.com' || content:within(TOKFIELD, 2, termOffsetMap, 'someone', '234someplace.com'))",
                         parseQuery("TOKFIELD:someone\\\\234someplace.com"));
         Assert.assertEquals(
-                        "(content:phrase(TOKFIELD, termOffsetMap, 'someone\\u005c234someplace.com', 'otherterm') || content:within(TOKFIELD, 3, termOffsetMap, 'someone', '234someplace.com', 'otherterm'))",
+                        "(content:phrase(TOKFIELD, termOffsetMap, 'someone\\u005c234someplace.com', 'otherterm') || content:phrase(TOKFIELD, termOffsetMap, 'someone', '234someplace.com', 'otherterm'))",
                         parseQuery("TOKFIELD:\"someone\\\\234someplace.com otherterm\""));
         // FIX THIS, trailing slashes in queries should be acceptable.
         // Assert.assertEquals("(TOKFIELD == 'someone\\u005c234someplace.com\\u005c' || content:within(TOKFIELD, 2, termOffsetMap, 'someone',


### PR DESCRIPTION
This Slop Query Parsing fix in #257 had an implementation bug that wasn't caught because the unit test that would have caught it was set to Ignore. Removed Ignore, fixed the test and fixed the underlying implementation issue.