### PR TITLE
fixes #587: Updated global index lookups to restrict results by fieldname.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/GlobalIndexFieldnameMatchingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/GlobalIndexFieldnameMatchingIterator.java
@@ -1,0 +1,111 @@
+package datawave.core.iterators;
+
+import datawave.core.iterators.filter.GlobalIndexFieldnameMatchingFilter;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+public class GlobalIndexFieldnameMatchingIterator extends GlobalIndexFieldnameMatchingFilter implements SortedKeyValueIterator<Key,Value>, OptionDescriber {
+    
+    private static final Logger log = Logger.getLogger(GlobalIndexFieldnameMatchingIterator.class);
+    
+    private SortedKeyValueIterator<Key,Value> source;
+    
+    private boolean foundMatch = false;
+    
+    public GlobalIndexFieldnameMatchingIterator() throws IOException {}
+    
+    public GlobalIndexFieldnameMatchingIterator deepCopy(IteratorEnvironment env) {
+        return new GlobalIndexFieldnameMatchingIterator(this, env);
+    }
+    
+    private GlobalIndexFieldnameMatchingIterator(GlobalIndexFieldnameMatchingIterator other, IteratorEnvironment env) {
+        setSource(other.getSource().deepCopy(env));
+    }
+    
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        super.init(source, options, env);
+        if (!validateOptions(options))
+            throw new IOException("Iterator options are not correct");
+        setSource(source);
+    }
+    
+    @Override
+    public Key getTopKey() {
+        Key key = null;
+        if (foundMatch) {
+            key = getSource().getTopKey();
+        }
+        return key;
+    }
+    
+    @Override
+    public Value getTopValue() {
+        if (foundMatch) {
+            return getSource().getTopValue();
+        } else {
+            return null;
+        }
+    }
+    
+    @Override
+    public boolean hasTop() {
+        return foundMatch && getSource().hasTop();
+    }
+    
+    @Override
+    public void next() throws IOException {
+        getSource().next();
+        findTopEntry();
+    }
+    
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        getSource().seek(range, columnFamilies, inclusive);
+        findTopEntry();
+    }
+    
+    private void findTopEntry() throws IOException {
+        foundMatch = false;
+        if (log.isTraceEnabled())
+            log.trace("has top ? " + getSource().hasTop());
+        while (!foundMatch && getSource().hasTop()) {
+            Key top = getSource().getTopKey();
+            if (log.isTraceEnabled())
+                log.trace("top key is " + top);
+            if (accept(top, getSource().getTopValue())) {
+                foundMatch = true;
+            } else {
+                getSource().next();
+            }
+        }
+    }
+    
+    protected void setSource(SortedKeyValueIterator<Key,Value> source) {
+        this.source = source;
+    }
+    
+    protected SortedKeyValueIterator<Key,Value> getSource() {
+        return source;
+    }
+    
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions io = super.describeOptions();
+        io.addNamedOption(LITERAL + "i", "A literal fieldname to match");
+        io.addNamedOption(PATTERN + "i", "A regex fieldname to match");
+        io.setDescription("GlobalIndexFieldnameMatchingIterator uses a set of literals and regexs to match global index key fieldnames");
+        return io;
+    }
+    
+}

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/filter/GlobalIndexFieldnameMatchingFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/filter/GlobalIndexFieldnameMatchingFilter.java
@@ -1,0 +1,81 @@
+package datawave.core.iterators.filter;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.Filter;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * The iterator skips entries in the global index for field names not matching one of a set of matching patterns
+ * 
+ */
+public class GlobalIndexFieldnameMatchingFilter extends Filter {
+    
+    protected static final Logger log = Logger.getLogger(GlobalIndexFieldnameMatchingFilter.class);
+    public static final String LITERAL = "fieldname.literal.";
+    public static final String PATTERN = "fieldname.pattern.";
+    private Map<String,Pattern> patterns = new HashMap<>();
+    private Set<String> literals = new HashSet<>();
+    
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        super.init(source, options, env);
+        
+        readOptions(options);
+    }
+    
+    protected void readOptions(Map<String,String> options) {
+        int i = 1;
+        while (options.containsKey(PATTERN + i)) {
+            patterns.put(options.get(PATTERN + i), getPattern(options.get(PATTERN + i)));
+            i++;
+        }
+        i = 1;
+        while (options.containsKey(LITERAL + i)) {
+            literals.add(options.get(LITERAL + i));
+            i++;
+        }
+        if (patterns.isEmpty() && literals.isEmpty()) {
+            throw new IllegalArgumentException("Missing configured patterns for the GlobalIndexFieldnameMatchingFilter: " + options);
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Set the literals to " + literals);
+            log.debug("Set the patterns to " + patterns);
+        }
+    }
+    
+    @Override
+    public boolean accept(Key k, Value v) {
+        // The row is the term
+        return matches(k.getColumnFamily().toString());
+    }
+    
+    private Pattern getPattern(String term) {
+        return Pattern.compile(term);
+    }
+    
+    private boolean matches(String fieldname) {
+        log.trace(fieldname + " -- term");
+        
+        if (literals.contains(fieldname)) {
+            return true;
+        }
+        
+        for (Map.Entry<String,Pattern> entry : patterns.entrySet()) {
+            if (entry.getValue().matcher(fieldname).matches()) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -176,6 +176,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private Set<String> projectFields = Collections.emptySet();
     private Set<String> blacklistedFields = new HashSet<>(0);
     private Set<String> indexedFields = Sets.newHashSet();
+    private Set<String> reverseIndexedFields = Sets.newHashSet();
     private Set<String> normalizedFields = Sets.newHashSet();
     private Multimap<String,Type<?>> dataTypes = HashMultimap.create();
     private Multimap<String,Type<?>> queryFieldsDatatypes = HashMultimap.create();
@@ -384,6 +385,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setProjectFields(null == other.getProjectFields() ? null : Sets.newHashSet(other.getProjectFields()));
         this.setBlacklistedFields(null == other.getBlacklistedFields() ? null : Sets.newHashSet(other.getBlacklistedFields()));
         this.setIndexedFields(null == other.getIndexedFields() ? null : Sets.newHashSet(other.getIndexedFields()));
+        this.setReverseIndexedFields(null == other.getReverseIndexedFields() ? null : Sets.newHashSet(other.getReverseIndexedFields()));
         this.setNormalizedFields(null == other.getNormalizedFields() ? null : Sets.newHashSet(other.getNormalizedFields()));
         this.setDataTypes(null == other.getDataTypes() ? null : HashMultimap.create(other.getDataTypes()));
         this.setQueryFieldsDatatypes(null == other.getQueryFieldsDatatypes() ? null : HashMultimap.create(other.getQueryFieldsDatatypes()));
@@ -1274,6 +1276,23 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     
     public void setIndexedFields(Set<String> indexedFields) {
         this.indexedFields = Sets.newHashSet(indexedFields);
+    }
+    
+    public Set<String> getReverseIndexedFields() {
+        return reverseIndexedFields;
+    }
+    
+    public void setReverseIndexedFields(Multimap<String,Type<?>> reverseIndexedFieldsAndTypes) {
+        this.reverseIndexedFields = Sets.newHashSet(reverseIndexedFieldsAndTypes.keySet());
+        for (Entry<String,Type<?>> entry : reverseIndexedFieldsAndTypes.entries()) {
+            if (entry.getValue() instanceof UnindexType) {
+                this.reverseIndexedFields.remove(entry.getKey());
+            }
+        }
+    }
+    
+    public void setReverseIndexedFields(Set<String> reverseIndexedFields) {
+        this.reverseIndexedFields = Sets.newHashSet(reverseIndexedFields);
     }
     
     public Set<String> getNormalizedFields() {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -223,6 +223,7 @@ public class DefaultQueryPlanner extends QueryPlanner {
     private static Multimap<String,Type<?>> normalizedFieldAsDataTypeMap;
     
     private static Set<String> cachedIndexedFields = null;
+    private static Set<String> cachedReverseIndexedFields = null;
     private static Set<String> cachedNormalizedFields = null;
     
     protected List<PushDownRule> rules = Lists.newArrayList();
@@ -892,6 +893,8 @@ public class DefaultQueryPlanner extends QueryPlanner {
             try {
                 
                 expansionFields = metadataHelper.getExpansionFields(config.getDatatypeFilter());
+                config.setIndexedFields(metadataHelper.getIndexedFields(config.getDatatypeFilter()));
+                config.setReverseIndexedFields(metadataHelper.getReverseIndexedFields(config.getDatatypeFilter()));
                 queryTree = FixUnfieldedTermsVisitor.fixUnfieldedTree(config, scannerFactory, metadataHelper, queryTree, expansionFields,
                                 config.isExpandFields(), config.isExpandValues());
             } catch (EmptyUnfieldedTermExpansionException e) {
@@ -963,18 +966,19 @@ public class DefaultQueryPlanner extends QueryPlanner {
             
         }
         
+        stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Fetch required dataTypes");
         Multimap<String,Type<?>> fieldToDatatypeMap = null;
         if (cacheDataTypes) {
             fieldToDatatypeMap = dataTypeMap.getIfPresent(String.valueOf(config.getDatatypeFilter().hashCode()));
             
         }
-        stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Fetch required dataTypes");
         try {
             if (null != fieldToDatatypeMap) {
                 Set<String> indexedFields = Sets.newHashSet();
+                Set<String> reverseIndexedFields = Sets.newHashSet();
                 Set<String> normalizedFields = Sets.newHashSet();
                 
-                loadDataTypeMetadata(fieldToDatatypeMap, indexedFields, normalizedFields, config, false);
+                loadDataTypeMetadata(fieldToDatatypeMap, indexedFields, reverseIndexedFields, normalizedFields, config, false);
                 
                 if (null == queryFieldsAsDataTypeMap) {
                     queryFieldsAsDataTypeMap = HashMultimap.create(Multimaps.filterKeys(fieldToDatatypeMap, input -> !cachedNormalizedFields.contains(input)));
@@ -985,12 +989,12 @@ public class DefaultQueryPlanner extends QueryPlanner {
                                     .create(Multimaps.filterKeys(fieldToDatatypeMap, input -> cachedNormalizedFields.contains(input)));
                 }
                 
-                setCachedFields(indexedFields, queryFieldsAsDataTypeMap, normalizedFieldAsDataTypeMap, config);
+                setCachedFields(indexedFields, reverseIndexedFields, queryFieldsAsDataTypeMap, normalizedFieldAsDataTypeMap, config);
             } else {
                 fieldToDatatypeMap = configureIndexedAndNormalizedFields(metadataHelper, config, queryTree);
                 
                 if (cacheDataTypes) {
-                    loadDataTypeMetadata(null, null, null, config, true);
+                    loadDataTypeMetadata(null, null, null, null, config, true);
                     
                     dataTypeMap.put(String.valueOf(config.getDatatypeFilter().hashCode()), metadataHelper.getFieldsToDatatypes(config.getDatatypeFilter()));
                 }
@@ -1218,18 +1222,21 @@ public class DefaultQueryPlanner extends QueryPlanner {
      * @throws InstantiationException
      * @throws IllegalAccessException
      */
-    private void loadDataTypeMetadata(Multimap<String,Type<?>> fieldToDatatypeMap, Set<String> indexedFields, Set<String> normalizedFields,
-                    ShardQueryConfiguration config, boolean reload) throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
-                    ExecutionException, InstantiationException, IllegalAccessException {
+    private void loadDataTypeMetadata(Multimap<String,Type<?>> fieldToDatatypeMap, Set<String> indexedFields, Set<String> reverseIndexedFields,
+                    Set<String> normalizedFields, ShardQueryConfiguration config, boolean reload) throws AccumuloException, AccumuloSecurityException,
+                    TableNotFoundException, ExecutionException, InstantiationException, IllegalAccessException {
         synchronized (dataTypeMap) {
-            if (!reload && (null != cachedIndexedFields && null != indexedFields) && (null != cachedNormalizedFields && null != normalizedFields)) {
+            if (!reload && (null != cachedIndexedFields && null != indexedFields) && (null != cachedNormalizedFields && null != normalizedFields)
+                            && (null != cachedReverseIndexedFields && null != reverseIndexedFields)) {
                 indexedFields.addAll(cachedIndexedFields);
+                reverseIndexedFields.addAll(cachedReverseIndexedFields);
                 normalizedFields.addAll(cachedNormalizedFields);
                 
                 return;
             }
             
             cachedIndexedFields = metadataHelper.getIndexedFields(null);
+            cachedReverseIndexedFields = metadataHelper.getReverseIndexedFields(null);
             cachedNormalizedFields = metadataHelper.getAllNormalized();
         }
     }
@@ -2142,28 +2149,30 @@ public class DefaultQueryPlanner extends QueryPlanner {
         Multimap<String,Type<?>> fieldToDatatypeMap = FetchDataTypesVisitor.fetchDataTypes(metadataHelper, config.getDatatypeFilter(), queryTree, false);
         
         try {
-            return configureIndexedAndNormalizedFields(fieldToDatatypeMap, metadataHelper.getIndexedFields(null), metadataHelper.getAllNormalized(), config,
-                            queryTree);
+            return configureIndexedAndNormalizedFields(fieldToDatatypeMap, metadataHelper.getIndexedFields(null), metadataHelper.getReverseIndexedFields(null),
+                            metadataHelper.getAllNormalized(), config, queryTree);
         } catch (InstantiationException | IllegalAccessException | TableNotFoundException e) {
             throw new DatawaveFatalQueryException(e);
         }
         
     }
     
-    protected void setCachedFields(final Set<String> indexedFields, Multimap<String,Type<?>> queryFieldMap, Multimap<String,Type<?>> normalizedFieldMap,
-                    ShardQueryConfiguration config) {
+    protected void setCachedFields(final Set<String> indexedFields, final Set<String> reverseIndexedFields, Multimap<String,Type<?>> queryFieldMap,
+                    Multimap<String,Type<?>> normalizedFieldMap, ShardQueryConfiguration config) {
         config.setIndexedFields(indexedFields);
+        config.setReverseIndexedFields(reverseIndexedFields);
         config.setQueryFieldsDatatypes(queryFieldMap);
         config.setNormalizedFieldsDatatypes(normalizedFieldMap);
     }
     
     protected Multimap<String,Type<?>> configureIndexedAndNormalizedFields(Multimap<String,Type<?>> fieldToDatatypeMap, final Set<String> indexedFields,
-                    final Set<String> normalizedFields, ShardQueryConfiguration config, ASTJexlScript queryTree) throws DatawaveQueryException,
-                    TableNotFoundException, InstantiationException, IllegalAccessException {
+                    final Set<String> reverseIndexedFields, final Set<String> normalizedFields, ShardQueryConfiguration config, ASTJexlScript queryTree)
+                    throws DatawaveQueryException, TableNotFoundException, InstantiationException, IllegalAccessException {
         log.debug("config.getDatatypeFilter() = " + config.getDatatypeFilter());
         log.debug("fieldToDatatypeMap.keySet() is " + fieldToDatatypeMap.keySet());
         
         config.setIndexedFields(indexedFields);
+        config.setReverseIndexedFields(reverseIndexedFields);
         
         log.debug("normalizedFields = " + normalizedFields);
         

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardIndexQueryTable.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardIndexQueryTable.java
@@ -27,6 +27,7 @@ import datawave.query.language.tree.QueryNode;
 import datawave.query.model.QueryModel;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.MetadataHelperFactory;
+import datawave.query.util.regex.RegexTrie;
 import datawave.util.TableName;
 import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.webservice.query.Query;
@@ -274,6 +275,9 @@ public class ShardIndexQueryTable extends BaseQueryLogic<DiscoveredThing> {
         final Set<String> indexedFields = metadataHelper.getIndexedFields(dataTypes);
         config.setIndexedFields(indexedFields);
         
+        final Set<String> reverseIndexedFields = metadataHelper.getReverseIndexedFields(dataTypes);
+        config.setReverseIndexedFields(reverseIndexedFields);
+        
         final Multimap<String,Type<?>> normalizedFields = metadataHelper.getFieldsToDatatypes(dataTypes);
         config.setNormalizedFieldsDatatypes(normalizedFields);
         
@@ -520,6 +524,9 @@ public class ShardIndexQueryTable extends BaseQueryLogic<DiscoveredThing> {
         ShardIndexQueryTableStaticMethods.configureGlobalIndexDateRangeFilter(config, bs, dateRange);
         ShardIndexQueryTableStaticMethods.configureGlobalIndexDataTypeFilter(config, bs, config.getDatatypeFilter());
         
+        ShardIndexQueryTableStaticMethods.configureGlobalIndexRegexFieldnameMatchingIterator(config, bs, (reverseIndex ? config.getReverseIndexedFields()
+                        : config.getIndexedFields()));
+        
         ShardIndexQueryTableStaticMethods.configureGlobalIndexTermMatchingIterator(config, bs, literals, patterns, reverseIndex, true);
         
         return bs;
@@ -548,6 +555,9 @@ public class ShardIndexQueryTable extends BaseQueryLogic<DiscoveredThing> {
         
         ShardIndexQueryTableStaticMethods.configureGlobalIndexDateRangeFilter(config, bs, dateRange);
         ShardIndexQueryTableStaticMethods.configureGlobalIndexDataTypeFilter(config, bs, config.getDatatypeFilter());
+        
+        ShardIndexQueryTableStaticMethods.configureGlobalIndexRegexFieldnameMatchingIterator(config, bs, (reverseIndex ? config.getReverseIndexedFields()
+                        : config.getIndexedFields()));
         
         ShardIndexQueryTableStaticMethods.configureGlobalIndexTermMatchingIterator(config, bs, literals, patterns, reverseIndex, uniqueTermsOnly);
         

--- a/warehouse/query-core/src/main/java/datawave/query/util/regex/RegexTrie.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/regex/RegexTrie.java
@@ -1,6 +1,7 @@
 package datawave.query.util.regex;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,9 +32,9 @@ public class RegexTrie {
      * Add a set of strings into the trie
      * 
      * @param strings
-     *            A list of strings. May contain the empty string.
+     *            A collection of strings. May contain the empty string.
      */
-    public void addAll(List<String> strings) {
+    public void addAll(Collection<String> strings) {
         for (String string : strings) {
             add(string);
         }

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/filter/GlobalIndexFieldnameMatchingFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/filter/GlobalIndexFieldnameMatchingFilterTest.java
@@ -1,0 +1,196 @@
+package datawave.core.iterators.filter;
+
+import datawave.data.normalizer.NumberNormalizer;
+import datawave.query.util.regex.RegexTrie;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class GlobalIndexFieldnameMatchingFilterTest {
+
+    @Test
+    public void testFilterList() throws Exception {
+        GlobalIndexFieldnameMatchingFilter filter = new GlobalIndexFieldnameMatchingFilter();
+
+        // add all filenames except for #10
+        Map<String, String> options = new HashMap<>();
+        int index = 1;
+        for (int i = 0; i < 10; i++) {
+            options.put(GlobalIndexFieldnameMatchingFilter.LITERAL + Integer.toString(index++), getFieldname(i));
+        }
+        for (int i = 11; i < 40; i++) {
+            options.put(GlobalIndexFieldnameMatchingFilter.LITERAL + Integer.toString(index++), getFieldname(i));
+        }
+
+        // create our generator source
+        GlobalIndexKeyValueGenerator source = new GlobalIndexKeyValueGenerator();
+        filter.init(source, options, null);
+
+        // range from 0 to 39
+        filter.seek(new Range(getKey(0), true, getKey(40), false), Collections.emptyList(), false);
+
+        // test that we skipped #10
+        int expected = 0;
+        for (; expected < 10; expected++) {
+            index = getIndex(filter.getTopKey().getColumnFamily().toString());
+            assertEquals(expected, index);
+            filter.next();
+        }
+
+        expected = 11;
+
+        while (filter.getTopKey() != null) {
+            index = getIndex(filter.getTopKey().getColumnFamily().toString());
+            assertEquals(expected++, index);
+            filter.next();
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testPerformance() throws Exception {
+
+        List<String> fieldnames = new ArrayList<>();
+        for (int i = 0; i <= 5000; i++) {
+            fieldnames.add(getFieldname(i));
+        }
+
+        for (int numFields = 1; numFields < 5000; numFields++) {
+
+            GlobalIndexFieldnameMatchingFilter filter = new GlobalIndexFieldnameMatchingFilter();
+            Map<String, String> options = new HashMap<>();
+            for (int index = 0; index < numFields; index++) {
+                options.put(GlobalIndexFieldnameMatchingFilter.LITERAL + Integer.toString(index+1), fieldnames.get(index));
+            }
+
+            // create our generator source
+            GlobalIndexKeyValueGenerator source = new GlobalIndexKeyValueGenerator();
+            filter.init(source, options, null);
+
+            long start = System.currentTimeMillis();
+
+            // range from 0 to 9999
+            filter.seek(new Range(getKey(0), true, getKey(10000), false), Collections.emptyList(), false);
+            while (filter.getTopKey() != null) {
+                filter.next();
+            }
+
+            long literalTime = System.currentTimeMillis() - start;
+
+
+            filter = new GlobalIndexFieldnameMatchingFilter();
+            options = new HashMap<>();
+            RegexTrie trie = new RegexTrie();
+            trie.addAll(fieldnames.subList(0, numFields));
+            options.put(GlobalIndexFieldnameMatchingFilter.PATTERN + "1", trie.toRegex());
+
+            // create our generator source
+            source = new GlobalIndexKeyValueGenerator();
+            filter.init(source, options, null);
+
+            start = System.currentTimeMillis();
+
+            // range from 0 to 9999
+            filter.seek(new Range(getKey(0), true, getKey(10000), false), Collections.emptyList(), false);
+            while (filter.getTopKey() != null) {
+                filter.next();
+            }
+
+            long regexTime = System.currentTimeMillis() - start;
+
+            System.out.println("#" + numFields + ": " + literalTime + " / " + regexTime + " " + options);
+        }
+    }
+
+
+
+    /**
+     * This is an iterator that simply generates a series of keys with the same row and a sequentially increasing fieldname
+     */
+    private static class GlobalIndexKeyValueGenerator implements SortedKeyValueIterator {
+        private Key next = null;
+        private static final Value EMPTY_VALUE = new Value();
+
+        @Override
+        public boolean hasTop() {
+            return next != null;
+        }
+
+        private int index = 0;
+        private int lastIndex = 0;
+        @Override
+        public void next() throws IOException {
+            if (index > lastIndex) {
+                next = null;
+            } else {
+                next = getKey(index++);
+            }
+        }
+
+        @Override
+        public WritableComparable<?> getTopKey() {
+            return next;
+        }
+
+        @Override
+        public Writable getTopValue() {
+            return EMPTY_VALUE;
+        }
+
+        @Override
+        public SortedKeyValueIterator deepCopy(IteratorEnvironment env) {
+            return new GlobalIndexKeyValueGenerator();
+        }
+
+        @Override
+        public void seek(Range range, Collection columnFamilies, boolean inclusive) throws IOException {
+            index = getIndex(range.getStartKey());
+            if (!range.isStartKeyInclusive()) {
+                index++;
+            }
+            lastIndex = getIndex(range.getEndKey());
+            if (!range.isEndKeyInclusive()) {
+                lastIndex--;
+            }
+            next();
+        }
+
+        @Override
+        public void init(SortedKeyValueIterator source, Map options, IteratorEnvironment env) throws IOException {
+        }
+    }
+
+    private static final NumberNormalizer n = new NumberNormalizer();
+    protected static String getFieldname(int index) {
+        return "FIELD." + n.normalize(Integer.toString(index++));
+    }
+
+    protected static Key getKey(int index) {
+        return new Key("row", getFieldname(index));
+    }
+
+    protected static int getIndex(String fieldname) {
+        return n.denormalize(fieldname.substring(6)).intValue();
+    }
+
+    protected static int getIndex(Key key) {
+        return getIndex(key.getColumnFamily().toString());
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -430,7 +430,7 @@ public class ShardQueryConfigurationTest {
      */
     @Test
     public void testCheckForNewAdditions() throws IOException {
-        int expectedObjectCount = 164;
+        int expectedObjectCount = 165;
         ShardQueryConfiguration config = ShardQueryConfiguration.create();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(mapper.writeValueAsString(config));


### PR DESCRIPTION
Ensure configuration contains both indexed and reverse indexed fields.