### PR TITLE
Fixes #391 - ShardedTableMapFile NPE for every table

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/ShardedTableMapFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/ShardedTableMapFile.java
@@ -349,7 +349,9 @@ public class ShardedTableMapFile {
                     Range range = new Range();
                     Locations locations = tableOps.locate(shardedTableName, Collections.singletonList(range));
                     List<TabletId> tabletIds = locations.groupByRange().get(range);
-                    tabletIds.forEach(tId -> splitToLocation.put(tId.getEndRow(), locations.getTabletLocation(tId)));
+                    
+                    tabletIds.stream().filter(tId -> tId.getEndRow() != null)
+                                    .forEach(tId -> splitToLocation.put(tId.getEndRow(), locations.getTabletLocation(tId)));
                 }
                 // made it here, no errors so break out
                 keepRetrying = false;


### PR DESCRIPTION
This fix prevents TabletId's with null endrows from populating the splitlocation map.  This is effectively what the old code did but it it would would retry until the number of retries ran out in the failure of the writeSplitsFile function.   I try to filter out the tabletId with the null end row with a Java 8 lambda but I am getting an UnsupportedOperationError which leads me to think that the Java version in my IDE is not the same as what DataWave is using.  On line 360 I had to do an ugly old school iteration and testing of the tabletId for the null end row because the removif lambda doensn't work and putting the test in the tabletIds.forEach lambda makes the code unreadable.