### PR TITLE
fixes #973: Assumed ASTAndNode returned from flatten tree

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -92,6 +92,7 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
             throw new DatawaveFatalQueryException(qe);
         }
         
+        script = TreeFlatteningRebuildingVisitor.flatten(script);
         return (T) script.jjtAccept(visitor, null);
     }
     
@@ -169,10 +170,9 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
             return node;
         }
         
-        ASTAndNode smashed = TreeFlatteningRebuildingVisitor.flatten(node);
         HashMap<String,JexlNode> lowerBounds = Maps.newHashMap(), upperBounds = Maps.newHashMap();
         List<JexlNode> others = Lists.newArrayList();
-        for (JexlNode child : JexlNodes.children(smashed)) {
+        for (JexlNode child : JexlNodes.children(node)) {
             // if the child has a method attached, it is not eligible for ranges
             if (JexlASTHelper.HasMethodVisitor.hasMethod(child)) {
                 others.add(child);
@@ -269,7 +269,7 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
          * The rebuilding visitor adds whatever {visit()} returns to the parent's child list, so we shouldn't have some weird object graph that means old nodes
          * never get GC'd because {super.visit()} will reset the parent in the call to {copy()}
          */
-        return super.visit(JexlNodes.children(smashed, others.toArray(new JexlNode[others.size()])), data);
+        return super.visit(JexlNodes.children(node, others.toArray(new JexlNode[others.size()])), data);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
@@ -81,6 +81,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
     public static ASTJexlScript applyModel(ASTJexlScript script, QueryModel queryModel, Set<String> validFields) {
         QueryModelVisitor visitor = new QueryModelVisitor(queryModel, validFields);
         
+        script = TreeFlatteningRebuildingVisitor.flatten(script);
         return (ASTJexlScript) script.jjtAccept(visitor, null);
     }
     
@@ -155,7 +156,6 @@ public class QueryModelVisitor extends RebuildingVisitor {
             return node;
         }
         
-        ASTAndNode smashed = TreeFlatteningRebuildingVisitor.flatten(node);
         Multimap<String,JexlNode> lowerBounds = ArrayListMultimap.create(), upperBounds = ArrayListMultimap.create();
         List<JexlNode> others = Lists.newArrayList();
         for (JexlNode child : JexlNodes.children(node)) {
@@ -242,7 +242,7 @@ public class QueryModelVisitor extends RebuildingVisitor {
          * The rebuilding visitor adds whatever {visit()} returns to the parent's child list, so we shouldn't have some weird object graph that means old nodes
          * never get GC'd because {super.visit()} will reset the parent in the call to {copy()}
          */
-        return super.visit(JexlNodes.children(smashed, others.toArray(new JexlNode[others.size()])), data);
+        return super.visit(JexlNodes.children(node, others.toArray(new JexlNode[others.size()])), data);
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryPruningVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryPruningVisitor.java
@@ -104,6 +104,10 @@ public class QueryPruningVisitor extends BaseVisitor {
         
         copy.jjtAccept(visitor, null);
         
+        // Now since we could have removed children within AND/OR nodes,
+        // reflatten to remove boolean operators with single children
+        copy = TreeFlatteningRebuildingVisitor.flatten(copy);
+        
         if (showPrune) {
             after = JexlStringBuildingVisitor.buildQuery(copy);
             if (StringUtils.equals(before, after)) {


### PR DESCRIPTION
 Updated to not assume flattened ASTAndNode subtree will return an ASTAndNode