### PR TITLE
re #637: periodic test failures

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -62,6 +62,10 @@ import java.util.stream.Collectors;
  */
 public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIterator {
     
+    public static final Text ANY_FINAME = new Text("fi\0" + Constants.ANY_FIELD);
+    public static final Text FI_START = new Text("fi\0");
+    public static final Text FI_END = new Text("fi\0~");
+    
     public abstract static class Builder<B extends Builder<B>> {
         private Text fieldName;
         protected Text fieldValue;

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexFilterIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexFilterIteratorJexl.java
@@ -91,7 +91,11 @@ public class DatawaveFieldIndexFilterIteratorJexl extends DatawaveFieldIndexRang
         Key startKey = null;
         Key endKey = null;
         // construct new range
-        
+        if (ANY_FINAME.equals(fiName)) {
+            startKey = new Key(rowId, FI_START);
+            endKey = new Key(rowId, FI_END);
+            return new RangeSplitter(new Range(startKey, true, endKey, false), getMaxRangeSplit());
+        }
         // we cannot simply use startKeyInclusive in the Range as the datatype and UID follow the value in the keys
         // hence we need to compute the min possibly value that would be inclusive
         this.boundingFiRangeStringBuilder.setLength(0);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexListIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexListIteratorJexl.java
@@ -107,6 +107,12 @@ public class DatawaveFieldIndexListIteratorJexl extends DatawaveFieldIndexCachin
     
     @Override
     protected List<Range> buildBoundingFiRanges(Text rowId, Text fiName, Text fieldValue) {
+        if (ANY_FINAME.equals(fiName)) {
+            Key startKey = new Key(rowId, FI_START);
+            Key endKey = new Key(rowId, FI_END);
+            return new RangeSplitter(new Range(startKey, true, endKey, false), getMaxRangeSplit());
+        }
+        
         if (fst != null || isNegated()) {
             Key startKey = null;
             Key endKey = null;

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRangeIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRangeIteratorJexl.java
@@ -117,7 +117,11 @@ public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachi
     
     @Override
     protected List<Range> buildBoundingFiRanges(Text rowId, Text fiName, Text fieldValue) {
-        if (subRanges != null && !subRanges.isEmpty()) {
+        if (ANY_FINAME.equals(fiName)) {
+            Key startKey = new Key(rowId, FI_START);
+            Key endKey = new Key(rowId, FI_END);
+            return new RangeSplitter(new Range(startKey, true, endKey, false), getMaxRangeSplit());
+        } else if (subRanges != null && !subRanges.isEmpty()) {
             List<Range> ranges = new ArrayList<>();
             
             // Note: The IndexRangeIteratorBuilder hard codes 'negated' to false, so unless that changes, this logic will never be executed.
@@ -162,9 +166,6 @@ public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachi
     }
     
     private Key createLowerBoundKey(Text rowId, Text fiName, Text lowerBound, boolean isLowerInclusive) {
-        if (ANY_FINAME.equals(fiName)) {
-            return new Key(rowId, FI_START);
-        }
         // we cannot simply use startKeyInclusive in the Range as the datatype and UID follow the value in the keys
         // hence we need to compute the min possibly value that would be inclusive
         this.boundingFiRangeStringBuilder.setLength(0);
@@ -178,9 +179,6 @@ public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachi
     }
     
     private Key createUpperBoundKey(Text rowId, Text fiName, Text upperBound, boolean isUpperInclusive) {
-        if (ANY_FINAME.equals(fiName)) {
-            return new Key(rowId, FI_END);
-        }
         // we cannot simply use endKeyInclusive in the Range as the datatype and UID follow the value in the keys
         // hence we need to compute the max possibly value that would be inclusive
         this.boundingFiRangeStringBuilder.setLength(0);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRangeIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRangeIteratorJexl.java
@@ -162,6 +162,9 @@ public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachi
     }
     
     private Key createLowerBoundKey(Text rowId, Text fiName, Text lowerBound, boolean isLowerInclusive) {
+        if (ANY_FINAME.equals(fiName)) {
+            return new Key(rowId, FI_START);
+        }
         // we cannot simply use startKeyInclusive in the Range as the datatype and UID follow the value in the keys
         // hence we need to compute the min possibly value that would be inclusive
         this.boundingFiRangeStringBuilder.setLength(0);
@@ -175,6 +178,9 @@ public class DatawaveFieldIndexRangeIteratorJexl extends DatawaveFieldIndexCachi
     }
     
     private Key createUpperBoundKey(Text rowId, Text fiName, Text upperBound, boolean isUpperInclusive) {
+        if (ANY_FINAME.equals(fiName)) {
+            return new Key(rowId, FI_END);
+        }
         // we cannot simply use endKeyInclusive in the Range as the datatype and UID follow the value in the keys
         // hence we need to compute the max possibly value that would be inclusive
         this.boundingFiRangeStringBuilder.setLength(0);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRegexIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRegexIteratorJexl.java
@@ -1,8 +1,10 @@
 package datawave.core.iterators;
 
+import datawave.data.ColumnFamilyConstants;
 import datawave.query.Constants;
 import datawave.query.parser.JavaRegexAnalyzer;
 import datawave.query.parser.JavaRegexAnalyzer.JavaRegexParseException;
+import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -93,6 +95,10 @@ public class DatawaveFieldIndexRegexIteratorJexl extends DatawaveFieldIndexCachi
             startKey = new Key(rowId, fiName);
             endKey = new Key(rowId, new Text(fiName.toString() + '\0'));
             return new RangeSplitter(new Range(startKey, true, endKey, true), getMaxRangeSplit());
+        } else if (ANY_FINAME.equals(fiName)) {
+            startKey = new Key(rowId, FI_START);
+            endKey = new Key(rowId, FI_END);
+            return new RangeSplitter(new Range(startKey, true, endKey, false), getMaxRangeSplit());
         } else {
             // construct new range
             this.boundingFiRangeStringBuilder.setLength(0);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRegexIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexRegexIteratorJexl.java
@@ -91,14 +91,14 @@ public class DatawaveFieldIndexRegexIteratorJexl extends DatawaveFieldIndexCachi
     protected List<Range> buildBoundingFiRanges(Text rowId, Text fiName, Text fieldValue) {
         Key startKey = null;
         Key endKey = null;
-        if (isNegated()) {
-            startKey = new Key(rowId, fiName);
-            endKey = new Key(rowId, new Text(fiName.toString() + '\0'));
-            return new RangeSplitter(new Range(startKey, true, endKey, true), getMaxRangeSplit());
-        } else if (ANY_FINAME.equals(fiName)) {
+        if (ANY_FINAME.equals(fiName)) {
             startKey = new Key(rowId, FI_START);
             endKey = new Key(rowId, FI_END);
             return new RangeSplitter(new Range(startKey, true, endKey, false), getMaxRangeSplit());
+        } else if (isNegated()) {
+            startKey = new Key(rowId, fiName);
+            endKey = new Key(rowId, new Text(fiName.toString() + '\0'));
+            return new RangeSplitter(new Range(startKey, true, endKey, true), getMaxRangeSplit());
         } else {
             // construct new range
             this.boundingFiRangeStringBuilder.setLength(0);

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnfieldedTermsVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnfieldedTermsVisitor.java
@@ -6,6 +6,7 @@ import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
 import datawave.query.jexl.lookups.FieldNameLookup;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods;
+import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.MetadataHelper;
 import datawave.webservice.query.Query;
@@ -216,6 +217,11 @@ public class FixUnfieldedTermsVisitor extends ParallelIndexExpansion {
     
     @Override
     public Object visit(ASTAndNode node, Object data) {
+        
+        // ignore already marked expressions
+        if (QueryPropertyMarker.instanceOf(node, null)) {
+            return node;
+        }
         
         ASTAndNode newNode = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
         newNode.image = node.image;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -1551,7 +1551,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
     }
     
     public IteratorBuildingVisitor setIncludes(Collection<String> includes) {
-        this.includeReferences = includes;
+        this.includeReferences = Sets.newHashSet(includes);
+        this.includeReferences.add(Constants.ANY_FIELD);
         return this;
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IvaratorRequiredVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IvaratorRequiredVisitor.java
@@ -1,0 +1,39 @@
+package datawave.query.jexl.visitors;
+
+import datawave.query.jexl.nodes.ExceededOrThresholdMarkerJexlNode;
+import datawave.query.jexl.nodes.ExceededValueThresholdMarkerJexlNode;
+import datawave.query.jexl.nodes.QueryPropertyMarker;
+import org.apache.commons.jexl2.parser.ASTAndNode;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.log4j.Logger;
+
+/**
+ * A visitor that checks the query tree to determine if the query requires an ivarator (ExceededValue or ExceededOr)
+ * 
+ */
+public class IvaratorRequiredVisitor extends BaseVisitor {
+    private static final Logger log = Logger.getLogger(IvaratorRequiredVisitor.class);
+    
+    private boolean ivaratorRequired = false;
+    
+    public boolean isIvaratorRequired() {
+        return ivaratorRequired;
+    }
+    
+    public static boolean isIvaratorRequired(JexlNode node) {
+        IvaratorRequiredVisitor visitor = new IvaratorRequiredVisitor();
+        node.jjtAccept(visitor, null);
+        return visitor.isIvaratorRequired();
+    }
+    
+    @Override
+    public Object visit(ASTAndNode and, Object data) {
+        
+        if (ExceededOrThresholdMarkerJexlNode.instanceOf(and) || ExceededValueThresholdMarkerJexlNode.instanceOf(and)) {
+            ivaratorRequired = true;
+        } else if (!QueryPropertyMarker.instanceOf(and, null)) {
+            super.visit(and, data);
+        }
+        return data;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -52,6 +52,7 @@ import datawave.query.jexl.visitors.FixUnfieldedTermsVisitor;
 import datawave.query.jexl.visitors.FixUnindexedNumericTerms;
 import datawave.query.jexl.visitors.FunctionIndexQueryExpansionVisitor;
 import datawave.query.jexl.visitors.IsNotNullIntentVisitor;
+import datawave.query.jexl.visitors.IvaratorRequiredVisitor;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.jexl.visitors.ParallelIndexExpansion;
 import datawave.query.jexl.visitors.PrintingVisitor;
@@ -1961,7 +1962,7 @@ public class DefaultQueryPlanner extends QueryPlanner {
             }
             // if a value threshold is exceeded and we cannot handle that, then
             // force a full table scan
-            else if (StreamContext.EXCEEDED_VALUE_THRESHOLD.equals(stream.context()) && !config.canHandleExceededValueThreshold()) {
+            else if (IvaratorRequiredVisitor.isIvaratorRequired(queryTree) && !config.canHandleExceededValueThreshold()) {
                 log.debug("Needs full table scan because we exceeded the value threshold and config.canHandleExceededValueThreshold() is false");
                 needsFullTable = true;
             }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
@@ -275,15 +275,19 @@ public class VisitorFunction implements Function<ScannerChunk,ScannerChunk> {
     protected ASTJexlScript pushdownLargeFieldedLists(ShardQueryConfiguration config, ASTJexlScript queryTree) throws IOException {
         Query settings = config.getQuery();
         
-        URI hdfsQueryCacheUri = getFstHdfsQueryCacheUri(config, settings);
-        
-        if (hdfsQueryCacheUri != null) {
-            FileSystem fs = VisitorFunction.fileSystemCache.getFileSystem(hdfsQueryCacheUri);
-            // Find large lists of values against the same field and push down into
-            // an Ivarator
-            return PushdownLargeFieldedListsVisitor.pushdown(config, queryTree, fs, hdfsQueryCacheUri.toString());
+        if (config.canHandleExceededValueThreshold()) {
+            URI hdfsQueryCacheUri = getFstHdfsQueryCacheUri(config, settings);
+            
+            if (hdfsQueryCacheUri != null) {
+                FileSystem fs = VisitorFunction.fileSystemCache.getFileSystem(hdfsQueryCacheUri);
+                // Find large lists of values against the same field and push down into
+                // an Ivarator
+                return PushdownLargeFieldedListsVisitor.pushdown(config, queryTree, fs, hdfsQueryCacheUri.toString());
+            } else {
+                return PushdownLargeFieldedListsVisitor.pushdown(config, queryTree, null, null);
+            }
         } else {
-            return PushdownLargeFieldedListsVisitor.pushdown(config, queryTree, null, null);
+            return queryTree;
         }
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -123,6 +123,8 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         String anyCity = this.dataManager.convertAnyField(city);
         String expect = anyRegex + AND_OP + anyCity;
         
+        ivaratorConfig();
+        
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
         parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
@@ -156,7 +158,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         try {
             runTest(query, expect);
             Assert.fail("exception expected");
-        } catch (RuntimeException re) {
+        } catch (FullTableScansDisallowedException e) {
             // expected
         }
         
@@ -180,6 +182,8 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         String regexPhrase = RN_OP + "'b.*'";
         String fieldVal = EQ_OP + "'a-1'";
         String query = Constants.ANY_FIELD + regexPhrase + AND_OP + Constants.ANY_FIELD + fieldVal;
+        
+        ivaratorConfig();
         
         // '!~' operation is not processed correctly - see QueryJexl docs
         // this is a hack for the expected results

--- a/warehouse/query-core/src/test/java/datawave/query/cardinality/TestCardinalityWithQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/cardinality/TestCardinalityWithQuery.java
@@ -1,8 +1,8 @@
 package datawave.query.cardinality;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.io.Files;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
@@ -89,7 +90,7 @@ public class TestCardinalityWithQuery {
     @Before
     public void setup() throws Exception {
         System.setProperty(NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
-        temporaryFolder = Files.createTempDirectory("tmp");
+        temporaryFolder = Paths.get(Files.createTempDir().toURI());
         
         logic = new ShardQueryLogic();
         logic.setMarkingFunctions(new MarkingFunctions.Default());

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -1,5 +1,6 @@
 package datawave.query.iterator;
 
+import com.google.common.io.Files;
 import datawave.query.Constants;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
@@ -20,8 +21,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,7 +80,7 @@ public class QueryIteratorIT extends EasyMockSupport {
     public void setup() throws IOException {
         iterator = new QueryIterator();
         options = new HashMap<>();
-        temporaryFolder = Files.createTempDirectory("tmp");
+        temporaryFolder = Paths.get(Files.createTempDir().toURI());
         
         // global options
         

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -1,6 +1,7 @@
 package datawave.query.testframework;
 
 import com.google.common.collect.Sets;
+import com.google.common.io.Files;
 import datawave.data.type.Type;
 import datawave.marking.MarkingFunctions.Default;
 import datawave.query.QueryTestTableHelper;
@@ -48,8 +49,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -140,7 +141,7 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
     
     @Before
     public void querySetUp() throws IOException {
-        temporaryFolder = Files.createTempDirectory("tmp");
+        temporaryFolder = Paths.get(Files.createTempDir().toURI());
         
         log.debug("---------  querySetUp  ---------");
         
@@ -536,12 +537,10 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         final List<String> dirs = new ArrayList<>();
         final List<String> fstDirs = new ArrayList<>();
         for (int d = 1; d <= hdfsLocations; d++) {
-            // avoid threading issues by using a random number as part of the directory path to create a distinct directory
-            int rand = rVal.nextInt(Integer.MAX_VALUE);
-            Path ivCache = Files.createTempDirectory("ivarator.cache-" + rand);
+            Path ivCache = Paths.get(Files.createTempDir().toURI());
             dirs.add(ivCache.toAbsolutePath().toString());
             if (fst) {
-                ivCache = Files.createTempDirectory("ivarator.cache-" + "fst-" + rand);
+                ivCache = Paths.get(Files.createTempDir().toURI());
                 fstDirs.add(ivCache.toAbsolutePath().toString());
             }
         }

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -43,7 +43,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ComparisonFailure;
-import org.junit.Rule;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -59,7 +58,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -79,8 +77,6 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
     protected static final String FILTER_EXCLUDE_REGEX = "filter:excludeRegex";
     
     private static final Logger log = Logger.getLogger(AbstractFunctionalQuery.class);
-    
-    private static final Random rVal = new Random(System.currentTimeMillis());
     
     static {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));


### PR DESCRIPTION
This one fixes the MaxExpansionRegexQueryTest and resulted in fixing #156 as well.

* Updated to use google Files to create temporary directories (avoid known bug in nio Files temporary dir creation)
* Updating planner to correctly fail when attempting to ivarator when not configured.
* Fixed to allow ivarating against _ANYFIELD_ expressions (#156)