### PR TITLE
Exclude dom4j 1.6.1 as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,6 +889,12 @@
                 <artifactId>picketbox-infinispan</artifactId>
                 <version>${version.picketbox}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>dom4j</groupId>
+                        <artifactId>dom4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wildfly</groupId>


### PR DESCRIPTION
* Not necessary for runtime operation
* Triggers a dependabot warning