### PR TITLE
Include ModelBean in API documentation

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -132,6 +132,12 @@
         </dependency>
         <dependency>
             <groupId>gov.nsa.datawave.webservices</groupId>
+            <artifactId>datawave-ws-model</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>gov.nsa.datawave.webservices</groupId>
             <artifactId>datawave-ws-modification</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>


### PR DESCRIPTION
Add datawave-ws-model as a dependency for datawave-docs so that the
source files (including ModelBean) will be read and included by the
enunciate plugin.

Fixes #498