### PR TITLE
Avoid read ahead for non-aggregating column families

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
@@ -323,7 +323,7 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
         try {
             return this.getClass().getClassLoader().loadClass(className).newInstance();
         } catch (Exception e) {
-            throw new IllegalArgumentException("Exception while attempting to create : " + className);
+            throw new IllegalArgumentException("Exception while attempting to create : " + className, e);
         }
     }
 }

--- a/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
@@ -132,23 +132,9 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
         
         final Key keyToAggregate = workKey;
         
-        PropogatingCombiner aggr = aggMap.get(workKey.getColumnFamilyData());
-        
-        if (null == aggr) {
-            if (log.isTraceEnabled()) {
-                log.trace("using the default aggregator");
-            }
-            aggr = defaultAgg;
-        }
+        PropogatingCombiner aggr = getAggregator(workKey);
         
         Value aggregatedValue = new Value(iterator.getTopValue());
-        
-        if (log.isTraceEnabled())
-            log.trace("Key is " + workKey);
-        
-        if (log.isTraceEnabled()) {
-            log.trace(workKey + "agg == " + (aggr == null) + " " + workKey.isDeleted());
-        }
         
         // always propogate deletes
         if (aggr != null) {
@@ -171,10 +157,6 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
                     log.trace("Not propogating " + workKey);
                 return false;
             }
-        } else {
-            
-            iterator.next();
-            
         }
         
         aggrKey = new Key(workKey);
@@ -183,6 +165,26 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
         
         return true;
         
+    }
+    
+    private PropogatingCombiner getAggregator(Key key) {
+        PropogatingCombiner aggr = aggMap.get(key.getColumnFamilyData());
+        
+        if (null == aggr) {
+            if (log.isTraceEnabled()) {
+                log.trace("using the default aggregator");
+            }
+            aggr = defaultAgg;
+        }
+        
+        if (log.isTraceEnabled()) {
+            log.trace("Key is " + key);
+        }
+        
+        if (log.isTraceEnabled()) {
+            log.trace(key + "agg == " + (aggr == null) + " " + key.isDeleted());
+        }
+        return aggr;
     }
     
     /**
@@ -233,6 +235,10 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
     @Override
     public void next() throws IOException {
         if (aggrKey != null) {
+            // if aggrKey isn't configured for aggregation, then we previously didn't call next and need to now
+            if (iterator.hasTop() && getAggregator(aggrKey) == null) {
+                iterator.next();
+            }
             aggrKey = null;
             aggrValue = null;
         }
@@ -246,15 +252,20 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
             aggrValue = null;
         }
         
-        // do not want to seek to the middle of a value that should be
-        // aggregated...
-        Range seekRange = IteratorUtil.maximizeStartKeyTimeStamp(range);
+        Range seekRange = range;
+        // if there isn't an aggregator configured for the start key, timestamp modification isn't necessary
+        if (range.getStartKey() != null && getAggregator(range.getStartKey()) != null) {
+            // do not want to seek to the middle of a value that should be
+            // aggregated...
+            seekRange = IteratorUtil.maximizeStartKeyTimeStamp(range);
+        }
         
         iterator.seek(seekRange, columnFamilies, inclusive);
         
         findTop();
         
-        if (range.getStartKey() != null) {
+        // (only if the range was modified) it's necessary to skip keys until the start key is found
+        if (seekRange != range) {
             while (hasTop() && getTopKey().equals(range.getStartKey(), PartialKey.ROW_COLFAM_COLQUAL_COLVIS)
                             && getTopKey().getTimestamp() > range.getStartKey().getTimestamp()) {
                 next();

--- a/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorSeekTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorSeekTest.java
@@ -25,91 +25,90 @@ public class PropogatingIteratorSeekTest {
     public static final String FIELD2_NO_AGGREGATION = "c";
     public static final String COL_QUAL = "colQual1";
     private PropogatingIterator iterator;
-    private TreeMap<Key, Value> expected;
-
+    private TreeMap<Key,Value> expected;
+    
     @Before
     public void before() throws IOException {
-        SortedMap<Key, Value> map = new TreeMap<>();
+        SortedMap<Key,Value> map = new TreeMap<>();
         map.put(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("magnolia")));
         map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 4), new Value(new Text("1")));
         map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 3), new Value(new Text("2")));
         map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 2), new Value(new Text("1")));
         map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 1), new Value(new Text("6")));
         map.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("milkweed")));
-        map.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 2), new Value(new Text("bayberry")));
-        map.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 1), new Value(new Text("dogwood")));
+        map.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 2), new Value(new Text("bayberry")));
+        map.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 1), new Value(new Text("dogwood")));
         SortedMapIterator source = new SortedMapIterator(map);
-
+        
         expected = new TreeMap<>();
         expected.put(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("magnolia")));
         // the only key that's values should be aggregated:
         expected.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 4), new Value(new Text("10")));
         expected.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("milkweed")));
-        expected.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 2), new Value(new Text("bayberry")));
-        expected.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 1), new Value(new Text("dogwood")));
-
+        expected.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 2), new Value(new Text("bayberry")));
+        expected.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 1), new Value(new Text("dogwood")));
+        
         Map<String,String> options = new HashMap<>();
         options.put(FIELD_TO_AGGREGATE, TestCombiner.class.getName());
-
+        
         TestIteratorEnvironment env = new TestIteratorEnvironment();
-
+        
         iterator = new PropogatingIterator();
         iterator.init(source, options, env);
     }
-
+    
     @Test
     public void testReseeksOverFullRange() throws IOException {
         // reseek after each key
         verifyAllDataFound(expected, new TestData(iterator, new Range(), true).data);
     }
-
+    
     @Test
     public void testNextCallsOverFullRange() throws IOException {
         // seek once, then call next through all the data
         verifyAllDataFound(expected, new TestData(iterator, new Range(), false).data);
     }
-
+    
     @Test
     public void startMidwayThroughTimestamps() throws IOException {
         // start partway through data for field to aggregate
         Key startKey = new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 3);
         Key endKey = new Key("row\\x00");
         Range range = new Range(startKey, true, endKey, false);
-
+        
         // don't expect the key that precedes the start key
         Assert.assertNotNull(expected.remove(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3)));
-
+        
         // the existing behavior - when starting partway through timestamps, skip key
         Assert.assertNotNull(expected.remove(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 4)));
-
+        
         // try both with the reseek and the next approaches
         verifyAllDataFound(expected, new TestData(iterator, range, false).data);
         verifyAllDataFound(expected, new TestData(iterator, range, true).data);
     }
-
+    
     @Test
     public void startJustBeforeFirstTimestamp() throws IOException {
         // start before data for field to aggregate
         Key startKey = new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 5);
         Key endKey = new Key("row\\x00");
         Range range = new Range(startKey, true, endKey, false);
-
+        
         // don't expect the key that precedes the start key
         Assert.assertNotNull(expected.remove(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3)));
-
+        
         // try both with the reseek and the next approaches
         verifyAllDataFound(expected, new TestData(iterator, range, false).data);
         verifyAllDataFound(expected, new TestData(iterator, range, true).data);
     }
-
-    private void verifyAllDataFound(TreeMap<Key, Value> expected, SortedMap<Key, Value> actual) {
+    
+    private void verifyAllDataFound(TreeMap<Key,Value> expected, SortedMap<Key,Value> actual) {
         Assert.assertEquals(expected, actual);
     }
-
+    
     public static class TestCombiner extends PropogatingCombiner {
-        public TestCombiner() {
-        }
-
+        public TestCombiner() {}
+        
         @Override
         public Value reduce(Key key, Iterator<Value> valueIterator) {
             int total = 0;
@@ -118,36 +117,34 @@ public class PropogatingIteratorSeekTest {
             }
             return new Value(new Text(Integer.toString(total)));
         }
-
+        
         private static int getCount(Value value) {
             return Integer.parseInt(new Text(value.get()).toString(), 10);
         }
     }
-
+    
     public static class TestIteratorEnvironment extends BaseIteratorEnvironment {
         public boolean isSamplingEnabled() {
             return false;
         }
-
+        
         public IteratorUtil.IteratorScope getIteratorScope() {
             return IteratorUtil.IteratorScope.scan;
         }
     }
-
+    
     public static class TestData {
-        final SortedMap<Key, Value> data = new TreeMap<>();
-
+        final SortedMap<Key,Value> data = new TreeMap<>();
+        
         // copied from Fluo
-        public TestData(SortedKeyValueIterator<Key, Value> iter, Range range, boolean reseek) {
+        public TestData(SortedKeyValueIterator<Key,Value> iter, Range range, boolean reseek) {
             try {
                 iter.seek(range, new HashSet<>(), false);
-
+                
                 while (iter.hasTop()) {
                     data.put(iter.getTopKey(), iter.getTopValue());
                     if (reseek) {
-                        iter.seek(
-                                new Range(iter.getTopKey(), false, range.getEndKey(), range.isEndKeyInclusive()),
-                                new HashSet<>(), false);
+                        iter.seek(new Range(iter.getTopKey(), false, range.getEndKey(), range.isEndKeyInclusive()), new HashSet<>(), false);
                     } else {
                         iter.next();
                     }
@@ -156,6 +153,6 @@ public class PropogatingIteratorSeekTest {
                 throw new RuntimeException(e);
             }
         }
-
+        
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorSeekTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorSeekTest.java
@@ -1,0 +1,161 @@
+package datawave.iterators;
+
+import datawave.ingest.table.aggregator.PropogatingCombiner;
+import org.apache.accumulo.core.client.impl.BaseIteratorEnvironment;
+import org.apache.accumulo.core.data.*;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.SortedMapIterator;
+import org.apache.hadoop.io.Text;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class PropogatingIteratorSeekTest {
+    public static final String FIELD_NO_AGGREGATION = "a";
+    public static final String FIELD_TO_AGGREGATE = "b";
+    public static final String FIELD2_NO_AGGREGATION = "c";
+    public static final String COL_QUAL = "colQual1";
+    private PropogatingIterator iterator;
+    private TreeMap<Key, Value> expected;
+
+    @Before
+    public void before() throws IOException {
+        SortedMap<Key, Value> map = new TreeMap<>();
+        map.put(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("magnolia")));
+        map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 4), new Value(new Text("1")));
+        map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 3), new Value(new Text("2")));
+        map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 2), new Value(new Text("1")));
+        map.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 1), new Value(new Text("6")));
+        map.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("milkweed")));
+        map.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 2), new Value(new Text("bayberry")));
+        map.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 1), new Value(new Text("dogwood")));
+        SortedMapIterator source = new SortedMapIterator(map);
+
+        expected = new TreeMap<>();
+        expected.put(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("magnolia")));
+        // the only key that's values should be aggregated:
+        expected.put(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 4), new Value(new Text("10")));
+        expected.put(new Key("row", FIELD2_NO_AGGREGATION, COL_QUAL, "", 3), new Value(new Text("milkweed")));
+        expected.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 2), new Value(new Text("bayberry")));
+        expected.put(new Key("row", FIELD2_NO_AGGREGATION , COL_QUAL, "", 1), new Value(new Text("dogwood")));
+
+        Map<String,String> options = new HashMap<>();
+        options.put(FIELD_TO_AGGREGATE, TestCombiner.class.getName());
+
+        TestIteratorEnvironment env = new TestIteratorEnvironment();
+
+        iterator = new PropogatingIterator();
+        iterator.init(source, options, env);
+    }
+
+    @Test
+    public void testReseeksOverFullRange() throws IOException {
+        // reseek after each key
+        verifyAllDataFound(expected, new TestData(iterator, new Range(), true).data);
+    }
+
+    @Test
+    public void testNextCallsOverFullRange() throws IOException {
+        // seek once, then call next through all the data
+        verifyAllDataFound(expected, new TestData(iterator, new Range(), false).data);
+    }
+
+    @Test
+    public void startMidwayThroughTimestamps() throws IOException {
+        // start partway through data for field to aggregate
+        Key startKey = new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 3);
+        Key endKey = new Key("row\\x00");
+        Range range = new Range(startKey, true, endKey, false);
+
+        // don't expect the key that precedes the start key
+        Assert.assertNotNull(expected.remove(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3)));
+
+        // the existing behavior - when starting partway through timestamps, skip key
+        Assert.assertNotNull(expected.remove(new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 4)));
+
+        // try both with the reseek and the next approaches
+        verifyAllDataFound(expected, new TestData(iterator, range, false).data);
+        verifyAllDataFound(expected, new TestData(iterator, range, true).data);
+    }
+
+    @Test
+    public void startJustBeforeFirstTimestamp() throws IOException {
+        // start before data for field to aggregate
+        Key startKey = new Key("row", FIELD_TO_AGGREGATE, COL_QUAL, "", 5);
+        Key endKey = new Key("row\\x00");
+        Range range = new Range(startKey, true, endKey, false);
+
+        // don't expect the key that precedes the start key
+        Assert.assertNotNull(expected.remove(new Key("row", FIELD_NO_AGGREGATION, COL_QUAL, "", 3)));
+
+        // try both with the reseek and the next approaches
+        verifyAllDataFound(expected, new TestData(iterator, range, false).data);
+        verifyAllDataFound(expected, new TestData(iterator, range, true).data);
+    }
+
+    private void verifyAllDataFound(TreeMap<Key, Value> expected, SortedMap<Key, Value> actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    public static class TestCombiner extends PropogatingCombiner {
+        public TestCombiner() {
+        }
+
+        @Override
+        public Value reduce(Key key, Iterator<Value> valueIterator) {
+            int total = 0;
+            while (valueIterator.hasNext()) {
+                total += getCount(valueIterator.next());
+            }
+            return new Value(new Text(Integer.toString(total)));
+        }
+
+        private static int getCount(Value value) {
+            return Integer.parseInt(new Text(value.get()).toString(), 10);
+        }
+    }
+
+    public static class TestIteratorEnvironment extends BaseIteratorEnvironment {
+        public boolean isSamplingEnabled() {
+            return false;
+        }
+
+        public IteratorUtil.IteratorScope getIteratorScope() {
+            return IteratorUtil.IteratorScope.scan;
+        }
+    }
+
+    public static class TestData {
+        final SortedMap<Key, Value> data = new TreeMap<>();
+
+        // copied from Fluo
+        public TestData(SortedKeyValueIterator<Key, Value> iter, Range range, boolean reseek) {
+            try {
+                iter.seek(range, new HashSet<>(), false);
+
+                while (iter.hasTop()) {
+                    data.put(iter.getTopKey(), iter.getTopValue());
+                    if (reseek) {
+                        iter.seek(
+                                new Range(iter.getTopKey(), false, range.getEndKey(), range.isEndKeyInclusive()),
+                                new HashSet<>(), false);
+                    } else {
+                        iter.next();
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorTest.java
@@ -36,7 +36,7 @@ public class PropogatingIteratorTest {
     private static final String SHARD = "20121002_1";
     private static final String FIELD_TO_AGGREGATE = "UUID";
     private static final long TIMESTAMP = 1349541830;
-
+    
     private void validateUids(Value topValue, String... uids) throws InvalidProtocolBufferException {
         Uid.List v = Uid.List.parseFrom(topValue.get());
         
@@ -45,7 +45,7 @@ public class PropogatingIteratorTest {
             v.getUIDList().contains(uid);
         }
     }
-
+    
     private void validateRemoval(Value topValue, String... uids) throws InvalidProtocolBufferException {
         Uid.List v = Uid.List.parseFrom(topValue.get());
         
@@ -54,22 +54,22 @@ public class PropogatingIteratorTest {
             v.getREMOVEDUIDList().contains(uid);
         }
     }
-
+    
     private Uid.List.Builder createValueWithUid(String uid) {
         Uid.List.Builder builder = Uid.List.newBuilder();
         builder.setIGNORE(false);
         builder.setCOUNT(1);
         builder.addUID(uid);
-
+        
         return builder;
     }
-
+    
     private Uid.List.Builder createValueWithRemoveUid(String uid) {
         Uid.List.Builder builder = Uid.List.newBuilder();
         builder.setIGNORE(false);
         builder.setCOUNT(-1);
         builder.addREMOVEDUID(uid);
-
+        
         return builder;
     }
     
@@ -124,13 +124,12 @@ public class PropogatingIteratorTest {
         public SamplerConfiguration getSamplerConfiguration() {
             return null;
         }
-
+        
         @Override
         public SortedKeyValueIterator<Key,Value> reserveMapFileReader(String arg0) throws IOException {
             return null;
         }
     }
-
     
     protected Key newKey(String row, String field, String uid, boolean delete) {
         Key key = new Key(uid, field, "dataType\0" + row, new ColumnVisibility("PUBLIC"), TIMESTAMP);
@@ -216,7 +215,7 @@ public class PropogatingIteratorTest {
     
     @Test(expected = NullPointerException.class)
     public void testNullOptions() throws IOException {
-
+        
         PropogatingIterator iter = new PropogatingIterator();
         Map<String,String> options = Maps.newHashMap();
         
@@ -228,21 +227,21 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
     }
-
+    
     private SortedMultiMapIterator createSourceWithTestData() {
         TreeMultimap<Key,Value> map = TreeMultimap.create();
-
+        
         map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc", true), new Value(createValueWithUid("abc.0").build().toByteArray()));
         map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.1").build().toByteArray()));
         map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.2").build().toByteArray()));
         map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.3").build().toByteArray()));
         map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.4").build().toByteArray()));
-
+        
         map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), new Value(createValueWithUid("abc.3").build().toByteArray()));
-
+        
         return new SortedMultiMapIterator(map);
     }
-
+    
     @Test(expected = NullPointerException.class)
     public void testNullEnvironment() throws IOException {
         PropogatingIterator iter = new PropogatingIterator();
@@ -352,7 +351,7 @@ public class PropogatingIteratorTest {
     
     @Test
     public void testDeleteFullMajc() throws IOException {
-
+        
         PropogatingIterator iter = new PropogatingIterator();
         Map<String,String> options = Maps.newHashMap();
         
@@ -381,7 +380,7 @@ public class PropogatingIteratorTest {
         PropogatingIterator uut = new PropogatingIterator();
         uut.deepCopy(new MockIteratorEnvironment(false));
     }
-
+    
     @Test
     public void testAggregateThreeWithDeepCopy() throws IOException {
         TreeMultimap<Key,Value> map = TreeMultimap.create();
@@ -646,9 +645,9 @@ public class PropogatingIteratorTest {
     @Test
     public void testDeepCopyOnDefaultConstructor() throws IOException {
         SortedKeyValueIterator source = createSourceWithTestData();
-        HashMap<String, String> emptyOptions = new HashMap<>();
+        HashMap<String,String> emptyOptions = new HashMap<>();
         MockIteratorEnvironment env = new MockIteratorEnvironment(true);
-
+        
         PropogatingIterator propogatingIterator = new PropogatingIterator();
         propogatingIterator.init(source, emptyOptions, env);
         PropogatingIterator deepCopiedPropogatingIterator = propogatingIterator.deepCopy(env);
@@ -658,21 +657,21 @@ public class PropogatingIteratorTest {
     @Test
     public void testDeepCopyOnConstructor() throws IOException {
         SortedKeyValueIterator source = createSourceWithTestData();
-        HashMap<String, String> emptyOptions = new HashMap<>();
+        HashMap<String,String> emptyOptions = new HashMap<>();
         MockIteratorEnvironment env = new MockIteratorEnvironment(true);
-
+        
         PropogatingIterator propogatingIterator = new PropogatingIterator(source, null);
         propogatingIterator.init(source, emptyOptions, env);
         PropogatingIterator deepCopiedPropogatingIterator = propogatingIterator.deepCopy(env);
         Assert.assertNotNull("PropogatingIterator constructor failed to create a valid instance.", deepCopiedPropogatingIterator);
     }
-
+    
     @Test
     public void testDefaultConstructor() {
         PropogatingIterator uut = new PropogatingIterator();
         Assert.assertNotNull("PropogatingIterator constructor failed to create a valid instance.", uut);
     }
-
+    
     @Test
     public void testConstructor() throws IOException {
         PropogatingIterator uut = new PropogatingIterator(createSourceWithTestData(), null);


### PR DESCRIPTION
PropogatingIterator makes an extra next() call, even for keys that do not require aggregation.  This change delays the call to next() and in some use cases prevents the need to call next() at all.  This can save a substantial amount of time for data that is being skipped by a filter.