### PR TITLE
Pass down IterEnvironment to IteratorThreadPoolManager

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/IteratorThreadPoolManager.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/IteratorThreadPoolManager.java
@@ -1,6 +1,7 @@
 package datawave.core.iterators;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -9,9 +10,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.util.NamingThreadFactory;
-import org.apache.accumulo.server.client.HdfsZooInstance;
-import org.apache.accumulo.server.conf.ServerConfigurationFactory;
 import org.apache.accumulo.server.util.time.SimpleTimer;
 import org.apache.log4j.Logger;
 
@@ -24,36 +25,33 @@ public class IteratorThreadPoolManager {
     private static final String IVARATOR_THREAD_NAME = "DATAWAVE Ivarator";
     private static final String EVALUATOR_THREAD_PROP = "tserver.datawave.evaluation.threads";
     private static final String EVALUATOR_THREAD_NAME = "DATAWAVE Evaluation";
-    private ExecutorService ivaratorThreadPool;
-    private ExecutorService evaluationThreadPool;
     private static final int DEFAULT_THREAD_POOL_SIZE = 100;
     
     private Map<String,ExecutorService> threadPools = new TreeMap<>();
-    
-    private ServerConfigurationFactory confFactory;
     
     private static final Object instanceSemaphore = new Object();
     private static final String instanceId = Integer.toHexString(instanceSemaphore.hashCode());
     private static volatile IteratorThreadPoolManager instance;
     
-    private IteratorThreadPoolManager() {
-        // create the thread pools\
-        try {
-            this.confFactory = new ServerConfigurationFactory(HdfsZooInstance.getInstance());
-        } catch (Throwable e) {
-            log.error("Unable to get the accumulo configuration, using default thread pool sizes (" + DEFAULT_THREAD_POOL_SIZE + " per pool)");
-        }
-        this.ivaratorThreadPool = createExecutorService(IVARATOR_THREAD_PROP, IVARATOR_THREAD_NAME);
-        this.evaluationThreadPool = createExecutorService(EVALUATOR_THREAD_PROP, EVALUATOR_THREAD_NAME);
+    private IteratorThreadPoolManager(IteratorEnvironment env) {
+        // create the thread pools
+        createExecutorService(IVARATOR_THREAD_PROP, IVARATOR_THREAD_NAME, env);
+        createExecutorService(EVALUATOR_THREAD_PROP, EVALUATOR_THREAD_NAME, env);
     }
     
-    private ThreadPoolExecutor createExecutorService(final String prop, final String name) {
-        final ThreadPoolExecutor service = createExecutorService(getMaxThreads(prop), name + " (" + instanceId + ')');
+    private ThreadPoolExecutor createExecutorService(final String prop, final String name, IteratorEnvironment env) {
+        final AccumuloConfiguration accumuloConfiguration;
+        if (env != null) {
+            accumuloConfiguration = env.getConfig();
+        } else {
+            accumuloConfiguration = DefaultConfiguration.getInstance();
+        }
+        final ThreadPoolExecutor service = createExecutorService(getMaxThreads(prop, accumuloConfiguration), name + " (" + instanceId + ')');
         threadPools.put(name, service);
-        SimpleTimer.getInstance(AccumuloConfiguration.getDefaultConfiguration()).schedule(() -> {
+        SimpleTimer.getInstance(accumuloConfiguration).schedule(() -> {
             try {
                 
-                int max = getMaxThreads(prop);
+                int max = getMaxThreads(prop, accumuloConfiguration);
                 if (service.getMaximumPoolSize() != max) {
                     log.info("Changing " + prop + " to " + max);
                     service.setCorePoolSize(max);
@@ -73,11 +71,10 @@ public class IteratorThreadPoolManager {
         return pool;
     }
     
-    private int getMaxThreads(final String prop) {
-        if (this.confFactory != null) {
-            AccumuloConfiguration conf = this.confFactory.getConfiguration();
+    private int getMaxThreads(final String prop, AccumuloConfiguration conf) {
+        if (conf != null) {
             Map<String,String> properties = new TreeMap<>();
-            conf.getProperties(properties, new AccumuloConfiguration.MatchFilter(prop));
+            conf.getProperties(properties, k -> Objects.equals(k, prop));
             if (properties.containsKey(prop)) {
                 return Integer.parseInt(properties.get(prop));
             }
@@ -85,11 +82,11 @@ public class IteratorThreadPoolManager {
         return DEFAULT_THREAD_POOL_SIZE;
     }
     
-    private static IteratorThreadPoolManager instance() {
+    private static IteratorThreadPoolManager instance(IteratorEnvironment env) {
         if (instance == null) {
             synchronized (instanceSemaphore) {
                 if (instance == null) {
-                    instance = new IteratorThreadPoolManager();
+                    instance = new IteratorThreadPoolManager(env);
                 }
             }
         }
@@ -108,12 +105,12 @@ public class IteratorThreadPoolManager {
         });
     }
     
-    public static Future<?> executeIvarator(Runnable task, String taskName) {
-        return instance().execute(IVARATOR_THREAD_NAME, task, taskName);
+    public static Future<?> executeIvarator(Runnable task, String taskName, IteratorEnvironment env) {
+        return instance(env).execute(IVARATOR_THREAD_NAME, task, taskName);
     }
     
-    public static Future<?> executeEvaluation(Runnable task, String taskName) {
-        return instance().execute(EVALUATOR_THREAD_NAME, task, taskName);
+    public static Future<?> executeEvaluation(Runnable task, String taskName, IteratorEnvironment env) {
+        return instance(env).execute(EVALUATOR_THREAD_NAME, task, taskName);
     }
     
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/NestedIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/NestedIterator.java
@@ -3,6 +3,8 @@ package datawave.query.iterator;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+
 import datawave.query.attributes.Document;
 
 /**
@@ -42,4 +44,9 @@ public interface NestedIterator<T> extends Iterator<T> {
      * Returns a <code>Document</code> object that is composed of attributes read in by the leaf nodes of this sub-tree.
      */
     Document document();
+    
+    /**
+     * Provides configuration information to the Iterator before initializing and seeking. Default does nothing.
+     */
+    default void setEnvironment(IteratorEnvironment env) {}
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -337,7 +337,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
                     log.trace("Received non-inclusive event specific range: " + documentRange);
                 }
                 if (gatherTimingDetails()) {
-                    this.seekKeySource = new EvaluationTrackingNestedIterator(QuerySpan.Stage.EmptyTree, trackingSpan, new EmptyTreeIterable());
+                    this.seekKeySource = new EvaluationTrackingNestedIterator(QuerySpan.Stage.EmptyTree, trackingSpan, new EmptyTreeIterable(), myEnvironment);
                 } else {
                     this.seekKeySource = new EmptyTreeIterable();
                 }
@@ -356,7 +356,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
                 
                 if (gatherTimingDetails()) {
                     this.seekKeySource = new EvaluationTrackingNestedIterator(QuerySpan.Stage.DocumentSpecificTree, trackingSpan,
-                                    new DocumentSpecificNestedIterator(documentKey));
+                                    new DocumentSpecificNestedIterator(documentKey), myEnvironment);
                 } else {
                     this.seekKeySource = new DocumentSpecificNestedIterator(documentKey);
                 }
@@ -597,7 +597,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
                 }
                 
                 if (gatherTimingDetails()) {
-                    subDocIter = new EvaluationTrackingNestedIterator(QuerySpan.Stage.FieldIndexTree, trackingSpan, subDocIter);
+                    subDocIter = new EvaluationTrackingNestedIterator(QuerySpan.Stage.FieldIndexTree, trackingSpan, subDocIter, myEnvironment);
                 }
                 
                 // Seek() the boolean logic stuff
@@ -631,7 +631,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
             }
             
             if (gatherTimingDetails()) {
-                docIter = new EvaluationTrackingNestedIterator(QuerySpan.Stage.FieldIndexTree, trackingSpan, docIter);
+                docIter = new EvaluationTrackingNestedIterator(QuerySpan.Stage.FieldIndexTree, trackingSpan, docIter, myEnvironment);
             }
             
             // Seek() the boolean logic stuff
@@ -1249,7 +1249,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
             debugBooleanLogicIterators(sourceIter);
             
             if (sourceIter != null) {
-                sourceIter = new SeekableNestedIterator(sourceIter);
+                sourceIter = new SeekableNestedIterator(sourceIter, this.myEnvironment);
             }
         }
         

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/SeekableNestedIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/SeekableNestedIterator.java
@@ -3,6 +3,7 @@ package datawave.query.iterator;
 import datawave.query.attributes.Document;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -18,8 +19,9 @@ public class SeekableNestedIterator<T> implements NestedIterator<T>, SeekableIte
     protected Collection<ByteSequence> columnFamilies = null;
     protected boolean inclusive = false;
     
-    public SeekableNestedIterator(NestedIterator<T> source) {
+    public SeekableNestedIterator(NestedIterator<T> source, IteratorEnvironment env) {
         this.source = source;
+        this.source.setEnvironment(env);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/AbstractIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/AbstractIteratorBuilder.java
@@ -3,6 +3,8 @@ package datawave.query.iterator.builder;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+
 import datawave.query.iterator.NestedIterator;
 
 import com.google.common.collect.HashMultimap;
@@ -106,6 +108,16 @@ public abstract class AbstractIteratorBuilder implements IteratorBuilder {
             observedFieldValues.put(field, value);
             return false;
         }
+    }
+    
+    IteratorEnvironment env;
+    
+    public void setEnv(IteratorEnvironment env) {
+        this.env = env;
+    }
+    
+    public IteratorEnvironment getEnv() {
+        return this.env;
     }
     
     public abstract <T> NestedIterator<T> build();

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexFilterIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexFilterIteratorBuilder.java
@@ -79,13 +79,13 @@ public class IndexFilterIteratorBuilder extends IvaratorBuilder implements Itera
                                 .withFileSystem(hdfsFileSystem).withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
                                 .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
                                 .withCompositeMetadata(compositeMetadata).withCompositeSeekThreshold(compositeSeekThreshold).withTypeMetadata(typeMetadata)
-                                .build();
+                                .withIteratorEnv(env).build();
                 
                 if (collectTimingDetails) {
                     rangeIterator.setCollectTimingDetails(true);
                     rangeIterator.setQuerySpanCollector(this.querySpanCollector);
                 }
-                rangeIterator.init(source, null, null);
+                rangeIterator.init(source, null, env);
                 log.debug("Created a DatawaveFieldIndexFilterIteratorJexl: " + rangeIterator);
                 
                 // Add an interator to aggregate documents. This is needed for index only fields.

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexListIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexListIteratorBuilder.java
@@ -91,7 +91,7 @@ public class IndexListIteratorBuilder extends IvaratorBuilder implements Iterato
                                     .withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
                                     .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
                                     .withCompositeMetadata(compositeMetadata).withCompositeSeekThreshold(compositeSeekThreshold).withTypeMetadata(typeMetadata)
-                                    .build();
+                                    .withIteratorEnv(env).build();
                     
                 } else {
                     listIterator = DatawaveFieldIndexListIteratorJexl.builder().withFieldName(new Text(field)).withFST(fst).withTimeFilter(timeFilter)
@@ -101,14 +101,14 @@ public class IndexListIteratorBuilder extends IvaratorBuilder implements Iterato
                                     .withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
                                     .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
                                     .withCompositeMetadata(compositeMetadata).withCompositeSeekThreshold(compositeSeekThreshold).withTypeMetadata(typeMetadata)
-                                    .build();
+                                    .withIteratorEnv(env).build();
                     
                 }
                 if (collectTimingDetails) {
                     listIterator.setCollectTimingDetails(true);
                     listIterator.setQuerySpanCollector(this.querySpanCollector);
                 }
-                listIterator.init(source, null, null);
+                listIterator.init(source, null, env);
                 log.debug("Created a DatawaveFieldIndexListIteratorJexl: " + listIterator);
                 
                 boolean canBuildDocument = this.fieldsToAggregate == null ? false : this.fieldsToAggregate.contains(field);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRangeIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRangeIteratorBuilder.java
@@ -82,13 +82,13 @@ public class IndexRangeIteratorBuilder extends IvaratorBuilder implements Iterat
                                 .withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
                                 .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
                                 .withCompositeMetadata(compositeMetadata).withCompositeSeekThreshold(compositeSeekThreshold).withTypeMetadata(typeMetadata)
-                                .withSubRanges(subRanges).build();
+                                .withSubRanges(subRanges).withIteratorEnv(env).build();
                 
                 if (collectTimingDetails) {
                     rangeIterator.setCollectTimingDetails(true);
                     rangeIterator.setQuerySpanCollector(this.querySpanCollector);
                 }
-                rangeIterator.init(source, null, null);
+                rangeIterator.init(source, null, env);
                 log.debug("Created a DatawaveFieldIndexRangeIteratorJexl: " + rangeIterator);
                 
                 boolean canBuildDocument = this.fieldsToAggregate == null ? false : this.fieldsToAggregate.contains(field);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRegexIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRegexIteratorBuilder.java
@@ -64,13 +64,13 @@ public class IndexRegexIteratorBuilder extends IvaratorBuilder implements Iterat
                                 .withFileSystem(hdfsFileSystem).withUniqueDir(new Path(hdfsCacheURI)).withQueryLock(queryLock).allowDirResuse(true)
                                 .withReturnKeyType(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME).withSortedUUIDs(sortedUIDs)
                                 .withCompositeMetadata(compositeMetadata).withCompositeSeekThreshold(compositeSeekThreshold).withTypeMetadata(typeMetadata)
-                                .build();
+                                .withIteratorEnv(env).build();
                 
                 if (collectTimingDetails) {
                     regexIterator.setCollectTimingDetails(true);
                     regexIterator.setQuerySpanCollector(this.querySpanCollector);
                 }
-                regexIterator.init(source, null, null);
+                regexIterator.init(source, null, env);
                 log.debug("Created a DatawaveFieldIndexRegexIteratorJexl: " + regexIterator);
                 
                 boolean canBuildDocument = this.fieldsToAggregate == null ? false : this.fieldsToAggregate.contains(field);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/TermFrequencyIndexBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/TermFrequencyIndexBuilder.java
@@ -13,6 +13,7 @@ import datawave.query.util.TypeMetadata;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 
 import com.google.common.base.Predicate;
@@ -34,6 +35,7 @@ public class TermFrequencyIndexBuilder implements IteratorBuilder {
     protected Set<String> fieldsToAggregate;
     protected EventDataQueryFilter attrFilter;
     protected TermFrequencyAggregator termFrequencyAggregator;
+    private IteratorEnvironment iteratorEnvironment;
     
     public void setSource(final SortedKeyValueIterator<Key,Value> source) {
         this.source = source;
@@ -101,6 +103,10 @@ public class TermFrequencyIndexBuilder implements IteratorBuilder {
     
     public void setTermFrequencyAggregator(TermFrequencyAggregator termFrequencyAggregator) {
         this.termFrequencyAggregator = termFrequencyAggregator;
+    }
+    
+    public void setEnv(IteratorEnvironment env) {
+        this.iteratorEnvironment = env;
     }
     
     @SuppressWarnings("unchecked")

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/TermFrequencyIndexBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/TermFrequencyIndexBuilder.java
@@ -35,7 +35,7 @@ public class TermFrequencyIndexBuilder implements IteratorBuilder {
     protected Set<String> fieldsToAggregate;
     protected EventDataQueryFilter attrFilter;
     protected TermFrequencyAggregator termFrequencyAggregator;
-    private IteratorEnvironment iteratorEnvironment;
+    protected IteratorEnvironment iteratorEnvironment;
     
     public void setSource(final SortedKeyValueIterator<Key,Value> source) {
         this.source = source;

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIteratorBridge.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIteratorBridge.java
@@ -7,6 +7,7 @@ import datawave.query.iterator.SeekableIterator;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIteratorBridge.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIteratorBridge.java
@@ -7,7 +7,6 @@ import datawave.query.iterator.SeekableIterator;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/pipeline/PipelineIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/pipeline/PipelineIterator.java
@@ -330,7 +330,7 @@ public class PipelineIterator implements Iterator<Entry<Key,Document>> {
         }
         Pipeline pipeline = pipelines.checkOut(key, document, nestedQuery);
         
-        evaluationQueue.add(new Tuple2<>(IteratorThreadPoolManager.executeEvaluation(pipeline, pipeline.toString()), pipeline));
+        evaluationQueue.add(new Tuple2<>(IteratorThreadPoolManager.executeEvaluation(pipeline, pipeline.toString(), env), pipeline));
     }
     
     /*

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/profile/EvaluationTrackingNestedIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/profile/EvaluationTrackingNestedIterator.java
@@ -4,6 +4,7 @@ import datawave.query.iterator.NestedIterator;
 import datawave.query.iterator.SeekableNestedIterator;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -15,8 +16,8 @@ public class EvaluationTrackingNestedIterator<T> extends SeekableNestedIterator<
     protected QuerySpan.Stage stageName;
     private Logger log = Logger.getLogger(EvaluationTrackingNestedIterator.class);
     
-    public EvaluationTrackingNestedIterator(QuerySpan.Stage stageName, QuerySpan mySpan, NestedIterator<T> itr) {
-        super(itr);
+    public EvaluationTrackingNestedIterator(QuerySpan.Stage stageName, QuerySpan mySpan, NestedIterator<T> itr, IteratorEnvironment env) {
+        super(itr, env);
         this.mySpan = mySpan;
         this.stageName = stageName;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -436,6 +436,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             builder.setTimeFilter(timeFilter);
             builder.setAttrFilter(attrFilter);
             builder.setDatatypeFilter(datatypeFilter);
+            builder.setEnv(env);
             builder.setTermFrequencyAggregator(getTermFrequencyAggregator(node, attrFilter, attrFilter != null ? attrFilter.getMaxNextCount() : -1));
             
             Range fiRange = getFiRangeForTF(range);
@@ -573,6 +574,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setTimeFilter(timeFilter);
         builder.setDatatypeFilter(datatypeFilter);
         builder.setKeyTransform(fiAggregator);
+        builder.setEnv(env);
         node.childrenAccept(this, builder);
         
         // A EQNode may be of the form FIELD == null. The evaluation can
@@ -644,6 +646,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setFieldsToAggregate(fieldsToAggregate);
         builder.setDatatypeFilter(datatypeFilter);
         builder.setKeyTransform(fiAggregator);
+        builder.setEnv(env);
         builder.forceDocumentBuild(!limitLookup && this.isQueryFullySatisfied);
         node.childrenAccept(this, builder);
         
@@ -878,6 +881,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setFieldsToAggregate(fieldsToAggregate);
         builder.setDatatypeFilter(datatypeFilter);
         builder.setKeyTransform(fiAggregator);
+        builder.setEnv(env);
         
         return builder.build();
     }
@@ -910,6 +914,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setFieldsToAggregate(fieldsToAggregate);
         builder.setDatatypeFilter(datatypeFilter);
         builder.setKeyTransform(fiAggregator);
+        builder.setEnv(env);
         
         node.childrenAccept(this, builder);
         
@@ -1325,6 +1330,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setCollectTimingDetails(collectTimingDetails);
         builder.setQuerySpanCollector(querySpanCollector);
         builder.setSortedUIDs(sortedUIDs);
+        builder.setEnv(env);
         
         // We have no parent already defined
         if (data == null) {

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -6,11 +6,14 @@ import datawave.query.attributes.Document;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.predicate.EventDataQueryFilter;
 import datawave.query.util.TypeMetadata;
+
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
 import org.junit.Before;
@@ -116,6 +119,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         typeMetadata.put("INDEX_ONLY_FIELD3", DEFAULT_DATATYPE, "datawave.data.type.LcNoDiacriticsType");
         
         environment = createMock(IteratorEnvironment.class);
+        EasyMock.expect(environment.getConfig()).andReturn(DefaultConfiguration.getInstance()).anyTimes();
         filter = createMock(EventDataQueryFilter.class);
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
@@ -14,6 +14,7 @@ import org.apache.accumulo.core.client.impl.BaseIteratorEnvironment;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.commons.jexl2.parser.ASTERNode;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
@@ -399,7 +400,8 @@ public class IteratorBuildingVisitorTest {
         TypeMetadata typeMetadata = new TypeMetadata();
         
         Iterator<Map.Entry<Key,Value>> iterator = source.iterator();
-        visitor.setSource(new SourceFactory(iterator), new BaseIteratorEnvironment());
+        IteratorEnvironment env = new BaseIteratorEnvironment();
+        visitor.setSource(new SourceFactory(iterator), env);
         
         // configure the visitor for use
         visitor.setTermFrequencyFields(termFrequencyFields);
@@ -412,7 +414,7 @@ public class IteratorBuildingVisitorTest {
         query.jjtAccept(visitor, null);
         NestedIterator result = visitor.root();
         Assert.assertTrue(result != null);
-        SeekableNestedIterator seekableNestedIterator = new SeekableNestedIterator(result);
+        SeekableNestedIterator seekableNestedIterator = new SeekableNestedIterator(result, env);
         seekableNestedIterator.seek(docRange, null, true);
         seekableNestedIterator.initialize();
         


### PR DESCRIPTION
* Pass IteratorEnvironment to the thread pool manager, allowing removal
of ServerConfigurationFactory and HdfsZooInstance in support of #533
* Added IteratorEnvironment to NestedIterator and many places in builders
* Removed unused threadpool objects in IteratorThreadPoolManager