### PR TITLE
Fixes #475 - Enable text wrap on the Data Dictionary page for long

### DIFF
--- a/services/spring-boot-starter-datawave/src/main/resources/static/css/screen.css
+++ b/services/spring-boot-starter-datawave/src/main/resources/static/css/screen.css
@@ -63,6 +63,7 @@ td {
 	padding-bottom: 0.15em;
 	color: #333333;
     font-size: 10pt;
+    word-wrap:break-all
 }
 
 th {

--- a/web-services/web-root/src/main/webapp/screen.css
+++ b/web-services/web-root/src/main/webapp/screen.css
@@ -63,6 +63,7 @@ td {
 	padding-bottom: 0.15em;
 	color: #333333;
     font-size: 10pt;
+    word-wrap:break-all
 }
 
 th {


### PR DESCRIPTION
field names.

Added attribute:   word-break: break-all  to the ```<TD>``` element style in the screen.css.    Tested in Firefox.  Works as requested in #475