### PR TITLE
Verify GeoWavePruningVisitor does not modify input tree

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
@@ -4,63 +4,100 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ASTReferenceExpression;
 import org.apache.commons.jexl2.parser.JexlNode;
-import org.junit.Assert;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import java.util.Map;
-
 import static datawave.query.jexl.functions.GeoWaveFunctionsDescriptorTest.convertFunctionToIndexQuery;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class GeoWavePruningVisitorTest {
     
+    private static final Logger log = Logger.getLogger(GeoWavePruningVisitorTest.class);
+    
     @Test
-    public void pruningVisitorTest() throws Exception {
-        String query = "geowave:intersects(GEO_FIELD, 'POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))')";
-        ShardQueryConfiguration config = new ShardQueryConfiguration();
+    public void testNonIntersectingTermIsPruned() throws ParseException {
+        String function = "geowave:intersects(GEO_FIELD, 'POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))')";
+        // Get the expanded geowave terms.
+        String indexQuery = convertFunctionToIndexQuery(function, new ShardQueryConfiguration());
         
-        // Get the expanded geowave terms, and add a term which would not normally be included for this polygon
-        String expandedQuery = query + " && (GEO_FIELD == '0100' || " + convertFunctionToIndexQuery(query, config) + ")";
+        // Add a term that should be pruned.
+        String query = function + " && (GEO_FIELD == '0100' || " + indexQuery + ")";
+        String expected = function + " && (" + indexQuery + ")";
         
-        // prune the tree, and see that the added term is removed
-        Multimap<String,String> prunedTerms = HashMultimap.create();
-        JexlNode prunedTree = GeoWavePruningVisitor.pruneTree(JexlASTHelper.parseJexlQuery(expandedQuery), prunedTerms, null);
+        Multimap<String,String> expectedPrunedTerms = HashMultimap.create();
+        expectedPrunedTerms.put("GEO_FIELD", "0100");
         
-        Assert.assertEquals(1, prunedTerms.entries().size());
-        Map.Entry<String,String> term = prunedTerms.entries().iterator().next();
-        
-        Assert.assertEquals("GEO_FIELD", term.getKey());
-        Assert.assertEquals("0100", term.getValue());
-        
-        Assert.assertEquals(query + " && (" + convertFunctionToIndexQuery(query, config) + ")", JexlStringBuildingVisitor.buildQuery(prunedTree));
-        assertTrue(JexlASTHelper.validateLineage(prunedTree, true));
+        assertResult(query, expected, expectedPrunedTerms);
     }
     
     @Test
-    public void emptyRefExpTest() throws Exception {
-        String query = "geowave:intersects(GEO_FIELD, 'POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))')";
-        ShardQueryConfiguration config = new ShardQueryConfiguration();
+    public void testPrunedWrappedTermDoesNotLeaveEmptyWrappedTerm() throws ParseException {
+        String function = "geowave:intersects(GEO_FIELD, 'POLYGON((10 10, 20 10, 20 20, 10 20, 10 10))')";
+        // Get the expanded geowave terms.
+        String indexQuery = convertFunctionToIndexQuery(function, new ShardQueryConfiguration());
         
-        // Get the expanded geowave terms, and add a term which would not normally be included for this polygon within a reference expression
-        String expandedQuery = query + " && ((GEO_FIELD == '0100') || " + convertFunctionToIndexQuery(query, config) + ")";
+        // Add a wrapped term that should be pruned.
+        String query = function + " && ((GEO_FIELD == '0100') || " + indexQuery + ")";
+        String expected = function + " && (" + indexQuery + ")";
         
-        // prune the tree, and see that the added term is removed
-        Multimap<String,String> prunedTerms = HashMultimap.create();
-        JexlNode prunedTree = GeoWavePruningVisitor.pruneTree(JexlASTHelper.parseJexlQuery(expandedQuery), prunedTerms, null);
+        Multimap<String,String> expectedPrunedTerms = HashMultimap.create();
+        expectedPrunedTerms.put("GEO_FIELD", "0100");
         
-        // ensure that there are no childless references or reference expressions in the tree
-        RefExpVisitor refExpVisitor = new RefExpVisitor();
-        prunedTree.jjtAccept(refExpVisitor, null);
-        
-        Assert.assertFalse(refExpVisitor.hasChildlessNode);
-        assertTrue(JexlASTHelper.validateLineage(prunedTree, true));
+        assertResult(query, expected, expectedPrunedTerms);
     }
     
-    private static class RefExpVisitor extends BaseVisitor {
-        public boolean hasChildlessNode = false;
+    private void assertResult(String original, String expected, Multimap<String,String> expectedPrunedTerms) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        
+        Multimap<String,String> prunedTerms = HashMultimap.create();
+        ASTJexlScript actualScript = GeoWavePruningVisitor.pruneTree(originalScript, prunedTerms, null);
+        
+        // Verify the result is as expected, with a valid lineage.
+        assertScriptEquality(actualScript, expected);
+        assertLineage(actualScript);
+        
+        // Verify there are no empty wrapped nodes.
+        assertNoChildlessReferences(actualScript);
+        
+        // Verify the correct terms were pruned.
+        assertEquals(prunedTerms, expectedPrunedTerms);
+        
+        // Verify the original script was not modified, and has a valid lineage.
+        assertScriptEquality(originalScript, original);
+        assertLineage(originalScript);
+    }
+    
+    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
+        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        assertTrue(reason.reason, equal);
+    }
+    
+    private void assertLineage(JexlNode node) {
+        assertTrue(JexlASTHelper.validateLineage(node, true));
+    }
+    
+    private void assertNoChildlessReferences(JexlNode node) {
+        HasChildlessReferenceVisitor visitor = new HasChildlessReferenceVisitor();
+        node.jjtAccept(visitor, null);
+        assertFalse(visitor.hasChildlessNode);
+    }
+    
+    private static class HasChildlessReferenceVisitor extends BaseVisitor {
+        private boolean hasChildlessNode = false;
         
         @Override
         public Object visit(ASTReference node, Object data) {


### PR DESCRIPTION
Verify that GeoWavePruningVisitor does not modify the provided original
JEXL tree, or invalidate its lineage.

Part of #968