### PR TITLE
fixes #550: Unique and Groupby functions should work with fields starting with $

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -17,6 +17,7 @@ import datawave.query.QueryParameters;
 import datawave.query.UnindexType;
 import datawave.query.function.DocumentPermutation;
 import datawave.query.iterator.QueryIterator;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.model.QueryModel;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tld.TLDQueryIterator;
@@ -43,6 +44,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * <p>
@@ -708,12 +710,16 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         return StringUtils.join(this.getDatatypeFilter(), Constants.PARAM_VALUE_SEP);
     }
     
+    private Set<String> deconstruct(Collection<String> fields) {
+        return fields.stream().map(field -> JexlASTHelper.deconstructIdentifier(field)).collect(Collectors.toSet());
+    }
+    
     public Set<String> getProjectFields() {
         return projectFields;
     }
     
     public void setProjectFields(Set<String> projectFields) {
-        this.projectFields = projectFields;
+        this.projectFields = deconstruct(projectFields);
     }
     
     public String getProjectFieldsAsString() {
@@ -725,7 +731,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     }
     
     public void setBlacklistedFields(Set<String> blacklistedFields) {
-        this.blacklistedFields = blacklistedFields;
+        this.blacklistedFields = deconstruct(blacklistedFields);
     }
     
     public String getBlacklistedFieldsAsString() {
@@ -943,7 +949,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         if (null == unevaluatedFields) {
             this.unevaluatedFields = new HashSet<>();
         } else {
-            this.unevaluatedFields = new HashSet<>(unevaluatedFields);
+            this.unevaluatedFields = deconstruct(unevaluatedFields);
         }
     }
     
@@ -1348,7 +1354,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     }
     
     public void setLimitFields(Set<String> limitFields) {
-        this.limitFields = limitFields;
+        this.limitFields = deconstruct(limitFields);
     }
     
     public String getLimitFieldsAsString() {
@@ -1400,7 +1406,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     }
     
     public void setGroupFields(Set<String> groupFields) {
-        this.groupFields = groupFields;
+        this.groupFields = deconstruct(groupFields);
     }
     
     public String getGroupFieldsAsString() {
@@ -1424,7 +1430,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     }
     
     public void setUniqueFields(Set<String> uniqueFields) {
-        this.uniqueFields = uniqueFields;
+        this.uniqueFields = deconstruct(uniqueFields);
     }
     
     public String getUniqueFieldsAsString() {
@@ -1704,7 +1710,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     }
     
     public void setQueryTermFrequencyFields(Set<String> queryTermFrequencyFields) {
-        this.queryTermFrequencyFields = queryTermFrequencyFields;
+        this.queryTermFrequencyFields = deconstruct(queryTermFrequencyFields);
     }
     
     public boolean isTermFrequenciesRequired() {

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
@@ -10,6 +10,7 @@ import datawave.marking.MarkingFunctions;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.TypeAttribute;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.model.QueryModel;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.webservice.query.Query;
@@ -116,7 +117,7 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
      * @param groupFieldsSet
      */
     public GroupingTransform(BaseQueryLogic<Entry<Key,Value>> logic, Collection<String> groupFieldsSet) {
-        this.groupFieldsSet = new HashSet<>(groupFieldsSet);
+        this.groupFieldsSet = deconstruct(groupFieldsSet);
         if (logic != null) {
             QueryModel model = ((ShardQueryLogic) logic).getQueryModel();
             if (model != null) {
@@ -124,6 +125,10 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
             }
         }
         log.trace("groupFieldsSet: {}", this.groupFieldsSet);
+    }
+    
+    private Set<String> deconstruct(Collection<String> fields) {
+        return fields.stream().map(field -> JexlASTHelper.deconstructIdentifier(field)).collect(Collectors.toSet());
     }
     
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
@@ -223,13 +223,13 @@ public abstract class UniqueTest {
         
         Set<Set<String>> expected = new HashSet<>();
         expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        extraParameters.put("unique.fields", "DEATH_DATE,MAGIC");
+        extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
         runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
         
         expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
         expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
         expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        extraParameters.put("unique.fields", "DEATH_DATE,BIRTH_DATE");
+        extraParameters.put("unique.fields", "$DEATH_DATE,BIRTH_DATE");
         runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
     }
     
@@ -241,12 +241,12 @@ public abstract class UniqueTest {
         Date startDate = format.parse("20091231");
         Date endDate = format.parse("20150101");
         
-        String queryString = "UUID =~ '^[CS].*' && f:unique(DEATH_DATE,MAGIC)";
+        String queryString = "UUID =~ '^[CS].*' && f:unique($DEATH_DATE,MAGIC)";
         Set<Set<String>> expected = new HashSet<>();
         expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
         runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
         
-        queryString = "UUID =~ '^[CS].*' && f:unique('DEATH_DATE','BIRTH_DATE')";
+        queryString = "UUID =~ '^[CS].*' && f:unique('DEATH_DATE','$BIRTH_DATE')";
         expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
         expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
         expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
@@ -262,12 +262,12 @@ public abstract class UniqueTest {
         Date startDate = format.parse("20091231");
         Date endDate = format.parse("20150101");
         
-        String queryString = "UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,MAGIC)";
+        String queryString = "UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,$MAGIC)";
         Set<Set<String>> expected = new HashSet<>();
         expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
         runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
         
-        queryString = "UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,BIRTH_DATE)";
+        queryString = "UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,$BIRTH_DATE)";
         expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
         expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
         expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -256,7 +256,7 @@ public abstract class GroupingTest {
                 .build();
         // @formatter:on
         
-        extraParameters.put("group.fields", "AGE,GENDER");
+        extraParameters.put("group.fields", "AGE,$GENDER");
         extraParameters.put("group.fields.batch.size", "6");
         
         List<List<EventBase>> responseEvents = new ArrayList<>();
@@ -377,7 +377,7 @@ public abstract class GroupingTest {
         Date startDate = format.parse("20091231");
         Date endDate = format.parse("20150101");
         
-        String queryString = "UUID =~ '^[CS].*' && f:groupby('AGE','GENDER')";
+        String queryString = "UUID =~ '^[CS].*' && f:groupby('$AGE','GENDER')";
         
         // @formatter:off
         Map<String,Integer> expectedMap = ImmutableMap.<String,Integer> builder()
@@ -408,7 +408,7 @@ public abstract class GroupingTest {
         Date startDate = format.parse("20091231");
         Date endDate = format.parse("20150101");
         
-        String queryString = "(UUID:C* or UUID:S* ) and #GROUPBY('AGE','GENDER')";
+        String queryString = "(UUID:C* or UUID:S* ) and #GROUPBY('AGE','$GENDER')";
         
         // @formatter:off
         Map<String,Integer> expectedMap = ImmutableMap.<String,Integer> builder()

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
@@ -12,6 +12,7 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Attributes;
 import datawave.query.attributes.DiacriticContent;
 import datawave.query.attributes.Document;
+import datawave.query.jexl.JexlASTHelper;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.collections4.Transformer;
@@ -28,6 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 public class UniqueTransformTest {
     private static final Logger log = Logger.getLogger(UniqueTransformTest.class);
@@ -71,6 +74,9 @@ public class UniqueTransformTest {
     
     private String createAttributeName(Random random, int index, boolean withGroups) {
         StringBuilder sb = new StringBuilder();
+        if (random.nextBoolean()) {
+            sb.append(JexlASTHelper.IDENTIFIER_PREFIX);
+        }
         sb.append("Attr").append(index);
         if (withGroups && random.nextBoolean()) {
             sb.append('.').append(random.nextInt(2)).append('.').append(random.nextInt(2));
@@ -170,6 +176,7 @@ public class UniqueTransformTest {
             return Maps.immutableEntry(d.getMetadata(), d);
         };
         TransformIterator inputIterator = new TransformIterator(input.iterator(), docToEntry);
+        fields = fields.stream().map(field -> (random.nextBoolean() ? '$' + field : field)).collect(Collectors.toSet());
         UniqueTransform transform = new UniqueTransform(fields);
         Iterator iter = Iterators.transform(inputIterator, transform);
         


### PR DESCRIPTION
* Updated to ensure that field lists can handle users's entering '$' prefixes on fields.