### PR TITLE
Closes #794: Display/verify quickstart tarballs prior to installation

### DIFF
--- a/contrib/datawave-quickstart/bin/common.sh
+++ b/contrib/datawave-quickstart/bin/common.sh
@@ -134,6 +134,16 @@ function allStart() {
    done
 }
 
+function allDisplayBinaryInfo() {
+   # Starts all registered services
+   local services=(${DW_CLOUD_SERVICES})
+   for servicename in "${services[@]}" ; do
+      echo "========================================================="
+      echo "$(printGreen "Binary info for ${servicename}")"
+      ${servicename}DisplayBinaryInfo
+   done
+}
+
 function allStop() {
 
    [[ "${1}" == "--hard" ]] && local kill9=true
@@ -218,10 +228,53 @@ function allInstall() {
       allStatus
       return 1
    fi
+   allDisplayBinaryInfo ; echo
    local services=(${DW_CLOUD_SERVICES})
+   if ! checkBinaries ; then
+      askYesNo "Please review the reported inconsistencies in your current setup.
+Hint: Existing local binaries will take precedence over source binaries during installation.
+If that's not what you want, please use $(printGreen "[servicename|all]Uninstall --remove-binaries") to remove local binaries first
+Continue with installation?" || return 1
+   fi
    for servicename in "${services[@]}" ; do
       ${servicename}Install
    done
+}
+
+function checkBinaries()  {
+  local status=0
+  # Dump source and local binaries into distinct arrays
+  local sourceBinaries=()
+  local localBinaries=()
+  while IFS= read -r line; do
+    if [[ "${line}" =~ ^Source:.* ]] ; then
+       sourceBinaries+=("$(cut -d: -f2- <<<${line})")
+    else
+       localBinaries+=("$(cut -d: -f2- <<<${line})")
+    fi
+  done < <( allDisplayBinaryInfo | grep -E 'Source:|Local:' )
+
+  # Compare each tarball pair
+  for ((i=0; i<${#sourceBinaries[@]}; i++)); do
+     local sbin="$(basename "${sourceBinaries[$i]}")"
+     local lbin="$(basename "${localBinaries[$i]}")"
+     if [[ "${sbin}" != "${lbin}" ]] && [[ ! "${lbin}" =~ .*Not\ loaded.* ]] ; then
+        warn "Source and Local binaries are inconsistent: Source == ${sbin}, Local == ${lbin}"
+        status=1
+     fi
+  done
+  return ${status}
+}
+
+function getDataWaveVersion() {
+  local pomFile="${DW_DATAWAVE_SOURCE_DIR}/pom.xml"
+  if [[ -f "${pomFile}" ]]; then
+     local version="$(grep -m 1 '<version>' "${pomFile}" 2>/dev/null | sed 's|.*<version>\(.*\)</version>.*|\1|')"
+     [[ -z "${version}" ]] && return 1
+  else
+     return 1
+  fi
+  echo "${version}"
 }
 
 function allUninstall() {

--- a/contrib/datawave-quickstart/bin/services/accumulo/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/accumulo/bootstrap.sh
@@ -257,3 +257,20 @@ function accumuloPidList() {
       echo "${DW_ACCUMULO_PID_LIST} ${DW_ZOOKEEPER_PID_LIST}"
    fi
 }
+
+function accumuloDisplayBinaryInfo() {
+  echo "Source: ${DW_ACCUMULO_DIST_URI}"
+  local tarballName="$(basename "$DW_ACCUMULO_DIST_URI")"
+  if [[ -f "${DW_ACCUMULO_SERVICE_DIR}/${tarballName}" ]]; then
+     echo " Local: ${DW_ACCUMULO_SERVICE_DIR}/${tarballName}"
+  else
+     echo " Local: Not loaded"
+  fi
+  echo "Source: ${DW_ZOOKEEPER_DIST_URI}"
+  tarballName="$(basename "$DW_ZOOKEEPER_DIST_URI")"
+  if [[ -f "${DW_ACCUMULO_SERVICE_DIR}/${tarballName}" ]]; then
+     echo " Local: ${DW_ACCUMULO_SERVICE_DIR}/${tarballName}"
+  else
+     echo " Local: Not loaded"
+  fi
+}

--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-ingest.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-ingest.sh
@@ -332,3 +332,18 @@ function datawaveIngestCreateTableSplits() {
    # Force splits file creation for use by any upcoming jobs, to ensure proper partitioning
    ${DW_DATAWAVE_INGEST_HOME}/bin/ingest/generate-splits-file.sh
 }
+
+function datawaveIngestDisplayBinaryInfo() {
+  echo "Source: DataWave Ingest Version $(getDataWaveVersion)//$(datawaveIngestTarballName)"
+  local installedTarball="$(ls -1 ${DW_DATAWAVE_SERVICE_DIR}/$(basename ${DW_DATAWAVE_INGEST_TARBALL}) 2>/dev/null)"
+  if [[ -n "${installedTarball}" ]]; then
+     echo " Local: ${installedTarball}"
+  else
+     echo " Local: Not loaded"
+  fi
+}
+
+function datawaveIngestTarballName() {
+   local dwVersion="$(getDataWaveVersion)"
+   echo "$( basename "${DW_DATAWAVE_INGEST_TARBALL/-\*-/-$dwVersion-}" )"
+}

--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
@@ -160,3 +160,25 @@ function datawaveWebStart() {
     done
     return 1
 }
+
+function datawaveWebDisplayBinaryInfo() {
+  echo "Source: DataWave Web Version $(getDataWaveVersion)//$(datawaveWebTarballName)"
+  local installedTarball="$(ls -1 ${DW_DATAWAVE_SERVICE_DIR}/$(basename ${DW_DATAWAVE_WEB_TARBALL}) 2>/dev/null)"
+  if [[ -n "${installedTarball}" ]]; then
+     echo " Local: ${installedTarball}"
+  else
+     echo " Local: Not loaded"
+  fi
+  echo "Source: ${DW_WILDFLY_DIST_URI}"
+  local tarballName="$(basename "$DW_WILDFLY_DIST_URI")"
+  if [[ -f "${DW_DATAWAVE_SERVICE_DIR}/${tarballName}" ]]; then
+     echo " Local: ${DW_DATAWAVE_SERVICE_DIR}/${tarballName}"
+  else
+     echo " Local: Not loaded"
+  fi
+}
+
+function datawaveWebTarballName() {
+   local dwVersion="$(getDataWaveVersion)"
+   echo "$( basename "${DW_DATAWAVE_WEB_TARBALL/-\*-/-$dwVersion-}" )"
+}

--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
@@ -399,3 +399,8 @@ function datawaveBuild() {
    rm -f "${DW_DATAWAVE_SERVICE_DIR}"/datawave*.tar.gz
    resetQuickstartEnvironment
 }
+
+function datawaveDisplayBinaryInfo() {
+   datawaveIngestDisplayBinaryInfo
+   datawaveWebDisplayBinaryInfo
+}

--- a/contrib/datawave-quickstart/bin/services/hadoop/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/hadoop/bootstrap.sh
@@ -203,3 +203,13 @@ function hadoopPidList() {
    hadoopIsRunning && echo "${DW_HADOOP_PID_LIST}"
 
 }
+
+function hadoopDisplayBinaryInfo() {
+  echo "Source: ${DW_HADOOP_DIST_URI}"
+  local tarballName="$(basename "$DW_HADOOP_DIST_URI")"
+  if [[ -f "${DW_HADOOP_SERVICE_DIR}/${tarballName}" ]]; then
+     echo " Local: ${DW_HADOOP_SERVICE_DIR}/${tarballName}"
+  else
+     echo " Local: Not loaded"
+  fi
+}

--- a/contrib/datawave-quickstart/bin/services/maven/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/maven/bootstrap.sh
@@ -104,6 +104,16 @@ function mavenPrintenv() {
    echo
 }
 
+function mavenDisplayBinaryInfo() {
+  echo "Source: ${DW_MAVEN_DIST_URI}"
+  local tarballName="$(basename "$DW_MAVEN_DIST_URI")"
+  if [[ -f "${DW_MAVEN_SERVICE_DIR}/${tarballName}" ]]; then
+     echo " Local: ${DW_MAVEN_SERVICE_DIR}/${tarballName}"
+  else
+     echo " Local: Not loaded"
+  fi
+}
+
 # Eager-loading here since Maven is required to build DataWave,
 # as opposed to lazy-loading like the other services...
 


### PR DESCRIPTION
Added new `[all|servicename]DisplayBinaryInfo` method that will print out the tarball names configured for each service along with the local tarball name, if it's already been downloaded/built

Also, `allInstall` will now print out the tarball info and prompt user with a WARN msg, if a local binary is found that doesn't match the configured source binary (i.e., the associated *_DIST_URI value)

E.g.,...
```
$ allInstall
=========================================================
Binary info for maven
Source: http://mirror.cogentco.com/pub/apache/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/maven/apache-maven-3.5.4-bin.tar.gz
=========================================================
Binary info for hadoop
Source: https://archive.cloudera.com/cdh5/cdh/5/hadoop-2.6.0-cdh5.9.3.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/hadoop/hadoop-2.6.0-cdh5.9.3.tar.gz
=========================================================
Binary info for accumulo
Source: http://apache.cs.utah.edu/accumulo/1.9.3/accumulo-1.9.3-bin.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/accumulo/accumulo-1.9.3-bin.tar.gz
Source: http://archive.cloudera.com/cdh5/cdh/5/zookeeper-3.4.5-cdh5.16.2.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/accumulo/zookeeper-3.4.5-cdh5.16.2.tar.gz
=========================================================
Binary info for datawave
Source: DataWave Ingest Version 2.8.13-SNAPSHOT//datawave-dev-2.8.13-SNAPSHOT-dist.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/datawave/datawave-dev-2.6.0-SNAPSHOT-dist.tar.gz
Source: DataWave Web Version 2.8.13-SNAPSHOT//datawave-ws-deploy-application-2.8.13-SNAPSHOT-dev.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/datawave/datawave-ws-deploy-application-2.6.0-SNAPSHOT-dev.tar.gz
Source: http://download.jboss.org/wildfly/17.0.1.Final/wildfly-17.0.1.Final.tar.gz
 Local: /dev/datawave/contrib/datawave-quickstart/bin/services/datawave/wildfly-17.0.1.Final.tar.gz

[DW-WARN] - Source and Local binaries are inconsistent: Source == datawave-dev-2.8.13-SNAPSHOT-dist.tar.gz, Local == datawave-dev-2.6.0-SNAPSHOT-dist.tar.gz
[DW-WARN] - Source and Local binaries are inconsistent: Source == datawave-ws-deploy-application-2.8.13-SNAPSHOT-dev.tar.gz, Local == datawave-ws-deploy-application-2.6.0-SNAPSHOT-dev.tar.gz

Please review the reported inconsistencies in your current setup.
Hint: Existing local binaries will take precedence over source binaries during installation.
If that's not what you want, please use [servicename|all]Uninstall --remove-binaries to remove local binaries first
Continue with installation? [y/n]:
```
