### PR TITLE
Improve metadata-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.microservice.authorization-api>1.3</version.microservice.authorization-api>
         <version.microservice.base-rest-responses>1.0</version.microservice.base-rest-responses>
         <version.microservice.common-utils>1.0</version.microservice.common-utils>
-        <version.microservice.metadata-utils>1.0</version.microservice.metadata-utils>
+        <version.microservice.metadata-utils>1.1</version.microservice.metadata-utils>
         <version.microservice.metrics-reporter>1.2</version.microservice.metrics-reporter>
         <version.microservice.type-utils>1.0</version.microservice.type-utils>
         <version.minlog>1.2</version.minlog>

--- a/services/metadata-utils/pom.xml
+++ b/services/metadata-utils/pom.xml
@@ -7,7 +7,7 @@
         <version>1.3</version>
     </parent>
     <artifactId>metadata-utils</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1</version>
     <properties>
         <version.accumulo-utils>1.2</version.accumulo-utils>
         <version.caffeine>2.6.2</version.caffeine>

--- a/services/metadata-utils/src/main/java/datawave/query/composite/CompositeMetadataHelper.java
+++ b/services/metadata-utils/src/main/java/datawave/query/composite/CompositeMetadataHelper.java
@@ -14,7 +14,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Scope;
@@ -160,13 +159,5 @@ public class CompositeMetadataHelper {
         bs.close();
         
         return compositeMetadata;
-    }
-    
-    /**
-     * Invalidates all elements in all internal caches
-     */
-    @CacheEvict(value = {"getCompositeMetadata"}, allEntries = true, cacheManager = "metadataHelperCacheManager")
-    public void evictCaches() {
-        log.debug("evictCaches");
     }
 }

--- a/services/metadata-utils/src/main/java/datawave/query/composite/CompositeMetadataHelper.java
+++ b/services/metadata-utils/src/main/java/datawave/query/composite/CompositeMetadataHelper.java
@@ -1,5 +1,6 @@
 package datawave.query.composite;
 
+import com.google.common.base.Preconditions;
 import datawave.data.ColumnFamilyConstants;
 import datawave.security.util.ScannerHelper;
 import org.apache.accumulo.core.client.Connector;
@@ -39,18 +40,14 @@ public class CompositeMetadataHelper {
     protected final List<Text> metadataCompositeColfs = Arrays.asList(ColumnFamilyConstants.COLF_CI, ColumnFamilyConstants.COLF_CITD,
                     ColumnFamilyConstants.COLF_CISEP);
     
-    protected Connector connector;
-    protected Instance instance;
-    protected String metadataTableName;
-    protected Set<Authorizations> auths;
-    
-    public CompositeMetadataHelper initialize(Connector connector, String metadataTableName, Set<Authorizations> auths) {
-        return this.initialize(connector, connector.getInstance(), metadataTableName, auths);
-    }
+    protected final Connector connector;
+    protected final Instance instance;
+    protected final String metadataTableName;
+    protected final Set<Authorizations> auths;
     
     /**
      * Initializes the instance with a provided update interval.
-     * 
+     *
      * @param connector
      *            A Connector to Accumulo
      * @param metadataTableName
@@ -58,20 +55,21 @@ public class CompositeMetadataHelper {
      * @param auths
      *            Any {@link Authorizations} to use
      */
-    public CompositeMetadataHelper initialize(Connector connector, Instance instance, String metadataTableName, Set<Authorizations> auths) {
-        if (this.connector != null) {
-            throw new RuntimeException("CompositeMetadataHelper may not be re-initialized");
-        }
+    public CompositeMetadataHelper(Connector connector, String metadataTableName, Set<Authorizations> auths) {
+        Preconditions.checkNotNull(connector, "A valid Accumulo Connector is required by CompositeMetadataHelper");
         this.connector = connector;
-        this.instance = instance;
+        this.instance = connector.getInstance();
+        
+        Preconditions.checkNotNull(metadataTableName, "The metadata table name is required by CompositeMetadataHelper");
         this.metadataTableName = metadataTableName;
+        
+        Preconditions.checkNotNull(auths, "Accumulo scan Authorizations are required by CompositeMetadataHelper");
         this.auths = auths;
         
         if (log.isTraceEnabled()) {
             log.trace("Constructor  connector: " + connector.getClass().getCanonicalName() + " with auths: " + auths + " and metadata table name: "
                             + metadataTableName);
         }
-        return this;
     }
     
     public Set<Authorizations> getAuths() {

--- a/services/metadata-utils/src/main/java/datawave/query/composite/CompositeMetadataHelper.java
+++ b/services/metadata-utils/src/main/java/datawave/query/composite/CompositeMetadataHelper.java
@@ -11,11 +11,12 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import java.text.ParseException;
@@ -26,13 +27,11 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
-/**
- */
-@Configuration
 @EnableCaching
 @Component("compositeMetadataHelper")
+@Scope("prototype")
 public class CompositeMetadataHelper {
-    private static final Logger log = Logger.getLogger(CompositeMetadataHelper.class);
+    private static final Logger log = LoggerFactory.getLogger(CompositeMetadataHelper.class);
     
     public static final String transitionDateFormat = "yyyyMMdd HHmmss.SSS";
     public static final String NULL_BYTE = "\0";

--- a/services/metadata-utils/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
+++ b/services/metadata-utils/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Scope;
@@ -1004,17 +1003,6 @@ public class AllFieldMetadataHelper {
     @Override
     public String toString() {
         return getKey(this);
-    }
-    
-    /**
-     * Invalidates all elements in all internal caches
-     */
-    @CacheEvict(value = {"loadAllFields", "isIndexed", "getAllDatatypes", "getCompositeToFieldMap", "getFieldsToDatatypes", "getFieldsForDatatype",
-            "getIndexOnlyFields", "loadTermFrequencyFields", "loadIndexedFields", "loadExpansionFields", "loadContentFields", "loadDatatypes"},
-                    allEntries = true, cacheManager = "metadataHelperCacheManager")
-    public void evictCaches() {
-        log.debug("evictCaches");
-        typeMetadataHelper.evictCaches();
     }
     
 }

--- a/services/metadata-utils/src/main/java/datawave/query/util/MetadataCacheManager.java
+++ b/services/metadata-utils/src/main/java/datawave/query/util/MetadataCacheManager.java
@@ -1,0 +1,68 @@
+package datawave.query.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * A utility to help with evicting entries from the caches used by {@link MetadataHelper}, {@link TypeMetadataHelper},
+ * {@link datawave.query.composite.CompositeMetadataHelper}, and {@link AllFieldMetadataHelper}. Normally this could be handled with the
+ * {@link org.springframework.cache.annotation.CacheEvict} annotation on a method. However, we want to be sure that all caches in the cache manager are cleared.
+ */
+@Component
+public class MetadataCacheManager {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final CacheManager cacheManager;
+    
+    public MetadataCacheManager(@Qualifier("metadataHelperCacheManager") CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+    
+    /**
+     * Evicts all entries from all caches in the metadata helper {@link CacheManager}.
+     */
+    public void evictCaches() {
+        cacheManager.getCacheNames().forEach(cacheName -> {
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache != null) {
+                log.debug("Clearing metadata cache {}.");
+                cache.clear();
+            }
+        });
+    }
+    
+    /**
+     * Dump all entries in the metadata helper {@link CacheManager}'s caches.
+     * 
+     * @param log
+     *            the logger to use when printing entries
+     * @param prefix
+     *            a prefix string to prepend on the log messages
+     */
+    public void showMeDaCache(Logger log, String prefix) {
+        for (String cacheName : cacheManager.getCacheNames()) {
+            log.trace(prefix + " got " + cacheName);
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache != null) {
+                Object nativeCache = cache.getNativeCache();
+                log.trace("nativeCache is a " + nativeCache);
+                if (nativeCache instanceof com.github.benmanes.caffeine.cache.Cache) {
+                    com.github.benmanes.caffeine.cache.Cache caffeineCache = (com.github.benmanes.caffeine.cache.Cache) nativeCache;
+                    Map map = caffeineCache.asMap();
+                    log.trace("cache map is " + map);
+                    log.trace("cache map size is " + map.size());
+                    for (Object key : map.keySet()) {
+                        log.trace("value for " + key + " is :" + map.get(key));
+                    }
+                } else {
+                    log.warn("Expected native cache to be a " + com.github.benmanes.caffeine.cache.Cache.class + " but it was a " + nativeCache.getClass());
+                }
+            }
+        }
+    }
+}

--- a/services/metadata-utils/src/main/java/datawave/query/util/MetadataHelperFactory.java
+++ b/services/metadata-utils/src/main/java/datawave/query/util/MetadataHelperFactory.java
@@ -1,13 +1,23 @@
 package datawave.query.util;
 
+import com.google.common.collect.Maps;
+import datawave.query.composite.CompositeMetadataHelper;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.security.Authorizations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.stereotype.Component;
 
-/**
- *
- *
- */
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
 public class MetadataHelperFactory {
+    
+    public static final String ALL_AUTHS_PROPERTY = "dw.metadatahelper.all.auths";
     
     public static final Logger log = LoggerFactory.getLogger(MetadataHelperFactory.class);
     
@@ -17,7 +27,43 @@ public class MetadataHelperFactory {
      * 
      * @return
      */
+    @Lookup
     public MetadataHelper createMetadataHelper() {
-        return MetadataHelper.getInstance();
+        log.warn("MetadataHelper created outside of dependency-injection context. This is fine for unit testing, but this is an error in production code");
+        if (log.isDebugEnabled())
+            log.debug("MetadataHelper created outside of dependency-injection context. This is fine for unit testing, but this is an error in production code",
+                            new Exception("exception for debug purposes"));
+        
+        Map<String,String> typeSubstitutions = new HashMap<>();
+        typeSubstitutions.put("datawave.data.type.DateType", "datawave.data.type.RawDateType");
+        Set<Authorizations> allMetadataAuths = Collections.singleton(MetadataDefaultsFactory.getDefaultAuthorizations());
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths);
+        CompositeMetadataHelper compositeMetadataHelper = new CompositeMetadataHelper();
+        AllFieldMetadataHelper allFieldMetadataHelper = new AllFieldMetadataHelper(typeMetadataHelper, compositeMetadataHelper);
+        return new MetadataHelper(allFieldMetadataHelper, allMetadataAuths);
     }
+    
+    @Lookup
+    public MetadataHelper createMetadataHelper(Connector connector, String metadataTableName, Set<Authorizations> auths) {
+        MetadataHelper metadataHelper = createMetadataHelper();
+        metadataHelper.initialize(connector, metadataTableName, auths);
+        return metadataHelper;
+    }
+    
+    /**
+     * Factory primarily for injecting default authorizations that may be needed when there is no Spring injection to fall back on. Previously default auths
+     * were hard-coded above, limiting portability of the code.
+     */
+    private static class MetadataDefaultsFactory {
+        static Authorizations getDefaultAuthorizations() {
+            String defaultAuths = System.getProperty(ALL_AUTHS_PROPERTY);
+            if (null == defaultAuths || defaultAuths.isEmpty()) {
+                log.info("No default authorizations are defined. Hopefully the empty set will suffice");
+                return new Authorizations();
+            } else {
+                return new Authorizations(defaultAuths.split(","));
+            }
+        }
+    }
+    
 }

--- a/services/metadata-utils/src/main/java/datawave/query/util/TypeMetadataHelper.java
+++ b/services/metadata-utils/src/main/java/datawave/query/util/TypeMetadataHelper.java
@@ -1,5 +1,6 @@
 package datawave.query.util;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import datawave.data.ColumnFamilyConstants;
@@ -16,12 +17,13 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Scope;
+import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -44,31 +46,17 @@ public class TypeMetadataHelper {
     
     protected final List<Text> metadataTypeColfs = Arrays.asList(ColumnFamilyConstants.COLF_T);
     
-    protected Connector connector;
-    protected Instance instance;
-    protected String metadataTableName;
-    protected Set<Authorizations> auths;
-    protected boolean useTypeSubstitution = false;
+    protected final Connector connector;
+    protected final Instance instance;
+    protected final String metadataTableName;
+    protected final Set<Authorizations> auths;
+    protected final boolean useTypeSubstitution;
     protected final Map<String,String> typeSubstitutions;
     protected final Set<Authorizations> allMetadataAuths;
     
-    public TypeMetadataHelper(@Qualifier("typeSubstitutions") Map<String,String> typeSubstitutions,
-                    @Qualifier("allMetadataAuths") Set<Authorizations> allMetadataAuths) {
-        this.typeSubstitutions = (typeSubstitutions == null) ? Maps.newHashMap() : typeSubstitutions;
-        this.allMetadataAuths = (allMetadataAuths == null) ? Collections.emptySet() : allMetadataAuths;
-    }
-    
-    public TypeMetadataHelper initialize(Connector connector, String metadataTableName, Set<Authorizations> auths) {
-        return this.initialize(connector, connector.getInstance(), metadataTableName, auths, false);
-    }
-    
-    public TypeMetadataHelper initialize(Connector connector, String metadataTableName, Set<Authorizations> auths, boolean useTypeSubstitution) {
-        return this.initialize(connector, connector.getInstance(), metadataTableName, auths, useTypeSubstitution);
-    }
-    
     /**
      * Initializes the instance with a provided update interval.
-     * 
+     *
      * @param connector
      *            A Connector to Accumulo
      * @param metadataTableName
@@ -76,22 +64,25 @@ public class TypeMetadataHelper {
      * @param auths
      *            Any {@link Authorizations} to use
      */
-    public TypeMetadataHelper initialize(Connector connector, Instance instance, String metadataTableName, Set<Authorizations> auths,
-                    boolean useTypeSubstitution) {
-        if (this.connector != null) {
-            throw new RuntimeException("TypeMetadataHelper may not be re-initialized");
-        }
+    public TypeMetadataHelper(@Qualifier("typeSubstitutions") Map<String,String> typeSubstitutions,
+                    @Qualifier("allMetadataAuths") Set<Authorizations> allMetadataAuths, Connector connector, String metadataTableName,
+                    Set<Authorizations> auths, boolean useTypeSubstitution) {
+        this.typeSubstitutions = (typeSubstitutions == null) ? Maps.newHashMap() : typeSubstitutions;
+        this.allMetadataAuths = (allMetadataAuths == null) ? Collections.emptySet() : allMetadataAuths;
+        
+        Preconditions.checkNotNull(connector, "A valid Accumulo Connector is required by TypeMetadataHelper");
         this.connector = connector;
-        this.instance = instance;
+        this.instance = connector.getInstance();
+        
+        Preconditions.checkNotNull(metadataTableName, "The metadata table name is required by TypeMetadataHelper");
         this.metadataTableName = metadataTableName;
+        
+        Preconditions.checkNotNull(auths, "Accumulo scan Authorizations are required by TypeMetadataHelper");
         this.auths = auths;
+        
         this.useTypeSubstitution = useTypeSubstitution;
         
-        if (log.isTraceEnabled()) {
-            log.trace("Constructor  connector: " + connector.getClass().getCanonicalName() + " with auths: " + auths + " and metadata table name: "
-                            + metadataTableName);
-        }
-        return this;
+        log.trace("Constructor connector: {} with auths: {} and metadata table name: {}", connector.getClass().getCanonicalName(), auths, metadataTableName);
     }
     
     public Set<Authorizations> getAuths() {
@@ -233,9 +224,25 @@ public class TypeMetadataHelper {
     
     @Component
     public static class Factory {
-        @Lookup
-        public TypeMetadataHelper createTypeMetadataHelper() {
-            return new TypeMetadataHelper(Maps.newHashMap(), Collections.emptySet());
+        private final BeanFactory beanFactory;
+        
+        public Factory(BeanFactory beanFactory) {
+            this.beanFactory = beanFactory;
+        }
+        
+        @SuppressWarnings("unchecked")
+        public TypeMetadataHelper createTypeMetadataHelper(Connector connector, String metadataTableName, Set<Authorizations> auths,
+                        boolean useTypeSubstitution) {
+            if (beanFactory == null) {
+                log.info("TypeMetadataHelper created without a beanFactory. This is fine for unit tests, but an error in production.");
+                return new TypeMetadataHelper(Maps.newHashMap(), Collections.emptySet(), connector, metadataTableName, auths, useTypeSubstitution);
+            } else {
+                Map<String,String> typeSubstitutions = (Map<String,String>) beanFactory.getBean("typeSubstitutions",
+                                ResolvableType.forClassWithGenerics(Map.class, String.class, String.class).resolve());
+                Set<Authorizations> allMetadataAuths = (Set<Authorizations>) beanFactory.getBean("allMetadataAuths",
+                                ResolvableType.forClassWithGenerics(Set.class, Authorizations.class).resolve());
+                return new TypeMetadataHelper(typeSubstitutions, allMetadataAuths, connector, metadataTableName, auths, useTypeSubstitution);
+            }
         }
     }
 }

--- a/services/metadata-utils/src/main/java/datawave/query/util/TypeMetadataHelper.java
+++ b/services/metadata-utils/src/main/java/datawave/query/util/TypeMetadataHelper.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Scope;
@@ -212,14 +211,6 @@ public class TypeMetadataHelper {
         bs.close();
         
         return typeMetadata;
-    }
-    
-    /**
-     * Invalidates all elements in all internal caches this should also write the new typemetadata to hdfs so that the tservers will get the latest.
-     */
-    @CacheEvict(value = {"getTypeMetadata"}, allEntries = true, cacheManager = "metadataHelperCacheManager")
-    public void evictCaches() {
-        log.debug("evictCaches");
     }
     
     @Component

--- a/warehouse/edge-dictionary-core/src/main/java/datawave/webservice/edgedictionary/DefaultDatawaveEdgeDictionaryImpl.java
+++ b/warehouse/edge-dictionary-core/src/main/java/datawave/webservice/edgedictionary/DefaultDatawaveEdgeDictionaryImpl.java
@@ -46,9 +46,7 @@ public class DefaultDatawaveEdgeDictionaryImpl implements DatawaveEdgeDictionary
     @Override
     public DefaultEdgeDictionary getEdgeDictionary(String metadataTableName, Connector connector, Set<Authorizations> auths, int numThreads) throws Exception {
         
-        MetadataHelper metadataHelper = this.metadataHelperFactory.createMetadataHelper();
-        
-        metadataHelper.initialize(connector, metadataTableName, auths);
+        MetadataHelper metadataHelper = this.metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
         
         // Convert them into a response object
         

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
@@ -82,12 +82,12 @@ public class PushdownScheduler extends Scheduler {
     protected MetadataHelper metadataHelper;
     
     public PushdownScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metaFactory) {
-        this(config, scannerFactory, metaFactory.createMetadataHelper());
+        this(config, scannerFactory, metaFactory.createMetadataHelper(config.getConnector(), config.getMetadataTableName(), config.getAuthorizations()));
     }
     
     protected PushdownScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelper helper) {
         this.config = config;
-        this.metadataHelper = helper.initialize(config.getConnector(), config.getMetadataTableName(), config.getAuthorizations());
+        this.metadataHelper = helper;
         this.scannerFactory = scannerFactory;
         customizedFunctionList = Lists.newArrayList();
         Preconditions.checkNotNull(config.getConnector());

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
@@ -81,14 +81,6 @@ public class PushdownScheduler extends Scheduler {
     
     protected MetadataHelper metadataHelper;
     
-    protected PushdownScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory) {
-        this.config = config;
-        this.scannerFactory = scannerFactory;
-        customizedFunctionList = Lists.newArrayList();
-        metadataHelper = MetadataHelper.getInstance(config.getConnector(), config.getMetadataTableName(), config.getAuthorizations());
-        Preconditions.checkNotNull(config.getConnector());
-    }
-    
     public PushdownScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metaFactory) {
         this(config, scannerFactory, metaFactory.createMetadataHelper());
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardIndexQueryTable.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardIndexQueryTable.java
@@ -149,7 +149,7 @@ public class ShardIndexQueryTable extends BaseQueryLogic<DiscoveredThing> {
      * @return a new initialized MetadataHelper
      */
     protected MetadataHelper initializeMetadataHelper(Connector connector, String metadataTableName, Set<Authorizations> auths) {
-        return this.metadataHelperFactory.createMetadataHelper().initialize(connector, metadataTableName, auths);
+        return this.metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
     }
     
     public MetadataHelperFactory getMetadataHelperFactory() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -456,19 +456,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     protected MetadataHelper prepareMetadataHelper(Connector connection, String metadataTableName, Set<Authorizations> auths, boolean rawTypes) {
         if (log.isTraceEnabled())
             log.trace("prepareMetadataHelper with " + connection);
-        MetadataHelper metadataHelper = this.metadataHelperFactory.createMetadataHelper();
-        // check to see if i need to initialize a new one
-        if (metadataHelper.getMetadataTableName() != null && metadataTableName != null && !metadataTableName.equals(metadataHelper.getMetadataTableName())) {
-            // initialize it
-            metadataHelper.initialize(connection, metadataTableName, auths, rawTypes);
-        } else if (metadataHelper.getAuths() == null || metadataHelper.getAuths().isEmpty()) {
-            return metadataHelper.initialize(connection, metadataTableName, auths, rawTypes);
-            // assumption is that it is already initialized. we shall see.....
-        } else {
-            if (log.isTraceEnabled())
-                log.trace("the MetadataHelper did not need to be initialized:" + metadataHelper + " and " + metadataTableName + " and " + auths);
-        }
-        return metadataHelper.initialize(connection, metadataTableName, auths, rawTypes);
+        return metadataHelperFactory.createMetadataHelper(connection, metadataTableName, auths, rawTypes);
     }
     
     public MetadataHelperFactory getMetadataHelperFactory() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/edge/DefaultEdgeEventQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/edge/DefaultEdgeEventQueryLogic.java
@@ -72,7 +72,7 @@ public class DefaultEdgeEventQueryLogic extends ShardQueryLogic {
         setEdgeDictionary(getEdgeDictionary(connection, auths, 8)); // TODO grab threads from somewhere
         
         // Load and apply the configured edge query model
-        loadEdgeQueryModel();
+        loadEdgeQueryModel(connection, auths);
         
         String queryString = applyQueryModel(getJexlQueryString(settings));
         
@@ -90,13 +90,13 @@ public class DefaultEdgeEventQueryLogic extends ShardQueryLogic {
     /**
      * Loads the query model specified by the current configuration, to be applied to the incoming query.
      */
-    protected void loadEdgeQueryModel() {
+    protected void loadEdgeQueryModel(Connector connector, Set<Authorizations> auths) {
         String model = getEdgeModelName() == null ? "" : getEdgeModelName();
         String modelTable = getModelTableName() == null ? "" : getModelTableName();
         if (null == getEdgeQueryModel() && (!model.isEmpty() && !modelTable.isEmpty())) {
             try {
-                setEdgeQueryModel(new EdgeQueryModel(getMetadataHelperFactory().createMetadataHelper().getQueryModel(config.getModelTableName(),
-                                config.getModelName())));
+                setEdgeQueryModel(new EdgeQueryModel(getMetadataHelperFactory().createMetadataHelper(connector, config.getMetadataTableName(), auths)
+                                .getQueryModel(config.getModelTableName(), config.getModelName())));
             } catch (Throwable t) {
                 log.error("Unable to load edgeQueryModel from metadata table", t);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
@@ -124,7 +124,6 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     public GenericQueryConfiguration initialize(Connector connection, Query settings, Set<Authorizations> auths) throws Exception {
         
         currentIteratorPriority = super.getBaseIteratorPriority() + 30;
-        MetadataHelper metadataHelper = prepareMetadataHelper(connection, modelTableName, auths);
         
         EdgeQueryConfiguration cfg = setUpConfig(settings);
         
@@ -197,19 +196,7 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     protected MetadataHelper prepareMetadataHelper(Connector connection, String metadataTableName, Set<Authorizations> auths) {
         if (log.isTraceEnabled())
             log.trace("prepareMetadataHelper with " + connection);
-        MetadataHelper metadataHelper = this.metadataHelperFactory.createMetadataHelper();
-        // check to see if i need to initialize a new one
-        if (metadataHelper.getMetadataTableName() != null && metadataTableName != null && !metadataTableName.equals(metadataHelper.getMetadataTableName())) {
-            // initialize it
-            metadataHelper.initialize(connection, metadataTableName, auths);
-        } else if (metadataHelper.getAuths() == null || metadataHelper.getAuths().isEmpty()) {
-            return metadataHelper.initialize(connection, metadataTableName, auths);
-            // assumption is that it is already initialized. we shall see.....
-        } else {
-            if (log.isTraceEnabled())
-                log.trace("the MetadataHelper did not need to be initialized:" + metadataHelper + " and " + metadataTableName + " and " + auths);
-        }
-        return metadataHelper.initialize(connection, metadataTableName, auths);
+        return metadataHelperFactory.createMetadataHelper(connection, metadataTableName, auths);
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/util/MetadataHelperUpdateHdfsListener.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/MetadataHelperUpdateHdfsListener.java
@@ -28,56 +28,26 @@ public class MetadataHelperUpdateHdfsListener {
     
     private static final Logger log = Logger.getLogger(MetadataHelperUpdateHdfsListener.class);
     
-    private String zookeepers;
-    private TypeMetadataHelper.Factory typeMetadataHelperFactory;
-    private String[] metadataTableNames;
-    private Set<Authorizations> allMetadataAuths;
+    private final String zookeepers;
+    private final TypeMetadataHelper.Factory typeMetadataHelperFactory;
+    private final Set<Authorizations> allMetadataAuths;
     private TypeMetadataWriter typeMetadataWriter = TypeMetadataWriter.Factory.createTypeMetadataWriter();
     
-    private String instance;
-    private String username;
-    private String password;
-    private long lockWaitTime = 1000L; // configurable in MetadataHelperCacheListenerContext.xml
+    private final String instance;
+    private final String username;
+    private final String password;
+    private final long lockWaitTime;
     
-    public void setPassword(String password) {
-        this.password = password;
-    }
-    
-    public void setUsername(String username) {
-        this.username = username;
-    }
-    
-    public void setInstance(String instance) {
-        this.instance = instance;
-    }
-    
-    public void setZookeepers(String zookeepers) {
+    public MetadataHelperUpdateHdfsListener(String zookeepers, TypeMetadataHelper.Factory typeMetadataHelperFactory, String[] metadataTableNames,
+                    Set<Authorizations> allMetadataAuths, String instance, String username, String password, long lockWaitTime) {
         this.zookeepers = zookeepers;
-    }
-    
-    public void setTypeMetadataHelperFactory(TypeMetadataHelper.Factory typeMetadataHelperFactory) {
         this.typeMetadataHelperFactory = typeMetadataHelperFactory;
-    }
-    
-    public void setAllMetadataAuths(Set<Authorizations> allMetadataAuths) {
         this.allMetadataAuths = allMetadataAuths;
-    }
-    
-    public void setMetadataTableNames(String[] metadataTableNames) {
-        
-        this.metadataTableNames = metadataTableNames;
-        registerCacheListeners();
-    }
-    
-    public long getLockWaitTime() {
-        return lockWaitTime;
-    }
-    
-    public void setLockWaitTime(long lockWaitTime) {
+        this.instance = instance;
+        this.username = username;
+        this.password = password;
         this.lockWaitTime = lockWaitTime;
-    }
-    
-    private void registerCacheListeners() {
+        
         for (String metadataTableName : metadataTableNames) {
             registerCacheListener(metadataTableName);
         }
@@ -154,8 +124,8 @@ public class MetadataHelperUpdateHdfsListener {
                         ZooKeeperInstance instance = new ZooKeeperInstance(ClientConfiguration.loadDefault().withInstance(this.instance)
                                         .withZkHosts(this.zookeepers));
                         Connector connector = instance.getConnector(this.username, new PasswordToken(this.password));
-                        TypeMetadataHelper typeMetadataHelper = this.typeMetadataHelperFactory.createTypeMetadataHelper();
-                        typeMetadataHelper.initialize(connector, metadataTableName, allMetadataAuths);
+                        TypeMetadataHelper typeMetadataHelper = this.typeMetadataHelperFactory.createTypeMetadataHelper(connector, metadataTableName,
+                                        allMetadataAuths, false);
                         typeMetadataWriter.writeTypeMetadataMap(typeMetadataHelper.getTypeMetadataMap(this.allMetadataAuths), metadataTableName);
                         if (log.isDebugEnabled()) {
                             log.debug("table:" + metadataTableName + " " + this + " set the sharedTriState needsUpdate to UPDATED for " + metadataTableName);

--- a/warehouse/query-core/src/main/java/datawave/query/util/MetadataHelperWithDescriptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/MetadataHelperWithDescriptions.java
@@ -1,7 +1,6 @@
 package datawave.query.util;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import datawave.data.ColumnFamilyConstants;
@@ -27,7 +26,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Configuration;
@@ -292,14 +290,5 @@ public class MetadataHelperWithDescriptions extends MetadataHelper {
     
     public ResponseObjectFactory getResponseObjectFactory() {
         return this.responseObjectFactory;
-    }
-    
-    /**
-     * Invalidates all elements in all internal caches
-     */
-    @CacheEvict(value = {"getMetadata"}, allEntries = true, cacheManager = "metadataHelperCacheManager")
-    public void evictCaches() {
-        log.debug("evictCaches");
-        super.evictCaches();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
@@ -844,7 +844,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
      */
     protected MetadataHelper getMetadataHelper(Connector con) throws AccumuloException, AccumuloSecurityException, TableNotFoundException, ExecutionException {
         Authorizations auths = con.securityOperations().getUserAuthorizations(con.whoami());
-        return metadataHelperFactory.createMetadataHelper().initialize(con, this.getMetadataTableName(), Collections.singleton(auths));
+        return metadataHelperFactory.createMetadataHelper(con, this.getMetadataTableName(), Collections.singleton(auths));
     }
     
     /**

--- a/warehouse/query-core/src/main/resources/metadata.properties
+++ b/warehouse/query-core/src/main/resources/metadata.properties
@@ -1,1 +1,0 @@
-metadatahelper.default.auths=${metadatahelper.default.auths}

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
@@ -206,7 +206,7 @@ public abstract class CompositeFunctionsTest {
         logic.setupQuery(config);
         
         TypeMetadataWriter typeMetadataWriter = TypeMetadataWriter.Factory.createTypeMetadataWriter();
-        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper();
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper.Factory().createTypeMetadataHelper();
         typeMetadataHelper.initialize(connector, MODEL_TABLE_NAME, authSet);
         Map<Set<String>,TypeMetadata> typeMetadataMap = typeMetadataHelper.getTypeMetadataMap(authSet);
         typeMetadataWriter.writeTypeMetadataMap(typeMetadataMap, MODEL_TABLE_NAME);

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
@@ -206,8 +206,7 @@ public abstract class CompositeFunctionsTest {
         logic.setupQuery(config);
         
         TypeMetadataWriter typeMetadataWriter = TypeMetadataWriter.Factory.createTypeMetadataWriter();
-        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper.Factory().createTypeMetadataHelper();
-        typeMetadataHelper.initialize(connector, MODEL_TABLE_NAME, authSet);
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper.Factory(null).createTypeMetadataHelper(connector, MODEL_TABLE_NAME, authSet, false);
         Map<Set<String>,TypeMetadata> typeMetadataMap = typeMetadataHelper.getTypeMetadataMap(authSet);
         typeMetadataWriter.writeTypeMetadataMap(typeMetadataMap, MODEL_TABLE_NAME);
         

--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -190,8 +190,7 @@ public class IfThisTestFailsThenHitTermsAreBroken {
         logic.setupQuery(config);
         
         TypeMetadataWriter typeMetadataWriter = TypeMetadataWriter.Factory.createTypeMetadataWriter();
-        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper.Factory().createTypeMetadataHelper();
-        typeMetadataHelper.initialize(connector, MODEL_TABLE_NAME, authSet);
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper.Factory(null).createTypeMetadataHelper(connector, MODEL_TABLE_NAME, authSet, false);
         Map<Set<String>,TypeMetadata> typeMetadataMap = typeMetadataHelper.getTypeMetadataMap(authSet);
         typeMetadataWriter.writeTypeMetadataMap(typeMetadataMap, MODEL_TABLE_NAME);
         

--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -78,7 +78,7 @@ import static datawave.query.QueryTestTableHelper.*;
 public class IfThisTestFailsThenHitTermsAreBroken {
     
     enum WhatKindaRange {
-        SHARD, DOCUMENT;
+        SHARD, DOCUMENT
     }
     
     private static final Logger log = Logger.getLogger(IfThisTestFailsThenHitTermsAreBroken.class);
@@ -138,6 +138,7 @@ public class IfThisTestFailsThenHitTermsAreBroken {
         File tempDir = Files.createTempDir();
         tempDir.deleteOnExit();
         System.setProperty("type.metadata.dir", tempDir.getAbsolutePath());
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D,T,U,V,W,X,Y,Z");
         log.info("using tempFolder " + tempDir);
         
         logic = new ShardQueryLogic();
@@ -189,7 +190,7 @@ public class IfThisTestFailsThenHitTermsAreBroken {
         logic.setupQuery(config);
         
         TypeMetadataWriter typeMetadataWriter = TypeMetadataWriter.Factory.createTypeMetadataWriter();
-        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper();
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper.Factory().createTypeMetadataHelper();
         typeMetadataHelper.initialize(connector, MODEL_TABLE_NAME, authSet);
         Map<Set<String>,TypeMetadata> typeMetadataMap = typeMetadataHelper.getTypeMetadataMap(authSet);
         typeMetadataWriter.writeTypeMetadataMap(typeMetadataMap, MODEL_TABLE_NAME);

--- a/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
@@ -72,6 +72,7 @@ public abstract class UseOccurrenceToCountInJexlContextTest {
         
         @BeforeClass
         public static void setUp() throws Exception {
+            System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D,T,U,V,W,X,Y,Z");
             QueryTestTableHelper qtth = new QueryTestTableHelper(UseOccurrenceToCountInJexlContextTest.ShardRange.class.toString(), log);
             connector = qtth.connector;
             
@@ -94,6 +95,7 @@ public abstract class UseOccurrenceToCountInJexlContextTest {
         
         @BeforeClass
         public static void setUp() throws Exception {
+            System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D,T,U,V,W,X,Y,Z");
             QueryTestTableHelper qtth = new QueryTestTableHelper(UseOccurrenceToCountInJexlContextTest.DocumentRange.class.toString(), log);
             connector = qtth.connector;
             

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexQueryExpansionVisitorTest.java
@@ -47,7 +47,7 @@ public class DateIndexQueryExpansionVisitorTest {
     
     protected ShardQueryLogic logic = null;
     
-    private MetadataHelper helper = new MetadataHelperFactory().createMetadataHelper();
+    private MetadataHelper helper;
     
     @BeforeClass
     public static void before() throws Exception {
@@ -58,6 +58,8 @@ public class DateIndexQueryExpansionVisitorTest {
     
     @Before
     public void setupTests() throws Exception {
+        
+        this.helper = new MetadataHelperFactory().createMetadataHelper(connector, DATE_INDEX_TABLE_NAME, Collections.singleton(auths));
         
         this.createTables();
         

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexQueryExpansionVisitorTest.java
@@ -8,6 +8,7 @@ import datawave.query.util.DateIndexTestIngest;
 import datawave.query.util.DateIndexHelper;
 import datawave.query.util.DateIndexHelperFactory;
 import datawave.query.util.MetadataHelper;
+import datawave.query.util.MetadataHelperFactory;
 import datawave.util.time.DateHelper;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -46,7 +47,7 @@ public class DateIndexQueryExpansionVisitorTest {
     
     protected ShardQueryLogic logic = null;
     
-    private MetadataHelper helper = MetadataHelper.getInstance();
+    private MetadataHelper helper = new MetadataHelperFactory().createMetadataHelper();
     
     @BeforeClass
     public static void before() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -1,11 +1,18 @@
 package datawave.query.jexl.visitors;
 
+import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.MetadataHelperFactory;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
 
 public class ExpandMultiNormalizedTermsTest {
     
@@ -21,8 +28,12 @@ public class ExpandMultiNormalizedTermsTest {
         
         ASTJexlScript smashed = TreeFlatteningRebuildingVisitor.flatten(queryTree);
         
+        InMemoryInstance instance = new InMemoryInstance();
+        Connector connector = instance.getConnector("root", new PasswordToken(""));
+        Set<Authorizations> auths = Collections.singleton(new Authorizations());
         ASTJexlScript script = (ASTJexlScript) smashed.jjtAccept(
-                        new ExpandMultiNormalizedTerms(new ShardQueryConfiguration(), new MetadataHelperFactory().createMetadataHelper()), null);
+                        new ExpandMultiNormalizedTerms(new ShardQueryConfiguration(), new MetadataHelperFactory().createMetadataHelper(connector,
+                                        "DatawaveMetadata", auths)), null);
         
         String originalRoundTrip = JexlStringBuildingVisitor.buildQuery(queryTree);
         String smashedRoundTrip = JexlStringBuildingVisitor.buildQuery(smashed);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -2,7 +2,7 @@ package datawave.query.jexl.visitors;
 
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.util.MetadataHelper;
+import datawave.query.util.MetadataHelperFactory;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,8 +21,8 @@ public class ExpandMultiNormalizedTermsTest {
         
         ASTJexlScript smashed = TreeFlatteningRebuildingVisitor.flatten(queryTree);
         
-        ASTJexlScript script = (ASTJexlScript) smashed.jjtAccept(new ExpandMultiNormalizedTerms(new ShardQueryConfiguration(), MetadataHelper.getInstance()),
-                        null);
+        ASTJexlScript script = (ASTJexlScript) smashed.jjtAccept(
+                        new ExpandMultiNormalizedTerms(new ShardQueryConfiguration(), new MetadataHelperFactory().createMetadataHelper()), null);
         
         String originalRoundTrip = JexlStringBuildingVisitor.buildQuery(queryTree);
         String smashedRoundTrip = JexlStringBuildingVisitor.buildQuery(smashed);

--- a/warehouse/query-core/src/test/java/datawave/query/util/MockMetadataHelper.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MockMetadataHelper.java
@@ -12,6 +12,7 @@ import datawave.data.MetadataCardinalityCounts;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.Type;
 import datawave.marking.MarkingFunctions;
+import datawave.query.composite.CompositeMetadataHelper;
 import datawave.query.model.QueryModel;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -53,6 +54,11 @@ public class MockMetadataHelper extends MetadataHelper {
             return input.getClass().getName();
         }
     };
+    
+    public MockMetadataHelper() {
+        super(new AllFieldMetadataHelper(new TypeMetadataHelper(Maps.newHashMap(), Collections.emptySet()), new CompositeMetadataHelper()), Collections
+                        .emptySet());
+    }
     
     public void addContentFields(Collection<String> fields) {
         this.contentFields.addAll(fields);

--- a/warehouse/query-core/src/test/resources/MetadataHelperContext.xml
+++ b/warehouse/query-core/src/test/resources/MetadataHelperContext.xml
@@ -19,10 +19,10 @@
         <constructor-arg name="allFieldMetadataHelper" ref="allFieldMetadataHelper"/>
         <constructor-arg name="allMetadataAuths" ref="allMetadataAuths"/>
     </bean>
-    
-    <bean id="metadataHelperFactory" class="datawave.query.util.MetadataHelperFactory" >
-        <lookup-method name="createMetadataHelper" bean="metadataHelper" />
-    </bean>
+
+    <bean id="typeMetadataHelperFactory" class="datawave.query.util.TypeMetadataHelper.Factory" autowire="constructor" />
+
+    <bean id="metadataHelperFactory" class="datawave.query.util.MetadataHelperFactory" autowire="constructor" />
 
     <bean id="allFieldMetadataHelper" scope="prototype" class="datawave.query.util.AllFieldMetadataHelper" >
         <constructor-arg name="typeMetadataHelper" ref="typeMetadataHelper"/>

--- a/warehouse/query-core/src/test/resources/MetadataHelperContext.xml
+++ b/warehouse/query-core/src/test/resources/MetadataHelperContext.xml
@@ -6,18 +6,18 @@
     xmlns:cache="http://www.springframework.org/schema/cache"
     xsi:schemaLocation="
      http://www.springframework.org/schema/beans 
-     http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+     http://www.springframework.org/schema/beans/spring-beans.xsd
      http://www.springframework.org/schema/cache 
-     http://www.springframework.org/schema/cache/spring-cache-4.0.xsd
-     http://www.springframework.org/schema/util 
-     http://www.springframework.org/schema/util/spring-util-4.0.xsd">
-     
+     http://www.springframework.org/schema/cache/spring-cache.xsd
+     http://www.springframework.org/schema/util
+     http://www.springframework.org/schema/util/spring-util.xsd">
+
      <!--  cacheManager is in CacheContext.xml. You must also include CacheContext.xml in any spring context that includes this file -->
-    <cache:annotation-driven cache-manager="cacheManager"/>
+    <cache:annotation-driven cache-manager="metadataHelperCacheManager"/>
     
-    <bean id="metadataHelper" scope="prototype" class="datawave.query.util.MetadataHelperWithDescriptions" >
-        <property name="allFieldMetadataHelper" ref="allFieldMetadataHelper"/>
-        <property name="allMetadataAuths" ref="allMetadataAuths"/>
+    <bean id="metadataHelper" scope="prototype" class="datawave.query.util.MetadataHelper" >
+        <constructor-arg name="allFieldMetadataHelper" ref="allFieldMetadataHelper"/>
+        <constructor-arg name="allMetadataAuths" ref="allMetadataAuths"/>
     </bean>
     
     <bean id="metadataHelperFactory" class="datawave.query.util.MetadataHelperFactory" >
@@ -25,19 +25,19 @@
     </bean>
 
     <bean id="allFieldMetadataHelper" scope="prototype" class="datawave.query.util.AllFieldMetadataHelper" >
-        <property name="typeMetadataHelper" ref="typeMetadataHelper"/>
-        <property name="compositeMetadataHelper" ref="compositeMetadataHelper"/>
+        <constructor-arg name="typeMetadataHelper" ref="typeMetadataHelper"/>
+        <constructor-arg name="compositeMetadataHelper" ref="compositeMetadataHelper"/>
     </bean>
 
     <bean id="typeMetadataHelper" scope="prototype" class="datawave.query.util.TypeMetadataHelper" >
-        <property name="typeSubstitutions" ref="typeSubstitutions" />
-        <property name="allMetadataAuths" ref="allMetadataAuths" />
+        <constructor-arg name="typeSubstitutions" ref="typeSubstitutions" />
+        <constructor-arg name="allMetadataAuths" ref="allMetadataAuths" />
     </bean>
 
     <bean id="compositeMetadataHelper" scope="prototype" class="datawave.query.composite.CompositeMetadataHelper" />
 
     <util:set id="allMetadataAuths" scope="prototype" value-type="org.apache.accumulo.core.security.Authorizations" >
-        <bean class="org.apache.accumulo.core.security.Authorizations" >
+        <bean class="org.apache.accumulo.core.security.Authorizations">
             <constructor-arg>
                 <list>
                     <value>ALL</value>

--- a/warehouse/query-core/src/test/resources/metadata.properties
+++ b/warehouse/query-core/src/test/resources/metadata.properties
@@ -1,1 +1,0 @@
-metadatahelper.default.auths=A,B,C,D,T,U,V,W,X,Y,Z

--- a/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
+++ b/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
@@ -47,6 +47,7 @@ embed-server --server-config=standalone-full.xml
 /system-property=dw.warehouse.pool.normal.size:add(value=${accumulo.normal.defaultpool.size})
 /system-property=dw.warehouse.pool.high.size:add(value=${accumulo.high.defaultpool.size})
 /system-property=dw.warehouse.pool.admin.size:add(value=${accumulo.admin.defaultpool.size})
+/system-property=dw.metadatahelper.all.auths:add(value="${metadatahelper.default.auths}")
 /system-property=dw.metrics.pool.low.size:add(value=${accumulo.low.defaultpool.size})
 /system-property=dw.metrics.pool.normal.size:add(value=${accumulo.normal.defaultpool.size})
 /system-property=dw.metrics.pool.high.size:add(value=${accumulo.high.defaultpool.size})

--- a/web-services/deploy/application/src/main/wildfly/remove-datawave-configuration.cli
+++ b/web-services/deploy/application/src/main/wildfly/remove-datawave-configuration.cli
@@ -146,6 +146,7 @@ jms-queue remove --queue-address=QueryMetricsQueue
 /system-property=dw.warehouse.pool.normal.size:remove
 /system-property=dw.warehouse.pool.high.size:remove
 /system-property=dw.warehouse.pool.admin.size:remove
+/system-property=dw.metadatahelper.all.auths:remove
 /system-property=dw.metrics.pool.low.size:remove
 /system-property=dw.metrics.pool.normal.size:remove
 /system-property=dw.metrics.pool.high.size:remove

--- a/web-services/deploy/configuration/src/main/resources/MetadataHelperCacheListenerContext.xml
+++ b/web-services/deploy/configuration/src/main/resources/MetadataHelperCacheListenerContext.xml
@@ -17,12 +17,12 @@
     <!-- a singleton -->
     <bean id="metadataHelperCacheManagementListener" class="datawave.query.util.MetadataHelperCacheManagementListener" destroy-method="shutdown" >
         <constructor-arg name="zookeepers" value="${zookeeper.hosts}" />
-    	<constructor-arg name="metadataHelperFactory" ref="metadataHelperFactory" />
-    	<constructor-arg name="metadataTableNames" >
+        <constructor-arg name="metadataCacheManager" ref="metadataCacheManager" />
+        <constructor-arg name="metadataTableNames" >
     		<util:list>
 				${metadata.table.names}
     		</util:list>
-    	</constructor-arg>
+        </constructor-arg>
     </bean>
 
 	<bean id="metadataHelperUpdateHdfsListener" class="datawave.query.util.MetadataHelperUpdateHdfsListener" >

--- a/web-services/deploy/configuration/src/main/resources/MetadataHelperCacheListenerContext.xml
+++ b/web-services/deploy/configuration/src/main/resources/MetadataHelperCacheListenerContext.xml
@@ -16,29 +16,29 @@
       -->
     <!-- a singleton -->
     <bean id="metadataHelperCacheManagementListener" class="datawave.query.util.MetadataHelperCacheManagementListener" destroy-method="shutdown" >
-        <property name="zookeepers" value="${zookeeper.hosts}" />
-    	<property name="metadataHelper" ref="metadataHelper" />
-    	<property name="metadataTableNames" >
+        <constructor-arg name="zookeepers" value="${zookeeper.hosts}" />
+    	<constructor-arg name="metadataHelperFactory" ref="metadataHelperFactory" />
+    	<constructor-arg name="metadataTableNames" >
     		<util:list>
 				${metadata.table.names}
     		</util:list>
-    	</property>
+    	</constructor-arg>
     </bean>
 
 	<bean id="metadataHelperUpdateHdfsListener" class="datawave.query.util.MetadataHelperUpdateHdfsListener" >
-		<property name="zookeepers" value="${zookeeper.hosts}" />
-		<property name="typeMetadataHelperFactory" ref="typeMetadataHelperFactory" />
-		<property name="instance" value="${accumulo.instance.name}" />
-		<property name="password" value="${accumulo.user.password}" />
-		<property name="username" value="${accumulo.user.name}" />
-		<property name="allMetadataAuths" ref="allMetadataAuths" />
-		<property name="lockWaitTime" value="1000" />
+		<constructor-arg name="zookeepers" value="${zookeeper.hosts}" />
+		<constructor-arg name="typeMetadataHelperFactory" ref="typeMetadataHelperFactory" />
+		<constructor-arg name="instance" value="${accumulo.instance.name}" />
+		<constructor-arg name="password" value="${accumulo.user.password}" />
+		<constructor-arg name="username" value="${accumulo.user.name}" />
+		<constructor-arg name="allMetadataAuths" ref="allMetadataAuths" />
+		<constructor-arg name="lockWaitTime" value="1000" />
 
-		<property name="metadataTableNames" >
+		<constructor-arg name="metadataTableNames" >
 			<util:list>
 				${metadata.table.names}
 			</util:list>
-		</property>
+		</constructor-arg>
 	</bean>
 
 </beans>

--- a/web-services/deploy/configuration/src/main/resources/MetadataHelperContext.xml
+++ b/web-services/deploy/configuration/src/main/resources/MetadataHelperContext.xml
@@ -21,32 +21,28 @@
     <cache:annotation-driven cache-manager="metadataHelperCacheManager"/>
     
     <bean id="metadataHelper" scope="prototype" class="datawave.query.util.MetadataHelper" >
-        <constructor-arg ref="allFieldMetadataHelper"/>
-        <constructor-arg ref="allMetadataAuths"/>
-    </bean>
-    
-    <bean id="metadataHelperFactory" class="datawave.query.util.MetadataHelperFactory" >
-        <lookup-method name="createMetadataHelper" bean="metadataHelper" />
+        <constructor-arg name="allFieldMetadataHelper" ref="allFieldMetadataHelper"/>
+        <constructor-arg name="allMetadataAuths" ref="allMetadataAuths"/>
     </bean>
 
-    <bean id="typeMetadataHelperFactory" class="datawave.query.util.TypeMetadataHelper.Factory" >
-        <lookup-method name="createTypeMetadataHelper" bean="typeMetadataHelper" />
-    </bean>
+    <bean id="typeMetadataHelperFactory" class="datawave.query.util.TypeMetadataHelper.Factory" autowire="constructor" />
+
+    <bean id="metadataHelperFactory" class="datawave.query.util.MetadataHelperFactory" autowire="constructor" />
 
     <bean id="allFieldMetadataHelper" scope="prototype" class="datawave.query.util.AllFieldMetadataHelper" >
-        <constructor-arg ref="typeMetadataHelper"/>
-        <constructor-arg ref="compositeMetadataHelper"/>
+        <constructor-arg name="typeMetadataHelper" ref="typeMetadataHelper"/>
+        <constructor-arg name="compositeMetadataHelper" ref="compositeMetadataHelper"/>
     </bean>
 
     <bean id="typeMetadataHelper" scope="prototype" class="datawave.query.util.TypeMetadataHelper" >
         <constructor-arg name="typeSubstitutions" ref="typeSubstitutions" />
         <constructor-arg name="allMetadataAuths" ref="allMetadataAuths" />
     </bean>
-    
+
     <bean id="compositeMetadataHelper" scope="prototype" class="datawave.query.composite.CompositeMetadataHelper" />
 
     <util:set id="allMetadataAuths" scope="prototype" value-type="org.apache.accumulo.core.security.Authorizations" >
-        <bean class="org.apache.accumulo.core.security.Authorizations" >
+        <bean class="org.apache.accumulo.core.security.Authorizations">
             <constructor-arg>
                 <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
                     <constructor-arg type="java.lang.String" value="${dw.metadatahelper.all.auths}"/>

--- a/web-services/deploy/configuration/src/main/resources/MetadataHelperContext.xml
+++ b/web-services/deploy/configuration/src/main/resources/MetadataHelperContext.xml
@@ -4,20 +4,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:util="http://www.springframework.org/schema/util"
     xmlns:cache="http://www.springframework.org/schema/cache"
+    xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="
      http://www.springframework.org/schema/beans 
      http://www.springframework.org/schema/beans/spring-beans.xsd
      http://www.springframework.org/schema/cache 
      http://www.springframework.org/schema/cache/spring-cache.xsd
-     http://www.springframework.org/schema/util 
+     http://www.springframework.org/schema/context
+     http://www.springframework.org/schema/context/spring-context.xsd
+     http://www.springframework.org/schema/util
      http://www.springframework.org/schema/util/spring-util.xsd">
-     
+
+    <context:property-placeholder system-properties-mode="OVERRIDE" ignore-unresolvable="true" order="100" />
+
      <!--  cacheManager is in CacheContext.xml. You must also include CacheContext.xml in any spring context that includes this file -->
-    <cache:annotation-driven cache-manager="cacheManager"/>
+    <cache:annotation-driven cache-manager="metadataHelperCacheManager"/>
     
     <bean id="metadataHelper" scope="prototype" class="datawave.query.util.MetadataHelper" >
-        <property name="allFieldMetadataHelper" ref="allFieldMetadataHelper"/>
-        <property name="allMetadataAuths" ref="allMetadataAuths"/>
+        <constructor-arg ref="allFieldMetadataHelper"/>
+        <constructor-arg ref="allMetadataAuths"/>
     </bean>
     
     <bean id="metadataHelperFactory" class="datawave.query.util.MetadataHelperFactory" >
@@ -29,13 +34,13 @@
     </bean>
 
     <bean id="allFieldMetadataHelper" scope="prototype" class="datawave.query.util.AllFieldMetadataHelper" >
-        <property name="typeMetadataHelper" ref="typeMetadataHelper"/>
-        <property name="compositeMetadataHelper" ref="compositeMetadataHelper"/>
+        <constructor-arg ref="typeMetadataHelper"/>
+        <constructor-arg ref="compositeMetadataHelper"/>
     </bean>
 
     <bean id="typeMetadataHelper" scope="prototype" class="datawave.query.util.TypeMetadataHelper" >
-        <property name="typeSubstitutions" ref="typeSubstitutions" />
-        <property name="allMetadataAuths" ref="allMetadataAuths" />
+        <constructor-arg name="typeSubstitutions" ref="typeSubstitutions" />
+        <constructor-arg name="allMetadataAuths" ref="allMetadataAuths" />
     </bean>
     
     <bean id="compositeMetadataHelper" scope="prototype" class="datawave.query.composite.CompositeMetadataHelper" />
@@ -43,9 +48,9 @@
     <util:set id="allMetadataAuths" scope="prototype" value-type="org.apache.accumulo.core.security.Authorizations" >
         <bean class="org.apache.accumulo.core.security.Authorizations" >
             <constructor-arg>
-                <list>
-                    <value>${metadatahelper.default.auths}</value>
-                </list>
+                <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
+                    <constructor-arg type="java.lang.String" value="${dw.metadatahelper.all.auths}"/>
+                </bean>
             </constructor-arg>
         </bean>
     </util:set>

--- a/web-services/deploy/configuration/src/main/resources/MetadataHelperContext.xml
+++ b/web-services/deploy/configuration/src/main/resources/MetadataHelperContext.xml
@@ -19,7 +19,11 @@
 
      <!--  cacheManager is in CacheContext.xml. You must also include CacheContext.xml in any spring context that includes this file -->
     <cache:annotation-driven cache-manager="metadataHelperCacheManager"/>
-    
+
+    <bean id="metadataCacheManager" class="datawave.query.util.MetadataCacheManager">
+        <constructor-arg name="cacheManager" ref="metadataHelperCacheManager" />
+    </bean>
+
     <bean id="metadataHelper" scope="prototype" class="datawave.query.util.MetadataHelper" >
         <constructor-arg name="allFieldMetadataHelper" ref="allFieldMetadataHelper"/>
         <constructor-arg name="allMetadataAuths" ref="allMetadataAuths"/>

--- a/web-services/deploy/spring-framework-integration/src/test/resources/springFrameworkBeanRefContext.xml
+++ b/web-services/deploy/spring-framework-integration/src/test/resources/springFrameworkBeanRefContext.xml
@@ -11,6 +11,7 @@
                 <value>classpath*:datawave/configuration/spring/CDIBeanPostProcessor.xml</value>
                 <value>classpath*:NoOpMarkingFunctionsContext.xml</value>
                 <value>classpath*:MetadataHelperContext.xml</value>
+                <value>classpath*:CacheContext.xml</value>
                 <value>classpath*:datawave/security/PrincipalFactory.xml</value>
                 <value>classpath*:datawave/query/QueryExpiration.xml</value>
                 <value>classpath*:datawave/query/*QueryLogicFactory.xml</value>

--- a/web-services/map-reduce/src/test/java/datawave/webservice/mr/MapReduceBeanTest.java
+++ b/web-services/map-reduce/src/test/java/datawave/webservice/mr/MapReduceBeanTest.java
@@ -75,7 +75,7 @@ public class MapReduceBeanTest extends EasyMockSupport {
     @Before
     public void setup() throws Exception {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         DatawaveUser user = new DatawaveUser(SubjectIssuerDNPair.of(userDN, "CN=ca, OU=acme"), UserType.USER, Arrays.asList(auths),
                         Collections.singleton("AuthorizedUser"), null, 0L);
         principal = new DatawavePrincipal(Collections.singletonList(user));

--- a/web-services/map-reduce/src/test/java/datawave/webservice/mr/state/MapReduceStatePersisterTest.java
+++ b/web-services/map-reduce/src/test/java/datawave/webservice/mr/state/MapReduceStatePersisterTest.java
@@ -73,7 +73,7 @@ public class MapReduceStatePersisterTest {
     @Before
     public void setup() throws Exception {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         connection = instance.getConnector("root", new PasswordToken(""));
         if (connection.tableOperations().exists(TABLE_NAME))
             connection.tableOperations().delete(TABLE_NAME);

--- a/web-services/model/src/test/java/datawave/webservice/query/model/ModelBeanTest.java
+++ b/web-services/model/src/test/java/datawave/webservice/query/model/ModelBeanTest.java
@@ -74,7 +74,7 @@ public class ModelBeanTest {
     @Before
     public void setup() throws Exception {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         bean = new ModelBean();
         connectionFactory = createStrictMock(AccumuloConnectionFactory.class);
         ctx = createMock(EJBContext.class);

--- a/web-services/query/src/test/java/datawave/webservice/query/interceptor/QueryMetricsEnrichmentInterceptorTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/interceptor/QueryMetricsEnrichmentInterceptorTest.java
@@ -115,7 +115,7 @@ public class QueryMetricsEnrichmentInterceptorTest {
     @Before
     public void setup() {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         
         // noinspection unchecked
         requestHeaders = PowerMock.createStrictMock(MultivaluedMap.class);

--- a/web-services/query/src/test/java/datawave/webservice/query/logic/DatawaveRoleManagerTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/logic/DatawaveRoleManagerTest.java
@@ -24,7 +24,7 @@ public class DatawaveRoleManagerTest {
     @Before
     public void beforeEachTest() {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         createAndSetWithSingleRole();
     }
     

--- a/web-services/query/src/test/java/datawave/webservice/query/logic/QueryLogicFactoryBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/logic/QueryLogicFactoryBeanTest.java
@@ -58,7 +58,7 @@ public class QueryLogicFactoryBeanTest extends EasyMockSupport {
     @Before
     public void setup() throws IllegalArgumentException, IllegalAccessException {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         Logger.getLogger(ClassPathXmlApplicationContext.class).setLevel(Level.OFF);
         Logger.getLogger(XmlBeanDefinitionReader.class).setLevel(Level.OFF);
         Logger.getLogger(DefaultListableBeanFactory.class).setLevel(Level.OFF);

--- a/web-services/query/src/test/java/datawave/webservice/query/logic/composite/CompositeQueryLogicTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/logic/composite/CompositeQueryLogicTest.java
@@ -346,7 +346,7 @@ public class CompositeQueryLogicTest {
     @Before
     public void setup() {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
     }
     
     @Test(expected = RuntimeException.class)

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -77,7 +77,7 @@ public class ExtendedRunningQueryTest {
     @Before
     public void setup() {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
     }
     
     @Test

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -150,7 +150,7 @@ public class QueryExecutorBeanTest {
     @Before
     public void setup() throws Exception {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         QueryTraceCache traceCache = new QueryTraceCache();
         Whitebox.invokeMethod(traceCache, "init");
         

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/RunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/RunningQueryTest.java
@@ -66,7 +66,7 @@ public class RunningQueryTest {
     public void setup() throws MalformedURLException, IllegalArgumentException, IllegalAccessException {
         
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        System.setProperty("metadatahelper.default.auths", "A,B,C,D");
+        System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
         
         settings.setQueryLogicName("testQueryLogic");
         settings.setQuery("FOO == BAR");


### PR DESCRIPTION
* Remove initialize methods, require initialize method args in constructor, make parameters final
  It used to be that a prototype metadata helper would be injected, and then initialized with specific params. However, initialize
  could never be called more than once, and really this should have been part of construction. However, the metadata helper needs
  to be proxied by Spring in order to perform caching, since at each injection point, the connector, metadata table name, and auths
  could all be different, there was no way to do this. However, it turns out this can be done by instantiating the bean directly with
  the bean factory and passing args. The MetadataHelperFactory was updated to require the args, and use the bean factory to
  construct a MetadataHelper with the passed parameters.
* Cache eviction (and the trace-level cache printing) was moved to an external class. The CacheEvict annotations require all cache
  names to be passed, and there are many different cache names used by the MetadataHelper. Not all were cleared by the cache
  evict method (and one class chained to the parent, which doesn't work with a proxied class -- the proxy won't be called). This
  also removed the need for MetadataHelper to implement ApplicationContextAware.
* Annotate helpers with prototype scope
* Annotate factory methods with @Lookup
* Make helpers take constructor parameters (and pass from XML configs)
* Fix issue with specifying auths in metadata helper XML file.

These changes will help when using these classes via spring boot. I set metadata-utils to release 1.1, since the intent is to release it as soon as the PR is merged.