### PR TITLE
Set type.metadata.dir for various tests.

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -129,7 +129,8 @@ public class IfThisTestFailsThenHitTermsAreBroken {
     @After
     public void after() {
         TypeRegistry.reset();
-        System.clearProperty("type.metadata.dir");
+        // Set type metadata back to default
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
     }
     
     @Before

--- a/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
@@ -189,6 +189,8 @@ public class MixedGeoAndGeoWaveTest {
         recNum = ingestData(conf, GEO_FIELD, geoData, recNum, BEGIN_DATE);
         recNum = ingestData(conf, POINT_FIELD, pointData, recNum, MID_DATE);
         ingestData(conf, POLY_POINT_FIELD, polyData, recNum, MID_DATE);
+        
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
     }
     
     public static int ingestData(Configuration conf, String fieldName, String[] data, int startRecNum, String ingestDate) throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
@@ -196,6 +196,7 @@ public class CompositeIndexTest {
     
     @BeforeClass
     public static void setupClass() throws Exception {
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
         System.setProperty("subject.dn.pattern", "(?:^|,)\\s*OU\\s*=\\s*My Department\\s*(?:,|$)");
         
         setupConfiguration(conf);

--- a/warehouse/query-core/src/test/java/datawave/query/planner/MultiValueCompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/MultiValueCompositeIndexTest.java
@@ -189,6 +189,7 @@ public class MultiValueCompositeIndexTest {
     
     @BeforeClass
     public static void setupClass() throws Exception {
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
         System.setProperty("subject.dn.pattern", "(?:^|,)\\s*OU\\s*=\\s*My Department\\s*(?:,|$)");
         
         createTestData();

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -86,6 +86,7 @@ import java.util.stream.Collectors;
  * <li>file.encoding => UTF-8</li>
  * <li>DATAWAVE_INGEST_HOME => target directory</li>
  * <li>hadoop.home.dir => target directory</li>
+ * <li>type.metadata.dir> => type-metadata-dir</li>
  * </ul>
  */
 public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.TestResultParser {
@@ -99,6 +100,7 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         System.setProperty("file.encoding", StandardCharsets.UTF_8.name());
         System.setProperty(DnUtils.NpeUtils.NPE_OU_PROPERTY, "iamnotaperson");
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
         try {
             File dir = new File(ClassLoader.getSystemClassLoader().getResource(".").toURI());
             File targetDir = dir.getParentFile();

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -43,6 +43,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -135,6 +136,11 @@ public abstract class GroupingTest {
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");
+    }
+    
+    @BeforeClass
+    public static void beforeAll() {
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
     }
     
     @AfterClass

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTestWithModel.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTestWithModel.java
@@ -43,6 +43,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -136,6 +137,11 @@ public abstract class GroupingTestWithModel {
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");
+    }
+    
+    @BeforeClass
+    public static void beforeAll() {
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
     }
     
     @AfterClass

--- a/warehouse/query-core/src/test/java/datawave/query/util/TypeMetadataProviderLoadingCacheTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/TypeMetadataProviderLoadingCacheTest.java
@@ -105,7 +105,8 @@ public class TypeMetadataProviderLoadingCacheTest {
     
     @After
     public void after() {
-        System.clearProperty("type.metadata.dir");
+        // Reset property to default
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
     }
     
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/util/TypeMetadataProviderTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/TypeMetadataProviderTest.java
@@ -89,7 +89,8 @@ public class TypeMetadataProviderTest {
     
     @After
     public void after() {
-        System.clearProperty("type.metadata.dir");
+        // Reset property back to default
+        System.setProperty("type.metadata.dir", "type-metadata-dir");
     }
     
     public void testThisThing(TypeMetadataProvider typeMetadataProvider, TypeMetadataWriter typeMetadataWriter) throws Exception {


### PR DESCRIPTION
Build time for query-core on my local machine went from about 9.5 mins to less than 7.5 mins