### PR TITLE
Address HTTP 404 from hadoop tarball download

### DIFF
--- a/contrib/datawave-quickstart/bin/services/hadoop/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/hadoop/bootstrap.sh
@@ -3,7 +3,7 @@
 DW_HADOOP_SERVICE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # You may override DW_HADOOP_DIST_URI in your env ahead of time, and set as file:///path/to/file.tar.gz for local tarball, if needed
-DW_HADOOP_DIST_URI="${DW_HADOOP_DIST_URI:-http://mirrors.advancedhosters.com/apache/hadoop/common/hadoop-3.1.1/hadoop-3.1.1.tar.gz}"
+DW_HADOOP_DIST_URI="${DW_HADOOP_DIST_URI:-http://mirrors.advancedhosters.com/apache/hadoop/common/hadoop-3.1.2/hadoop-3.1.2.tar.gz}"
 DW_HADOOP_DIST="$( downloadTarball "${DW_HADOOP_DIST_URI}" "${DW_HADOOP_SERVICE_DIR}" && echo "${tarball}" )"
 DW_HADOOP_BASEDIR="hadoop-install"
 DW_HADOOP_SYMLINK="hadoop"


### PR DESCRIPTION
Version 3.1.1 is not hosted on that server, but 3.1.2 is.

Refs #543