### PR TITLE
Fixes #477 - Index only fields in data dictionary vs data model

### DIFF
--- a/services/dictionary-api/src/main/java/datawave/webservice/results/datadictionary/DefaultDataDictionary.java
+++ b/services/dictionary-api/src/main/java/datawave/webservice/results/datadictionary/DefaultDataDictionary.java
@@ -202,14 +202,12 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
         builder.append("<div>");
         builder.append("<p style=\"width:60%; margin-left: auto; margin-right: auto;\">When a value is present in the forward index types, this means that a field is indexed and informs you how your ");
         builder.append("query terms will be treated (e.g. text, number, IPv4 address, etc). The same applies for the reverse index types with ");
-        builder.append("the caveat that you can also query these fields using leading wildcards. Fields that are marked as 'Index only' will not ");
-        builder.append("appear in a result set unless explicitly queried on. Index only fields are typically composite fields, derived from actual data, ");
-        builder.append("created by the software to make querying easier.</p>");
+        builder.append("the caveat that you can also query these fields using leading wildcards. </p>");
         builder.append("</div>");
         builder.append("<table id=\"myTable\">\n");
         
         builder.append("<thead><tr><th>FieldName</th><th>Internal FieldName</th><th>DataType</th>");
-        builder.append("<th>Index only</th><th>Forward Indexed</th><th>Reverse Indexed</th><th>Normalized</th><th>Types</th><th>Description</th><th>LastUpdated</th></tr></thead>");
+        builder.append("<th>Forward Indexed</th><th>Reverse Indexed</th><th>Normalized</th><th>Types</th><th>Description</th><th>LastUpdated</th></tr></thead>");
         
         builder.append("<tbody>");
         for (DefaultMetadataField f : this.getFields()) {
@@ -232,7 +230,6 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
             builder.append("<td>").append(fieldName).append("</td>");
             builder.append("<td>").append(internalFieldName).append("</td>");
             builder.append("<td>").append(datatype).append("</td>");
-            builder.append("<td>").append(f.isIndexOnly()).append("</td>");
             builder.append("<td>").append(f.isForwardIndexed() ? true : "").append("</td>");
             builder.append("<td>").append(f.isReverseIndexed() ? true : "").append("</td>");
             builder.append("<td>").append(f.isNormalized() ? true : "").append("</td>");

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -12,14 +12,17 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.easymock.EasyMockSupport;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,14 +62,13 @@ public class QueryIteratorIT extends EasyMockSupport {
     protected IteratorEnvironment environment;
     protected EventDataQueryFilter filter;
     protected TypeMetadata typeMetadata;
-    
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    protected Path temporaryFolder;
     
     @Before
     public void setup() throws IOException {
         iterator = new QueryIterator();
         options = new HashMap<>();
+        temporaryFolder = Files.createTempDirectory("tmp");
         
         // global options
         
@@ -85,7 +87,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         options.put(QUERY_ID, "000001");
         
         // setup ivarator settings
-        options.put(IVARATOR_CACHE_BASE_URI_ALTERNATIVES, "file://" + temporaryFolder.newFolder().getAbsolutePath());
+        options.put(IVARATOR_CACHE_BASE_URI_ALTERNATIVES, "file://" + temporaryFolder.toAbsolutePath().toString());
         URL hdfsSiteConfig = this.getClass().getResource("/testhadoop.config");
         options.put(HDFS_SITE_CONFIG_URLS, hdfsSiteConfig.toExternalForm());
         
@@ -106,6 +108,11 @@ public class QueryIteratorIT extends EasyMockSupport {
         
         environment = createMock(IteratorEnvironment.class);
         filter = createMock(EventDataQueryFilter.class);
+    }
+    
+    @After
+    public void cleanUp() {
+        temporaryFolder.toFile().deleteOnExit();
     }
     
     private List<Map.Entry<Key,Value>> addEvent(long eventTime, String uid) {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,7 +61,7 @@ public class IndexQueryLogicTest extends AbstractFunctionalQuery {
     }
     
     @Before
-    public void querySetUp() {
+    public void querySetUp() throws IOException {
         log.debug("---------  querySetUp  ---------");
         
         // Super call to pick up authSet initialization


### PR DESCRIPTION
Removed the "index only" column in the datawave model which is not used. That field was dropped as well as the index only column in the model webpage endpoint.