### PR TITLE
Update zookeeper to version fixing CVE-2019-0201

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <version.woodstox-core>5.0.3</version.woodstox-core>
         <version.woodstox-stax2>3.1.4</version.woodstox-stax2>
         <version.xerces>2.12.0.SP02</version.xerces>
-        <version.zookeeper>3.4.5-cdh5.9.1</version.zookeeper>
+        <version.zookeeper>3.4.5-cdh6.3.1</version.zookeeper>
         <!-- Unless a version is duplicated multiple times, just place the version on the dependency in dependencyManagement. -->
         <!-- <runOrder>random</runOrder> -->
     </properties>


### PR DESCRIPTION
According to [this](https://github.com/cloudera/zookeeper/commits/cdh6.3.1), the specified version of zookeeper fixes ZOOKEEPER-1392 which fixes the CVE.