### PR TITLE
fixex #428: Deprecate maxRowsToScan, add maxWork

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -147,7 +147,7 @@ public class IfThisTestFailsThenHitTermsAreBroken {
         logic.setIndexTableName(SHARD_INDEX_TABLE_NAME);
         logic.setReverseIndexTableName(SHARD_RINDEX_TABLE_NAME);
         logic.setMaxResults(5000);
-        logic.setMaxRowsToScan(25000);
+        logic.setMaxWork(25000);
         logic.setModelTableName(MODEL_TABLE_NAME);
         logic.setQueryPlanner(new DefaultQueryPlanner());
         logic.setIncludeGroupingContext(true);

--- a/warehouse/query-core/src/test/java/datawave/query/QueryTestTableHelper.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryTestTableHelper.java
@@ -165,6 +165,6 @@ public final class QueryTestTableHelper {
         logic.setReverseIndexTableName(SHARD_RINDEX_TABLE_NAME);
         logic.setModelTableName(MODEL_TABLE_NAME);
         logic.setMaxResults(5000);
-        logic.setMaxRowsToScan(25000);
+        logic.setMaxWork(25000);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
@@ -149,7 +149,7 @@ public abstract class UseOccurrenceToCountInJexlContextTest {
         logic.setIndexTableName(QueryTestTableHelper.SHARD_INDEX_TABLE_NAME);
         logic.setReverseIndexTableName(QueryTestTableHelper.SHARD_RINDEX_TABLE_NAME);
         logic.setMaxResults(5000);
-        logic.setMaxRowsToScan(25000);
+        logic.setMaxWork(25000);
         logic.setModelTableName(QueryTestTableHelper.METADATA_TABLE_NAME);
         logic.setQueryPlanner(new DefaultQueryPlanner());
         logic.setIncludeGroupingContext(true);

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -49,7 +49,7 @@
 <!--         <property name="tableName" value="${edge.table.name}" /> -->
 		<property name="tableName" value="edge" />
         <property name="maxResults" value="25000" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="undisplayedVisibilities">
             <util:set>
             </util:set>

--- a/web-services/client/src/main/java/datawave/webservice/query/metric/BaseQueryMetric.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/metric/BaseQueryMetric.java
@@ -584,7 +584,7 @@ public abstract class BaseQueryMetric implements HasMarkings, Serializable {
     
     public enum Lifecycle {
         
-        NONE, DEFINED, INITIALIZED, RESULTS, CLOSED, CANCELLED, MAXRESULTS, NEXTTIMEOUT, TIMEOUT, SHUTDOWN
+        NONE, DEFINED, INITIALIZED, RESULTS, CLOSED, CANCELLED, MAXRESULTS, NEXTTIMEOUT, TIMEOUT, SHUTDOWN, MAXWORK
     }
     
     public String getQueryType() {

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/EdgeQueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/EdgeQueryLogicFactory.xml
@@ -21,7 +21,7 @@
         <property name="modelTableName" value="${metadata.table.name}" />
         <property name="modelName" value="DATAWAVE_EDGE" />
         <property name="maxResults" value="25000" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="undisplayedVisibilities">
             <util:set>
             </util:set>

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -303,7 +303,7 @@
         <property name="metadataTableName" value="${metadata.table.name}" />
         <property name="metadataHelperFactory" ref="metadataHelperFactory" />
         <property name="maxResults" value="-1" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="queryThreads" value="${shard.query.threads}" />
         <property name="modelTableName" value="${metadata.table.name}" />
         <property name="modelName" value="DATAWAVE" />
@@ -321,7 +321,7 @@
     <bean id="ContentQuery" parent="baseQueryLogic" scope="prototype"  class="datawave.query.tables.content.ContentQueryTable">
         <property name="tableName" value="${shard.table.name}" />
         <property name="maxResults" value="-1" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="undisplayedVisibilities">
             <util:set>
             </util:set>
@@ -338,7 +338,7 @@
         <property name="metadataTableName" value="${error.metadata.table.name}" />
         <property name="metadataHelperFactory" ref="metadataHelperFactory" />
         <property name="maxResults" value="-1" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="queryThreads" value="${shard.query.threads}" />
         <property name="modelTableName" value="${metadata.table.name}" />
         <property name="modelName" value="DATAWAVE" />
@@ -436,7 +436,7 @@
         <property name="indexTableName" value="${index.table.name}" />
         <property name="reverseIndexTableName" value="${rindex.table.name}" />
         <property name="maxResults" value="-1" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="modelTableName" value="${metadata.table.name}" />
         <property name="modelName" value="DATAWAVE" />
         <property name="metadataHelperFactory" ref="metadataHelperFactory" />
@@ -458,7 +458,7 @@
         <property name="indexTableName" value="${error.index.table.name}" />
         <property name="reverseIndexTableName" value="${error.rindex.table.name}" />
         <property name="maxResults" value="-1" />
-        <property name="maxRowsToScan" value="-1" />
+        <property name="maxWork" value="-1" />
         <property name="modelTableName" value="${metadata.table.name}" />
         <property name="modelName" value="DATAWAVE" />
         <property name="metadataHelperFactory" ref="metadataHelperFactory" />

--- a/web-services/query/src/main/java/datawave/webservice/query/configuration/GenericQueryConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/configuration/GenericQueryConfiguration.java
@@ -35,7 +35,8 @@ public abstract class GenericQueryConfiguration {
     private Date beginDate = null;
     private Date endDate = null;
     
-    private Long maxRowsToScan = 25000L;
+    // The max number of next + seek calls made by the underlying iterators
+    private Long maxWork = -1L;
     
     private Set<String> undisplayedVisibilities = new HashSet<>();
     protected int baseIteratorPriority = 100;
@@ -71,7 +72,7 @@ public abstract class GenericQueryConfiguration {
         this.setBeginDate(genericConfig.getBeginDate());
         this.setConnector(genericConfig.getConnector());
         this.setEndDate(genericConfig.getEndDate());
-        this.setMaxRowsToScan(genericConfig.getMaxRowsToScan());
+        this.setMaxWork(genericConfig.getMaxWork());
         this.setQueries(genericConfig.getQueries());
         this.setQueryString(genericConfig.getQueryString());
         this.setTableName(genericConfig.getTableName());
@@ -144,12 +145,12 @@ public abstract class GenericQueryConfiguration {
         this.endDate = endDate;
     }
     
-    public Long getMaxRowsToScan() {
-        return maxRowsToScan;
+    public Long getMaxWork() {
+        return maxWork;
     }
     
-    public void setMaxRowsToScan(Long maxRowsToScan) {
-        this.maxRowsToScan = maxRowsToScan <= 0L ? Long.MAX_VALUE : maxRowsToScan;
+    public void setMaxWork(Long maxWork) {
+        this.maxWork = maxWork;
     }
     
     public String getTableName() {

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -51,7 +51,7 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     public BaseQueryLogic(BaseQueryLogic<T> other) {
         // Generic Query Config variables
         setTableName(other.getTableName());
-        setMaxRowsToScan(other.getMaxRowsToScan());
+        setMaxWork(other.getMaxWork());
         setMaxResults(other.getMaxResults());
         setUndisplayedVisibilities(other.getUndisplayedVisibilities());
         setBaseIteratorPriority(other.getBaseIteratorPriority());
@@ -118,8 +118,14 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     }
     
     @Override
+    @Deprecated
     public long getMaxRowsToScan() {
-        return getConfig().getMaxRowsToScan();
+        return getMaxWork();
+    }
+    
+    @Override
+    public long getMaxWork() {
+        return getConfig().getMaxWork();
     }
     
     @Override
@@ -133,8 +139,14 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     }
     
     @Override
+    @Deprecated
     public void setMaxRowsToScan(long maxRowsToScan) {
-        getConfig().setMaxRowsToScan(maxRowsToScan);
+        setMaxWork(maxRowsToScan);
+    }
+    
+    @Override
+    public void setMaxWork(long maxWork) {
+        getConfig().setMaxWork(maxWork);
     }
     
     @Override

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
@@ -102,9 +102,15 @@ public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidato
     long getMaxResults();
     
     /**
-     * @return max number of rows to scan from the iterator
+     * @return the results of getMaxWork
      */
+    @Deprecated
     long getMaxRowsToScan();
+    
+    /**
+     * @return max number of nexts + seeks performed by the underlying iterators in total
+     */
+    long getMaxWork();
     
     /**
      * @return max number of records to return in a page (max pagesize allowed)
@@ -137,9 +143,16 @@ public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidato
     
     /**
      * @param maxRowsToScan
-     *            max number of rows to scan from the iterator
+     *            This is now deprecated and setMaxWork should be used instead. This is equivalent to setMaxWork.
      */
+    @Deprecated
     void setMaxRowsToScan(long maxRowsToScan);
+    
+    /**
+     * @param maxWork
+     *            max work which is normally calculated as the number of next + seek calls made by the underlying iterators
+     */
+    void setMaxWork(long maxWork);
     
     /**
      * @param maxPageSize

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/GenericQueryConfigurationMockTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/GenericQueryConfigurationMockTest.java
@@ -51,7 +51,7 @@ public class GenericQueryConfigurationMockTest {
         GenericQueryConfiguration oldConfig = new GenericQueryConfiguration() {};
         oldConfig.setTableName("TEST");
         oldConfig.setBaseIteratorPriority(100);
-        oldConfig.setMaxRowsToScan(1000L);
+        oldConfig.setMaxWork(1000L);
         oldConfig.setUndisplayedVisibilities(new HashSet<>());
         oldConfig.setBypassAccumulo(false);
         
@@ -87,7 +87,7 @@ public class GenericQueryConfigurationMockTest {
     public void testBasicInit() {
         // Assert good init
         assertEquals("shard", config.getTableName());
-        assertEquals(25000L, config.getMaxRowsToScan().longValue());
+        assertEquals(-1L, config.getMaxWork().longValue());
         assertEquals(new HashSet<>(), config.getUndisplayedVisibilities());
         assertEquals(100, config.getBaseIteratorPriority());
         assertFalse(config.getBypassAccumulo());

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
@@ -42,7 +42,7 @@ public class TestBaseQueryLogic {
         expect(this.copy.getAuditType(null)).andReturn(Auditor.AuditType.ACTIVE);
         expect(this.copy.getTableName()).andReturn("tableName");
         expect(this.copy.getMaxResults()).andReturn(Long.MAX_VALUE);
-        expect(this.copy.getMaxRowsToScan()).andReturn(10L);
+        expect(this.copy.getMaxWork()).andReturn(10L);
         expect(this.copy.getUndisplayedVisibilities()).andReturn(new HashSet<>());
         expect(this.copy.getMaxPageSize()).andReturn(25);
         expect(this.copy.getPageByteTrigger()).andReturn(1024L);

--- a/web-services/query/src/test/java/datawave/webservice/query/logic/QueryLogicFactoryBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/logic/QueryLogicFactoryBeanTest.java
@@ -89,7 +89,7 @@ public class QueryLogicFactoryBeanTest extends EasyMockSupport {
         TestQueryLogic<?> logic = (TestQueryLogic<?>) bean.getQueryLogic("TestQuery", principal);
         assertEquals("MyMetadataTable", logic.getTableName());
         assertEquals(12345, logic.getMaxResults());
-        assertEquals(98765, logic.getMaxRowsToScan());
+        assertEquals(98765, logic.getMaxWork());
     }
     
     @Test

--- a/web-services/query/src/test/java/datawave/webservice/query/logic/TestQueryLogic.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/logic/TestQueryLogic.java
@@ -36,7 +36,7 @@ public class TestQueryLogic<T> extends BaseQueryLogic<T> {
         TestQueryLogic<Object> other = new TestQueryLogic<>();
         other.setTableName(this.getTableName());
         other.setMaxResults(this.getMaxResults());
-        other.setMaxRowsToScan(this.getMaxRowsToScan());
+        other.setMaxWork(this.getMaxWork());
         return other;
     }
     

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -136,7 +136,7 @@ public class ExtendedRunningQueryTest {
         int pageSize = 3;
         int maxPageSize = 10;
         long pageByteTrigger = 4 * 1024L;
-        long maxRowsToScan = Long.MAX_VALUE;
+        long maxWork = Long.MAX_VALUE;
         long maxResults = 100L;
         List<Object> resultObjects = Arrays.asList(new Object(), "resultObject1", null);
         
@@ -164,11 +164,12 @@ public class ExtendedRunningQueryTest {
         while (iterator.hasNext()) {
             expect(this.transformIterator.hasNext()).andReturn(iterator.hasNext());
             expect(this.transformIterator.next()).andReturn(iterator.next());
+            expect(this.transformIterator.getTransformer()).andReturn(transformer);
         }
         expect(this.query.getPagesize()).andReturn(pageSize).anyTimes();
         expect(this.queryLogic.getMaxPageSize()).andReturn(maxPageSize).anyTimes();
         expect(this.queryLogic.getPageByteTrigger()).andReturn(pageByteTrigger).anyTimes();
-        expect(this.queryLogic.getMaxRowsToScan()).andReturn(maxRowsToScan).anyTimes();
+        expect(this.queryLogic.getMaxWork()).andReturn(maxWork).anyTimes();
         expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
         expect(this.genericConfiguration.getQueryString()).andReturn(query).once();
         
@@ -215,7 +216,7 @@ public class ExtendedRunningQueryTest {
         int maxPageSize = 5;
         
         long pageByteTrigger = 4 * 1024L;
-        long maxRowsToScan = Long.MAX_VALUE;
+        long maxWork = Long.MAX_VALUE;
         long maxResults = 4L;
         List<Object> resultObjects = Arrays.asList(new Object(), "resultObject1", "resultObject2", "resultObject3", "resultObject4", "resultObject5");
         
@@ -248,11 +249,12 @@ public class ExtendedRunningQueryTest {
             expect(this.transformIterator.next()).andReturn(iterator.next());
             count++;
         }
+        expect(this.transformIterator.getTransformer()).andReturn(transformer).times(count);
         
         expect(this.query.getPagesize()).andReturn(pageSize).anyTimes();
         expect(this.queryLogic.getMaxPageSize()).andReturn(maxPageSize).anyTimes();
         expect(this.queryLogic.getPageByteTrigger()).andReturn(pageByteTrigger).anyTimes();
-        expect(this.queryLogic.getMaxRowsToScan()).andReturn(maxRowsToScan).anyTimes();
+        expect(this.queryLogic.getMaxWork()).andReturn(maxWork).anyTimes();
         expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
         expect(this.genericConfiguration.getQueryString()).andReturn(query).once();
         
@@ -295,7 +297,6 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getUserDN()).andReturn(userDN).times(2);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
-        expect(this.transformIterator.getTransformer()).andReturn(transformer);
         this.queryMetrics.updateMetric(isA(QueryMetric.class));
         PowerMock.expectLastCall().times(3);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);

--- a/web-services/query/src/test/resources/TestQueryLogicFactory.xml
+++ b/web-services/query/src/test/resources/TestQueryLogicFactory.xml
@@ -27,7 +27,7 @@
 	<bean id="TestQuery" class="datawave.webservice.query.logic.TestQueryLogic">
 		<property name="tableName" value="${metadata.table.name}" />
 		<property name="maxResults" value="12345" />
-		<property name="maxRowsToScan" value="98765" />
+		<property name="maxWork" value="98765" />
 		<property name="roleManager" ref="easyRoleManager" />
 	</bean>
 	
@@ -38,7 +38,7 @@
 	<bean id="TestQuery2" class="datawave.webservice.query.logic.TestQueryLogic">
 		<property name="tableName" value="${metadata.table.name}" />
 		<property name="maxResults" value="12345" />
-		<property name="maxRowsToScan" value="98765" />
+		<property name="maxWork" value="98765" />
 	</bean>
 
     <bean id="datawaveRoleManager" class="datawave.webservice.query.logic.DatawaveRoleManager" />

--- a/web-services/query/src/test/resources/TestQueryLogicFactoryWithAuditType.xml
+++ b/web-services/query/src/test/resources/TestQueryLogicFactoryWithAuditType.xml
@@ -23,7 +23,7 @@
     <bean id="TestQuery" class="datawave.webservice.query.logic.TestQueryLogic">
 		<property name="tableName" value="${metadata.table.name}" />
 		<property name="maxResults" value="12345" />
-		<property name="maxRowsToScan" value="98765" />
+		<property name="maxWork" value="98765" />
 		<property name="auditType" value="LOCALONLY" />
     </bean>
 


### PR DESCRIPTION
Deprecate the maxRowsToScan feature and replace with a maxWork feature.