### PR TITLE
Re #559 Track active queries in the QueryIterator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <version.commons-pool>1.6</version.commons-pool>
         <version.curator>2.13.0</version.curator>
         <version.deltaspike>1.9.0</version.deltaspike>
-        <version.dropwizard-metrics>1.6.0</version.dropwizard-metrics>
         <version.easymock>4.0.2</version.easymock>
         <version.geoserver>2.14.2</version.geoserver>
         <version.geotools>20.1</version.geotools>
@@ -76,6 +75,7 @@
         <version.log4j>1.2.16</version.log4j>
         <version.log4j-extras>1.0</version.log4j-extras>
         <version.lucene>7.5.0</version.lucene>
+        <version.metrics-cdi>1.6.0</version.metrics-cdi>
         <version.microservice.accumulo-api>1.1</version.microservice.accumulo-api>
         <version.microservice.accumulo-utils>1.3</version.microservice.accumulo-utils>
         <version.microservice.audit-api>1.4</version.microservice.audit-api>
@@ -336,7 +336,7 @@
             <dependency>
                 <groupId>io.astefanutti.metrics.cdi</groupId>
                 <artifactId>metrics-cdi</artifactId>
-                <version>${version.dropwizard-metrics}</version>
+                <version>${version.metrics-cdi}</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>

--- a/services/spring-boot-starter-datawave/pom.xml
+++ b/services/spring-boot-starter-datawave/pom.xml
@@ -11,7 +11,6 @@
     <version>1.6-SNAPSHOT</version>
     <properties>
         <version.accumulo>1.9.2</version.accumulo>
-        <version.dropwizard-metrics>3.1.5</version.dropwizard-metrics>
         <version.in-memory-accumulo>1.9.2.1</version.in-memory-accumulo>
         <version.jackson>2.9.6</version.jackson>
         <version.jzlib>1.1.3</version.jzlib>

--- a/warehouse/assemble/datawave/pom.xml
+++ b/warehouse/assemble/datawave/pom.xml
@@ -112,6 +112,10 @@
             <artifactId>datawave-ws-query</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>

--- a/warehouse/assemble/datawave/src/main/assembly/dist.xml
+++ b/warehouse/assemble/datawave/src/main/assembly/dist.xml
@@ -116,6 +116,7 @@
                 <include>gov.nsa.datawave.webservices:datawave-ws-common-util</include>
                 <include>gov.nsa.datawave.webservices:datawave-ws-client</include>
                 <include>gov.nsa.datawave.webservices:datawave-ws-query</include>
+                <include>io.dropwizard.metrics:metrics-core</include>
                 <include>org.javatuples:javatuples</include>
                 <include>com.google.code.gson:gson</include>
                 <include>org.apache.lucene:lucene-core</include>

--- a/warehouse/pom.xml
+++ b/warehouse/pom.xml
@@ -45,6 +45,7 @@
         <tests.to.skip />
         <!-- default value - override on command-line to skip tests -->
         <version.basis-rlp>7.5.0</version.basis-rlp>
+        <version.dropwizard-metrics>3.2.6</version.dropwizard-metrics>
         <version.hadoop.processors>2.2.3</version.hadoop.processors>
         <version.hamcrest>1.3</version.hamcrest>
     </properties>
@@ -191,6 +192,11 @@
                 <groupId>gov.nsa.datawave.webservices</groupId>
                 <artifactId>datawave-ws-query</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${version.dropwizard-metrics}</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.json-lib</groupId>

--- a/warehouse/query-core/pom.xml
+++ b/warehouse/query-core/pom.xml
@@ -80,6 +80,10 @@
             <type>ejb</type>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
         </dependency>

--- a/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuery.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuery.java
@@ -5,6 +5,8 @@ import com.codahale.metrics.Timer;
 import datawave.query.attributes.Document;
 import datawave.query.iterator.profile.QuerySpan;
 import org.apache.accumulo.core.data.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -13,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class ActiveQuery {
+    
+    private static Logger LOG = LoggerFactory.getLogger(ActiveQuery.class);
     
     private String queryId = null;
     private long initTs = 0;
@@ -70,10 +74,14 @@ public class ActiveQuery {
     }
     
     synchronized public void recordStats(Document document, QuerySpan querySpan) {
-        this.documentSizeBytes = document.sizeInBytes();
-        this.lastSourceCount = querySpan.getSourceCount();
-        this.lastSeekCount = querySpan.getSeekCount();
-        this.lastNextCount = querySpan.getNextCount();
+        if (document != null) {
+            this.documentSizeBytes = document.sizeInBytes();
+        }
+        if (querySpan != null) {
+            this.lastSourceCount = querySpan.getSourceCount();
+            this.lastSeekCount = querySpan.getSeekCount();
+            this.lastNextCount = querySpan.getNextCount();
+        }
     }
     
     synchronized public int removeRange(Range range) {
@@ -128,6 +136,7 @@ public class ActiveQuery {
             newNumCalls = numCalls.intValue() - 1;
         }
         if (newNumCalls < 0) {
+            LOG.info("inCall count for callType:" + type.toString() + "=" + newNumCalls + ", resetting to 0");
             newNumCalls = 0;
         }
         this.inCallMap.put(type, newNumCalls);

--- a/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuery.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuery.java
@@ -1,0 +1,154 @@
+package datawave.query.tracking;
+
+import com.codahale.metrics.SlidingWindowReservoir;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import datawave.query.attributes.Document;
+import datawave.query.iterator.profile.QuerySpan;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public class ActiveQuery {
+    
+    private String queryId = null;
+    private long initTs = 0;
+    private QuerySpan lastQuerySpan = null;
+    private long documentSizeBytes = 0;
+    private int windowSize = 0;
+    
+    public enum CallType {
+        SEEK, NEXT
+    };
+    
+    private Map<CallType,Long> startTimeMap = new HashMap<>();
+    private Map<CallType,Timer> timerMap = new HashMap<>();
+    private Map<CallType,Long> numCallsMap = new HashMap<>();
+    private Map<CallType,Boolean> inCallMap = new HashMap<>();
+    
+    public ActiveQuery(String queryId, int windowSize) {
+        this.queryId = queryId;
+        this.windowSize = windowSize;
+        this.initTs = System.currentTimeMillis();
+    }
+    
+    public long getNumCalls(CallType type) {
+        Long val = this.numCallsMap.get(type);
+        if (val == null) {
+            val = 0l;
+            this.numCallsMap.put(type, val);
+        }
+        return val;
+    }
+    
+    public void beginCall(CallType type) {
+        this.startTimeMap.put(type, System.currentTimeMillis());
+        setInCall(type, true);
+    }
+    
+    public void endCall(CallType type) {
+        Long val = getNumCalls(type);
+        this.numCallsMap.put(type, (val.longValue() + 1));
+        
+        Long start = this.startTimeMap.get(type);
+        if (start != null) {
+            getTimer(type).update(System.currentTimeMillis() - start, TimeUnit.MILLISECONDS);
+            this.startTimeMap.remove(type);
+            setInCall(type, false);
+        }
+    }
+    
+    public void recordStats(Document document, QuerySpan querySpan) {
+        this.documentSizeBytes = document.sizeInBytes();
+        this.lastQuerySpan = querySpan;
+    }
+    
+    public long totalElapsedTime() {
+        return System.currentTimeMillis() - this.initTs;
+    }
+    
+    public boolean isInCall() {
+        return this.inCallMap.values().stream().anyMatch(Predicate.isEqual(Boolean.TRUE));
+    }
+    
+    public String getQueryId() {
+        return queryId;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[").append(this.queryId).append("] ");
+        if (isInCall()) {
+            sb.append("(tot/cur) ").append(totalElapsedTime()).append("/").append(currentCallTime()).append(" ");
+        } else {
+            sb.append("(tot) ").append(totalElapsedTime()).append(" ");
+        }
+        sb.append("(call num/max/avg/min) ");
+        for (CallType type : CallType.values()) {
+            String t = type.toString().toLowerCase();
+            Snapshot s = getTimer(type).getSnapshot();
+            sb.append(t).append("=");
+            sb.append(getNumCalls(type)).append("/").append(s.getMax() / 1000000).append("/").append(Math.round(s.getMean()) / 1000000).append("/")
+                            .append(s.getMin() / 1000000).append(" ");
+        }
+        
+        if (this.documentSizeBytes != 0 && this.lastQuerySpan != null) {
+            sb.append("(lastDoc bytes/sources/seek/next) ");
+            sb.append(this.documentSizeBytes).append("/");
+            sb.append(lastSourceCount()).append("/");
+            sb.append(lastSeekCount()).append("/");
+            sb.append(lastNextCount());
+        }
+        return sb.toString();
+    }
+    
+    private Timer getTimer(CallType type) {
+        Timer t = timerMap.get(type);
+        if (t == null) {
+            t = new Timer(new SlidingWindowReservoir(this.windowSize));
+            this.timerMap.put(type, t);
+        }
+        return t;
+    }
+    
+    private long lastSourceCount() {
+        if (this.lastQuerySpan == null) {
+            return 0;
+        } else {
+            return lastQuerySpan.getSourceCount();
+        }
+    }
+    
+    private long lastNextCount() {
+        if (this.lastQuerySpan == null) {
+            return 0;
+        } else {
+            return lastQuerySpan.getNextCount();
+        }
+    }
+    
+    private long lastSeekCount() {
+        if (this.lastQuerySpan == null) {
+            return 0;
+        } else {
+            return lastQuerySpan.getSeekCount();
+        }
+    }
+    
+    private long currentCallTime() {
+        if (this.inCallMap.values().stream().anyMatch(Predicate.isEqual(Boolean.TRUE))) {
+            long now = System.currentTimeMillis();
+            long startTime = this.startTimeMap.values().stream().mapToLong(v -> v).min().orElse(now);
+            return now - startTime;
+        } else {
+            return 0;
+        }
+    }
+    
+    private void setInCall(CallType type, boolean inCall) {
+        this.inCallMap.put(type, inCall);
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuery.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuery.java
@@ -136,7 +136,7 @@ public class ActiveQuery {
             newNumCalls = numCalls.intValue() - 1;
         }
         if (newNumCalls < 0) {
-            LOG.info("inCall count for callType:" + type.toString() + "=" + newNumCalls + ", resetting to 0");
+            LOG.warn("inCall count for callType:" + type.toString() + "=" + newNumCalls + ", resetting to 0");
             newNumCalls = 0;
         }
         this.inCallMap.put(type, newNumCalls);

--- a/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQueryLog.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQueryLog.java
@@ -1,0 +1,167 @@
+package datawave.query.tracking;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+
+public class ActiveQueryLog {
+    
+    private static Logger LOG = LoggerFactory.getLogger(ActiveQueryLog.class);
+    private static ActiveQueryLog instance = null;
+    private static AccumuloConfiguration conf = null;
+    
+    // Accumulo properties
+    public static final String MAX_IDLE = "datawave.query.active.maxIdle";
+    public static final String LOG_PERIOD = "datawave.query.active.logPeriod";
+    public static final String WINDOW_SIZE = "datawave.query.active.windowSize";
+    
+    // Changeable via Accumulo properties
+    private long maxIdle = 900000l;
+    private long logPeriod = 60000l;
+    private int windowSize = 10;
+    
+    private Cache<String,ActiveQuery> CACHE = null;
+    private Timer timer = new Timer("ActiveQueryLog");
+    
+    synchronized public static void setConfig(AccumuloConfiguration conf) {
+        if (conf != null) {
+            if (ActiveQueryLog.conf == null || conf.getUpdateCount() > ActiveQueryLog.conf.getUpdateCount()) {
+                ActiveQueryLog.getInstance().checkSettings(conf, false);
+                ActiveQueryLog.conf = conf;
+            }
+        }
+    }
+    
+    public static ActiveQueryLog getInstance() {
+        
+        if (ActiveQueryLog.instance == null) {
+            synchronized (ActiveQueryLog.class) {
+                if (ActiveQueryLog.instance == null) {
+                    ActiveQueryLog.instance = new ActiveQueryLog(conf);
+                }
+            }
+        }
+        return ActiveQueryLog.instance;
+    }
+    
+    private ActiveQueryLog(AccumuloConfiguration conf) {
+        if (conf != null) {
+            checkSettings(conf, true);
+        } else {
+            // use the default values
+            setLogPeriod(this.logPeriod);
+            setMaxIdle(this.maxIdle);
+        }
+    }
+    
+    public void setLogPeriod(long logPeriod) {
+        if (logPeriod > 0) {
+            if (logPeriod != this.logPeriod || this.timer == null) {
+                if (this.timer != null) {
+                    this.timer.cancel();
+                    this.timer = new Timer("ActiveQueryLog");
+                }
+                this.logPeriod = logPeriod;
+                this.timer.schedule(new ActiveQueryTimerTask(), this.logPeriod, this.logPeriod);
+            }
+        } else {
+            LOG.error("Bad value: (" + logPeriod + ") for logPeriod");
+        }
+        
+    }
+    
+    public void setWindowSize(int windowSize) {
+        if (windowSize > 0) {
+            this.windowSize = windowSize;
+        } else {
+            LOG.error("Bad value: (" + windowSize + ") for windowSize");
+        }
+    }
+    
+    public void setMaxIdle(long maxIdle) {
+        if (this.maxIdle != maxIdle || this.CACHE == null) {
+            if (maxIdle > 0) {
+                Cache<String,ActiveQuery> newCache = setupCache(maxIdle);
+                if (this.CACHE == null) {
+                    this.CACHE = newCache;
+                } else {
+                    synchronized (this) {
+                        Cache<String,ActiveQuery> oldCache = this.CACHE;
+                        this.CACHE = newCache;
+                        this.CACHE.putAll(oldCache.asMap());
+                    }
+                }
+            } else {
+                LOG.error("Bad value: (" + maxIdle + ") for maxIdle");
+            }
+        }
+    }
+    
+    private void checkSettings(AccumuloConfiguration conf, boolean useDefaults) {
+        
+        String maxIdleStr = conf.get(MAX_IDLE);
+        if (maxIdleStr != null) {
+            try {
+                setMaxIdle(Long.valueOf(maxIdleStr));
+            } catch (NumberFormatException e) {
+                LOG.error("Bad value: (" + maxIdleStr + ") in " + MAX_IDLE + " : " + e.getMessage());
+            }
+        } else if (useDefaults) {
+            setMaxIdle(this.maxIdle);
+        }
+        
+        String logPeriodStr = conf.get(LOG_PERIOD);
+        if (logPeriodStr != null) {
+            try {
+                setLogPeriod(Long.valueOf(logPeriodStr));
+            } catch (NumberFormatException e) {
+                LOG.error("Bad value: (" + logPeriodStr + ") in " + LOG_PERIOD + " : " + e.getMessage());
+            }
+        } else if (useDefaults) {
+            setLogPeriod(this.logPeriod);
+        }
+        
+        String windowSizeStr = conf.get(WINDOW_SIZE);
+        if (windowSizeStr != null) {
+            try {
+                setWindowSize(Integer.valueOf(windowSizeStr));
+            } catch (NumberFormatException e) {
+                LOG.error("Bad value: (" + windowSizeStr + ") in " + WINDOW_SIZE + " : " + e.getMessage());
+            }
+        }
+    }
+    
+    private Cache<String,ActiveQuery> setupCache(long maxIdle) {
+        Caffeine<Object,Object> caffeine = Caffeine.newBuilder();
+        caffeine.expireAfterAccess(maxIdle, TimeUnit.MILLISECONDS);
+        Cache<String,ActiveQuery> cache = caffeine.build();
+        return cache;
+    }
+    
+    synchronized public void remove(String queryId) {
+        this.CACHE.invalidate(queryId);
+    }
+    
+    synchronized public ActiveQuery get(String queryId) {
+        return this.CACHE.get(queryId, s -> new ActiveQuery(queryId, this.windowSize));
+    }
+    
+    class ActiveQueryTimerTask extends TimerTask {
+        @Override
+        public void run() {
+            synchronized (this) {
+                for (ActiveQuery q : CACHE.asMap().values()) {
+                    if (q.isInCall()) {
+                        LOG.debug(q.toString());
+                    }
+                }
+            }
+        }
+    };
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuerySnapshot.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQuerySnapshot.java
@@ -1,0 +1,92 @@
+package datawave.query.tracking;
+
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ActiveQuerySnapshot {
+    
+    public static Comparator<ActiveQuerySnapshot> greatestElapsedTime = Comparator.comparingLong(ActiveQuerySnapshot::totalElapsedTime).reversed();
+    
+    private final String queryId;
+    private final long lastSourceCount;
+    private final long lastNextCount;
+    private final long lastSeekCount;
+    private final long documentSizeBytes;
+    
+    private final long totalElapsedTime;
+    private final long currentCallTime;
+    private final boolean isInCall;
+    private final int numActiveRanges;
+    
+    private final Map<ActiveQuery.CallType,Long> numCallsMap = new HashMap<>();
+    private final Map<ActiveQuery.CallType,Snapshot> snapshotMap = new HashMap<>();
+    
+    public ActiveQuerySnapshot(String queryId, long lastSourceCount, long lastNextCount, long lastSeekCount, long documentSizeBytes, int numActiveRanges,
+                    long totalElapsedTime, boolean isInCall, long currentCallTime, Map<ActiveQuery.CallType,Long> numCallsMap,
+                    Map<ActiveQuery.CallType,Timer> timerMap) {
+        
+        this.queryId = queryId;
+        this.lastSourceCount = lastSourceCount;
+        this.lastNextCount = lastNextCount;
+        this.lastSeekCount = lastSeekCount;
+        this.documentSizeBytes = documentSizeBytes;
+        this.numActiveRanges = numActiveRanges;
+        
+        this.totalElapsedTime = totalElapsedTime;
+        this.currentCallTime = currentCallTime;
+        this.isInCall = isInCall;
+        for (Map.Entry<ActiveQuery.CallType,Long> entry : numCallsMap.entrySet()) {
+            this.numCallsMap.put(entry.getKey(), entry.getValue().longValue());
+        }
+        for (Map.Entry<ActiveQuery.CallType,Timer> entry : timerMap.entrySet()) {
+            this.snapshotMap.put(entry.getKey(), entry.getValue().getSnapshot());
+        }
+    }
+    
+    public long getNumCalls(ActiveQuery.CallType type) {
+        if (this.numCallsMap.containsKey(type)) {
+            return this.numCallsMap.get(type);
+        } else {
+            return 0;
+        }
+    }
+    
+    public long totalElapsedTime() {
+        return totalElapsedTime;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[").append(this.queryId).append("] ");
+        sb.append("ranges=").append(this.numActiveRanges).append(" ");
+        if (this.isInCall) {
+            sb.append("(tot/cur) ").append(this.totalElapsedTime).append("/").append(this.currentCallTime).append(" ");
+        } else {
+            sb.append("(tot) ").append(this.totalElapsedTime).append(" ");
+        }
+        sb.append("(call num/max/avg/min) ");
+        for (ActiveQuery.CallType type : ActiveQuery.CallType.values()) {
+            String t = type.toString().toLowerCase();
+            Snapshot s = this.snapshotMap.get(type);
+            if (s != null) {
+                sb.append(t).append("=");
+                sb.append(getNumCalls(type)).append("/").append(s.getMax() / 1000000).append("/").append(Math.round(s.getMean()) / 1000000).append("/")
+                                .append(s.getMin() / 1000000).append(" ");
+            }
+        }
+        
+        if (this.documentSizeBytes > 0) {
+            sb.append("(lastDoc bytes/sources/seek/next) ");
+            sb.append(this.documentSizeBytes).append("/");
+            sb.append(this.lastSourceCount).append("/");
+            sb.append(this.lastSeekCount).append("/");
+            sb.append(this.lastNextCount);
+        }
+        return sb.toString();
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -6,11 +6,13 @@ import datawave.query.attributes.Document;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.predicate.EventDataQueryFilter;
 import datawave.query.util.TypeMetadata;
+import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
 import org.junit.Before;
@@ -116,6 +118,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         typeMetadata.put("INDEX_ONLY_FIELD3", DEFAULT_DATATYPE, "datawave.data.type.LcNoDiacriticsType");
         
         environment = createMock(IteratorEnvironment.class);
+        EasyMock.expect(environment.getConfig()).andReturn(new DefaultConfiguration());
         filter = createMock(EventDataQueryFilter.class);
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/tracking/ActiveQueryLogTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tracking/ActiveQueryLogTest.java
@@ -1,0 +1,106 @@
+package datawave.query.tracking;
+
+import datawave.query.attributes.Document;
+import datawave.query.attributes.PreNormalizedAttribute;
+import datawave.query.iterator.profile.QuerySpan;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ActiveQueryLogTest {
+    
+    private static Random rand = new Random();
+    
+    private static String createQueryId() {
+        return (RandomStringUtils.randomAlphanumeric(5) + "-" + RandomStringUtils.randomAlphanumeric(5) + "-" + RandomStringUtils.randomAlphanumeric(5) + "-" + RandomStringUtils
+                        .randomAlphanumeric(5)).toUpperCase();
+    }
+    
+    private static long createRandomDelay() {
+        return rand.nextInt(3) + 1;
+    }
+    
+    public class QueryTask implements Runnable {
+        private String queryId;
+        private int numSeeks;
+        private int numNexts;
+        private boolean randomSleep;
+        
+        public QueryTask(String queryId, int numSeeks, int numNexts, boolean randomSleep) {
+            this.queryId = queryId;
+            this.numSeeks = numSeeks;
+            this.numNexts = numNexts;
+            this.randomSleep = randomSleep;
+        }
+        
+        public void run() {
+            try {
+                QuerySpan qs = new QuerySpan(null);
+                for (int seek = 0; seek < numSeeks; seek++) {
+                    ActiveQueryLog.getInstance().get(queryId).beginCall(ActiveQuery.CallType.SEEK);
+                    if (randomSleep) {
+                        TimeUnit.SECONDS.sleep(createRandomDelay());
+                    }
+                    ActiveQueryLog.getInstance().get(queryId).endCall(ActiveQuery.CallType.SEEK);
+                    qs.seek();
+                    qs.seek();
+                }
+                
+                for (int next = 0; next < numNexts; next++) {
+                    ActiveQueryLog.getInstance().get(queryId).beginCall(ActiveQuery.CallType.NEXT);
+                    if (randomSleep) {
+                        TimeUnit.SECONDS.sleep(createRandomDelay());
+                    }
+                    ActiveQueryLog.getInstance().get(queryId).endCall(ActiveQuery.CallType.NEXT);
+                    qs.next();
+                    qs.next();
+                }
+                Document d = new Document();
+                d.put("TEST1", new PreNormalizedAttribute("value", null, true));
+                d.put("TEST2", new PreNormalizedAttribute("value", null, true));
+                ActiveQueryLog.getInstance().get(queryId).recordStats(d, qs);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+    
+    @Test
+    public void testThreadSafety() {
+        
+        int numQueries = 20;
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(numQueries);
+        
+        Map<String,QueryTask> tasks = new HashMap<>();
+        for (int i = 1; i <= numQueries; i++) {
+            String queryId = createQueryId();
+            int numSeeks = rand.nextInt(5) + 1;
+            int numNexts = rand.nextInt(20) + 1;
+            QueryTask task = new QueryTask(queryId, numSeeks, numNexts, false);
+            tasks.put(queryId, task);
+            executor.execute(task);
+        }
+        executor.shutdown();
+        while (executor.getCompletedTaskCount() < numQueries) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(50);
+            } catch (InterruptedException e) {
+                
+            }
+        }
+        
+        for (Map.Entry<String,QueryTask> e : tasks.entrySet()) {
+            ActiveQuery activeQuery = ActiveQueryLog.getInstance().get(e.getKey());
+            QueryTask queryTask = e.getValue();
+            Assert.assertEquals(queryTask.numSeeks, activeQuery.getNumCalls(ActiveQuery.CallType.SEEK));
+            Assert.assertEquals(queryTask.numNexts, activeQuery.getNumCalls(ActiveQuery.CallType.NEXT));
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tracking/ActiveQueryLogTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tracking/ActiveQueryLogTest.java
@@ -99,9 +99,9 @@ public class ActiveQueryLogTest {
         Logger.getLogger(ActiveQueryLog.class).setLevel(Level.DEBUG);
         Logger.getLogger(ActiveQueryLog.class).addAppender(new ConsoleAppender());
         
-        ActiveQueryLog.getInstance().setLogPeriod(1000);
+        ActiveQueryLog.getInstance().setLogPeriod(2000);
         
-        int numQueries = 50;
+        int numQueries = 10;
         ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(numQueries);
         
         Map<String,QueryTask> tasks = new HashMap<>();
@@ -109,7 +109,7 @@ public class ActiveQueryLogTest {
             String queryId = createQueryId();
             int numSeeks = rand.nextInt(5) + 1;
             int numNexts = rand.nextInt(20) + 1;
-            QueryTask task = new QueryTask(queryId, numSeeks, numNexts, true);
+            QueryTask task = new QueryTask(queryId, numSeeks, numNexts, false);
             tasks.put(queryId, task);
             executor.execute(task);
         }
@@ -125,8 +125,9 @@ public class ActiveQueryLogTest {
         for (Map.Entry<String,QueryTask> e : tasks.entrySet()) {
             ActiveQuery activeQuery = ActiveQueryLog.getInstance().get(e.getKey());
             QueryTask queryTask = e.getValue();
-            Assert.assertEquals(queryTask.numSeeks, activeQuery.getNumCalls(ActiveQuery.CallType.SEEK));
-            Assert.assertEquals(queryTask.numNexts, activeQuery.getNumCalls(ActiveQuery.CallType.NEXT));
+            ActiveQuerySnapshot snapshot = activeQuery.snapshot();
+            Assert.assertEquals(queryTask.numSeeks, snapshot.getNumCalls(ActiveQuery.CallType.SEEK));
+            Assert.assertEquals(queryTask.numNexts, snapshot.getNumCalls(ActiveQuery.CallType.NEXT));
         }
     }
 }


### PR DESCRIPTION
We want a way to see in the logs which queries are putting a load on a specific tserver.

Example logging output:

[GAPZW-47TWB-TUDP7-W7JHA] (tot/cur) 4123/3130 (call num/max/avg/min) seek=2/6/4/3 next=11/1/0/0 (lastDoc bytes/sources/seek/next) 352/1/4/22

The frame of reference is successive seek and next calls on a specific tserver for the same queryId
[query_id] 
total_call_time/current_call_time 
numSeeks/maxMsec/avgMsec/minMsec 
numNexts/maxMsec/avgMsec/minMsec lastDocReturnedSizeButes/numSources/numSourceSeeks/numSourceNexts

- Query records that have not been accessed in maxIdle time will be dropped (configurable)
- The timer in ActiveQueryLog will print this message at the DEBUG level for each query that is in a call (seek or next) at a configurable period.
- The max/avg/min calculations for seek and next are based on a sliding window of the last N calls.  N defaults to 10 and is configurable via AccumuloConfiguration.

datawave.query.active.maxIdle - default=900000 (15 minutes)
datawave.query.active.logPeriod - default=60000 (1 minute)
datawave.query.active.windowSize - default=10