### PR TITLE
WIP Validate lineage for all JexlNode rebuilding visitors

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -1609,14 +1609,14 @@ public class JexlASTHelper {
                     if (child != null) {
                         if (child.jjtGetParent() == null) {
                             if (failHard)
-                                throw new RuntimeException("Failed to validate lineage: Tree included a child with a null parent.");
+                                throw new RuntimeException("Failed to validate lineage: Tree included a child with a null parent. " + child );
                             else
                                 log.error("Failed to validate lineage: Tree included a child with a null parent.");
                             
                             result = false;
                         } else if (child.jjtGetParent() != node) {
                             if (failHard)
-                                throw new RuntimeException("Failed to validate lineage:  Included a child with a conflicting parent.");
+                                throw new RuntimeException("Failed to validate lineage:  Included a child with a conflicting parent. " + child);
                             else
                                 log.error("Failed to validate lineage:  Included a child with a conflicting parent.");
                             
@@ -1625,7 +1625,7 @@ public class JexlASTHelper {
                         workingStack.push(child);
                     } else {
                         if (failHard)
-                            throw new RuntimeException("Failed to validate lineage: Included a null child.");
+                            throw new RuntimeException("Failed to validate lineage: Included a null child. " + child);
                         else
                             log.error("Failed to validate lineage: Included a null child.");
                         

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
@@ -28,25 +28,29 @@ import org.apache.commons.jexl2.parser.ASTNRNode;
 import org.apache.commons.jexl2.parser.ASTOrNode;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.JexlNodes;
-import org.apache.commons.jexl2.parser.Node;
-import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.apache.log4j.Logger;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import static org.apache.commons.jexl2.parser.JexlNodes.promote;
 
 /**
- * 
+ *
  */
 public class AllTermsIndexedVisitor extends RebuildingVisitor {
+    
     private static final Logger log = Logger.getLogger(AllTermsIndexedVisitor.class);
     
     protected final ShardQueryConfiguration config;
     protected final MetadataHelper helper;
     
     public AllTermsIndexedVisitor(ShardQueryConfiguration config, MetadataHelper helper) {
-        Preconditions.checkNotNull(config);
-        Preconditions.checkNotNull(helper);
+        Preconditions.checkNotNull(config, "ShardQueryConfiguration must not be null");
+        Preconditions.checkNotNull(helper, "MetadataHelper must not be null");
         
         this.config = config;
         this.helper = helper;
@@ -54,7 +58,7 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
     
     @SuppressWarnings("unchecked")
     public static <T extends JexlNode> T isIndexed(T script, ShardQueryConfiguration config, MetadataHelper helper) {
-        Preconditions.checkNotNull(script);
+        Preconditions.checkNotNull(script, "JEXL script must not be null");
         
         AllTermsIndexedVisitor visitor = new AllTermsIndexedVisitor(config, helper);
         
@@ -63,143 +67,91 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTJexlScript node, Object data) {
-        ASTJexlScript newNode = new ASTJexlScript(ParserTreeConstants.JJTJEXLSCRIPT);
-        newNode.image = node.image;
+        JexlNode copy = getCopyWithVisitedChildren(node, data);
         
-        int newIndex = 0;
-        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-            Node newChild = (Node) node.jjtGetChild(i).jjtAccept(this, data);
-            
-            if (newChild != null) {
-                // When we have an AND or OR
-                if ((newChild instanceof ASTOrNode || newChild instanceof ASTAndNode)) {
-                    // Only add that node if it actually has children
-                    if (0 < newChild.jjtGetNumChildren()) {
-                        newNode.jjtAddChild(newChild, newIndex);
-                        newIndex++;
-                    }
-                } else {
-                    // Otherwise, we want to add the child regardless
-                    newNode.jjtAddChild(newChild, newIndex);
-                    newIndex++;
-                }
-            }
-        }
-        
-        if (newNode.jjtGetNumChildren() == 0) {
+        if (copy.jjtGetNumChildren() == 0) {
             NotFoundQueryException qe = new NotFoundQueryException(DatawaveErrorCode.NO_ANYFIELD_EXPANSION_MATCH);
             log.warn(qe);
             throw new EmptyUnfieldedTermExpansionException(qe);
         }
         
-        return newNode;
+        return copy;
     }
     
     @Override
     public Object visit(ASTOrNode node, Object data) {
-        ASTOrNode newNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
-        newNode.image = node.image;
-        
-        int newIndex = 0;
-        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-            Node newChild = (Node) node.jjtGetChild(i).jjtAccept(this, data);
-            
-            if (newChild != null) {
-                // When we have an AND or OR
-                if ((newChild instanceof ASTOrNode || newChild instanceof ASTAndNode)) {
-                    // Only add that node if it actually has children
-                    if (0 < newChild.jjtGetNumChildren()) {
-                        newNode.jjtAddChild(newChild, newIndex);
-                        newIndex++;
-                    }
-                } else {
-                    // Otherwise, we want to add the child regardless
-                    newNode.jjtAddChild(newChild, newIndex);
-                    newIndex++;
-                }
-            }
-        }
-        
-        switch (newNode.jjtGetNumChildren()) {
-            case 0:
-                return null;
-            case 1:
-                JexlNode child = newNode.jjtGetChild(0);
-                JexlNodes.promote(newNode, child);
-                return child;
-            default:
-                return newNode;
-        }
+        return visitJunctionNode(node, data);
     }
     
     @Override
     public Object visit(ASTAndNode node, Object data) {
-        ASTAndNode newNode = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
-        newNode.image = node.image;
+        return visitJunctionNode(node, data);
+    }
+    
+    private Object visitJunctionNode(JexlNode node, Object data) {
+        JexlNode copy = getCopyWithVisitedChildren(node, data);
         
-        int newIndex = 0;
-        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-            Node newChild = (Node) node.jjtGetChild(i).jjtAccept(this, data);
-            
-            if (newChild != null) {
-                // When we have an AND or OR
-                if ((newChild instanceof ASTOrNode || newChild instanceof ASTAndNode)) {
-                    // Only add that node if it actually has children
-                    if (0 < newChild.jjtGetNumChildren()) {
-                        newNode.jjtAddChild(newChild, newIndex);
-                        newIndex++;
-                    }
-                } else {
-                    // Otherwise, we want to add the child regardless
-                    newNode.jjtAddChild(newChild, newIndex);
-                    newIndex++;
-                }
-            }
-        }
-        switch (newNode.jjtGetNumChildren()) {
+        switch (copy.jjtGetNumChildren()) {
             case 0:
                 return null;
             case 1:
-                JexlNode child = newNode.jjtGetChild(0);
-                JexlNodes.promote(newNode, child);
+                JexlNode child = copy.jjtGetChild(0);
+                promote(copy, child);
                 return child;
             default:
-                return newNode;
+                return copy;
         }
+    }
+    
+    private JexlNode getCopyWithVisitedChildren(JexlNode node, Object data) {
+        // @formatter:off
+        JexlNode[] children = Arrays.stream(JexlNodes.children(node))
+                        .map(n -> (JexlNode) n.jjtAccept(this, data)) // Visit the node
+                        .filter(Objects::nonNull) // Filter out null nodes
+                        .filter(n -> (!JexlNodes.isAnd(n) && !JexlNodes.isOr(n)) || JexlNodes.isNotChildless(n)) // Filter out empty junction nodes
+                        .toArray(JexlNode[]::new);
+        // @formatter:on
+        JexlNode copy = JexlNodes.newInstanceOfType(node);
+        copy.image = node.image;
+        System.out.println("Copy: " + copy);
+        System.out.println("Children: " + Arrays.toString(children));
+        JexlNodes.children(copy, children);
+        return copy;
     }
     
     @Override
     public Object visit(ASTEQNode node, Object data) {
-        return equalityVisitor(node, data);
+        return visitEqualityNode(node, data);
     }
     
     @Override
     public Object visit(ASTNENode node, Object data) {
-        return equalityVisitor(node, data);
+        return visitEqualityNode(node, data);
     }
     
     /**
-     * Determine, for a binary equality node, if the field name is indexed
-     * 
+     * Determine, for a binary equality node, if the field name is indexed.
+     *
      * @param node
+     *            the node to verify the indexed status of
      * @param data
-     * @return
+     *            the node data
+     * @return a copy of the
      */
-    protected JexlNode equalityVisitor(JexlNode node, Object data) {
-        String fieldName = null;
+    protected JexlNode visitEqualityNode(JexlNode node, Object data) {
+        String fieldName;
         try {
             fieldName = JexlASTHelper.getIdentifier(node);
         } catch (NoSuchElementException e) {
-            // We only have literals
-            PreConditionFailedQueryException qe = new PreConditionFailedQueryException(DatawaveErrorCode.EQUALS_NODE_TWO_LITERALS, e, MessageFormat.format(
-                            "Node: {0}", PrintingVisitor.formattedQueryString(node).replace('\n', ' ')));
-            throw new InvalidFieldIndexQueryFatalQueryException(qe);
+            // We only have literals.
+            throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.EQUALS_NODE_TWO_LITERALS,
+                            PreConditionFailedQueryException::new));
         }
         try {
-            // in the case of an ANY_FIELD or NO_FIELD, the query could not be exapnded against the index and hence this
+            // In the case of an ANY_FIELD or NO_FIELD, the query could not be expanded against the index and hence this
             // term has no results. Leave it in the query as such.
             if (Constants.ANY_FIELD.equals(fieldName) || Constants.NO_FIELD.equals(fieldName)) {
-                return copy(node);
+                return node;
             }
             
             if (!this.helper.isIndexed(fieldName, config.getDatatypeFilter())) {
@@ -211,62 +163,129 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
             QueryException qe = new QueryException(DatawaveErrorCode.INDETERMINATE_INDEX_STATUS, e);
             throw new DatawaveFatalQueryException(qe);
         }
-        return copy(node);
         
+        return node;
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTERNode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.EQUALS_REGEX_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.EQUALS_REGEX_NODE_PROCESSING_ERROR,
+                        QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.NOT_EQUALS_REGEX_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.NOT_EQUALS_REGEX_NODE_PROCESSING_ERROR,
+                        QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTLTNode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.LT_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.LT_NODE_PROCESSING_ERROR, QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTGTNode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.GT_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.GT_NODE_PROCESSING_ERROR, QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTLENode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.LTE_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.LTE_NODE_PROCESSING_ERROR, QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTGENode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.GTE_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.GTE_NODE_PROCESSING_ERROR, QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
     @Override
     public Object visit(ASTAssignment node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.ASSIGNMENT_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.ASSIGNMENT_NODE_PROCESSING_ERROR,
+                        QueryException::new));
     }
     
+    /**
+     * Throw an {@link datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException}.
+     *
+     * @param node
+     *            the node
+     * @param data
+     *            the node data
+     * @return nothing
+     */
+    @Override
     public Object visit(ASTFunctionNode node, Object data) {
-        QueryException qe = new QueryException(DatawaveErrorCode.FUNCTION_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
-                        .formattedQueryString(node).replace('\n', ' ')));
-        throw new InvalidFieldIndexQueryFatalQueryException(qe);
+        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.FUNCTION_NODE_PROCESSING_ERROR,
+                        QueryException::new));
+    }
+    
+    private <T extends Throwable> T getExceptionWithPrintedNode(JexlNode node, DatawaveErrorCode errorCode,
+                    BiFunction<DatawaveErrorCode,String,T> throwableConstructor) {
+        String debugMessage = MessageFormat.format("Node: {0}", PrintingVisitor.formattedQueryString(node).replace('\n', ' '));
+        return throwableConstructor.apply(errorCode, debugMessage);
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
@@ -113,8 +113,6 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
         // @formatter:on
         JexlNode copy = JexlNodes.newInstanceOfType(node);
         copy.image = node.image;
-        System.out.println("Copy: " + copy);
-        System.out.println("Children: " + Arrays.toString(children));
         JexlNodes.children(copy, children);
         return copy;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/AllTermsIndexedVisitor.java
@@ -34,7 +34,6 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.function.BiFunction;
 
 import static org.apache.commons.jexl2.parser.JexlNodes.promote;
 
@@ -119,12 +118,12 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTEQNode node, Object data) {
-        return visitEqualityNode(node, data);
+        return equalityVisitor(node, data);
     }
     
     @Override
     public Object visit(ASTNENode node, Object data) {
-        return visitEqualityNode(node, data);
+        return equalityVisitor(node, data);
     }
     
     /**
@@ -136,14 +135,15 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      *            the node data
      * @return a copy of the
      */
-    protected JexlNode visitEqualityNode(JexlNode node, Object data) {
+    protected JexlNode equalityVisitor(JexlNode node, Object data) {
         String fieldName;
         try {
             fieldName = JexlASTHelper.getIdentifier(node);
         } catch (NoSuchElementException e) {
-            // We only have literals.
-            throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.EQUALS_NODE_TWO_LITERALS,
-                            PreConditionFailedQueryException::new));
+            // We only have literals
+            PreConditionFailedQueryException qe = new PreConditionFailedQueryException(DatawaveErrorCode.EQUALS_NODE_TWO_LITERALS, e, MessageFormat.format(
+                            "Node: {0}", PrintingVisitor.formattedQueryString(node).replace('\n', ' ')));
+            throw new InvalidFieldIndexQueryFatalQueryException(qe);
         }
         try {
             // In the case of an ANY_FIELD or NO_FIELD, the query could not be expanded against the index and hence this
@@ -176,8 +176,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTERNode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.EQUALS_REGEX_NODE_PROCESSING_ERROR,
-                        QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.EQUALS_REGEX_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -191,8 +192,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.NOT_EQUALS_REGEX_NODE_PROCESSING_ERROR,
-                        QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.NOT_EQUALS_REGEX_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -206,7 +208,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTLTNode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.LT_NODE_PROCESSING_ERROR, QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.LT_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -220,7 +224,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTGTNode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.GT_NODE_PROCESSING_ERROR, QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.GT_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -234,7 +240,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTLENode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.LTE_NODE_PROCESSING_ERROR, QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.LTE_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -248,7 +256,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTGENode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.GTE_NODE_PROCESSING_ERROR, QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.GTE_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -262,8 +272,9 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTAssignment node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.ASSIGNMENT_NODE_PROCESSING_ERROR,
-                        QueryException::new));
+        QueryException qe = new QueryException(DatawaveErrorCode.ASSIGNMENT_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
     
     /**
@@ -277,13 +288,8 @@ public class AllTermsIndexedVisitor extends RebuildingVisitor {
      */
     @Override
     public Object visit(ASTFunctionNode node, Object data) {
-        throw new InvalidFieldIndexQueryFatalQueryException(getExceptionWithPrintedNode(node, DatawaveErrorCode.FUNCTION_NODE_PROCESSING_ERROR,
-                        QueryException::new));
-    }
-    
-    private <T extends Throwable> T getExceptionWithPrintedNode(JexlNode node, DatawaveErrorCode errorCode,
-                    BiFunction<DatawaveErrorCode,String,T> throwableConstructor) {
-        String debugMessage = MessageFormat.format("Node: {0}", PrintingVisitor.formattedQueryString(node).replace('\n', ' '));
-        return throwableConstructor.apply(errorCode, debugMessage);
+        QueryException qe = new QueryException(DatawaveErrorCode.FUNCTION_NODE_PROCESSING_ERROR, MessageFormat.format("Node: {0}", PrintingVisitor
+                        .formattedQueryString(node).replace('\n', ' ')));
+        throw new InvalidFieldIndexQueryFatalQueryException(qe);
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitor.java
@@ -1,7 +1,6 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.util.Tuple2;
-
 import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTOrNode;
@@ -31,18 +30,15 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
     @Override
     public Object visit(ASTAndNode node, Object data) {
         if (hasChildOr(node)) {
-            ASTOrNode orNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
-            orNode.image = node.image;
-            
-            return optimizeTree(node, orNode, data);
+            return optimizeTree(node, data);
         } else {
             log.trace("nothing to optimize");
             return super.visit(node, data);
         }
     }
     
-    protected JexlNode optimizeTree(JexlNode currentNode, JexlNode newNode, Object data) {
-        if ((currentNode instanceof ASTAndNode) && hasChildOr(currentNode)) {
+    protected JexlNode optimizeTree(JexlNode currentNode, Object data) {
+        if (currentNode instanceof ASTAndNode) {
             ASTAndNode andNode = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
             andNode.image = currentNode.image;
             andNode.jjtSetParent(currentNode.jjtGetParent());
@@ -54,27 +50,22 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
             Tuple2<JexlNode,JexlNode> nodes = prune(currentNode, andNode, orNode);
             
             JexlNode prunedNode = nodes.first();
-            
             JexlNode toAttach = nodes.second();
             toAttach = TreeFlatteningRebuildingVisitor.flatten(toAttach);
+            ASTOrNode newNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
+            newNode.image = currentNode.image;
             
             for (int i = 0; i < toAttach.jjtGetNumChildren(); i++) {
                 JexlNode node = copy(prunedNode);
                 JexlNode attach = (JexlNode) toAttach.jjtGetChild(i).jjtAccept(this, data);
+                attach.jjtSetParent(node);
                 node.jjtAddChild(attach, node.jjtGetNumChildren());
                 newNode.jjtAddChild(node, newNode.jjtGetNumChildren());
                 node.jjtSetParent(newNode);
             }
-        } else {
-            return currentNode;
-        }
-        
-        if (newNode.jjtGetNumChildren() > 0) {
             return newNode;
-        } else {
-            log.trace("Optimization failed somewhere ... returning currentNode!");
-            return currentNode;
         }
+        return currentNode;
     }
     
     /**
@@ -94,8 +85,7 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
                     prunedNode.jjtSetParent(newNode);
                 }
                 prunedNode = child;
-            } else if (((child instanceof ASTReference) || (child instanceof ASTReferenceExpression) || child.getClass().equals(currentNode.getClass()))
-                            && hasChildOr(child)) {
+            } else if (isWrapperNodeOrSameClass(child, currentNode) && hasChildOr(child)) {
                 Tuple2<JexlNode,JexlNode> nodes = prune(child, newNode, prunedNode);
                 newNode = nodes.first();
                 prunedNode = nodes.second();
@@ -108,26 +98,21 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
         return new Tuple2<>(newNode, prunedNode);
     }
     
-    /**
-     * Returns true if there is a child OR (or OR directly inside ASTReference or ASTReferenceException).
-     * 
-     * @param currentNode
-     * @return
-     */
-    protected boolean hasChildOr(JexlNode currentNode) {
-        boolean foundChildOr = false;
+    // Return whether or not if the provided node has a child OR, wrapped or otherwise.
+    private boolean hasChildOr(JexlNode currentNode) {
         for (int i = 0; i < currentNode.jjtGetNumChildren(); i++) {
             JexlNode child = currentNode.jjtGetChild(i);
-            
             if (child instanceof ASTOrNode) {
                 return true;
-            } else if ((child instanceof ASTReference) || (child instanceof ASTReferenceExpression)) {
-                foundChildOr = foundChildOr || hasChildOr(child);
-            } else if (child.getClass().equals(currentNode.getClass())) {
-                foundChildOr = foundChildOr || hasChildOr(child);
+            } else if (isWrapperNodeOrSameClass(child, currentNode) && hasChildOr(child)) {
+                return true;
             }
         }
-        
-        return foundChildOr;
+        return false;
+    }
+    
+    // Return true if the node is a reference, reference expression, or the same class as other.
+    private boolean isWrapperNodeOrSameClass(JexlNode node, JexlNode other) {
+        return node instanceof ASTReference || node instanceof ASTReferenceExpression || node.getClass().equals(other.getClass());
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitor.java
@@ -37,5 +37,4 @@ public class FixNegativeNumbersVisitor extends RebuildingVisitor {
         }
         
     }
-    
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitor.java
@@ -37,4 +37,5 @@ public class FixNegativeNumbersVisitor extends RebuildingVisitor {
         }
         
     }
+    
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/GeoWavePruningVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/GeoWavePruningVisitor.java
@@ -33,8 +33,8 @@ import static org.apache.commons.jexl2.parser.JexlNodes.children;
  */
 public class GeoWavePruningVisitor extends RebuildingVisitor {
     
-    private Multimap<String,String> prunedTerms;
-    private MetadataHelper metadataHelper;
+    private final Multimap<String,String> prunedTerms;
+    private final MetadataHelper metadataHelper;
     
     private GeoWavePruningVisitor(Multimap<String,String> prunedTerms, MetadataHelper metadataHelper) {
         this.prunedTerms = prunedTerms;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/GeoWavePruningVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/GeoWavePruningVisitor.java
@@ -33,8 +33,8 @@ import static org.apache.commons.jexl2.parser.JexlNodes.children;
  */
 public class GeoWavePruningVisitor extends RebuildingVisitor {
     
-    private final Multimap<String,String> prunedTerms;
-    private final MetadataHelper metadataHelper;
+    private Multimap<String,String> prunedTerms;
+    private MetadataHelper metadataHelper;
     
     private GeoWavePruningVisitor(Multimap<String,String> prunedTerms, MetadataHelper metadataHelper) {
         this.prunedTerms = prunedTerms;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
@@ -1,16 +1,14 @@
 package datawave.query.jexl.visitors;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import datawave.query.model.QueryModel;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.JexlNodeFactory.ContainerType;
+import datawave.query.model.QueryModel;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
@@ -43,8 +41,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.jexl2.parser.JexlNodes.id;
 
@@ -54,29 +54,19 @@ import static org.apache.commons.jexl2.parser.JexlNodes.id;
 public class QueryModelVisitor extends RebuildingVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(QueryModelVisitor.class);
     
-    private QueryModel queryModel;
-    private HashSet<ASTAndNode> expandedNodes;
-    private Set<String> validFields;
-    private SimpleQueryModelVisitor simpleQueryModelVisitor;
+    private final QueryModel queryModel;
+    private final HashSet<ASTAndNode> expandedNodes;
+    private final Set<String> validFields;
+    private final IdentifierExpansionVisitor identifierExpansionVisitor;
     
     public QueryModelVisitor(QueryModel queryModel, Set<String> validFields) {
         this.queryModel = queryModel;
         this.expandedNodes = Sets.newHashSet();
         this.validFields = validFields;
-        this.simpleQueryModelVisitor = new SimpleQueryModelVisitor(queryModel, validFields);
+        this.identifierExpansionVisitor = new IdentifierExpansionVisitor(queryModel, validFields);
     }
     
-    /**
-     * Get the aliases for the field, and retain only those in the "validFields" set.
-     * 
-     * @param field
-     * @return the list of field aliases
-     */
-    protected Collection<String> getAliasesForField(String field) {
-        List<String> aliases = new ArrayList<>(this.queryModel.getMappingsForAlias(field));
-        aliases.retainAll(validFields);
-        return aliases;
-    }
+    
     
     public static ASTJexlScript applyModel(ASTJexlScript script, QueryModel queryModel, Set<String> validFields) {
         QueryModelVisitor visitor = new QueryModelVisitor(queryModel, validFields);
@@ -126,14 +116,13 @@ public class QueryModelVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTFunctionNode node, Object data) {
-        return node.jjtAccept(this.simpleQueryModelVisitor, data);
+        return node.jjtAccept(this.identifierExpansionVisitor, data);
     }
     
     @Override
     public Object visit(ASTReference node, Object data) {
-        if (JexlASTHelper.HasMethodVisitor.hasMethod(node)) {
-            // this reference has a child that is a method
-            return (ASTReference) node.jjtAccept(this.simpleQueryModelVisitor, null);
+        if (hasMethod(node)) {
+            return node.jjtAccept(this.identifierExpansionVisitor, null);
         } else {
             return super.visit(node, data);
         }
@@ -141,12 +130,12 @@ public class QueryModelVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTMethodNode node, Object data) {
-        return node.jjtAccept(this.simpleQueryModelVisitor, data);
+        return node.jjtAccept(this.identifierExpansionVisitor, data);
     }
     
     @Override
     public Object visit(ASTSizeMethod node, Object data) {
-        return node.jjtAccept(this.simpleQueryModelVisitor, data);
+        return node.jjtAccept(this.identifierExpansionVisitor, data);
     }
     
     @Override
@@ -164,7 +153,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
             }
             // if this child has a method attached, be sure to descend into it for model substitutions
             if (JexlASTHelper.HasMethodVisitor.hasMethod(child)) {
-                child = (JexlNode) child.jjtAccept(this.simpleQueryModelVisitor, null);
+                child = (JexlNode) child.jjtAccept(this.identifierExpansionVisitor, null);
             }
             
             switch (id(child)) {
@@ -183,17 +172,18 @@ public class QueryModelVisitor extends RebuildingVisitor {
         
         if (!lowerBounds.isEmpty() && !upperBounds.isEmpty()) {
             // this is the set of fields that have an upper and a lower bound operand
-            // make a copy of the intersection, as I will be modifying lowererBounds and upperBounds below
+            // make a copy of the intersection, as I will be modifying lowerBounds and upperBounds below
             Set<String> tightBounds = Sets.newHashSet(Sets.intersection(lowerBounds.keySet(), upperBounds.keySet()));
-            if (log.isDebugEnabled())
+            if (log.isDebugEnabled()) {
                 log.debug("Found bounds to match: " + tightBounds);
+            }
             for (String field : tightBounds) {
                 // String field = JexlASTHelper.getIdentifier(theNode);
                 List<ASTAndNode> aliasedBounds = Lists.newArrayList();
                 
-                Collection<String> aliases = getAliasesForField(field);
+                Collection<String> aliases = getValidAliases(field);
                 if (aliases.isEmpty()) {
-                    aliases = Lists.newArrayList(field);
+                    aliases.add(field);
                 }
                 
                 for (String alias : aliases) {
@@ -212,7 +202,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
                     }
                 }
                 // we don't need the original, unexpanded nodes any more
-                if (aliasedBounds.isEmpty() == false) {
+                if (!aliasedBounds.isEmpty()) {
                     lowerBounds.removeAll(field);
                     upperBounds.removeAll(field);
                     this.expandedNodes.addAll(aliasedBounds);
@@ -226,7 +216,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
                 } else {
                     ASTOrNode unionOfAliases = new ASTOrNode(ParserTreeConstants.JJTORNODE);
                     List<ASTReferenceExpression> var = JexlASTHelper.wrapInParens(aliasedBounds);
-                    JexlNodes.children(unionOfAliases, var.toArray(new JexlNode[var.size()]));
+                    JexlNodes.children(unionOfAliases, var.toArray(new JexlNode[0]));
                     nodeToAdd = JexlNodes.wrap(unionOfAliases);
                 }
                 
@@ -238,36 +228,30 @@ public class QueryModelVisitor extends RebuildingVisitor {
         others.addAll(lowerBounds.values());
         others.addAll(upperBounds.values());
         
-        /*
-         * The rebuilding visitor adds whatever {visit()} returns to the parent's child list, so we shouldn't have some weird object graph that means old nodes
-         * never get GC'd because {super.visit()} will reset the parent in the call to {copy()}
-         */
-        return super.visit(JexlNodes.children(smashed, others.toArray(new JexlNode[others.size()])), data);
+        
+        // The rebuilding visitor adds whatever {visit()} returns to the parent's child list, so we shouldn't have some weird object graph that means old nodes
+        // never get GC'd because {super.visit()} will reset the parent in the call to {copy()}
+        return super.visit(JexlNodes.children(smashed, others.toArray(new JexlNode[0])), data);
     }
     
     /**
      * Applies the forward mapping from the QueryModel to a node, expanding the node into an Or if needed.
-     * 
-     * @param node
-     * @param data
-     * @return
+     *
+     * @param node the node
+     * @param data the node's data
+     * @return the expanded node
      */
-    protected JexlNode expandBinaryNodeFromModel(JexlNode node, Object data) {
-        
+    private JexlNode expandBinaryNodeFromModel(JexlNode node, Object data) {
         // Count the immediate children:
         int childCount = node.jjtGetNumChildren();
-        
         if (childCount != 2) {
-            QueryException qe = new QueryException(DatawaveErrorCode.BINARY_NODE_TOO_MANY_CHILDREN, MessageFormat.format("Node: {0}",
-                            PrintingVisitor.formattedQueryString(node)));
+            QueryException qe = new QueryException(DatawaveErrorCode.BINARY_NODE_TOO_MANY_CHILDREN,
+                            MessageFormat.format("Node: {0}", PrintingVisitor.formattedQueryString(node)));
             throw new DatawaveFatalQueryException(qe);
         }
         
-        // Find identifiers
-        List<ASTIdentifier> allidentifiers = JexlASTHelper.getIdentifiers(node);
-        
-        // If we don't have any identifiers, we have nothing to expand
-        if (allidentifiers.isEmpty()) {
+        // There is nothing to expand if there are no identifiers.
+        if (hasNoIdentifiers(node)) {
             return node;
         }
         
@@ -279,225 +263,221 @@ public class QueryModelVisitor extends RebuildingVisitor {
             log.trace("rightNode:" + PrintingVisitor.formattedQueryString(rightNode));
             log.trace("rightNodeQuery:" + JexlStringBuildingVisitor.buildQuery(rightNode));
         }
-        // this will expand identifiers that have a method connected to them
-        boolean leftState = JexlASTHelper.HasMethodVisitor.hasMethod(leftNode);
-        if (leftState) {
-            // there is a method under leftNode
-            leftNode = (JexlNode) leftNode.jjtAccept(this.simpleQueryModelVisitor, null);
+    
+        // If either side has a method, return a new binary node with expanded identifiers.
+        if (hasMethod(leftNode) || hasMethod(rightNode)) {
+            return expandMethods(node, leftNode, rightNode);
+        } else {
+            return expandIdentifiersWithinNode(node);
         }
-        boolean rightState = JexlASTHelper.HasMethodVisitor.hasMethod(rightNode);
-        if (rightState) {
-            // there is a method under rightNode
-            rightNode = (JexlNode) rightNode.jjtAccept(this.simpleQueryModelVisitor, null);
+    }
+    
+    // Expand identifiers in the left and right nodes that have a method connected to them.
+    private JexlNode expandMethods(JexlNode parent, JexlNode left, JexlNode right) {
+        if (hasMethod(left)) {
+            left = (JexlNode) left.jjtAccept(this.identifierExpansionVisitor, null);
         }
-        
-        // expand any identifiers inside of methods/functions in the left and right nodes
-        leftNode = (JexlNode) leftNode.jjtAccept(this, null);
-        rightNode = (JexlNode) rightNode.jjtAccept(this, null);
+        if (hasMethod(right)) {
+            right = (JexlNode) right.jjtAccept(this.identifierExpansionVisitor, null);
+        }
+    
+        // Expand identifiers inside of methods/functions in the left and right nodes.
+        left = (JexlNode) left.jjtAccept(this, null);
+        right = (JexlNode) right.jjtAccept(this, null);
         if (log.isTraceEnabled()) {
-            log.trace("after expansion, leftNode:" + PrintingVisitor.formattedQueryString(leftNode));
-            log.trace("after expansion, leftNodeQuery:" + JexlStringBuildingVisitor.buildQuery(leftNode));
-            log.trace("after expansion, rightNode:" + PrintingVisitor.formattedQueryString(rightNode));
-            log.trace("after expansion, rightNodeQuery:" + JexlStringBuildingVisitor.buildQuery(rightNode));
+            log.trace("after expansion, leftNode:" + PrintingVisitor.formattedQueryString(left));
+            log.trace("after expansion, leftNodeQuery:" + JexlStringBuildingVisitor.buildQuery(left));
+            log.trace("after expansion, rightNode:" + PrintingVisitor.formattedQueryString(right));
+            log.trace("after expansion, rightNodeQuery:" + JexlStringBuildingVisitor.buildQuery(right));
         }
-        
-        // if state == true on either side, then there is a method on one side and we are done applying the model
-        if (leftState || rightState) {
-            JexlNode toReturn = JexlNodeFactory.buildUntypedBinaryNode(node, leftNode, rightNode);
-            if (log.isTraceEnabled()) {
-                log.trace("done early. returning:" + JexlStringBuildingVisitor.buildQuery(toReturn));
-            }
-            return toReturn;
+    
+        JexlNode node = JexlNodeFactory.buildUntypedBinaryNode(parent, left, right);
+        if (log.isTraceEnabled()) {
+            log.trace("done early. returning:" + JexlStringBuildingVisitor.buildQuery(node));
         }
-        
-        Object leftSeed = null, rightSeed = null;
-        Set<Object> left = Sets.newHashSet(), right = Sets.newHashSet();
-        boolean isNullEquality = false;
-        
-        if (node instanceof ASTEQNode && (leftNode instanceof ASTNullLiteral || rightNode instanceof ASTNullLiteral)) {
-            isNullEquality = true;
-        }
-        
-        // the query has been previously groomed so that identifiers are on the left and literals are on the right
-        // an identifier with a method attached will have already been substituted above (and will return null for the IdentifierOpLiteral)
-        // The normal case of `IDENTIFIER op 'literal'`
-        JexlASTHelper.IdentifierOpLiteral op = JexlASTHelper.getIdentifierOpLiteral(node);
-        if (op != null) {
-            // One identifier
-            leftSeed = op.getIdentifier();
-            
-            rightSeed = op.getLiteral();
-            if (rightSeed instanceof ASTNullLiteral && node instanceof ASTEQNode) {
-                isNullEquality = true;
-            }
-        } else {
-            // We know from above that childCount == 2. We may have a reference on both sides of the expression
-            leftSeed = node.jjtGetChild(0);
-            rightSeed = node.jjtGetChild(1);
-        }
-        
-        if (leftSeed instanceof ASTReference) {
-            // String fieldName = JexlASTHelper.getIdentifier((JexlNode)leftSeed);
-            List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers((ASTReference) leftSeed);
-            if (identifiers.size() > 1) {
-                log.warn("I did not expect to see more than one Identifier here for " + JexlStringBuildingVisitor.buildQuery((ASTReference) leftSeed)
-                                + " from " + JexlStringBuildingVisitor.buildQuery(leftNode));
-            }
-            for (ASTIdentifier identifier : identifiers) {
-                for (String fieldName : getAliasesForField(JexlASTHelper.deconstructIdentifier(identifier))) {
-                    left.add(JexlNodeFactory.buildIdentifier(fieldName));
-                }
-            }
-        } else if (leftSeed instanceof ASTIdentifier) {
-            for (String fieldName : getAliasesForField(JexlASTHelper.deconstructIdentifier((ASTIdentifier) leftSeed))) {
-                left.add(JexlNodeFactory.buildIdentifier(fieldName));
-            }
-        } else {
-            // Not an identifier, therefore it's probably a literal
-            left.add(leftSeed);
-        }
-        
-        if (rightSeed instanceof ASTReference) {
-            List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers((ASTReference) rightSeed);
-            if (identifiers.size() > 1) {
-                log.warn("I did not expect to see more than one Identifier here for " + JexlStringBuildingVisitor.buildQuery((ASTReference) rightSeed)
-                                + " from " + JexlStringBuildingVisitor.buildQuery(rightNode));
-            }
-            for (ASTIdentifier identifier : identifiers) {
-                for (String fieldName : getAliasesForField(JexlASTHelper.deconstructIdentifier(identifier))) {
-                    right.add(JexlNodeFactory.buildIdentifier(fieldName));
-                }
-            }
-        } else if (rightSeed instanceof ASTIdentifier) {
-            for (String fieldName : getAliasesForField(JexlASTHelper.deconstructIdentifier((ASTIdentifier) rightSeed))) {
-                right.add(JexlNodeFactory.buildIdentifier(fieldName));
-            }
-            
-        } else {
-            // Not an identifier, therefore it's probably a literal
-            right.add(rightSeed);
-        }
-        boolean requiresAnd = isNullEquality || node instanceof ASTNENode;
-        
-        if (leftSeed == null) {
-            leftSeed = leftNode;
-        }
-        if (rightSeed == null) {
-            rightSeed = rightNode;
-        }
-        
-        @SuppressWarnings("unchecked")
-        // retrieve the cartesian product
-        Set<List<Object>> product = Sets.cartesianProduct(left, right);
-        
-        /**
-         * use the product transformer to shallow copy the jexl nodes. We've created new nodes that will be embedded within an ast reference. As a result, we
-         * need to ensure that if we create a logical structure ( such as an or ) -- each literal references a unique identifier from the right. Otherwise,
-         * subsequent visitors will reference incorrection sub trees, and potentially negate the activity of the query model visitor
-         */
-        Set<List<Object>> newSet = Sets.newHashSet(FluentIterable.from(product).transform(new ProductTransformer()));
-        
-        if (product.size() > 1) {
-            if (requiresAnd) {
-                JexlNode expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.AND_NODE, node, newSet);
-                if (log.isTraceEnabled())
-                    log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
-                return expanded;
-            } else {
-                JexlNode expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.OR_NODE, node, newSet);
-                if (log.isTraceEnabled())
-                    log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
-                return expanded;
-            }
-        } else if (1 == product.size()) {
-            List<Object> pair = product.iterator().next();
-            JexlNode expanded = JexlNodeFactory.buildUntypedBinaryNode(node, pair.get(0), pair.get(1));
-            if (log.isTraceEnabled())
-                log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
-            return expanded;
-        }
-        
-        // If we couldn't map anything, return a copy
-        if (log.isTraceEnabled())
-            log.trace("just returning the original:" + PrintingVisitor.formattedQueryString(node));
         return node;
     }
     
-    /**
-     * Ensures that each object created as a result of the cartesian product of the literal and identifiers gives us unique references within the tree. Without
-     * this functional transformation you may have subsequent methods that use your objects to create nodes, referencing the embedded literals
-     */
-    protected static class ProductTransformer implements Function<List<Object>,List<Object>> {
-        @Override
-        public List<Object> apply(List<Object> objects) {
-            List<Object> newObjectList = Lists.newArrayListWithCapacity(objects.size());
-            for (Object obj : objects) {
-                Object newObj = obj;
-                if (obj instanceof JexlNode) {
-                    newObj = RebuildingVisitor.copy((JexlNode) obj);
-                }
-                newObjectList.add(newObj);
-            }
-            return newObjectList;
-            
+    // Expand any remaining identifiers within the node's expression.
+    private JexlNode expandIdentifiersWithinNode(JexlNode node) {
+        // Determine if the current node is part of a null equality. It has been established at this point that there are only two children.
+        boolean isNullEquality = false;
+        if (node instanceof ASTEQNode && (node.jjtGetChild(0) instanceof ASTNullLiteral || node.jjtGetChild(1) instanceof ASTNullLiteral)) {
+            isNullEquality = true;
         }
+    
+        // The query has been previously groomed so that identifiers are on the left and literals are on the right. There should be no identifiers with a method
+        // attached at this point. Instead, the normal case should be `IDENTIFIER op 'literal'`
+        Object leftSeed;
+        Object rightSeed;
+        JexlASTHelper.IdentifierOpLiteral op = JexlASTHelper.getIdentifierOpLiteral(node);
+        if (op != null) {
+            // If there is an identifier and literal, establish the identifier on the left, and the literal on the right.
+            leftSeed = op.getIdentifier();
+            rightSeed = op.getLiteral();
+        } else {
+            // Otherwise, there may be a reference on both sides of the expression.
+            leftSeed = node.jjtGetChild(0);
+            rightSeed = node.jjtGetChild(1);
+        }
+    
+        // Expand the identifiers on both sides.
+        Set<Object> left = expandIdentifiersWithinObject(leftSeed);
+        Set<Object> right = expandIdentifiersWithinObject(rightSeed);
+    
+        boolean requiresAnd = isNullEquality || node instanceof ASTNENode;
+    
+        // Retrieve the cartesian product and make shallow copies of any jexl nodes. We've created new nodes that will be embedded within an ast reference. As a
+        // result, we need to ensure that if we create a logical structure ( such as an or ) -- each literal references a unique identifier from the right.
+        // Otherwise, subsequent visitors will reference incorrect sub trees, and potentially negate the activity of the query model visitor.
+        Set<List<Object>> product = Sets.cartesianProduct(left, right);
+        Set<List<Object>> newSet = product.stream().map(this::copyJexlNodes).collect(Collectors.toSet());
+    
+        if (product.size() > 1) {
+            JexlNode expanded;
+            if (requiresAnd) {
+                expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.AND_NODE, node, newSet);
+            } else {
+                expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.OR_NODE, node, newSet);
+            }
+            if (log.isTraceEnabled()) {
+                log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
+            }
+            return expanded;
+        } else if (1 == product.size()) {
+            List<Object> pair = product.iterator().next();
+            JexlNode expanded = JexlNodeFactory.buildUntypedBinaryNode(node, pair.get(0), pair.get(1));
+            if (log.isTraceEnabled()) {
+                log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
+            }
+            return expanded;
+        }
+    
+        // If we couldn't map anything, return a copy.
+        if (log.isTraceEnabled()) {
+            log.trace("just returning the original:" + PrintingVisitor.formattedQueryString(node));
+        }
+        return node;
+    }
+    
+    // Return whether or not the provided node has a method within its structure.
+    private boolean hasMethod(JexlNode node) {
+        return JexlASTHelper.HasMethodVisitor.hasMethod(node);
+    }
+    
+    // Return all valid aliases for the provided identifier.
+    private Collection<String> getValidAliases(ASTIdentifier identifier) {
+        return getValidAliases(JexlASTHelper.deconstructIdentifier(identifier));
+    }
+    
+    // Return all valid aliases for the provided field.
+    private Collection<String> getValidAliases(String field) {
+        List<String> aliases = new ArrayList<>(this.queryModel.getMappingsForAlias(field));
+        aliases.retainAll(validFields);
+        return aliases;
+    }
+    
+    // Return a transformed list that contain either the original object or copies of any JexlNode elements.
+    private List<Object> copyJexlNodes(List<Object> objects) {
+        return objects.stream().map(o -> {
+            if (o instanceof JexlNode) {
+                return copy((JexlNode) o);
+            } else {
+                return o;
+            }
+        }).collect(Collectors.toList());
+    }
+    
+    // Return whether or not the node has no identifiers.
+    private boolean hasNoIdentifiers(JexlNode node) {
+        return JexlASTHelper.getIdentifiers(node).isEmpty();
+    }
+    
+    // Return a set of expanded nodes for the given object, depending on the type of JEXL node it is (if one).
+    private Set<Object> expandIdentifiersWithinObject(Object object) {
+        Set<Object> set = new HashSet<>();
+        if (object instanceof ASTReference) {
+            List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers((ASTReference) object);
+            // @formatter::off
+            identifiers.stream()
+                            .map(this::getValidAliases)
+                            .flatMap(Collection::stream)
+                            .map(JexlNodeFactory::buildIdentifier)
+                            .forEach(set::add);
+            // @formatter::on
+        } else if (object instanceof ASTIdentifier) {
+            // @formatter::off
+            getValidAliases((ASTIdentifier) object).stream()
+                            .map(JexlNodeFactory::buildIdentifier)
+                            .forEach(set::add);
+            // @formatter::on
+        } else {
+            set.add(object);
+        }
+        return set;
     }
     
     /**
-     * The SimpleQueryModelVisitor will only change identifiers into a disjunction of their aliases: FOO becomes (ALIASONE||ALIASTWO) It is used within function
-     * and method node arguments and in the reference that a method is called on
+     * The {@link IdentifierExpansionVisitor} will expand identifiers into their aliases, if any exists. If multiple aliases exist for an identifier, it will be
+     * replace with a disjunction of the aliases, e.g. 'FOO' becomes '( ALIASONE || ALIASTWO )'. It is used within function and method node arguments, as well
+     * as in the reference that a method is called on.
      */
-    protected static class SimpleQueryModelVisitor extends RebuildingVisitor {
+    private static class IdentifierExpansionVisitor extends RebuildingVisitor {
         
-        private static final Logger log = ThreadConfigurableLogger.getLogger(SimpleQueryModelVisitor.class);
-        private QueryModel queryModel;
-        private Set<String> validFields;
+        private final QueryModel queryModel;
+        private final Set<String> validFields;
         
-        public SimpleQueryModelVisitor(QueryModel queryModel, Set<String> validFields) {
+        public IdentifierExpansionVisitor(QueryModel queryModel, Set<String> validFields) {
             this.queryModel = queryModel;
             this.validFields = validFields;
         }
         
         @Override
         public Object visit(ASTIdentifier node, Object data) {
-            JexlNode newNode;
             String fieldName = JexlASTHelper.getIdentifier(node);
             
-            Collection<String> aliases = Sets.newLinkedHashSet(getAliasesForField(fieldName)); // de-dupe
-            
-            Set<ASTIdentifier> nodes = Sets.newLinkedHashSet();
+            // @formatter::off
+            Set<ASTIdentifier> aliases = getValidAliases(fieldName).stream()
+                            .distinct()
+                            .map(this::createIdentifier)
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+            // @formatter:on
             
             if (aliases.isEmpty()) {
                 return super.visit(node, data);
             }
-            for (String alias : aliases) {
-                ASTIdentifier newKid = new ASTIdentifier(ParserTreeConstants.JJTIDENTIFIER);
-                newKid.image = JexlASTHelper.rebuildIdentifier(alias);
-                nodes.add(newKid);
-            }
-            if (nodes.size() == 1) {
-                newNode = JexlNodeFactory.wrap(nodes.iterator().next());
-            } else {
-                newNode = JexlNodeFactory.createOrNode(nodes);
-            }
-            newNode.jjtSetParent(node.jjtGetParent());
             
-            for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-                newNode.jjtAddChild((Node) node.jjtGetChild(i).jjtAccept(this, data), i);
-            }
-            return newNode;
+            return wrapAliases(aliases, node, data);
         }
         
-        /**
-         * Get the aliases for the field, and retain only those in the "validFields" set.
-         *
-         * @param field
-         * @return the list of field aliases
-         */
-        protected Collection<String> getAliasesForField(String field) {
+        // Return all valid aliases for the provided field.
+        private Collection<String> getValidAliases(String field) {
             List<String> aliases = new ArrayList<>(this.queryModel.getMappingsForAlias(field));
             aliases.retainAll(validFields);
             return aliases;
         }
+        
+        // Return a JEXL Identifier for the given field name.
+        private ASTIdentifier createIdentifier(String fieldName) {
+            ASTIdentifier identifier = new ASTIdentifier(ParserTreeConstants.JJTIDENTIFIER);
+            identifier.image = JexlASTHelper.rebuildIdentifier(fieldName);
+            return identifier;
+        }
+    
+        // Create a replacement node wrapping the provided aliases.
+        private JexlNode wrapAliases(Set<ASTIdentifier> aliases, JexlNode original, Object data) {
+            JexlNode node;
+            if (aliases.size() == 1) {
+                node = JexlNodeFactory.wrap(aliases.iterator().next());
+            } else {
+                node = JexlNodeFactory.createOrNode(aliases);
+            }
+            node.jjtSetParent(original.jjtGetParent());
+            for (int i = 0; i < original.jjtGetNumChildren(); i++) {
+                node.jjtAddChild((Node) original.jjtGetChild(i).jjtAccept(this, data), i);
+            }
+            return node;
+        }
+        
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
@@ -50,6 +50,7 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
             JexlNodes.ensureCapacity(andNode, node.jjtGetNumChildren());
             for (int i = 0; i < node.jjtGetNumChildren(); i++) {
                 JexlNode newChild = (JexlNode) node.jjtGetChild(i).jjtAccept(this, data);
+                
                 andNode.jjtAddChild(newChild, i);
                 newChild.jjtSetParent(andNode);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
@@ -1,31 +1,21 @@
 package datawave.query.jexl.visitors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.LiteralRange;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
-
 import org.apache.commons.jexl2.parser.ASTAndNode;
-import org.apache.commons.jexl2.parser.ASTERNode;
-import org.apache.commons.jexl2.parser.ASTGENode;
-import org.apache.commons.jexl2.parser.ASTGTNode;
-import org.apache.commons.jexl2.parser.ASTLENode;
-import org.apache.commons.jexl2.parser.ASTLTNode;
-import org.apache.commons.jexl2.parser.ASTNRNode;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.JexlNodes;
 import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.apache.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Visits an JexlNode tree, and coalesces bounded ranges into separate AND expressions.
- *
- * 
- *
  */
 public class RangeCoalescingVisitor extends RebuildingVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(RangeCoalescingVisitor.class);
@@ -41,36 +31,6 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
         RangeCoalescingVisitor visitor = new RangeCoalescingVisitor();
         
         return (T) script.jjtAccept(visitor, null);
-    }
-    
-    @Override
-    public Object visit(ASTERNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTNRNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTLTNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTGTNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTLENode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTGENode node, Object data) {
-        return node;
     }
     
     @Override
@@ -90,12 +50,12 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
             JexlNodes.ensureCapacity(andNode, node.jjtGetNumChildren());
             for (int i = 0; i < node.jjtGetNumChildren(); i++) {
                 JexlNode newChild = (JexlNode) node.jjtGetChild(i).jjtAccept(this, data);
-                
                 andNode.jjtAddChild(newChild, i);
                 newChild.jjtSetParent(andNode);
             }
         }
-        
+    
+        JexlNodes.replaceChild(node.jjtGetParent(), node, andNode);
         return andNode;
     }
     
@@ -125,7 +85,9 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
             
             JexlNodes.ensureCapacity(onlyRangeNodes, range.getValue().size());
             for (int i = 0; i < range.getValue().size(); i++) {
-                onlyRangeNodes.jjtAddChild(range.getValue().get(i), i);
+                JexlNode node = range.getValue().get(i);
+                onlyRangeNodes.jjtAddChild(node, i);
+                node.jjtSetParent(onlyRangeNodes);
             }
             
             JexlNode wrappedNode = JexlNodeFactory.wrap(onlyRangeNodes);
@@ -137,8 +99,9 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
         
         // If we had no other nodes than this bounded range, we can strip out the original parent
         if (newNode.jjtGetNumChildren() == 1) {
-            newNode.jjtGetChild(0).jjtSetParent(newNode.jjtGetParent());
-            return newNode.jjtGetChild(0);
+            JexlNode child = newNode.jjtGetChild(0);
+            JexlNodes.replaceChild(newNode.jjtGetParent(), newNode, child);
+            return child;
         }
         
         return newNode;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexFunctionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexFunctionVisitor.java
@@ -1,11 +1,7 @@
 package datawave.query.jexl.visitors;
 
-import java.util.List;
-import java.util.Set;
-
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
-
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.functions.FunctionJexlNodeVisitor;
@@ -13,10 +9,8 @@ import datawave.query.parser.JavaRegexAnalyzer;
 import datawave.query.parser.JavaRegexAnalyzer.JavaRegexParseException;
 import datawave.query.util.MetadataHelper;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
-
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
-
 import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTEQNode;
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
@@ -27,8 +21,16 @@ import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.apache.log4j.Logger;
 
+import java.util.List;
+import java.util.Set;
+
 public class RegexFunctionVisitor extends FunctionIndexQueryExpansionVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(RegexFunctionVisitor.class);
+    private static final String INCLUDE_REGEX = "includeRegex";
+    private static final String EXCLUDE_REGEX = "excludeRegex";
+    private static final String IS_NULL = "isNull";
+    private static final String IS_NOT_NULL = "isNotNull";
+    
     protected Set<String> nonEventFields;
     
     public RegexFunctionVisitor(ShardQueryConfiguration config, MetadataHelper metadataHelper, Set<String> nonEventFields) {
@@ -48,55 +50,59 @@ public class RegexFunctionVisitor extends FunctionIndexQueryExpansionVisitor {
         JexlNode returnNode = node;
         FunctionJexlNodeVisitor functionMetadata = new FunctionJexlNodeVisitor();
         node.jjtAccept(functionMetadata, null);
-        
-        if (functionMetadata.name().equals("includeRegex") || functionMetadata.name().equals("excludeRegex")) {
-            List<JexlNode> arguments = functionMetadata.args();
-            JexlNode node0 = arguments.get(0);
-            if (node0 instanceof ASTIdentifier) {
-                JexlNode regexNode = buildRegexNode((ASTIdentifier) node0, functionMetadata.name(), arguments.get(1).image);
-                if (regexNode != null) {
-                    returnNode = regexNode;
-                }
-            } else {
-                JexlNode newParent = null;
-                if (functionMetadata.name().equals("excludeRegex")) {
-                    newParent = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
+    
+        switch (functionMetadata.name()) {
+            case INCLUDE_REGEX:
+            case EXCLUDE_REGEX: {
+                List<JexlNode> arguments = functionMetadata.args();
+                JexlNode firstArg = arguments.get(0);
+                if (firstArg instanceof ASTIdentifier) {
+                    JexlNode regexNode = buildRegexNode((ASTIdentifier) firstArg, functionMetadata.name(), arguments.get(1).image);
+                    if (regexNode != null) {
+                        returnNode = regexNode;
+                    }
                 } else {
-                    // it is likely an 'or' node...
-                    newParent = JexlNodeFactory.shallowCopy(node0);
-                }
-                for (int i = 0; i < node0.jjtGetNumChildren(); i++) {
-                    
-                    JexlNode child = node0.jjtGetChild(i);
-                    
-                    if (child instanceof ASTIdentifier) {
-                        this.adopt(newParent, buildRegexNode((ASTIdentifier) child, functionMetadata.name(), arguments.get(1).image));
-                    } else { // probably a Reference
-                        for (int j = 0; j < child.jjtGetNumChildren(); j++) {
-                            JexlNode maybeIdentifier = child.jjtGetChild(j);
-                            if (maybeIdentifier instanceof ASTIdentifier) {
-                                this.adopt(newParent, buildRegexNode((ASTIdentifier) maybeIdentifier, functionMetadata.name(), arguments.get(1).image));
+                    JexlNode newParent;
+                    if (functionMetadata.name().equals(EXCLUDE_REGEX)) {
+                        newParent = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
+                    } else {
+                        // it is likely an 'or' node...
+                        newParent = JexlNodeFactory.shallowCopy(firstArg);
+                    }
+                    for (int i = 0; i < firstArg.jjtGetNumChildren(); i++) {
+                        JexlNode child = firstArg.jjtGetChild(i);
+                        if (child instanceof ASTIdentifier) {
+                            this.adopt(newParent, buildRegexNode((ASTIdentifier) child, functionMetadata.name(), arguments.get(1).image));
+                        } else { // probably a Reference
+                            for (int j = 0; j < child.jjtGetNumChildren(); j++) {
+                                JexlNode grandChild = child.jjtGetChild(j);
+                                if (grandChild instanceof ASTIdentifier) {
+                                    this.adopt(newParent, buildRegexNode((ASTIdentifier) grandChild, functionMetadata.name(), arguments.get(1).image));
+                                }
                             }
                         }
                     }
+                    if (newParent.jjtGetNumChildren() == firstArg.jjtGetNumChildren() && newParent.jjtGetNumChildren() != 0) {
+                        returnNode = newParent;
+                    }
                 }
-                if (newParent.jjtGetNumChildren() == node0.jjtGetNumChildren() && newParent.jjtGetNumChildren() != 0) {
-                    returnNode = newParent;
+                break;
+            }
+            case IS_NULL: {
+                JexlNode firstArg = functionMetadata.args().get(0);
+                if (firstArg instanceof ASTIdentifier) {
+                    returnNode = JexlNodeFactory.buildNode(new ASTEQNode(ParserTreeConstants.JJTEQNODE), firstArg.image,
+                                    new ASTNullLiteral(ParserTreeConstants.JJTNULLLITERAL));
                 }
+                break;
             }
-        } else if (functionMetadata.name().equals("isNull")) {
-            List<JexlNode> arguments = functionMetadata.args();
-            JexlNode node0 = arguments.get(0);
-            if (node0 instanceof ASTIdentifier) {
-                returnNode = JexlNodeFactory.buildNode(new ASTEQNode(ParserTreeConstants.JJTEQNODE), node0.image, new ASTNullLiteral(
-                                ParserTreeConstants.JJTNULLLITERAL));
-            }
-        } else if (functionMetadata.name().equals("isNotNull")) {
-            List<JexlNode> arguments = functionMetadata.args();
-            JexlNode node0 = arguments.get(0);
-            if (node0 instanceof ASTIdentifier) {
-                returnNode = JexlNodeFactory.buildNode(new ASTNENode(ParserTreeConstants.JJTNENODE), node0.image, new ASTNullLiteral(
-                                ParserTreeConstants.JJTNULLLITERAL));
+            case IS_NOT_NULL: {
+                JexlNode firstArg = functionMetadata.args().get(0);
+                if (firstArg instanceof ASTIdentifier) {
+                    returnNode = JexlNodeFactory.buildNode(new ASTNENode(ParserTreeConstants.JJTNENODE), firstArg.image,
+                                    new ASTNullLiteral(ParserTreeConstants.JJTNULLLITERAL));
+                }
+                break;
             }
         }
         return returnNode;
@@ -115,8 +121,7 @@ public class RegexFunctionVisitor extends FunctionIndexQueryExpansionVisitor {
             try {
                 JavaRegexAnalyzer jra = new JavaRegexAnalyzer(regex);
                 if (!jra.isNgram()) {
-                    JexlNode kid = null;
-                    if (functionName.equals("includeRegex")) {
+                    if (functionName.equals(INCLUDE_REGEX)) {
                         if (log.isDebugEnabled())
                             log.debug("Building new ER Node");
                         return JexlNodeFactory.buildERNode(field, regex);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetCheck.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetCheck.java
@@ -1,22 +1,20 @@
 package datawave.query.tables.facets;
 
-import java.text.MessageFormat;
-import java.util.NoSuchElementException;
-
-import datawave.query.jexl.JexlASTHelper;
-import datawave.query.jexl.visitors.PrintingVisitor;
+import com.google.common.collect.Multimap;
 import datawave.query.Constants;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.AllTermsIndexedVisitor;
+import datawave.query.jexl.visitors.PrintingVisitor;
 import datawave.query.util.MetadataHelper;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.PreConditionFailedQueryException;
-
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl2.parser.JexlNode;
 
-import com.google.common.collect.Multimap;
+import java.text.MessageFormat;
+import java.util.NoSuchElementException;
 
 public class FacetCheck extends AllTermsIndexedVisitor {
     
@@ -39,7 +37,7 @@ public class FacetCheck extends AllTermsIndexedVisitor {
      * @return
      */
     @Override
-    protected JexlNode equalityVisitor(JexlNode node, Object data) {
+    protected JexlNode visitEqualityNode(JexlNode node, Object data) {
         String fieldName = null;
         try {
             fieldName = JexlASTHelper.getIdentifier(node);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetCheck.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetCheck.java
@@ -37,7 +37,7 @@ public class FacetCheck extends AllTermsIndexedVisitor {
      * @return
      */
     @Override
-    protected JexlNode visitEqualityNode(JexlNode node, Object data) {
+    protected JexlNode equalityVisitor(JexlNode node, Object data) {
         String fieldName = null;
         try {
             fieldName = JexlASTHelper.getIdentifier(node);

--- a/warehouse/query-core/src/main/java/org/apache/commons/jexl2/parser/JexlNodes.java
+++ b/warehouse/query-core/src/main/java/org/apache/commons/jexl2/parser/JexlNodes.java
@@ -1,11 +1,10 @@
 package org.apache.commons.jexl2.parser;
 
+import com.google.common.base.Preconditions;
+
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-
-import com.google.common.base.Preconditions;
 
 /**
  * A utility class that can introspect JexlNodes for useful things like raw access to the children array and type ID. This makes cloning and mutation easier.
@@ -241,5 +240,17 @@ public class JexlNodes {
         }
         
         return found;
+    }
+    
+    public static boolean isAnd(JexlNode node) {
+        return node instanceof ASTAndNode;
+    }
+    
+    public static boolean isOr(JexlNode node) {
+        return node instanceof ASTOrNode;
+    }
+    
+    public static boolean isNotChildless(JexlNode node) {
+        return node != null && node.jjtGetNumChildren() > 0;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
@@ -6,11 +6,14 @@ import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.MockMetadataHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
 
 public class AllTermsIndexedVisitorTest {
     
@@ -167,6 +170,7 @@ public class AllTermsIndexedVisitorTest {
     
     private void testIsIndexed(String query) throws ParseException {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-        AllTermsIndexedVisitor.isIndexed(script, config, helper);
+        JexlNode result = AllTermsIndexedVisitor.isIndexed(script, config, helper);
+        assertTrue(JexlASTHelper.validateLineage(result, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
@@ -1,45 +1,45 @@
 package datawave.query.jexl.visitors;
 
+import datawave.query.jexl.JexlASTHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.junit.Test;
 
 import static datawave.query.jexl.JexlASTHelper.parseJexlQuery;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BooleanOptimizationRebuildingVisitorTest {
-    
-    private BooleanOptimizationRebuildingVisitor visitor = new BooleanOptimizationRebuildingVisitor();
     
     @Test
     public void testConjunction() throws ParseException {
         String original = "a && b && c";
-        optimize(original, original, false, false);
+        optimize(original, original, false);
     }
     
     @Test
     public void testConjunctionWithFlatten() throws ParseException {
         String original = "a && b && c";
-        optimize(original, original, false, true);
+        optimize(original, original, true);
     }
     
     @Test
     public void testDisjunction() throws ParseException {
         String original = "a || b || c";
-        optimize(original, original, true, false);
+        optimize(original, original, false);
     }
     
     @Test
     public void testDisjunctionWithFlatten() throws ParseException {
         String original = "a || b || c";
-        optimize(original, original, true, true);
+        optimize(original, original, true);
     }
     
     @Test
     public void testChildDisjunction() throws ParseException {
         String original = "a && b || c";
         String expected = "(a && b) || c";
-        optimize(original, expected, true, false);
+        optimize(original, expected, false);
     }
     
     @Test
@@ -47,7 +47,7 @@ public class BooleanOptimizationRebuildingVisitorTest {
         String original = "a && b && c && d && (e || f)";
         String expected = "(a && b && c && d && e) || (a && b && c && d && f)";
         // The OR node's terms are distributed throughout the AND nodes
-        optimize(original, expected, true, false);
+        optimize(original, expected, false);
     }
     
     @Test
@@ -55,7 +55,7 @@ public class BooleanOptimizationRebuildingVisitorTest {
         String original = "(a || b) && (c || d) && (e || f)";
         String expected = "((c || d) && (e || f) && a) || ((c || d) && (e || f) && b)";
         // The OR node's terms are distributed throughout the AND nodes
-        optimize(original, expected, true, true);
+        optimize(original, expected, true);
     }
     
     @Test
@@ -63,7 +63,7 @@ public class BooleanOptimizationRebuildingVisitorTest {
         String original = "(a || b) && (c || d) && (e || f || g)";
         String expected = "((c || d) && (e || f || g) && a) || ((c || d) && (e || f || g) && b)";
         // Without flatten the first OR node's terms are distributed throughout the query.
-        optimize(original, expected, true, false);
+        optimize(original, expected, false);
     }
     
     @Test
@@ -71,22 +71,21 @@ public class BooleanOptimizationRebuildingVisitorTest {
         String original = "(a || b) && (c || d) && (e || f || g)";
         String expected = "((c || d) && (a || b) && e) || ((c || d) && (a || b) && f) || ((c || d) && (a || b) && g)";
         // With flatten the largest OR node's terms are distributed throughout the query.
-        optimize(original, expected, true, true);
+        optimize(original, expected, true);
     }
     
-    private void optimize(String original, String expected, boolean hasChildOr, boolean withFlatten) throws ParseException {
-        
+    private void optimize(String original, String expected, boolean flattenScript) throws ParseException {
         ASTJexlScript expectedScript = parseJexlQuery(expected);
         String expectedQuery = JexlStringBuildingVisitor.buildQuery(expectedScript);
         
         ASTJexlScript originalScript = parseJexlQuery(original);
-        if (withFlatten) {
+        if (flattenScript) {
             originalScript = TreeFlatteningRebuildingVisitor.flatten(originalScript);
         }
         ASTJexlScript resultScript = BooleanOptimizationRebuildingVisitor.optimize(originalScript);
         String resultQuery = JexlStringBuildingVisitor.buildQuery(resultScript);
         
         assertEquals(expectedQuery, resultQuery);
-        assertEquals(hasChildOr, visitor.hasChildOr(resultScript));
+        assertTrue(JexlASTHelper.validateLineage(resultScript, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexCleanupVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexCleanupVisitorTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import static datawave.query.Constants.SHARD_DAY_HINT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DateIndexCleanupVisitorTest {
     
@@ -50,5 +51,6 @@ public class DateIndexCleanupVisitorTest {
         ASTJexlScript cleaned = DateIndexCleanupVisitor.cleanup(script);
         String builtQuery = JexlStringBuildingVisitor.buildQuery(cleaned);
         assertEquals(expected, builtQuery);
+        assertTrue(JexlASTHelper.validateLineage(cleaned, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExpandMultiNormalizedTermsTest {
     
@@ -407,5 +408,6 @@ public class ExpandMultiNormalizedTermsTest {
         
         assertEquals(originalRoundTrip, smashedRoundTrip);
         assertEquals(smashedRoundTrip, visitedRountTrip);
+        assertTrue(JexlASTHelper.validateLineage(script, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
@@ -1,0 +1,26 @@
+package datawave.query.jexl.visitors;
+
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ASTNumberLiteral;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FixNegativeNumbersVisitorTest {
+    
+    @Test
+    public void testUnaryMinusModeConvertedToNumberLiteral() throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == -1");
+        ASTJexlScript fixed = FixNegativeNumbersVisitor.fix(script);
+        JexlNode convertedNode = fixed.jjtGetChild(0).jjtGetChild(1);
+        
+        assertTrue(convertedNode instanceof ASTNumberLiteral);
+        assertEquals("-1", convertedNode.jjtGetValue());
+        assertEquals("FOO == -1", JexlStringBuildingVisitor.buildQuery(fixed));
+        assertTrue(JexlASTHelper.validateLineage(fixed, true));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixUnindexedNumericTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixUnindexedNumericTermsTest.java
@@ -1,0 +1,69 @@
+package datawave.query.jexl.visitors;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import datawave.data.type.GeoLatType;
+import datawave.data.type.Type;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FixUnindexedNumericTermsTest {
+    
+    private ShardQueryConfiguration config;
+    
+    @Before
+    public void setUp() throws Exception {
+        config = new ShardQueryConfiguration();
+        Multimap<String,Type<?>> queryFieldsDataTypes = HashMultimap.create();
+        queryFieldsDataTypes.put("INDEXED", new GeoLatType());
+        config.setQueryFieldsDatatypes(queryFieldsDataTypes);
+    }
+    
+    @Test
+    public void testUnindexedStringLiteral() throws ParseException {
+        String original = "FOO == '-1'";
+        String expected = "FOO == -1";
+        assertResult(original, expected);
+    }
+    
+    @Test
+    public void testMultipleUnindexedStringLiterals() throws ParseException {
+        String original = "BAR == '-2' && FOO == '-1'";
+        String expected = "BAR == -2 && FOO == -1";
+        assertResult(original, expected);
+    }
+    
+    @Test
+    public void testIndexedStringLiteral() throws ParseException {
+        String original = "INDEXED == '-1'";
+        assertResult(original, original);
+    }
+    
+    @Test
+    public void testMultipleIndexedStringLiterals() throws ParseException {
+        String original = "INDEXED == '-2' && INDEXED == '-1'";
+        assertResult(original, original);
+    }
+    
+    @Test
+    public void testIndexedAndUnindexedCombination() throws ParseException {
+        String original = "BAR == '-2' && INDEXED == '-1'";
+        String expected = "BAR == -2 && INDEXED == '-1'";
+        assertResult(original, expected);
+    }
+    
+    private void assertResult(String original, String expected) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript result = FixUnindexedNumericTerms.fixNumerics(config, script);
+        
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(result));
+        assertTrue(JexlASTHelper.validateLineage(result, true));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static datawave.query.jexl.functions.GeoWaveFunctionsDescriptorTest.convertFunctionToIndexQuery;
+import static org.junit.Assert.assertTrue;
 
 public class GeoWavePruningVisitorTest {
     
@@ -35,7 +36,7 @@ public class GeoWavePruningVisitorTest {
         Assert.assertEquals("0100", term.getValue());
         
         Assert.assertEquals(query + " && (" + convertFunctionToIndexQuery(query, config) + ")", JexlStringBuildingVisitor.buildQuery(prunedTree));
-        
+        assertTrue(JexlASTHelper.validateLineage(prunedTree, true));
     }
     
     @Test
@@ -55,6 +56,7 @@ public class GeoWavePruningVisitorTest {
         prunedTree.jjtAccept(refExpVisitor, null);
         
         Assert.assertFalse(refExpVisitor.hasChildlessNode);
+        assertTrue(JexlASTHelper.validateLineage(prunedTree, true));
     }
     
     private static class RefExpVisitor extends BaseVisitor {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -15,7 +15,6 @@ import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,6 +22,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class QueryModelVisitorTest {
     
@@ -89,298 +91,230 @@ public class QueryModelVisitorTest {
         allFields.add("GENERE");
     }
     
-    private void assertScriptEquality(ASTJexlScript expectedScript, ASTJexlScript actualScript) {
-        Reason reason = new Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        Assert.assertTrue(reason.reason, equal);
-    }
-    
     @Test
     public void noAppliedMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("NOMAPPINGNAME == 'baz'");
-        ASTJexlScript newScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(script, newScript);
+        String original = "NOMAPPINGNAME == 'baz'";
+        assertVisitorResult(original, original);
     }
     
     @Test
     public void singleMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("OUT == 'baz'");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("IN == 'baz'");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "OUT == 'baz'";
+        String expected = "IN == 'baz'";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void singleTermMapping() throws ParseException {
         for (int i = 0; i < 1000; i++) {
-            ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == 'baz'");
-            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 == 'baz' || BAR2 == 'baz')");
-            ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-            assertScriptEquality(expectedScript, actualScript);
+            String original = "FOO == 'baz'";
+            String expected = "(BAR1 == 'baz' || BAR2 == 'baz')";
+            assertVisitorResult(original, expected);
         }
     }
     
     @Test
     public void singleTermMappingNot() throws ParseException {
         for (int i = 0; i < 1000; i++) {
-            ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO != 'baz'");
-            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 != 'baz' && BAR2 != 'baz')");
-            ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-            assertScriptEquality(expectedScript, actualScript);
+            String original = "FOO != 'baz'";
+            String expected = "(BAR1 != 'baz' && BAR2 != 'baz')";
+            assertVisitorResult(original, expected);
         }
     }
     
     @Test
     public void multipleMappings() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == 'baz' && FIELD == 'taco' && OUT == 2");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 == 'baz' || BAR2 == 'baz') && FIELD == 'taco' && IN == 2");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO == 'baz' && FIELD == 'taco' && OUT == 2";
+        String expected = "(BAR1 == 'baz' || BAR2 == 'baz') && FIELD == 'taco' && IN == 2";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void multipleMappingsWithBounds() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO > 'a' && FOO < 'z'");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 > 'a' && BAR1 < 'z') || (BAR2 > 'a' && BAR2 < 'z')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO > 'a' && FOO < 'z'";
+        String expected = "(BAR1 > 'a' && BAR1 < 'z') || (BAR2 > 'a' && BAR2 < 'z')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void multipleMappingsWithBoundsIdentity() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z'");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z') || (CYCLIC_FIELD_ > 'a' && CYCLIC_FIELD_ < 'z')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z'";
+        String expected = "(CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z') || (CYCLIC_FIELD_ > 'a' && CYCLIC_FIELD_ < 'z')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:isNotNull(FOO)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:isNotNull(BAR1||BAR2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:isNotNull(FOO)";
+        String expected = "filter:isNotNull(BAR1||BAR2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionWithMethod() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:includeRegex(FOO, '1').size()");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:includeRegex(BAR1||BAR2, '1').size()");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:includeRegex(FOO, '1').size()";
+        String expected = "filter:includeRegex(BAR1||BAR2, '1').size()";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionWithMethodInExpression() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:includeRegex(FOO, '1').size() > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:includeRegex(BAR1||BAR2, '1').size() > 0");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:includeRegex(FOO, '1').size() > 0";
+        String expected = "filter:includeRegex(BAR1||BAR2, '1').size() > 0";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void identifierWithMethodWithFunctionInExpression() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("AG.containsAll(filter:someFunction(NAM, '1')) > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(AGE||ETA).containsAll(filter:someFunction((NAME||NOME), '1')) > 0");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AG.containsAll(filter:someFunction(NAM, '1')) > 0";
+        String expected = "(AGE||ETA).containsAll(filter:someFunction((NAME||NOME), '1')) > 0";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void identifierWithMethodWithOneModelDoesNotAddParens() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("OUT.containsAll(filter:someFunction(OUT, '1')) > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("IN.containsAll(filter:someFunction(IN, '1')) > 0");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
-        Assert.assertEquals(JexlStringBuildingVisitor.buildQuery(expectedScript), JexlStringBuildingVisitor.buildQuery(actualScript));
+        String original = "OUT.containsAll(filter:someFunction(OUT, '1')) > 0";
+        String expected = "IN.containsAll(filter:someFunction(IN, '1')) > 0";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void wrongOptimizationInQueryModelVisitor() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("AGE > 10 && AGE > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("AGE > 0 && AGE > 10");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AGE > 10 && AGE > 0";
+        String expected = "AGE > 0 && AGE > 10";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void identifiersWithMethodsInAndWithGT() throws ParseException {
-        ASTJexlScript script = JexlASTHelper
-                        .parseJexlQuery("AGE.containsAll(filter:someFunction(BLAH, '1')) > 0 && AGE.containsAll(filter:someFunction(BOO, '1')) > 10");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("AGE.containsAll(filter:someFunction(BLAH, '1')) > 0 && AGE.containsAll(filter:someFunction(BOO, '1')) > 10");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AGE.containsAll(filter:someFunction(BLAH, '1')) > 0 && AGE.containsAll(filter:someFunction(BOO, '1')) > 10";
+        assertVisitorResult(original, original);
     }
     
     @Test
     public void anotherFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:isNull(FOO)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:isNull(BAR1||BAR2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:isNull(FOO)";
+        String expected = "filter:isNull(BAR1||BAR2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionMappingWithTwoArgs() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:someFunction(NAM,1,GEN,2)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:someFunction(NAME||NOME, 1, GENDER||GENERE, 2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:someFunction(NAM,1,GEN,2)";
+        String expected = "filter:someFunction(NAME||NOME, 1, GENDER||GENERE, 2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void isNullFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:isNull(FOO)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:isNull(BAR1||BAR2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:isNull(FOO)";
+        String expected = "filter:isNull(BAR1||BAR2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void attributeWithMethodMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO.getValuesForGroups(0) == 1");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR2||BAR1).getValuesForGroups(0) == 1");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO.getValuesForGroups(0) == 1";
+        String expected = "(BAR2||BAR1).getValuesForGroups(0) == 1";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void attributeWithMethodAndFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19";
+        String expected = "(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void attributeWithMethodAndFunctionMappingInsideAndNode() throws ParseException {
-        ASTJexlScript script = JexlASTHelper
-                        .parseJexlQuery("FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) < 19 && FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) > 16");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) < 19 && (BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) > 16");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) < 19 && FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) > 16";
+        String expected = "(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) < 19 && (BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) > 16";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void sizeMethodOnFunction() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:includeRegex(NAM, 'MICHAEL').size() == 1");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:includeRegex(NAME||NOME, 'MICHAEL').size() == 1");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:includeRegex(NAM, 'MICHAEL').size() == 1";
+        String expected = "filter:includeRegex(NAME||NOME, 'MICHAEL').size() == 1";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testSubstitutionsEverywhere() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(AGE||ETA).getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE')) < 19");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19";
+        String expected = "(AGE||ETA).getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE')) < 19";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testMoreMethods() throws ParseException {
-        // @formatter:off
-        String[] queries = {
-                "NAM.size()",
-                "(NAM).size()",
-                "(NAME).size()",
-                "NAM.values()",
-                "NAM.getGroupsForValue(FOO)",
-                "NAM.min().hashCode() != 0"
-        };
-        String [] expectedResults = {
-                "(NAME||NOME).size()",
-                "(NAME||NOME).size()",
-                "NAME.size()",
-                "(NAME||NOME).values()",
-                "(NAME||NOME).getGroupsForValue(BAR1||BAR2)",
-                "(NAME||NOME).min().hashCode() != 0"
-        };
-        // @formatter:on
-        
-        for (int i = 0; i < queries.length; i++) {
-            ASTJexlScript script = JexlASTHelper.parseJexlQuery(queries[i]);
-            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expectedResults[i]);
-            ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-            assertScriptEquality(expectedScript, actualScript);
-        }
+        assertVisitorResult("NAM.size()", "(NAME||NOME).size()");
+        assertVisitorResult("(NAM).size()", "(NAME||NOME).size()");
+        assertVisitorResult("(NAME).size()", "NAME.size()");
+        assertVisitorResult("NAM.values()", "(NAME||NOME).values()");
+        assertVisitorResult("NAM.getGroupsForValue(FOO)", "(NAME||NOME).getGroupsForValue(BAR1||BAR2)");
+        assertVisitorResult("NAM.min().hashCode() != 0", "(NAME||NOME).min().hashCode() != 0");
     }
     
     @Test
     public void additiveExpansion() throws ParseException {
-        ASTJexlScript script = JexlASTHelper
-                        .parseJexlQuery("grouping:matchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE').size() + grouping:matchesInGroup(NAM, 'ANTHONY', GEN, 'MALE').size() >= 1");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("grouping:matchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE').size() + grouping:matchesInGroup(NAME||NOME, 'ANTHONY', GENDER||GENERE, 'MALE').size() >= 1");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "grouping:matchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE').size() + grouping:matchesInGroup(NAM, 'ANTHONY', GEN, 'MALE').size() >= 1";
+        String expected = "grouping:matchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE').size() + grouping:matchesInGroup(NAME||NOME, 'ANTHONY', GENDER||GENERE, 'MALE').size() >= 1";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void contentFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("content:phrase(FOO, termOffsetMap, 'a', 'little', 'phrase')");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("content:phrase(BAR1||BAR2, termOffsetMap, 'a', 'little', 'phrase')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "content:phrase(FOO, termOffsetMap, 'a', 'little', 'phrase')";
+        String expected = "content:phrase(BAR1||BAR2, termOffsetMap, 'a', 'little', 'phrase')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testSpecialCharAppliedToNumericQuery() throws ParseException {
         model.addTermToModel("FOO1", "1BAR");
         model.addTermToModel("FOO1", "2BAR");
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz'");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("($1BAR == 'baz' || $2BAR == 'baz')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+    
+        String original = "FOO1 == 'baz'";
+        String expected = "($1BAR == 'baz' || $2BAR == 'baz')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testNullInQuery() throws ParseException {
         model.addTermToModel("FOO1", "1BAR");
         model.addTermToModel("FOO1", "2BAR");
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz' && FOO1 == null");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("($1BAR == 'baz' || $2BAR == 'baz') && ($1BAR == null && $2BAR == null)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+    
+        String original = "FOO1 == 'baz' && FOO1 == null";
+        String expected = "($1BAR == 'baz' || $2BAR == 'baz') && ($1BAR == null && $2BAR == null)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testCastesianProduct() throws ParseException {
         model.addTermToModel("FOO1", "1BAR");
         model.addTermToModel("FOO1", "2BAR");
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == FOO1");
-        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(script);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 == $1BAR || BAR2 == $1BAR || BAR1 == $2BAR || BAR2 == $2BAR)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(groomed, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+    
+        String original = "FOO == FOO1";
+        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(JexlASTHelper.parseJexlQuery(original));
+        String expected = "(BAR1 == $1BAR || BAR2 == $1BAR || BAR1 == $2BAR || BAR2 == $2BAR)";
+        assertVisitorResult(groomed, expected);
     }
     
     @Test
     public void testModelApplication() throws ParseException {
         model.addTermToModel("FOO1", "1BAR");
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz'");
-        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(script);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("$1BAR == 'baz'");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(groomed, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+    
+        String original = "FOO1 == 'baz'";
+        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(JexlASTHelper.parseJexlQuery(original));
+        String expected = "$1BAR == 'baz'";
+        ASTJexlScript actualScript = assertVisitorResult(groomed, expected);
         
         List<ASTEQNode> actualNodes = JexlASTHelper.getEQNodes(actualScript);
-        
         for (ASTEQNode node : actualNodes) {
-            Assert.assertTrue(node.jjtGetChild(0) instanceof ASTReference);
-            Assert.assertTrue(node.jjtGetChild(1) instanceof ASTReference);
+            assertTrue(node.jjtGetChild(0) instanceof ASTReference);
+            assertTrue(node.jjtGetChild(1) instanceof ASTReference);
         }
     }
     
@@ -388,12 +322,11 @@ public class QueryModelVisitorTest {
     public void testAppliedModelWithNullNoFail() throws ParseException {
         model.addTermToModel("FOO1", "BAR1");
         model.addTermToModel("OTHER", "9_2");
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz' and OTHER == null");
-        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(script);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("BAR1 == 'baz' and $9_2 == null");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(groomed, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+    
+        String original = "FOO1 == 'baz' and OTHER == null";
+        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(JexlASTHelper.parseJexlQuery(original));
+        String expected = "BAR1 == 'baz' and $9_2 == null";
+        ASTJexlScript actualScript = assertVisitorResult(groomed, expected);
         
         MockMetadataHelper helper = new MockMetadataHelper();
         helper.addNormalizers("FOO1", Sets.newHashSet(new LcNoDiacriticsType()));
@@ -401,8 +334,31 @@ public class QueryModelVisitorTest {
         maps.put("9_2", "datatype1");
         helper.addFieldsToDatatypes(maps);
         Multimap<String,Type<?>> types = FetchDataTypesVisitor.fetchDataTypes(helper, Collections.singleton("datatype1"), actualScript);
-        Assert.assertEquals(types.size(), 4);
+        assertEquals(types.size(), 4);
         
-        Assert.assertTrue(types.values().stream().allMatch((o) -> o instanceof LcNoDiacriticsType || o instanceof NoOpType));
+        assertTrue(types.values().stream().allMatch((o) -> o instanceof LcNoDiacriticsType || o instanceof NoOpType));
+    }
+    
+    private void assertVisitorResult(String original, String expected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        assertVisitorResult(originalScript, expected);
+    }
+    
+    private ASTJexlScript assertVisitorResult(ASTJexlScript originalScript, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript actualScript = QueryModelVisitor.applyModel(originalScript, model, allFields);
+        assertScriptEquality(actualScript, expectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+        return actualScript;
+    }
+    
+    private void assertScriptEquality(ASTJexlScript expectedScript, ASTJexlScript actualScript) {
+        Reason reason = new Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        assertTrue(reason.reason, equal);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
@@ -3,9 +3,9 @@ package datawave.query.jexl.visitors;
 import datawave.query.jexl.JexlASTHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ParseException;
+import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -13,28 +13,22 @@ import static org.junit.Assert.assertTrue;
  */
 public class RangeCoalescingVisitorTest {
     
+    private static final Logger log = Logger.getLogger(RangeCoalescingVisitor.class);
+    
     @Test
     public void testCoalesceTwoRanges() throws ParseException {
         String originalQuery = "NUM >= '+aE2' && NUM <= '+aE5'";
         String expectedQuery = "(NUM >= '+aE2' && NUM <= '+aE5')";
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+    
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
     public void testCoalesceTwoRangesWithAnchor() throws ParseException {
         String originalQuery = "FOO == 'ba' && NUM >= '+aE2' && NUM <= '+aE5'";
         String expectedQuery = "FOO == 'ba' && (NUM >= '+aE2' && NUM <= '+aE5')";
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+    
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -42,11 +36,7 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "(NUM > '+aE1' && FOO == 'ba') && NUM < '+aE5'";
         String expectedQuery = "FOO == 'ba' && (NUM > '+aE1' && NUM < '+aE5')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -54,12 +44,8 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "(NUM >= '+aE1' && NUM <= '+aE4') && TACO == 'tacocat'";
         // Ordering of query terms is not deterministic
         String expectedQuery = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4')";
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+    
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -67,12 +53,8 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "(FOO >= 'bar' && FOO <= 'bas') && TACO == 'tacocat'";
         // Ordering of query terms is not deterministic
         String expectedQuery = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas')";
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+    
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -82,12 +64,7 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas') && (NUM >= '+aE1' && NUM <= '+aE4')";
         String expectedQuery2 = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4') && (FOO >= 'bar' && FOO <= 'bas')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertTrue("Expected " + expectedQuery1 + " or " + expectedQuery2 + " but was " + newQuery,
-                        (expectedQuery1.equals(newQuery) || expectedQuery2.equalsIgnoreCase(newQuery)));
+        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
     @Test
@@ -96,13 +73,8 @@ public class RangeCoalescingVisitorTest {
         // Ordering of query terms is not deterministic, assert both possibilities
         String expectedQuery1 = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas') && (NUM >= '+aE1' && NUM <= '+aE4')";
         String expectedQuery2 = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4') && (FOO >= 'bar' && FOO <= 'bas')";
-        
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertTrue("Expected " + expectedQuery1 + " or " + expectedQuery2 + " but was " + newQuery,
-                        (expectedQuery1.equals(newQuery) || expectedQuery2.equalsIgnoreCase(newQuery)));
+    
+        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
     @Test
@@ -112,12 +84,49 @@ public class RangeCoalescingVisitorTest {
         // Ordering of query terms is not deterministic, assert both possibilities
         String expectedQuery1 = "TACO == 'tacocat' && NUM3 == '+aE3' && (NUM2 >= '+aE2' && NUM2 <= '+aE4') && (NUM >= '+aE1' && NUM <= '+aE5')";
         String expectedQuery2 = "TACO == 'tacocat' && NUM3 == '+aE3' && (NUM >= '+aE1' && NUM <= '+aE5') && (NUM2 >= '+aE2' && NUM2 <= '+aE4')";
+    
+        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
+    }
+    
+    private void assertVisitorResult(String original, String expected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
+    
+        assertScriptEquality(actualScript, expectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+    }
+    
+    private void assertVisitorResult(String original, String expected, String altExpected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript altExpectedScript = JexlASTHelper.parseJexlQuery(altExpected);
+        ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
+    
+        assertScriptEquality(actualScript, expectedScript, altExpectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actualScript, ASTJexlScript expectedScript) {
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actualScript, ASTJexlScript expectedScript, ASTJexlScript altExpectedScript) {
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        TreeEqualityVisitor.Reason altReason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        boolean altEqual = TreeEqualityVisitor.isEqual(altExpectedScript, actualScript, altReason);
+        if (!equal || !altEqual) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Alt Expected: " + PrintingVisitor.formattedQueryString(altExpectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertTrue("Expected [" + expectedQuery1 + "] or [" + expectedQuery2 + "] but was " + newQuery,
-                        (expectedQuery1.equals(newQuery) || expectedQuery2.equalsIgnoreCase(newQuery)));
+        assertTrue(equal || altEqual);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
@@ -1,18 +1,23 @@
 package datawave.query.jexl.visitors;
 
 import com.google.common.collect.Sets;
-import datawave.query.jexl.JexlASTHelper;
 import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.junit.Assert;
+import org.apache.log4j.Logger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Set;
 
+import static org.junit.Assert.assertTrue;
+
 public class RegexFunctionVisitorTest {
+    
+    private static final Logger log = Logger.getLogger(RegexFunctionVisitorTest.class);
     
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -20,74 +25,75 @@ public class RegexFunctionVisitorTest {
     @Test
     public void testDoubleEndedWildCard() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA,'.*all_.*')";
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '.*all_.*')";
+        String field = "FIELDA";
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '.*all_.*')",
-                        JexlStringBuildingVisitor.buildQuery(result));
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testDoubleEndedWildCard2() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA,'?.*all_.*?')";
-        
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '?.*all_.*?')",
-                        JexlStringBuildingVisitor.buildQuery(result));
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '?.*all_.*?')";
+        String field = "FIELDA";
+    
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testEndWildcard() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA,'all_.*?')";
-        
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && FIELDA =~ 'all_.*?'", JexlStringBuildingVisitor.buildQuery(result));
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && FIELDA =~ 'all_.*?'";
+        String field = "FIELDA";
+    
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testEndWildCardNotIndexOnly() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDB, 'all_.*?')";
-        
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDB, 'all_.*?')",
-                        JexlStringBuildingVisitor.buildQuery(result));
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDB, 'all_.*?')";
+        String field = "FIELDA";
+    
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testBadRegex() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA, '(?#icu)Friendly')";
-        
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
+        String field = "FIELDA";
+    
         exception.expect(DatawaveFatalQueryException.class);
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
+        assertVisitorResult(query, query, field);
     }
     
     @Test
     public void testMixedEventNonEvent() throws ParseException {
         String query = "filter:includeRegex(EVENT_FIELD || NON_EVENT_FIELD,'all_.*?')";
+        String field = "NON_EVENT_FIELD";
+    
+        assertVisitorResult(query, query, field);
+    }
+    
+    private void assertVisitorResult(String original, String expected, String field) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+    
+        Set<String> indexOnlyFields = Sets.newHashSet(field);
+    
+        JexlNode actual = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, originalScript);
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("NON_EVENT_FIELD");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertTrue(JexlASTHelper.validateLineage(result, true));
+        assertScriptEquality(actual, expectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actual, true));
+    }
+    
+    private void assertScriptEquality(JexlNode actual, ASTJexlScript expectedScript) throws ParseException {
+        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
@@ -95,5 +95,6 @@ public class RegexFunctionVisitorTest {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
+        assertTrue(reason.reason, equal);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitorTest.java
@@ -1,8 +1,5 @@
 package datawave.query.jexl.visitors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
@@ -13,7 +10,6 @@ import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.commons.jexl2.parser.Parser;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.StringReader;
@@ -150,6 +146,7 @@ public class TreeFlatteningRebuildingVisitorTest {
         assertEquals(expectedQueryString, originalQueryString);
         
         assertTrue(TreeEqualityVisitor.isEqual(expectedScript, flattened, new TreeEqualityVisitor.Reason()));
+        assertTrue(JexlASTHelper.validateLineage(flattened, true));
     }
     
     @Test
@@ -158,15 +155,16 @@ public class TreeFlatteningRebuildingVisitorTest {
         String expected = "(ASTDelayedPredicate = true) || (GEO == '1f36c71c71c71c71c7' && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH < '+bE8')) || GEO >= '1f36c71c71c71c71c7\uDBFF\uDFFF+AE0' || GEO < '1f36c71c71c71c71c8\uDBFF\uDFFF+bE8'";
         JexlNode node = TreeFlatteningRebuildingVisitor.flatten(JexlASTHelper.parseJexlQuery(query));
         Assert.assertEquals(expected, JexlStringBuildingVisitor.buildQuery(node));
+        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
     
     @Test
     public void depthNoStackTraceOrTest() throws Exception {
         final int numTerms = 10000;
         final StringBuilder sb = new StringBuilder(13 * numTerms); // 13 == "abc_" + 5 + " OR "
-        sb.append("abc_" + StringUtils.leftPad(Integer.toString(numTerms, 10), 5, '0'));
+        sb.append("abc_").append(StringUtils.leftPad(Integer.toString(numTerms, 10), 5, '0'));
         for (int i = 2; i <= numTerms; i++) {
-            sb.append(" OR " + i);
+            sb.append(" OR ").append(i);
         }
         Assert.assertNotNull(TreeFlatteningRebuildingVisitor.flattenAll(new Parser(new StringReader(";")).parse(new StringReader(new LuceneToJexlQueryParser()
                         .parse(sb.toString()).toString()), null)));
@@ -178,6 +176,7 @@ public class TreeFlatteningRebuildingVisitorTest {
         String expected = "((a && b && c && d) || b || c || d || e || f || g || h || i || j || k)";
         JexlNode node = TreeFlatteningRebuildingVisitor.flatten(JexlASTHelper.parseJexlQuery(query));
         Assert.assertEquals(expected, JexlStringBuildingVisitor.buildQuery(node));
+        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
     
     @Test
@@ -186,6 +185,7 @@ public class TreeFlatteningRebuildingVisitorTest {
         String expected = "((a && b && (c1 || c2 || c3) && d) || b || c || d || e || f || g || (h1 && h2 && h3) || i || j || k)";
         JexlNode node = TreeFlatteningRebuildingVisitor.flatten(JexlASTHelper.parseJexlQuery(query));
         Assert.assertEquals(expected, JexlStringBuildingVisitor.buildQuery(node));
+        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
     
     @Test
@@ -200,6 +200,7 @@ public class TreeFlatteningRebuildingVisitorTest {
         Assert.assertEquals(1, flattened.jjtGetNumChildren());
         Assert.assertEquals(ASTEQNode.class, flattened.jjtGetChild(0).getClass());
         Assert.assertEquals(JexlStringBuildingVisitor.buildQuery(eqNode), JexlStringBuildingVisitor.buildQuery(flattened));
+        assertTrue(JexlASTHelper.validateLineage(flattened, true));
     }
     
 }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetCheckTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetCheckTest.java
@@ -1,0 +1,210 @@
+package datawave.query.tables.facets;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import datawave.query.Constants;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.util.MetadataHelper;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.getCurrentArguments;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertTrue;
+
+public class FacetCheckTest {
+    
+    private static final Set<String> indexedFields = Collections.unmodifiableSet(Sets.newHashSet("FOO", "FOO2", "FOO3"));
+    private final Multimap<String, String> facets = HashMultimap.create();
+    
+    private FacetCheck facetCheck;
+    
+    @Before
+    public void before() throws TableNotFoundException, IllegalAccessException, InstantiationException {
+        facets.put("FACET1", "VALUE");
+        facets.put("FACET2", "VALUE");
+        facets.put("FACET3", "VALUE");
+    
+        ShardQueryConfiguration shardQueryConfiguration = mock(ShardQueryConfiguration.class);
+        FacetedConfiguration facetedConfiguration = mock(FacetedConfiguration.class);
+        expect(facetedConfiguration.getFacetMetadataTableName()).andReturn("facetMetadata");
+        MetadataHelper metadataHelper = mock(MetadataHelper.class);
+        expect(metadataHelper.isIndexed(anyString(), anyObject())).andAnswer(() -> indexedFields.contains(getCurrentArguments()[0]));
+        expect(metadataHelper.getFacets("facetMetadata")).andReturn(facets);
+        
+        replay(shardQueryConfiguration, facetedConfiguration, metadataHelper);
+        
+        facetCheck = new FacetCheck(shardQueryConfiguration, facetedConfiguration, metadataHelper);
+    }
+    
+    @Test(expected = EmptyUnfieldedTermExpansionException.class)
+    public void testAnyFieldSingleTerm() throws ParseException {
+        String query = Constants.ANY_FIELD + " == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = EmptyUnfieldedTermExpansionException.class)
+    public void testNoFieldSingleTerm() throws ParseException {
+        String query = Constants.NO_FIELD + " == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test
+    public void testFacetedSingleTerm() throws ParseException {
+        String query = "FACET1 == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test
+    public void testFacetedConjunction() throws ParseException {
+        String query = "FACET1 == 'bar' || FACET2 == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test
+    public void testFacetedDisjunction() throws ParseException {
+        String query = "FACET1 == 'bar' && FACET2 == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNonFacetedSingleTerm() throws ParseException {
+        String query = "BAR == 'foo'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNonFacetedConjunction() throws ParseException {
+        String query = "BAR == 'foo' && BAR2 == 'foo'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNonFacetedDisjunction() throws ParseException {
+        String query = "FOO == 'bar' || BAR == 'foo'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNonFacetedDoubleDisjunction() throws ParseException {
+        String query = "BAR == 'foo' || BAR2 == 'foo'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNonFacetedTripleDisjunction() throws ParseException {
+        String query = "FOO == 'bar' || BAR == 'foo' || BAR2 == 'foo'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testFunction() throws ParseException {
+        String query = "FOO == 'bar' || content:phrase(termOffsetMap, 'bar', 'too')";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testOnlyFunction() throws ParseException {
+        String query = "content:phrase(termOffsetMap, 'bar', 'too')";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testFunctionOverIndexedField() throws ParseException {
+        String query = "content:phrase(termOffsetMap, FOO, 'bar', 'too')";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testRegex() throws ParseException {
+        String query = "FOO =~ 'bar.*'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testRegexWithExtraTerm() throws ParseException {
+        String query = "FOO =~ 'bar.*' || FOO == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNegatedRegex() throws ParseException {
+        String query = "FOO !~ 'bar.*'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testNegatedRegexWithExtraTerm() throws ParseException {
+        String query = "FOO !~ 'bar.*' || FOO == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testLessThan() throws ParseException {
+        String query = "FOO < '+aE1'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testLessThanWithExtraTerm() throws ParseException {
+        String query = "FOO < '+aE1' || FOO == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testLessThanEquals() throws ParseException {
+        String query = "FOO <= '+aE1'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testLessThanEqualsWithExtraTerm() throws ParseException {
+        String query = "FOO <= '+aE1' || FOO == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testGreaterThan() throws ParseException {
+        String query = "FOO > '+aE1'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testGreaterThanWithExtraTerm() throws ParseException {
+        String query = "FOO > '+aE1' || FOO == 'bar'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testGreaterThanEquals() throws ParseException {
+        String query = "FOO >= '+aE1'";
+        testVisitor(query);
+    }
+    
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testGreaterThanEqualsWithExtraTerm() throws ParseException {
+        String query = "FOO >= '+aE1' || FOO == 'bar'";
+        testVisitor(query);
+    }
+    
+    private void testVisitor(String query) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+        JexlNode result = (JexlNode) script.jjtAccept(facetCheck, null);
+        assertTrue(JexlASTHelper.validateLineage(result, true));
+    }
+}


### PR DESCRIPTION
WIP for #880 for verifying/fixing JexlNode rebuilding visitors to ensure that they preserve proper parentage. 

I have fixed/verified parentage for the following visitors:

* `AllTermsIndexedVisitor`
* `BooleanOptimizationVisitor`
* `FacetCheck`
* `DateIndexCleanupVisitor`
* `ExpandMultinormalizedTerms`
* `TreeFlatteningRebuildingVisitor`
* `FixNegativeNumbersVisitor`
* `GeowavePruningVisitor`
* `QueryModelVisitor`
* `RangeCoalescingVisitor`
* `RegexFunctionVisitor`

I am currently working on fixing parentage for the following visitors:

* `UniqueExpressionTermsVisitor`
* `ExpandCompositeTerms`

There are a number of rebuilding visitors that do not have any unit tests associated with them that I could find, nor was there enough documentation for me to be able to extrapolate test cases for them. I would appreciate any help with examples or desired test cases so that I can write tests for each of the following and verify parentage.

* `BoundedRangeDetectionVisitor`
* `FunctionIndexQueryExpansionVisitor`
* `FunctionNormalizationRebuildingVisitor`
* `IsNotNullIntentVisitor`
* `ParallelIndexExpansion`
* `PruneLessSelectiveFieldsVisitor`
* `PushdownLargeFieldedListsVisitor`
* `PushdownMissingIndexRangeNodesVisitor`
* `PushFunctionsIntoExceededValueRanges`
* `RangeConjunctionRebuildingVisitor`
* `RangeExpansionThresholdRebuildingVisitor`