### PR TITLE
Fix lineage for RangeCoalescingVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
@@ -1,31 +1,21 @@
 package datawave.query.jexl.visitors;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.LiteralRange;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
-
 import org.apache.commons.jexl2.parser.ASTAndNode;
-import org.apache.commons.jexl2.parser.ASTERNode;
-import org.apache.commons.jexl2.parser.ASTGENode;
-import org.apache.commons.jexl2.parser.ASTGTNode;
-import org.apache.commons.jexl2.parser.ASTLENode;
-import org.apache.commons.jexl2.parser.ASTLTNode;
-import org.apache.commons.jexl2.parser.ASTNRNode;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.JexlNodes;
 import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.apache.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Visits an JexlNode tree, and coalesces bounded ranges into separate AND expressions.
- *
- * 
- *
  */
 public class RangeCoalescingVisitor extends RebuildingVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(RangeCoalescingVisitor.class);
@@ -41,36 +31,6 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
         RangeCoalescingVisitor visitor = new RangeCoalescingVisitor();
         
         return (T) script.jjtAccept(visitor, null);
-    }
-    
-    @Override
-    public Object visit(ASTERNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTNRNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTLTNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTGTNode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTLENode node, Object data) {
-        return node;
-    }
-    
-    @Override
-    public Object visit(ASTGENode node, Object data) {
-        return node;
     }
     
     @Override
@@ -90,12 +50,12 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
             JexlNodes.ensureCapacity(andNode, node.jjtGetNumChildren());
             for (int i = 0; i < node.jjtGetNumChildren(); i++) {
                 JexlNode newChild = (JexlNode) node.jjtGetChild(i).jjtAccept(this, data);
-                
                 andNode.jjtAddChild(newChild, i);
                 newChild.jjtSetParent(andNode);
             }
         }
         
+        JexlNodes.replaceChild(node.jjtGetParent(), node, andNode);
         return andNode;
     }
     
@@ -125,7 +85,9 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
             
             JexlNodes.ensureCapacity(onlyRangeNodes, range.getValue().size());
             for (int i = 0; i < range.getValue().size(); i++) {
-                onlyRangeNodes.jjtAddChild(range.getValue().get(i), i);
+                JexlNode node = range.getValue().get(i);
+                onlyRangeNodes.jjtAddChild(node, i);
+                node.jjtSetParent(onlyRangeNodes);
             }
             
             JexlNode wrappedNode = JexlNodeFactory.wrap(onlyRangeNodes);
@@ -137,8 +99,9 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
         
         // If we had no other nodes than this bounded range, we can strip out the original parent
         if (newNode.jjtGetNumChildren() == 1) {
-            newNode.jjtGetChild(0).jjtSetParent(newNode.jjtGetParent());
-            return newNode.jjtGetChild(0);
+            JexlNode child = newNode.jjtGetChild(0);
+            JexlNodes.replaceChild(newNode.jjtGetParent(), newNode, child);
+            return child;
         }
         
         return newNode;

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
@@ -3,9 +3,9 @@ package datawave.query.jexl.visitors;
 import datawave.query.jexl.JexlASTHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ParseException;
+import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -13,16 +13,14 @@ import static org.junit.Assert.assertTrue;
  */
 public class RangeCoalescingVisitorTest {
     
+    private static final Logger log = Logger.getLogger(RangeCoalescingVisitor.class);
+    
     @Test
     public void testCoalesceTwoRanges() throws ParseException {
         String originalQuery = "NUM >= '+aE2' && NUM <= '+aE5'";
         String expectedQuery = "(NUM >= '+aE2' && NUM <= '+aE5')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -30,11 +28,7 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "FOO == 'ba' && NUM >= '+aE2' && NUM <= '+aE5'";
         String expectedQuery = "FOO == 'ba' && (NUM >= '+aE2' && NUM <= '+aE5')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -42,11 +36,7 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "(NUM > '+aE1' && FOO == 'ba') && NUM < '+aE5'";
         String expectedQuery = "FOO == 'ba' && (NUM > '+aE1' && NUM < '+aE5')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -55,11 +45,7 @@ public class RangeCoalescingVisitorTest {
         // Ordering of query terms is not deterministic
         String expectedQuery = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -68,11 +54,7 @@ public class RangeCoalescingVisitorTest {
         // Ordering of query terms is not deterministic
         String expectedQuery = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertEquals("Expected " + expectedQuery + " but was " + newQuery, expectedQuery, newQuery);
+        assertVisitorResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -82,12 +64,7 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas') && (NUM >= '+aE1' && NUM <= '+aE4')";
         String expectedQuery2 = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4') && (FOO >= 'bar' && FOO <= 'bas')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertTrue("Expected " + expectedQuery1 + " or " + expectedQuery2 + " but was " + newQuery,
-                        (expectedQuery1.equals(newQuery) || expectedQuery2.equalsIgnoreCase(newQuery)));
+        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
     @Test
@@ -97,12 +74,7 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas') && (NUM >= '+aE1' && NUM <= '+aE4')";
         String expectedQuery2 = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4') && (FOO >= 'bar' && FOO <= 'bas')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertTrue("Expected " + expectedQuery1 + " or " + expectedQuery2 + " but was " + newQuery,
-                        (expectedQuery1.equals(newQuery) || expectedQuery2.equalsIgnoreCase(newQuery)));
+        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
     @Test
@@ -113,11 +85,48 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && NUM3 == '+aE3' && (NUM2 >= '+aE2' && NUM2 <= '+aE4') && (NUM >= '+aE1' && NUM <= '+aE5')";
         String expectedQuery2 = "TACO == 'tacocat' && NUM3 == '+aE3' && (NUM >= '+aE1' && NUM <= '+aE5') && (NUM2 >= '+aE2' && NUM2 <= '+aE4')";
         
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        ASTJexlScript newScript = RangeCoalescingVisitor.coalesceRanges(script);
+        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
+    }
+    
+    private void assertVisitorResult(String original, String expected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
         
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        assertTrue("Expected [" + expectedQuery1 + "] or [" + expectedQuery2 + "] but was " + newQuery,
-                        (expectedQuery1.equals(newQuery) || expectedQuery2.equalsIgnoreCase(newQuery)));
+        assertScriptEquality(actualScript, expectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+    }
+    
+    private void assertVisitorResult(String original, String expected, String altExpected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript altExpectedScript = JexlASTHelper.parseJexlQuery(altExpected);
+        ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
+        
+        assertScriptEquality(actualScript, expectedScript, altExpectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actualScript, ASTJexlScript expectedScript) {
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actualScript, ASTJexlScript expectedScript, ASTJexlScript altExpectedScript) {
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        TreeEqualityVisitor.Reason altReason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        boolean altEqual = TreeEqualityVisitor.isEqual(altExpectedScript, actualScript, altReason);
+        if (!equal && !altEqual) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Alt Expected: " + PrintingVisitor.formattedQueryString(altExpectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        
+        assertTrue(equal || altEqual);
     }
 }


### PR DESCRIPTION
RangeCoalescingVisitor does not return a query tree with a valid
lineage. Ensure that lineage is properly established, and modify unit
tests to assert this.

Part of #880.