### PR TITLE
Fixes #556 - Age-off filter event data exclusion

### DIFF
--- a/warehouse/core/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
@@ -53,4 +53,9 @@ public class AgeOffConfigParams {
      * A flag that indicates that the table being aged off is an index table
      */
     public static final String IS_INDEX_TABLE = "isindextable";
+    
+    /**
+     * Exclude schema components from age-off
+     */
+    public static final String EXCLUDE_DATA = "excludeData";
 }


### PR DESCRIPTION
Implements ability to exclude event data from a field age-off rule.

Specify the following to enable capability on a rule:
```
excludeData=event
```