### PR TITLE
Do not modify input tree in BooleanOptimizationRebuildingVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitor.java
@@ -30,6 +30,7 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTAndNode node, Object data) {
+        node = (ASTAndNode) copy(node);
         if (hasChildOr(node)) {
             ASTOrNode orNode = new ASTOrNode(ParserTreeConstants.JJTORNODE);
             orNode.image = node.image;
@@ -41,7 +42,7 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
         }
     }
     
-    protected JexlNode optimizeTree(JexlNode currentNode, JexlNode newNode, Object data) {
+    private JexlNode optimizeTree(JexlNode currentNode, JexlNode newNode, Object data) {
         if ((currentNode instanceof ASTAndNode) && hasChildOr(currentNode)) {
             ASTAndNode andNode = new ASTAndNode(ParserTreeConstants.JJTANDNODE);
             andNode.image = currentNode.image;
@@ -85,7 +86,7 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
      * @param newNode
      * @param prunedNode
      */
-    protected Tuple2<JexlNode,JexlNode> prune(JexlNode currentNode, JexlNode newNode, JexlNode prunedNode) {
+    private Tuple2<JexlNode,JexlNode> prune(JexlNode currentNode, JexlNode newNode, JexlNode prunedNode) {
         for (int i = 0; i < currentNode.jjtGetNumChildren(); i++) {
             JexlNode child = currentNode.jjtGetChild(i);
             
@@ -115,7 +116,7 @@ public class BooleanOptimizationRebuildingVisitor extends RebuildingVisitor {
      * @param currentNode
      * @return
      */
-    protected boolean hasChildOr(JexlNode currentNode) {
+    private boolean hasChildOr(JexlNode currentNode) {
         boolean foundChildOr = false;
         for (int i = 0; i < currentNode.jjtGetNumChildren(); i++) {
             JexlNode child = currentNode.jjtGetChild(i);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
@@ -2,14 +2,17 @@ package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
+import org.apache.log4j.Logger;
 import org.junit.Test;
 
 import static datawave.query.jexl.JexlASTHelper.parseJexlQuery;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class BooleanOptimizationRebuildingVisitorTest {
+    
+    private static final Logger log = Logger.getLogger(BooleanOptimizationRebuildingVisitorTest.class);
     
     @Test
     public void testConjunction() throws ParseException {
@@ -75,17 +78,36 @@ public class BooleanOptimizationRebuildingVisitorTest {
     }
     
     private void assertResult(String original, String expected, boolean flattenScript) throws ParseException {
-        ASTJexlScript expectedScript = parseJexlQuery(expected);
-        String expectedQuery = JexlStringBuildingVisitor.buildQuery(expectedScript);
-        
         ASTJexlScript originalScript = parseJexlQuery(original);
         if (flattenScript) {
             originalScript = TreeFlatteningRebuildingVisitor.flatten(originalScript);
+            original = JexlStringBuildingVisitor.buildQuery(originalScript);
         }
-        ASTJexlScript resultScript = BooleanOptimizationRebuildingVisitor.optimize(originalScript);
-        String resultQuery = JexlStringBuildingVisitor.buildQuery(resultScript);
         
-        assertEquals(expectedQuery, resultQuery);
-        assertTrue(JexlASTHelper.validateLineage(resultScript, true));
+        ASTJexlScript resultScript = BooleanOptimizationRebuildingVisitor.optimize(originalScript);
+    
+        // Verify the resulting script is as expected, and has a valid lineage.
+        assertScriptEquality(resultScript, expected);
+        assertLineage(resultScript);
+        
+        // Verify the original script was not modified, and has a valid lineage.
+        assertScriptEquality(originalScript, original);
+        assertLineage(originalScript);
+    }
+    
+    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
+        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        assertTrue(reason.reason, equal);
+    }
+    
+    private void assertLineage(JexlNode node) {
+        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
@@ -85,7 +85,7 @@ public class BooleanOptimizationRebuildingVisitorTest {
         }
         
         ASTJexlScript resultScript = BooleanOptimizationRebuildingVisitor.optimize(originalScript);
-    
+        
         // Verify the resulting script is as expected, and has a valid lineage.
         assertScriptEquality(resultScript, expected);
         assertLineage(resultScript);


### PR DESCRIPTION
Fix BooleanOptimizationRebuildingVisitor so that it does not modify the
original input JEXL tree, and verify that it maintains a valid lineage.

Part of #968