### PR TITLE
Replaced use of Junit TemporaryFolder with Files.createTempDirectory

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -12,14 +12,17 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.easymock.EasyMockSupport;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,14 +62,13 @@ public class QueryIteratorIT extends EasyMockSupport {
     protected IteratorEnvironment environment;
     protected EventDataQueryFilter filter;
     protected TypeMetadata typeMetadata;
-    
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    protected Path temporaryFolder;
     
     @Before
     public void setup() throws IOException {
         iterator = new QueryIterator();
         options = new HashMap<>();
+        temporaryFolder = Files.createTempDirectory("tmp");
         
         // global options
         
@@ -85,7 +87,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         options.put(QUERY_ID, "000001");
         
         // setup ivarator settings
-        options.put(IVARATOR_CACHE_BASE_URI_ALTERNATIVES, "file://" + temporaryFolder.newFolder().getAbsolutePath());
+        options.put(IVARATOR_CACHE_BASE_URI_ALTERNATIVES, "file://" + temporaryFolder.toAbsolutePath().toString());
         URL hdfsSiteConfig = this.getClass().getResource("/testhadoop.config");
         options.put(HDFS_SITE_CONFIG_URLS, hdfsSiteConfig.toExternalForm());
         
@@ -106,6 +108,11 @@ public class QueryIteratorIT extends EasyMockSupport {
         
         environment = createMock(IteratorEnvironment.class);
         filter = createMock(EventDataQueryFilter.class);
+    }
+    
+    @After
+    public void cleanUp() {
+        temporaryFolder.toFile().deleteOnExit();
     }
     
     private List<Map.Entry<Key,Value>> addEvent(long eventTime, String uid) {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,7 +61,7 @@ public class IndexQueryLogicTest extends AbstractFunctionalQuery {
     }
     
     @Before
-    public void querySetUp() {
+    public void querySetUp() throws IOException {
         log.debug("---------  querySetUp  ---------");
         
         // Super call to pick up authSet initialization


### PR DESCRIPTION
in a few tests to prevent random test failures.  This was recommended on the Junit4 thread to fix this temporary issue.  This code change has been tested on a single machine and the code builds with:
'mvn -Pdev -Ddeploy -Dtar  clean install'
