### PR TITLE
Closes #805 - updated to point to osgeo instead of boundless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -883,6 +883,11 @@
                 <version>${version.geotools}</version>
             </dependency>
             <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-annotations</artifactId>
+                <version>3.4.0.GA</version>
+            </dependency>
+            <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-commons</artifactId>
                 <version>${version.infinispan}</version>
@@ -1123,9 +1128,10 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>boundless</id>
-            <url>https://repo.boundlessgeo.com/main/</url>
+            <id>osgeo</id>
+            <url>https://repo.osgeo.org/repository/release/</url>
         </repository>
+        <!--
         <repository>
             <snapshots>
                 <enabled>false</enabled>
@@ -1134,6 +1140,7 @@
             <name>Open Source Geospatial Foundation Repository</name>
             <url>https://download.osgeo.org/webdav/geotools/</url>
         </repository>
+        -->
     </repositories>
     <pluginRepositories>
         <!--


### PR DESCRIPTION
 . Building from an empty maven repo also required a version of hibernate that did not use the jta 1.0.1B jar