### PR TITLE
Bugfix/flatten and regex

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveJexlEngine.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveJexlEngine.java
@@ -6,6 +6,7 @@ import org.apache.commons.jexl2.Interpreter;
 import org.apache.commons.jexl2.JexlArithmetic;
 import org.apache.commons.jexl2.JexlContext;
 import org.apache.commons.jexl2.JexlEngine;
+import org.apache.commons.jexl2.JexlInfo;
 import org.apache.commons.jexl2.introspection.Uberspect;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.logging.Log;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -111,7 +111,7 @@ public class JexlASTHelper {
     /**
      * Parse a query string using a JEXL parser and transform it into a parse tree of our RefactoredDatawaveTreeNodes. This also sets all convenience maps that
      * the analyzer provides.
-     * 
+     *
      * @param query
      *            The query string in JEXL syntax to parse
      * @return Root node of the query parse tree.

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/JexlStringBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/JexlStringBuildingVisitor.java
@@ -401,6 +401,10 @@ public class JexlStringBuildingVisitor extends BaseVisitor {
         StringBuilder sb = (StringBuilder) data;
         
         String literal = node.image;
+        
+        // first, escape any backslashes in the literal
+        literal = literal.replace("\\", "\\\\");
+        
         int index = literal.indexOf(STRING_QUOTE);
         if (-1 != index) {
             // Slightly larger buffer
@@ -420,20 +424,6 @@ public class JexlStringBuildingVisitor extends BaseVisitor {
             builder.append(literal.substring(begin));
             
             // Set the new version on the literal
-            literal = builder.toString();
-        }
-        
-        // Make sure we don't accidentally escape the closing quotation mark
-        // e.g. FOO == 'C:\Foo\'
-        if (literal.charAt(literal.length() - 1) == BACKSLASH) {
-            StringBuilder builder = new StringBuilder(literal);
-            
-            // Nuke that last backslash
-            builder.setLength(literal.length() - 1);
-            
-            // We need to ensure that a literal backslash makes it down to the tservers
-            builder.append(BACKSLASH).append(BACKSLASH);
-            
             literal = builder.toString();
         }
         

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/JexlNode.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/JexlNode.java
@@ -25,7 +25,7 @@ public class JexlNode {
     
     public static String jexlEscapeSelector(String s) {
         String escapedSelector = s;
-        escapedSelector = escapedSelector.replace("\\", "\\u005c");
+        escapedSelector = escapedSelector.replace("\\", "\\\\");
         
         // escape apostrophes becasue we uses these to enclose string
         // literals in jexl syntax.

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/JexlSelectorNode.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/JexlSelectorNode.java
@@ -95,11 +95,11 @@ public class JexlSelectorNode extends JexlNode {
                     
                     // For these chars, we need to escape them to do what the user wants
                     if (ESCAPE_CHARS.contains(chars[x])) {
-                        sb.append(UNICODE_BACKSLASH);
+                        sb.append(BACKSLASH);
                     }
                     
                     if (chars[x] == BACKSLASH) {
-                        sb.append(UNICODE_BACKSLASH);
+                        sb.append(BACKSLASH);
                     } else {
                         sb.append(chars[x]);
                     }
@@ -109,7 +109,7 @@ public class JexlSelectorNode extends JexlNode {
             } else if (currChar == '?') {
                 sb.append(".");
             } else if (currChar == '.') {
-                sb.append(UNICODE_BACKSLASH).append(currChar);
+                sb.append(BACKSLASH).append(currChar);
             } else if (currChar == '\'' && (x == 0 || (x > 0 && chars[x - 1] != BACKSLASH))) {
                 sb.append(BACKSLASH).append(currChar);
             } else {
@@ -122,11 +122,11 @@ public class JexlSelectorNode extends JexlNode {
             if (sb.length() > 1) {
                 // If we have more than two chars, we need to make sure we don't inadvertently undo the correct escape
                 if (!BACKSLASH.equals(sb.charAt(sb.length() - 2))) {
-                    sb.append(UNICODE_BACKSLASH);
+                    sb.append(BACKSLASH);
                 }
             } else {
                 // Is only a backslash, and as such we need to escape it
-                sb.append(UNICODE_BACKSLASH);
+                sb.append(BACKSLASH);
             }
         }
         

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1387,6 +1387,7 @@ public class DefaultQueryPlanner extends QueryPlanner {
         ASTJexlScript queryTree;
         try {
             queryTree = JexlASTHelper.parseJexlQuery(query);
+            queryTree = TreeFlatteningRebuildingVisitor.flatten(queryTree);
             ValidPatternVisitor.check(queryTree);
         } catch (StackOverflowError soe) {
             if (log.isTraceEnabled()) {

--- a/warehouse/query-core/src/test/java/datawave/query/RegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/RegexQueryTest.java
@@ -192,6 +192,69 @@ public class RegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, query);
     }
     
+    @Test
+    public void testBackslashEdgeCase1() throws Exception {
+        String term = "'\\\\Edge-City-1'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase2() throws Exception {
+        String term = "'\\\\\\\\Edge-City-2'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase3() throws Exception {
+        String term = "'\\\\\\\\\\\\Edge-City-3'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase4() throws Exception {
+        String term = "'Edge-City-4\\\\'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase5() throws Exception {
+        String term = "'Edge-City-5\\\\\\\\'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase6() throws Exception {
+        String term = "'Edge-City-6\\\\\\\\\\\\'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase7() throws Exception {
+        String term = "'Edge-C\\\\ity-7'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase8() throws Exception {
+        String term = "'Edge-C\\\\\\\\ity-8'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
+    @Test
+    public void testBackslashEdgeCase9() throws Exception {
+        String term = "'Edge-C\\\\\\\\\\\\ity-9'";
+        String query = CityField.CITY.name() + EQ_OP + term;
+        runTest(query, query);
+    }
+    
     // ============================================
     // error conditions
     @Test(expected = FullTableScansDisallowedException.class)

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -304,7 +304,7 @@ public class ExpandMultiNormalizedTermsTest {
         config.setQueryFieldsDatatypes(dataTypes);
         
         String original = "filter:includeRegex(IP, '1\\.2\\.3\\..*')";
-        String expected = "filter:includeRegex(IP, '1\\.2\\.3\\..*')";
+        String expected = "filter:includeRegex(IP, '1\\\\.2\\\\.3\\\\..*')";
         expandTerms(original, expected);
     }
     
@@ -320,7 +320,7 @@ public class ExpandMultiNormalizedTermsTest {
         config.setQueryFieldsDatatypes(dataTypes);
         
         String original = "filter:includeRegex(IP, '1\\.2\\.3\\..*')";
-        String expected = "filter:includeRegex(IP, '1\\.2\\.3\\..*')";
+        String expected = "filter:includeRegex(IP, '1\\\\.2\\\\.3\\\\..*')";
         expandTerms(original, expected);
     }
     
@@ -336,7 +336,7 @@ public class ExpandMultiNormalizedTermsTest {
         config.setQueryFieldsDatatypes(dataTypes);
         
         String original = "filter:includeRegex(IP, '1\\.2\\.3\\.4')";
-        String expected = "filter:includeRegex(IP, '1\\.2\\.3\\.4')";
+        String expected = "filter:includeRegex(IP, '1\\\\.2\\\\.3\\\\.4')";
         expandTerms(original, expected);
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -160,9 +160,9 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("A == '1' && B == '2' && C == '3' && !(D == '4')", parseQuery("A:1 B:2 C:3 NOT D:4"));
         Assert.assertEquals("(A == '1' && B == '2' && C == '3') && !(D == '4')", parseQuery("(A:1 B:2 C:3) NOT D:4"));
         
-        Assert.assertEquals("A =~ '11\\u005c.22.*?'", parseQuery("A:11.22*"));
-        Assert.assertEquals("A =~ '11\\u005c\\u005c22.*?'", parseQuery("A:11\\\\22*"));
-        Assert.assertEquals("A =~ 'TESTING.1\\u005c\\u005c22.*?'", parseQuery("A:TESTING?1\\\\22*"));
+        Assert.assertEquals("A =~ '11\\.22.*?'", parseQuery("A:11.22*"));
+        Assert.assertEquals("A =~ '11\\\\22.*?'", parseQuery("A:11\\\\22*"));
+        Assert.assertEquals("A =~ 'TESTING.1\\\\22.*?'", parseQuery("A:TESTING?1\\\\22*"));
     }
     
     @Test
@@ -267,11 +267,11 @@ public class TestLuceneToJexlQueryParser {
     @Test
     public void testWildcards() throws ParseException {
         Assert.assertEquals("F1 == '*1234'", parseQuery("F1:\\*1234"));
-        Assert.assertEquals("F1 =~ '\\u005c*12.34'", parseQuery("F1:\\*12?34"));
+        Assert.assertEquals("F1 =~ '\\*12.34'", parseQuery("F1:\\*12?34"));
         Assert.assertEquals("F1 == '*'", parseQuery("F1:\\*"));
-        Assert.assertEquals("F1 =~ '\\u005c\\u005c.*?'", parseQuery("F1:\\\\*"));
-        Assert.assertEquals("F1 == '\\u005c*'", parseQuery("F1:\\\\\\*"));
-        Assert.assertEquals("F1 =~ '\\u005c\\u005c.*?x.*?'", parseQuery("F1:\\\\*x*"));
+        Assert.assertEquals("F1 =~ '\\\\.*?'", parseQuery("F1:\\\\*"));
+        Assert.assertEquals("F1 == '\\\\*'", parseQuery("F1:\\\\\\*"));
+        Assert.assertEquals("F1 =~ '\\\\.*?x.*?'", parseQuery("F1:\\\\*x*"));
     }
     
     @Test
@@ -281,7 +281,7 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("fieldName1 == 'value1' && (fieldName2 >= 'aaa' && fieldName2 <= 'bbb') && fieldName3 == 'value3'",
                         parseQuery("fieldName1:value1 AND fieldName2:[aaa TO bbb] AND fieldName3:value3"));
         Assert.assertEquals("(F >= 'A' && F <= 'B')", parseQuery("F:[A TO B]"));
-        Assert.assertEquals("(F >= 'A\\u005c*' && F <= 'B')", parseQuery("F:[A\\\\\\* TO B]"));
+        Assert.assertEquals("(F >= 'A\\\\*' && F <= 'B')", parseQuery("F:[A\\\\\\* TO B]"));
         Assert.assertEquals("(F > 'lower' && F <= 'upper')", parseQuery("F:{lower TO upper]"));
         Assert.assertEquals("(F >= 'lower' && F < 'upper')", parseQuery("F:[lower TO upper}"));
     }
@@ -322,11 +322,11 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("A =~ '11\\'22.*?'", parseQuery("A:11'22*"));
         //
         // // F:[A'\\\* TO B'], searching from A'\\* ("A" followed by a single quote, a backslash, and an asterisk to "B" followed by a single quote
-        Assert.assertEquals("(F >= 'A\\'\\u005c*' && F <= 'B\\'')", parseQuery("F:[A'\\\\\\* TO B']"));
+        Assert.assertEquals("(F >= 'A\\'\\\\*' && F <= 'B\\'')", parseQuery("F:[A'\\\\\\* TO B']"));
         //
         // // space escapes
         Assert.assertEquals(anyField + " == 'joh.nny chicken'", parseQuery("joh.nny\\ chicken"));
-        Assert.assertEquals(anyField + " =~ 'joh\\u005c.nny chick.*?'", parseQuery("joh.nny\\ chick*"));
+        Assert.assertEquals(anyField + " =~ 'joh\\.nny chick.*?'", parseQuery("joh.nny\\ chick*"));
         Assert.assertEquals(anyField + " == 'joh.nny chicken'", parseQuery("\"joh.nny\\ chicken\""));
         Assert.assertEquals("content:phrase(termOffsetMap, 'joh.nny', 'chic ken')", parseQuery("\"joh.nny chic\\ ken\""));
         Assert.assertEquals("content:phrase(termOffsetMap, 'joh.nny', 'chic k*')", parseQuery("\"joh.nny chic\\ k*\""));
@@ -335,12 +335,12 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("content:phrase(termOffsetMap, 'joh.nny', '\"chicken\"')", parseQuery("\"joh.nny \\\"chicken\\\"\""));
         
         // unicode escapes.
-        Assert.assertEquals("FIELD =~ 'joh\\u005c.nny.*?\\u005c\\u005c''", parseQuery("FIELD:joh.nny*\\\\'"));
-        Assert.assertEquals("FIELD =~ 'joh\\u005c.nny\\u005c\\u005cu005cfive.*?\\''", parseQuery("FIELD:joh.nny\\\\u005cfive*'"));
+        Assert.assertEquals("FIELD =~ 'joh\\.nny.*?\\\\''", parseQuery("FIELD:joh.nny*\\\\'"));
+        Assert.assertEquals("FIELD =~ 'joh\\.nny\\\\five.*?\\''", parseQuery("FIELD:joh.nny\\\\five*'"));
         
         // literal blackslashes
-        Assert.assertEquals(anyField + " == 'yep\\u005cyep'", parseQuery("yep\\\\yep"));
-        Assert.assertEquals("content:phrase(termOffsetMap, 'yep\\u005cyep', 'otherterm')", parseQuery("\"yep\\\\yep otherterm\""));
+        Assert.assertEquals(anyField + " == 'yep\\\\yep'", parseQuery("yep\\\\yep"));
+        Assert.assertEquals("content:phrase(termOffsetMap, 'yep\\\\yep', 'otherterm')", parseQuery("\"yep\\\\yep otherterm\""));
     }
     
     @Test
@@ -353,12 +353,12 @@ public class TestLuceneToJexlQueryParser {
                         "(content:phrase(TOKFIELD, termOffsetMap, 'johnny\\'s', 'chicken') || content:phrase(TOKFIELD, termOffsetMap, 'johnny', 'chicken'))",
                         parseQuery("TOKFIELD:\"johnny's chicken\""));
         Assert.assertEquals("TOKFIELD =~ '11\\'22.*?'", parseQuery("TOKFIELD:11'22*"));
-        Assert.assertEquals("(TOKFIELD >= 'A\\'\\u005c*' && TOKFIELD <= 'B\\'')", parseQuery("TOKFIELD:[A'\\\\\\* TO B']"));
+        Assert.assertEquals("(TOKFIELD >= 'A\\'\\\\*' && TOKFIELD <= 'B\\'')", parseQuery("TOKFIELD:[A'\\\\\\* TO B']"));
         
         // space escapes
         Assert.assertEquals("(TOKFIELD == 'joh.nny chicken' || content:within(TOKFIELD, 2, termOffsetMap, 'joh.nny', 'chicken'))",
                         parseQuery("TOKFIELD:joh.nny\\ chicken"));
-        Assert.assertEquals("TOKFIELD =~ 'joh\\u005c.nny chick.*?'", parseQuery("TOKFIELD:joh.nny\\ chick*"));
+        Assert.assertEquals("TOKFIELD =~ 'joh\\.nny chick.*?'", parseQuery("TOKFIELD:joh.nny\\ chick*"));
         Assert.assertEquals("(TOKFIELD == 'joh.nny chicken' || content:phrase(TOKFIELD, termOffsetMap, 'joh.nny', 'chicken'))",
                         parseQuery("TOKFIELD:\"joh.nny\\ chicken\""));
         
@@ -375,17 +375,17 @@ public class TestLuceneToJexlQueryParser {
                         parseQuery("TOKFIELD:\"joh.nny \\\"chicken\\\"\""));
         
         // unicode escapes.
-        Assert.assertEquals("TOKFIELD =~ 'joh\\u005c.nny.*?\\u005c\\u005c''", parseQuery("TOKFIELD:joh.nny*\\\\'"));
-        Assert.assertEquals("TOKFIELD =~ 'joh\\u005c.nny\\u005c\\u005cu005cfive.*?\\''", parseQuery("TOKFIELD:joh.nny\\\\u005cfive*'"));
+        Assert.assertEquals("TOKFIELD =~ 'joh\\.nny.*?\\\\''", parseQuery("TOKFIELD:joh.nny*\\\\'"));
+        Assert.assertEquals("TOKFIELD =~ 'joh\\.nny\\\\five.*?\\''", parseQuery("TOKFIELD:joh.nny\\\\five*'"));
         
         // literal blackslashes
-        Assert.assertEquals("(TOKFIELD == 'someone\\u005c234someplace.com' || content:within(TOKFIELD, 2, termOffsetMap, 'someone', '234someplace.com'))",
+        Assert.assertEquals("(TOKFIELD == 'someone\\\\234someplace.com' || content:within(TOKFIELD, 2, termOffsetMap, 'someone', '234someplace.com'))",
                         parseQuery("TOKFIELD:someone\\\\234someplace.com"));
         Assert.assertEquals(
-                        "(content:phrase(TOKFIELD, termOffsetMap, 'someone\\u005c234someplace.com', 'otherterm') || content:phrase(TOKFIELD, termOffsetMap, 'someone', '234someplace.com', 'otherterm'))",
+                        "(content:phrase(TOKFIELD, termOffsetMap, 'someone\\\\234someplace.com', 'otherterm') || content:phrase(TOKFIELD, termOffsetMap, 'someone', '234someplace.com', 'otherterm'))",
                         parseQuery("TOKFIELD:\"someone\\\\234someplace.com otherterm\""));
         // FIX THIS, trailing slashes in queries should be acceptable.
-        // Assert.assertEquals("(TOKFIELD == 'someone\\u005c234someplace.com\\u005c' || content:within(TOKFIELD, 2, termOffsetMap, 'someone',
+        // Assert.assertEquals("(TOKFIELD == 'someone\\234someplace.com\\' || content:within(TOKFIELD, 2, termOffsetMap, 'someone',
         // '234someplace.com'))",
         // parseQuery("TOKFIELD:someone\\\\234someplace.com\\\\"));
     }
@@ -558,8 +558,7 @@ public class TestLuceneToJexlQueryParser {
     
     @Test
     public void testParseRegexsWithEscapes() throws ParseException {
-        Assert.assertEquals("F == '6515' && FOOBAR =~ 'Foo/5\\u005c.0 \\u005c(ibar.*?'", parser.parse("F:6515 and FOOBAR:Foo\\/5.0\\ \\(ibar*")
-                        .getOriginalQuery());
+        Assert.assertEquals("F == '6515' && FOOBAR =~ 'Foo/5\\.0 \\(ibar.*?'", parser.parse("F:6515 and FOOBAR:Foo\\/5.0\\ \\(ibar*").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo Foo Foo.*?'", parser.parse("FOO:bar BAZ:Foo\\ Foo\\ Foo*").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo Foo Foo.*'", parser.parse("FOO:bar BAZ:/Foo Foo Foo.*/").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo Foo Foo.*?'", parser.parse("FOO:bar BAZ:/Foo Foo Foo.*?/").getOriginalQuery());

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/CityDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/CityDataManager.java
@@ -33,7 +33,7 @@ public class CityDataManager extends AbstractDataManager {
     @Override
     public void addTestData(final URI file, final String datatype, final Set<String> indexes) throws IOException {
         Assert.assertFalse("datatype has already been configured(" + datatype + ")", this.rawData.containsKey(datatype));
-        try (final Reader reader = Files.newBufferedReader(Paths.get(file)); final CSVReader csv = new CSVReader(reader)) {
+        try (final Reader reader = Files.newBufferedReader(Paths.get(file)); final CSVReader csv = new CSVReader(reader, ',', '\"', '\0')) {
             String[] data;
             int count = 0;
             Set<RawData> cityData = new HashSet<>();

--- a/warehouse/query-core/src/test/resources/input/generic-cities.csv
+++ b/warehouse/query-core/src/test/resources/input/generic-cities.csv
@@ -14,3 +14,12 @@
 20151111,par-ita-11,Paris,Lazio,Italy,Europe,ITA,Euro,30
 20151111,rom-bel-11,Rome,Hainaut,Belgium,Europe,BEL,Euro,50
 20151111,ldn-fra-lle-11,London,lle-de-France,France,Europe,FRA,Euro,20
+20151111,edge-case-id-1,\Edge-City-1,Edgeville,Edgeland,Edgeope,EDG,NA,110
+20151111,edge-case-id-2,\\Edge-City-2,Edgeville,Edgeland,Edgeope,EDG,NA,220
+20151111,edge-case-id-3,\\\Edge-City-3,Edgeville,Edgeland,Edgeope,EDG,NA,330
+20151111,edge-case-id-4,Edge-City-4\,Edgeville,Edgeland,Edgeope,EDG,NA,110
+20151111,edge-case-id-5,Edge-City-5\\,Edgeville,Edgeland,Edgeope,EDG,NA,220
+20151111,edge-case-id-6,Edge-City-6\\\,Edgeville,Edgeland,Edgeope,EDG,NA,330
+20151111,edge-case-id-7,Edge-C\ity-7,Edgeville,Edgeland,Edgeope,EDG,NA,110
+20151111,edge-case-id-8,Edge-C\\ity-8,Edgeville,Edgeland,Edgeope,EDG,NA,220
+20151111,edge-case-id-9,Edge-C\\\ity-9,Edgeville,Edgeland,Edgeope,EDG,NA,330


### PR DESCRIPTION
This PR covers two fixes:
1) Update the DefaultQueryPlanner to avoid stack overflows by flattening the query after parsing.
2) Updated the lucene parser to correctly handle regex terms which start with backslashes.