### PR TITLE
Fixes #627: Double escape before a Lucene wildcard can cause incorrec…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/jexl/FieldQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/jexl/FieldQueryNodeBuilder.java
@@ -99,28 +99,24 @@ public class FieldQueryNodeBuilder implements QueryBuilder {
             // queryNode instanceof FieldQueryNode
             
             FieldQueryNode fieldNode = (FieldQueryNode) queryNode;
+            boolean hasUnescapedWildcard = WildcardFieldedTerm.hasUnescapedWildcard(fieldNode, Sets.newHashSet(' ', '/'));
             
             String field = fieldNode.getFieldAsString();
-            String selector = fieldNode.getTextAsString();
-            
-            JexlSelectorNode.Type type = null;
-            
-            int firstWildcard = WildcardFieldedTerm.getFirstWildcardIndex(fieldNode, Sets.newHashSet(' ', '/'));
-            
-            if (firstWildcard == -1) {
-                type = JexlSelectorNode.Type.EXACT;
-            } else {
+            String selector;
+            JexlSelectorNode.Type type;
+            if (hasUnescapedWildcard) {
                 // When we have a regular expression, we want to maintain the original escaped characters in the term
                 selector = EscapedNodes.getEscapedTerm(fieldNode, new EscapeQuerySyntaxImpl());
-                
                 type = JexlSelectorNode.Type.WILDCARDS;
+            } else {
+                selector = fieldNode.getTextAsString();
+                type = JexlSelectorNode.Type.EXACT;
             }
             
             if (field == null || field.isEmpty()) {
                 returnNode = new JexlSelectorNode(type, "", selector);
             } else {
                 returnNode = new JexlSelectorNode(type, field, selector);
-                
             }
         }
         

--- a/warehouse/query-core/src/main/java/datawave/query/search/WildcardFieldedTerm.java
+++ b/warehouse/query-core/src/main/java/datawave/query/search/WildcardFieldedTerm.java
@@ -77,7 +77,7 @@ public class WildcardFieldedTerm extends FieldedTerm {
         return Pattern.compile(sb.toString(), flags);
     }
     
-    public static int getFirstWildcardIndex(FieldQueryNode node, Set<Character> charactersToNotEscape) {
+    public static boolean hasUnescapedWildcard(FieldQueryNode node, Set<Character> charactersToNotEscape) {
         CharSequence textSeq = node.getText();
         
         if (textSeq instanceof UnescapedCharSequence) {
@@ -92,9 +92,9 @@ public class WildcardFieldedTerm extends FieldedTerm {
                 escBuilder.append(escSeq.charAt(i));
             }
             
-            return getFirstWildcardIndex(escBuilder.toString());
+            return getFirstWildcardIndex(escBuilder.toString()) > -1;
         } else {
-            return getFirstWildcardIndex(textSeq.toString());
+            return getFirstWildcardIndex(textSeq.toString()) > -1;
         }
     }
     
@@ -104,12 +104,12 @@ public class WildcardFieldedTerm extends FieldedTerm {
         char[] chars = selector.toCharArray();
         for (int x = 0; x < chars.length; x++) {
             char currChar = chars[x];
-            if (currChar == '*' || currChar == '?') {
-                char prevChar = chars[(x > 0 ? x - 1 : x)];
-                if (prevChar != '\\') {
-                    firstNonEscapedWildcard = x;
-                    break;
-                }
+            if (currChar == '\\') {
+                // skip next character since it's escaped
+                x++;
+            } else if (currChar == '*' || currChar == '?') {
+                firstNonEscapedWildcard = x;
+                break;
             }
         }
         return firstNonEscapedWildcard;

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -268,9 +268,10 @@ public class TestLuceneToJexlQueryParser {
     public void testWildcards() throws ParseException {
         Assert.assertEquals("F1 == '*1234'", parseQuery("F1:\\*1234"));
         Assert.assertEquals("F1 =~ '\\u005c*12.34'", parseQuery("F1:\\*12?34"));
-        
-        Assert.assertEquals("F1 == '.1234'", parseQuery("F1:\\.1234"));
-        Assert.assertEquals("F1 =~ '\\u005c.12.34'", parseQuery("F1:\\.12?34"));
+        Assert.assertEquals("F1 == '*'", parseQuery("F1:\\*"));
+        Assert.assertEquals("F1 =~ '\\u005c\\u005c.*?'", parseQuery("F1:\\\\*"));
+        Assert.assertEquals("F1 == '\\u005c*'", parseQuery("F1:\\\\\\*"));
+        Assert.assertEquals("F1 =~ '\\u005c\\u005c.*?x.*?'", parseQuery("F1:\\\\*x*"));
     }
     
     @Test


### PR DESCRIPTION
WildcardFieldedTerm.getFirstWildcardIndex was using a single character lookback when encountering a wildcard character to determine if it was escaped. This is incorrect when the escape itself is escaped.

When the only (or all) wildcards in a term were masked in this way, the translation determined that there was no unescaped wildcard in the term and created an EXACT SelectorNode instead of a WILDCARDS SelectorNode.