### PR TITLE
fixes #309: #TEXT function

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -217,7 +217,7 @@ public class EvaluationPhaseFilterFunctions {
         return FunctionalSet.unmodifiableSet(matches);
     }
     
-    // Evaluate a regex. Note this is being done against the un-normalized value.
+    // Evaluate a regex. Note this is being done against the un-normalized value unless the regex is not case sensitive.
     public static FunctionalSet<ValueTuple> includeRegex(Object fieldValue, String regex) {
         FunctionalSet<ValueTuple> matches = FunctionalSet.emptySet();
         if (fieldValue != null
@@ -228,7 +228,7 @@ public class EvaluationPhaseFilterFunctions {
         return matches;
     }
     
-    // Evaluate a regex. Note this is being done against the un-normalized value.
+    // Evaluate a regex. Note this is being done against the un-normalized value unless the regex is not case sensitive.
     public static FunctionalSet<ValueTuple> includeRegex(Iterable<?> values, String regex) {
         FunctionalSet<ValueTuple> matches = FunctionalSet.emptySet();
         // Important to note that a regex of ".*" still requires
@@ -314,6 +314,34 @@ public class EvaluationPhaseFilterFunctions {
     
     public static FunctionalSet<ValueTuple> getAllMatches(Object fieldValue, String regex) {
         return includeRegex(fieldValue, regex);
+    }
+    
+    // Evaluate text. Note this is being done against the un-normalized value.
+    public static FunctionalSet<ValueTuple> includeText(Object fieldValue, String valueToMatch) {
+        FunctionalSet<ValueTuple> matches = FunctionalSet.emptySet();
+        if (fieldValue != null && ValueTuple.getStringValue(fieldValue).equals(valueToMatch)) {
+            matches = FunctionalSet.singleton(getHitTerm(fieldValue));
+        }
+        return matches;
+    }
+    
+    // Evaluate text. Note this is being done against the un-normalized value.
+    public static FunctionalSet<ValueTuple> includeText(Iterable<?> values, String valueToMatch) {
+        FunctionalSet<ValueTuple> matches = FunctionalSet.emptySet();
+        if (null == values) {
+            return matches;
+        }
+        
+        for (Object value : values) {
+            if (null == value)
+                continue;
+            
+            if (ValueTuple.getStringValue(value).equals(valueToMatch)) {
+                matches = FunctionalSet.singleton(getHitTerm(value));
+                return matches;
+            }
+        }
+        return matches;
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
@@ -19,6 +19,7 @@ import datawave.query.util.DateIndexHelper;
 import datawave.query.util.MetadataHelper;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.commons.jexl2.parser.ASTEQNode;
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
 import org.apache.commons.jexl2.parser.ASTIdentifier;
 import org.apache.commons.jexl2.parser.ASTOrNode;
@@ -44,6 +45,7 @@ public class EvaluationPhaseFilterFunctionsDescriptor implements JexlFunctionArg
         private static final ImmutableSet<String> dateBetweenFunctions = ImmutableSet.of("betweenDates", "betweenLoadDates");
         private static final String MATCHCOUNTOF = "matchesAtLeastCountOf";
         private static final String TIMEFUNCTION = "timeFunction";
+        private static final String TEXT = "includeText";
         private final ASTFunctionNode node;
         
         public EvaluationPhaseFilterJexlArgumentDescriptor(ASTFunctionNode node) {
@@ -51,33 +53,105 @@ public class EvaluationPhaseFilterFunctionsDescriptor implements JexlFunctionArg
         }
         
         /**
-         * Returns 'true' because none of these functions should influence the index query.
+         * Returns 'true' for most of these functions because they are evaluation phase filter functions. However in a couple of special cases we add an index
+         * query: 1) betweenDates and betweenLoadDates: we add a SHARDS_AND_DAYS statement 2) text: we add the index query but the function does not use the
+         * indexed values
          */
         @Override
         public JexlNode getIndexQuery(ShardQueryConfiguration config, MetadataHelper helper, DateIndexHelper dateIndexHelper, Set<String> datatypeFilter) {
             FunctionJexlNodeVisitor functionMetadata = new FunctionJexlNodeVisitor();
             node.jjtAccept(functionMetadata, null);
+            // in the special case of the text function, add an index query.
             // in the special case of date functions and then only with the between methods,
             // we want to add a range stream hint in terms of SHARDS_AND_DAYS
-            if (dateBetweenFunctions.contains(functionMetadata.name()) && dateIndexHelper != null) {
-                try {
-                    List<JexlNode> arguments = functionMetadata.args();
-                    JexlNode node0 = arguments.get(0);
-                    final String beginArg = (arguments.size() == 5 ? arguments.get(2).image : arguments.get(1).image);
-                    final String endArg = (arguments.size() == 5 ? arguments.get(3).image : arguments.get(2).image);
-                    Date begin, end = null;
-                    if (arguments.size() >= 4) {
-                        String formatArg = arguments.get(arguments.size() - 1).image;
-                        DateFormat formatter = EvaluationPhaseFilterFunctions.newSimpleDateFormat(formatArg);
-                        begin = new Date(EvaluationPhaseFilterFunctions.getTime(beginArg, formatter));
-                        end = new Date(EvaluationPhaseFilterFunctions.getTime(endArg, formatter));
-                    } else {
-                        begin = new Date(EvaluationPhaseFilterFunctions.getTime(beginArg));
-                        end = new Date(EvaluationPhaseFilterFunctions.getTime(endArg));
+            if (TEXT.equals(functionMetadata.name())) {
+                return getTextIndexQuery(functionMetadata, config);
+            } else if (dateBetweenFunctions.contains(functionMetadata.name()) && dateIndexHelper != null) {
+                return getShardsAndDaysQuery(functionMetadata, config, helper, dateIndexHelper, datatypeFilter);
+            }
+            
+            // 'true' is returned to imply that there is no range lookup possible for this function
+            return TRUE_NODE;
+        }
+        
+        private JexlNode getTextIndexQuery(FunctionJexlNodeVisitor functionMetadata, ShardQueryConfiguration config) {
+            List<JexlNode> arguments = functionMetadata.args();
+            JexlNode node0 = arguments.get(0);
+            final String value = arguments.get(1).image;
+            if (node0 instanceof ASTIdentifier) {
+                
+                final String field = JexlASTHelper.deconstructIdentifier(node0.image);
+                
+                if (log.isDebugEnabled()) {
+                    log.debug("Evaluating text with " + field + ", " + value);
+                }
+                
+                return JexlNodeFactory.buildNode((ASTEQNode) null, field, value);
+            } else {
+                // node0 is an Or node or an And node
+                // copy it
+                JexlNode newParent = JexlNodeFactory.shallowCopy(node0);
+                int i = 0;
+                for (ASTIdentifier identifier : JexlASTHelper.getIdentifiers(node0)) {
+                    String field = JexlASTHelper.deconstructIdentifier(identifier.image);
+                    
+                    if (log.isDebugEnabled()) {
+                        log.debug("Evaluating text with " + field + ", " + value);
                     }
-                    if (node0 instanceof ASTIdentifier) {
-                        
-                        final String field = JexlASTHelper.deconstructIdentifier(node0.image);
+                    
+                    JexlNode kid = JexlNodeFactory.buildNode((ASTEQNode) null, field, value);
+                    
+                    kid.jjtSetParent(newParent);
+                    newParent.jjtAddChild(kid, i++);
+                }
+                return newParent;
+            }
+        }
+        
+        private JexlNode getShardsAndDaysQuery(FunctionJexlNodeVisitor functionMetadata, ShardQueryConfiguration config, MetadataHelper helper,
+                        DateIndexHelper dateIndexHelper, Set<String> datatypeFilter) {
+            try {
+                List<JexlNode> arguments = functionMetadata.args();
+                JexlNode node0 = arguments.get(0);
+                final String beginArg = (arguments.size() == 5 ? arguments.get(2).image : arguments.get(1).image);
+                final String endArg = (arguments.size() == 5 ? arguments.get(3).image : arguments.get(2).image);
+                Date begin, end = null;
+                if (arguments.size() >= 4) {
+                    String formatArg = arguments.get(arguments.size() - 1).image;
+                    DateFormat formatter = EvaluationPhaseFilterFunctions.newSimpleDateFormat(formatArg);
+                    begin = new Date(EvaluationPhaseFilterFunctions.getTime(beginArg, formatter));
+                    end = new Date(EvaluationPhaseFilterFunctions.getTime(endArg, formatter));
+                } else {
+                    begin = new Date(EvaluationPhaseFilterFunctions.getTime(beginArg));
+                    end = new Date(EvaluationPhaseFilterFunctions.getTime(endArg));
+                }
+                if (node0 instanceof ASTIdentifier) {
+                    
+                    final String field = JexlASTHelper.deconstructIdentifier(node0.image);
+                    
+                    if (log.isDebugEnabled()) {
+                        log.debug("Evaluating date index with " + field + ", [" + begin + "," + end + "], " + datatypeFilter);
+                    }
+                    String shardsAndDaysHint = dateIndexHelper.getShardsAndDaysHint(field, begin, end, config.getBeginDate(), config.getEndDate(),
+                                    datatypeFilter);
+                    // if we did not get any shards or days, then we have a field that is not indexed for the specified datatypes
+                    if (shardsAndDaysHint == null || shardsAndDaysHint.isEmpty()) {
+                        log.info("Found no index for field " + field + " and data types " + datatypeFilter);
+                        return TRUE_NODE;
+                    }
+                    // create an assignment node
+                    log.info("Found index for field " + field + " and data types " + datatypeFilter);
+                    if (log.isTraceEnabled()) {
+                        log.info("Found the following shards and days: " + shardsAndDaysHint);
+                    }
+                    return JexlNodeFactory.createExpression(JexlNodeFactory.createAssignment(Constants.SHARD_DAY_HINT, shardsAndDaysHint));
+                } else {
+                    // node0 is an Or node or an And node
+                    // copy it
+                    JexlNode newParent = JexlNodeFactory.shallowCopy(node0);
+                    int i = 0;
+                    for (ASTIdentifier identifier : JexlASTHelper.getIdentifiers(node0)) {
+                        String field = JexlASTHelper.deconstructIdentifier(identifier.image);
                         
                         if (log.isDebugEnabled()) {
                             log.debug("Evaluating date index with " + field + ", [" + begin + "," + end + "], " + datatypeFilter);
@@ -87,64 +161,41 @@ public class EvaluationPhaseFilterFunctionsDescriptor implements JexlFunctionArg
                         // if we did not get any shards or days, then we have a field that is not indexed for the specified datatypes
                         if (shardsAndDaysHint == null || shardsAndDaysHint.isEmpty()) {
                             log.info("Found no index for field " + field + " and data types " + datatypeFilter);
-                            return TRUE_NODE;
-                        }
-                        // create an assignment node
-                        log.info("Found index for field " + field + " and data types " + datatypeFilter);
-                        if (log.isTraceEnabled()) {
-                            log.info("Found the following shards and days: " + shardsAndDaysHint);
-                        }
-                        return JexlNodeFactory.createExpression(JexlNodeFactory.createAssignment(Constants.SHARD_DAY_HINT, shardsAndDaysHint));
-                    } else {
-                        // node0 is an Or node or an And node
-                        // copy it
-                        JexlNode newParent = JexlNodeFactory.shallowCopy(node0);
-                        int i = 0;
-                        for (ASTIdentifier identifier : JexlASTHelper.getIdentifiers(node0)) {
-                            String field = JexlASTHelper.deconstructIdentifier(identifier.image);
-                            
-                            if (log.isDebugEnabled()) {
-                                log.debug("Evaluating date index with " + field + ", [" + begin + "," + end + "], " + datatypeFilter);
+                            // if an or node, then basically we need to search the entire range
+                            if (newParent instanceof ASTOrNode) {
+                                return TRUE_NODE;
                             }
-                            String shardsAndDaysHint = dateIndexHelper.getShardsAndDaysHint(field, begin, end, config.getBeginDate(), config.getEndDate(),
-                                            datatypeFilter);
-                            // if we did not get any shards or days, then we have a field that is not indexed for the specified datatypes
-                            if (shardsAndDaysHint == null || shardsAndDaysHint.isEmpty()) {
-                                log.info("Found no index for field " + field + " and data types " + datatypeFilter);
-                                // if an or node, then basically we need to search the entire range
-                                if (newParent instanceof ASTOrNode) {
-                                    return TRUE_NODE;
-                                }
-                                // if an and node, then simply drop this one out of the mix
-                            } else {
-                                // create an assignment node
-                                log.info("Found index for field " + field + " and data types " + datatypeFilter);
-                                if (log.isTraceEnabled()) {
-                                    log.info("Found the following shards and days: " + shardsAndDaysHint);
-                                }
-                                JexlNode kid = JexlNodeFactory.createExpression(JexlNodeFactory.createAssignment(Constants.SHARD_DAY_HINT, shardsAndDaysHint));
-                                kid.jjtSetParent(newParent);
-                                newParent.jjtAddChild(kid, i++);
+                            // if an and node, then simply drop this one out of the mix
+                        } else {
+                            // create an assignment node
+                            log.info("Found index for field " + field + " and data types " + datatypeFilter);
+                            if (log.isTraceEnabled()) {
+                                log.info("Found the following shards and days: " + shardsAndDaysHint);
                             }
+                            JexlNode kid = JexlNodeFactory.createExpression(JexlNodeFactory.createAssignment(Constants.SHARD_DAY_HINT, shardsAndDaysHint));
+                            kid.jjtSetParent(newParent);
+                            newParent.jjtAddChild(kid, i++);
                         }
-                        return newParent;
-                        
                     }
-                } catch (ParseException e) {
-                    throw new IllegalArgumentException("Unable to parse dates from date function", e);
-                } catch (TableNotFoundException e) {
-                    // if we are missing the table, then lets assume the date index is simply not configured on this system
-                    log.warn("Missing date index, scanning entire range", e);
-                    return TRUE_NODE;
+                    return newParent;
+                    
                 }
+            } catch (ParseException e) {
+                throw new IllegalArgumentException("Unable to parse dates from date function", e);
+            } catch (TableNotFoundException e) {
+                // if we are missing the table, then lets assume the date index is simply not configured on this system
+                log.warn("Missing date index, scanning entire range", e);
+                return TRUE_NODE;
             }
-            
-            // 'true' is returned to imply that there is no range lookup possible for this function
-            return TRUE_NODE;
         }
         
         @Override
         public void addFilters(AttributeFactory attributeFactory, Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> filterMap) {
+            // only the text function actually returns an index query, so ignore this one
+            if (TEXT.equals(node.jjtGetChild(2).image)) {
+                return;
+            }
+            
             // Since the getIndexQuery does not supply actual filters on the fields, we need to add those filters here
             Set<String> queryFields = fields(null, null);
             // argument 0 (child 2) is the fieldname, argument 1 (child 3) is the regex

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctions.java
@@ -11,8 +11,8 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * NOTE: The JexlFunctionArgumentDescriptorFactory is implemented by GeoFunctionsDescriptor. This is kept as a separate class to reduce accumulo dependencies on
- * other jars.
+ * NOTE: The JexlFunctionArgumentDescriptorFactory is implemented by QueryFunctionsDescriptor. This is kept as a separate class to reduce accumulo dependencies
+ * on other jars.
  * 
  **/
 @JexlFunctions(descriptorFactory = "datawave.query.jexl.functions.QueryFunctionsDescriptor")

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/jexl/JexlTreeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/jexl/JexlTreeBuilder.java
@@ -26,6 +26,7 @@ import datawave.query.language.functions.jexl.MatchesInGroupFunction;
 import datawave.query.language.functions.jexl.MatchesInGroupLeft;
 import datawave.query.language.functions.jexl.OccurrenceFunction;
 import datawave.query.language.functions.jexl.Options;
+import datawave.query.language.functions.jexl.Text;
 import datawave.query.language.functions.jexl.TimeFunction;
 import datawave.query.language.functions.jexl.Unique;
 import datawave.query.language.parser.jexl.JexlNode;
@@ -47,10 +48,10 @@ import com.google.common.collect.ImmutableList;
 
 public class JexlTreeBuilder extends QueryTreeBuilder {
     
-    public static final JexlQueryFunction[] DEFAULT_ALLOWED_FUNCTIONS = {new IsNull(), new IsNotNull(), new Include(), new Exclude(), new GeoFunction(),
-            new Contains(), new CoveredBy(), new Covers(), new Crosses(), new Intersects(), new Overlaps(), new Within(), new Loaded(), new DateFunction(),
-            new OccurrenceFunction(), new MatchesInGroupFunction(), new MatchesInGroupLeft(), new GetAllMatches(), new MatchesAtLeastCountOf(), new Jexl(),
-            new TimeFunction(), new AtomValuesMatchFunction(), new Options(), new Unique(), new GroupBy()};
+    public static final JexlQueryFunction[] DEFAULT_ALLOWED_FUNCTIONS = {new IsNull(), new IsNotNull(), new Include(), new Exclude(), new Text(),
+            new GeoFunction(), new Contains(), new CoveredBy(), new Covers(), new Crosses(), new Intersects(), new Overlaps(), new Within(), new Loaded(),
+            new DateFunction(), new OccurrenceFunction(), new MatchesInGroupFunction(), new MatchesInGroupLeft(), new GetAllMatches(),
+            new MatchesAtLeastCountOf(), new Jexl(), new TimeFunction(), new AtomValuesMatchFunction(), new Options(), new Unique(), new GroupBy()};
     
     public static final List<JexlQueryFunction> DEFAULT_ALLOWED_FUNCTION_LIST;
     

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FunctionQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FunctionQueryNodeBuilder.java
@@ -30,6 +30,7 @@ import datawave.query.language.functions.lucene.IsNotNull;
 import datawave.query.language.functions.lucene.IsNull;
 import datawave.query.language.functions.lucene.LuceneQueryFunction;
 import datawave.query.language.functions.lucene.Occurrence;
+import datawave.query.language.functions.lucene.Text;
 import datawave.query.language.tree.FunctionNode;
 
 import datawave.webservice.query.exception.DatawaveErrorCode;
@@ -53,6 +54,7 @@ public class FunctionQueryNodeBuilder implements QueryBuilder {
         addFunction(new IsNotNull());
         addFunction(new Include());
         addFunction(new Exclude());
+        addFunction(new Text());
         addFunction(new Occurrence());
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/AbstractEvaluationPhaseFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/AbstractEvaluationPhaseFunction.java
@@ -1,0 +1,85 @@
+package datawave.query.language.functions.jexl;
+
+import datawave.query.Constants;
+import datawave.query.search.WildcardFieldedFilter;
+import datawave.webservice.query.exception.BadRequestQueryException;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractEvaluationPhaseFunction extends JexlQueryFunction {
+    WildcardFieldedFilter.BooleanType type = null;
+    
+    public AbstractEvaluationPhaseFunction(String functionName) {
+        super(functionName, new ArrayList<>());
+    }
+    
+    @Override
+    public void initialize(List<String> parameterList, int depth, QueryNode parent) throws IllegalArgumentException {
+        // super initialize will call validate
+        super.initialize(parameterList, depth, parent);
+        type = WildcardFieldedFilter.BooleanType.AND;
+        int x = 0;
+        if (this.parameterList.size() != 1 && this.parameterList.size() % 2 == 1) {
+            try {
+                String firstArg = this.parameterList.get(0);
+                type = WildcardFieldedFilter.BooleanType.valueOf(firstArg.toUpperCase());
+            } catch (Exception e) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+                throw new IllegalArgumentException(qe);
+            }
+            x = 1;
+            this.parameterList.remove(0);
+        }
+    }
+    
+    @Override
+    public void validate() throws IllegalArgumentException {
+        // special case where we allow one value to be run against _ANYFIELD_
+        if (this.parameterList.size() == 1) {
+            return;
+        }
+        if (this.parameterList.isEmpty()) {
+            BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+            throw new IllegalArgumentException(qe);
+        }
+        String firstArg = this.parameterList.get(0);
+        if (firstArg.equalsIgnoreCase("and") || firstArg.equalsIgnoreCase("or")) {
+            if (this.parameterList.size() % 2 != 1) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+                throw new IllegalArgumentException(qe);
+            }
+        } else {
+            if (this.parameterList.size() % 2 != 0) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+                throw new IllegalArgumentException(qe);
+            }
+        }
+    }
+    
+    protected String toString(String prefix, String suffix) {
+        StringBuilder sb = new StringBuilder();
+        String operation = (this.type.equals(WildcardFieldedFilter.BooleanType.AND)) ? " && " : " || ";
+        
+        if (parameterList.size() == 1) {
+            sb.append(prefix).append(Constants.ANY_FIELD).append(", ").append(escapeString(parameterList.get(0))).append(suffix);
+        } else {
+            sb.append("(");
+            int x = 0;
+            while (x < parameterList.size()) {
+                if (x >= 2) {
+                    sb.append(operation);
+                }
+                String field = parameterList.get(x++);
+                String regex = parameterList.get(x++);
+                sb.append(prefix).append(field).append(", ").append(escapeString(regex)).append(suffix);
+            }
+            sb.append(")");
+        }
+        return sb.toString();
+    }
+    
+}

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Exclude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Exclude.java
@@ -1,78 +1,16 @@
 package datawave.query.language.functions.jexl;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
-
 import datawave.query.language.functions.QueryFunction;
 import datawave.query.search.WildcardFieldedFilter;
 
-import datawave.webservice.query.exception.BadRequestQueryException;
-import datawave.webservice.query.exception.DatawaveErrorCode;
-import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
-
-public class Exclude extends JexlQueryFunction {
-    WildcardFieldedFilter.BooleanType type = null;
-    
+public class Exclude extends AbstractEvaluationPhaseFunction {
     public Exclude() {
-        super("exclude", new ArrayList<>());
-    }
-    
-    @Override
-    public void initialize(List<String> parameterList, int depth, QueryNode parent) throws IllegalArgumentException {
-        super.initialize(parameterList, depth, parent);
-        type = WildcardFieldedFilter.BooleanType.AND;
-        int x = 0;
-        if (this.parameterList.size() % 2 == 1) {
-            try {
-                String firstArg = this.parameterList.get(0);
-                type = WildcardFieldedFilter.BooleanType.valueOf(firstArg.toUpperCase());
-            } catch (Exception e) {
-                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-                throw new IllegalArgumentException(qe);
-            }
-            x = 1;
-            this.parameterList.remove(0);
-        }
-    }
-    
-    @Override
-    public void validate() throws IllegalArgumentException {
-        if (this.parameterList.size() < 2) {
-            BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-            throw new IllegalArgumentException(qe);
-        }
-        String firstArg = this.parameterList.get(0);
-        if (firstArg.equalsIgnoreCase("and") || firstArg.equalsIgnoreCase("or")) {
-            if (this.parameterList.size() % 2 != 1) {
-                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-                throw new IllegalArgumentException(qe);
-            }
-        } else {
-            if (this.parameterList.size() % 2 != 0) {
-                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-                throw new IllegalArgumentException(qe);
-            }
-        }
+        super("exclude");
     }
     
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        String operation = (this.type.equals(WildcardFieldedFilter.BooleanType.AND)) ? " || " : " && ";
-        
-        sb.append("(");
-        int x = 0;
-        while (x < parameterList.size()) {
-            if (x >= 2) {
-                sb.append(operation);
-            }
-            String field = parameterList.get(x++);
-            String regex = parameterList.get(x++);
-            sb.append("not(filter:includeRegex(").append(field).append(", ").append(escapeString(regex)).append("))");
-        }
-        sb.append(")");
-        return sb.toString();
+        return super.toString("not(filter:includeRegex(", "))");
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/GroupBy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/GroupBy.java
@@ -15,7 +15,7 @@ public class GroupBy extends JexlQueryFunction {
     }
     
     /**
-     * query options are pairs of key/value. Ensure that the number of args is even
+     * query options is a list of fields. Cannot be the empty list.
      * 
      * @throws IllegalArgumentException
      */

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Text.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Text.java
@@ -2,18 +2,19 @@ package datawave.query.language.functions.jexl;
 
 import datawave.query.language.functions.QueryFunction;
 
-public class Include extends AbstractEvaluationPhaseFunction {
-    public Include() {
-        super("include");
+public class Text extends AbstractEvaluationPhaseFunction {
+    public Text() {
+        super("text");
     }
     
     @Override
     public String toString() {
-        return super.toString("filter:includeRegex(", ")");
+        return super.toString("filter:includeText(", ")");
     }
     
     @Override
     public QueryFunction duplicate() {
-        return new Include();
+        return new Text();
     }
+    
 }

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Unique.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/Unique.java
@@ -15,7 +15,7 @@ public class Unique extends JexlQueryFunction {
     }
     
     /**
-     * query options are pairs of key/value. Ensure that the number of args is even
+     * query options contain a list of fields. Cannot be the empty list.
      * 
      * @throws IllegalArgumentException
      */

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/AbstractEvaluationPhaseFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/AbstractEvaluationPhaseFunction.java
@@ -1,0 +1,84 @@
+package datawave.query.language.functions.lucene;
+
+import datawave.query.Constants;
+import datawave.query.search.WildcardFieldedFilter;
+import datawave.webservice.query.exception.BadRequestQueryException;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.BooleanQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class AbstractEvaluationPhaseFunction extends LuceneQueryFunction {
+    private boolean includeIfMatch;
+    
+    public AbstractEvaluationPhaseFunction(String functionName, boolean includeIfMatch) {
+        super(functionName, new ArrayList<>());
+        this.includeIfMatch = includeIfMatch;
+    }
+    
+    @Override
+    public void initialize(List<String> parameterList, int depth, QueryNode parent) throws IllegalArgumentException {
+        // super initialize will call validate
+        super.initialize(parameterList, depth, parent);
+        WildcardFieldedFilter.BooleanType type = WildcardFieldedFilter.BooleanType.AND;
+        int x = 0;
+        if (this.parameterList.size() != 1 && this.parameterList.size() % 2 == 1) {
+            try {
+                String firstArg = this.parameterList.get(0);
+                type = WildcardFieldedFilter.BooleanType.valueOf(firstArg.toUpperCase());
+            } catch (Exception e) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", e,
+                                this.name));
+                throw new IllegalArgumentException(qe);
+            }
+            x = 1;
+        }
+        this.fieldedFilter = new WildcardFieldedFilter(includeIfMatch, type);
+        
+        // special case where one argument will be matched against any field
+        if (this.parameterList.size() == 1) {
+            this.fieldedFilter.addCondition(Constants.ANY_FIELD, parameterList.get(0));
+        } else {
+            while (x < parameterList.size()) {
+                String field = parameterList.get(x++);
+                String regex = parameterList.get(x++);
+                this.fieldedFilter.addCondition(field, regex);
+            }
+        }
+    }
+    
+    @Override
+    public void validate() throws IllegalArgumentException {
+        // special case where we allow one value to be run against _ANYFIELD_
+        if (this.parameterList.size() == 1) {
+            return;
+        }
+        if (this.parameterList.isEmpty()) {
+            BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+            throw new IllegalArgumentException(qe);
+        }
+        
+        String firstArg = this.parameterList.get(0);
+        if (firstArg.equalsIgnoreCase("and") || firstArg.equalsIgnoreCase("or")) {
+            if (this.parameterList.size() % 2 != 1) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+                throw new IllegalArgumentException(qe);
+            }
+        } else {
+            if (this.parameterList.size() % 2 != 0) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
+                throw new IllegalArgumentException(qe);
+            }
+        }
+    }
+    
+    @Override
+    public String toString() {
+        return this.fieldedFilter.toString();
+    }
+    
+}

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Exclude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Exclude.java
@@ -1,77 +1,10 @@
 package datawave.query.language.functions.lucene;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
-
 import datawave.query.language.functions.QueryFunction;
-import datawave.query.search.WildcardFieldedFilter;
 
-import datawave.webservice.query.exception.BadRequestQueryException;
-import datawave.webservice.query.exception.DatawaveErrorCode;
-import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
-import org.apache.lucene.queryparser.flexible.core.nodes.BooleanQueryNode;
-import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
-
-public class Exclude extends LuceneQueryFunction {
+public class Exclude extends AbstractEvaluationPhaseFunction {
     public Exclude() {
-        super("exclude", new ArrayList<>());
-    }
-    
-    @Override
-    public void initialize(List<String> parameterList, int depth, QueryNode parent) throws IllegalArgumentException {
-        super.initialize(parameterList, depth, parent);
-        WildcardFieldedFilter.BooleanType type = WildcardFieldedFilter.BooleanType.AND;
-        int x = 0;
-        if (this.parameterList.size() % 2 == 1) {
-            try {
-                String firstArg = this.parameterList.get(0);
-                type = WildcardFieldedFilter.BooleanType.valueOf(firstArg.toUpperCase());
-            } catch (Exception e) {
-                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", e,
-                                this.name));
-                throw new IllegalArgumentException(qe);
-            }
-            x = 1;
-        }
-        this.fieldedFilter = new WildcardFieldedFilter(false, type);
-        
-        while (x < parameterList.size()) {
-            String field = parameterList.get(x++);
-            String regex = parameterList.get(x++);
-            this.fieldedFilter.addCondition(field, regex);
-        }
-    }
-    
-    @Override
-    public void validate() throws IllegalArgumentException {
-        if (this.depth != 1) {
-            throw new IllegalArgumentException("function: " + this.name + " must be at the top level of the query");
-        }
-        if (!(this.parent instanceof AndQueryNode || this.parent instanceof BooleanQueryNode)) {
-            throw new IllegalArgumentException("function: " + this.name + " must be part of an AND expression");
-        }
-        if (this.parameterList.size() < 2) {
-            BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-            throw new IllegalArgumentException(qe);
-        }
-        String firstArg = this.parameterList.get(0);
-        if (firstArg.equalsIgnoreCase("and") || firstArg.equalsIgnoreCase("or")) {
-            if (this.parameterList.size() % 2 != 1) {
-                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-                throw new IllegalArgumentException(qe);
-            }
-        } else {
-            if (this.parameterList.size() % 2 != 0) {
-                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
-                throw new IllegalArgumentException(qe);
-            }
-        }
-    }
-    
-    @Override
-    public String toString() {
-        return this.fieldedFilter.toString();
+        super("exclude", false);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/GroupBy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/GroupBy.java
@@ -24,7 +24,7 @@ public class GroupBy extends LuceneQueryFunction {
     
     @Override
     public void validate() throws IllegalArgumentException {
-        if (this.parameterList.size() % 2 != 0) { // must have even number of args
+        if (this.parameterList.isEmpty()) {
             BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
             throw new IllegalArgumentException(qe);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Text.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Text.java
@@ -2,13 +2,13 @@ package datawave.query.language.functions.lucene;
 
 import datawave.query.language.functions.QueryFunction;
 
-public class Include extends AbstractEvaluationPhaseFunction {
-    public Include() {
-        super("include", true);
+public class Text extends AbstractEvaluationPhaseFunction {
+    public Text() {
+        super("text", true);
     }
     
     @Override
     public QueryFunction duplicate() {
-        return new Include();
+        return new Text();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Unique.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Unique.java
@@ -24,7 +24,7 @@ public class Unique extends LuceneQueryFunction {
     
     @Override
     public void validate() throws IllegalArgumentException {
-        if (this.parameterList.size() % 2 != 0) { // must have even number of args
+        if (this.parameterList.isEmpty()) {
             BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.INVALID_FUNCTION_ARGUMENTS, MessageFormat.format("{0}", this.name));
             throw new IllegalArgumentException(qe);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -849,15 +849,31 @@ public class DefaultQueryPlanner extends QueryPlanner {
     protected ASTJexlScript processTree(final ASTJexlScript originalQueryTree, ShardQueryConfiguration config, Query settings, MetadataHelper metadataHelper,
                     ScannerFactory scannerFactory, QueryData queryData, QueryStopwatch timers, QueryModel queryModel) throws DatawaveQueryException {
         ASTJexlScript queryTree = originalQueryTree;
+        
+        TraceStopwatch stopwatch = null;
+        
+        if (!disableExpandIndexFunction) {
+            stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Expand function index queries");
+            
+            // Coalesce any bounded ranges into separate AND subtrees
+            queryTree = FunctionIndexQueryExpansionVisitor.expandFunctions(config, metadataHelper, dateIndexHelper, queryTree);
+            if (log.isDebugEnabled()) {
+                logQuery(queryTree, "Query after function index queries were expanded:");
+            }
+            
+            stopwatch.stop();
+        }
+        
         // Find unfielded terms, and fully qualify them with an OR of all fields
         // found in the index
         // If the max term expansion is reached, then the original query tree is
         // returned.
         // If the max regex expansion is reached for a term, then it will be
         // left as a regex
-        TraceStopwatch stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Expand ANYFIELD regex nodes");
         Set<String> expansionFields = null;
         if (!disableAnyFieldLookup) {
+            stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Expand ANYFIELD regex nodes");
+            
             try {
                 
                 expansionFields = metadataHelper.getExpansionFields(config.getDatatypeFilter());
@@ -880,9 +896,9 @@ public class DefaultQueryPlanner extends QueryPlanner {
             if (log.isDebugEnabled()) {
                 logQuery(queryTree, "Query after fixing unfielded queries:");
             }
+            stopwatch.stop();
         }
         
-        stopwatch.stop();
         if (!disableTestNonExistentFields) {
             stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Test for non-existent fields");
             
@@ -914,18 +930,6 @@ public class DefaultQueryPlanner extends QueryPlanner {
                                 "Datatype Filter: {0}, Missing Fields: {1}, Auths: {2}", datatypeFilterSet, nonexistentFields, config.getAuthorizations()));
                 log.error(qe);
                 throw new InvalidQueryException(qe);
-            }
-            
-            stopwatch.stop();
-        }
-        
-        if (!disableExpandIndexFunction) {
-            stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Expand function index queries");
-            
-            // Coalesce any bounded ranges into separate AND subtrees
-            queryTree = FunctionIndexQueryExpansionVisitor.expandFunctions(config, metadataHelper, dateIndexHelper, queryTree);
-            if (log.isDebugEnabled()) {
-                logQuery(queryTree, "Query after function index queries were expanded:");
             }
             
             stopwatch.stop();

--- a/warehouse/query-core/src/test/java/datawave/query/FilterFieldsQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FilterFieldsQueryTest.java
@@ -162,6 +162,19 @@ public class FilterFieldsQueryTest extends AbstractFunctionalQuery {
     }
     
     @Test
+    public void testAnyFieldLuceneText() throws Exception {
+        log.info("------  testAnyFieldLuceneText  ------");
+        String state = "ohio";
+        String anyState = this.dataManager.convertAnyField(EQ_OP + "'" + state + "'");
+        for (final TestCities city : TestCities.values()) {
+            String query = CityField.CITY.name() + ":" + city.name() + AND_OP + " #TEXT(Ohio)";
+            String expectQuery = CityField.CITY.name() + EQ_OP + "'" + city.name() + "'" + AND_OP + anyState;
+            this.logic.setParser(new LuceneToJexlQueryParser());
+            runTest(query, expectQuery, true, false);
+        }
+    }
+    
+    @Test
     public void testOccurrenceFunction() throws Exception {
         log.info("------  testOccurrenceFunction  ------");
         String cont = "'europe'";

--- a/warehouse/query-core/src/test/java/datawave/query/LuceneQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LuceneQueryTest.java
@@ -1,6 +1,7 @@
 package datawave.query;
 
 import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
+import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetupHelper;
 import datawave.query.testframework.CitiesDataType;
@@ -9,6 +10,7 @@ import datawave.query.testframework.CitiesDataType.CityField;
 import datawave.query.testframework.GenericCityFields;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,6 +52,17 @@ public class LuceneQueryTest extends AbstractFunctionalQuery {
     @Test
     public void testAnyFieldInclude() throws Exception {
         log.info("------  testAnyFieldInclude  ------");
+        String code = "europe";
+        String state = "lazio";
+        String phrase = RE_OP + "'" + state + "'";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#INCLUDE(" + state + ")";
+        String expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + this.dataManager.convertAnyField(phrase);
+        runTest(query, expect);
+    }
+    
+    @Test
+    public void testExplicitAnyFieldInclude() throws Exception {
+        log.info("------  testExplicitAnyFieldInclude  ------");
         String code = "europe";
         String state = "lazio";
         String phrase = RE_OP + "'" + state + "'";

--- a/warehouse/query-core/src/test/java/datawave/query/TextFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TextFunctionQueryTest.java
@@ -84,8 +84,8 @@ public class TextFunctionQueryTest extends AbstractFunctionalQuery {
         // testing that incorrect case misses results
         state2 = "london";
         query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(OR, STATE," + state1 + ", STATE, " + state2 + ")";
+        // should return only the Lazio events, and not the London events
         expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + "STATE" + phrase1;
-        // should return the empty set
         runTest(query, expect);
         
         // testing that incorrect case misses results

--- a/warehouse/query-core/src/test/java/datawave/query/TextFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TextFunctionQueryTest.java
@@ -1,0 +1,106 @@
+package datawave.query;
+
+import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
+import datawave.query.testframework.AbstractFunctionalQuery;
+import datawave.query.testframework.AccumuloSetupHelper;
+import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CitiesDataType.CityEntry;
+import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.DataTypeHadoopConfig;
+import datawave.query.testframework.FieldConfig;
+import datawave.query.testframework.GenericCityFields;
+import org.apache.log4j.Logger;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import static datawave.query.testframework.RawDataManager.AND_OP;
+import static datawave.query.testframework.RawDataManager.EQ_OP;
+import static datawave.query.testframework.RawDataManager.OR_OP;
+import static datawave.query.testframework.RawDataManager.RE_OP;
+
+public class TextFunctionQueryTest extends AbstractFunctionalQuery {
+    
+    private static final Logger log = Logger.getLogger(TextFunctionQueryTest.class);
+    
+    @BeforeClass
+    public static void filterSetup() throws Exception {
+        Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
+        FieldConfig generic = new GenericCityFields();
+        dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
+        
+        final AccumuloSetupHelper helper = new AccumuloSetupHelper(dataTypes);
+        connector = helper.loadTables(log);
+    }
+    
+    public TextFunctionQueryTest() {
+        super(CitiesDataType.getManager());
+    }
+    
+    @Test
+    public void testAnyFieldText() throws Exception {
+        log.info("------  testAnyFieldText  ------");
+        String code = "europe";
+        // must be same case as original value in event
+        String state = "Lazio";
+        String phrase = EQ_OP + "'" + state + "'";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(" + state + ")";
+        String expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + this.dataManager.convertAnyField(phrase);
+        runTest(query, expect);
+        
+        // testing that incorrect case misses results
+        state = "lazio";
+        query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(" + state + ")";
+        // should return the empty set
+        runTestQuery(Collections.EMPTY_SET, query);
+    }
+    
+    @Test
+    public void testExplicitAnyFieldText() throws Exception {
+        log.info("------  testExplicitAnyFieldText  ------");
+        String code = "europe";
+        String state = "Lazio";
+        String phrase = EQ_OP + "'" + state + "'";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(" + Constants.ANY_FIELD + "," + state + ")";
+        String expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + this.dataManager.convertAnyField(phrase);
+        runTest(query, expect);
+    }
+    
+    @Test
+    public void testMultiFieldText() throws Exception {
+        log.info("------  testMultiFieldText  ------");
+        String code = "europe";
+        String state1 = "Lazio";
+        String state2 = "London";
+        String phrase1 = EQ_OP + "'" + state1 + "'";
+        String phrase2 = EQ_OP + "'" + state2 + "'";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(OR, STATE," + state1 + ", STATE, " + state2 + ")";
+        String expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + "( STATE" + phrase1 + OR_OP + "STATE" + phrase2 + " )";
+        runTest(query, expect);
+        
+        // testing that incorrect case misses results
+        state2 = "london";
+        query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(OR, STATE," + state1 + ", STATE, " + state2 + ")";
+        expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + "STATE" + phrase1;
+        // should return the empty set
+        runTest(query, expect);
+        
+        // testing that incorrect case misses results
+        state1 = "lazio";
+        query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#TEXT(OR, STATE," + state1 + ", STATE, " + state2 + ")";
+        // should return the empty set
+        runTestQuery(Collections.EMPTY_SET, query);
+    }
+    
+    // ============================================
+    // implemented abstract methods
+    protected void testInit() {
+        this.auths = CitiesDataType.getTestAuths();
+        this.documentKey = CityField.EVENT_ID.name();
+        
+        this.logic.setParser(new LuceneToJexlQueryParser());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlParser.java
@@ -17,7 +17,7 @@ public class TestLuceneToJexlParser {
             QueryNode node = null;
             
             node = parser.parse("FIELD:SELECTOR AND #EXCLUDE(AND, F1, GB.*, F2, GB.*)");
-            Assert.assertEquals("FIELD == 'SELECTOR' && (not(filter:includeRegex(F1, 'GB.*')) || not(filter:includeRegex(F2, 'GB.*')))",
+            Assert.assertEquals("FIELD == 'SELECTOR' && (not(filter:includeRegex(F1, 'GB.*')) && not(filter:includeRegex(F2, 'GB.*')))",
                             node.getOriginalQuery());
             
             node = parser.parse("FIELD:SELECTOR AND #INCLUDE(AND, F1, GB.*, F2, GB.*)");

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -425,9 +425,18 @@ public class TestLuceneToJexlQueryParser {
     public void testFunctions() throws ParseException {
         testFunction("filter:isNull(nullfield)", "#isnull(nullfield)");
         testFunction("not(filter:isNull(field))", "#isnotnull(field)");
+        testFunction("filter:includeRegex(_ANYFIELD_, 'r1')", "#include(r1)");
+        testFunction("(filter:includeRegex(f1, 'r1') && filter:includeRegex(f2, 'r2'))", "#include(f1, r1, f2, r2)");
         testFunction("(filter:includeRegex(f1, 'r1') && filter:includeRegex(f2, 'r2'))", "#include(AND, f1, r1, f2, r2)");
+        testFunction("(filter:includeRegex(f1, 'r1') || filter:includeRegex(f2, 'r2'))", "#include(OR, f1, r1, f2, r2)");
         testFunction("(not(filter:includeRegex(f1, 'see.*jane.*run')) && not(filter:includeRegex(f2, 'test,escaping')))",
+                        "#exclude(f1, see.*jane.*run, f2, test\\,escaping)");
+        testFunction("(not(filter:includeRegex(f1, 'see.*jane.*run')) || not(filter:includeRegex(f2, 'test,escaping')))",
                         "#exclude(OR, f1, see.*jane.*run, f2, test\\,escaping)");
+        testFunction("filter:includeText(_ANYFIELD_, 'r1')", "#text(r1)");
+        testFunction("(filter:includeText(f1, 'r1') && filter:includeText(f2, 'r2'))", "#text(f1, r1, f2, r2)");
+        testFunction("(filter:includeText(f1, 'r1') && filter:includeText(f2, 'r2'))", "#text(AND, f1, r1, f2, r2)");
+        testFunction("(filter:includeText(f1, 'r1') || filter:includeText(f2, 'r2'))", "#text(OR, f1, r1, f2, r2)");
         
         testFunction("filter:afterLoadDate(LOAD_DATE, '20140101')", "#loaded(after, 20140101)");
         testFunction("filter:afterLoadDate(LOAD_DATE, '20140101', 'yyyyMMdd')", "#loaded(after, 20140101, yyyyMMdd)");

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/lucene/TestLuceneQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/lucene/TestLuceneQueryParser.java
@@ -202,6 +202,21 @@ public class TestLuceneQueryParser {
                         .getContents());
         Assert.assertEquals("[AND,field:selector][posFilter: filter(true, AND, field, testbade\\.scape)]",
                         luceneParser.parse("field:selector AND #include(field, testbade\\.scape)").getContents());
+        Assert.assertEquals("[AND,field:selector][posFilter: filter(true, AND, field, testbade\\.scape)]",
+                        luceneParser.parse("field:selector AND #text(field, testbade\\.scape)").getContents());
+    }
+    
+    @Test
+    public void testUnfieldedFunctions() throws ParseException {
+        LuceneQueryParser luceneParser = new LuceneQueryParser();
+        
+        // parameters to functions do not have to be escaped
+        Assert.assertEquals("[AND,field:selector][posFilter: filter(true, AND, _ANYFIELD_, testbade\\.scape)]",
+                        luceneParser.parse("field:selector AND #include(testbade\\.scape)").getContents());
+        Assert.assertEquals("[AND,field:selector][posFilter: filter(false, AND, _ANYFIELD_, testbade\\.scape)]",
+                        luceneParser.parse("field:selector AND #exclude(testbade\\.scape)").getContents());
+        Assert.assertEquals("[AND,field:selector][posFilter: filter(true, AND, _ANYFIELD_, testbade\\.scape)]",
+                        luceneParser.parse("field:selector AND #text(testbade\\.scape)").getContents());
     }
     
     @Test(expected = ParseException.class)
@@ -234,11 +249,12 @@ public class TestLuceneQueryParser {
         luceneParser.parse("#isnull(field) #include(field, test[abc]*.*)");
     }
     
-    @Test(expected = ParseException.class)
-    public void testFunctionWrongStructure() throws ParseException {
-        LuceneQueryParser luceneParser = new LuceneQueryParser();
-        luceneParser.parse("field:selector OR #include(field, test[abc]*.*)");
-    }
+    /**
+     * The include is now allowed within an or as it could be pushed down or handled by a full table scan. This is no longer an error.
+     * 
+     * @Test(expected = ParseException.class) public void testFunctionWrongStructure() throws ParseException { LuceneQueryParser luceneParser = new
+     *                LuceneQueryParser(); luceneParser.parse("field:selector OR #include(field, test[abc]*.*)"); }
+     */
     
     @Test
     public void testFunctionEscaping1() throws ParseException {

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -289,6 +289,11 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         runTestQuery(expected, queryStr, startDate, endDate, Collections.emptyMap());
     }
     
+    protected void runTestQuery(Collection<String> expected, String queryStr) throws Exception {
+        Date[] startEndDate = this.dataManager.getShardStartEndDate();
+        runTestQuery(expected, queryStr, startEndDate[0], startEndDate[1], Collections.emptyMap());
+    }
+    
     /**
      * Equivalent to {@link #runTestQuery(Collection, String, Date, Date, Map, List)}, with an empty list for the checkers.
      *
@@ -338,6 +343,7 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         
         GenericQueryConfiguration config = this.logic.initialize(connector, q, this.authSet);
         this.logic.setupQuery(config);
+        log.debug("Plan: " + config.getQueryString());
         testHarness.assertLogicResults(this.logic, expected, checkers);
     }
     

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -19,6 +19,7 @@
         <bean class="datawave.query.language.functions.jexl.IsNotNull"/>
         <bean class="datawave.query.language.functions.jexl.Include"/>
         <bean class="datawave.query.language.functions.jexl.Exclude"/>
+        <bean class="datawave.query.language.functions.jexl.Text"/>
         <bean class="datawave.query.language.functions.jexl.Loaded"/>
         <bean class="datawave.query.language.functions.jexl.DateFunction"/>
         <bean class="datawave.query.language.functions.jexl.OccurrenceFunction"/>

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -13,6 +13,7 @@
         <bean class="datawave.query.language.functions.jexl.IsNotNull"/>
         <bean class="datawave.query.language.functions.jexl.Include"/>
         <bean class="datawave.query.language.functions.jexl.Exclude"/>
+        <bean class="datawave.query.language.functions.jexl.Text"/>
         <bean class="datawave.query.language.functions.jexl.GeoFunction"/>
         <bean class="datawave.query.language.functions.jexl.Loaded"/>
         <bean class="datawave.query.language.functions.jexl.DateFunction"/>

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -24,6 +24,7 @@
         <bean class="datawave.query.language.functions.jexl.IsNotNull"/>
         <bean class="datawave.query.language.functions.jexl.Include"/>
         <bean class="datawave.query.language.functions.jexl.Exclude"/>
+        <bean class="datawave.query.language.functions.jexl.Text"/>
         <bean class="datawave.query.language.functions.jexl.GeoFunction"/>
         <bean class="datawave.query.language.functions.jexl.Loaded"/>
         <bean class="datawave.query.language.functions.jexl.DateFunction"/>


### PR DESCRIPTION
Added a #TEXT (filter.includeText) function which takes the same syntax as #INCLUDE or #EXCLUDE.
Added a shortcut of #TEXT(x) which implies #TEXT(_ANYFIELD_,x).  Same for #INCLUDE and #EXCLUDE.
Modified planner to expand function index queries before expanding anyfield expressions to #TEXT(x).
Added test cases for lucene and jexl expansions as well as functional tests.