### PR TITLE
Verify FunctionIndexQueryExpansionVisitor does not modify input tree

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitor.java
@@ -7,7 +7,6 @@ import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
 import datawave.query.jexl.functions.arguments.RebuildingJexlArgumentDescriptor;
 import datawave.query.util.DateIndexHelper;
 import datawave.query.util.MetadataHelper;
-import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTERNode;
 import org.apache.commons.jexl2.parser.ASTEvaluationOnly;
@@ -20,7 +19,6 @@ import org.apache.commons.jexl2.parser.ASTNRNode;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ASTTrueNode;
 import org.apache.commons.jexl2.parser.JexlNode;
-import org.apache.log4j.Logger;
 
 import java.util.Arrays;
 
@@ -30,7 +28,6 @@ import java.util.Arrays;
  *
  */
 public class FunctionIndexQueryExpansionVisitor extends RebuildingVisitor {
-    private static final Logger log = ThreadConfigurableLogger.getLogger(FunctionIndexQueryExpansionVisitor.class);
     
     protected ShardQueryConfiguration config;
     protected MetadataHelper metadataHelper;
@@ -51,7 +48,7 @@ public class FunctionIndexQueryExpansionVisitor extends RebuildingVisitor {
     @SuppressWarnings("unchecked")
     public static <T extends JexlNode> T expandFunctions(ShardQueryConfiguration config, MetadataHelper metadataHelper, DateIndexHelper dateIndexHelper,
                     T script) {
-        JexlNode copy = RebuildingVisitor.copy(script);
+        JexlNode copy = copy(script);
         
         FunctionIndexQueryExpansionVisitor visitor = new FunctionIndexQueryExpansionVisitor(config, metadataHelper, dateIndexHelper);
         
@@ -60,32 +57,32 @@ public class FunctionIndexQueryExpansionVisitor extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTERNode node, Object data) {
-        return node;
+        return copy(node);
     }
     
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        return node;
+        return copy(node);
     }
     
     @Override
     public Object visit(ASTLTNode node, Object data) {
-        return node;
+        return copy(node);
     }
     
     @Override
     public Object visit(ASTGTNode node, Object data) {
-        return node;
+        return copy(node);
     }
     
     @Override
     public Object visit(ASTLENode node, Object data) {
-        return node;
+        return copy(node);
     }
     
     @Override
     public Object visit(ASTGENode node, Object data) {
-        return node;
+        return copy(node);
     }
     
     @Override
@@ -111,7 +108,7 @@ public class FunctionIndexQueryExpansionVisitor extends RebuildingVisitor {
             }
         }
         
-        return node;
+        return copy(node);
     }
     
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
@@ -49,7 +49,7 @@ public class FunctionIndexQueryExpansionVisitorTest {
     @Test
     public void expandContentFields() throws ParseException {
         Set<String> fields = Sets.newHashSet("FOO", "BAR");
-    
+        
         // Configure the mock metadata helper.
         MockMetadataHelper mockMetadataHelper = new MockMetadataHelper();
         mockMetadataHelper.setIndexedFields(fields);
@@ -73,29 +73,29 @@ public class FunctionIndexQueryExpansionVisitorTest {
         Connector connector = instance.getConnector("root", new PasswordToken(""));
         connector.tableOperations().create(TableName.DATE_INDEX);
         DateIndexTestIngest.writeItAll(connector);
-    
+        
         // Configure the helpers.
         Authorizations auths = new Authorizations("HUSH");
         metadataHelper = new MetadataHelperFactory().createMetadataHelper(connector, TableName.DATE_INDEX, Collections.singleton(auths));
-        dateIndexHelper = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX,
-                        Collections.singleton(auths), 2, 0.9f);
-    
+        dateIndexHelper = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX, Collections.singleton(auths), 2,
+                        0.9f);
+        
         // Configure the shard query configuration.
-        config.setBeginDate( DateHelper.parse("20100701"));
+        config.setBeginDate(DateHelper.parse("20100701"));
         config.setEndDate(DateHelper.parse("20100710"));
         
         // Execute the test.
         String original = "filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000')";
         String expected = "(filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000') && (SHARDS_AND_DAYS = '20100703_0,20100704_0,20100704_2,20100705_1'))";
-    
+        
         runTest(original, expected);
     }
     
     private void runTest(String originalQuery, String expected) throws ParseException {
         ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(originalQuery);
-    
+        
         ASTJexlScript actualScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, metadataHelper, dateIndexHelper, originalScript);
-    
+        
         // Verify the script is as expected, and has a valid lineage.
         assertScriptEquality(actualScript, expected);
         assertLineage(actualScript);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
@@ -1,0 +1,124 @@
+package datawave.query.jexl.visitors;
+
+import com.google.common.collect.Sets;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.util.DateIndexHelper;
+import datawave.query.util.DateIndexHelperFactory;
+import datawave.query.util.DateIndexTestIngest;
+import datawave.query.util.MetadataHelper;
+import datawave.query.util.MetadataHelperFactory;
+import datawave.query.util.MockDateIndexHelper;
+import datawave.query.util.MockMetadataHelper;
+import datawave.util.TableName;
+import datawave.util.time.DateHelper;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.apache.log4j.Logger;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertTrue;
+
+public class FunctionIndexQueryExpansionVisitorTest {
+    
+    private static final Logger log = Logger.getLogger(FunctionIndexQueryExpansionVisitorTest.class);
+    
+    private ShardQueryConfiguration config;
+    
+    private MetadataHelper metadataHelper;
+    
+    private DateIndexHelper dateIndexHelper;
+    
+    @Before
+    public void setUp() throws Exception {
+        config = new ShardQueryConfiguration();
+        metadataHelper = new MockMetadataHelper();
+        dateIndexHelper = new MockDateIndexHelper();
+    }
+    
+    @Test
+    public void expandContentFields() throws ParseException {
+        Set<String> fields = Sets.newHashSet("FOO", "BAR");
+    
+        // Configure the mock metadata helper.
+        MockMetadataHelper mockMetadataHelper = new MockMetadataHelper();
+        mockMetadataHelper.setIndexedFields(fields);
+        mockMetadataHelper.addTermFrequencyFields(fields);
+        this.metadataHelper = mockMetadataHelper;
+        
+        // Execute the test.
+        String original = "content:phrase(termOffsetMap, 'abc', 'def')";
+        String expected = "(content:phrase(termOffsetMap, 'abc', 'def') && ((BAR == 'def' && BAR == 'abc') || (FOO == 'def' && FOO == 'abc')))";
+        
+        runTest(original, expected);
+    }
+    
+    @Test
+    public void expandDateIndex() throws Exception {
+        // Set the default TimeZone.
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        
+        // Create an in-memory accumulo instance and write the data index table.
+        InMemoryInstance instance = new InMemoryInstance(FunctionIndexQueryExpansionVisitorTest.class.getName());
+        Connector connector = instance.getConnector("root", new PasswordToken(""));
+        connector.tableOperations().create(TableName.DATE_INDEX);
+        DateIndexTestIngest.writeItAll(connector);
+    
+        // Configure the helpers.
+        Authorizations auths = new Authorizations("HUSH");
+        metadataHelper = new MetadataHelperFactory().createMetadataHelper(connector, TableName.DATE_INDEX, Collections.singleton(auths));
+        dateIndexHelper = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX,
+                        Collections.singleton(auths), 2, 0.9f);
+    
+        // Configure the shard query configuration.
+        config.setBeginDate( DateHelper.parse("20100701"));
+        config.setEndDate(DateHelper.parse("20100710"));
+        
+        // Execute the test.
+        String original = "filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000')";
+        String expected = "(filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000') && (SHARDS_AND_DAYS = '20100703_0,20100704_0,20100704_2,20100705_1'))";
+    
+        runTest(original, expected);
+    }
+    
+    private void runTest(String originalQuery, String expected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(originalQuery);
+    
+        ASTJexlScript actualScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, metadataHelper, dateIndexHelper, originalScript);
+    
+        // Verify the script is as expected, and has a valid lineage.
+        assertScriptEquality(actualScript, expected);
+        assertLineage(actualScript);
+        
+        // Verify that the original script was not modified.
+        assertScriptEquality(originalScript, originalQuery);
+        assertLineage(originalScript);
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
+        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
+        if (!equal) {
+            log.error("Expected: " + expected);
+            log.error("Actual:   " + JexlStringBuildingVisitor.buildQueryWithoutParse(actualScript));
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+        }
+        assertTrue(reason.reason, equal);
+    }
+    
+    private void assertLineage(JexlNode node) {
+        assertTrue(JexlASTHelper.validateLineage(node, true));
+    }
+}


### PR DESCRIPTION
Verify that FunctionIndexQueryExpansionVisitor does not modify the
original input JEXL tree, or invalidate its lineage. In addition, verify
that the visitor returns a JEXL tree with a valid lineage.

Part of #880 and #968