### PR TITLE
Updated the datawave interpreter to use iterative traversal for or nodes

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/jexl/DatawaveInterpreterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/DatawaveInterpreterTest.java
@@ -4,6 +4,10 @@ import org.apache.commons.jexl2.Script;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 public class DatawaveInterpreterTest {
     
     @Test
@@ -16,6 +20,21 @@ public class DatawaveInterpreterTest {
         
         context.set("GEO", "0321􏿿+bE4.4");
         context.set("WKT_BYTE_LENGTH", "+bE4.4");
+        
+        Assert.assertTrue(DatawaveInterpreter.isMatched(script.execute(context)));
+    }
+    
+    @Test
+    public void largeOrListTest() {
+        List<String> uuids = new ArrayList<>();
+        for (int i = 0; i < 1000000; i++)
+            uuids.add("'" + UUID.randomUUID().toString() + "'");
+        
+        String query = String.join(" || ", uuids);
+        
+        DatawaveJexlContext context = new DatawaveJexlContext();
+        
+        Script script = ArithmeticJexlEngines.getEngine(new DefaultArithmetic()).createScript(query);
         
         Assert.assertTrue(DatawaveInterpreter.isMatched(script.execute(context)));
     }


### PR DESCRIPTION
This should stop the stack overflows caused by recursively traversing or nodes composed of too many terms.  