### PR TITLE
Refactored the FileSortedSet to avoid dependency on java Serializable.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/FileKeySortedSet.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/FileKeySortedSet.java
@@ -1,0 +1,160 @@
+package datawave.query.util.sortedset;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.log4j.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Comparator;
+import java.util.SortedSet;
+
+/**
+ * A sorted set that can be persisted into a file and still be read in its persisted state. The set can always be re-loaded and then all operations will work as
+ * expected. This will support null contained in the underlying sets iff a comparator is supplied that can handle null values.
+ *
+ * The persisted file will contain the serialized entries, followed by the actual size.
+ *
+ */
+public class FileKeySortedSet extends FileSortedSet<Key> {
+    private static Logger log = Logger.getLogger(FileKeySortedSet.class);
+    
+    /**
+     * Create a file sorted set from another one
+     * 
+     * @param other
+     */
+    public FileKeySortedSet(FileKeySortedSet other) {
+        super(other);
+    }
+    
+    /**
+     * Create a persisted sorted set
+     * 
+     * @param handler
+     * @param persisted
+     */
+    public FileKeySortedSet(SortedSetFileHandler handler, boolean persisted) {
+        super(handler, persisted);
+    }
+    
+    /**
+     * Create a persistede sorted set
+     * 
+     * @param comparator
+     * @param handler
+     * @param persisted
+     */
+    public FileKeySortedSet(Comparator<? super Key> comparator, SortedSetFileHandler handler, boolean persisted) {
+        super(comparator, handler, persisted);
+    }
+    
+    /**
+     * Create an unpersisted sorted set (still in memory)
+     * 
+     * @param set
+     * @param handler
+     */
+    public FileKeySortedSet(SortedSet<Key> set, SortedSetFileHandler handler) {
+        super(set, handler);
+    }
+    
+    /**
+     * Create an sorted set out of another sorted set. If persist is true, then the set will be directly persisted using the set's iterator which avoid pulling
+     * all of its entries into memory at once.
+     *
+     * @param set
+     * @param handler
+     */
+    public FileKeySortedSet(SortedSet<Key> set, SortedSetFileHandler handler, boolean persist) throws IOException {
+        super(set, handler, persist);
+    }
+    
+    /**
+     * Get an input stream
+     * 
+     * @return the input stream
+     * @throws FileNotFoundException
+     * @throws IOException
+     */
+    @Override
+    protected DataInputStream getInputStream() throws IOException {
+        return new DataInputStream(new BufferedInputStream(handler.getInputStream()));
+    }
+    
+    /**
+     * Get an output stream
+     * 
+     * @return the output stream
+     * @throws IOException
+     */
+    @Override
+    protected DataOutputStream getOutputStream() throws IOException {
+        return new DataOutputStream(new BufferedOutputStream(handler.getOutputStream()));
+    }
+    
+    /**
+     * Write T to an object output stream
+     * 
+     * @param stream
+     * @param t
+     * @throws IOException
+     */
+    @Override
+    protected void writeObject(OutputStream stream, Key t) throws IOException {
+        t.write((DataOutputStream) stream);
+    }
+    
+    /**
+     * Read T from an object input stream
+     *
+     * @param stream
+     * @return a key
+     * @throws IOException
+     */
+    @Override
+    protected Key readObject(InputStream stream) throws IOException {
+        Key o = new Key();
+        o.readFields((DataInputStream) stream);
+        return o;
+    }
+    
+    /**
+     * Clone this set
+     */
+    @Override
+    public FileKeySortedSet clone() {
+        return new FileKeySortedSet(this);
+    }
+    
+    /**
+     * A factory for these file sorted sets
+     */
+    public static class Factory implements FileSortedSetFactory<Key> {
+        
+        @Override
+        public FileKeySortedSet newInstance(SortedSetFileHandler handler, boolean persisted) {
+            return new FileKeySortedSet(handler, persisted);
+        }
+        
+        @Override
+        public FileKeySortedSet newInstance(Comparator<? super Key> comparator, SortedSetFileHandler handler, boolean persisted) {
+            return new FileKeySortedSet(comparator, handler, persisted);
+        }
+        
+        @Override
+        public FileKeySortedSet newInstance(SortedSet<Key> set, SortedSetFileHandler handler) {
+            return new FileKeySortedSet(set, handler);
+        }
+        
+        @Override
+        public FileKeySortedSet newInstance(SortedSet<Key> set, SortedSetFileHandler handler, boolean persist) throws IOException {
+            return new FileKeySortedSet(set, handler, persist);
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/FileSerializableSortedSet.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/FileSerializableSortedSet.java
@@ -1,0 +1,160 @@
+package datawave.query.util.sortedset;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.SortedSet;
+import org.apache.log4j.Logger;
+
+/**
+ * A sorted set that can be persisted into a file and still be read in its persisted state. The set can always be re-loaded and then all operations will work as
+ * expected. This will support null contained in the underlying sets iff a comparator is supplied that can handle null values.
+ *
+ * The persisted file will contain the serialized entries, followed by the actual size.
+ *
+ */
+public class FileSerializableSortedSet<E extends Serializable> extends FileSortedSet<E> {
+    private static Logger log = Logger.getLogger(FileSerializableSortedSet.class);
+    
+    /**
+     * Create a file sorted set from another one
+     *
+     * @param other
+     */
+    public FileSerializableSortedSet(FileSerializableSortedSet other) {
+        super(other);
+    }
+    
+    /**
+     * Create a persisted sorted set
+     *
+     * @param handler
+     * @param persisted
+     */
+    public FileSerializableSortedSet(SortedSetFileHandler handler, boolean persisted) {
+        super(handler, persisted);
+    }
+    
+    /**
+     * Create a persistede sorted set
+     *
+     * @param comparator
+     * @param handler
+     * @param persisted
+     */
+    public FileSerializableSortedSet(Comparator<? super E> comparator, SortedSetFileHandler handler, boolean persisted) {
+        super(comparator, handler, persisted);
+    }
+    
+    /**
+     * Create an unpersisted sorted set (still in memory)
+     *
+     * @param set
+     * @param handler
+     */
+    public FileSerializableSortedSet(SortedSet<E> set, SortedSetFileHandler handler) {
+        super(set, handler);
+    }
+    
+    /**
+     * Create an sorted set out of another sorted set. If persist is true, then the set will be directly persisted using the set's iterator which avoid pulling
+     * all of its entries into memory at once.
+     *
+     * @param set
+     * @param handler
+     */
+    public FileSerializableSortedSet(SortedSet<E> set, SortedSetFileHandler handler, boolean persist) throws IOException {
+        super(set, handler, persist);
+    }
+    
+    /**
+     * Get an input stream
+     * 
+     * @return the input stream
+     * @throws FileNotFoundException
+     * @throws IOException
+     */
+    @Override
+    protected ObjectInputStream getInputStream() throws IOException {
+        return new ObjectInputStream(new BufferedInputStream(handler.getInputStream()));
+    }
+    
+    /**
+     * Get an output stream
+     * 
+     * @return the output stream
+     * @throws IOException
+     */
+    @Override
+    protected ObjectOutputStream getOutputStream() throws IOException {
+        return new ObjectOutputStream(new BufferedOutputStream(handler.getOutputStream()));
+    }
+    
+    /**
+     * Write KeyValueSerializable to an object output stream
+     * 
+     * @param stream
+     * @param t
+     * @throws IOException
+     */
+    @Override
+    protected void writeObject(OutputStream stream, E t) throws IOException {
+        ((ObjectOutputStream) stream).writeObject(t);
+    }
+    
+    /**
+     * Read KeyValueSerializable from an object input stream
+     *
+     * @param stream
+     * @return a key
+     * @throws IOException
+     */
+    @Override
+    protected E readObject(InputStream stream) throws IOException {
+        try {
+            Object o = ((ObjectInputStream) stream).readObject();
+            return (E) o;
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Could not deserialize object", e);
+        }
+    }
+    
+    @Override
+    public FileSortedSet<E> clone() {
+        return new FileSerializableSortedSet(this);
+    }
+    
+    /**
+     * A factory for this set
+     */
+    public static class Factory<E extends Serializable> implements FileSortedSetFactory<E> {
+        
+        @Override
+        public FileSerializableSortedSet<E> newInstance(SortedSetFileHandler handler, boolean persisted) {
+            return new FileSerializableSortedSet(handler, persisted);
+        }
+        
+        @Override
+        public FileSerializableSortedSet<E> newInstance(Comparator<? super E> comparator, SortedSetFileHandler handler, boolean persisted) {
+            return new FileSerializableSortedSet(comparator, handler, persisted);
+        }
+        
+        @Override
+        public FileSerializableSortedSet<E> newInstance(SortedSet<E> set, SortedSetFileHandler handler) {
+            return new FileSerializableSortedSet(set, handler);
+        }
+        
+        @Override
+        public FileSerializableSortedSet<E> newInstance(SortedSet<E> set, SortedSetFileHandler handler, boolean persist) throws IOException {
+            return new FileSerializableSortedSet(set, handler, persist);
+        }
+    }
+    
+}


### PR DESCRIPTION
This allows extending the implementation to use a Writable such as the
accumulo Key object.  Updated the ivarator to use sets of Key objects
instead of sets of KeyValueSerializable object avoiding unnecessary object
creations.