### PR TITLE
Remove unused managed dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -979,12 +979,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
-                <artifactId>wildfly-undertow</artifactId>
-                <version>${version.wildfly}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.deltaspike.core</groupId>
                 <artifactId>deltaspike-core-impl</artifactId>
                 <version>${version.deltaspike}</version>


### PR DESCRIPTION
It looks like this wildfly-undertow dependency is declared in the dependencyManagement section, but is never used as a dependency in any module, nor a transitive dependency of any declared dependencies. So, this section of the pom gets ignored in the build, and should be removed, to avoid triggering false positives when GitHub automatically analyses projects for vulnerable declared dependencies.