### PR TITLE
Replace use of Accumulo internals with 1.8 API

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/BulkIngestMapFileLoader.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/BulkIngestMapFileLoader.java
@@ -15,7 +15,6 @@ import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.impl.ClientContext;
 import org.apache.accumulo.core.client.impl.Credentials;
 import org.apache.accumulo.core.client.impl.MasterClient;
-import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.master.thrift.MasterClientService.Iface;
@@ -665,7 +664,7 @@ public final class BulkIngestMapFileLoader implements Runnable {
         
         Instance instance = new ZooKeeperInstance(ClientConfiguration.loadDefault().withInstance(instanceName).withZkHosts(zooKeepers));
         TableOperations tops = instance.getConnector(credentials.getPrincipal(), credentials.getToken()).tableOperations();
-        Map<String,String> tableIds = Tables.getNameToIdMap(instance);
+        Map<String,String> tableIds = tops.tableIdMap();
         FileStatus[] tableDirs = fs.globStatus(new Path(mapFilesDir, "*"));
         
         // sort the table dirs in priority order based on the configuration

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
@@ -37,6 +37,7 @@ import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.NamespaceExistsException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -48,7 +49,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.KeyValue;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.data.thrift.IterInfo;
 import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -1256,7 +1256,7 @@ public class IngestJob implements Tool {
         // aggregator is a scan aggregator.
         IteratorScope scope = IteratorScope.scan;
         for (String table : tableNames) {
-            ArrayList<IterInfo> iters = new ArrayList<>();
+            ArrayList<IteratorSetting> iters = new ArrayList<>();
             HashMap<String,Map<String,String>> allOptions = new HashMap<>();
             
             // Go through all of the configuration properties of this table and figure out which
@@ -1278,7 +1278,7 @@ public class IngestJob implements Tool {
                         String sa[] = entry.getValue().split(",");
                         int prio = Integer.parseInt(sa[0]);
                         String className = sa[1];
-                        iters.add(new IterInfo(prio, className, suffixSplit[1]));
+                        iters.add(new IteratorSetting(prio, suffixSplit[1], className));
                     } else if (suffixSplit.length == 4 && suffixSplit[2].equals("opt")) {
                         String iterName = suffixSplit[1];
                         String optName = suffixSplit[3];
@@ -1299,36 +1299,36 @@ public class IngestJob implements Tool {
             
             // Now go through all of the iterators, and for those that are aggregators, store
             // the options in the Hadoop config so that we can parse it back out in the reducer.
-            for (IterInfo iter : iters) {
-                Class<?> klass = Class.forName(iter.getClassName());
+            for (IteratorSetting iter : iters) {
+                Class<?> klass = Class.forName(iter.getIteratorClass());
                 if (PropogatingIterator.class.isAssignableFrom(klass)) {
-                    Map<String,String> options = allOptions.get(iter.getIterName());
+                    Map<String,String> options = allOptions.get(iter.getName());
                     if (null != options) {
                         for (Entry<String,String> option : options.entrySet()) {
                             String key = String.format("aggregator.%s.%d.%s", table, iter.getPriority(), option.getKey());
                             conf.set(key, option.getValue());
                         }
                     } else
-                        log.trace("Skipping iterator class " + iter.getClassName() + " since it doesn't have options.");
+                        log.trace("Skipping iterator class " + iter.getIteratorClass() + " since it doesn't have options.");
                     
                 } else {
-                    log.trace("Skipping iterator class " + iter.getClassName() + " since it doesn't appear to be a combiner.");
+                    log.trace("Skipping iterator class " + iter.getIteratorClass() + " since it doesn't appear to be a combiner.");
                 }
             }
             
-            for (IterInfo iter : iters) {
-                Class<?> klass = Class.forName(iter.getClassName());
+            for (IteratorSetting iter : iters) {
+                Class<?> klass = Class.forName(iter.getIteratorClass());
                 if (Combiner.class.isAssignableFrom(klass)) {
-                    Map<String,String> options = allOptions.get(iter.getIterName());
+                    Map<String,String> options = allOptions.get(iter.getName());
                     if (null != options) {
                         String key = String.format("combiner.%s.%d.iterClazz", table, iter.getPriority());
-                        conf.set(key, iter.getClassName());
+                        conf.set(key, iter.getIteratorClass());
                         for (Entry<String,String> option : options.entrySet()) {
                             key = String.format("combiner.%s.%d.%s", table, iter.getPriority(), option.getKey());
                             conf.set(key, option.getValue());
                         }
                     } else
-                        log.trace("Skipping iterator class " + iter.getClassName() + " since it doesn't have options.");
+                        log.trace("Skipping iterator class " + iter.getIteratorClass() + " since it doesn't have options.");
                     
                 }
             }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
@@ -25,9 +25,10 @@ import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.conf.ColumnSet;
 import org.apache.accumulo.core.iterators.conf.ColumnToClassMapping;
-import org.apache.accumulo.core.iterators.conf.PerColumnIteratorConfig;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Reducer;
@@ -189,7 +190,7 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                             Map<String,Entry<Map<String,String>,String>> columnMap = Maps.newHashMap();
                             
                             for (String column : columns) {
-                                columnMap.put(PerColumnIteratorConfig.encodeColumns(new Text(column), null), Maps.immutableEntry(options, clazz));
+                                columnMap.put(ColumnSet.encodeColumns(new Text(column), null), Maps.immutableEntry(options, clazz));
                             }
                             
                             mapping = new CustomColumnToClassMapping(columnMap, priority);
@@ -377,7 +378,7 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                 
                 final String className = entry.getValue();
                 
-                PerColumnIteratorConfig pcic = PerColumnIteratorConfig.decodeColumns(column, className);
+                Pair<Text,Text> pcic = ColumnSet.decodeColumns(column);
                 
                 Combiner agg = null;
                 
@@ -390,10 +391,10 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                     throw new RuntimeException(e);
                 }
                 
-                if (pcic.getColumnQualifier() == null) {
-                    addObject(pcic.getColumnFamily(), agg);
+                if (pcic.getSecond() == null) {
+                    addObject(pcic.getFirst(), agg);
                 } else {
-                    addObject(pcic.getColumnFamily(), pcic.getColumnQualifier(), agg);
+                    addObject(pcic.getFirst(), pcic.getSecond(), agg);
                 }
             }
             
@@ -411,7 +412,7 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                 
                 final String className = clazzOptions.getValue();
                 
-                PerColumnIteratorConfig pcic = PerColumnIteratorConfig.decodeColumns(column, className);
+                Pair<Text,Text> pcic = ColumnSet.decodeColumns(column);
                 
                 Combiner agg = null;
                 
@@ -471,10 +472,10 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                     throw new RuntimeException(e);
                 }
                 
-                if (pcic.getColumnQualifier() == null) {
-                    addObject(pcic.getColumnFamily(), agg);
+                if (pcic.getSecond() == null) {
+                    addObject(pcic.getFirst(), agg);
                 } else {
-                    addObject(pcic.getColumnFamily(), pcic.getColumnQualifier(), agg);
+                    addObject(pcic.getFirst(), pcic.getSecond(), agg);
                 }
             }
             

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/FileByteSummaryLoader.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/FileByteSummaryLoader.java
@@ -21,6 +21,7 @@ import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.Text;
@@ -107,7 +108,7 @@ public class FileByteSummaryLoader extends Configured implements Tool {
         job.setInputFormatClass(AccumuloInputFormat.class);
         AccumuloInputFormat.setConnectorInfo(job, userName, new PasswordToken(password));
         AccumuloInputFormat.setInputTableName(job, inputTable);
-        AccumuloInputFormat.setScanAuthorizations(job, Constants.NO_AUTHS);
+        AccumuloInputFormat.setScanAuthorizations(job, Authorizations.EMPTY);
         AccumuloInputFormat.setZooKeeperInstance(job, ClientConfiguration.loadDefault().withInstance(instance.trim()).withZkHosts(zookeepers.trim()));
         AccumuloInputFormat.setRanges(job, Collections.singletonList(dayRange));
         // Ensure all data for a day goes to the same reducer so that we aggregate it correctly before sending to Accumulo

--- a/warehouse/query-core/src/main/java/datawave/mr/bulk/MultiRfileInputformat.java
+++ b/warehouse/query-core/src/main/java/datawave/mr/bulk/MultiRfileInputformat.java
@@ -21,7 +21,6 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Instance;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.InstanceOperations;
-import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -144,7 +143,7 @@ public class MultiRfileInputformat extends RFileInputFormat {
         final Instance instance = conn.getInstance();
         final PasswordToken token = new PasswordToken(BulkInputFormat.getPassword(conf));
         
-        final String tableId = Tables.getTableId(instance, tableName);
+        final String tableId = conn.tableOperations().tableIdMap().get(tableName);
         
         final List<InputSplit> inputSplitList = Lists.newArrayList();
         

--- a/warehouse/query-core/src/main/java/datawave/mr/bulk/RfileScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/mr/bulk/RfileScanner.java
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.client.impl.Tables;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -164,7 +163,7 @@ public class RfileScanner extends SessionOptions implements BatchScanner, Closea
                 }
                 String tableId = tableIdMap.getIfPresent(table);
                 if (null == tableId) {
-                    tableId = Tables.getTableId(connector.getInstance(), table);
+                    tableId = connector.tableOperations().tableIdMap().get(table);
                     tableIdMap.put(table, tableId);
                 }
                 AccumuloConfiguration acuTableConf = tableConfigMap.getIfPresent(tableId);

--- a/warehouse/query-core/src/main/java/datawave/query/metrics/AccumuloRecordWriter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/metrics/AccumuloRecordWriter.java
@@ -22,8 +22,8 @@ import org.apache.accumulo.core.client.ZooKeeperInstance;
 import datawave.accumulo.inmemory.InMemoryInstance;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.ColumnUpdate;
-import org.apache.accumulo.core.data.KeyExtent;
 import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import datawave.common.util.ArgumentChecker;
 import org.apache.commons.codec.binary.Base64;
@@ -202,10 +202,10 @@ public class AccumuloRecordWriter extends RecordWriter<Text,Mutation> {
         try {
             mtbw.close();
         } catch (MutationsRejectedException e) {
-            if (e.getAuthorizationFailures().size() >= 0) {
+            if (e.getSecurityErrorCodes().size() >= 0) {
                 HashSet<String> tables = new HashSet<>();
-                for (KeyExtent ke : e.getAuthorizationFailures()) {
-                    tables.add(ke.getTableId().toString());
+                for (TabletId tabletId : e.getSecurityErrorCodes().keySet()) {
+                    tables.add(tabletId.getTableId().toString());
                 }
                 
                 log.error("Not authorized to write to tables : " + tables);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ScannerFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ScannerFactory.java
@@ -16,7 +16,6 @@ import datawave.webservice.common.connection.WrappedConnector;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 
-import org.apache.accumulo.core.Constants;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
@@ -129,7 +128,7 @@ public class ScannerFactory {
     }
     
     public BatchScanner newScanner(String tableName, Query query) throws TableNotFoundException {
-        return newScanner(tableName, Collections.singleton(Constants.NO_AUTHS), query);
+        return newScanner(tableName, Collections.singleton(Authorizations.EMPTY), query);
     }
     
     /**


### PR DESCRIPTION
* Replace IterInfo with IteratorSetting in IngestJob
* Use the Accumulo API IteratorSetting instead of internal thrift
IterInfo class
* Replace old accumulo code in AggregatingReducer
* Replace Constants.NO_AUTHS with Authorizations.EMPTY
* Replace Tables class with Accumulo API

Since my other request (#321) was already approved I didn't want to push more changes to that branch. These changes are similar in that they should be safe and will work with Accumulo versions 1.8, 1.9 and 2.0.