### PR TITLE
Do not modify input tree in RangeCoalescingVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeCoalescingVisitor.java
@@ -35,6 +35,8 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTAndNode node, Object data) {
+        node = (ASTAndNode) copy(node);
+        
         List<JexlNode> leaves = new ArrayList<>();
         Map<LiteralRange<?>,List<JexlNode>> ranges = JexlASTHelper.getBoundedRangesIndexAgnostic(node, leaves, false);
         
@@ -43,7 +45,7 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
         
         // We have a bounded range completely inside of an AND/OR
         if (!ranges.isEmpty()) {
-            andNode = coalesceBoundedRanges(ranges, leaves, node, andNode, data);
+            andNode = coalesceBoundedRanges(ranges, leaves, node, andNode);
         } else {
             // We have no bounded range to replace, just proceed as normal
             JexlNodes.ensureCapacity(andNode, node.jjtGetNumChildren());
@@ -57,8 +59,7 @@ public class RangeCoalescingVisitor extends RebuildingVisitor {
         return andNode;
     }
     
-    protected JexlNode coalesceBoundedRanges(Map<LiteralRange<?>,List<JexlNode>> ranges, List<JexlNode> leaves, ASTAndNode currentNode, JexlNode newNode,
-                    Object data) {
+    private JexlNode coalesceBoundedRanges(Map<LiteralRange<?>,List<JexlNode>> ranges, List<JexlNode> leaves, ASTAndNode currentNode, JexlNode newNode) {
         // Sanity check to ensure that we found some nodes (redundant since we couldn't have made a bounded LiteralRange in the first
         // place if we had found not range nodes)
         if (ranges.isEmpty()) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
@@ -2,6 +2,7 @@ package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.log4j.Logger;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "NUM >= '+aE2' && NUM <= '+aE5'";
         String expectedQuery = "(NUM >= '+aE2' && NUM <= '+aE5')";
         
-        assertVisitorResult(originalQuery, expectedQuery);
+        assertResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -28,7 +29,7 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "FOO == 'ba' && NUM >= '+aE2' && NUM <= '+aE5'";
         String expectedQuery = "FOO == 'ba' && (NUM >= '+aE2' && NUM <= '+aE5')";
         
-        assertVisitorResult(originalQuery, expectedQuery);
+        assertResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -36,7 +37,7 @@ public class RangeCoalescingVisitorTest {
         String originalQuery = "(NUM > '+aE1' && FOO == 'ba') && NUM < '+aE5'";
         String expectedQuery = "FOO == 'ba' && (NUM > '+aE1' && NUM < '+aE5')";
         
-        assertVisitorResult(originalQuery, expectedQuery);
+        assertResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -45,7 +46,7 @@ public class RangeCoalescingVisitorTest {
         // Ordering of query terms is not deterministic
         String expectedQuery = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4')";
         
-        assertVisitorResult(originalQuery, expectedQuery);
+        assertResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -54,7 +55,7 @@ public class RangeCoalescingVisitorTest {
         // Ordering of query terms is not deterministic
         String expectedQuery = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas')";
         
-        assertVisitorResult(originalQuery, expectedQuery);
+        assertResult(originalQuery, expectedQuery);
     }
     
     @Test
@@ -64,7 +65,7 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas') && (NUM >= '+aE1' && NUM <= '+aE4')";
         String expectedQuery2 = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4') && (FOO >= 'bar' && FOO <= 'bas')";
         
-        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
+        assertResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
     @Test
@@ -74,7 +75,7 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && (FOO >= 'bar' && FOO <= 'bas') && (NUM >= '+aE1' && NUM <= '+aE4')";
         String expectedQuery2 = "TACO == 'tacocat' && (NUM >= '+aE1' && NUM <= '+aE4') && (FOO >= 'bar' && FOO <= 'bas')";
         
-        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
+        assertResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
     @Test
@@ -85,38 +86,53 @@ public class RangeCoalescingVisitorTest {
         String expectedQuery1 = "TACO == 'tacocat' && NUM3 == '+aE3' && (NUM2 >= '+aE2' && NUM2 <= '+aE4') && (NUM >= '+aE1' && NUM <= '+aE5')";
         String expectedQuery2 = "TACO == 'tacocat' && NUM3 == '+aE3' && (NUM >= '+aE1' && NUM <= '+aE5') && (NUM2 >= '+aE2' && NUM2 <= '+aE4')";
         
-        assertVisitorResult(originalQuery, expectedQuery1, expectedQuery2);
+        assertResult(originalQuery, expectedQuery1, expectedQuery2);
     }
     
-    private void assertVisitorResult(String original, String expected) throws ParseException {
+    private void assertResult(String original, String expected) throws ParseException {
         ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        
         ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
         
-        assertScriptEquality(actualScript, expectedScript);
-        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+        // Verify that the resulting script is as expected with a valid lineage.
+        assertScriptEquality(actualScript, expected);
+        assertLineage(actualScript);
+    
+        // Verify the original script was not modified and has a valid lineage.
+        assertScriptEquality(originalScript, original);
+        assertLineage(originalScript);
     }
     
-    private void assertVisitorResult(String original, String expected, String altExpected) throws ParseException {
+    private void assertResult(String original, String expected, String altExpected) throws ParseException {
         ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        ASTJexlScript altExpectedScript = JexlASTHelper.parseJexlQuery(altExpected);
-        ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
         
-        assertScriptEquality(actualScript, expectedScript, altExpectedScript);
-        assertTrue(JexlASTHelper.validateLineage(actualScript, true));
+        ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
+    
+        // Verify that the resulting script is as expected with a valid lineage.
+        assertScriptEquality(actualScript, expected, altExpected);
+        assertLineage(actualScript);
+    
+        // Verify the original script was not modified and has a valid lineage.
+        assertScriptEquality(originalScript, original);
+        assertLineage(originalScript);
     }
     
-    private void assertScriptEquality(ASTJexlScript actualScript, ASTJexlScript expectedScript) {
+    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        
         TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
         boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
         if (!equal) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
+        assertTrue(reason.reason, equal);
     }
     
-    private void assertScriptEquality(ASTJexlScript actualScript, ASTJexlScript expectedScript, ASTJexlScript altExpectedScript) {
+    private void assertScriptEquality(ASTJexlScript actualScript, String expected, String altExpected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript altExpectedScript = JexlASTHelper.parseJexlQuery(altExpected);
+        
         TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
         TreeEqualityVisitor.Reason altReason = new TreeEqualityVisitor.Reason();
         boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
@@ -128,5 +144,9 @@ public class RangeCoalescingVisitorTest {
         }
         
         assertTrue(equal || altEqual);
+    }
+    
+    private void assertLineage(JexlNode node) {
+        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RangeCoalescingVisitorTest.java
@@ -97,7 +97,7 @@ public class RangeCoalescingVisitorTest {
         // Verify that the resulting script is as expected with a valid lineage.
         assertScriptEquality(actualScript, expected);
         assertLineage(actualScript);
-    
+        
         // Verify the original script was not modified and has a valid lineage.
         assertScriptEquality(originalScript, original);
         assertLineage(originalScript);
@@ -107,11 +107,11 @@ public class RangeCoalescingVisitorTest {
         ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
         
         ASTJexlScript actualScript = RangeCoalescingVisitor.coalesceRanges(originalScript);
-    
+        
         // Verify that the resulting script is as expected with a valid lineage.
         assertScriptEquality(actualScript, expected, altExpected);
         assertLineage(actualScript);
-    
+        
         // Verify the original script was not modified and has a valid lineage.
         assertScriptEquality(originalScript, original);
         assertLineage(originalScript);


### PR DESCRIPTION
Fix RangeCoalescingVisitor so that it does not modify the original input
JEXL tree, and verify that it maintains a valid lineage.

Part of #968