### PR TITLE
re #345: Moving max results override out of query logics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.microservice.accumulo-utils>1.0</version.microservice.accumulo-utils>
         <version.microservice.audit-api>1.4</version.microservice.audit-api>
         <version.microservice.authorization-api>1.3</version.microservice.authorization-api>
-        <version.microservice.base-rest-responses>1.0</version.microservice.base-rest-responses>
+        <version.microservice.base-rest-responses>1.1</version.microservice.base-rest-responses>
         <version.microservice.metrics-reporter>1.2</version.microservice.metrics-reporter>
         <version.minlog>1.2</version.minlog>
         <version.mysql-connector>5.1.35</version.mysql-connector>

--- a/services/base-rest-responses/src/main/java/datawave/webservice/query/exception/DatawaveErrorCode.java
+++ b/services/base-rest-responses/src/main/java/datawave/webservice/query/exception/DatawaveErrorCode.java
@@ -216,6 +216,7 @@ public enum DatawaveErrorCode {
     MISSING_REQUIRED_PARAMETER(400, 40, "Missing required parameter."),
     INVALID_PAGE_TIMEOUT(400, 41, "Invalid page timeout."),
     BEGIN_DATE_AFTER_END_DATE(400, 42, "The begin date occurs after the end date."),
+    INVALID_MAX_RESULTS_OVERRIDE(400, 43, "Invalid max results override value."),
     // 401 Unauthorized
     QUERY_OWNER_MISMATCH(401, 1, "Current user does not match user that defined query."),
     JOB_EXECUTION_UNAUTHORIZED(401, 2, "User not authorized to run this job."),

--- a/warehouse/query-core/src/main/java/datawave/query/QueryParameters.java
+++ b/warehouse/query-core/src/main/java/datawave/query/QueryParameters.java
@@ -26,11 +26,6 @@ public class QueryParameters {
     public static final String TRANFORM_CONTENT_TO_UID = "transform.content.to.uid";
     
     /**
-     * Override number of results to return in a query, will not be higher that what is set in the web service configuration.
-     */
-    public static final String MAX_RESULTS_OVERRIDE = "max.results.override";
-    
-    /**
      * Allows user to specify query syntax (i.e. JEXL or LUCENE)
      */
     public static final String QUERY_SYNTAX = "query.syntax";

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -459,7 +459,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         
         // Setters that would have been picked up in a super(logic) call
         this.setTableName(logic.getTableName());
-        this.setMaxQueryResults(logic.getMaxResults());
         this.setMaxRowsToScan(logic.getMaxRowsToScan());
         this.setUndisplayedVisibilities(logic.getUndisplayedVisibilities());
         this.setBaseIteratorPriority(logic.getBaseIteratorPriority());
@@ -495,10 +494,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     public static ShardQueryConfiguration create(ShardQueryLogic shardQueryLogic) {
         
         ShardQueryConfiguration config = create(shardQueryLogic.getConfig());
-        
-        if (shardQueryLogic.getMaxResults() < 0) {
-            config.setMaxQueryResults(Long.MAX_VALUE);
-        }
         
         // Lastly, honor overrides passed in via query parameters
         Set<QueryImpl.Parameter> parameterSet = config.getQuery().getParameters();

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -137,25 +137,6 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
             }
         }
         
-        // Get the MAX_RESULTS_OVERRIDE parameter if given
-        if (null != settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE)
-                        && null != settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE).getParameterValue()
-                        && !settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE).getParameterValue().isEmpty()) {
-            try {
-                long override = Long.parseLong(settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE).getParameterValue());
-                
-                if (override < config.getMaxQueryResults()) {
-                    config.setMaxQueryResults(override);
-                    // this.maxresults is initially set to the value in the config, we are overriding it here for this instance
-                    // of the query.
-                    this.setMaxResults(override);
-                }
-            } catch (NumberFormatException nfe) {
-                log.error(QueryParameters.MAX_RESULTS_OVERRIDE + " query parameter is not a valid number: "
-                                + settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE).getParameterValue() + ", using default value");
-            }
-        }
-        
         // Set the connector
         config.setConnector(connection);
         

--- a/warehouse/query-core/src/main/java/datawave/query/tables/PartitionedQueryTable.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/PartitionedQueryTable.java
@@ -62,27 +62,6 @@ public class PartitionedQueryTable extends ShardQueryLogic {
         params.add(new Parameter(QueryParameters.QUERY_SYNTAX, "JEXL"));
         this.settings.setParameters(params);
         
-        long maxConfiguredResults = 0;
-        // General query options
-        if (-1 == this.getMaxResults()) {
-            maxConfiguredResults = Long.MAX_VALUE;
-        } else {
-            maxConfiguredResults = this.getMaxResults();
-        }
-        
-        // Get the MAX_RESULTS_OVERRIDE parameter if given
-        String maxResultsOverrideStr = settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE).getParameterValue().trim();
-        if (org.apache.commons.lang.StringUtils.isNotBlank(maxResultsOverrideStr)) {
-            try {
-                long override = Long.parseLong(maxResultsOverrideStr);
-                if (override < maxConfiguredResults) {
-                    this.setMaxResults(override);
-                }
-            } catch (NumberFormatException nfe) {
-                log.error(QueryParameters.MAX_RESULTS_OVERRIDE + " query parameter is not a valid number: " + maxResultsOverrideStr + ", using default value");
-            }
-        }
-        
         if (chunker.preInitializeQueryLogic()) {
             GenericQueryConfiguration config = super.initialize(this.connector, this.settings, this.auths);
             if (!config.getQueries().hasNext()) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -146,9 +146,7 @@ import java.util.concurrent.TimeUnit;
  *     evaluate an Event based on information not already present in the Event or information that doesn't need to be returned with the Event.
  *     Filtering must be enabled by setting {@link ShardQueryConfiguration#useFilters} to true and providing a list of {@link datawave.query.index.lookup.DataTypeFilter} class
  *     names in {@link ShardQueryConfiguration#filterClassNames}.
- *  6. The query limits the results (default: 5000) using the setMaxResults method. In addition, "max.results.override" can be passed to the
- *     query as part of the Parameters object which allows query specific limits (but will not be more than set default)
- *  7. Projection can be accomplished by setting the {@link QueryParameters RETURN_FIELDS} parameter to a '/'-separated list of field names.
+ *  6. Projection can be accomplished by setting the {@link QueryParameters RETURN_FIELDS} parameter to a '/'-separated list of field names.
  * 
  * </pre>
  * 
@@ -694,28 +692,6 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
                     log.debug("Blacklisted fields: " + tBlacklistedFields);
                 }
             }
-        }
-        
-        // Get the MAX_RESULTS_OVERRIDE parameter if given
-        String maxResultsOverrideStr = settings.findParameter(MAX_RESULTS_OVERRIDE).getParameterValue().trim();
-        if (org.apache.commons.lang.StringUtils.isNotBlank(maxResultsOverrideStr)) {
-            try {
-                long override = Long.parseLong(maxResultsOverrideStr);
-                
-                if (override < config.getMaxQueryResults()) {
-                    config.setMaxQueryResults(override);
-                    // this.maxresults is initially set to the value in the
-                    // config, we are overriding it here for this instance
-                    // of the query.
-                    this.setMaxResults(override);
-                }
-            } catch (NumberFormatException nfe) {
-                log.error(MAX_RESULTS_OVERRIDE + " query parameter is not a valid number: " + maxResultsOverrideStr + ", using default value");
-            }
-        }
-        
-        if (log.isDebugEnabled()) {
-            log.debug("Max Results: " + config.getMaxQueryResults());
         }
         
         // Get the LIMIT_FIELDS parameter if given
@@ -1850,7 +1826,6 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         params.add(QueryParameters.DATATYPE_FILTER_SET);
         params.add(QueryParameters.RETURN_FIELDS);
         params.add(QueryParameters.BLACKLISTED_FIELDS);
-        params.add(QueryParameters.MAX_RESULTS_OVERRIDE);
         params.add(QueryParameters.FILTER_MASKED_VALUES);
         params.add(QueryParameters.INCLUDE_DATATYPE_AS_FIELD);
         params.add(QueryParameters.INCLUDE_GROUPING_CONTEXT);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/chained/ChainedQueryTable.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/chained/ChainedQueryTable.java
@@ -82,26 +82,6 @@ public abstract class ChainedQueryTable<T1,T2> extends BaseQueryLogic<T2> {
         
         ChainedQueryConfiguration config = new ChainedQueryConfiguration();
         
-        long maxConfiguredResults = 0;
-        // General query options
-        if (-1 == this.getMaxResults()) {
-            maxConfiguredResults = Long.MAX_VALUE;
-        } else {
-            maxConfiguredResults = this.getMaxResults();
-        }
-        // Get the MAX_RESULTS_OVERRIDE parameter if given
-        String maxResultsOverrideStr = settings.findParameter(QueryParameters.MAX_RESULTS_OVERRIDE).getParameterValue().trim();
-        if (org.apache.commons.lang.StringUtils.isNotBlank(maxResultsOverrideStr)) {
-            try {
-                long override = Long.parseLong(maxResultsOverrideStr);
-                if (override < maxConfiguredResults) {
-                    this.setMaxResults(override);
-                }
-            } catch (NumberFormatException nfe) {
-                log.error(QueryParameters.MAX_RESULTS_OVERRIDE + " query parameter is not a valid number: " + maxResultsOverrideStr + ", using default value");
-            }
-        }
-        
         if (log.isDebugEnabled()) {
             log.debug("Max Results: " + this.getMaxResults());
         }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
@@ -1,37 +1,22 @@
 package datawave.query.tables.edge;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.io.StringReader;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeSet;
-
 import datawave.core.iterators.ColumnQualifierRangeIterator;
 import datawave.core.iterators.ColumnRangeIterator;
 import datawave.data.type.Type;
+import datawave.query.Constants;
 import datawave.query.QueryParameters;
 import datawave.query.config.EdgeQueryConfiguration;
-import datawave.query.model.edge.EdgeQueryModel;
-import datawave.query.Constants;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.iterator.filter.DateTypeFilter;
 import datawave.query.iterator.filter.EdgeFilterIterator;
 import datawave.query.iterator.filter.LoadDateFilter;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.EdgeTableRangeBuildingVisitor;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.jexl.visitors.QueryModelVisitor;
-import datawave.query.jexl.visitors.EdgeTableRangeBuildingVisitor;
+import datawave.query.model.edge.EdgeQueryModel;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.tables.edge.contexts.VisitationContext;
 import datawave.query.transformer.EdgeQueryTransformer;
@@ -44,7 +29,6 @@ import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.configuration.QueryData;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.QueryLogicTransformer;
-
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -62,7 +46,20 @@ import org.apache.commons.jexl2.parser.Parser;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
-import com.google.common.collect.HashMultimap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     
@@ -130,25 +127,6 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         
         cfg.setConnector(connection);
         cfg.setAuthorizations(auths);
-        
-        // Get the MAX_RESULTS_OVERRIDE parameter if given
-        String maxResultsOverrideStr = settings.findParameter(MAX_RESULTS_OVERRIDE).getParameterValue().trim();
-        if (org.apache.commons.lang.StringUtils.isNotBlank(maxResultsOverrideStr)) {
-            try {
-                long override = Long.parseLong(maxResultsOverrideStr);
-                
-                if (override < cfg.getMaxQueryResults()) {
-                    cfg.setMaxQueryResults(override);
-                    
-                    // this.maxresults is initially set to the value in the config,
-                    // we are overriding it here for this instance of the query.
-                    this.setMaxResults(override);
-                }
-            } catch (NumberFormatException nfe) {
-                log.error(MAX_RESULTS_OVERRIDE + " query parameter is not a valid number: " + maxResultsOverrideStr + ", using default value");
-                throw new IllegalArgumentException("Error parsing parameter for " + MAX_RESULTS_OVERRIDE + ". Supplied value is not a number.");
-            }
-        }
         
         String queryString = settings.getQuery();
         if (null == queryString) {
@@ -711,7 +689,6 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         params.add(datawave.webservice.query.QueryParameters.QUERY_BEGIN);
         params.add(datawave.webservice.query.QueryParameters.QUERY_END);
         params.add(QueryParameters.DATATYPE_FILTER_SET);
-        params.add(MAX_RESULTS_OVERRIDE);
         params.add(EdgeQueryConfiguration.INCLUDE_STATS);
         params.add(EdgeQueryConfiguration.DATE_RANGE_TYPE);
         return params;

--- a/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
@@ -912,7 +912,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
         try {
             GenericResponse<String> createResponse = queryService.createQuery(logicName, QueryParametersImpl.paramsToMap(logicName, query.toString(),
                             "Query to find matching records for metadata modification", columnVisibility, new Date(0), new Date(),
-                            StringUtils.join(auths, ','), expiration, 2, -1, QueryPersistence.TRANSIENT, queryOptions.toString(), false));
+                            StringUtils.join(auths, ','), expiration, 2, -1, null, QueryPersistence.TRANSIENT, queryOptions.toString(), false));
             
             id = createResponse.getResult();
             BaseQueryResponse response = queryService.next(id);

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -426,7 +426,7 @@ public class ShardQueryConfigurationTest {
      */
     @Test
     public void testCheckForNewAdditions() throws IOException {
-        int expectedObjectCount = 160;
+        int expectedObjectCount = 159;
         ShardQueryConfiguration config = ShardQueryConfiguration.create();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(mapper.writeValueAsString(config));
@@ -437,6 +437,6 @@ public class ShardQueryConfigurationTest {
             objectCount++;
         }
         
-        Assert.assertEquals("New variable was added to the ShardQueryConfiguration", expectedObjectCount, objectCount);
+        Assert.assertEquals("New variable was added to or removed from the ShardQueryConfiguration", expectedObjectCount, objectCount);
     }
 }

--- a/web-services/client/src/main/java/datawave/webservice/query/Query.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/Query.java
@@ -56,6 +56,12 @@ public abstract class Query {
     
     public abstract void setPageTimeout(int pageTimeout);
     
+    public abstract long getMaxResultsOverride();
+    
+    public abstract void setMaxResultsOverride(long maxResults);
+    
+    public abstract boolean isMaxResultsOverridden();
+    
     public abstract Set<Parameter> getParameters();
     
     public abstract void setParameters(Set<Parameter> params);

--- a/web-services/client/src/main/java/datawave/webservice/query/QueryImpl.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/QueryImpl.java
@@ -218,6 +218,10 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
     @XmlElement
     protected int pageTimeout;
     @XmlElement
+    protected boolean isMaxResultsOverridden;
+    @XmlElement
+    protected long maxResultsOverride;
+    @XmlElement
     protected HashSet<Parameter> parameters = new HashSet<Parameter>();
     @XmlElement
     protected List<String> dnList;
@@ -270,6 +274,14 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         return pageTimeout;
     }
     
+    public long getMaxResultsOverride() {
+        return maxResultsOverride;
+    }
+    
+    public boolean isMaxResultsOverridden() {
+        return isMaxResultsOverridden;
+    }
+    
     public Set<Parameter> getParameters() {
         return parameters == null ? null : Collections.unmodifiableSet(parameters);
     }
@@ -300,6 +312,11 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
     
     public void setExpirationDate(Date expirationDate) {
         this.expirationDate = expirationDate;
+    }
+    
+    public void setMaxResultsOverride(long maxResults) {
+        this.maxResultsOverride = maxResults;
+        this.isMaxResultsOverridden = true;
     }
     
     public void setPagesize(int pagesize) {
@@ -388,6 +405,9 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         query.setId(UUID.randomUUID());
         query.setPagesize(this.getPagesize());
         query.setPageTimeout(this.getPageTimeout());
+        if (query.isMaxResultsOverridden()) {
+            query.setMaxResultsOverride(this.getMaxResultsOverride());
+        }
         query.setQuery(this.getQuery());
         query.setQueryAuthorizations(this.getQueryAuthorizations());
         query.setUserDN(this.getUserDN());
@@ -404,9 +424,10 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37).append(this.getQueryLogicName()).append(this.getQueryName()).append(this.getExpirationDate())
-                        .append(UUID.randomUUID()).append(this.getPagesize()).append(this.getPageTimeout()).append(this.getQuery())
-                        .append(this.getQueryAuthorizations()).append(this.getUserDN()).append(this.getOwner()).append(this.getParameters())
-                        .append(this.getDnList()).append(this.getColumnVisibility()).append(this.getBeginDate()).append(this.getEndDate()).toHashCode();
+                        .append(UUID.randomUUID()).append(this.getPagesize()).append(this.getPageTimeout())
+                        .append(this.isMaxResultsOverridden() ? this.getMaxResultsOverride() : 0).append(this.getQuery()).append(this.getQueryAuthorizations())
+                        .append(this.getUserDN()).append(this.getOwner()).append(this.getParameters()).append(this.getDnList())
+                        .append(this.getColumnVisibility()).append(this.getBeginDate()).append(this.getEndDate()).toHashCode();
     }
     
     @Override
@@ -418,6 +439,7 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         tsb.append("uuid", this.getId());
         tsb.append("pagesize", this.getPagesize());
         tsb.append("pageTimeout", this.getPageTimeout());
+        tsb.append("maxResultsOverride", (this.isMaxResultsOverridden() ? this.getMaxResultsOverride() : "NA"));
         tsb.append("query", this.getQuery());
         tsb.append("queryAuthorizations", this.getQueryAuthorizations());
         tsb.append("userDN", this.getUserDN());
@@ -450,6 +472,10 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         eb.append(this.getExpirationDate(), other.getExpirationDate());
         eb.append(this.getPagesize(), other.getPagesize());
         eb.append(this.getPageTimeout(), other.getPageTimeout());
+        eb.append(this.isMaxResultsOverridden(), other.isMaxResultsOverridden());
+        if (this.isMaxResultsOverridden()) {
+            eb.append(this.getMaxResultsOverride(), other.getMaxResultsOverride());
+        }
         eb.append(this.getColumnVisibility(), other.getColumnVisibility());
         eb.append(this.getBeginDate(), other.getBeginDate());
         eb.append(this.getEndDate(), other.getEndDate());

--- a/web-services/client/src/main/java/datawave/webservice/query/QueryParameters.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/QueryParameters.java
@@ -13,6 +13,7 @@ public interface QueryParameters extends ParameterValidator {
     String QUERY_PERSISTENCE = "persistence";
     String QUERY_PAGESIZE = "pagesize";
     String QUERY_PAGETIMEOUT = "pageTimeout";
+    String QUERY_MAX_RESULTS_OVERRIDE = "max.results.override";
     String QUERY_AUTHORIZATIONS = "auths";
     String QUERY_EXPIRATION = "expiration";
     String QUERY_TRACE = "trace";
@@ -41,6 +42,12 @@ public interface QueryParameters extends ParameterValidator {
     int getPageTimeout();
     
     void setPageTimeout(int pageTimeout);
+    
+    long getMaxResultsOverride();
+    
+    void setMaxResultsOverride(long maxResults);
+    
+    boolean isMaxResultsOverridden();
     
     String getAuths();
     

--- a/web-services/query/src/main/java/datawave/webservice/query/configuration/GenericQueryConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/configuration/GenericQueryConfiguration.java
@@ -34,7 +34,6 @@ public abstract class GenericQueryConfiguration {
     private Date beginDate = null;
     private Date endDate = null;
     
-    private Long maxQueryResults = 5000l;
     private Long maxRowsToScan = 25000l;
     
     private Set<String> undisplayedVisibilities = new HashSet<>();
@@ -60,7 +59,6 @@ public abstract class GenericQueryConfiguration {
      */
     public GenericQueryConfiguration(BaseQueryLogic<?> configuredLogic) {
         this.setTableName(configuredLogic.getTableName());
-        this.setMaxQueryResults(configuredLogic.getMaxResults());
         this.setMaxRowsToScan(configuredLogic.getMaxRowsToScan());
         this.setUndisplayedVisibilities(configuredLogic.getUndisplayedVisibilities());
         this.setBaseIteratorPriority(configuredLogic.getBaseIteratorPriority());
@@ -130,14 +128,6 @@ public abstract class GenericQueryConfiguration {
     
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
-    }
-    
-    public Long getMaxQueryResults() {
-        return maxQueryResults;
-    }
-    
-    public void setMaxQueryResults(Long maxQueryResults) {
-        this.maxQueryResults = maxQueryResults <= 0l ? Long.MAX_VALUE : maxQueryResults;
     }
     
     public Long getMaxRowsToScan() {

--- a/web-services/query/src/main/java/datawave/webservice/query/dashboard/DashboardQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/dashboard/DashboardQuery.java
@@ -21,6 +21,7 @@ public class DashboardQuery {
     private static final boolean trace = false;
     private static final int pageSize = 10000;
     private static final int pageTimeout = -1;
+    private static final Long maxResultsOverride = null;
     
     private DashboardQuery() {}
     
@@ -31,6 +32,6 @@ public class DashboardQuery {
         return (ExtJsResponse) queryExecutor.createQueryAndNext(
                         logicName,
                         QueryParametersImpl.paramsToMap(logicName, queryString, queryName, columnVisibility, beginDate, endDate, auths,
-                                        DateUtils.addDays(now, 1), pageSize, pageTimeout, persistence, parameters, trace));
+                                        DateUtils.addDays(now, 1), pageSize, pageTimeout, maxResultsOverride, persistence, parameters, trace));
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -45,11 +45,6 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     
     public static final String BYPASS_ACCUMULO = "rfile.debug";
     
-    /**
-     * Override number of results to return in a query, will not be higher that what is set in the web service configuration.
-     */
-    public static final String MAX_RESULTS_OVERRIDE = "max.results.override";
-    
     public BaseQueryLogic() {}
     
     public BaseQueryLogic(BaseQueryLogic<T> other) {

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutor.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutor.java
@@ -206,6 +206,8 @@ public interface QueryExecutor {
      *            - number of results to return on each call to next() (optional)
      * @param newPageTimeout
      *            - specify timeout (in minutes) for each call to next(), default to -1 for disabled (optional)
+     * @param newMaxResultsOverride
+     *            - max results (optional)
      * @param newPersistenceMode
      *            - indicates whether or not the query is persistent (optional)
      * @param newParameters
@@ -213,8 +215,8 @@ public interface QueryExecutor {
      * @return base response
      */
     GenericResponse<String> updateQuery(String id, String queryLogicName, String newQuery, String newColumnVisibility, Date newBeginDate, Date newEndDate,
-                    String newQueryAuthorizations, Date newExpirationDate, Integer newPagesize, Integer newPageTimeout, QueryPersistence newPersistenceMode,
-                    String newParameters);
+                    String newQueryAuthorizations, Date newExpirationDate, Integer newPagesize, Integer newPageTimeout, Long newMaxResultsOverride,
+                    QueryPersistence newPersistenceMode, String newParameters);
     
     /**
      * Duplicates a query and allows modification of optional properties
@@ -241,6 +243,8 @@ public interface QueryExecutor {
      *            - number of results to return on each call to next() (optional)
      * @param newPageTimeout
      *            - specify timeout (in minutes) for each call to next(), default to -1 for disabled (optional)
+     * @param newMaxResultsOverride
+     *            - max results (optional)
      * @param newPersistenceMode
      *            - indicates whether or not the query is persistent (optional)
      * @param newParameters
@@ -251,7 +255,7 @@ public interface QueryExecutor {
      */
     GenericResponse<String> duplicateQuery(String id, String newQueryName, String newQueryLogicName, String newQuery, String newColumnVisibility,
                     Date newBeginDate, Date newEndDate, String newQueryAuthorizations, Date newExpirationDate, Integer newPagesize, Integer newPageTimeout,
-                    QueryPersistence newPersistenceMode, String newParameters, boolean trace);
+                    Long newMaxResultsOverride, QueryPersistence newPersistenceMode, String newParameters, boolean trace);
     
     /**
      * Release the resources associated with this query

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
@@ -228,8 +228,14 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
                     log.info("Query logic max rows to scan has been reached, aborting query.next call");
                     break;
                 }
-                // if the logic had a max num results (across all pages) and we have reached that, then break out
-                if (this.logic.getMaxResults() > 0 && numResults >= this.logic.getMaxResults()) {
+                // if the logic had a max num results (across all pages) and we have reached that (or the maxResultsOverride if set), then break out
+                if (this.settings.isMaxResultsOverridden()) {
+                    if (this.settings.getMaxResultsOverride() > 0 && numResults >= this.settings.getMaxResultsOverride()) {
+                        log.info("Max results override has been reached, aborting query.next call");
+                        this.getMetric().setLifecycle(QueryMetric.Lifecycle.MAXRESULTS);
+                        break;
+                    }
+                } else if (this.logic.getMaxResults() > 0 && numResults >= this.logic.getMaxResults()) {
                     log.info("Query logic max results has been reached, aborting query.next call");
                     this.getMetric().setLifecycle(QueryMetric.Lifecycle.MAXRESULTS);
                     break;

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/TestGenericQueryConfiguration.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/TestGenericQueryConfiguration.java
@@ -35,7 +35,6 @@ public class TestGenericQueryConfiguration {
         // Set expectations
         expect(this.baseQueryLogic.getTableName()).andReturn("TEST");
         expect(this.baseQueryLogic.getBaseIteratorPriority()).andReturn(100);
-        expect(this.baseQueryLogic.getMaxResults()).andReturn(Long.MAX_VALUE);
         expect(this.baseQueryLogic.getMaxRowsToScan()).andReturn(1000L);
         expect(this.baseQueryLogic.getUndisplayedVisibilities()).andReturn(new HashSet<>(0));
         

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -1320,12 +1320,13 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime - 500);
         int pagesize = 1;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = null;
         boolean trace = false;
         
         MultivaluedMap<String,String> p = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate,
-                        queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         
         // Run the test
         PowerMock.replayAll();
@@ -1361,12 +1362,13 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime);
         int pagesize = 0;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = null;
         boolean trace = false;
         
         MultivaluedMap<String,String> p = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate,
-                        queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         
         // Run the test
         PowerMock.replayAll();
@@ -1402,13 +1404,14 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 1000;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = null;
         boolean trace = false;
         // Set expectations
         
         MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate,
-                        queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
         marking.validate(queryParameters);
@@ -1467,6 +1470,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 999999);
         int pagesize = 1;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = null;
         boolean trace = false;
@@ -1487,7 +1491,7 @@ public class ExtendedQueryExecutorBeanTest {
         Throwable result1 = null;
         try {
             MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate,
-                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
             
             subject.createQueryAndNext(queryLogicName, queryParameters);
             
@@ -1516,6 +1520,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime - 500);
         int pagesize = 1;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = null;
         boolean trace = false;
@@ -1528,7 +1533,7 @@ public class ExtendedQueryExecutorBeanTest {
         Throwable result1 = null;
         try {
             MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate,
-                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
             
             subject.defineQuery(queryLogicName, queryParameters);
             
@@ -1556,6 +1561,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime);
         int pagesize = 0;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = null;
         
@@ -1569,7 +1575,7 @@ public class ExtendedQueryExecutorBeanTest {
         Throwable result1 = null;
         try {
             MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate,
-                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
             
             subject.defineQuery(queryLogicName, queryParameters);
         } catch (DatawaveWebApplicationException e) {
@@ -1597,6 +1603,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 10000);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String userName = "userName";
         String userSid = "userSid";
@@ -1607,7 +1614,7 @@ public class ExtendedQueryExecutorBeanTest {
         UUID queryId = UUID.randomUUID();
         
         MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(null, query, queryName, queryVisibility, beginDate, endDate,
-                        queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, null, trace);
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, null, trace);
         queryParameters.putSingle("valid", "param");
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
@@ -1734,6 +1741,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = true;
@@ -1827,7 +1835,7 @@ public class ExtendedQueryExecutorBeanTest {
         setInternalState(subject, QueryParameters.class, new QueryParametersImpl());
         setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
         GenericResponse<String> result1 = subject.duplicateQuery(queryId.toString(), newQueryName, queryLogicName, query, queryVisibility, beginDate, endDate,
-                        queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         PowerMock.verifyAll();
         
         // Verify results
@@ -1849,6 +1857,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = false;
@@ -1878,7 +1887,7 @@ public class ExtendedQueryExecutorBeanTest {
         
         try {
             subject.duplicateQuery(queryId.toString(), queryName, queryLogicName, query, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         } finally {
             PowerMock.verifyAll();
         }
@@ -1900,6 +1909,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = true;
@@ -1954,7 +1964,7 @@ public class ExtendedQueryExecutorBeanTest {
         
         try {
             subject.duplicateQuery(queryId.toString(), newQueryName, queryLogicName, query, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         } finally {
             PowerMock.verifyAll();
         }
@@ -1974,6 +1984,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = true;
@@ -1991,7 +2002,7 @@ public class ExtendedQueryExecutorBeanTest {
         
         try {
             subject.duplicateQuery(queryId.toString(), newQueryName, queryLogicName, query, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         } finally {
             PowerMock.verifyAll();
         }
@@ -2011,6 +2022,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = true;
@@ -2023,7 +2035,7 @@ public class ExtendedQueryExecutorBeanTest {
         Exception result1 = null;
         try {
             subject.duplicateQuery(queryId.toString(), newQueryName, queryLogicName, query, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
         } catch (DatawaveWebApplicationException e) {
             result1 = e;
         }
@@ -2903,6 +2915,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         String userName = "userName";
@@ -2979,7 +2992,7 @@ public class ExtendedQueryExecutorBeanTest {
         setInternalState(subject, AuditBean.class, auditor);
         setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
         GenericResponse<String> result1 = subject.updateQuery(queryId.toString(), queryLogicName, query, queryVisibility, beginDate, endDate,
-                        queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters);
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters);
         PowerMock.verifyAll();
         
         // Verify results
@@ -3001,6 +3014,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = false;
@@ -3078,6 +3092,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pagesize = 10;
         int pageTimeout = -1;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         boolean trace = false;
@@ -3115,7 +3130,7 @@ public class ExtendedQueryExecutorBeanTest {
         StreamingOutput result1 = null;
         try {
             MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate,
-                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, persistenceMode, parameters, trace);
+                            endDate, queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
             
             result1 = subject.execute(queryLogicName, queryParameters, httpHeaders);
             
@@ -3377,6 +3392,7 @@ public class ExtendedQueryExecutorBeanTest {
         Date expirationDate = new Date(currentTime + 9999);
         int pageTimeout = 60;
         int pagesize = 10;
+        Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
         String parameters = "invalidparam; valid:param";
         String userName = "userName";
@@ -3447,7 +3463,7 @@ public class ExtendedQueryExecutorBeanTest {
         setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
         
         subject.updateQuery(queryId.toString(), queryLogicName, query, queryVisibility, beginDate, endDate, queryAuthorizations, expirationDate, pagesize,
-                        pageTimeout, persistenceMode, parameters);
+                        pageTimeout, maxResultsOverride, persistenceMode, parameters);
         PowerMock.verifyAll();
     }
     

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -152,6 +152,7 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getQueryName()).andReturn(queryName);
         expect(this.query.getBeginDate()).andReturn(beginDate);
         expect(this.query.getEndDate()).andReturn(endDate);
+        expect(this.query.isMaxResultsOverridden()).andReturn(false).anyTimes();
         expect(this.query.getExpirationDate()).andReturn(expirationDate);
         expect(this.query.getParameters()).andReturn(new HashSet<>());
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths);
@@ -230,6 +231,7 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getQueryName()).andReturn(queryName);
         expect(this.query.getBeginDate()).andReturn(beginDate);
         expect(this.query.getEndDate()).andReturn(endDate);
+        expect(this.query.isMaxResultsOverridden()).andReturn(false).anyTimes();
         expect(this.query.getExpirationDate()).andReturn(expirationDate);
         expect(this.query.getParameters()).andReturn(new HashSet<>());
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths);


### PR DESCRIPTION
The goal is to allow a PrivilegedUser to be able to override the maxResults setting with values larger than that configured on a query logic.  This involved moving the processing of the max.results.override handling out of the query logics and into the QueryExecutorBean and RunningQuery classes.