### PR TITLE
Update ASTEvaluationOnly to properly prevent ranges and regex from expanding

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ParallelIndexExpansion.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ParallelIndexExpansion.java
@@ -297,7 +297,7 @@ public class ParallelIndexExpansion extends RebuildingVisitor {
         if (markedParents != null) {
             for (JexlNode markedParent : markedParents) {
                 if (ExceededValueThresholdMarkerJexlNode.instanceOf(markedParent) || ExceededOrThresholdMarkerJexlNode.instanceOf(markedParent)
-                                || ExceededValueThresholdMarkerJexlNode.instanceOf(markedParent) || ASTEvaluationOnly.instanceOf(node))
+                                || ExceededValueThresholdMarkerJexlNode.instanceOf(markedParent) || ASTEvaluationOnly.instanceOf(markedParent))
                     return node;
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitor.java
@@ -237,7 +237,7 @@ public class TreeFlatteningRebuildingVisitor extends RebuildingVisitor {
             JexlNode node = (JexlNode) currentNode.jjtGetChild(i).jjtAccept(this, null);
             JexlNode dereferenced = JexlASTHelper.dereference(node);
             
-            if (acceptableNodesToCombine(currentNode, dereferenced)) {
+            if (acceptableNodesToCombine(currentNode, dereferenced, !node.equals(dereferenced))) {
                 flattenTree(dereferenced, newNode, data);
             } else {
                 newNode.jjtAddChild(node, newNode.jjtGetNumChildren());
@@ -248,12 +248,14 @@ public class TreeFlatteningRebuildingVisitor extends RebuildingVisitor {
         return newNode;
     }
     
-    protected boolean acceptableNodesToCombine(JexlNode currentNode, JexlNode newNode) {
+    protected boolean acceptableNodesToCombine(JexlNode currentNode, JexlNode newNode, boolean isWrapped) {
         if (currentNode.getClass().equals(newNode.getClass())) {
             // if this is a bounded range or marker node, then to not combine
             if (newNode instanceof ASTAndNode && isBoundedRange((ASTAndNode) newNode)) {
                 return false;
-            } else if (newNode instanceof ASTAndNode && QueryPropertyMarker.instanceOf(newNode, null)) {
+            }
+            // don't allow combination of a marker node UNLESS it's already unwrapped
+            else if (newNode instanceof ASTAndNode && QueryPropertyMarker.instanceOf(newNode, null) && isWrapped) {
                 return false;
             }
             

--- a/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
@@ -584,8 +584,8 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         // Test the plan with all expansions
         String expect = "(" + CityField.CITY.name() + '_' + CityField.STATE.name() + EQ_OP + "'rome" + CompositeIngest.DEFAULT_SEPARATOR + "lazio'"
                         + JEXL_OR_OP + CityField.CITY.name() + '_' + CityField.STATE.name() + EQ_OP + "'rome" + CompositeIngest.DEFAULT_SEPARATOR + "ohio')"
-                        + JEXL_AND_OP + "((ASTEvaluationOnly = true)" + JEXL_AND_OP + "(" + CityField.CITY.name() + " == 'rome'" + JEXL_AND_OP + "("
-                        + CityField.STATE.name() + " == 'lazio'" + JEXL_OR_OP + CityField.STATE.name() + " == 'ohio')))";
+                        + JEXL_AND_OP + "((ASTEvaluationOnly = true)" + JEXL_AND_OP + "(" + CityField.CITY.name() + " == 'rome'" + JEXL_AND_OP
+                        + CityField.STATE.name() + oPhrase + "))";
         String plan = getPlan(query, true, true);
         assertPlanEquals(expect, plan);
         

--- a/warehouse/query-core/src/test/java/datawave/query/LuceneQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LuceneQueryTest.java
@@ -23,6 +23,7 @@ import static datawave.query.testframework.RawDataManager.AND_OP;
 import static datawave.query.testframework.RawDataManager.EQ_OP;
 import static datawave.query.testframework.RawDataManager.JEXL_AND_OP;
 import static datawave.query.testframework.RawDataManager.RE_OP;
+import static org.junit.Assert.assertEquals;
 
 public class LuceneQueryTest extends AbstractFunctionalQuery {
     
@@ -117,6 +118,69 @@ public class LuceneQueryTest extends AbstractFunctionalQuery {
         assertPlanEquals(expect, plan);
         
         expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + this.dataManager.convertAnyField(phrase);
+        runTest(query, expect);
+    }
+    
+    @Test
+    public void testExplicitFieldEvaluationOnlyWithRegex() throws Exception {
+        log.info("------  testExplicitFieldRegexEvaluationOnly  ------");
+        String code = "europe";
+        String state = "l.*";
+        String phrase = RE_OP + "'" + state + "'";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#JEXL(\"((ASTEvaluationOnly = true)" + JEXL_AND_OP + CityField.STATE.name()
+                        + " =~ '" + state + "')\")";
+        
+        String expect = CityField.CONTINENT.name() + " == '" + code + "'" + JEXL_AND_OP + "((ASTEvaluationOnly = true)" + JEXL_AND_OP + CityField.STATE.name()
+                        + " =~ '" + state + "')";
+        String plan = getPlan(query, true, true);
+        assertPlanEquals(expect, plan);
+        
+        expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + this.dataManager.convertAnyField(phrase);
+        runTest(query, expect);
+    }
+    
+    @Test
+    public void testExplicitFieldEvaluationOnlyWithRange() throws Exception {
+        log.info("------  testExplicitFieldRange  ------");
+        String code = "europe";
+        String startState = "alabama";
+        String endState = "wyoming";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#JEXL(\"((ASTEvaluationOnly = true)" + JEXL_AND_OP + CityField.STATE.name()
+                        + " >= '" + startState + "'" + JEXL_AND_OP + CityField.STATE.name() + " <= '" + endState + "')\")";
+        
+        String expect = CityField.CONTINENT.name() + " == '" + code + "'" + JEXL_AND_OP + "((ASTEvaluationOnly = true)" + JEXL_AND_OP + CityField.STATE.name()
+                        + " >= '" + startState + "'" + JEXL_AND_OP + CityField.STATE.name() + " <= '" + endState + "')";
+        String plan = getPlan(query, true, true);
+        assertEquals(expect, plan);
+        assertPlanEquals(expect, plan);
+        
+        expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + CityField.STATE.name() + " >= '" + startState + "'" + AND_OP
+                        + CityField.STATE.name() + " <= '" + endState + "'";
+        runTest(query, expect);
+    }
+    
+    @Test
+    public void testExplicitFieldEvaluationOnlyWithRanges() throws Exception {
+        log.info("------  testExplicitFieldRanges  ------");
+        String code = "europe";
+        String startState1 = "alabama";
+        String endState1 = "connecticut";
+        String startState2 = "iowa";
+        String endState2 = "wyoming";
+        String query = CityField.CONTINENT.name() + ":\"" + code + "\"" + AND_OP + "#JEXL(\"((ASTEvaluationOnly = true)" + JEXL_AND_OP + CityField.STATE.name()
+                        + " >= '" + startState1 + "'" + JEXL_AND_OP + CityField.STATE.name() + " <= '" + endState1 + "'" + JEXL_AND_OP + CityField.STATE.name()
+                        + " >= '" + startState2 + "'" + JEXL_AND_OP + CityField.STATE.name() + " <= '" + endState2 + "'" + ")\")";
+        
+        String expect = CityField.CONTINENT.name() + " == '" + code + "'" + JEXL_AND_OP + "((ASTEvaluationOnly = true)" + JEXL_AND_OP + CityField.STATE.name()
+                        + " >= '" + startState1 + "'" + JEXL_AND_OP + CityField.STATE.name() + " <= '" + endState1 + "'" + JEXL_AND_OP + CityField.STATE.name()
+                        + " >= '" + startState2 + "'" + JEXL_AND_OP + CityField.STATE.name() + " <= '" + endState2 + "'" + ")";
+        String plan = getPlan(query, true, true);
+        assertEquals(expect, plan);
+        assertPlanEquals(expect, plan);
+        
+        expect = CityField.CONTINENT.name() + EQ_OP + "'" + code + "'" + AND_OP + CityField.STATE.name() + " >= '" + startState1 + "'" + AND_OP
+                        + CityField.STATE.name() + " <= '" + endState1 + "'" + AND_OP + CityField.STATE.name() + " >= '" + startState2 + "'" + AND_OP
+                        + CityField.STATE.name() + " <= '" + endState2 + "'";
         runTest(query, expect);
     }
     


### PR DESCRIPTION
This also required updating the tree flattening rebuilding visitor to combine a marked node with other anded sibling nodes as long as none of them are wrapped.  