### PR TITLE
Added missing jar to analytic.sh

### DIFF
--- a/warehouse/ingest-scripts/src/main/resources/bin/metrics/analytic.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/metrics/analytic.sh
@@ -33,6 +33,7 @@ then
 	CLASSPATH=$(findJar guava):${CLASSPATH}
 	CLASSPATH=$(findJar javatuples):${CLASSPATH}
 	CLASSPATH=$(findJar datawave-core):${CLASSPATH}
+	CLASSPATH=$(findJar common-utils):${CLASSPATH}
 
 	#
 	# Transform the classpath into a comma-separated list also


### PR DESCRIPTION
analytic.sh doesn't use ingest-libs.sh and instead builds it's own classpath. adding a missing jar.