### PR TITLE
Fixes #479 - Populate normalization column in the data dictionary

### DIFF
--- a/services/dictionary-api/src/main/java/datawave/webservice/results/datadictionary/DefaultDataDictionary.java
+++ b/services/dictionary-api/src/main/java/datawave/webservice/results/datadictionary/DefaultDataDictionary.java
@@ -235,7 +235,7 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
             builder.append("<td>").append(f.isIndexOnly()).append("</td>");
             builder.append("<td>").append(f.isForwardIndexed() ? true : "").append("</td>");
             builder.append("<td>").append(f.isReverseIndexed() ? true : "").append("</td>");
-            builder.append("<td>").append(f.isNormalized() ? true : "").append("</td>");
+            builder.append("<td>").append(f.getTypes() != null && f.getTypes().size() > 0 ? "true" : "false").append("</td>");
             builder.append("<td>").append(types).append("</td>");
             builder.append("<td>");
             


### PR DESCRIPTION
So the solution is to say that a Field Name in the Metadata  table is normalize if it has an underlying datatype which was what was decided in the issue #479 

I had to make pom.xml changes to get this to see my code modification to actually get used in the services project and I can push those changes if required.  The SNAPSHOT jar for dictionary-api was not being used.

This solution has been tested and stepped through in a debugger.