### PR TITLE
Update zookeeper to version fixing CVE-2019-0201

### DIFF
--- a/contrib/datawave-quickstart/bin/services/accumulo/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/accumulo/bootstrap.sh
@@ -15,7 +15,7 @@ DW_ACCUMULO_SERVICE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Zookeeper config
 
 # You may override DW_ZOOKEEPER_DIST_URI in your env ahead of time, and set as file:///path/to/file.tar.gz for local tarball, if needed
-DW_ZOOKEEPER_DIST_URI="${DW_ZOOKEEPER_DIST_URI:-http://archive.cloudera.com/cdh5/cdh/5/zookeeper-3.4.5-cdh5.9.1.tar.gz}"
+DW_ZOOKEEPER_DIST_URI="${DW_ZOOKEEPER_DIST_URI:-http://archive.cloudera.com/cdh5/cdh/5/zookeeper-3.4.5-cdh5.16.2.tar.gz}"
 DW_ZOOKEEPER_DIST="$( downloadTarball "${DW_ZOOKEEPER_DIST_URI}" "${DW_ACCUMULO_SERVICE_DIR}" && echo "${tarball}" )"
 DW_ZOOKEEPER_BASEDIR="zookeeper-install"
 DW_ZOOKEEPER_SYMLINK="zookeeper"

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <version.weld-se>2.3.5.Final</version.weld-se>
         <version.wildfly>10.1.0.Final</version.wildfly>
         <version.xerces>2.11.0.SP4</version.xerces>
-        <version.zookeeper>3.4.5-cdh5.9.1</version.zookeeper>
+        <version.zookeeper>3.4.5-cdh5.16.2</version.zookeeper>
         <!-- Unless a version is duplicated multiple times, just place the version on the dependency in dependencyManagement. -->
         <!-- <runOrder>random</runOrder> -->
     </properties>


### PR DESCRIPTION
According to [this](https://github.com/cloudera/zookeeper/commits/cdh5-3.4.5_5.16.2), the specified version of zookeeper fixes ZOOKEEPER-1392 which fixes the CVE.