### PR TITLE
Verify lineage for RegexFunctionVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexFunctionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexFunctionVisitor.java
@@ -1,11 +1,7 @@
 package datawave.query.jexl.visitors;
 
-import java.util.List;
-import java.util.Set;
-
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
-
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.functions.FunctionJexlNodeVisitor;
@@ -13,10 +9,8 @@ import datawave.query.parser.JavaRegexAnalyzer;
 import datawave.query.parser.JavaRegexAnalyzer.JavaRegexParseException;
 import datawave.query.util.MetadataHelper;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
-
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
-
 import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTEQNode;
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
@@ -26,6 +20,9 @@ import org.apache.commons.jexl2.parser.ASTNullLiteral;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.apache.log4j.Logger;
+
+import java.util.List;
+import java.util.Set;
 
 public class RegexFunctionVisitor extends FunctionIndexQueryExpansionVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(RegexFunctionVisitor.class);
@@ -58,7 +55,7 @@ public class RegexFunctionVisitor extends FunctionIndexQueryExpansionVisitor {
                     returnNode = regexNode;
                 }
             } else {
-                JexlNode newParent = null;
+                JexlNode newParent;
                 if (functionMetadata.name().equals("excludeRegex")) {
                     newParent = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
                 } else {
@@ -115,7 +112,6 @@ public class RegexFunctionVisitor extends FunctionIndexQueryExpansionVisitor {
             try {
                 JavaRegexAnalyzer jra = new JavaRegexAnalyzer(regex);
                 if (!jra.isNgram()) {
-                    JexlNode kid = null;
                     if (functionName.equals("includeRegex")) {
                         if (log.isDebugEnabled())
                             log.debug("Building new ER Node");

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
@@ -1,18 +1,23 @@
 package datawave.query.jexl.visitors;
 
 import com.google.common.collect.Sets;
-import datawave.query.jexl.JexlASTHelper;
 import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.junit.Assert;
+import org.apache.log4j.Logger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Set;
 
+import static org.junit.Assert.assertTrue;
+
 public class RegexFunctionVisitorTest {
+    
+    private static final Logger log = Logger.getLogger(RegexFunctionVisitorTest.class);
     
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -20,74 +25,76 @@ public class RegexFunctionVisitorTest {
     @Test
     public void testDoubleEndedWildCard() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA,'.*all_.*')";
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '.*all_.*')";
+        String field = "FIELDA";
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '.*all_.*')",
-                        JexlStringBuildingVisitor.buildQuery(result));
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testDoubleEndedWildCard2() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA,'?.*all_.*?')";
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '?.*all_.*?')";
+        String field = "FIELDA";
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDA, '?.*all_.*?')",
-                        JexlStringBuildingVisitor.buildQuery(result));
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testEndWildcard() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA,'all_.*?')";
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && FIELDA =~ 'all_.*?'";
+        String field = "FIELDA";
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && FIELDA =~ 'all_.*?'", JexlStringBuildingVisitor.buildQuery(result));
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testEndWildCardNotIndexOnly() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDB, 'all_.*?')";
+        String expected = "_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDB, 'all_.*?')";
+        String field = "FIELDA";
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
-        
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
-        
-        Assert.assertEquals("_ANYFIELD_ == 'email' && ANOTHER_FIELD == 'blah' && filter:includeRegex(FIELDB, 'all_.*?')",
-                        JexlStringBuildingVisitor.buildQuery(result));
+        assertVisitorResult(query, expected, field);
     }
     
     @Test
     public void testBadRegex() throws ParseException {
         String query = "_ANYFIELD_=='email' and ANOTHER_FIELD=='blah' and filter:includeRegex(FIELDA, '(?#icu)Friendly')";
-        
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("FIELDA");
+        String field = "FIELDA";
         
         exception.expect(DatawaveFatalQueryException.class);
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
+        assertVisitorResult(query, query, field);
     }
     
     @Test
     public void testMixedEventNonEvent() throws ParseException {
         String query = "filter:includeRegex(EVENT_FIELD || NON_EVENT_FIELD,'all_.*?')";
+        String field = "NON_EVENT_FIELD";
         
-        Set<String> indexOnlyFields = Sets.newHashSet();
-        indexOnlyFields.add("NON_EVENT_FIELD");
+        assertVisitorResult(query, query, field);
+    }
+    
+    private void assertVisitorResult(String original, String expected, String field) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
         
-        JexlNode result = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, JexlASTHelper.parseJexlQuery(query));
+        Set<String> indexOnlyFields = Sets.newHashSet(field);
         
-        Assert.assertTrue(JexlASTHelper.validateLineage(result, true));
+        JexlNode actual = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, originalScript);
+        
+        assertScriptEquality(actual, expectedScript);
+        assertTrue(JexlASTHelper.validateLineage(actual, true));
+    }
+    
+    private void assertScriptEquality(JexlNode actual, ASTJexlScript expectedScript) throws ParseException {
+        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        assertTrue(reason.reason, equal);
     }
 }


### PR DESCRIPTION
Add asserts to tests for RegexFunctionVisitor to verify that it returns
a query tree with valid lineage.

Part of #880.