### PR TITLE
Non-functional tweaks to generics usage

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
+++ b/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
@@ -1,15 +1,16 @@
 package datawave;
 
 import java.util.Collection;
+import datawave.data.type.Type;
 
-public class IdentityDataType implements datawave.data.type.Type {
+public class IdentityDataType implements Type<String> {
     @Override
     public String normalize() {
         throw new UnsupportedOperationException();
     }
     
     @Override
-    public Comparable denormalize() {
+    public String denormalize() {
         throw new UnsupportedOperationException();
     }
     
@@ -34,12 +35,12 @@ public class IdentityDataType implements datawave.data.type.Type {
     }
     
     @Override
-    public Comparable denormalize(String in) {
+    public String denormalize(String in) {
         throw new UnsupportedOperationException();
     }
     
     @Override
-    public void setDelegate(Comparable delegate) {
+    public void setDelegate(String delegate) {
         throw new UnsupportedOperationException();
     }
     
@@ -54,7 +55,7 @@ public class IdentityDataType implements datawave.data.type.Type {
     }
     
     @Override
-    public Comparable getDelegate() {
+    public String getDelegate() {
         throw new UnsupportedOperationException();
     }
     
@@ -69,7 +70,7 @@ public class IdentityDataType implements datawave.data.type.Type {
     }
     
     @Override
-    public void normalizeAndSetNormalizedValue(Comparable valueToNormalize) {
+    public void normalizeAndSetNormalizedValue(String valueToNormalize) {
         throw new UnsupportedOperationException();
     }
     
@@ -79,7 +80,7 @@ public class IdentityDataType implements datawave.data.type.Type {
     }
     
     @Override
-    public int compareTo(Object o) {
+    public int compareTo(Type<String> o) {
         throw new UnsupportedOperationException();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -4,14 +4,12 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.WKTReader;
 import datawave.data.normalizer.NoOpNormalizer;
 import datawave.data.normalizer.Normalizer;
 import datawave.data.type.BaseType;
 import datawave.data.type.DiscreteIndexType;
 import datawave.data.type.GeometryType;
-import datawave.ingest.data.config.ingest.CompositeIngest;
+import datawave.data.type.Type;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.DateIndexHelper;
@@ -1262,7 +1260,7 @@ public class ExpandCompositeTermsTest {
         System.err.println();
     }
     
-    private static class MockDiscreteIndexType extends BaseType implements DiscreteIndexType {
+    private static class MockDiscreteIndexType extends BaseType<String> implements DiscreteIndexType<String> {
         
         public MockDiscreteIndexType() {
             super(new NoOpNormalizer());
@@ -1289,7 +1287,7 @@ public class ExpandCompositeTermsTest {
         }
         
         @Override
-        public int compareTo(Object o) {
+        public int compareTo(Type<String> o) {
             return 0;
         }
     }


### PR DESCRIPTION
...to avoid build failures in VSCode.

Some commentary: These are all changes to the way generics were managed and thus have implications to compile time as opposed to runtime. IntelliJ and even `javac` as we execute from maven don't care about these, but the syntax/language engine in VSCode does.

In fact, upon analysis, this seems that each of these implementations differ in how they handle a non-parameterized type, e.g: `datawave.data.type.Type` vs. a wildcard parameterized type `datawave.data.type.Type<?>`. 

The case in the mock for `ExpandCompositeTermsTest` is especially interesting because of the use of `Object` in the `compareTo` method. This doesn't adhere to either of the parameter constraints established in `BaseType`, that the templated object be `Comparable` or `Serializable`. So that seems more clearly incorrect (at compile time)...