### PR TITLE
Added exclusion for error events being dropped (#594)

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/EventMapper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/EventMapper.java
@@ -456,8 +456,8 @@ public class EventMapper<K1,V1 extends RawRecordContainer,K2,V2> extends StatsDE
             value.setAuxProperty(ErrorDataTypeHandler.PROCESSED_COUNT, "1");
         }
         
-        // Determine whether the event date is greater than the interval.
-        if (null != myInterval && 0L != myInterval && (value.getDate() < (now.get() - myInterval))) {
+        // Determine whether the event date is greater than the interval. Excluding fatal error events.
+        if (!value.fatalError() && null != myInterval && 0L != myInterval && (value.getDate() < (now.get() - myInterval))) {
             if (log.isInfoEnabled())
                 log.info("Event with time " + value.getDate() + " older than specified interval of " + (now.get() - myInterval) + ", skipping...");
             getCounter(context, IngestInput.OLD_EVENT).increment(1);

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
@@ -51,8 +51,11 @@ public class EventMapperTest {
         conf.setClass(EventMapper.CONTEXT_WRITER_CLASS, TestContextWriter.class, ContextWriter.class);
         
         Type type = new Type("file", null, null, new String[] {SimpleDataTypeHandler.class.getName()}, 10, null);
+        Type errorType = new Type(TypeRegistry.ERROR_PREFIX, null, null, new String[] {SimpleDataTypeHandler.class.getName()}, 20, null);
+        
         TypeRegistry registry = TypeRegistry.getInstance(conf);
         registry.put(type.typeName(), type);
+        registry.put(errorType.typeName(), errorType);
         
         Multimap<String,NormalizedContentInterface> fields = HashMultimap.create();
         fields.put("fileExtension", new BaseNormalizedContent("fileExtension", "gz"));
@@ -192,8 +195,9 @@ public class EventMapperTest {
         
         Multimap<BulkIngestKey,Value> written = TestContextWriter.getWritten();
         
-        // no handlers configured for errors
-        assertEquals(0, written.size());
+        // two fields mutations + LOAD_DATE + ORIG_FILE
+        // previously this would have been zero
+        assertEquals(4, written.size());
     }
     
     private Map.Entry<BulkIngestKey,Value> getMetric(Multimap<BulkIngestKey,Value> written) {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
@@ -12,6 +12,7 @@ import org.apache.hadoop.io.Writable;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -30,7 +31,7 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
     private UID id = uidBuilder.newId();
     private Type dataType;
     private long date = 0;
-    private Collection<String> errors = Collections.emptyList();
+    private Collection<String> errors = new ArrayList<>();
     private Collection<String> altIds = Collections.emptyList();
     private String rawFileName = "";
     private long rawRecordNumber = 0;
@@ -39,6 +40,7 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
     private Object auxData;
     private Map<String,String> auxMap;
     private ColumnVisibility visibility;
+    private boolean fatalError = false;
     
     @Override
     public Map<String,String> getSecurityMarkings() {
@@ -120,9 +122,13 @@ public class SimpleRawRecord implements RawRecordContainer, Writable {
         return this.errors.contains(error);
     }
     
+    public void setFatalError(boolean fatalError) {
+        this.fatalError = fatalError;
+    }
+    
     @Override
     public boolean fatalError() {
-        return false;
+        return fatalError;
     }
     
     @Override


### PR DESCRIPTION
Exclude error events with timestamp less than discard interval from
being dropped.  An event may be in error when the timestamp is unable
to be parsed.  We don't want to drop these events, but send them to
the error tables.