### PR TITLE
Modified Shard Balance check to allow multiple per tserver

### DIFF
--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/ShardedTableMapFileTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/ShardedTableMapFileTest.java
@@ -295,8 +295,8 @@ public class ShardedTableMapFileTest {
     @Test(expected = IllegalStateException.class)
     public void testUnbalancedMaxMoreThanConfigured() throws Exception {
         String tableName = "unbalancedMoreSplitsThenMaxPer";
-        SortedMap<Text,String> splits = simulateMultipleShardsPerTablet(tableName, 3);
-        conf.setInt(ShardedTableMapFile.SHARD_MAX_TABLETS_PER, 2);
+        SortedMap<Text,String> splits = simulateMultipleShardsPerTServer(tableName, 3);
+        conf.setInt(ShardedTableMapFile.MAX_SHARDS_PER_TSERVER, 2);
         
         createSplitsFile(splits, conf, splits.size(), tableName);
         Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
@@ -307,8 +307,8 @@ public class ShardedTableMapFileTest {
     @Test
     public void testUnbalancedButNotMoreThanConfigured() throws Exception {
         String tableName = "unbalancedNotMoreSplitsThenMaxPer";
-        SortedMap<Text,String> splits = simulateMultipleShardsPerTablet(tableName, 3);
-        conf.setInt(ShardedTableMapFile.SHARD_MAX_TABLETS_PER, 3);
+        SortedMap<Text,String> splits = simulateMultipleShardsPerTServer(tableName, 3);
+        conf.setInt(ShardedTableMapFile.MAX_SHARDS_PER_TSERVER, 3);
         
         createSplitsFile(splits, conf, splits.size(), tableName);
         Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
@@ -329,7 +329,7 @@ public class ShardedTableMapFileTest {
         return locations;
     }
     
-    private SortedMap<Text,String> simulateMultipleShardsPerTablet(String tableName, int shardsPerTablet) throws IOException {
+    private SortedMap<Text,String> simulateMultipleShardsPerTServer(String tableName, int shardsPerTServer) throws IOException {
         SortedMap<Text,String> locations = new TreeMap<>();
         long now = System.currentTimeMillis();
         int tserverId = 1;
@@ -338,9 +338,9 @@ public class ShardedTableMapFileTest {
             
             int currShard = 0;
             while (currShard < SHARDS_PER_DAY) {
-                // increment once, apply this tserver shardsPerTablet times
+                // increment once, apply this tserver shardsPerTServer times
                 tserverId++;
-                for (int i = 0; i < shardsPerTablet; i++) {
+                for (int i = 0; i < shardsPerTServer; i++) {
                     if (currShard >= SHARDS_PER_DAY) {
                         break;
                     }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/ShardedTableMapFileTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/ShardedTableMapFileTest.java
@@ -292,6 +292,30 @@ public class ShardedTableMapFileTest {
         ShardedTableMapFile.validateShardIdLocations(conf, tableName, 1, locations);
     }
     
+    @Test(expected = IllegalStateException.class)
+    public void testUnbalancedMaxMoreThanConfigured() throws Exception {
+        String tableName = "unbalancedMoreSplitsThenMaxPer";
+        SortedMap<Text,String> splits = simulateMultipleShardsPerTablet(tableName, 3);
+        conf.setInt(ShardedTableMapFile.SHARD_MAX_TABLETS_PER, 2);
+        
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        // this should cause the exception
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+    }
+    
+    @Test
+    public void testUnbalancedButNotMoreThanConfigured() throws Exception {
+        String tableName = "unbalancedNotMoreSplitsThenMaxPer";
+        SortedMap<Text,String> splits = simulateMultipleShardsPerTablet(tableName, 3);
+        conf.setInt(ShardedTableMapFile.SHARD_MAX_TABLETS_PER, 3);
+        
+        createSplitsFile(splits, conf, splits.size(), tableName);
+        Map<Text,String> locations = ShardedTableMapFile.getShardIdToLocations(conf, tableName);
+        // this should NOT cause an exception
+        ShardedTableMapFile.validateShardIdLocations(conf, tableName, 0, locations);
+    }
+    
     private SortedMap<Text,String> simulateUnbalancedSplitsForDay(int daysAgo, String tableName) throws IOException {
         // start with a well distributed set of shards per day for 3 days
         SortedMap<Text,String> locations = createDistributedLocations(tableName);
@@ -302,6 +326,28 @@ public class ShardedTableMapFileTest {
             locations.put(new Text(date + "_" + currShard), tserverId);
         }
         
+        return locations;
+    }
+    
+    private SortedMap<Text,String> simulateMultipleShardsPerTablet(String tableName, int shardsPerTablet) throws IOException {
+        SortedMap<Text,String> locations = new TreeMap<>();
+        long now = System.currentTimeMillis();
+        int tserverId = 1;
+        for (int daysAgo = 0; daysAgo <= 2; daysAgo++) {
+            String day = DateHelper.format(now - (daysAgo * DateUtils.MILLIS_PER_DAY));
+            
+            int currShard = 0;
+            while (currShard < SHARDS_PER_DAY) {
+                // increment once, apply this tserver shardsPerTablet times
+                tserverId++;
+                for (int i = 0; i < shardsPerTablet; i++) {
+                    if (currShard >= SHARDS_PER_DAY) {
+                        break;
+                    }
+                    locations.put(new Text(day + "_" + currShard++), Integer.toString(tserverId));
+                }
+            }
+        }
         return locations;
     }
     


### PR DESCRIPTION
New shardedMap.max.tablets.per.shard config property will allow a maximum
number of shards per tablet.  This is useful for the case that there
are more shards then there are tservers on the system. We still want to be
balanced as much as possible, but some can be on more then one up to max.