### PR TITLE
ValidPatternVisitor now checks #INCLUDE and #EXCLUDE functions. (#787)

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ValidPatternVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ValidPatternVisitor.java
@@ -1,16 +1,21 @@
 package datawave.query.jexl.visitors;
 
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.regex.Pattern;
-
-import datawave.query.jexl.JexlASTHelper;
-
-import org.apache.commons.jexl2.parser.ASTERNode;
-import org.apache.commons.jexl2.parser.ASTNRNode;
-import org.apache.commons.jexl2.parser.JexlNode;
-
 import com.google.common.collect.Maps;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.functions.FunctionJexlNodeVisitor;
+import datawave.query.jexl.functions.JexlFunctionArgumentDescriptorFactory;
+import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
+import org.apache.commons.jexl2.parser.ASTERNode;
+import org.apache.commons.jexl2.parser.ASTFunctionNode;
+import org.apache.commons.jexl2.parser.ASTNRNode;
+import org.apache.commons.jexl2.parser.ASTStringLiteral;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Validates all patterns in a query tree. Uses a cache to avoid parsing the same pattern twice.
@@ -20,7 +25,7 @@ public class ValidPatternVisitor extends BaseVisitor {
     private Map<String,Pattern> patternCache;
     
     public ValidPatternVisitor() {
-        patternCache = Maps.newHashMap();
+        this.patternCache = Maps.newHashMap();
     }
     
     public static void check(JexlNode node) {
@@ -39,22 +44,7 @@ public class ValidPatternVisitor extends BaseVisitor {
      */
     @Override
     public Object visit(ASTERNode node, Object data) {
-        Object literalValue;
-        
-        // Catch the situation where a user might enter FIELD1 =~ VALUE1
-        try {
-            literalValue = JexlASTHelper.getLiteralValue(node);
-        } catch (NoSuchElementException e) {
-            return data;
-        }
-        
-        if (literalValue != null && String.class.equals(literalValue.getClass())) {
-            String literalString = (String) literalValue;
-            if (patternCache.containsKey(literalString)) {
-                return data;
-            }
-            patternCache.put(literalString, Pattern.compile(literalString));
-        }
+        parseAndPutPattern(node);
         return data;
     }
     
@@ -69,22 +59,64 @@ public class ValidPatternVisitor extends BaseVisitor {
      */
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        Object literalValue;
+        parseAndPutPattern(node);
+        return data;
+    }
+    
+    /**
+     * Visit an ASTFunctionNode to catch cases like #INCLUDE or #EXCLUDE that accept a regex as an argument
+     * 
+     * @param node
+     *            - an ASTFunctionNode
+     * @param data
+     *            - the data
+     * @return
+     */
+    @Override
+    public Object visit(ASTFunctionNode node, Object data) {
         
-        // Catch the situation where a user might enter FIELD1 !~ VALUE1
-        try {
-            literalValue = JexlASTHelper.getLiteralValue(node);
-        } catch (NoSuchElementException e) {
-            return data;
+        // Should pull back an EvaluationPhaseFilterFunctionsDescriptor
+        JexlArgumentDescriptor descriptor = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(node);
+        if (descriptor == null) {
+            throw new IllegalStateException("Could not get descriptor for ASTFunctionNode");
         }
         
+        if (descriptor.regexArguments()) {
+            // Extract the args for this function
+            FunctionJexlNodeVisitor functionVisitor = new FunctionJexlNodeVisitor();
+            functionVisitor.visit(node, null);
+            List<JexlNode> args = functionVisitor.args();
+            for (JexlNode arg : args) {
+                // Only take the literals
+                if (arg instanceof ASTStringLiteral) {
+                    parseAndPutPattern(arg);
+                }
+            }
+        }
+        // Do not descend to children, the ValidPatternVisitor views a function node as a leaf node.
+        return data;
+    }
+    
+    /**
+     * Parse a literal value and put into the pattern cache if it does not exist.
+     *
+     * @param node
+     */
+    public void parseAndPutPattern(JexlNode node) {
+        // Catch the situation where a user might enter FIELD1 !~ VALUE1
+        Object literalValue = JexlASTHelper.getLiteralValue(node);
         if (literalValue != null && String.class.equals(literalValue.getClass())) {
             String literalString = (String) literalValue;
-            if (patternCache.containsKey(literalString)) {
-                return data;
+            try {
+                if (patternCache.containsKey(literalString)) {
+                    return;
+                }
+                patternCache.put(literalString, Pattern.compile(literalString));
+            } catch (PatternSyntaxException e) {
+                String builtNode = JexlStringBuildingVisitor.buildQueryWithoutParse(node);
+                String errMsg = "Invalid pattern found in filter function '" + builtNode + "'";
+                throw new PatternSyntaxException(errMsg, e.getPattern(), e.getIndex());
             }
-            patternCache.put(literalString, Pattern.compile(literalString));
         }
-        return data;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ValidPatternVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ValidPatternVisitorTest.java
@@ -11,42 +11,56 @@ public class ValidPatternVisitorTest {
     
     @Test
     public void testValidER() throws ParseException {
-        String queryString = "BAR == 1 && FOO =~ '1234.*\\d'";
+        String queryString = "BAR == '1' && FOO =~ '1234.*\\d'";
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
         ValidPatternVisitor.check(script);
     }
     
     @Test
     public void testValidERWithCacheHit() throws ParseException {
-        String queryString = "BAR == 1 && FOO =~ '1234.*\\d' && FOO2 =~ '1234.*\\d'";
+        String queryString = "BAR == '1' && FOO =~ '1234.*\\d' && FOO2 =~ '1234.*\\d'";
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
         ValidPatternVisitor.check(script);
     }
     
     @Test(expected = PatternSyntaxException.class)
     public void testInvalidER() throws ParseException {
-        String queryString = "BAR == 1 && FOO =~ '1234.**'";
+        String queryString = "BAR == '1' && FOO =~ '1234.**'";
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
         ValidPatternVisitor.check(script);
     }
     
     @Test
     public void testValidNR() throws ParseException {
-        String queryString = "BAR == 1 && FOO !~ '1234.*\\d'";
+        String queryString = "BAR == '1' && FOO !~ '1234.*\\d'";
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
         ValidPatternVisitor.check(script);
     }
     
     @Test
     public void testValidNRWithCacheHit() throws ParseException {
-        String queryString = "BAR == 1 && FOO !~ '1234.*\\d' && FOO2 !~ '1234.*\\d'";
+        String queryString = "BAR == '1' && FOO !~ '1234.*\\d' && FOO2 !~ '1234.*\\d'";
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
         ValidPatternVisitor.check(script);
     }
     
     @Test(expected = PatternSyntaxException.class)
     public void testInvalidNR() throws ParseException {
-        String queryString = "BAR == 1 && FOO !~ '1234.**'";
+        String queryString = "BAR == '1' && FOO !~ '1234.**'";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
+        ValidPatternVisitor.check(script);
+    }
+    
+    @Test(expected = PatternSyntaxException.class)
+    public void testFilterFunctionIncludeRegex() throws ParseException {
+        String queryString = "A == '1' && filter:includeRegex(B,'*2*')";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
+        ValidPatternVisitor.check(script);
+    }
+    
+    @Test(expected = PatternSyntaxException.class)
+    public void testFilterFunctionExcludeRegex() throws ParseException {
+        String queryString = "A == '1' && filter:excludeRegex(B,'*2*')";
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(queryString);
         ValidPatternVisitor.check(script);
     }


### PR DESCRIPTION
Backport fix for valid pattern visitor to 2.9, original feature was merged into master.

* ValidPatternVisitor now checks #INCLUDE and #EXCLUDE functions.

* Address PR comments.

* Address PR comments.

Co-authored-by: Brian Loss <brianloss@gmail.com>
Co-authored-by: Ivan Bella <ivan@bella.name>