### PR TITLE
Better way to configure unique terms within an expression

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
@@ -125,7 +125,6 @@ public class LookupUUIDTune implements Profile {
             if (maxShardsPerDayThreshold != -1) {
                 rsqc.setShardsPerDayThreshold(maxShardsPerDayThreshold);
             }
-            rsqc.setEnforceUniqueTermsWithinExpressions(enforceUniqueTermsWithinExpressions);
             
             // we need this since we've finished the deep copy already
             rsqc.setSpeculativeScanning(speculativeScanning);

--- a/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
@@ -54,8 +54,7 @@ public class LookupUUIDTune implements Profile {
             rsq.setSpeculativeScanning(speculativeScanning);
             rsq.setCacheModel(enableCaching);
             rsq.setPrimaryToSecondaryFieldMap(primaryToSecondaryFieldMap);
-            if (enforceUniqueTermsWithinExpressions)
-                rsq.setEnforceUniqueTermsWithinExpressions(true);
+            rsq.setEnforceUniqueTermsWithinExpressions(enforceUniqueTermsWithinExpressions);
             
             if (querySyntaxParsers != null) {
                 rsq.setQuerySyntaxParsers(querySyntaxParsers);
@@ -68,8 +67,6 @@ public class LookupUUIDTune implements Profile {
                 SeekingQueryPlanner planner = new SeekingQueryPlanner();
                 planner.setMaxFieldHitsBeforeSeek(maxFieldHitsBeforeSeek);
                 planner.setMaxKeysBeforeSeek(maxKeysBeforeSeek);
-                if (enforceUniqueTermsWithinExpressions)
-                    planner.setEnforceUniqueTermsWithinExpressions(true);
                 
                 rsq.setQueryPlanner(planner);
                 
@@ -90,8 +87,6 @@ public class LookupUUIDTune implements Profile {
             DefaultQueryPlanner dqp = DefaultQueryPlanner.class.cast(planner);
             dqp.setCacheDataTypes(enableCaching);
             dqp.setCondenseUidsInRangeStream(false);
-            // Should the query planner attempt to de-dupe query terms post model expansion?
-            dqp.setEnforceUniqueTermsWithinExpressions(enforceUniqueTermsWithinExpressions);
             
             if (transforms != null) {
                 dqp.setTransformRules(transforms);
@@ -130,8 +125,8 @@ public class LookupUUIDTune implements Profile {
             if (maxShardsPerDayThreshold != -1) {
                 rsqc.setShardsPerDayThreshold(maxShardsPerDayThreshold);
             }
-            if (enforceUniqueTermsWithinExpressions)
-                rsqc.setEnforceUniqueTermsWithinExpressions(true);
+            rsqc.setEnforceUniqueTermsWithinExpressions(enforceUniqueTermsWithinExpressions);
+            
             // we need this since we've finished the deep copy already
             rsqc.setSpeculativeScanning(speculativeScanning);
             rsqc.setTrackSizes(trackSizes);

--- a/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import datawave.query.Constants;
 import datawave.query.language.parser.QueryParser;
-import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.planner.QueryPlanner;
 import datawave.query.planner.SeekingQueryPlanner;
@@ -43,6 +42,7 @@ public class LookupUUIDTune implements Profile {
     protected boolean reduceFieldsPreQueryEvaluation = false;
     protected String limitFieldsField = null;
     protected boolean reduceQuery = false;
+    private boolean enforceUniqueTermsWithinExpressions = false;
     protected List<NodeTransformRule> transforms = null;
     protected Map<String,QueryParser> querySyntaxParsers = null;
     
@@ -54,6 +54,8 @@ public class LookupUUIDTune implements Profile {
             rsq.setSpeculativeScanning(speculativeScanning);
             rsq.setCacheModel(enableCaching);
             rsq.setPrimaryToSecondaryFieldMap(primaryToSecondaryFieldMap);
+            if (enforceUniqueTermsWithinExpressions)
+                rsq.setEnforceUniqueTermsWithinExpressions(true);
             
             if (querySyntaxParsers != null) {
                 rsq.setQuerySyntaxParsers(querySyntaxParsers);
@@ -66,6 +68,9 @@ public class LookupUUIDTune implements Profile {
                 SeekingQueryPlanner planner = new SeekingQueryPlanner();
                 planner.setMaxFieldHitsBeforeSeek(maxFieldHitsBeforeSeek);
                 planner.setMaxKeysBeforeSeek(maxKeysBeforeSeek);
+                if (enforceUniqueTermsWithinExpressions)
+                    planner.setEnforceUniqueTermsWithinExpressions(true);
+                
                 rsq.setQueryPlanner(planner);
                 
                 if (maxPageSize != -1) {
@@ -86,7 +91,7 @@ public class LookupUUIDTune implements Profile {
             dqp.setCacheDataTypes(enableCaching);
             dqp.setCondenseUidsInRangeStream(false);
             // Should the query planner attempt to de-dupe query terms post model expansion?
-            dqp.setEnforceUniqueTermsWithinExpressions(reduceQuery);
+            dqp.setEnforceUniqueTermsWithinExpressions(enforceUniqueTermsWithinExpressions);
             
             if (transforms != null) {
                 dqp.setTransformRules(transforms);
@@ -125,6 +130,8 @@ public class LookupUUIDTune implements Profile {
             if (maxShardsPerDayThreshold != -1) {
                 rsqc.setShardsPerDayThreshold(maxShardsPerDayThreshold);
             }
+            if (enforceUniqueTermsWithinExpressions)
+                rsqc.setEnforceUniqueTermsWithinExpressions(true);
             // we need this since we've finished the deep copy already
             rsqc.setSpeculativeScanning(speculativeScanning);
             rsqc.setTrackSizes(trackSizes);
@@ -291,6 +298,14 @@ public class LookupUUIDTune implements Profile {
     
     public void setReduceQuery(boolean reduceQuery) {
         this.reduceQuery = reduceQuery;
+    }
+    
+    public boolean isEnforceUniqueTermsWithinExpressions() {
+        return enforceUniqueTermsWithinExpressions;
+    }
+    
+    public void setEnforceUniqueTermsWithinExpressions(boolean enforceUniqueTermsWithinExpressions) {
+        this.enforceUniqueTermsWithinExpressions = enforceUniqueTermsWithinExpressions;
     }
     
     public List<NodeTransformRule> getTransforms() {

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -83,6 +83,8 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private boolean parseTldUids = false;
     private boolean collapseUids = false;
     private int collapseUidsThreshold = -1;
+    // Should this query dedupe terms within ANDs and ORs
+    private boolean enforceUniqueTermsWithinExpressions = false;
     private boolean sequentialScheduler = false;
     private boolean collectTimingDetails = false;
     private boolean logTimingDetails = false;
@@ -341,6 +343,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setMaxIndexScanTimeMillis(other.getMaxIndexScanTimeMillis());
         this.setCollapseUids(other.getCollapseUids());
         this.setCollapseUidsThreshold(other.getCollapseUidsThreshold());
+        this.setEnforceUniqueTermsWithinExpressions(other.getEnforceUniqueTermsWithinExpressions());
         this.setParseTldUids(other.getParseTldUids());
         this.setSequentialScheduler(other.getSequentialScheduler());
         this.setCollectTimingDetails(other.getCollectTimingDetails());
@@ -1795,6 +1798,14 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     
     public void setCollapseUidsThreshold(int collapseUidsThreshold) {
         this.collapseUidsThreshold = collapseUidsThreshold;
+    }
+    
+    public boolean getEnforceUniqueTermsWithinExpressions() {
+        return enforceUniqueTermsWithinExpressions;
+    }
+    
+    public void setEnforceUniqueTermsWithinExpressions(boolean enforceUniqueTermsWithinExpressions) {
+        this.enforceUniqueTermsWithinExpressions = enforceUniqueTermsWithinExpressions;
     }
     
     public boolean getSequentialScheduler() {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -131,7 +131,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
@@ -149,11 +148,6 @@ public class DefaultQueryPlanner extends QueryPlanner {
     public static String EXCEED_TERM_EXPANSION_ERROR = "Query failed because it exceeded the query term expansion threshold";
     
     protected boolean limitScanners = false;
-    
-    /**
-     * Allows developers to enable/disable the enforcing of unique nodes with OR and AND nodes.
-     */
-    private boolean enforceUniqueTermsWithinExpressions = false;
     
     /**
      * Allows developers to disable bounded lookup of ranges and regexes. This will be optimized in future releases.
@@ -746,8 +740,8 @@ public class DefaultQueryPlanner extends QueryPlanner {
         
         stopwatch.stop();
         
-        // Enforce if either DefaultQueryPlanner or ShardQueryConfig is true
-        if (enforceUniqueTermsWithinExpressions || config.getEnforceUniqueTermsWithinExpressions()) {
+        // Enforce unique terms within an AND or OR expression.
+        if (config.getEnforceUniqueTermsWithinExpressions()) {
             stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Enforce unique terms within AND and OR expressions");
             queryTree = UniqueExpressionTermsVisitor.enforce(queryTree);
             if (log.isDebugEnabled()) {
@@ -2438,13 +2432,5 @@ public class DefaultQueryPlanner extends QueryPlanner {
         if (null != builderThread) {
             builderThread.shutdown();
         }
-    }
-    
-    public boolean isEnforceUniqueTermsWithinExpressions() {
-        return enforceUniqueTermsWithinExpressions;
-    }
-    
-    public void setEnforceUniqueTermsWithinExpressions(boolean enforceUniqueTermsWithinExpressions) {
-        this.enforceUniqueTermsWithinExpressions = enforceUniqueTermsWithinExpressions;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -746,7 +746,8 @@ public class DefaultQueryPlanner extends QueryPlanner {
         
         stopwatch.stop();
         
-        if (enforceUniqueTermsWithinExpressions) {
+        // Enforce if either DefaultQueryPlanner or ShardQueryConfig is true
+        if (enforceUniqueTermsWithinExpressions || config.getEnforceUniqueTermsWithinExpressions()) {
             stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Enforce unique terms within AND and OR expressions");
             queryTree = UniqueExpressionTermsVisitor.enforce(queryTree);
             if (log.isDebugEnabled()) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -1952,6 +1952,14 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         this.config.setCollapseUidsThreshold(collapseUidsThreshold);
     }
     
+    public boolean getEnforceUniqueTermsWithinExpressions() {
+        return this.config.getEnforceUniqueTermsWithinExpressions();
+    }
+    
+    public void setEnforceUniqueTermsWithinExpressions(boolean enforceUniqueTermsWithinExpressions) {
+        this.getConfig().setEnforceUniqueTermsWithinExpressions(enforceUniqueTermsWithinExpressions);
+    }
+    
     public long getMaxIndexScanTimeMillis() {
         return getConfig().getMaxIndexScanTimeMillis();
     }

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -432,7 +432,7 @@ public class ShardQueryConfigurationTest {
      */
     @Test
     public void testCheckForNewAdditions() throws IOException {
-        int expectedObjectCount = 168;
+        int expectedObjectCount = 169;
         ShardQueryConfiguration config = ShardQueryConfiguration.create();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(mapper.writeValueAsString(config));


### PR DESCRIPTION
Push the configuration for the UniqueExpressionTermsVisitor down to the logic level vs. the DefaultQueryPlanner level.