### PR TITLE
fixes #342: Unfielded NOTs dropped from query plan

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/Constants.java
+++ b/warehouse/query-core/src/main/java/datawave/query/Constants.java
@@ -39,6 +39,8 @@ public class Constants {
     
     public static final String ANY_FIELD = "_ANYFIELD_";
     
+    public static final String NO_FIELD = "_NOFIELD_";
+    
     public static final Authorizations EMPTY_AUTHS = new Authorizations();
     
     public static final ColumnVisibility EMPTY_VISIBILITY = new ColumnVisibility();

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -421,7 +421,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
     @Override
     public ScannerStream visit(ASTEQNode node, Object data) {
         
-        if (isUnfielded(node)) {
+        if (isUnOrNotFielded(node)) {
             return ScannerStream.noData(node);
         }
         
@@ -588,7 +588,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
             return ScannerStream.unindexed(node);
         }
         
-        if (isUnfielded(node)) {
+        if (isUnOrNotFielded(node)) {
             return ScannerStream.noData(node);
         }
         
@@ -613,10 +613,10 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         return ScannerStream.delayedExpression(node);
     }
     
-    private boolean isUnfielded(JexlNode node) {
+    private boolean isUnOrNotFielded(JexlNode node) {
         List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(node);
         for (ASTIdentifier identifier : identifiers) {
-            if (identifier.image.equals(Constants.ANY_FIELD)) {
+            if (identifier.image.equals(Constants.ANY_FIELD) || identifier.image.equals(Constants.NO_FIELD)) {
                 return true;
             }
         }
@@ -627,7 +627,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(node);
         for (ASTIdentifier identifier : identifiers) {
             try {
-                if (!identifier.image.equals(Constants.ANY_FIELD)) {
+                if (!(identifier.image.equals(Constants.ANY_FIELD) || identifier.image.equals(Constants.NO_FIELD))) {
                     if (!metadataHelper.isIndexed(JexlASTHelper.deconstructIdentifier(identifier), config.getDatatypeFilter())) {
                         return true;
                     }
@@ -653,7 +653,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
     
     @Override
     public Object visit(ASTLTNode node, Object data) {
-        if (isUnfielded(node)) {
+        if (isUnOrNotFielded(node)) {
             return ScannerStream.noData(node);
         }
         
@@ -671,7 +671,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
     
     @Override
     public Object visit(ASTGTNode node, Object data) {
-        if (isUnfielded(node)) {
+        if (isUnOrNotFielded(node)) {
             return ScannerStream.noData(node);
         }
         
@@ -689,7 +689,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
     
     @Override
     public Object visit(ASTLENode node, Object data) {
-        if (isUnfielded(node)) {
+        if (isUnOrNotFielded(node)) {
             return ScannerStream.noData(node);
         }
         
@@ -706,7 +706,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
     
     @Override
     public Object visit(ASTGENode node, Object data) {
-        if (isUnfielded(node)) {
+        if (isUnOrNotFielded(node)) {
             return ScannerStream.noData(node);
         }
         

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
@@ -198,8 +198,10 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
             throw new InvalidFieldIndexQueryFatalQueryException(qe);
         }
         try {
-            if (Constants.ANY_FIELD.equals(fieldName)) {
-                return null;
+            // in the case of an ANY_FIELD or NO_FIELD, the query could not be exapnded against the index and hence this
+            // term has no results. Leave it in the query as such.
+            if (Constants.ANY_FIELD.equals(fieldName) || Constants.NO_FIELD.equals(fieldName)) {
+                return copy(node);
             }
             
             if (!this.helper.isIndexed(fieldName, config.getDatatypeFilter())) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExecutableDeterminationVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExecutableDeterminationVisitor.java
@@ -338,7 +338,7 @@ public class ExecutableDeterminationVisitor extends BaseVisitor {
     @Override
     public Object visit(ASTEQNode node, Object data) {
         STATE state;
-        if (isUnfielded(node)) {
+        if (isUnOrNoFielded(node)) {
             state = STATE.EXECUTABLE;
         } else if (isUnindexed(node)) {
             state = STATE.NON_EXECUTABLE;
@@ -358,7 +358,7 @@ public class ExecutableDeterminationVisitor extends BaseVisitor {
     @Override
     public Object visit(ASTNENode node, Object data) {
         STATE state;
-        if (isUnfielded(node)) {
+        if (isUnOrNoFielded(node)) {
             state = STATE.NON_EXECUTABLE;
         } else if (isUnindexed(node)) {
             state = STATE.NON_EXECUTABLE;
@@ -405,7 +405,7 @@ public class ExecutableDeterminationVisitor extends BaseVisitor {
     public Object visit(ASTERNode node, Object data) {
         STATE state;
         // if we got here, then we were not wrapped in an ivarator, or in a delayed predicate. So we know it returns 0 results unless unindexed.
-        if (isUnfielded(node)) {
+        if (isUnOrNoFielded(node)) {
             state = STATE.EXECUTABLE;
         } else if (isUnindexed(node)) {
             state = STATE.NON_EXECUTABLE;
@@ -433,10 +433,10 @@ public class ExecutableDeterminationVisitor extends BaseVisitor {
         return state;
     }
     
-    private boolean isUnfielded(JexlNode node) {
+    private boolean isUnOrNoFielded(JexlNode node) {
         List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(node);
         for (ASTIdentifier identifier : identifiers) {
-            if (identifier.image.equals(Constants.ANY_FIELD)) {
+            if (identifier.image.equals(Constants.ANY_FIELD) || identifier.image.equals(Constants.NO_FIELD)) {
                 return true;
             }
         }
@@ -446,7 +446,7 @@ public class ExecutableDeterminationVisitor extends BaseVisitor {
     private boolean isUnindexed(JexlNode node) {
         List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(node);
         for (ASTIdentifier identifier : identifiers) {
-            if (!identifier.image.equals(Constants.ANY_FIELD)) {
+            if (!(identifier.image.equals(Constants.ANY_FIELD) || identifier.image.equals(Constants.NO_FIELD))) {
                 if (this.indexedFields == null) {
                     if (config.getIndexedFields() != null && !config.getIndexedFields().isEmpty()) {
                         this.indexedFields = config.getIndexedFields();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnfieldedTermsVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnfieldedTermsVisitor.java
@@ -235,18 +235,7 @@ public class FixUnfieldedTermsVisitor extends ParallelIndexExpansion {
     
     @Override
     public Object visit(ASTNENode node, Object data) {
-        
-        concurrentExecution();
-        try {
-            Object obj = expandFieldNames(node, false);
-            concurrentExecution();
-            return obj;
-        } catch (CannotExpandUnfieldedTermFatalException e) {
-            log.error(e);
-            ASTOrNode emptyOrNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
-            emptyOrNode.jjtSetParent(node.jjtGetParent());
-            return emptyOrNode;
-        }
+        return expandFieldNames(node, false);
     }
     
     @Override
@@ -256,17 +245,7 @@ public class FixUnfieldedTermsVisitor extends ParallelIndexExpansion {
     
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        
-        concurrentExecution();
-        try {
-            Object obj = expandFieldNames(node, false);
-            concurrentExecution();
-            return obj;
-        } catch (CannotExpandUnfieldedTermFatalException e) {
-            ASTOrNode emptyOrNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
-            emptyOrNode.jjtSetParent(node.jjtGetParent());
-            return emptyOrNode;
-        }
+        return expandFieldNames(node, false);
     }
     
     @Override
@@ -291,18 +270,7 @@ public class FixUnfieldedTermsVisitor extends ParallelIndexExpansion {
     
     @Override
     public Object visit(ASTNotNode node, Object data) {
-        
-        concurrentExecution();
-        try {
-            Object obj = super.visit(node, data);
-            concurrentExecution();
-            return obj;
-        } catch (CannotExpandUnfieldedTermFatalException e) {
-            log.error(e);
-            ASTOrNode emptyOrNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
-            emptyOrNode.jjtSetParent(node.jjtGetParent());
-            return emptyOrNode;
-        }
+        return super.visit(node, data);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/PushdownLargeFieldedListsVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/PushdownLargeFieldedListsVisitor.java
@@ -100,7 +100,7 @@ public class PushdownLargeFieldedListsVisitor extends RebuildingVisitor {
             
             // if "OTHER_NODES", then simply add the subset back into the children list
             // or if "_ANYFIELD_" , then simply add the subset back into the children list
-            if (OTHER_NODES.equals(field) || Constants.ANY_FIELD.equals(field)) {
+            if (OTHER_NODES.equals(field) || Constants.ANY_FIELD.equals(field) || Constants.NO_FIELD.equals(field)) {
                 children.addAll(subsetChildrenCopies);
             }
             // if past our threshold, then add a ExceededValueThresholdMarker with an OR of this subset to the children list

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -879,13 +879,12 @@ public class DefaultQueryPlanner extends QueryPlanner {
                 expansionFields = metadataHelper.getExpansionFields(config.getDatatypeFilter());
                 queryTree = FixUnfieldedTermsVisitor.fixUnfieldedTree(config, scannerFactory, metadataHelper, queryTree, expansionFields);
             } catch (CannotExpandUnfieldedTermFatalException e) {
-                // The visitor will only throw this if we cannot expand a term that is not nested in an or.
-                // Hence this query would return no results.
+                // The visitor will only throw this if we cannot expand a term from some critical reason
                 stopwatch.stop();
                 NotFoundQueryException qe = new NotFoundQueryException(DatawaveErrorCode.UNFIELDED_QUERY_ZERO_MATCHES, e, MessageFormat.format("Query: ",
                                 queryData.getQuery()));
                 log.info(qe);
-                throw new NoResultsException(qe);
+                throw new DatawaveFatalQueryException(qe);
             } catch (InstantiationException | TableNotFoundException | IllegalAccessException e) {
                 stopwatch.stop();
                 QueryException qe = new QueryException(DatawaveErrorCode.METADATA_ACCESS_ERROR, e);
@@ -905,9 +904,7 @@ public class DefaultQueryPlanner extends QueryPlanner {
             // Verify that the query does not contain fields we've never seen
             // before
             Set<String> nonexistentFields = FieldMissingFromSchemaVisitor.getNonExistentFields(metadataHelper, queryTree, config.getDatatypeFilter(),
-                            Sets.newHashSet(QueryOptions.DEFAULT_DATATYPE_FIELDNAME, Constants.ANY_FIELD));// ,
-                                                                                                           // "filter",
-                                                                                                           // "countOf"));
+                            Sets.newHashSet(QueryOptions.DEFAULT_DATATYPE_FIELDNAME, Constants.ANY_FIELD, Constants.NO_FIELD));
             if (log.isDebugEnabled()) {
                 log.debug("Testing for non-existent fields, found: " + nonexistentFields.size());
             }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/FacetedQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/FacetedQueryPlanner.java
@@ -111,7 +111,6 @@ public class FacetedQueryPlanner extends IndexQueryPlanner {
     @Override
     protected ASTJexlScript limitQueryTree(ASTJexlScript script, ShardQueryConfiguration config) throws NoResultsException {
         // Assert that all of the terms in the query are indexed (so we can completely use the field index)
-        // Also removes any spurious _ANYFIELD_ nodes left in from upstream
         try {
             switch (facetedConfig.getType()) {
                 case DAY_COUNT:

--- a/warehouse/query-core/src/main/java/datawave/query/planner/IndexQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/IndexQueryPlanner.java
@@ -69,7 +69,6 @@ public class IndexQueryPlanner extends DefaultQueryPlanner {
     protected ASTJexlScript limitQueryTree(ASTJexlScript script, ShardQueryConfiguration config) throws NoResultsException {
         // Assert that all of the terms in the query are indexed (so we can
         // completely use the field index)
-        // Also removes any spurious _ANYFIELD_ nodes left in from upstream
         try {
             return AllTermsIndexedVisitor.isIndexed(script, config, metadataHelper);
         } catch (CannotExpandUnfieldedTermFatalException e) {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/pushdown/CostEstimator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/pushdown/CostEstimator.java
@@ -51,7 +51,7 @@ public class CostEstimator {
                     String pattern = JexlASTHelper.getLiteralValue(node).toString();
                     
                     // if the term is _ANYFIELD_ (could not expand), then treat as 0 cost
-                    if (fieldName.equals(Constants.ANY_FIELD)) {
+                    if (fieldName.equals(Constants.ANY_FIELD) || fieldName.equals(Constants.NO_FIELD)) {
                         return new Cost(0l, 0l);
                     }
                     
@@ -85,7 +85,7 @@ public class CostEstimator {
                     String fieldName = JexlASTHelper.getIdentifier(node);
                     
                     // if the term is _ANYFIELD_ (could not expand), then treat as 0 cost
-                    if (fieldName.equals(Constants.ANY_FIELD)) {
+                    if (fieldName.equals(Constants.ANY_FIELD) || fieldName.equals(Constants.NO_FIELD)) {
                         return new Cost(0l, 0l);
                     }
                     

--- a/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetCheck.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetCheck.java
@@ -50,7 +50,7 @@ public class FacetCheck extends AllTermsIndexedVisitor {
             throw new InvalidFieldIndexQueryFatalQueryException(qe);
         }
         
-        if (Constants.ANY_FIELD.equals(fieldName)) {
+        if (Constants.ANY_FIELD.equals(fieldName) || Constants.NO_FIELD.equals(fieldName)) {
             return null;
         }
         

--- a/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
@@ -1,5 +1,6 @@
 package datawave.query;
 
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetupHelper;
@@ -202,14 +203,14 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
     public void testRegexZeroResults() throws Exception {
         String phrase = RE_OP + "'zero.*'";
         for (TestCities city : TestCities.values()) {
-            String qCity = CityField.CITY.name() + EQ_OP + city.name();
+            String qCity = CityField.CITY.name() + EQ_OP + "'" + city.name() + "'";
             String query = qCity + AND_OP + Constants.ANY_FIELD + phrase;
             String expect = qCity + AND_OP + this.dataManager.convertAnyField(phrase);
             runTest(query, expect);
         }
     }
     
-    @Test
+    @Test(expected = DatawaveFatalQueryException.class)
     public void testRegexWithFIAndRI() throws Exception {
         String phrase = RE_OP + "'.*iss.*'";
         String query = Constants.ANY_FIELD + phrase;


### PR DESCRIPTION
Changes non-expandable un-fielded terms to _NOFIELD_ instead of throwing errors when not nested in an OR.