### PR TITLE
Fixes #248 - faulty logic in MetadataTableSplitsCacheStatus causes NPE

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/MetadataTableSplitsCacheStatus.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/MetadataTableSplitsCacheStatus.java
@@ -25,6 +25,7 @@ public class MetadataTableSplitsCacheStatus {
             fileStatus = FileSystem.get(splitsPath.toUri(), conf).getFileStatus(splitsPath);
         } catch (IOException ex) {
             log.warn("Could not get the FileStatus of the splits file " + splitsPath);
+            return false;
         }
         long expirationTime = System.currentTimeMillis() - conf.getLong(SPLITS_CACHE_TIMEOUT_MS, DEFAULT_CACHE_TIMEOUT);
         boolean isFileAgeValid = fileStatus.getModificationTime() >= expirationTime;


### PR DESCRIPTION
If IOException is thrown in 'try' block then just return false from isCacheValid without calling methods on the what will be null 'fileStatus' object which will cause the NullPointerException.