### PR TITLE
Flag maker updates to handle race condition and duplicate input files

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/runFMLoadTest.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/runFMLoadTest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+#========================================================================
+# Purpose
+# This provides a method of running the flag file load test. In lue of
+# running using this script, the FlagMakerLoad class can be run from
+# within Intellj or Eclipse. Two input parameters are required, the
+# configuration file and the test jar that contains the FlagMakerLoad
+# class.
+#
+# A default configuration file is located in the ingest-core project
+# (<ingest-core>/src/test/resources/FlagLoadConfig.json). The path to
+# the ingest files must be set properly. The tvmaze-flagmaker.sh script
+# can be used to download the necessary ingest files but any set of
+# ingest files will work.
+
+function usage() {
+    set +x
+    test -n "$*" && echo "$@"
+    echo "USAGE: ${_Argv0} -c config -j jar"
+    echo -e "\tc: configuration file"
+    echo -e "\tj: jar file"
+
+    exit 1
+}
+
+function createJarClassPath() {
+    local _fullCP=$1
+
+    test -d "${_LibDir}" || {
+        echo "${_LibDir} directory does not exist"
+        exit 1
+    }
+
+    local _cp
+    for j in $(find ${_LibDir} -name "*.jar"); do
+        if [[ -n "${_cp}" ]]; then
+            _cp=${_cp}:${j}
+        else
+            _cp=${j}
+        fi
+    done
+
+    eval ${_fullCP}="${_cp}"
+}
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+declare -r _Argv0=$(basename $0)
+declare -r _LibDir="../datawave-ingest-install/lib"
+
+while getopts ":c:j:" _arg; do
+    case ${_arg} in
+        c) test -z "${_ConfigFile}" && declare -r _ConfigFile=$OPTARG;;
+        j) test -z "${_RunJar}" && declare -r _RunJar=$OPTARG;;
+        *) usage;;
+    esac
+done
+
+test -z "${_ConfigFile}" -o -z "${_RunJar}" && usage
+test -e "${_ConfigFile}" || usage "config file not found"
+test -e "${_RunJar}" || usage "jar file not found"
+
+declare _ClassPath
+createJarClassPath _ClassPath
+
+java -cp ${_RunJar}:${_ClassPath} datawave.util.flag.FlagMakerLoad ${_ConfigFile}

--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-flagmaker.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-flagmaker.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+#========================================================================
+# Purpose
+# Downloads json files from TVMaze for testing of the FlagMaker. The
+# FlagMaker load test uses multiple threads that select files at random.
+# The number of ingest files should be modified to conform to the test
+# requirements.
+
+function usage() {
+    set +x
+    echo "USAGE: ${_Argv0} -c -s [-d dir] [-n count]"
+    echo -e "\tc: download cast data"
+    echo -e "\td: output directory for TVMaze files (default => ${_DefaultOutputDir})"
+    echo -e "\tn: number of entries to download (default => ${_DefaultEntryCount})"
+    echo -e "\ts: dowload show data"
+
+    exit 1
+}
+
+#=============================================================
+# Performs the download of the specified URL to a local file.
+function download() {
+    local -r _urlSuffix=$1
+    local -r _outFile=$2
+
+    local -r _url=${_TVMAZE_API}/${_urlSuffix}
+    local -i _retry=5
+    while [[ ${_retry} -gt 0 ]]; do
+        local _code=$(curl --silent --output ${_outFile} --write-out '%{http_code}' -X GET "${_url}")
+        local _rc=$?
+        test $_rc -eq 0 && return
+        # check for rate limiting
+        if [[ "${_code}" -eq 429 ]]; then
+            ((_retry = _retry - 1))
+            if [[ "${_retry}" -gt 0 ]]; then
+                sleep 1
+            else
+                echo "ERROR: rate limiting retry failure for url(${_url})"
+            fi
+        else
+            echo "ERROR: ${_url} => http code(${_code}) retry for url(${_url})"
+            return
+        fi
+    done
+}
+
+#=============================================================
+# Downloads shows from the TVmaze site.
+function downloadShows() {
+    local -ir _max=$1
+
+    local -i _num=2501
+    local -ir _Interval=50
+    while [[ "${_num}" -le "${_max}" ]]; do
+        download "shows/${_num}" "shows-${_num}.json"
+        ((_num = _num + 1))
+        local -i _mod
+        ((_mod = _num % _Interval))
+        test "${_mod}" -eq 0 && echo "current show count ($_num)"
+    done
+   echo "show download total(${_max})"
+}
+
+#=============================================================
+# Downloads shows with cast from the TVmaze site.
+function downloadCast() {
+   local -ir _max=$1
+
+   local -i _num=1
+   local -ir _Interval=50
+   while [[ "${_num}" -le "${_max}" ]]; do
+        download "shows/${_num}/cast" "shows-cast-${_num}.json"
+        ((_num = _num + 1))
+        local -i _mod
+        ((_mod = _num % _Interval))
+        test "${_mod}" -eq 0 && echo "current cast count ($_num)"
+   done
+   echo "cast download total(${_max})"
+}
+
+#================================================
+
+declare -r _Argv0=$(basename $0)
+declare -r _TVMAZE_API="http://api.tvmaze.com"
+declare -r _DefaultOutputDir=tvmaze
+declare -r _DefaultEntryCount=2500
+
+while getopts ":cd:n:s" _arg; do
+    case $_arg in
+        c) test -z "${_Cast}" && _Cast=true;;
+        d) test -z "${_TVMazeDir}" && _TVMazeDir=${OPTARG};;
+        n) test -z "${_Num}" && _Num=${OPTARG};;
+        s) test -z "${_Shows}" && _Shows=true;;
+        *) usage;;
+    esac
+done
+
+test -z "${_TVMazeDir}" && _TVMazeDir=${_DefaultOutputDir}
+test -d "${_TVMazeDir}" || {
+    mkdir -p ${_TVMazeDir} || exit 1
+}
+cd ${_TVMazeDir} || exit 1
+test -z "${_Num}" && _Num=${_DefaultEntryCount}
+
+echo "download directory => ${_TVMazeDir}"
+echo "download count (${_Num})"
+
+test -n "${_Shows}" && downloadShows ${_Num}
+test -n "${_Cast}" && downloadCast ${_Num}

--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-flagmaker.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-flagmaker.sh
@@ -13,7 +13,7 @@ function usage() {
     echo -e "\tc: download cast data"
     echo -e "\td: output directory for TVMaze files (default => ${_DefaultOutputDir})"
     echo -e "\tn: number of entries to download (default => ${_DefaultEntryCount})"
-    echo -e "\ts: dowload show data"
+    echo -e "\ts: download show data"
 
     exit 1
 }
@@ -50,7 +50,7 @@ function download() {
 function downloadShows() {
     local -ir _max=$1
 
-    local -i _num=2501
+    local -i _num=1
     local -ir _Interval=50
     while [[ "${_num}" -le "${_max}" ]]; do
         download "shows/${_num}" "shows-${_num}.json"

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagEntryMover.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagEntryMover.java
@@ -1,0 +1,123 @@
+package datawave.util.flag;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import datawave.util.flag.InputFile.TrackedDir;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.google.common.cache.Cache;
+
+/**
+ * Handles stage 1 of the job creation flow. Checks for destination directories, creates as needed, and returns information on whether it was successful.
+ */
+public class FlagEntryMover extends SimpleMover {
+    
+    private static final Logger log = Logger.getLogger(FlagEntryMover.class);
+    private static final int CHKSUM_MAX = 10 * 1024 * 1000; // 10M
+    
+    public FlagEntryMover(Cache<Path,Path> directoryCache, FileSystem fs, InputFile entry) {
+        super(directoryCache, entry, TrackedDir.FLAGGING_DIR, fs);
+    }
+    
+    @Override
+    public InputFile call() throws IOException {
+        
+        // Create the flagging, flagged and loaded directory if they do not exist
+        Path dstFlagging = checkParent(entry.getFlagging());
+        Path dstFlagged = checkParent(entry.getFlagged());
+        Path dstLoaded = checkParent(entry.getLoaded());
+        
+        // Check for existence of the file already in the flagging, flagged, or loaded directories
+        Path src = entry.getPath();
+        boolean doMove = true;
+        if (fs.exists(dstFlagging)) {
+            doMove = resolveConflict(src, dstFlagging);
+        } else if (fs.exists(dstFlagged)) {
+            doMove = resolveConflict(src, dstFlagged);
+        } else if (fs.exists(dstLoaded)) {
+            doMove = resolveConflict(src, dstLoaded);
+        }
+        
+        // do the move
+        if (doMove) {
+            super.call();
+        }
+        
+        return entry;
+    }
+    
+    /**
+     * Resolves the ingest file name to a unique file name for ingestion.
+     *
+     * @param src
+     *            source file for ingestion
+     * @param dest
+     *            conflict file
+     */
+    private boolean resolveConflict(final Path src, final Path dest) throws IOException {
+        // check to see if checksum matches
+        boolean resolved = false;
+        long srcLen = this.fs.getFileStatus(src).getLen();
+        long destLen = this.fs.getFileStatus(dest).getLen();
+        if (srcLen == destLen) {
+            String sumSrc = calculateChecksum(src);
+            String sumDest = calculateChecksum(dest);
+            if (!sumSrc.equals(sumDest)) {
+                resolved = true;
+            }
+        } else {
+            resolved = true;
+        }
+        
+        if (resolved) {
+            // rename tracked locations
+            log.warn("duplicate ingest file name with different payload(" + src.toUri().toString() + ") - appending timestamp to destination file name");
+            this.entry.renameTrackedLocations();
+        } else {
+            log.warn("discarding duplicate ingest file (" + src.toUri().toString() + ") duplicate (" + dest.toUri().toString() + ")");
+            if (!fs.delete(src, false)) {
+                log.error("unable to delete duplicate ingest file (" + src.toUri().toString() + ")");
+            }
+        }
+        
+        return resolved;
+    }
+    
+    /**
+     * Calculates a checksum for a file.
+     *
+     * @param file
+     *            checksum file
+     * @return hex string representation of checksum
+     * @throws IOException
+     */
+    private String calculateChecksum(final Path file) throws IOException {
+        try (final InputStream is = this.fs.open(file)) {
+            byte[] buf = new byte[8096];
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            int len = 0;
+            long totalLen = 0;
+            // use CHKSUM_MAX as limit for checksum
+            while (-1 != (len = is.read(buf)) && CHKSUM_MAX > totalLen) {
+                digest.update(buf, 0, len);
+                totalLen += len;
+            }
+            
+            byte[] mdBytes = digest.digest();
+            final StringBuilder sb = new StringBuilder();
+            for (int n = 0; n < mdBytes.length; n++) {
+                sb.append(Integer.toString((mdBytes[n] & 0xff) + 0x100, 16).substring(1));
+            }
+            
+            return sb.toString();
+        } catch (NoSuchAlgorithmException ae) {
+            throw new IOException(ae);
+        }
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMaker.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMaker.java
@@ -227,7 +227,6 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
             loadFilesForDistributor(fc, fs);
             
             while (fd.hasNext(shouldOnlyCreateFullFlags(fc)) && running) {
-                // initStats(startTime);
                 writeFlagFile(fc, fd.next(this));
             }
         }
@@ -458,13 +457,17 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
     }
     
     /**
-     * Creates the flag file using all of the
+     * Creates the flag file using all of the valid ingest files.
      * 
      * @param flagging
+     *            ingest files
      * @param fc
+     *            data type for ingest
      * @param baseName
-     * @return
+     *            base name for flag file
+     * @return handle for flag file
      * @throws IOException
+     *             error creating flag file
      */
     protected File write(Collection<InputFile> flagging, FlagDataTypeConfig fc, String baseName) throws IOException {
         // create the flag.generating file
@@ -504,11 +507,6 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
                     sb.append(inFile.getFlagged().toUri()).append('\n');
                 }
             }
-            
-            // bmw - ? do we care about length
-            // if (estSize != sb.length()) {
-            // log.error("Estimated size is not accurate: {} vs {}", estSize, sb.length());
-            // }
             
             flagOS.write(sb.toString().getBytes());
         }

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMaker.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMaker.java
@@ -1,5 +1,31 @@
 package datawave.util.flag;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
+import datawave.ingest.mapreduce.StandaloneTaskAttemptContext;
+import datawave.metrics.util.flag.FlagFile;
+import datawave.util.flag.config.ConfigUtil;
+import datawave.util.flag.config.FlagDataTypeConfig;
+import datawave.util.flag.config.FlagMakerConfig;
+import datawave.util.flag.processor.DateUtils;
+import datawave.util.flag.processor.FlagDistributor;
+import datawave.util.flag.processor.SizeValidator;
+import datawave.util.flag.processor.UnusableFileException;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.apache.commons.lang.mutable.MutableInt;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile.CompressionType;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.mapred.JobConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileOutputStream;
@@ -13,16 +39,11 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -30,47 +51,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import datawave.util.StringUtils;
-import datawave.metrics.util.flag.FlagFile;
-import datawave.ingest.mapreduce.StandaloneStatusReporter;
-import datawave.ingest.mapreduce.StandaloneTaskAttemptContext;
-import datawave.util.flag.config.ConfigUtil;
-import datawave.util.flag.config.FlagDataTypeConfig;
-import datawave.util.flag.config.FlagMakerConfig;
-import datawave.util.flag.processor.DateFlagDistributor;
-import datawave.util.flag.processor.DateFolderFlagDistributor;
-import datawave.util.flag.processor.DateUtils;
-import datawave.util.flag.processor.FlagDistributor;
-import datawave.util.flag.processor.SimpleFlagDistributor;
-import datawave.util.flag.processor.SizeValidator;
-import datawave.util.flag.processor.UnusableFileException;
-
-import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.commons.lang.mutable.MutableInt;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.SequenceFile;
-import org.apache.hadoop.io.SequenceFile.CompressionType;
-import org.apache.hadoop.io.SequenceFile.Writer;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.GzipCodec;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapreduce.Counters;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.bind.JAXBException;
 
 /**
  * 
@@ -84,36 +65,44 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
     // our yyyy/mm/dd pattern for most things.
     public static final Pattern pattern = Pattern.compile(".*/([0-9]{4}(/[0-9]{2}){2})(?:/.*|$)");
     private static final String DATE_FORMAT_STRING = "yyyy" + File.separator + "MM" + File.separator + "dd";
+    
+    private static final String COUNTER_LIMIT_HADOOP_2 = "mapreduce.job.counters.max";
+    private static final String COUNTER_LIMIT_HADOOP_1 = "mapreduce.job.counters.limit";
+    private static final int COUNTERS_PER_INPUT_FILE = 2;
+    
     /**
      * Directory cache will serve as a place holder the directories in HDFS that were created. This will cut down on the number of RPC calls tot he NameNode
      */
     private final Cache<Path,Path> directoryCache;
     // Executor will be used for directory lookups
-    protected ExecutorService executor;
+    private ExecutorService executor;
     private final FlagMakerConfig fmc;
-    private FlagDistributor fd;
+    final FlagDistributor fd;
     private volatile boolean running = true;
     private FlagSocket flagSocket;
     private final DecimalFormat df = new DecimalFormat("#0.00");
-    private static final byte ONE = '1';
-    private final ReentrantLock lock = new ReentrantLock();
     private DateUtils util = new DateUtils();
     private StandaloneTaskAttemptContext<?,?,?,?> ctx;
-    private static final SimpleDateFormat metricsFormat = new SimpleDateFormat("_yyyyMMdd_HHmmssSS");
-    private static final String COUNTER_LIMIT_HADOOP_2 = "mapreduce.job.counters.max";
-    private static final String COUNTER_LIMIT_HADOOP_1 = "mapreduce.job.counters.limit";
-    private static final int COUNTERS_PER_INPUT_FILE = 2;
+    
     protected JobConf config;
     
     public FlagMaker(FlagMakerConfig fmconfig) {
         this.fmc = fmconfig;
         this.config = new JobConf(new Configuration());
         
-        setup();
+        this.fmc.validate();
+        // configure the executor per the FlagMakerConfig input
+        this.executor = Executors.newFixedThreadPool(this.fmc.getMaxHdfsThreads());
+        this.fd = this.fmc.getFlagDistributor();
         
         // build the cache per the default configuration.
-        directoryCache = CacheBuilder.newBuilder().maximumSize(fmc.getDirectoryCacheSize())
-                        .expireAfterWrite(fmc.getDirectoryCacheTimeout(), TimeUnit.MILLISECONDS).concurrencyLevel(fmc.getMaxHdfsThreads()).build();
+        // @formatter:off
+        this.directoryCache = CacheBuilder.newBuilder()
+                .maximumSize(fmc.getDirectoryCacheSize())
+                .expireAfterWrite(fmc.getDirectoryCacheTimeout(), TimeUnit.MILLISECONDS)
+                .concurrencyLevel(fmc.getMaxHdfsThreads())
+                .build();
+        // @formatter:on
     }
     
     public static void main(String... args) throws Exception {
@@ -130,6 +119,7 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
             shutdown(flagMakerConfig.getSocketPort());
             System.exit(0);
         }
+        
         try {
             FlagMaker m = new FlagMaker(flagMakerConfig);
             m.run();
@@ -185,12 +175,10 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
     }
     
     private static void shutdown(int port) throws IOException {
-        Socket s = new Socket("localhost", port);
-        PrintWriter pw = new PrintWriter(s.getOutputStream(), true);
-        pw.write("shutdown");
-        pw.flush();
-        pw.close();
-        s.close();
+        try (Socket s = new Socket("localhost", port); PrintWriter pw = new PrintWriter(s.getOutputStream(), true)) {
+            pw.write("shutdown");
+            pw.flush();
+        }
     }
     
     private static void printUsage() {
@@ -201,12 +189,11 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
         System.out.println("\t\t-baseHDFSDirOverride [HDFS Path]\tDescription: overrides baseHDFSDir in xml");
         System.out.println("\t\t-extraIngestArgsOverride [extra ingest args]\tDescription: overrides extraIngestArgs value in xml config");
         System.out.println("\t\t-flagFileDirectoryOverride [local path]\tDescription: overrides flagFileDirectory value in xml config");
-        
     }
     
     @Override
     public void run() {
-        log.debug("FlagMaker run() starting");
+        log.info(this.getClass().getSimpleName() + " run() starting");
         startSocket();
         try {
             while (running) {
@@ -220,9 +207,8 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
             }
         } finally {
             executor.shutdown();
-            
         }
-        log.info("FlagMaker Exiting.");
+        log.info(this.getClass().getSimpleName() + " Exiting.");
     }
     
     /**
@@ -238,45 +224,53 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
             fd.setup(fc);
             log.trace("Checking for files for {}", dataName);
             
-            for (String folder : fc.getFolder()) {
-                String folderPattern = folder + "/" + fmc.getFilePattern();
-                log.trace("searching for {} files in {}", dataName, folderPattern);
-                FileStatus[] files = fs.globStatus(new Path(folderPattern));
-                if (files == null || files.length == 0) {
-                    log.trace("files: {}", (files == null ? "null" : files.length));
-                    continue;
-                }
-                
-                // pull the base directory off of the folder
-                if (folder.startsWith(fmc.getBaseHDFSDir())) {
-                    log.trace("Removing base directory off folder {}", folder);
-                    folder = folder.substring(fmc.getBaseHDFSDir().length());
-                    log.trace("Adjusted folder: {}", folder);
-                    
-                    if (folder.startsWith(File.separator)) {
-                        folder = folder.substring(File.separator.length());
-                        log.trace("Removed separator: {}", folder);
-                    }
-                }
-                
-                // add the files
-                for (FileStatus status : files) {
-                    if (status.isDir()) {
-                        log.warn("Skipping subdirectory {}", status.getPath());
-                    } else {
-                        try {
-                            fd.addInputFile(new InputFile(folder, status.getPath(), status.getBlockSize(), status.getLen(), getTimestamp(status.getPath(),
-                                            status.getModificationTime())));
-                        } catch (UnusableFileException e) {
-                            log.warn("Skipping unusable file " + status.getPath(), e);
-                        }
-                    }
+            loadFilesForDistributor(fc, fs);
+            
+            while (fd.hasNext(shouldOnlyCreateFullFlags(fc)) && running) {
+                // initStats(startTime);
+                writeFlagFile(fc, fd.next(this));
+            }
+        }
+    }
+    
+    /**
+     * Adds all input files for the data type to the {@link FlagDistributor}.
+     * 
+     * @param fc
+     *            flag datatype configuration data
+     * @param fs
+     *            hadoop filesystem
+     * @throws IOException
+     *             error condition finding files in hadoop
+     */
+    void loadFilesForDistributor(FlagDataTypeConfig fc, FileSystem fs) throws IOException {
+        for (String folder : fc.getFolder()) {
+            String folderPattern = folder + "/" + fmc.getFilePattern();
+            log.debug("searching for " + fc.getDataName() + " files in " + folderPattern);
+            FileStatus[] files = fs.globStatus(new Path(folderPattern));
+            if (files == null || files.length == 0) {
+                continue;
+            }
+            
+            // remove the base directory from the folder
+            if (folder.startsWith(this.fmc.getBaseHDFSDir())) {
+                folder = folder.substring(this.fmc.getBaseHDFSDir().length());
+                if (folder.startsWith(File.separator)) {
+                    folder = folder.substring(File.separator.length());
                 }
             }
             
-            while (fd.hasNext(shouldOnlyCreateFullFlags(fc)) && running) {
-                initStats(startTime);
-                writeFlagFile(fc, fd.next(this));
+            // add the files
+            for (FileStatus status : files) {
+                if (status.isDirectory()) {
+                    log.warn("Skipping subdirectory " + status.getPath());
+                } else {
+                    try {
+                        this.fd.addInputFile(new InputFile(folder, status, this.fmc.getBaseHDFSDir(), this.fmc.isUseFolderTimestamp()));
+                    } catch (UnusableFileException e) {
+                        log.warn("Skipping unusable file " + status.getPath(), e);
+                    }
+                }
             }
         }
     }
@@ -308,7 +302,7 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
         return hasTimeoutOccurred;
     }
     
-    public long getTimestamp(Path path, long fileTimestamp) {
+    private long getTimestamp(Path path, long fileTimestamp) {
         if (fmc.isUseFolderTimestamp()) {
             // if using the folder timestamp, then pull the day out of the folder timestamp
             try {
@@ -329,7 +323,7 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
      * @param fc
      * @return the flag found for this ingest pool
      */
-    int countFlagFileBacklog(final FlagDataTypeConfig fc) {
+    private int countFlagFileBacklog(final FlagDataTypeConfig fc) {
         final MutableInt fileCounter = new MutableInt(0);
         final FileFilter fileFilter = new WildcardFileFilter("*_" + fc.getIngestPool() + "_" + fc.getDataName() + "_*.flag");
         final FileVisitor<java.nio.file.Path> visitor = new SimpleFileVisitor<java.nio.file.Path>() {
@@ -352,20 +346,31 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
         return fileCounter.intValue();
     }
     
+    //@formatter:off
     /**
      * Write the flag file. This is done in several steps to ensure we can easily recover if we are killed somewhere in-between.
+     *
+     * <ul>
+     *     <li>>move the files to the flagging directory for those that do not already exist in flagging, flagged, or loaded</li>
+     *     <li>create the flag.generating file for those files we were able to move, and do not exist elsewhere</li>
+     *     <li>set the timestamp of the flag file to that of the most recent file</li>
+     *     <li>move the flagging files to the flagged directory</li>
+     *     <li>move the generating file to the final flag file form</li>
+     *     <li>create the cleanup file</li>
+     * </ul>
+     *
+     * Using these steps, a cleanup of an abnormal termination is as follows:
+     * <ul>
+     *     <li>move all flagging files to the base directory</li>
+     *     <li>for all flag.generating files, move the flagged files to the base directory</li>
+     *     <li>remove the flag.generating files.</li>
+     * </ul>
      * 
-     * 1) move the files to the flagging directory for those that do not already exist in flagging, flagged, or loaded 2) create the flag.generating file for
-     * those files we were able to move, and do not exist elsewhere 3) set the timestamp of the flag file to that of the most recent file 4) move the flagging
-     * files to the flagged directory 5) move the generating file to the final flag file form 6) create the cleanup file
-     * 
-     * Using these steps, a cleanup of an abnormal termination is as follows: 1) move all flagging files to the base directory 2) for all flag.generating files,
-     * move the flagged files to the base directory 3) remove the flag.generating files.
-     * 
-     * @param fc
-     * @param inFiles
+     * @param fc flag configuration
+     * @param inFiles input files to write to flag file
      * @throws IOException
      */
+    //@formatter:on
     void writeFlagFile(final FlagDataTypeConfig fc, Collection<InputFile> inFiles) throws IOException {
         
         long estSize = getFlagFileSize(fc, inFiles);
@@ -374,95 +379,109 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
         final ConcurrentHashMap<InputFile,Path> moved = new ConcurrentHashMap<>();
         File flagFile = null;
         final FileSystem fs = getHadoopFS();
+        long now = System.currentTimeMillis();
+        final FlagMetrics metrics = new FlagMetrics(fs, fc.isCollectMetrics());
+        List<Future<InputFile>> futures = Lists.newArrayList();
+        
         try {
             // first lets create the dest directories, and move the files into the flagging directory
             final AtomicLong latestTime = new AtomicLong(-1);
-            List<Callable<Path>> callables = Lists.newArrayList();
-            for (final InputFile inFile : inFiles) {
-                // Create the flagging directory
-                Callable<Path> mover = () -> {
-                    Path dstFlagging = getDestPath(inFile, "flagging", fc);
-                    if (directoryCache.getIfPresent(dstFlagging) == null && !fs.exists(dstFlagging.getParent())) {
-                        log.debug("Creating flagging directory: {}", dstFlagging.getParent());
-                        fs.mkdirs(dstFlagging.getParent());
-                        directoryCache.put(dstFlagging, dstFlagging);
-                    }
-                    // Create the flagged directory
-                    Path dstFlagged = getDestPath(inFile, "flagged", fc);
-                    if (directoryCache.getIfPresent(dstFlagged) == null && !fs.exists(dstFlagged.getParent())) {
-                        log.debug("Creating flagged directory: {}", dstFlagging.getParent());
-                        fs.mkdirs(dstFlagged.getParent());
-                        directoryCache.put(dstFlagged, dstFlagged);
-                    }
-                    // Check for existence of the file already in the flagging, flagged, or loaded directories
-                    Path dstLoaded = getDestPath(inFile, "loaded", fc);
-                    if (fs.exists(dstFlagged) || fs.exists(dstFlagging) || fs.exists(dstLoaded)) {
-                        log.warn("Unable to move file {}/{} as it already exists in the flagging, flagged, or loaded directory", inFile.getDirectory(),
-                                        inFile.getFileName());
-                    } else {
-                        // now move the file into the flagging directory
-                        if (fs.rename(inFile.getPath(), dstFlagging)) {
-                            log.trace("Moved {} to destination: {}", inFile.getFileName(), dstFlagging);
-                            moved.put(inFile, dstFlagging);
-                            latestTime.set(Math.max(inFile.getTimestamp(), latestTime.get()));
-                        } else {
-                            log.error("Unable to move file {}/{}, skipping", inFile.getDirectory(), inFile.getFileName());
-                        }
-                    }
-                    return dstLoaded;
-                };
-                // can look at I files that have a logical ts greater than the logical ts of the last compaction. that would indicate what has been imported
-                // since that compaction started. which is basically the pile up we've seen.
-                // we can look at the size of that compacted file and use that to determine how to size the next one
-                
-                // two prior compactions: 3139106321 3139418030, (311k) apart. and 4,274,086,297 4.2GB
-                // 3139017948 - 3138938475 = 79473 (22 minutes) 3822549588 bytes = 3.8GB 3138796228 to 3139468770
-                // can determine how many I files came in since the most recent C file
-                // can find 5 most recent logical changes
-                
-                callables.add(mover);
-            }
-            try {
-                List<Future<Path>> execResults = executor.invokeAll(callables);
-                
-                for (Future<Path> future : execResults) {
-                    if (future.get() == null)
-                        throw new IOException("Error while attempting to create path");
-                }
-                
-            } catch (InterruptedException e) {
-                throw new IOException(e.getCause());
-            } catch (ExecutionException e) {
-                throw new IOException(e.getCause());
+            
+            for (final InputFile e : inFiles) {
+                // Create directories and move to flagging
+                final FlagEntryMover mover = new FlagEntryMover(directoryCache, fs, e);
+                final Future<InputFile> exec = executor.submit(mover);
+                futures.add(exec);
             }
             
+            HashSet<InputFile> flagging = new HashSet<>();
             // if no files moved, then abort
-            if (moved.isEmpty()) {
-                log.warn("No pending files were able to be moved to the flagging directory. Please investigate.");
+            if (!processResults(futures, flagging)) {
+                log.warn("No pending files were moved to the flagging directory. Please investigate.");
                 return;
             }
             
-            // create the flag.generating file
-            Path first = moved.entrySet().iterator().next().getValue();
-            long now = System.currentTimeMillis();
+            Path first = flagging.iterator().next().getCurrentDir();
             String baseName = fmc.getFlagFileDirectory() + File.separator + df.format(now / 1000) + "_" + fc.getIngestPool() + "_" + fc.getDataName() + "_"
-                            + first.getName() + "+" + moved.size();
-            log.info("Creating flag file {}.flag for data type {} containing {} files", baseName, fc.getDataName(), moved.size());
-            File f = new File(baseName + ".flag.generating");
-            if (f.createNewFile()) {
-                flagFile = f;
-            } else {
-                throw new IOException("Unable to create flag file " + f);
+                            + first.getName() + "+" + flagging.size();
+            flagFile = write(flagging, fc, baseName);
+            for (InputFile entry : flagging) {
+                long time = entry.getTimestamp();
+                metrics.updateCounter(InputFile.class.getSimpleName(), entry.getFileName(), time);
+                latestTime.set(Math.max(entry.getTimestamp(), latestTime.get()));
             }
-            FileOutputStream flagOS = new FileOutputStream(f);
+            
+            // now set the modification time of the flag file
+            if (fmc.isSetFlagFileTimestamp()) {
+                if (!flagFile.setLastModified(latestTime.get())) {
+                    log.warn("unable to set last modified time for flagfile (" + flagFile.getAbsolutePath() + ")");
+                }
+            }
+            
+            // Now we have files moved into the flagging directory, and a flag.generating file created
+            
+            // move the files to the flagged directory
+            for (InputFile entry : flagging) {
+                final SimpleMover mover = new SimpleMover(directoryCache, entry, InputFile.TrackedDir.FLAGGED_DIR, fs);
+                final Future<InputFile> exec = executor.submit(mover);
+                futures.add(exec);
+            }
+            HashSet<InputFile> flagged = new HashSet<>();
+            if (!processResults(futures, flagged)) {
+                throw new IOException("Files went to flagging, but not flagged. Investigate");
+            }
+            
+            for (InputFile entry : flagged) {
+                metrics.updateCounter(FlagFile.class.getSimpleName(), entry.getCurrentDir().getName(), System.currentTimeMillis());
+            }
+            
+            File f2 = new File(baseName + ".flag");
+            if (!flagFile.renameTo(f2)) {
+                throw new IOException("Failed to rename" + flagFile.toString() + " to " + f2);
+            }
+            flagFile = f2;
+            
+            // after we write a file, set the timeout to the forceInterval
+            fc.setLast(now + fc.getTimeoutMilliSecs());
+            
+            metrics.writeMetrics(this.fmc.getFlagMetricsDirectory(), new Path(baseName).getName());
+        } catch (IOException ex) {
+            log.error("Unable to complete flag file ", ex);
+            moveFilesBack(inFiles, futures, fs);
+            if (flagFile != null) {
+                if (!flagFile.delete()) {
+                    log.warn("unable to delete flagfile (" + flagFile.getAbsolutePath() + ")");
+                }
+            }
+            throw ex;
+        }
+    }
+    
+    /**
+     * Creates the flag file using all of the
+     * 
+     * @param flagging
+     * @param fc
+     * @param baseName
+     * @return
+     * @throws IOException
+     */
+    protected File write(Collection<InputFile> flagging, FlagDataTypeConfig fc, String baseName) throws IOException {
+        // create the flag.generating file
+        log.debug("Creating flag file" + baseName + ".flag" + " for data type " + fc.getDataName() + " containing " + flagging.size() + " files");
+        File f = new File(baseName + ".flag.generating");
+        if (!f.createNewFile()) {
+            throw new IOException("Unable to create flag file " + f);
+        }
+        
+        try (FileOutputStream flagOS = new FileOutputStream(f)) {
             StringBuilder sb = new StringBuilder(fmc.getDatawaveHome() + File.separator + fc.getScript());
             if (fc.getFileListMarker() == null) {
                 String sep = " ";
-                for (InputFile inFile : moved.keySet()) {
+                for (InputFile inFile : flagging) {
                     if (fc.isCollectMetrics())
                         ctx.getCounter(InputFile.class.getSimpleName(), inFile.getFileName()).setValue(inFile.getTimestamp());
-                    Path dstFlagged = getDestPath(inFile, "flagged", fc);
-                    sb.append(sep).append(dstFlagged.toUri());
+                    sb.append(sep).append(inFile.getFlagged().toUri());
                     sep = ",";
                 }
             } else {
@@ -479,151 +498,63 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
             sb.append("\n");
             if (fc.getFileListMarker() != null) {
                 sb.append(fc.getFileListMarker()).append('\n');
-                for (InputFile inFile : moved.keySet()) {
+                for (InputFile inFile : flagging) {
                     if (fc.isCollectMetrics())
                         ctx.getCounter(InputFile.class.getSimpleName(), inFile.getFileName()).setValue(inFile.getTimestamp());
-                    Path dstFlagged = getDestPath(inFile, "flagged", fc);
-                    sb.append(dstFlagged.toUri()).append('\n');
+                    sb.append(inFile.getFlagged().toUri()).append('\n');
                 }
             }
-            if (estSize != sb.length()) {
-                log.error("Estimated size is not accurate: {} vs {}", estSize, sb.length());
-            }
+            
+            // bmw - ? do we care about length
+            // if (estSize != sb.length()) {
+            // log.error("Estimated size is not accurate: {} vs {}", estSize, sb.length());
+            // }
             
             flagOS.write(sb.toString().getBytes());
-            flagOS.close();
-            
-            // now set the modification time of the flag file
-            if (fmc.isSetFlagFileTimestamp()) {
-                f.setLastModified(latestTime.get());
-            }
-            
-            // Now we have files moved into the flagging directory, and a flag.generating file created
-            
-            // move the files to the flagged directory
-            callables = Lists.newArrayList();
-            
-            for (Map.Entry<InputFile,Path> entry : moved.entrySet()) {
-                final InputFile inFile = entry.getKey();
-                final Path dstFlagging = entry.getValue();
-                final Path dstFlagged = getDestPath(inFile, "flagged", fc);
-                Callable<Path> mover = () -> {
-                    if (fs.rename(dstFlagging, dstFlagged)) {
-                        log.trace("Moved {} to {} ", dstFlagging, dstFlagged);
-                        moved.put(inFile, dstFlagged);
-                        if (fc.isCollectMetrics())
-                            ctx.getCounter(FlagFile.class.getSimpleName(), dstFlagged.getName()).setValue(System.currentTimeMillis());
-                    } else {
-                        throw new IOException("Unable to move file " + inFile.getDirectory() + "/" + inFile.getFileName());
-                    }
-                    
-                    return dstFlagged;
-                };
-                callables.add(mover);
-            }
-            
-            try {
-                List<Future<Path>> execResults = executor.invokeAll(callables);
-                
-                for (Future<Path> future : execResults) {
-                    if (future.get() == null)
-                        throw new IOException("Error while attempting to create path");
-                }
-                
-            } catch (InterruptedException e) {
-                throw new IOException(e.getCause());
-            } catch (ExecutionException e) {
-                throw new IOException(e.getCause());
-            }
-            
-            File f2 = new File(baseName + ".flag");
-            if (f.renameTo(f2)) {
-                flagFile = f2;
-            } else {
-                throw new IOException("Failed to rename" + f + " to " + f2);
-            }
-            
-            try {
-                lock.lock();
-                // after we write a file, set the timeout to the forceInterval
-                fc.setLast(now + fc.getTimeoutMilliSecs());
-            } finally {
-                lock.unlock();
-            }
-            
-            if (fc.isCollectMetrics())
-                updateStats();
-            
-            if (fc.isCollectMetrics()) {
-                writeMetrics(ctx.getReporter(), this.fmc.getFlagMetricsDirectory(), new Path(baseName).getName(), ct, cc);
-            }
-        } catch (IOException ex) {
-            log.error("Unable to complete flag file ", ex);
-            moveFilesBack(moved);
-            if (flagFile != null) {
-                flagFile.delete();
-            }
-            throw ex;
         }
+        
+        return f;
     }
     
-    private void moveFilesBack(ConcurrentHashMap<InputFile,Path> moved) throws IOException {
-        if (moved.isEmpty())
+    private boolean processResults(List<Future<InputFile>> futures, Collection<InputFile> entries) throws IOException {
+        IOException ioex = null;
+        for (Future<InputFile> future : futures) {
+            try {
+                InputFile fe = future.get();
+                if (fe != null && fe.isMoved()) {
+                    entries.add(fe);
+                }
+            } catch (InterruptedException | ExecutionException ex) {
+                ioex = new IOException("Failure during move", ex.getCause());
+            }
+        }
+        futures.clear();
+        if (ioex != null) {
+            throw ioex;
+        }
+        return !entries.isEmpty();
+    }
+    
+    private void moveFilesBack(Collection<InputFile> files, List<Future<InputFile>> futures, FileSystem fs) throws IOException {
+        if (files.isEmpty()) {
             return;
-        try {
-            FileSystem fs = getHadoopFS();
-            Iterator<Map.Entry<InputFile,Path>> it = moved.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry<InputFile,Path> kv = it.next();
-                if (fs.rename(kv.getValue(), kv.getKey().getPath())) {
-                    it.remove();
+        }
+        for (InputFile flagEntry : files) {
+            final SimpleMover mover = new SimpleMover(directoryCache, flagEntry, InputFile.TrackedDir.PATH_DIR, fs);
+            final Future<InputFile> exec = executor.submit(mover);
+            futures.add(exec);
+        }
+        HashSet<InputFile> moved = new HashSet<>();
+        processResults(futures, moved);
+        if (moved.size() != files.size()) {
+            StringBuilder sb = new StringBuilder();
+            for (InputFile entry : files) {
+                if (!entry.getPath().equals(entry.getCurrentDir())) {
+                    sb.append("\n").append(entry.getCurrentDir().toString());
                 }
             }
-        } catch (IOException ex) {
-            StringBuilder sb = new StringBuilder();
-            for (Map.Entry<InputFile,Path> orphan : moved.entrySet()) {
-                sb.append("\n").append(orphan.getValue());
-            }
-            log.error("An error occurred while attempting to move files. The following files were orphaned: {}", sb.toString());
+            log.error("An error occurred while attempting to move files. The following files were orphaned:" + sb.toString());
         }
-    }
-    
-    /**
-     * if it matches the date pattern, use that, otherwise use a pattern of now
-     * 
-     * @param inFile
-     * @return
-     */
-    private Path getDestPath(InputFile inFile, String subdir, FlagDataTypeConfig fc) {
-        Matcher m = pattern.matcher(inFile.getDirectory());
-        String dst = fmc.getBaseHDFSDir() + subdir + File.separator + inFile.getFolder() + File.separator;
-        if (m.find()) {
-            String grp = m.group(1);
-            dst += grp;
-        } else {
-            SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT_STRING);
-            dst += format.format(new Date());
-        }
-        return new Path(dst + File.separator + inFile.getFileName());
-    }
-    
-    /**
-     * Get the length of the URI produced by getDestPath(inFile,subdir,fc)
-     * 
-     * @param inFile
-     * @return the length of the URI
-     */
-    private int getDestPathLength(InputFile inFile, String subdir, FlagDataTypeConfig fc) {
-        Matcher m = pattern.matcher(inFile.getDirectory());
-        int len = fmc.getBaseHDFSDir().length() + subdir.length() + 1 + inFile.getFolder().length() + 1;
-        if (m.find()) {
-            String grp = m.group(1);
-            len += grp.length();
-        } else {
-            SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT_STRING);
-            len += format.format(new Date()).length();
-        }
-        return len + 1 + inFile.getFileName().length();
     }
     
     FileSystem getHadoopFS() throws IOException {
@@ -650,15 +581,9 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
             String dtype = s.substring(4).trim();
             for (FlagDataTypeConfig cfg : fmc.getFlagConfigs()) {
                 if (cfg.getDataName().equals(dtype)) {
-                    try {
-                        lock.lock();
-                        log.info("Forcing {} to generate flag file", dtype);
-                        cfg.setLast(System.currentTimeMillis() - cfg.getTimeoutMilliSecs());
-                        break;
-                    } finally {
-                        lock.unlock();
-                    }
-                    
+                    log.info("Forcing {} to generate flag file", dtype);
+                    cfg.setLast(System.currentTimeMillis() - cfg.getTimeoutMilliSecs());
+                    break;
                 }
             }
         }
@@ -679,184 +604,17 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
     }
     
     /**
-     * Validate config and set up folders for each data type. Here we have a few rules: if you provide no folders, then we will assume that the folder is the
-     * the data type which will be appended to the base directory (e.g. /data/ShardIngest). Users can provide absolute file paths by leading with a slash ("/")
-     */
-    private void setup() {
-        String prefix = "FlagDataTypeConfig Error: ";
-        // validate the config
-        if (fmc.getDefaultCfg().getScript() == null) {
-            throw new IllegalArgumentException(prefix + "default script is required");
-        }
-        String hdfsbasedir = fmc.getBaseHDFSDir();
-        if (hdfsbasedir == null) {
-            throw new IllegalArgumentException(prefix + "baseHDFSDir is required");
-        }
-        
-        if (!hdfsbasedir.endsWith("/")) {
-            fmc.setBaseHDFSDir(hdfsbasedir + "/");
-        }
-        
-        int socketPort = fmc.getSocketPort();
-        if (socketPort < 1025 || socketPort > 65534) {
-            throw new IllegalArgumentException(prefix + "socketPort is required and must be greater than 1024 and less than 65535");
-        }
-        
-        if (fmc.getFlagFileDirectory() == null) {
-            throw new IllegalArgumentException(prefix + "flagFileDirectory is required");
-        }
-        
-        if (fmc.getDefaultCfg().getMaxFlags() < 1) {
-            throw new IllegalArgumentException(prefix + "Default Max Flags must be set.");
-        }
-        
-        String dtype = fmc.getDistributorType();
-        if (dtype == null || !dtype.matches("(simple|date|folderdate)")) {
-            throw new IllegalArgumentException("Invalid Distributor type provided: " + dtype + ". Must be one of the following: simple|date|folderdate");
-        }
-        
-        if ("simple".equals(dtype)) {
-            fd = new SimpleFlagDistributor();
-        } else if ("date".equals(dtype)) {
-            fd = new DateFlagDistributor();
-        } else if ("folderdate".equals(dtype)) {
-            fd = new DateFolderFlagDistributor();
-        }
-        for (FlagDataTypeConfig cfg : fmc.getFlagConfigs()) {
-            if (cfg.getInputFormat() == null)
-                throw new IllegalArgumentException("Input Format Class must be specified for data type: " + cfg.getDataName());
-            if (cfg.getIngestPool() == null)
-                throw new IllegalArgumentException("Ingest Pool must be specified for data type: " + cfg.getDataName());
-            if (cfg.getFlagCountThreshold() == FlagMakerConfig.UNSET) {
-                cfg.setFlagCountThreshold(fmc.getFlagCountThreshold());
-            }
-            if (cfg.getTimeoutMilliSecs() == FlagMakerConfig.UNSET) {
-                cfg.setTimeoutMilliSecs(fmc.getTimeoutMilliSecs());
-            }
-            cfg.setLast(System.currentTimeMillis() + cfg.getTimeoutMilliSecs());
-            if (cfg.getMaxFlags() < 1) {
-                cfg.setMaxFlags(fmc.getDefaultCfg().getMaxFlags());
-            }
-            if (cfg.getReducers() < 1) {
-                cfg.setReducers(fmc.getDefaultCfg().getReducers());
-            }
-            if (cfg.getScript() == null || "".equals(cfg.getScript())) {
-                cfg.setScript(fmc.getDefaultCfg().getScript());
-            }
-            if (cfg.getFileListMarker() == null || "".equals(cfg.getFileListMarker())) {
-                cfg.setFileListMarker(fmc.getDefaultCfg().getFileListMarker());
-            }
-            if (cfg.getFileListMarker() != null) {
-                if (cfg.getFileListMarker().indexOf(' ') >= 0) {
-                    throw new IllegalArgumentException(prefix + "fileListMarker cannot contain spaces");
-                }
-            }
-            if (cfg.getCollectMetrics() == null || "".equals(cfg.getCollectMetrics())) {
-                cfg.setCollectMetrics(fmc.getDefaultCfg().getCollectMetrics());
-            }
-            List<String> folders = cfg.getFolder();
-            if (folders == null || folders.isEmpty()) {
-                folders = new ArrayList<>();
-                cfg.setFolder(folders);
-                // add the default path. we'll bomb later if it's not there.
-                folders.add(cfg.getDataName());
-            }
-            List<String> fixedFolders = new ArrayList<>();
-            for (int i = 0; i < folders.size(); i++) {
-                for (String folder : StringUtils.split(folders.get(i), ',')) {
-                    folder = folder.trim();
-                    // let someone specify an absolute path.
-                    if (!folder.startsWith("/")) {
-                        fixedFolders.add(fmc.getBaseHDFSDir() + folder);
-                    } else {
-                        fixedFolders.add(folder);
-                    }
-                }
-            }
-            cfg.setFolder(fixedFolders);
-        }
-        
-        // configure the executor per the FlagMakerConfig input
-        executor = Executors.newFixedThreadPool(fmc.getMaxHdfsThreads());
-    }
-    
-    private void initStats(long startTime) {
-        this.ctx = new StandaloneTaskAttemptContext<>(new Configuration(), new StandaloneStatusReporter());
-        ctx.putIfAbsent(datawave.metrics.util.flag.InputFile.FLAGMAKER_START_TIME, startTime);
-    }
-    
-    private void updateStats() {
-        ctx.getCounter(datawave.metrics.util.flag.InputFile.FLAGMAKER_END_TIME).setValue(System.currentTimeMillis());
-    }
-    
-    protected void writeMetrics(final StandaloneStatusReporter reporter, final String metricsDirectory, final String baseName, final CompressionType ct,
-                    final CompressionCodec cc) throws IOException {
-        
-        FileSystem fs = getHadoopFS();
-        
-        if (reporter == null)
-            return;
-        
-        final Counters c = reporter.getCounters();
-        if (c == null || c.countCounters() <= 0)
-            return;
-        
-        final String baseFileName = metricsDirectory + File.separator + baseName + ".metrics";
-        
-        String fileName = baseFileName;
-        Path finishedMetricsFile = new Path(fileName);
-        Path src = new Path(fileName + ".working");
-        
-        if (!fs.exists(finishedMetricsFile.getParent())) {
-            fs.mkdirs(finishedMetricsFile.getParent());
-        }
-        
-        if (!fs.exists(src.getParent())) {
-            fs.mkdirs(src.getParent());
-        }
-        
-        int count = 0;
-        
-        while (true) {
-            while (fs.exists(finishedMetricsFile) || !fs.createNewFile(src)) {
-                count++;
-                
-                fileName = baseFileName + '.' + count;
-                finishedMetricsFile = new Path(fileName);
-                src = new Path(fileName + ".working");
-            }
-            
-            if (!fs.exists(finishedMetricsFile))
-                break;
-            fs.delete(src, false);
-        }
-        
-        final Writer writer = SequenceFile.createWriter(fs, new Configuration(), src, Text.class, Counters.class, ct, cc);
-        writer.append(new Text(baseName), c);
-        writer.close();
-        
-        if (!fs.rename(src, finishedMetricsFile))
-            log.error("Could not rename metrics file to completed name. Failed file will persist until manually removed.");
-    }
-    
-    /**
      * Get the length of the flag file that would be created using this set of files.
      * 
      * @param fc
      * @param inFiles
      * @return The size in characters of the flag file
      */
-    long getFlagFileSize(FlagDataTypeConfig fc, Collection<InputFile> inFiles) {
-        long length = 0;
-        length += fmc.getDatawaveHome().length() + 1 + fc.getScript().length();
+    private long getFlagFileSize(FlagDataTypeConfig fc, Collection<InputFile> inFiles) {
+        long length = fmc.getDatawaveHome().length() + 1 + fc.getScript().length();
         int first = -1;
         for (InputFile inFile : inFiles) {
-            if (first == -1) {
-                first = getDestPathLength(inFile, "flagged", fc);
-                length += 1 + first;
-            } else {
-                length += 1 + getDestPathLength(inFile, "flagged", fc);
-            }
+            length += 1 + inFile.getTrackedDirLength(InputFile.TrackedDir.FLAGGED_DIR);
         }
         
         length += 1 + Integer.toString(fc.getReducers()).length() + " -inputFormat ".length() + fc.getInputFormat().getName().length() + 1
@@ -870,7 +628,6 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
         }
         
         return length;
-        
     }
     
     @Override
@@ -905,5 +662,4 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
     private int filesPerPartition(int maxCounters) {
         return ((maxCounters - 2) / 2);
     }
-    
 }

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMetrics.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMetrics.java
@@ -34,8 +34,10 @@ public class FlagMetrics {
     
     /**
      *
-     * @param hadoopFS HDFS file system object
-     * @param enableMetrics enable write of metrics
+     * @param hadoopFS
+     *            HDFS file system object
+     * @param enableMetrics
+     *            enable write of metrics
      */
     FlagMetrics(FileSystem hadoopFS, boolean enableMetrics) {
         this.fs = hadoopFS;
@@ -43,7 +45,7 @@ public class FlagMetrics {
         this.ctx = new StandaloneTaskAttemptContext<>(new Configuration(), new StandaloneStatusReporter());
         ctx.putIfAbsent(datawave.metrics.util.flag.InputFile.FLAGMAKER_START_TIME, System.currentTimeMillis());
     }
-
+    
     protected void updateCounter(String groupName, String counterName, long val) {
         ctx.getCounter(groupName, counterName).setValue(val);
     }

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMetrics.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMetrics.java
@@ -1,0 +1,113 @@
+package datawave.util.flag;
+
+import java.io.File;
+import java.io.IOException;
+
+import datawave.ingest.mapreduce.StandaloneStatusReporter;
+import datawave.ingest.mapreduce.StandaloneTaskAttemptContext;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
+import org.apache.hadoop.mapreduce.Counters;
+import org.apache.log4j.Logger;
+
+/**
+ * Collects and reports FlagMaker metrics.
+ */
+public class FlagMetrics {
+    
+    private static final Logger log = Logger.getLogger(FlagMetrics.class);
+    
+    private static final CompressionCodec cc = new GzipCodec();
+    private static final SequenceFile.CompressionType ct = SequenceFile.CompressionType.BLOCK;
+    
+    private final StandaloneTaskAttemptContext<?,?,?,?> ctx;
+    
+    private final FileSystem fs;
+    
+    private final boolean enabled;
+    
+    /**
+     *
+     * @param hadoopFS HDFS file system object
+     * @param enableMetrics enable write of metrics
+     */
+    FlagMetrics(FileSystem hadoopFS, boolean enableMetrics) {
+        this.fs = hadoopFS;
+        this.enabled = enableMetrics;
+        this.ctx = new StandaloneTaskAttemptContext<>(new Configuration(), new StandaloneStatusReporter());
+        ctx.putIfAbsent(datawave.metrics.util.flag.InputFile.FLAGMAKER_START_TIME, System.currentTimeMillis());
+    }
+
+    protected void updateCounter(String groupName, String counterName, long val) {
+        ctx.getCounter(groupName, counterName).setValue(val);
+    }
+    
+    protected void writeMetrics(final String metricsDirectory, final String baseName) throws IOException {
+        if (!this.enabled) {
+            return;
+        }
+        
+        ctx.getCounter(datawave.metrics.util.flag.InputFile.FLAGMAKER_END_TIME).setValue(System.currentTimeMillis());
+        final StandaloneStatusReporter reporter = ctx.getReporter();
+        if (reporter == null)
+            return;
+        
+        ctx.getCounter(datawave.metrics.util.flag.InputFile.FLAGMAKER_END_TIME).setValue(System.currentTimeMillis());
+        final Counters counters = reporter.getCounters();
+        if (counters == null || counters.countCounters() <= 0)
+            return;
+        
+        final String baseFileName = metricsDirectory + File.separator + baseName + ".metrics";
+        
+        String fileName = baseFileName;
+        Path finishedMetricsFile = new Path(fileName);
+        Path src = new Path(fileName + ".working");
+        
+        if (!fs.exists(finishedMetricsFile.getParent())) {
+            if (!fs.mkdirs(finishedMetricsFile.getParent())) {
+                log.warn("unable to create directory (" + finishedMetricsFile.getParent() + ") metrics write terminated");
+                return;
+            }
+        }
+        
+        if (!fs.exists(src.getParent())) {
+            if (!fs.mkdirs(src.getParent())) {
+                log.warn("unable to create directory (" + src.getParent() + ") metrics write terminated");
+                return;
+            }
+        }
+        
+        int count = 0;
+        
+        while (true) {
+            while (fs.exists(finishedMetricsFile) || !fs.createNewFile(src)) {
+                count++;
+                
+                fileName = baseFileName + '.' + count;
+                finishedMetricsFile = new Path(fileName);
+                src = new Path(fileName + ".working");
+            }
+            
+            if (!fs.exists(finishedMetricsFile))
+                break;
+            // delete src - it will be recreated by while statement
+            if (fs.delete(src, false)) {
+                log.warn("unable to delete metrics file (" + src + ")");
+            }
+        }
+        
+        try (final SequenceFile.Writer writer = SequenceFile.createWriter(new Configuration(), SequenceFile.Writer.file(src),
+                        SequenceFile.Writer.keyClass(Text.class), SequenceFile.Writer.valueClass(Counters.class), SequenceFile.Writer.compression(ct, cc))) {
+            writer.append(new Text(baseName), counters);
+        }
+        
+        if (!fs.rename(src, finishedMetricsFile))
+            log.error("Could not rename metrics file to completed name. Failed file will persist until manually removed.");
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/InputFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/InputFile.java
@@ -1,21 +1,62 @@
 package datawave.util.flag;
 
+import java.io.File;
+import java.text.SimpleDateFormat;
 import java.util.Comparator;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import datawave.util.flag.processor.DateUtils;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper for input file meta data
  */
 public class InputFile implements Comparable<InputFile> {
     
-    long blocksize;
-    long filesize;
+    private static final Logger log = LoggerFactory.getLogger(InputFile.class);
+    static final String DATE_FORMAT_STRING = "yyyy" + File.separator + "MM" + File.separator + "dd";
+    // our yyyy/mm/dd pattern for most things.
+    public static final Pattern PATTERN = Pattern.compile(".*/([0-9]{4}(/[0-9]{2}){2})(?:/.*|$)");
+    
+    /**
+     * Defines the tracked directory locations within the flag hdfs.
+     */
+    enum TrackedDir {
+        // @formatter:off
+        PATH_DIR("path"),
+        FLAGGING_DIR("flagging"),
+        FLAGGED_DIR("flagged"),
+        LOADED_DIR("loaded");
+        // @formatter:on
+        
+        private final String path;
+        
+        TrackedDir(String path) {
+            this.path = path;
+        }
+    }
+    
+    private long blocksize;
+    private long filesize;
     private Path path;
     private long timestamp;
     private String folder;
     
-    public InputFile() {}
+    // flag file paths
+    private Path flagging;
+    private Path flagged;
+    private Path loaded;
+    
+    // state variables
+    private TrackedDir currentDir;
+    private boolean moved;
+    
+    // public InputFile() {}
     
     /**
      * Create an InputFile
@@ -30,13 +71,25 @@ public class InputFile implements Comparable<InputFile> {
      *            the filesize
      * @param timestamp
      *            the last modified timestamp
+     * @param baseDir
+     *            base directory
      */
-    public InputFile(String folder, Path path, long blocksize, long filesize, long timestamp) {
+    InputFile(String folder, Path path, long blocksize, long filesize, long timestamp, String baseDir) {
         this.folder = folder;
         this.path = path;
         this.blocksize = blocksize;
         this.filesize = filesize;
         this.timestamp = timestamp;
+        
+        this.flagging = getDestPath(path, TrackedDir.FLAGGING_DIR.path, baseDir, folder);
+        this.flagged = getDestPath(path, TrackedDir.FLAGGED_DIR.path, baseDir, folder);
+        this.loaded = getDestPath(path, TrackedDir.LOADED_DIR.path, baseDir, folder);
+        this.currentDir = TrackedDir.PATH_DIR;
+    }
+    
+    InputFile(String folder, FileStatus status, String baseDir, boolean useFolderTimestamp) {
+        this(folder, status.getPath(), status.getBlockSize(), status.getLen(), createTimestamp(status.getPath(), status.getModificationTime(),
+                        useFolderTimestamp), baseDir);
     }
     
     public long getTimestamp() {
@@ -55,12 +108,24 @@ public class InputFile implements Comparable<InputFile> {
         return filesize;
     }
     
-    public void setFilesize(int filesize) {
+    public void setFilesize(long filesize) {
         this.filesize = filesize;
     }
     
     public String getDirectory() {
         return path.getParent().toString();
+    }
+    
+    Path getFlagging() {
+        return flagging;
+    }
+    
+    public Path getFlagged() {
+        return flagged;
+    }
+    
+    public Path getLoaded() {
+        return loaded;
     }
     
     public Path getPath() {
@@ -74,6 +139,79 @@ public class InputFile implements Comparable<InputFile> {
     public int getMaps() {
         double maps = (blocksize == 0 ? 1 : (double) filesize / blocksize);
         return (int) Math.ceil(maps);
+    }
+    
+    public Path getCurrentDir() {
+        return getTrackedDir(this.currentDir);
+    }
+    
+    public boolean isMoved() {
+        return moved;
+    }
+    
+    void setMoved(boolean moved) {
+        this.moved = moved;
+    }
+    
+    // ===============================================
+    // utility methods
+    /**
+     * Indicates the file has been moved to one of the tracked locations.
+     *
+     * @param update
+     *            updated location for file
+     */
+    void updateCurrentDir(TrackedDir update) {
+        this.currentDir = update;
+        this.moved = true;
+    }
+    
+    /**
+     * Returns the {@link Path} for the file in the specific tracked directory.
+     * 
+     * @param loc
+     *            tracked directory
+     * @return
+     */
+    Path getTrackedDir(TrackedDir loc) {
+        Path file = null;
+        switch (loc) {
+            case PATH_DIR:
+                file = this.path;
+                break;
+            case FLAGGING_DIR:
+                file = this.flagging;
+                break;
+            case FLAGGED_DIR:
+                file = this.flagged;
+                break;
+            case LOADED_DIR:
+                file = this.loaded;
+        }
+        
+        return file;
+    }
+    
+    /**
+     * Returns the {@link Path} for the file in the specific tracked directory.
+     * 
+     * @param loc
+     *            tracked directory
+     * @return
+     */
+    int getTrackedDirLength(TrackedDir loc) {
+        Path file = getTrackedDir(loc);
+        return file.toUri().toString().length();
+    }
+    
+    /**
+     * Updates the tracked locations to use the current timestamp to resolve naming conflicts.
+     */
+    void renameTrackedLocations() {
+        final String now = "-" + System.currentTimeMillis();
+        this.flagged = this.flagged.suffix(now);
+        this.flagging = this.flagging.suffix(now);
+        this.loaded = this.loaded.suffix(now);
     }
     
     @Override
@@ -112,7 +250,20 @@ public class InputFile implements Comparable<InputFile> {
     
     @Override
     public String toString() {
-        return "InputFile{" + "blocksize=" + blocksize + ", filesize=" + filesize + ", timestamp=" + timestamp + ", path=" + path + '}';
+        // @formatter:off
+        return "InputFile{" +
+                "blocksize=" + blocksize +
+                ", filesize=" + filesize +
+                ", path=" + path +
+                ", timestamp=" + timestamp +
+                ", folder='" + folder + '\'' +
+                ", flagging=" + flagging +
+                ", flagged=" + flagged +
+                ", loaded=" + loaded +
+                ", currentDir=" + currentDir +
+                ", moved=" + moved +
+                '}';
+        // @formatter:on
     }
     
     /**
@@ -163,4 +314,52 @@ public class InputFile implements Comparable<InputFile> {
         return FIFO.compare(this, o);
     }
     
+    /**
+     * if it matches the date pattern, use that, otherwise use a pattern of now
+     *
+     * @param inFile
+     * @return
+     */
+    static Path getDestPath(Path inFile, String subdir, String baseDir, String folder) {
+        Matcher m = PATTERN.matcher(inFile.getParent().toString());
+        StringBuilder dstPath = new StringBuilder(baseDir);
+        appendWithSep(dstPath, subdir);
+        appendWithSep(dstPath, folder);
+        if (m.find()) {
+            appendWithSep(dstPath, m.group(1));
+        } else {
+            SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT_STRING);
+            appendWithSep(dstPath, format.format(new Date()));
+        }
+        return new Path(appendWithSep(dstPath, inFile.getName()).toString());
+    }
+    
+    private static StringBuilder appendWithSep(StringBuilder b, String next) {
+        if (b.charAt(b.length() - 1) != File.separatorChar) {
+            b.append(File.separatorChar);
+        }
+        b.append(next);
+        return b;
+    }
+    
+    /**
+     * Returns a timestamp to use for the specified {@link Path} entry.
+     *
+     * @param path
+     *            entry for determination of timestamp
+     * @param fileTimestamp
+     *            default timestamp for file
+     * @param useFolderTimestamp
+     *            if true then use the path of the file to determine the timestamp
+     * @return timestamp value
+     */
+    private static long createTimestamp(Path path, long fileTimestamp, boolean useFolderTimestamp) {
+        // if using the folder timestamp, then pull the day out of the folder timestamp
+        try {
+            return useFolderTimestamp ? DateUtils.getFolderTimestamp(path.toString()) : fileTimestamp;
+        } catch (Exception e) {
+            log.warn("Path does not contain yyyy/mm/dd...using file timestamp for " + path);
+            return fileTimestamp;
+        }
+    }
 }

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/SimpleMover.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/SimpleMover.java
@@ -1,0 +1,58 @@
+package datawave.util.flag;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import datawave.util.flag.InputFile.TrackedDir;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import com.google.common.cache.Cache;
+
+/**
+ * Moves an entry to it's next targeted location. Updates current location and move status upon completion.
+ */
+public class SimpleMover implements Callable<InputFile> {
+    
+    private static final Logger log = Logger.getLogger(SimpleMover.class);
+    
+    final InputFile entry;
+    final TrackedDir target;
+    final FileSystem fs;
+    final Cache<Path,Path> directoryCache;
+    
+    public SimpleMover(Cache<Path,Path> directoryCache, InputFile entry, TrackedDir destination, FileSystem fs) {
+        this.directoryCache = directoryCache;
+        this.entry = entry;
+        this.target = destination;
+        this.fs = fs;
+        this.entry.setMoved(false);
+    }
+    
+    @Override
+    public InputFile call() throws IOException {
+        final Path dst = this.entry.getTrackedDir(this.target);
+        checkParent(dst);
+        if (entry.getCurrentDir() == dst || (!fs.exists(dst) && fs.rename(entry.getCurrentDir(), dst))) {
+            entry.updateCurrentDir(this.target);
+        } else {
+            log.error("Unable to move file " + entry.getCurrentDir().toUri() + " to " + dst.toUri() + ", skipping");
+        }
+        
+        return entry;
+    }
+    
+    Path checkParent(Path path) throws IOException {
+        Path parent = path.getParent();
+        if (directoryCache.getIfPresent(parent) == null && !fs.exists(parent)) {
+            if (fs.mkdirs(parent)) {
+                directoryCache.put(parent, parent);
+            } else {
+                log.warn("unable to create directory (" + parent + ")");
+            }
+        }
+        return path;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/config/FlagMakerConfig.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/config/FlagMakerConfig.java
@@ -1,6 +1,11 @@
 package datawave.util.flag.config;
 
+import datawave.util.StringUtils;
+import datawave.util.flag.processor.DateFlagDistributor;
+import datawave.util.flag.processor.DateFolderFlagDistributor;
 import datawave.util.flag.processor.DateUtils;
+import datawave.util.flag.processor.FlagDistributor;
+import datawave.util.flag.processor.SimpleFlagDistributor;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -218,6 +223,116 @@ public class FlagMakerConfig {
     
     public String getFlagMetricsDirectory() {
         return flagMetricsDirectory;
+    }
+    
+    public FlagDistributor getFlagDistributor() {
+        FlagDistributor fd = null;
+        if ("simple".equals(this.distributorType)) {
+            fd = new SimpleFlagDistributor();
+        } else if ("date".equals(this.distributorType)) {
+            fd = new DateFlagDistributor();
+        } else if ("folderdate".equals(this.distributorType)) {
+            fd = new DateFolderFlagDistributor();
+        }
+        
+        return fd;
+    }
+    
+    /**
+     * Validate config and set up folders for each data type. Here we have a few rules:
+     * <ul>
+     * <li>if you provide no folders, then we will assume that the folder is the data type which will be appended to the base directory (e.g.
+     * /data/ShardIngest).</li>
+     * <li>Users can provide absolute file paths by leading with a slash ("/")</li>
+     * </ul>
+     */
+    public void validate() {
+        String prefix = this.getClass().getSimpleName() + " Error: ";
+        // validate the config
+        if (this.defaultCfg.getScript() == null) {
+            throw new IllegalArgumentException(prefix + "default script is required");
+        }
+        if (this.baseHDFSDir == null) {
+            throw new IllegalArgumentException(prefix + "baseHDFSDir is required");
+        }
+        
+        if (!this.baseHDFSDir.endsWith("/")) {
+            setBaseHDFSDir(this.baseHDFSDir + "/");
+        }
+        
+        if (this.socketPort < 1025 || socketPort > 65534) {
+            throw new IllegalArgumentException(prefix + "socketPort is required and must be greater than 1024 and less than 65535");
+        }
+        
+        if (this.flagFileDirectory == null) {
+            throw new IllegalArgumentException(prefix + "flagFileDirectory is required");
+        }
+        
+        if (this.defaultCfg.getMaxFlags() < 1) {
+            throw new IllegalArgumentException(prefix + "Default Max Flags must be set.");
+        }
+        
+        if (this.distributorType == null || !this.distributorType.matches("(simple|date|folderdate)")) {
+            throw new IllegalArgumentException("Invalid Distributor type provided: " + this.distributorType
+                            + ". Must be one of the following: simple|date|folderdate");
+        }
+        
+        for (FlagDataTypeConfig cfg : this.flagCfg) {
+            if (cfg.getInputFormat() == null)
+                throw new IllegalArgumentException("Input Format Class must be specified for data type: " + cfg.getDataName());
+            if (cfg.getIngestPool() == null)
+                throw new IllegalArgumentException("Ingest Pool must be specified for data type: " + cfg.getDataName());
+            if (cfg.getFlagCountThreshold() == FlagMakerConfig.UNSET) {
+                cfg.setFlagCountThreshold(this.flagCountThreshold);
+            }
+            if (cfg.getTimeoutMilliSecs() == FlagMakerConfig.UNSET) {
+                cfg.setTimeoutMilliSecs(this.timeoutMilliSecs);
+            }
+            cfg.setLast(System.currentTimeMillis() + cfg.getTimeoutMilliSecs());
+            if (cfg.getMaxFlags() < 1) {
+                cfg.setMaxFlags(this.defaultCfg.getMaxFlags());
+            }
+            if (cfg.getReducers() < 1) {
+                cfg.setReducers(this.defaultCfg.getReducers());
+            }
+            if (cfg.getScript() == null || "".equals(cfg.getScript())) {
+                cfg.setScript(this.defaultCfg.getScript());
+            }
+            if (cfg.getFileListMarker() == null || "".equals(cfg.getFileListMarker())) {
+                cfg.setFileListMarker(this.defaultCfg.getFileListMarker());
+            }
+            if (cfg.getFileListMarker() != null) {
+                if (cfg.getFileListMarker().indexOf(' ') >= 0) {
+                    throw new IllegalArgumentException(prefix + "fileListMarker cannot contain spaces");
+                }
+            }
+            if (cfg.getCollectMetrics() == null || "".equals(cfg.getCollectMetrics())) {
+                cfg.setCollectMetrics(this.defaultCfg.getCollectMetrics());
+            }
+            List<String> folders = cfg.getFolder();
+            if (folders == null || folders.isEmpty()) {
+                folders = new ArrayList<>();
+                cfg.setFolder(folders);
+                // add the default path. we'll bomb later if it's not there.
+                folders.add(cfg.getDataName());
+            }
+            List<String> fixedFolders = new ArrayList<>();
+            for (int i = 0; i < folders.size(); i++) {
+                for (String folder : StringUtils.split(folders.get(i), ',')) {
+                    folder = folder.trim();
+                    // let someone specify an absolute path.
+                    if (!folder.startsWith("/")) {
+                        fixedFolders.add(this.baseHDFSDir + folder);
+                    } else {
+                        fixedFolders.add(folder);
+                    }
+                }
+            }
+            cfg.setFolder(fixedFolders);
+        }
+        
+        // configure the executor per the FlagMakerConfig input
+        // executor = Executors.newFixedThreadPool(this.maxHdfsThreads);
     }
     
     @Override

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/config/FlagMakerConfig.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/config/FlagMakerConfig.java
@@ -330,9 +330,6 @@ public class FlagMakerConfig {
             }
             cfg.setFolder(fixedFolders);
         }
-        
-        // configure the executor per the FlagMakerConfig input
-        // executor = Executors.newFixedThreadPool(this.maxHdfsThreads);
     }
     
     @Override

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/processor/DateUtils.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/processor/DateUtils.java
@@ -32,7 +32,7 @@ public class DateUtils {
      * @param group
      * @param path
      */
-    public long getBucket(String group, String path) throws UnusableFileException {
+    public static long getBucket(String group, String path) throws UnusableFileException {
         if (group == null || "none".equals(group)) {
             return 0L;
         }
@@ -71,7 +71,7 @@ public class DateUtils {
      * 
      * @param path
      */
-    public long getFolderTimestamp(String path) throws UnusableFileException {
+    public static long getFolderTimestamp(String path) throws UnusableFileException {
         return getBucket("day", path);
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/AbstractFlagConfig.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/AbstractFlagConfig.java
@@ -1,0 +1,164 @@
+package datawave.util.flag;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.TimeZone;
+import java.util.UUID;
+
+import javax.xml.bind.JAXBException;
+
+import datawave.util.StringUtils;
+import datawave.util.flag.config.ConfigUtil;
+import datawave.util.flag.config.FlagDataTypeConfig;
+import datawave.util.flag.config.FlagMakerConfig;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.math.LongRange;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+public class AbstractFlagConfig {
+    
+    protected static final String TEST_CONFIG = "target/test-classes/TestFlagMakerConfig.xml";
+
+    protected FlagMakerConfig fmc;
+    
+    protected void cleanTestDirs() throws IOException {
+        File f = new File(this.fmc.getBaseHDFSDir());
+        if (f.exists()) {
+            // commons io has recursive delete.
+            FileUtils.deleteDirectory(f);
+        }
+        if (!f.mkdirs()) {
+            throw new IOException("unable to create base HDFS directory (" + f.getAbsolutePath() + ")");
+        }
+    }
+    
+    protected void createTrackedDirs(final FileSystem fs, final InputFile file) throws IOException {
+        final Path[] dirs = {file.getFlagged(), file.getFlagging(), file.getLoaded()};
+        for (final Path dir : dirs) {
+            final Path p = dir.getParent();
+            if (!fs.mkdirs(p)) {
+                throw new IllegalStateException("unable to create tracked directory (" + dir.getParent() + ")");
+            }
+        }
+    }
+    
+    protected FlagMakerConfig getDefaultFMC() throws JAXBException, IOException {
+        return ConfigUtil.getXmlObject(FlagMakerConfig.class, TEST_CONFIG);
+    }
+    
+    protected LongRange createTestFiles(int days, int filesPerDay) throws IOException {
+        return createTestFiles(days, filesPerDay, false);
+    }
+    
+    protected LongRange createTestFiles(int days, int filesPerDay, boolean folderRange) throws IOException {
+        return createTestFiles(days, filesPerDay, "2013/01", folderRange, "");
+    }
+    
+    protected LongRange createBogusTestFiles(int days, int filesPerDay) throws IOException {
+        return createTestFiles(days, filesPerDay, "20xx/dd", false, "");
+    }
+    
+    protected LongRange createCopyingTestFiles(int days, int filesPerDay) throws IOException {
+        return createTestFiles(days, filesPerDay, "2013/01", false, "._COPYING_");
+    }
+    
+    protected LongRange createTestFiles(int days, int filesPerDay, String datepath, boolean folderRange, String postfix) throws IOException {
+        Calendar c = Calendar.getInstance();
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+        c.set(Calendar.YEAR, 2013);
+        c.set(Calendar.MONTH, Calendar.JANUARY);
+        if (days < 1 || days > 9)
+            throw new IllegalArgumentException("days argument must be [1-9]. Incorrect value was: " + days);
+        // there should only be relative paths for testing!
+        ArrayList<File> inputdirs = new ArrayList<>(10);
+        for (FlagDataTypeConfig fc : this.fmc.getFlagConfigs()) {
+            for (String s : fc.getFolder()) {
+                for (String folder : StringUtils.split(s, ',')) {
+                    folder = folder.trim();
+                    if (!folder.startsWith(this.fmc.getBaseHDFSDir())) {
+                        // we do this conditionally because once the FileMaker is created and the setup call is made, this
+                        // is already done.
+                        folder = this.fmc.getBaseHDFSDir() + File.separator + folder;
+                    }
+                    inputdirs.add(new File(folder));
+                }
+            }
+        }
+        LongRange range = null;
+        for (File file : inputdirs) {
+            for (int i = 0; i < days;) {
+                File one = new File(file.getAbsolutePath() + File.separator + datepath + File.separator + "0" + ++i);
+                // set a day that is 10 days past the folder date
+                c.set(Calendar.DAY_OF_MONTH, i + 10);
+                final LongRange endRange = writeTestFiles(one, filesPerDay, c.getTimeInMillis(), folderRange, postfix);
+                range = merge(range, endRange);
+            }
+        }
+        return range;
+    }
+    
+    private LongRange merge(LongRange range1, LongRange range2) {
+        if (range1 == null) {
+            return range2;
+        } else if (range2 == null) {
+            return range1;
+        } else {
+            long min = Math.min(range1.getMinimumLong(), range2.getMinimumLong());
+            long max = Math.max(range1.getMaximumLong(), range2.getMaximumLong());
+            return new LongRange(min, max);
+        }
+    }
+    
+    private LongRange writeTestFiles(File f, int count, long time, boolean folderRange, String postfix) throws IOException {
+        if (!f.exists()) {
+            f.mkdirs();
+        }
+        for (int i = 0; i < count; i++) {
+            File testFile = new File(f.getAbsolutePath() + File.separator + UUID.randomUUID() + postfix);
+            if (testFile.exists()) {
+                testFile.delete();
+            }
+            try (FileOutputStream fos = new FileOutputStream(testFile)) {
+                fos.write(("" + System.currentTimeMillis()).getBytes());
+            }
+            testFile.setLastModified(time + (i * 1000));
+        }
+        if (folderRange) {
+            Calendar c = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+            c.set(Calendar.HOUR_OF_DAY, 0);
+            c.set(Calendar.MINUTE, 0);
+            c.set(Calendar.SECOND, 0);
+            c.set(Calendar.MILLISECOND, 0);
+            String[] dir = StringUtils.split(f.getAbsolutePath(), File.separatorChar);
+            c.set(Calendar.YEAR, Integer.parseInt(dir[dir.length - 3]));
+            c.set(Calendar.MONTH, Integer.parseInt(dir[dir.length - 2]) - 1);
+            c.set(Calendar.DAY_OF_MONTH, Integer.parseInt(dir[dir.length - 1]));
+            return new LongRange(c.getTimeInMillis(), c.getTimeInMillis());
+        } else {
+            return new LongRange(time, time + ((count - 1) * 1000));
+        }
+    }
+    
+    protected Path getTestFile(FileSystem fs) throws IOException {
+        createTestFiles(1, 1);
+        Path file = null;
+        for (RemoteIterator<LocatedFileStatus> it = fs.listFiles(new Path(this.fmc.getBaseHDFSDir()), true); it.hasNext();) {
+            LocatedFileStatus status = it.next();
+            if (status.isFile()) {
+                file = status.getPath();
+                break;
+            }
+        }
+        return file;
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/AbstractFlagConfig.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/AbstractFlagConfig.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 public class AbstractFlagConfig {
     
     protected static final String TEST_CONFIG = "target/test-classes/TestFlagMakerConfig.xml";
-
+    
     protected FlagMakerConfig fmc;
     
     protected void cleanTestDirs() throws IOException {

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagEntryMoverTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagEntryMoverTest.java
@@ -38,18 +38,17 @@ public class FlagEntryMoverTest extends AbstractFlagConfig {
         
         cleanTestDirs();
     }
-
-
+    
     @Test
     public void testWrite() throws IOException {
         final String METRICS_DIR = "target/test/metrics";
-
+        
         FlagMetrics metrics = new FlagMetrics(this.fs, false);
         metrics.updateCounter(this.getClass().getSimpleName(), "COUNTER_ONE", System.currentTimeMillis());
         metrics.writeMetrics(METRICS_DIR, "base");
-
+        
     }
-
+    
     /**
      * Test of call method, of class FlagEntryMover.
      */

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagEntryMoverTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagEntryMoverTest.java
@@ -1,0 +1,124 @@
+package datawave.util.flag;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+/**
+ *
+ */
+public class FlagEntryMoverTest extends AbstractFlagConfig {
+    
+    private static final Cache<Path,Path> directoryCache = CacheBuilder.newBuilder().maximumSize(100).expireAfterWrite(10, TimeUnit.MINUTES)
+                    .concurrencyLevel(10).build();
+    private FileSystem fs;
+    
+    public FlagEntryMoverTest() {}
+    
+    @Before
+    public void before() throws Exception {
+        fmc = getDefaultFMC();
+        fmc.setBaseHDFSDir(fmc.getBaseHDFSDir().replace("target", "target/FlagEntryMoverTest"));
+        fs = FileSystem.getLocal(new Configuration());
+        
+        cleanTestDirs();
+    }
+
+
+    @Test
+    public void testWrite() throws IOException {
+        final String METRICS_DIR = "target/test/metrics";
+
+        FlagMetrics metrics = new FlagMetrics(this.fs, false);
+        metrics.updateCounter(this.getClass().getSimpleName(), "COUNTER_ONE", System.currentTimeMillis());
+        metrics.writeMetrics(METRICS_DIR, "base");
+
+    }
+
+    /**
+     * Test of call method, of class FlagEntryMover.
+     */
+    @Test
+    public void testCall() throws Exception {
+        
+        Path file = getTestFile(fs);
+        
+        InputFile entry = new InputFile("foo", file, 0, 0, 0, fmc.getBaseHDFSDir());
+        createTrackedDirs(fs, entry);
+        
+        FlagEntryMover instance = new FlagEntryMover(directoryCache, fs, entry);
+        InputFile result = instance.call();
+        assertSame(result, entry);
+        assertTrue(result.isMoved());
+        Assert.assertEquals(result.getFlagging(), result.getCurrentDir());
+        Assert.assertEquals(entry.getPath().getName(), entry.getFlagged().getName());
+        Assert.assertEquals(entry.getPath().getName(), entry.getFlagging().getName());
+        Assert.assertEquals(entry.getPath().getName(), entry.getLoaded().getName());
+    }
+    
+    @Test
+    public void testConflict() throws Exception {
+        
+        Path file = getTestFile(fs);
+        
+        InputFile entry = new InputFile("foo", file, 0, 0, 0, fmc.getBaseHDFSDir());
+        createTrackedDirs(fs, entry);
+        
+        fs.copyFromLocalFile(file, entry.getFlagging());
+        
+        FlagEntryMover instance = new FlagEntryMover(directoryCache, fs, entry);
+        InputFile result = instance.call();
+        assertFalse("Should not have moved", result.isMoved());
+        Assert.assertEquals(entry, result);
+        Assert.assertEquals(entry.getPath(), result.getCurrentDir());
+        Assert.assertEquals(entry.getPath().getName(), entry.getFlagged().getName());
+        Assert.assertEquals(entry.getPath().getName(), entry.getFlagging().getName());
+        Assert.assertEquals(entry.getPath().getName(), entry.getLoaded().getName());
+    }
+    
+    @Test
+    public void testConflictMove() throws Exception {
+        
+        Path file = getTestFile(fs);
+        InputFile entry = new InputFile("foo", file, 0, 0, 0, fmc.getBaseHDFSDir());
+        createTrackedDirs(fs, entry);
+        
+        // create conflict file with different checksum
+        final Path loadFile = entry.getLoaded();
+        Thread.sleep(10);
+        try (final OutputStream os = fs.create(loadFile)) {
+            os.write(("" + System.currentTimeMillis()).getBytes());
+        }
+        
+        FlagEntryMover instance = new FlagEntryMover(directoryCache, fs, entry);
+        final InputFile result = instance.call();
+        assertTrue(result.isMoved());
+        assertTrue(entry.equals(result));
+        // current path should match flagging
+        assertNotEquals(result.getPath(), result.getCurrentDir());
+        Assert.assertEquals(entry.getFlagging(), result.getCurrentDir());
+        // path name should differ from flagged/flagging/loaded
+        final String pathName = result.getPath().getName();
+        final String flaggedName = result.getFlagged().getName();
+        Assert.assertNotEquals(pathName, flaggedName);
+        final String flaggingName = result.getFlagging().getName();
+        Assert.assertEquals(flaggingName, flaggedName);
+        final String loadedName = result.getLoaded().getName();
+        Assert.assertEquals(loadedName, flaggedName);
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagMakerLoad.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagMakerLoad.java
@@ -1,0 +1,86 @@
+package datawave.util.flag;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a load test for the flag maker. The configuration {@link IngestConfig} allows the flag maker to function as several different modes (system, load, or
+ * stress). The configuration consists of the following parameters:
+ * <ul>
+ * <li>duration of the test</li>
+ * <li>source directory containing ingest files</li>
+ * <li>hdfs flag maker ingest directory</li>
+ * <li>hdfs url</li>
+ * <li>number of worker threads to distribute the ingest load</li>
+ * <li>minimum and maximum number of files for each worker to create for ingest</li>
+ * <li>minimum and maximum interval between ingest executions</li>
+ * </ul>
+ * Each worker thread performs the following (see {@link IngestWorker}):
+ *
+ * <pre>
+ *    while duration of test has not expired
+ *       obtain a list of ingest files
+ *       copy files into the hdfs ingest directory
+ *       wait a random interval before next ingest execution
+ * </pre>
+ */
+public class FlagMakerLoad {
+    
+    private static final Logger logger = LoggerFactory.getLogger(FlagMakerLoad.class);
+    
+    private static void usage() {
+        logger.info("USAGE: " + FlagMakerLoad.class.getName() + " configFileName");
+    }
+    
+    public static void main(String[] args) throws IOException {
+        // load json config file
+        if (1 > args.length) {
+            usage();
+        } else {
+            final FlagMakerLoad tester = new FlagMakerLoad(args[0]);
+            tester.runTest();
+        }
+    }
+    
+    private FlagMakerLoad(final String cfgFile) throws IOException {
+        IngestConfig.create(cfgFile);
+    }
+    
+    /**
+     * Creates worker threads to perform ingest and waits for worker threads to complete.
+     */
+    private void runTest() {
+        final IngestConfig cfg = IngestConfig.getInstance();
+        logger.info("test execution parameters: " + cfg.toJson());
+        ExecutorService executor = Executors.newFixedThreadPool(cfg.getWorkers());
+        
+        try {
+            final List<Future<Void>> workers = new ArrayList<>();
+            for (int w = 0; w < cfg.getWorkers(); w++) {
+                final IngestWorker worker = new IngestWorker();
+                final Future<Void> task = executor.submit(worker);
+                workers.add(task);
+            }
+            
+            logger.info("waiting for workers to complete");
+            for (final Future<Void> worker : workers) {
+                try {
+                    Void fut = worker.get();
+                } catch (ExecutionException | InterruptedException e) {
+                    logger.error("task failure", e);
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+        logger.info("test complete");
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagMakerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagMakerTest.java
@@ -60,7 +60,7 @@ public class FlagMakerTest extends AbstractFlagConfig {
         }
         f.mkdirs();
     }
-
+    
     private File setUpFlagDir() throws Exception {
         File f = new File(FLAG_DIR);
         if (f.exists())

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagMakerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/FlagMakerTest.java
@@ -1,58 +1,54 @@
 package datawave.util.flag;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.UUID;
-
-import datawave.util.StringUtils;
-import datawave.ingest.mapreduce.StandaloneStatusReporter;
 import datawave.util.flag.config.ConfigUtil;
 import datawave.util.flag.config.FlagDataTypeConfig;
 import datawave.util.flag.config.FlagMakerConfig;
 import datawave.util.flag.processor.DateUtils;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.math.LongRange;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.SequenceFile.CompressionType;
-import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.JAXBException;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
  */
-public class FlagMakerTest {
+public class FlagMakerTest extends AbstractFlagConfig {
     
-    static final String TEST_CONFIG = "target/test-classes/TestFlagMakerConfig.xml";
-    static final String FLAG_DIR = "target/test/flags";
-    static final int COUNTER_LIMIT = 102;
-    public static final String CONFIG_BASE_HDFS_DIR = "target/test/BulkIngest";
-    public static final String CONFIG_FLAG_FILE_DIR = "target/test/flags";
-    public static final Object CONFIG_EXTRA_INGEST_ARGS = null;
-    private FlagMakerConfig fmc;
+    private static final Logger log = LoggerFactory.getLogger(FlagMaker.class);
+    
+    private static final String TEST_CONFIG = "target/test-classes/TestFlagMakerConfig.xml";
+    private static final String FLAG_DIR = "target/test/flags";
+    private static final int COUNTER_LIMIT = 102;
+    private static final String CONFIG_BASE_HDFS_DIR = "target/test/BulkIngest";
+    private static final String CONFIG_FLAG_FILE_DIR = "target/test/flags";
+    private static final Object CONFIG_EXTRA_INGEST_ARGS = null;
+    
+    // private FlagMakerConfig fmc;
     
     @Before
     public void setUp() throws Exception {
@@ -64,10 +60,7 @@ public class FlagMakerTest {
         }
         f.mkdirs();
     }
-    
-    @After
-    public void tearDown() {}
-    
+
     private File setUpFlagDir() throws Exception {
         File f = new File(FLAG_DIR);
         if (f.exists())
@@ -81,6 +74,7 @@ public class FlagMakerTest {
      */
     @Test
     public void testGetHadoopFS() throws Exception {
+        log.info("-----  testGetHadoopFS  -----");
         File fdir = new File(FLAG_DIR);
         if (fdir.exists())
             fdir.delete();
@@ -93,6 +87,7 @@ public class FlagMakerTest {
     
     @Test
     public void testFlagMakerConfigArg() throws JAXBException, IOException {
+        log.info("-----  testFlagMakerConfigArg  -----");
         FlagMakerConfig flagMakerConfig = FlagMaker.getFlagMakerConfig(new String[] {"-flagConfig", TEST_CONFIG});
         assertEquals(CONFIG_FLAG_FILE_DIR, flagMakerConfig.getFlagFileDirectory());
         assertEquals(CONFIG_BASE_HDFS_DIR, flagMakerConfig.getBaseHDFSDir());
@@ -101,6 +96,7 @@ public class FlagMakerTest {
     
     @Test
     public void testFlagMakerConfigWithFlagFileDirectoryOverride() throws JAXBException, IOException {
+        log.info("-----  testFlagMakerConfigWithFlagFileDirectoryOverride  -----");
         final String overrideValue = "/srv/data/somewhere/else/";
         FlagMakerConfig flagMakerConfig = FlagMaker.getFlagMakerConfig(new String[] {"-flagConfig", TEST_CONFIG, "-flagFileDirectoryOverride", overrideValue});
         assertEquals(overrideValue, flagMakerConfig.getFlagFileDirectory());
@@ -110,6 +106,7 @@ public class FlagMakerTest {
     
     @Test
     public void testFlagMakerConfigWithHdfsOverride() throws JAXBException, IOException {
+        log.info("-----  testFlagMakerConfigWithHdfsOverride  -----");
         String overrideValue = "testDir/BulkIngest";
         FlagMakerConfig flagMakerConfig = FlagMaker.getFlagMakerConfig(new String[] {"-flagConfig", TEST_CONFIG, "-baseHDFSDirOverride", overrideValue});
         assertEquals(CONFIG_FLAG_FILE_DIR, flagMakerConfig.getFlagFileDirectory());
@@ -119,6 +116,7 @@ public class FlagMakerTest {
     
     @Test
     public void testFlagMakerConfigWithExtraArgsOverride() throws JAXBException, IOException {
+        log.info("-----  testFlagMakerConfigWithExtraArgsOverride  -----");
         final String overrideValue = "-fastMode -topSpeed=MAX";
         FlagMakerConfig flagMakerConfig = FlagMaker.getFlagMakerConfig(new String[] {"-flagConfig", TEST_CONFIG, "-extraIngestArgsOverride", overrideValue});
         assertEquals(CONFIG_FLAG_FILE_DIR, flagMakerConfig.getFlagFileDirectory());
@@ -131,13 +129,13 @@ public class FlagMakerTest {
      */
     @Test
     public void testProcessFlags() throws Exception {
+        log.info("-----  testProcessFlags  -----");
         File f = setUpFlagDir();
         // two days, 5 files each day, two folders in fmc = 20 flags
         LongRange range = createTestFiles(2, 5);
         FlagMaker instance = new TestWrappedFlagMaker(fmc);
         instance.processFlags();
-        // should have made 2 flag files per
-        assertEquals("Incorrect files.  Expected 2 but got " + f.listFiles().length + ": " + Arrays.toString(f.listFiles()), 2, f.listFiles().length);
+        
         // ensure the flag files endings
         int flagCnt = 0;
         int cleanCnt = 0;
@@ -158,12 +156,14 @@ public class FlagMakerTest {
      */
     @Test
     public void testFlagFileTimeStamps() throws Exception {
+        log.info("-----  testFlagFileTimeStamps  -----");
         File f = setUpFlagDir();
         // two days, 5 files each day, two folders in fmc = 20 flags
         LongRange range = createTestFiles(2, 5);
         fmc.setSetFlagFileTimestamp(true);
         FlagMaker instance = new TestWrappedFlagMaker(fmc);
         instance.processFlags();
+        assertEquals("Incorrect files.  Expected 2 but got " + f.listFiles().length + ": " + Arrays.toString(f.listFiles()), 2, f.listFiles().length);
         // ensure the flag files have appropriate dates
         for (File file : f.listFiles()) {
             if (file.getName().endsWith(".flag")) {
@@ -177,12 +177,15 @@ public class FlagMakerTest {
      */
     @Test
     public void testUnsetFlagFileTimeStamps() throws Exception {
+        log.info("-----  testUnsetFlagFileTimeStamps  -----");
         File f = setUpFlagDir();
         // two days, 5 files each day, two folders in fmc = 20 flags
         LongRange range = createTestFiles(2, 5);
         fmc.setSetFlagFileTimestamp(false);
         FlagMaker instance = new TestWrappedFlagMaker(fmc);
         instance.processFlags();
+        assertEquals("Incorrect files.  Expected 2 but got " + f.listFiles().length + ": " + Arrays.toString(f.listFiles()), 2, f.listFiles().length);
+        
         // ensure the flag files have appropriate dates
         for (File file : f.listFiles()) {
             if (file.getName().endsWith(".flag")) {
@@ -196,6 +199,7 @@ public class FlagMakerTest {
      */
     @Test
     public void testFolderTimeStamps() throws Exception {
+        log.info("-----  testFolderTimeStamps  -----");
         File f = setUpFlagDir();
         // two days, 5 files each day, two folders in fmc = 20 flags
         LongRange range = createTestFiles(2, 5, true);
@@ -203,6 +207,8 @@ public class FlagMakerTest {
         fmc.setUseFolderTimestamp(true);
         FlagMaker instance = new TestWrappedFlagMaker(fmc);
         instance.processFlags();
+        assertEquals("Incorrect files.  Expected 2 but got " + f.listFiles().length + ": " + Arrays.toString(f.listFiles()), 2, f.listFiles().length);
+        
         // ensure the flag files have appropriate dates
         for (File file : f.listFiles()) {
             if (file.getName().endsWith(".flag")) {
@@ -213,6 +219,7 @@ public class FlagMakerTest {
     
     @Test
     public void testCounterLimitExceeded() throws Exception {
+        log.info("-----  testCounterLimitExceeded  -----");
         int expectedMax = (COUNTER_LIMIT - 2) / 2;
         File f = setUpFlagDir();
         // two days, expectedMax + 20 files each day
@@ -240,6 +247,7 @@ public class FlagMakerTest {
      */
     @Test
     public void testFlagCountExceeded() throws Exception {
+        log.info("-----  testFlagCountExceeded  -----");
         File f = setUpFlagDir();
         
         fmc.setTimeoutMilliSecs(0);
@@ -274,6 +282,7 @@ public class FlagMakerTest {
     
     @Test
     public void testMaxFileLength() throws Exception {
+        log.info("-----  testMaxFileLength  -----");
         File f = setUpFlagDir();
         // two days, expectedMax + 20 files each day
         LongRange range = createTestFiles(2, 20, true);
@@ -311,6 +320,7 @@ public class FlagMakerTest {
      */
     @Test
     public void testProcessFlagsOrder() throws Exception {
+        log.info("-----  testProcessFlagsOrder  -----");
         setUpFlagDir();
         // two days, 5 files each day, two folders in fmc = 20 flags
         createTestFiles(2, 5);
@@ -340,6 +350,7 @@ public class FlagMakerTest {
      */
     @Test
     public void testProcessFlagsOrderLifo() throws Exception {
+        log.info("-----  testProcessFlagsOrderLifo  -----");
         setUpFlagDir();
         // two days, 5 files each day, two folders in fmc = 20 flags
         createTestFiles(2, 5);
@@ -370,6 +381,7 @@ public class FlagMakerTest {
      */
     @Test
     public void testDateFolderDistributor() throws Exception {
+        log.info("-----  testDateFolderDistributor  -----");
         File f = setUpFlagDir();
         // 5 days, 5 files each day, two folders in fmc = 50 flags
         createTestFiles(5, 5);
@@ -383,146 +395,133 @@ public class FlagMakerTest {
         HashSet<Long> buckets = new HashSet<>();
         DateUtils du = new DateUtils();
         for (File file : flags) {
-            BufferedReader r = new BufferedReader(new FileReader(file));
-            String[] files = r.readLine().split(" ")[1].split(",");
-            // 10 inputs per flag file
-            assertEquals("Incorrect number of files: " + Arrays.toString(files), 10, files.length);
-            Map<String,Integer> folderCounts = new HashMap<>();
-            Map<String,Integer> dateCounts = new HashMap<>();
-            for (String string : files) {
-                assertTrue(string.startsWith("target/test/BulkIngest/flagged"));
-                // pull off the sub folder
-                String folder = string.substring(31, 34);
-                folderCounts.put(folder, (folderCounts.containsKey(folder) ? folderCounts.get(folder) : 0) + 1);
-                String date = string.substring(35, 45);
-                dateCounts.put(date, (dateCounts.containsKey(date) ? dateCounts.get(date) : 0) + 1);
-                buckets.add(du.getBucket("day", string));
+            try (BufferedReader r = new BufferedReader(new FileReader(file))) {
+                String[] files = r.readLine().split(" ")[1].split(",");
+                
+                // 10 inputs per flag file
+                assertEquals("Incorrect number of files: " + Arrays.toString(files), 10, files.length);
+                Map<String,Integer> folderCounts = new HashMap<>();
+                Map<String,Integer> dateCounts = new HashMap<>();
+                for (String string : files) {
+                    assertTrue(string.startsWith("target/test/BulkIngest/flagged"));
+                    // pull off the sub folder
+                    String folder = string.substring(31, 34);
+                    folderCounts.put(folder, (folderCounts.containsKey(folder) ? folderCounts.get(folder) : 0) + 1);
+                    String date = string.substring(35, 45);
+                    dateCounts.put(date, (dateCounts.containsKey(date) ? dateCounts.get(date) : 0) + 1);
+                    buckets.add(DateUtils.getBucket("day", string));
+                }
+                assertEquals(2, folderCounts.size());
+                for (String folder : folderCounts.keySet()) {
+                    assertEquals(5, folderCounts.get(folder).intValue());
+                }
+                assertEquals(5, dateCounts.size());
+                for (String date : dateCounts.keySet()) {
+                    assertEquals(2, dateCounts.get(date).intValue());
+                }
+                // 2 from each folder for each day
+                assertEquals("Incorrect number of buckets: " + buckets, 5, buckets.size());
+                buckets.clear();
             }
-            assertEquals(2, folderCounts.size());
-            for (String folder : folderCounts.keySet()) {
-                assertEquals(5, folderCounts.get(folder).intValue());
-            }
-            assertEquals(5, dateCounts.size());
-            for (String date : dateCounts.keySet()) {
-                assertEquals(2, dateCounts.get(date).intValue());
-            }
-            // 2 from each folder for each day
-            assertEquals("Incorrect number of buckets: " + buckets, 5, buckets.size());
-            buckets.clear();
-            r.close();
         }
         
     }
     
-    private static final String data = "data";
+    // ======================================
+    // file list marker tests
     
-    private LongRange createTestFiles(int days, int filesPerDay) throws Exception {
-        return createTestFiles(days, filesPerDay, false);
+    private static final String FLAG_MARKER = "XXXX--test-marker--XXXX";
+    private static final String INVALID_MARKER = "xxxx  invalid-marker  xxxx";
+    // this needs to be in sync
+    private static final String FLAG_PRE = " ${JOB_FILE} 10 -inputFormat datawave.ingest.input.reader.event.EventSequenceFileInputFormat -inputFileLists -inputFileListMarker "
+                    + FLAG_MARKER + " \n" + FLAG_MARKER;
+    
+    @Test
+    public void testFlagFileMarkerError() throws Exception {
+        log.info("-----  testFlagFileMarkerError  -----");
+        File f = setUpFlagDir();
+        // two days, 5 files each day, two folders in fmc = 20 flags
+        LongRange range = createTestFiles(2, 5);
+        fmc.setSetFlagFileTimestamp(true);
+        List<FlagDataTypeConfig> cfgs = fmc.getFlagConfigs();
+        FlagDataTypeConfig cfg = cfgs.get(0);
+        cfg.setFileListMarker(INVALID_MARKER);
+        try {
+            FlagMaker instance = new TestWrappedFlagMaker(fmc);
+            Assert.fail("invalid marker expected");
+        } catch (IllegalArgumentException ie) {
+            // expected
+        }
     }
     
-    private LongRange createTestFiles(int days, int filesPerDay, boolean folderRange) throws Exception {
-        return createTestFiles(days, filesPerDay, "2013/01", folderRange, "");
-    }
-    
-    private LongRange createBogusTestFiles(int days, int filesPerDay) throws Exception {
-        return createTestFiles(days, filesPerDay, "20xx/dd", false, "");
-    }
-    
-    private LongRange createCopyingTestFiles(int days, int filesPerDay) throws Exception {
-        return createTestFiles(days, filesPerDay, "2013/01", false, "._COPYING_");
-    }
-    
-    private LongRange createTestFiles(int days, int filesPerDay, String datepath, boolean folderRange, String postfix) throws Exception {
-        Calendar c = Calendar.getInstance();
-        c.set(Calendar.HOUR_OF_DAY, 0);
-        c.set(Calendar.MINUTE, 0);
-        c.set(Calendar.SECOND, 0);
-        c.set(Calendar.MILLISECOND, 0);
-        c.set(Calendar.YEAR, 2013);
-        c.set(Calendar.MONTH, Calendar.JANUARY);
-        if (days < 1 || days > 9)
-            throw new IllegalArgumentException("days argument must be [1-9]. Incorrect value was: " + days);
-        // there should only be relative paths for testing!
-        ArrayList<File> inputdirs = new ArrayList<>(10);
-        for (FlagDataTypeConfig fc : fmc.getFlagConfigs()) {
-            for (String s : fc.getFolder()) {
-                for (String folder : StringUtils.split(s, ',')) {
-                    folder = folder.trim();
-                    if (!folder.startsWith(fmc.getBaseHDFSDir())) {
-                        // we do this conditionally because once the FileMaker is created and the setup call is made, this
-                        // is already done.
-                        folder = fmc.getBaseHDFSDir() + File.separator + folder;
-                    }
-                    inputdirs.add(new File(folder));
-                }
+    @Test
+    public void testFlagFileMarker() throws Exception {
+        log.info("-----  testFlagFileMarker  -----");
+        File f = setUpFlagDir();
+        // two days, 5 files each day, two folders in fmc = 20 flags
+        LongRange range = createTestFiles(2, 5);
+        // fmc.setSetFlagFileTimestamp(true);
+        List<FlagDataTypeConfig> cfgs = fmc.getFlagConfigs();
+        FlagDataTypeConfig cfg = cfgs.get(0);
+        cfg.setFileListMarker("XXXX--test-marker--XXXX");
+        FlagMaker instance = new TestWrappedFlagMaker(fmc);
+        instance.processFlags();
+        // ensure the flag files have appropriate dates
+        for (File file : f.listFiles()) {
+            if (file.getName().endsWith(".flag")) {
+                assertTrue(range.containsLong(file.lastModified()));
             }
         }
-        LongRange range = null;
-        for (File file : inputdirs) {
-            for (int i = 0; i < days;) {
-                File one = new File(file.getAbsolutePath() + File.separator + datepath + File.separator + "0" + ++i);
-                // set a day that is 10 days past the folder date
-                c.set(Calendar.DAY_OF_MONTH, i + 10);
-                range = merge(range, writeTestFiles(one, filesPerDay, c.getTimeInMillis(), folderRange, postfix));
-            }
-        }
-        return range;
+        assertEquals("Incorrect files.  Expected 2 but got " + f.listFiles().length + ": " + Arrays.toString(f.listFiles()), 2, f.listFiles().length);
     }
     
-    private LongRange merge(LongRange range1, LongRange range2) {
-        if (range1 == null) {
-            return range2;
-        } else if (range2 == null) {
-            return range1;
-        } else {
-            long min = Math.min(range1.getMinimumLong(), range2.getMinimumLong());
-            long max = Math.max(range1.getMaximumLong(), range2.getMaximumLong());
-            return new LongRange(min, max);
+    /**
+     * Tests the flag file output when the file list marker is set.
+     * 
+     * @throws Exception
+     *             test error condition
+     */
+    @Test
+    public void testFlagFileWriter() throws Exception {
+        log.info("-----  testFlagFileWriter  -----");
+        File f = setUpFlagDir();
+        
+        FlagMaker instance = new TestWrappedFlagMaker(fmc);
+        FlagDataTypeConfig fc = fmc.getFlagConfigs().get(0);
+        createTestFiles(1, 5);
+        instance.fd.setup(fc);
+        instance.loadFilesForDistributor(fc, instance.getHadoopFS());
+        Collection<InputFile> inFiles = instance.fd.next(instance);
+        List<FlagDataTypeConfig> cfgs = fmc.getFlagConfigs();
+        FlagDataTypeConfig cfg = cfgs.get(0);
+        cfg.setFileListMarker(FLAG_MARKER);
+        
+        assertTrue("Should be 10 InputFiles", inFiles != null && inFiles.size() == 10);
+        File flag = instance.write(inFiles, fc, FLAG_DIR + "/testflagwriter");
+        flag.deleteOnExit();
+        String b;
+        try (BufferedReader br = new BufferedReader(new FileReader(flag))) {
+            b = br.lines().collect(Collectors.joining("\n"));
         }
-    }
-    
-    private LongRange writeTestFiles(File f, int count, long time, boolean folderRange, String postfix) throws Exception {
-        if (!f.exists()) {
-            f.mkdirs();
+        
+        StringBuilder expected = new StringBuilder(fmc.getDatawaveHome());
+        expected.append(File.separatorChar).append(fc.getScript()).append(FLAG_PRE);
+        for (InputFile inFile : inFiles) {
+            expected.append('\n').append(inFile.getFlagged().toUri());
         }
-        for (int i = 0; i < count; i++) {
-            File testFile = new File(f.getAbsolutePath() + File.separator + UUID.randomUUID() + postfix);
-            if (testFile.exists()) {
-                testFile.delete();
-            }
-            FileOutputStream fos = new FileOutputStream(testFile);
-            fos.write(data.getBytes());
-            fos.close();
-            testFile.setLastModified(time + (i * 1000));
-        }
-        if (folderRange) {
-            Calendar c = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-            c.set(Calendar.HOUR_OF_DAY, 0);
-            c.set(Calendar.MINUTE, 0);
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MILLISECOND, 0);
-            String[] dir = StringUtils.split(f.getAbsolutePath(), File.separatorChar);
-            c.set(Calendar.YEAR, Integer.parseInt(dir[dir.length - 3]));
-            c.set(Calendar.MONTH, Integer.parseInt(dir[dir.length - 2]) - 1);
-            c.set(Calendar.DAY_OF_MONTH, Integer.parseInt(dir[dir.length - 1]));
-            return new LongRange(c.getTimeInMillis(), c.getTimeInMillis());
-        } else {
-            return new LongRange(time, time + ((count - 1) * 1000));
+        
+        Assert.assertEquals(expected.length(), b.length());
+        for (int n = 0; n < b.length(); n++) {
+            Assert.assertEquals("flag file char mismatch at char #" + n, expected.charAt(n), b.charAt(n));
         }
     }
     
-    public static class TestWrappedFlagMaker extends FlagMaker {
-        public TestWrappedFlagMaker(FlagMakerConfig fmc) {
+    static class TestWrappedFlagMaker extends FlagMaker {
+        TestWrappedFlagMaker(FlagMakerConfig fmc) {
             super(fmc);
             Configuration conf = new Configuration();
             conf.set("mapreduce.job.counters.max", Integer.toString(COUNTER_LIMIT));
             this.config = new JobConf(conf);
-        }
-        
-        @Override
-        protected void writeMetrics(final StandaloneStatusReporter reporter, final String metricsDirectory, final String dataTypeName,
-                        final CompressionType ct, final CompressionCodec cc) throws IOException {
-            // Do Nothing
         }
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestConfig.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestConfig.java
@@ -193,12 +193,56 @@ class IngestConfig {
      */
     private boolean validate() {
         // all int values must be > 0 and source directory must exist
-        boolean valid = false;
-        if (0 < this.workers && 0 < duration && 0 < this.minChunks && 0 < this.maxChunks && 0 < this.minInterval && 0 < this.maxInterval) {
-            if (0 < this.hdfs.trim().length() && 0 < this.hdfsIngestDir.trim().length() && 0 < this.sourceDir.trim().length()) {
-                final File d = new File(this.sourceDir);
-                valid = d.isDirectory();
+        boolean valid = true;
+        if (0 >= this.workers) {
+            logger.error("invalid workers({})", this.workers);
+            valid = false;
+        }
+        if (0 >= this.duration) {
+            logger.error("invalid duration({})", this.duration);
+            valid = false;
+        }
+        if (0 >= this.minChunks) {
+            logger.error("invalid minChunks({})", this.minChunks);
+            valid = false;
+        }
+        if (0 >= this.maxChunks) {
+            logger.error("invalid maxChunks({})", this.maxChunks);
+            valid = false;
+        }
+        if (0 >= this.minInterval) {
+            logger.error("invalid minInterval({})", this.minInterval);
+            valid = false;
+        }
+        if (0 >= this.maxInterval) {
+            logger.error("invalid mmaxInterval({})", this.maxInterval);
+            valid = false;
+        }
+        if (this.minInterval > this.maxInterval) {
+            logger.error("minInterval is > maxInterval");
+            valid = false;
+        }
+        if (null == this.hdfs || 0 == this.hdfs.trim().length()) {
+            logger.error("hdfs path is null or empty");
+            valid = false;
+        }
+        if (null == this.hdfsIngestDir || 0 == this.hdfsIngestDir.trim().length()) {
+            logger.error("hdfsIngestDir is null or empty");
+            valid = false;
+        }
+        if (null == this.sourceDir || 0 == this.sourceDir.trim().length()) {
+            logger.error("source directory is null or empty");
+            valid = false;
+        } else {
+            final File d = new File(this.sourceDir);
+            if (!d.isDirectory()) {
+                valid = false;
+                logger.error("invalid source directory ({})", this.sourceDir);
             }
+        }
+        
+        if (!valid) {
+            logger.trace("configuration is valid");
         }
         
         return valid;

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestConfig.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestConfig.java
@@ -1,0 +1,206 @@
+package datawave.util.flag;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+/**
+ * Contains configuration parameters for Flag Maker testing. The class functions as a singleton. Any configuration or initialization errors will cause the class
+ * to go into an illegal state condition.
+ */
+class IngestConfig {
+    private static final Logger logger = LoggerFactory.getLogger(IngestConfig.class);
+    final static Gson gson = new Gson();
+    
+    private static final AtomicReference<IngestConfig> cfg = new AtomicReference<>();
+    
+    // instance members
+    // dir location of ingest files
+    private String sourceDir;
+    // HDFS ingest directory path
+    private String hdfsIngestDir;
+    // hdfs url
+    private String hdfs;
+    // duration in minutes for test
+    private int duration;
+    // number of worker threads to allocate
+    private int workers;
+    // minimum number of files to ingest for a single worker for each interval
+    private int minChunks;
+    // maximum number of files to ingest for a single worker for each interval
+    private int maxChunks;
+    // minimum interval in milliseconds between executions
+    private int minInterval;
+    // maximum interval in milliseconds between executions
+    private int maxInterval;
+    
+    // transient data
+    private transient List<Path> ingestPaths = new ArrayList<>();
+    private transient FileSystem fs;
+    
+    /**
+     * (U) Creates a singleton instance of the ingest load configuration.
+     *
+     * @param fName
+     *            configuration file name
+     * @return populated configuration data
+     * @throws IOException
+     *             error reading file
+     */
+    static void create(final String fName) throws IOException {
+        final File f = new File(fName);
+        if (!f.exists()) {
+            throw new IllegalArgumentException("configuration file does not exist (" + f.getAbsolutePath() + ")");
+        }
+        
+        final JsonParser parser = new JsonParser();
+        try (final Reader rdr = new FileReader(fName)) {
+            final JsonElement json = parser.parse(rdr);
+            final IngestConfig val = gson.fromJson(json.toString(), IngestConfig.class);
+            cfg.set(val);
+            
+            if (!val.validate()) {
+                throw new IllegalStateException("invalid configuration: " + val.toJson());
+            }
+            val.getHadoopFS();
+            val.loadIngestFiles();
+        }
+    }
+    
+    static IngestConfig getInstance() {
+        IngestConfig val = cfg.get();
+        if (null == val) {
+            throw new IllegalStateException("ingest configuration has not been initialized");
+        }
+        return val;
+    }
+    
+    FileSystem getHdfs() {
+        return this.fs;
+    }
+    
+    String getHdfsIngestDir() {
+        return this.hdfsIngestDir;
+    }
+    
+    int getWorkers() {
+        return this.workers;
+    }
+    
+    /**
+     * Returns the duration of the test in milliseconds.
+     *
+     * @return duration of test in milliseconds
+     */
+    int getDurtion() {
+        return this.duration * 1000 * 60;
+    }
+    
+    /**
+     * Returns a random interval based upon the minimum and maximum interval settings.
+     * 
+     * @return wait interval in milliseconds
+     */
+    int getRandomInterval() {
+        final int diff = this.maxInterval - this.minInterval;
+        final int rand = ThreadLocalRandom.current().nextInt(diff);
+        return this.minInterval + rand;
+    }
+    
+    /**
+     * Returns a random list of files to ingest based upon the minimum and maximum ingest file settings.
+     *
+     * @return list of files
+     */
+    List<Path> getRandomIngestFiles() {
+        final int diff = this.maxChunks - this.minChunks;
+        final int rand = ThreadLocalRandom.current().nextInt(diff);
+        final int num = this.minChunks + rand;
+        
+        final List<Path> files = new ArrayList<>();
+        final int max = this.ingestPaths.size();
+        for (int n = 0; n < num; n++) {
+            final int idx = ThreadLocalRandom.current().nextInt(max);
+            files.add(this.ingestPaths.get(idx));
+        }
+        
+        logger.info("ingest files(" + files.size() + ")");
+        return files;
+    }
+    
+    String toJson() {
+        return gson.toJson(this);
+    }
+    
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + ": " + gson.toJson(this);
+    }
+    
+    /**
+     * Creates a {@link FileSystem} object based upon the hdfs configuration property.
+     *
+     * @return populated FileSystem object
+     * @throws IOException
+     *             error creating Hadoop FileSystem object
+     */
+    private void getHadoopFS() throws IOException {
+        logger.info("connecting to HDFS (" + this.hdfs + ")");
+        Configuration hadoopConfiguration = new Configuration();
+        hadoopConfiguration.set("fs.defaultFS", this.hdfs);
+        this.fs = FileSystem.get(hadoopConfiguration);
+    }
+    
+    /**
+     * Creates a list of files that are available for ingest during the test.
+     */
+    private void loadIngestFiles() {
+        final File srcDir = new File(this.sourceDir);
+        final File[] srcFiles = srcDir.listFiles();
+        final Set<String> names = new HashSet<>();
+        for (final File src : srcFiles) {
+            names.add(src.toURI().toString());
+            final Path path = new Path(src.toURI());
+            this.ingestPaths.add(path);
+        }
+        logger.info("num: " + ingestPaths.size());
+        if (ingestPaths.isEmpty()) {
+            throw new IllegalStateException("no source ingest files loaded");
+        }
+    }
+    
+    /**
+     * Validates the configuration data.
+     *
+     * @return true if all values are valid
+     */
+    private boolean validate() {
+        // all int values must be > 0 and source directory must exist
+        boolean valid = false;
+        if (0 < this.workers && 0 < duration && 0 < this.minChunks && 0 < this.maxChunks && 0 < this.minInterval && 0 < this.maxInterval) {
+            if (0 < this.hdfs.trim().length() && 0 < this.hdfsIngestDir.trim().length() && 0 < this.sourceDir.trim().length()) {
+                final File d = new File(this.sourceDir);
+                valid = d.isDirectory();
+            }
+        }
+        
+        return valid;
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestWorker.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestWorker.java
@@ -1,0 +1,44 @@
+package datawave.util.flag;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jline.internal.Log;
+
+/**
+ * (U) Worker thread for moving ingest files from the native file system into the ingest directory for the specific ingest data type.
+ */
+class IngestWorker implements Callable<Void> {
+    
+    private static final Logger logger = LoggerFactory.getLogger(IngestWorker.class);
+    
+    @Override
+    public Void call() throws InterruptedException {
+        final IngestConfig cfg = IngestConfig.getInstance();
+        final FileSystem fs = cfg.getHdfs();
+        final Path dst = new Path(cfg.getHdfsIngestDir());
+        final long endTime = cfg.getDurtion() + System.currentTimeMillis();
+        logger.info("starting task thread " + Thread.currentThread().getId() + " duration(" + cfg.getDurtion() + ")ms");
+        while (endTime >= System.currentTimeMillis()) {
+            final List<Path> moveFiles = cfg.getRandomIngestFiles();
+            Path[] srcFiles = new Path[moveFiles.size()];
+            srcFiles = moveFiles.toArray(srcFiles);
+            try {
+                fs.copyFromLocalFile(false, false, srcFiles, dst);
+            } catch (IOException ioe) {
+                Log.error("unable to copy ingest files", ioe);
+            }
+            final int waitDur = cfg.getRandomInterval();
+            Thread.sleep(waitDur);
+        }
+        
+        logger.info("task thread complete " + Thread.currentThread().getId());
+        return null;
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestWorker.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/IngestWorker.java
@@ -24,7 +24,7 @@ class IngestWorker implements Callable<Void> {
         final FileSystem fs = cfg.getHdfs();
         final Path dst = new Path(cfg.getHdfsIngestDir());
         final long endTime = cfg.getDurtion() + System.currentTimeMillis();
-        logger.info("starting task thread " + Thread.currentThread().getId() + " duration(" + cfg.getDurtion() + ")ms");
+        logger.info("starting task thread(" + Thread.currentThread().getId() + ") duration(" + cfg.getDurtion() + ")ms");
         while (endTime >= System.currentTimeMillis()) {
             final List<Path> moveFiles = cfg.getRandomIngestFiles();
             Path[] srcFiles = new Path[moveFiles.size()];
@@ -32,13 +32,13 @@ class IngestWorker implements Callable<Void> {
             try {
                 fs.copyFromLocalFile(false, false, srcFiles, dst);
             } catch (IOException ioe) {
-                Log.error("unable to copy ingest files", ioe);
+                Log.error("thread(" + Thread.currentThread().getId() + ") unable to copy ingest files: " + ioe.getMessage());
             }
             final int waitDur = cfg.getRandomInterval();
             Thread.sleep(waitDur);
         }
         
-        logger.info("task thread complete " + Thread.currentThread().getId());
+        logger.info("task thread(" + Thread.currentThread().getId() + ") completed");
         return null;
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/InputFileTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/InputFileTest.java
@@ -1,0 +1,64 @@
+package datawave.util.flag;
+
+import datawave.util.flag.InputFile.TrackedDir;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class InputFileTest {
+    private static final Logger log = LoggerFactory.getLogger(InputFileTest.class);
+    
+    private static final Random rVal = new Random(System.currentTimeMillis());
+    private static final String BASE_DIR = "/base";
+    private InputFile inFile;
+    
+    @Before
+    public void setup() {
+        Path p = new Path("path");
+        this.inFile = new InputFile("foo", p, 10, 10, 0, BASE_DIR);
+    }
+    
+    @Test
+    public void testUpdateDir() {
+        log.info("-----  testUpdateDir  -----");
+        TrackedDir update = TrackedDir.FLAGGING_DIR;
+        for (int n = 0; n < 10; n++) {
+            TrackedDir dir = getRandomDir(update);
+            inFile.updateCurrentDir(dir);
+            Path cur = inFile.getCurrentDir();
+            Path expect = inFile.getTrackedDir(dir);
+            Assert.assertEquals(expect, cur);
+            Assert.assertTrue(inFile.isMoved());
+            inFile.setMoved(false);
+        }
+    }
+    
+    @Test
+    public void testEqualsHashCode() {
+        InputFile test = new InputFile(inFile.getFolder(), inFile.getPath(), inFile.getBlocksize(), inFile.getFilesize(), inFile.getTimestamp(), "/xx");
+        Assert.assertEquals(test, this.inFile);
+        Assert.assertEquals(test.hashCode(), this.inFile.hashCode());
+        test.setFilesize(test.getFilesize() + 1);
+        Assert.assertNotEquals(test, this.inFile);
+        Assert.assertNotEquals(test.hashCode(), this.inFile.hashCode());
+    }
+    
+    private TrackedDir getRandomDir(TrackedDir exclude) {
+        List<TrackedDir> valid = new ArrayList<>();
+        for (TrackedDir dir : TrackedDir.values()) {
+            if (!(dir.equals(TrackedDir.PATH_DIR) || dir.equals(exclude))) {
+                valid.add(dir);
+            }
+        }
+        
+        int idx = rVal.nextInt(valid.size());
+        return valid.get(idx);
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/util/flag/SimpleMoverTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/util/flag/SimpleMoverTest.java
@@ -1,0 +1,80 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package datawave.util.flag;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import datawave.util.flag.InputFile.TrackedDir;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+/**
+ *
+ */
+public class SimpleMoverTest extends AbstractFlagConfig {
+    
+    private static Cache<Path,Path> directoryCache = CacheBuilder.newBuilder().maximumSize(100).expireAfterWrite(10, TimeUnit.MINUTES).concurrencyLevel(10)
+                    .build();
+    
+    @Before
+    public void before() throws Exception {
+        this.fmc = getDefaultFMC();
+        this.fmc.setBaseHDFSDir(this.fmc.getBaseHDFSDir().replace("target", "target/SimpleMoverTest"));
+        
+        // cleanup flagging and flagged directories
+        cleanTestDirs();
+    }
+    
+    /**
+     * Test of call method, of class SimpleMover.
+     */
+    @Test
+    public void testCall() throws Exception {
+        
+        FileSystem fs = FileSystem.getLocal(new Configuration());
+        
+        Path file = getTestFile(fs);
+        InputFile inFile = new InputFile("foo", file, 0, 0, 0, fmc.getBaseHDFSDir());
+        
+        SimpleMover instance = new SimpleMover(directoryCache, inFile, TrackedDir.FLAGGED_DIR, fs);
+        InputFile result = instance.call();
+        assertTrue("Should have moved to flagged", result.isMoved());
+        assertTrue(result.getCurrentDir().equals(result.getFlagged()));
+    }
+    
+    /**
+     * Test of checkParent method, of class SimpleMover.
+     */
+    @Test
+    public void testFailCall() throws Exception {
+        
+        FileSystem fs = FileSystem.getLocal(new Configuration());
+        
+        Path file = getTestFile(fs);
+        InputFile entry = new InputFile("foo", file, 0, 0, 0, fmc.getBaseHDFSDir());
+        
+        // copy to the move will fail
+        fs.mkdirs(entry.getFlagging().getParent());
+        fs.copyFromLocalFile(file, entry.getFlagging());
+        
+        SimpleMover instance = new SimpleMover(directoryCache, entry, TrackedDir.FLAGGING_DIR, fs);
+        
+        InputFile result = instance.call();
+        assertFalse("should not have moved due to collision", result.isMoved());
+        assertTrue(result.getCurrentDir().equals(result.getPath()));
+    }
+    
+}

--- a/warehouse/ingest-core/src/test/resources/FlagLoadConfig.json
+++ b/warehouse/ingest-core/src/test/resources/FlagLoadConfig.json
@@ -1,0 +1,11 @@
+{
+    "hdfs": "hdfs://localhost:9000",
+    "hdfsIngestDir": "/datawave/ingest/myjson",
+    "sourceDir": "<PATH>/datawave/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze",
+    "duration": 1,
+    "workers": 1,
+    "minChunks": 4,
+    "maxChunks": 12,
+    "minInterval": 20000,
+    "maxInterval": 30000
+}

--- a/warehouse/ingest-core/src/test/resources/TestFlagMakerConfig.xml
+++ b/warehouse/ingest-core/src/test/resources/TestFlagMakerConfig.xml
@@ -22,6 +22,7 @@
     <!-- No dot "." files -->
     <filePattern>2*/*/*/[0-9a-zA-Z]*[0-9a-zA-Z]</filePattern>
     <hdfs>file://target</hdfs>
+    <collectMetrics>false</collectMetrics>
     <socketPort>22222</socketPort>
     <maxHdfsThreads>1</maxHdfsThreads>
 	<directoryCacheSize>2</directoryCacheSize>

--- a/warehouse/ingest-core/src/test/resources/log4j.properties
+++ b/warehouse/ingest-core/src/test/resources/log4j.properties
@@ -1,6 +1,8 @@
 log4j.rootCategory=INFO, CONSOLE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.Threshold=INFO
+log4j.appender.CONSOLE.Threshold=trace
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%-5p [%C{1}:%M] %m%n
+
+log4j.logger.datawave.util.flag=info


### PR DESCRIPTION
The following modifications were made to the flag maker:

- Unused static and instance variables were removed.
- Validation of the configuration data was moved to the FlagMakerConfig class.
- The class FlagEntryMover and SimpleMover have been introduced to manage the state of an input file.
- The class FlagMetrics has been introduced to write flag metrics.
- Unit test classes have been added for the new classes.
- A test class and associated scripts have been added for system/load/stress testing for the flag maker. The system test can be used to inject input files into the flag maker for processing and will result in the data being populated into Accumulo.