### PR TITLE
Add GitHub action workflow to run tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: Tests
+
+on:
+  push:
+    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+    branches:
+    - 'master'
+    - 'release/version*'
+  pull_request:
+    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build and Run Unit Tests
+      run: mvn -V -B -e -Dsurefire.rerunFailingTestsCount=3 -Pdev,examples,assemble -Ddist -T1C clean verify
+
+  # This job is disabled for the release/2.5 branch.
+  # quickstart-build-and-test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Checkout Code
+  #     uses: actions/checkout@v1
+  #   - name: Set up JDK 1.8
+  #     uses: actions/setup-java@v1
+  #     with:
+  #       java-version: 1.8
+  #   # Allow us to use the "--squash" option below
+  #   - name: Turn on Docker Experimental Features
+  #     run: |
+  #       sudo sed -ri 's/\s*}\s*$/, "experimental": true }/' /etc/docker/daemon.json
+  #       sudo systemctl restart docker
+  #   # Builds the quickstart docker image and run the query tests
+  #   - name: Quickstart Query Tests
+  #     env:
+  #       DW_DATAWAVE_BUILD_COMMAND: "mvn -B -V -e -Pdev -Ddeploy -Dtar -DskipTests clean install"
+  #       DOCKER_BUILD_OPTS: "--squash --force-rm"
+  #     run: |
+  #       TAG=$(mvn -q -N -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
+  #       contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
+
+    # Here's an example of how you'd deploy the image to the github package registry.
+    # We don't want to do this by default since packages on github cannot be deleted
+    # or overwritten. So this could only be done for tags, however it seems the quickstart
+    # image may also exceed the maximum size allowed by github.
+    # - name: Deploy Quickstart Image
+    #   env:
+    #     IMAGE_REGISTRY: "docker.pkg.github.com"
+    #     IMAGE_USERNAME: "brianloss"
+    #     IMAGE_NAME: "datawave/quickstart"
+    #   run: |
+    #     # Set up env vars
+    #     TAG=$(mvn -q -N -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
+    #     REMOTE_IMAGE_NAME="${IMAGE_REGISTRY}/${IMAGE_USERNAME}/${IMAGE_NAME}"
+    #     # Log in to the package registry
+    #     echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${GITHUB_ACTOR} --password-stdin
+    #     # Tag and push the image
+    #     docker tag ${IMAGE_NAME}:${TAG} ${REMOTE_IMAGE_NAME}:${TAG}
+    #     docker images
+    #     docker push ${REMOTE_IMAGE_NAME}:${TAG}
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,17 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    # This is a hack to pre-populate the maven repo and reduce downloads. This can
+    # go away whenever GitHub actions support caching (supposedly in November 2019).
+    - name: Set up maven repo
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${GITHUB_ACTOR} --password-stdin
+        mkdir ~/.m2 || true
+        docker run --rm -u $(id -u):$(id -g) -v ~/.m2:/m2 docker.pkg.github.com/brianloss/maven_repo/repo:v1
     - name: Build and Run Unit Tests
       run: mvn -V -B -e -Dsurefire.rerunFailingTestsCount=3 -Pdev,examples,assemble -Ddist -T1C clean verify
+      env:
+        MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
 
   # This job is disabled for the release/2.5 branch.
   # quickstart-build-and-test:
@@ -37,11 +46,19 @@ jobs:
   #     run: |
   #       sudo sed -ri 's/\s*}\s*$/, "experimental": true }/' /etc/docker/daemon.json
   #       sudo systemctl restart docker
+  #   # This is a hack to pre-populate the maven repo and reduce downloads. This can
+  #   # go away whenever GitHub actions support caching (supposedly in November 2019).
+  #   - name: Set up maven repo
+  #     run: |
+  #       echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${GITHUB_ACTOR} --password-stdin
+  #       mkdir ~/.m2 || true
+  #       docker run --rm -u $(id -u):$(id -g) -v ~/.m2:/m2 docker.pkg.github.com/brianloss/maven_repo/repo:v1
   #   # Builds the quickstart docker image and run the query tests
   #   - name: Quickstart Query Tests
   #     env:
   #       DW_DATAWAVE_BUILD_COMMAND: "mvn -B -V -e -Pdev -Ddeploy -Dtar -DskipTests clean install"
   #       DOCKER_BUILD_OPTS: "--squash --force-rm"
+  #       MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true"
   #     run: |
   #       TAG=$(mvn -q -N -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
   #       contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
    <img src="datawave-readme.png" />
 </p>
 
-[![Apache License][li]][ll]
+[![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/workflows/Tests/badge.svg)
 
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...
 


### PR DESCRIPTION
We have access to GitHub actions which might be a viable CI replacement for the private GitLab repo that we are currently using.