### PR TITLE
Verify lineage for QueryModelVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
@@ -2,15 +2,14 @@ package datawave.query.jexl.visitors;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import datawave.query.model.QueryModel;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.JexlNodeFactory.ContainerType;
+import datawave.query.model.QueryModel;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
@@ -45,6 +44,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.jexl2.parser.JexlNodes.id;
 
@@ -54,10 +54,10 @@ import static org.apache.commons.jexl2.parser.JexlNodes.id;
 public class QueryModelVisitor extends RebuildingVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(QueryModelVisitor.class);
     
-    private QueryModel queryModel;
-    private HashSet<ASTAndNode> expandedNodes;
-    private Set<String> validFields;
-    private SimpleQueryModelVisitor simpleQueryModelVisitor;
+    private final QueryModel queryModel;
+    private final HashSet<ASTAndNode> expandedNodes;
+    private final Set<String> validFields;
+    private final SimpleQueryModelVisitor simpleQueryModelVisitor;
     
     public QueryModelVisitor(QueryModel queryModel, Set<String> validFields) {
         this.queryModel = queryModel;
@@ -133,7 +133,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
     public Object visit(ASTReference node, Object data) {
         if (JexlASTHelper.HasMethodVisitor.hasMethod(node)) {
             // this reference has a child that is a method
-            return (ASTReference) node.jjtAccept(this.simpleQueryModelVisitor, null);
+            return node.jjtAccept(this.simpleQueryModelVisitor, null);
         } else {
             return super.visit(node, data);
         }
@@ -212,7 +212,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
                     }
                 }
                 // we don't need the original, unexpanded nodes any more
-                if (aliasedBounds.isEmpty() == false) {
+                if (!aliasedBounds.isEmpty()) {
                     lowerBounds.removeAll(field);
                     upperBounds.removeAll(field);
                     this.expandedNodes.addAll(aliasedBounds);
@@ -242,7 +242,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
          * The rebuilding visitor adds whatever {visit()} returns to the parent's child list, so we shouldn't have some weird object graph that means old nodes
          * never get GC'd because {super.visit()} will reset the parent in the call to {copy()}
          */
-        return super.visit(JexlNodes.children(smashed, others.toArray(new JexlNode[others.size()])), data);
+        return super.visit(JexlNodes.children(smashed, others.toArray(new JexlNode[0])), data);
     }
     
     /**
@@ -310,7 +310,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
             return toReturn;
         }
         
-        Object leftSeed = null, rightSeed = null;
+        Object leftSeed, rightSeed;
         Set<Object> left = Sets.newHashSet(), right = Sets.newHashSet();
         boolean isNullEquality = false;
         
@@ -379,13 +379,6 @@ public class QueryModelVisitor extends RebuildingVisitor {
         }
         boolean requiresAnd = isNullEquality || node instanceof ASTNENode;
         
-        if (leftSeed == null) {
-            leftSeed = leftNode;
-        }
-        if (rightSeed == null) {
-            rightSeed = rightNode;
-        }
-        
         @SuppressWarnings("unchecked")
         // retrieve the cartesian product
         Set<List<Object>> product = Sets.cartesianProduct(left, right);
@@ -395,20 +388,18 @@ public class QueryModelVisitor extends RebuildingVisitor {
          * need to ensure that if we create a logical structure ( such as an or ) -- each literal references a unique identifier from the right. Otherwise,
          * subsequent visitors will reference incorrection sub trees, and potentially negate the activity of the query model visitor
          */
-        Set<List<Object>> newSet = Sets.newHashSet(FluentIterable.from(product).transform(new ProductTransformer()));
+        Set<List<Object>> newSet = product.stream().map(new ProductTransformer()::apply).collect(Collectors.toSet());
         
         if (product.size() > 1) {
+            JexlNode expanded;
             if (requiresAnd) {
-                JexlNode expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.AND_NODE, node, newSet);
-                if (log.isTraceEnabled())
-                    log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
-                return expanded;
+                expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.AND_NODE, node, newSet);
             } else {
-                JexlNode expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.OR_NODE, node, newSet);
-                if (log.isTraceEnabled())
-                    log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
-                return expanded;
+                expanded = JexlNodeFactory.createNodeTreeFromPairs(ContainerType.OR_NODE, node, newSet);
             }
+            if (log.isTraceEnabled())
+                log.trace("expanded:" + PrintingVisitor.formattedQueryString(expanded));
+            return expanded;
         } else if (1 == product.size()) {
             List<Object> pair = product.iterator().next();
             JexlNode expanded = JexlNodeFactory.buildUntypedBinaryNode(node, pair.get(0), pair.get(1));
@@ -430,16 +421,13 @@ public class QueryModelVisitor extends RebuildingVisitor {
     protected static class ProductTransformer implements Function<List<Object>,List<Object>> {
         @Override
         public List<Object> apply(List<Object> objects) {
-            List<Object> newObjectList = Lists.newArrayListWithCapacity(objects.size());
-            for (Object obj : objects) {
-                Object newObj = obj;
-                if (obj instanceof JexlNode) {
-                    newObj = RebuildingVisitor.copy((JexlNode) obj);
+            return objects.stream().map(o -> {
+                if (o instanceof JexlNode) {
+                    return copy((JexlNode) o);
+                } else {
+                    return o;
                 }
-                newObjectList.add(newObj);
-            }
-            return newObjectList;
-            
+            }).collect(Collectors.toList());
         }
     }
     
@@ -449,9 +437,8 @@ public class QueryModelVisitor extends RebuildingVisitor {
      */
     protected static class SimpleQueryModelVisitor extends RebuildingVisitor {
         
-        private static final Logger log = ThreadConfigurableLogger.getLogger(SimpleQueryModelVisitor.class);
-        private QueryModel queryModel;
-        private Set<String> validFields;
+        private final QueryModel queryModel;
+        private final Set<String> validFields;
         
         public SimpleQueryModelVisitor(QueryModel queryModel, Set<String> validFields) {
             this.queryModel = queryModel;

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -15,7 +15,6 @@ import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,6 +22,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class QueryModelVisitorTest {
     
@@ -89,248 +91,184 @@ public class QueryModelVisitorTest {
         allFields.add("GENERE");
     }
     
-    private void assertScriptEquality(ASTJexlScript expectedScript, ASTJexlScript actualScript) {
-        Reason reason = new Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        Assert.assertTrue(reason.reason, equal);
-    }
-    
     @Test
     public void noAppliedMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("NOMAPPINGNAME == 'baz'");
-        ASTJexlScript newScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(script, newScript);
+        String original = "NOMAPPINGNAME == 'baz'";
+        assertVisitorResult(original, original);
     }
     
     @Test
     public void singleMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("OUT == 'baz'");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("IN == 'baz'");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "OUT == 'baz'";
+        String expected = "IN == 'baz'";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void singleTermMapping() throws ParseException {
         for (int i = 0; i < 1000; i++) {
-            ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == 'baz'");
-            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 == 'baz' || BAR2 == 'baz')");
-            ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-            assertScriptEquality(expectedScript, actualScript);
+            String original = "FOO == 'baz'";
+            String expected = "(BAR1 == 'baz' || BAR2 == 'baz')";
+            assertVisitorResult(original, expected);
         }
     }
     
     @Test
     public void singleTermMappingNot() throws ParseException {
         for (int i = 0; i < 1000; i++) {
-            ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO != 'baz'");
-            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 != 'baz' && BAR2 != 'baz')");
-            ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-            assertScriptEquality(expectedScript, actualScript);
+            String original = "FOO != 'baz'";
+            String expected = "(BAR1 != 'baz' && BAR2 != 'baz')";
+            assertVisitorResult(original, expected);
         }
     }
     
     @Test
     public void multipleMappings() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == 'baz' && FIELD == 'taco' && OUT == 2");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 == 'baz' || BAR2 == 'baz') && FIELD == 'taco' && IN == 2");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO == 'baz' && FIELD == 'taco' && OUT == 2";
+        String expected = "(BAR1 == 'baz' || BAR2 == 'baz') && FIELD == 'taco' && IN == 2";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void multipleMappingsWithBounds() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO > 'a' && FOO < 'z'");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 > 'a' && BAR1 < 'z') || (BAR2 > 'a' && BAR2 < 'z')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO > 'a' && FOO < 'z'";
+        String expected = "(BAR1 > 'a' && BAR1 < 'z') || (BAR2 > 'a' && BAR2 < 'z')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void multipleMappingsWithBoundsIdentity() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z'");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z') || (CYCLIC_FIELD_ > 'a' && CYCLIC_FIELD_ < 'z')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z'";
+        String expected = "(CYCLIC_FIELD > 'a' && CYCLIC_FIELD < 'z') || (CYCLIC_FIELD_ > 'a' && CYCLIC_FIELD_ < 'z')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:isNotNull(FOO)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:isNotNull(BAR1||BAR2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:isNotNull(FOO)";
+        String expected = "filter:isNotNull(BAR1||BAR2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionWithMethod() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:includeRegex(FOO, '1').size()");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:includeRegex(BAR1||BAR2, '1').size()");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:includeRegex(FOO, '1').size()";
+        String expected = "filter:includeRegex(BAR1||BAR2, '1').size()";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionWithMethodInExpression() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:includeRegex(FOO, '1').size() > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:includeRegex(BAR1||BAR2, '1').size() > 0");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:includeRegex(FOO, '1').size() > 0";
+        String expected = "filter:includeRegex(BAR1||BAR2, '1').size() > 0";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void identifierWithMethodWithFunctionInExpression() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("AG.containsAll(filter:someFunction(NAM, '1')) > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(AGE||ETA).containsAll(filter:someFunction((NAME||NOME), '1')) > 0");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AG.containsAll(filter:someFunction(NAM, '1')) > 0";
+        String expected = "(AGE||ETA).containsAll(filter:someFunction((NAME||NOME), '1')) > 0";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void identifierWithMethodWithOneModelDoesNotAddParens() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("OUT.containsAll(filter:someFunction(OUT, '1')) > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("IN.containsAll(filter:someFunction(IN, '1')) > 0");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
-        Assert.assertEquals(JexlStringBuildingVisitor.buildQuery(expectedScript), JexlStringBuildingVisitor.buildQuery(actualScript));
+        String original = "OUT.containsAll(filter:someFunction(OUT, '1')) > 0";
+        String expected = "IN.containsAll(filter:someFunction(IN, '1')) > 0";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void wrongOptimizationInQueryModelVisitor() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("AGE > 10 && AGE > 0");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("AGE > 0 && AGE > 10");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AGE > 10 && AGE > 0";
+        String expected = "AGE > 0 && AGE > 10";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void identifiersWithMethodsInAndWithGT() throws ParseException {
-        ASTJexlScript script = JexlASTHelper
-                        .parseJexlQuery("AGE.containsAll(filter:someFunction(BLAH, '1')) > 0 && AGE.containsAll(filter:someFunction(BOO, '1')) > 10");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("AGE.containsAll(filter:someFunction(BLAH, '1')) > 0 && AGE.containsAll(filter:someFunction(BOO, '1')) > 10");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AGE.containsAll(filter:someFunction(BLAH, '1')) > 0 && AGE.containsAll(filter:someFunction(BOO, '1')) > 10";
+        assertVisitorResult(original, original);
     }
     
     @Test
     public void anotherFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:isNull(FOO)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:isNull(BAR1||BAR2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:isNull(FOO)";
+        String expected = "filter:isNull(BAR1||BAR2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void functionMappingWithTwoArgs() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:someFunction(NAM,1,GEN,2)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:someFunction(NAME||NOME, 1, GENDER||GENERE, 2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:someFunction(NAM,1,GEN,2)";
+        String expected = "filter:someFunction(NAME||NOME, 1, GENDER||GENERE, 2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void isNullFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:isNull(FOO)");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:isNull(BAR1||BAR2)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:isNull(FOO)";
+        String expected = "filter:isNull(BAR1||BAR2)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void attributeWithMethodMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO.getValuesForGroups(0) == 1");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR2||BAR1).getValuesForGroups(0) == 1");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO.getValuesForGroups(0) == 1";
+        String expected = "(BAR2||BAR1).getValuesForGroups(0) == 1";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void attributeWithMethodAndFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19";
+        String expected = "(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(A, 'MEADOW', B, 'FEMALE')) < 19";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void attributeWithMethodAndFunctionMappingInsideAndNode() throws ParseException {
-        ASTJexlScript script = JexlASTHelper
-                        .parseJexlQuery("FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) < 19 && FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) > 16");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) < 19 && (BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) > 16");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) < 19 && FOO.getValuesForGroups(grouping:getGroupsForMatchesInGroup(OUT, 'MEADOW')) > 16";
+        String expected = "(BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) < 19 && (BAR2||BAR1).getValuesForGroups(grouping:getGroupsForMatchesInGroup(IN, 'MEADOW')) > 16";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void sizeMethodOnFunction() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("filter:includeRegex(NAM, 'MICHAEL').size() == 1");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("filter:includeRegex(NAME||NOME, 'MICHAEL').size() == 1");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "filter:includeRegex(NAM, 'MICHAEL').size() == 1";
+        String expected = "filter:includeRegex(NAME||NOME, 'MICHAEL').size() == 1";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testSubstitutionsEverywhere() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("(AGE||ETA).getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE')) < 19");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19";
+        String expected = "(AGE||ETA).getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE')) < 19";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void testMoreMethods() throws ParseException {
-        // @formatter:off
-        String[] queries = {
-                "NAM.size()",
-                "(NAM).size()",
-                "(NAME).size()",
-                "NAM.values()",
-                "NAM.getGroupsForValue(FOO)",
-                "NAM.min().hashCode() != 0"
-        };
-        String [] expectedResults = {
-                "(NAME||NOME).size()",
-                "(NAME||NOME).size()",
-                "NAME.size()",
-                "(NAME||NOME).values()",
-                "(NAME||NOME).getGroupsForValue(BAR1||BAR2)",
-                "(NAME||NOME).min().hashCode() != 0"
-        };
-        // @formatter:on
-        
-        for (int i = 0; i < queries.length; i++) {
-            ASTJexlScript script = JexlASTHelper.parseJexlQuery(queries[i]);
-            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expectedResults[i]);
-            ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-            assertScriptEquality(expectedScript, actualScript);
-        }
+        assertVisitorResult("NAM.size()", "(NAME||NOME).size()");
+        assertVisitorResult("(NAM).size()", "(NAME||NOME).size()");
+        assertVisitorResult("(NAME).size()", "NAME.size()");
+        assertVisitorResult("NAM.values()", "(NAME||NOME).values()");
+        assertVisitorResult("NAM.getGroupsForValue(FOO)", "(NAME||NOME).getGroupsForValue(BAR1||BAR2)");
+        assertVisitorResult("NAM.min().hashCode() != 0", "(NAME||NOME).min().hashCode() != 0");
     }
     
     @Test
     public void additiveExpansion() throws ParseException {
-        ASTJexlScript script = JexlASTHelper
-                        .parseJexlQuery("grouping:matchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE').size() + grouping:matchesInGroup(NAM, 'ANTHONY', GEN, 'MALE').size() >= 1");
-        ASTJexlScript expectedScript = JexlASTHelper
-                        .parseJexlQuery("grouping:matchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE').size() + grouping:matchesInGroup(NAME||NOME, 'ANTHONY', GENDER||GENERE, 'MALE').size() >= 1");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "grouping:matchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE').size() + grouping:matchesInGroup(NAM, 'ANTHONY', GEN, 'MALE').size() >= 1";
+        String expected = "grouping:matchesInGroup(NAME||NOME, 'MEADOW', GENDER||GENERE, 'FEMALE').size() + grouping:matchesInGroup(NAME||NOME, 'ANTHONY', GENDER||GENERE, 'MALE').size() >= 1";
+        assertVisitorResult(original, expected);
     }
     
     @Test
     public void contentFunctionMapping() throws ParseException {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("content:phrase(FOO, termOffsetMap, 'a', 'little', 'phrase')");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("content:phrase(BAR1||BAR2, termOffsetMap, 'a', 'little', 'phrase')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "content:phrase(FOO, termOffsetMap, 'a', 'little', 'phrase')";
+        String expected = "content:phrase(BAR1||BAR2, termOffsetMap, 'a', 'little', 'phrase')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
@@ -338,10 +276,9 @@ public class QueryModelVisitorTest {
         model.addTermToModel("FOO1", "1BAR");
         model.addTermToModel("FOO1", "2BAR");
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz'");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("($1BAR == 'baz' || $2BAR == 'baz')");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO1 == 'baz'";
+        String expected = "($1BAR == 'baz' || $2BAR == 'baz')";
+        assertVisitorResult(original, expected);
     }
     
     @Test
@@ -349,10 +286,9 @@ public class QueryModelVisitorTest {
         model.addTermToModel("FOO1", "1BAR");
         model.addTermToModel("FOO1", "2BAR");
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz' && FOO1 == null");
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("($1BAR == 'baz' || $2BAR == 'baz') && ($1BAR == null && $2BAR == null)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(script, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO1 == 'baz' && FOO1 == null";
+        String expected = "($1BAR == 'baz' || $2BAR == 'baz') && ($1BAR == null && $2BAR == null)";
+        assertVisitorResult(original, expected);
     }
     
     @Test
@@ -360,27 +296,25 @@ public class QueryModelVisitorTest {
         model.addTermToModel("FOO1", "1BAR");
         model.addTermToModel("FOO1", "2BAR");
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO == FOO1");
-        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(script);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("(BAR1 == $1BAR || BAR2 == $1BAR || BAR1 == $2BAR || BAR2 == $2BAR)");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(groomed, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO == FOO1";
+        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(JexlASTHelper.parseJexlQuery(original));
+        String expected = "(BAR1 == $1BAR || BAR2 == $1BAR || BAR1 == $2BAR || BAR2 == $2BAR)";
+        assertVisitorResult(groomed, expected);
     }
     
     @Test
     public void testModelApplication() throws ParseException {
         model.addTermToModel("FOO1", "1BAR");
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz'");
-        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(script);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("$1BAR == 'baz'");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(groomed, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        
+        String original = "FOO1 == 'baz'";
+        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(JexlASTHelper.parseJexlQuery(original));
+        String expected = "$1BAR == 'baz'";
+        ASTJexlScript actualScript = assertVisitorResult(groomed, expected);
         
         List<ASTEQNode> actualNodes = JexlASTHelper.getEQNodes(actualScript);
-        
         for (ASTEQNode node : actualNodes) {
-            Assert.assertTrue(node.jjtGetChild(0) instanceof ASTReference);
-            Assert.assertTrue(node.jjtGetChild(1) instanceof ASTReference);
+            assertTrue(node.jjtGetChild(0) instanceof ASTReference);
+            assertTrue(node.jjtGetChild(1) instanceof ASTReference);
         }
     }
     
@@ -389,11 +323,10 @@ public class QueryModelVisitorTest {
         model.addTermToModel("FOO1", "BAR1");
         model.addTermToModel("OTHER", "9_2");
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO1 == 'baz' and OTHER == null");
-        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(script);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery("BAR1 == 'baz' and $9_2 == null");
-        ASTJexlScript actualScript = QueryModelVisitor.applyModel(groomed, model, allFields);
-        assertScriptEquality(expectedScript, actualScript);
+        String original = "FOO1 == 'baz' and OTHER == null";
+        ASTJexlScript groomed = JexlASTHelper.InvertNodeVisitor.invertSwappedNodes(JexlASTHelper.parseJexlQuery(original));
+        String expected = "BAR1 == 'baz' and $9_2 == null";
+        ASTJexlScript actualScript = assertVisitorResult(groomed, expected);
         
         MockMetadataHelper helper = new MockMetadataHelper();
         helper.addNormalizers("FOO1", Sets.newHashSet(new LcNoDiacriticsType()));
@@ -401,8 +334,31 @@ public class QueryModelVisitorTest {
         maps.put("9_2", "datatype1");
         helper.addFieldsToDatatypes(maps);
         Multimap<String,Type<?>> types = FetchDataTypesVisitor.fetchDataTypes(helper, Collections.singleton("datatype1"), actualScript);
-        Assert.assertEquals(types.size(), 4);
+        assertEquals(types.size(), 4);
         
-        Assert.assertTrue(types.values().stream().allMatch((o) -> o instanceof LcNoDiacriticsType || o instanceof NoOpType));
+        assertTrue(types.values().stream().allMatch((o) -> o instanceof LcNoDiacriticsType || o instanceof NoOpType));
+    }
+    
+    private void assertVisitorResult(String original, String expected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        assertVisitorResult(originalScript, expected);
+    }
+    
+    private ASTJexlScript assertVisitorResult(ASTJexlScript originalScript, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript actualScript = QueryModelVisitor.applyModel(originalScript, model, allFields);
+        assertScriptEquality(actualScript, expectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+        return actualScript;
+    }
+    
+    private void assertScriptEquality(ASTJexlScript expectedScript, ASTJexlScript actualScript) {
+        Reason reason = new Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        assertTrue(reason.reason, equal);
     }
 }


### PR DESCRIPTION
Add asserts to tests for QueryModelVisitor to verify that it returns a
query tree for valid lineage.

Part of #880.