### PR TITLE
IndexStreams support seeking

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/AncestorIndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/AncestorIndexStream.java
@@ -44,6 +44,18 @@ public class AncestorIndexStream implements IndexStream {
         return delegate.currentNode();
     }
     
+    /**
+     * Seek the delegate IndexStream
+     * 
+     * @param seekShard
+     *            the seek target
+     * @return
+     */
+    @Override
+    public String seek(String seekShard) {
+        return delegate.seek(seekShard);
+    }
+    
     @Override
     public Tuple2<String,IndexInfo> peek() {
         return removeOverlappingRanges(delegate.peek());

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/BaseIndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/BaseIndexStream.java
@@ -1,0 +1,122 @@
+package datawave.query.index.lookup;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.tables.RangeStreamScanner;
+import datawave.query.util.Tuple2;
+import org.apache.commons.jexl2.parser.JexlNode;
+
+import java.util.Iterator;
+
+/**
+ * Provides a core set of variables for the ScannerStream, Union, and Intersection.
+ *
+ * A reference to the underlying {@link datawave.query.tables.RangeStreamScanner} is required for seeking.
+ *
+ * Note that the BaseIndexStream does not implement the {@link IndexStream#seek(String)} method. Inheriting classes are responsible for determining the correct
+ * implementation.
+ */
+public abstract class BaseIndexStream implements IndexStream {
+    
+    protected RangeStreamScanner rangeStreamScanner;
+    
+    protected EntryParser entryParser;
+    
+    protected JexlNode node;
+    
+    protected StreamContext context;
+    
+    protected IndexStream debugDelegate;
+    
+    // variables to support the PeekingIterator interface
+    protected Iterator<Tuple2<String,IndexInfo>> backingIter;
+    protected Tuple2<String,IndexInfo> peekedElement;
+    protected boolean hasPeeked = false;
+    
+    public BaseIndexStream(RangeStreamScanner rangeStreamScanner, EntryParser entryParser, JexlNode node, StreamContext context, IndexStream debugDelegate) {
+        this.rangeStreamScanner = Preconditions.checkNotNull(rangeStreamScanner);
+        this.entryParser = Preconditions.checkNotNull(entryParser);
+        this.node = node;
+        this.backingIter = Iterators.transform(this.rangeStreamScanner, this.entryParser);
+        this.context = context;
+        this.debugDelegate = debugDelegate;
+    }
+    
+    public BaseIndexStream(Iterator<Tuple2<String,IndexInfo>> iterator, JexlNode node, StreamContext context, IndexStream debugDelegate) {
+        this.rangeStreamScanner = null;
+        this.entryParser = null;
+        this.node = node;
+        this.backingIter = Preconditions.checkNotNull(iterator);
+        this.context = context;
+        this.debugDelegate = debugDelegate;
+    }
+    
+    // Empty constructor used by the Union and Intersection classes.
+    public BaseIndexStream() {
+        
+    }
+    
+    /**
+     * Reset the backing iterator after a seek. State must stay in sync with changes to the RangeStreamScanner.
+     */
+    public void resetBackingIterator() {
+        if (rangeStreamScanner != null && entryParser != null) {
+            this.peekedElement = null;
+            this.hasPeeked = false;
+            this.backingIter = Iterators.transform(this.rangeStreamScanner, this.entryParser);
+        }
+    }
+    
+    @Override
+    public boolean hasNext() {
+        return (hasPeeked && peekedElement != null) || backingIter.hasNext();
+    }
+    
+    @Override
+    public Tuple2<String,IndexInfo> peek() {
+        if (!hasPeeked) {
+            if (backingIter.hasNext()) {
+                peekedElement = backingIter.next();
+            } else {
+                peekedElement = null;
+            }
+            hasPeeked = true;
+        }
+        return peekedElement;
+    }
+    
+    @Override
+    public Tuple2<String,IndexInfo> next() {
+        if (!hasPeeked) {
+            return backingIter.next();
+        }
+        Tuple2<String,IndexInfo> result = peekedElement;
+        hasPeeked = false;
+        peekedElement = null;
+        return result;
+    }
+    
+    @Override
+    public void remove() {}
+    
+    @Override
+    public StreamContext context() {
+        return context;
+    }
+    
+    @Override
+    public String getContextDebug() {
+        if (debugDelegate == null) {
+            return context + ": ScannerStream for " + JexlStringBuildingVisitor.buildQuery(node) + " (next = " + (hasNext() ? peek() : null) + ")";
+        } else {
+            return debugDelegate.getContextDebug();
+        }
+    }
+    
+    @Override
+    public JexlNode currentNode() {
+        return node;
+    }
+    
+}

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
@@ -164,7 +164,6 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
         Key startKey = range.getStartKey();
         Key newKey = new Key(startKey.getRow(), startKey.getColumnFamily(), new Text(startKey.getColumnQualifier() + "\u0000\uffff"));
         return new Range(newKey, true, range.getEndKey(), range.isEndKeyInclusive());
-        
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/EntryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/EntryParser.java
@@ -80,7 +80,7 @@ public class EntryParser implements Function<Entry<Key,Value>,Tuple2<String,Inde
             }
         }
         
-        if (!skipNodeDelay && Union.isDay(date) && info.uids().isEmpty()) {
+        if (!skipNodeDelay && ShardEquality.isDay(date) && info.uids().isEmpty()) {
             
             if (isDelayedPredicate(currNode)) {
                 if (log.isTraceEnabled()) {

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
@@ -6,6 +6,11 @@ import datawave.query.util.Tuple2;
 
 import com.google.common.collect.PeekingIterator;
 
+/**
+ * IndexStreams must support the PeekingIterator interface.
+ *
+ * All inheriting classes must support the ability to seek to a specific shard.
+ */
 public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
     enum StreamContext {
         /**
@@ -72,4 +77,14 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
     
     JexlNode currentNode();
     
+    /**
+     * Advance the underlying iterator to the first element that is greater than or equal to the <code>seekShard</code>.
+     *
+     * If no data exists beyond the <code>seekShard</code> then a null value is returned, signifying the end of this index stream.
+     *
+     * @param seekShard
+     *            the seek target
+     * @return the top shard after seeking, or null if no more values exist
+     */
+    String seek(String seekShard);
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Intersection.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Intersection.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.collect.TreeMultimap;
+
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.concurrent.ExecutorService;
+
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.nodes.ExceededTermThresholdMarkerJexlNode;
@@ -31,15 +33,52 @@ import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.log4j.Logger;
 
 /**
+ * Intersect global index range streams by the shard key denoting a day range or a shard range.
+ *
  * Intersect global index range streams. This will take a set of underlying streams and will intersect them: e.g. stream 1: 20130102_4/UID1,UID2,UID3
  * 20130104_5/UID5 20130106_2/UID6 20130107/{inf} stream 2: 20130102_4/UID2,UID3 20130104_5/UID5 20130105_3/{inf} 20130106_2/{inf} 20130107_3/{inf}
  * 
  * result: 20130102_4/UID2,UID3 20130104_5/UID5 20130106_2/UID6 20130107_3/{inf}
+ *
+ * <code>
+ * Assumptions:
+ * 1) The streams are ordered
+ * 2) Any one stream cannot contain a mix of day and shards for the same day (e.g. 20130101, 20130101_4, ...)
+ *    In other words, each stream being intersected is a stream of days (20130101, 20130102 ...)
+ *    or a stream of shards (20130101_4, 20130101_8, 20130102_3 ...).
+ * </code>
+ *
+ * More formally, we are intersecting 2 to K iterators of 1 to N sorted elements. The iterators support seeking to the highest top key.
+ *
+ *
+ * Some notes about base cases and edge cases.
+ *
+ * At a high level this class is concerned with intersecting a stream of keys that represent day or shard ranges. To see how individual hits are intersected see
+ * {@link IndexInfo#intersect(IndexInfo)}.
+ *
+ * Only similar shards may be intersected (20190314_22 and 20190314_22), or shards that fall within a day range (20190314_22 and 20190314).
+ *
+ * This class implements an Iterator interface, as well as a PeekingIterator, and a seeking iterator. This functionality holds true at nearly all levels in the
+ * iterator stack. As such it is imperative that care is taken when modifying code in this class or one of the other classes in this stack.
+ *
+ * <code>
+ *     Simple Diagram of IndexStream stack
  * 
- * Assumptions: 1) The streams are ordered 2) Any one stream cannot contain a mix of day and shards for the same day (e.g. 20130101, 20130101_4, ...) In other
- * words, each stream being intersected is a stream of days (20130101, 20130102 ...) or a stream of shards (20130101_4, 20130101_8, 20130102_3 ...).
+ *     Intersection ( you are here )
+ *     - (1 or more layers of Unions, nested Unions and/or Intersections as described by the JexlNode tree)
+ *     - Scanner Stream (1 per query term)
+ *     - RangeStreamScanner (1 per ScannerStream)
+ *     - Iterator on the global index (CreateUidsIterator, 1 per RangeStreamScanner)
+ * </code>
+ *
+ * A note on Seeking to a shard. According to the method contract a seek call will return one of three values;
+ * <ul>
+ * <li>The shard specified.</li>
+ * <li>The next-highest shard if the specified shard does not exist in the IndexStream.</li>
+ * <li>Null if the specified shard lies beyond the bounds of this IndexStream.</li>
+ * </ul>
  */
-public class Intersection implements IndexStream {
+public class Intersection extends BaseIndexStream {
     private TreeMultimap<String,IndexStream> children;
     private final StreamContext context;
     private final String contextDebug;
@@ -148,7 +187,6 @@ public class Intersection implements IndexStream {
                 this.contextDebug = "children may intersect";
                 next();
             }
-            
         } else {
             this.context = StreamContext.ABSENT;
             this.contextDebug = "no children";
@@ -173,6 +211,11 @@ public class Intersection implements IndexStream {
     }
     
     @Override
+    public Tuple2<String,IndexInfo> peek() {
+        return next;
+    }
+    
+    @Override
     public boolean hasNext() {
         return next != null;
     }
@@ -180,28 +223,33 @@ public class Intersection implements IndexStream {
     @Override
     public Tuple2<String,IndexInfo> next() {
         Tuple2<String,IndexInfo> ret = next;
-        
         next = null;
-        
         while (!children.isEmpty() && next == null) {
             final SortedSet<String> keys = children.keySet();
             if (keys.size() == 1) {
-                IndexInfo shard = intersect(children.values());
-                
-                if (shard.count() != 0) {
-                    next = Tuples.tuple(keys.first(), shard);
-                }
-                children = nextAll(keys.first(), children.get(keys.first()));
+                intersect(keys);
             } else {
-                children = pivot(children);
+                // Seek all child IndexStreams to the highest top key.
+                String max = children.keySet().last();
+                children = advanceStreams(children, max);
             }
         }
         return ret;
     }
     
-    @Override
-    public Tuple2<String,IndexInfo> peek() {
-        return next;
+    /**
+     * Intersect the top elements of all child IndexStreams, then advance.
+     *
+     * @param keys
+     *            a sorted set of child IndexStreams. Should be of size 1.
+     */
+    public void intersect(SortedSet<String> keys) {
+        IndexInfo shard = intersect(children.values());
+        
+        if (shard.count() != 0) {
+            next = Tuples.tuple(keys.first(), shard);
+        }
+        children = nextAll(keys.first(), children.get(keys.first()));
     }
     
     @Override
@@ -211,11 +259,18 @@ public class Intersection implements IndexStream {
         return key(itr.peek());
     }
     
-    static String key(Tuple2<String,IndexInfo> tuple) {
+    public static String key(Tuple2<String,IndexInfo> tuple) {
         return tuple.first();
     }
     
-    static Iterable<IndexInfo> convert(Iterable<? extends PeekingIterator<Tuple2<String,IndexInfo>>> i) {
+    /**
+     * Converts an iterator of String-IndexInfo to an iterator of IndexInfo objects
+     *
+     * @param i
+     *            an iterator of iterators, irritating isn't it?
+     * @return an iterator whose elements are IndexInfo objects
+     */
+    public static Iterable<IndexInfo> convert(Iterable<? extends PeekingIterator<Tuple2<String,IndexInfo>>> i) {
         final Function<PeekingIterator<Tuple2<String,IndexInfo>>,IndexInfo> f = itr -> {
             if (log.isTraceEnabled())
                 log.trace("ah" + itr.peek().first() + " " + itr.peek().second());
@@ -224,7 +279,14 @@ public class Intersection implements IndexStream {
         return Iterables.transform(i, f);
     }
     
-    IndexInfo intersect(Iterable<? extends PeekingIterator<Tuple2<String,IndexInfo>>> iterators) {
+    /**
+     * Intersect the top {@link IndexInfo} elements.
+     *
+     * @param iterators
+     *            an iterator of child IndexStreams
+     * @return
+     */
+    public IndexInfo intersect(Iterable<? extends PeekingIterator<Tuple2<String,IndexInfo>>> iterators) {
         Iterator<IndexInfo> infos = convert(iterators).iterator();
         IndexInfo merged = infos.next();
         
@@ -262,7 +324,7 @@ public class Intersection implements IndexStream {
         return merged;
     }
     
-    static boolean allChildrenAreUnindexed(Iterable<IndexStream> stuff) {
+    public static boolean allChildrenAreUnindexed(Iterable<IndexStream> stuff) {
         for (IndexStream is : stuff) {
             if (StreamContext.UNINDEXED != is.context()) {
                 return false;
@@ -278,10 +340,12 @@ public class Intersection implements IndexStream {
      * then it is added into the returned multimap with the next key it will return. If an iterator ever does not have a have a next, an empty multimap is
      * returned, signifying the exhaustion of this intersection.
      */
-    static TreeMultimap<String,IndexStream> nextAll(String key, Collection<IndexStream> streams) {
+    public static TreeMultimap<String,IndexStream> nextAll(String key, Collection<IndexStream> streams) {
         TreeMultimap<String,IndexStream> newChildren = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
         for (IndexStream itr : streams) {
-            if (!isDay(key) && isDay(key(itr.peek()))) {
+            
+            // If we are next'ing based on a shard and this is a day, keep the day.
+            if (!ShardEquality.isDay(key) && ShardEquality.isDay(key(itr.peek()))) {
                 newChildren.put(itr.peek().first(), itr);
             } else {
                 itr.next();
@@ -296,6 +360,13 @@ public class Intersection implements IndexStream {
     }
     
     /*
+     * This method is deprecated because it is faster to seek() the underlying RangeStreamScanner than to next() through the IndexStream.
+     * 
+     * Consider the arbitrary case of intersecting two streams of integers. One stream contains every integer between 1 and 100, inclusive. The second stream
+     * has two values, 1 and 100. There is no point in advancing the stream with a hundred integers by calling next() 99 times when a single seek() call would
+     * suffice.
+     * 
+     * 
      * Calls `next()` on all iterators that aren't mapped to the highest key in the multimap until that iterator's next value (as returned by `peek()`) is
      * greater than or equal to the previous max key.
      * 
@@ -303,7 +374,8 @@ public class Intersection implements IndexStream {
      * 
      * <code>children</code> must be non-empty
      */
-    static TreeMultimap<String,IndexStream> pivot(TreeMultimap<String,IndexStream> children) {
+    @Deprecated
+    public static TreeMultimap<String,IndexStream> pivot(TreeMultimap<String,IndexStream> children) {
         TreeMultimap<String,IndexStream> newChildren = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
         final String max = children.keySet().last();
         newChildren.putAll(max, children.removeAll(max));
@@ -316,7 +388,7 @@ public class Intersection implements IndexStream {
                 if (dayOrShard.compareTo(max) >= 0) {
                     break;
                 }
-                if (isDay(dayOrShard) && max.startsWith(dayOrShard)) {
+                if (ShardEquality.isDay(dayOrShard) && max.startsWith(dayOrShard)) {
                     // use the existing max instead of the day to add to the list
                     dayOrShard = max;
                     break;
@@ -334,12 +406,152 @@ public class Intersection implements IndexStream {
         return newChildren;
     }
     
-    static boolean isDay(String dayOrShard) {
-        return (dayOrShard.indexOf('_') < 0);
+    /**
+     * For each IndexStream not already mapped to the high key, advance the stream to the specified high key. This method will dynamically update the high key
+     * if a new high key is found.
+     *
+     * If an IndexStream is exhausted by the seek call, an empty multi-map is returned to signify the end of this intersection.
+     *
+     * @param children
+     *            a non-empty sorted multi-map of {@link IndexStream}
+     * @param max
+     *            the seek key
+     * @return a new sorted multi-map of {@link IndexStream}, or an empty multi-map if the intersection is exhausted
+     */
+    public static TreeMultimap<String,IndexStream> advanceStreams(TreeMultimap<String,IndexStream> children, String max) {
+        TreeMultimap<String,IndexStream> newChildren = TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
+        
+        // Remove all IndexStreams already mapped to the highest key.
+        newChildren.putAll(max, children.removeAll(max));
+        
+        for (IndexStream stream : children.values()) {
+            
+            // Advance the IndexStream to the high key.
+            String dayOrShard = advanceStream(stream, max);
+            
+            // Cannot intersect with an empty IndexStream, return empty multi-map to signify end of intersection.
+            if (dayOrShard == null || !stream.hasNext()) {
+                return TreeMultimap.create(Ordering.natural(), Ordering.arbitrary());
+            } else {
+                // add the item into our map
+                newChildren.put(dayOrShard, stream);
+                
+                // Adaptive max.
+                if (dayOrShard.compareTo(max) > 0) {
+                    max = dayOrShard;
+                }
+            }
+        }
+        return newChildren;
     }
     
-    static boolean isShard(String dayOrShard) {
-        return !isDay(dayOrShard);
+    /**
+     * Advance the IndexStream to the high key (shard), or the next-highest key if the high key does not exist but there are still results.
+     *
+     * If no results exist at or beyond the high key, a null value is returned.
+     *
+     * @param stream
+     *            the IndexStream
+     * @param max
+     *            the seek key
+     * @return the shard advanced to, or null if the IndexStream is exhausted
+     */
+    public static String advanceStream(IndexStream stream, String max) {
+        String dayOrShard = null;
+        while (stream.hasNext()) {
+            
+            dayOrShard = stream.peek().first();
+            
+            if (ShardEquality.greaterThanOrEqual(dayOrShard, max)) {
+                break;
+            }
+            if (ShardEquality.matches(dayOrShard, max)) {
+                dayOrShard = max;
+                break;
+            }
+            
+            // Delegate seek operation to the underlying IndexStream
+            dayOrShard = stream.seek(max);
+        }
+        return dayOrShard;
+    }
+    
+    /**
+     * Seek the underlying IndexStreams to the specified high key.
+     *
+     * This method is a wrapper around {@link #advanceStreams}. It ensures this intersection always seeks to the next common key.
+     *
+     * @param seekShard
+     *            the shard to advance to.
+     * @return the lowest shard after seeking
+     */
+    @Override
+    public String seek(String seekShard) {
+        
+        // Guard against the case when an seek range like YYYYMMDD_ is provided.
+        if (seekShard.charAt(seekShard.length() - 1) == '_')
+            seekShard = new String(seekShard.getBytes(), 0, seekShard.length() - 1);
+        
+        // Check the current element first
+        String currShard = isTopElementAMatch(seekShard);
+        if (currShard != null) {
+            // If the top element is a day and we are seeking to a shard range within the day, re-map the top element to the shard range. This allows us to
+            // actually intersect.
+            if (ShardEquality.matches(this.next.first(), seekShard) && ShardEquality.isShard(seekShard)) {
+                this.next = new Tuple2<>(seekShard, this.next.second());
+            }
+            
+            return currShard;
+        } else {
+            // If the top element did not match then null it out. We're skipping forward.
+            this.next = null;
+        }
+        
+        // Initial seek
+        children = advanceStreams(children, seekShard);
+        
+        // Continue seeking until the next intersection is reached (when each IndexStream maps to a single common key)
+        while (children.keySet().size() > 1) {
+            String max = children.keySet().last();
+            children = advanceStreams(children, max);
+        }
+        
+        if (!children.isEmpty()) {
+            // We only advanced the IndexStreams. Now intersect them and return the shard key for this intersection.
+            next();
+            
+            // Check to make sure this intersection did not advance beyond the end of it's data.
+            if (next != null) {
+                return next.first();
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Used to determine if this intersection should be seek'd to the provided shard.
+     *
+     * Returns false if the top element sorts less than the provided shard.
+     *
+     * @param shard
+     *            the shard to match
+     * @return true if the top element is equal or greater than the shard
+     */
+    public String isTopElementAMatch(String shard) {
+        // Check the current element first
+        if (next != null) {
+            
+            // Is it greater than or equal to the seek shard
+            String topShard = next.first();
+            
+            if (ShardEquality.greaterThanOrEqual(topShard, shard)) {
+                return topShard;
+            }
+            if (ShardEquality.matches(topShard, shard)) {
+                return shard;
+            }
+        }
+        return null;
     }
     
     public static class Builder {
@@ -347,7 +559,7 @@ public class Intersection implements IndexStream {
         
         protected UidIntersector uidIntersector = new IndexInfo();
         
-        protected IdentityHashMap<IndexStream,Object> children = new IdentityHashMap<>();
+        protected IdentityHashMap<BaseIndexStream,Object> children = new IdentityHashMap<>();
         
         protected List<ConcurrentScannerInitializer> todo = Lists.newArrayList();
         
@@ -357,7 +569,7 @@ public class Intersection implements IndexStream {
             this.uidIntersector = uidIntersector;
         }
         
-        public boolean addChild(IndexStream child) {
+        public boolean addChild(BaseIndexStream child) {
             if (built) {
                 throw new IllegalStateException("Builder already built an Intersection!");
             } else {
@@ -365,7 +577,7 @@ public class Intersection implements IndexStream {
             }
         }
         
-        public ArrayList<IndexStream> children() {
+        public ArrayList<BaseIndexStream> children() {
             return Lists.newArrayList(children.keySet());
         }
         
@@ -374,8 +586,8 @@ public class Intersection implements IndexStream {
             if (!todo.isEmpty()) {
                 if (log.isTraceEnabled())
                     log.trace("building " + todo.size() + " scanners concurrently");
-                Collection<IndexStream> streams = ConcurrentScannerInitializer.initializeScannerStreams(todo, service);
-                for (IndexStream stream : streams) {
+                Collection<BaseIndexStream> streams = ConcurrentScannerInitializer.initializeScannerStreams(todo, service);
+                for (BaseIndexStream stream : streams) {
                     addChild(stream);
                 }
             }
@@ -389,7 +601,7 @@ public class Intersection implements IndexStream {
         }
         
         public void consume(Builder builder) {
-            for (IndexStream childStream : builder.children()) {
+            for (BaseIndexStream childStream : builder.children()) {
                 addChild(childStream);
             }
             todo.addAll(builder.todo);

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ScannerStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ScannerStream.java
@@ -1,92 +1,52 @@
 package datawave.query.index.lookup;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.tables.RangeStreamScanner;
+import datawave.query.util.Tuple2;
+import org.apache.commons.jexl2.parser.JexlNode;
+
 import java.util.Collections;
 import java.util.Iterator;
 
-import datawave.query.jexl.JexlNodeFactory;
-import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
-import datawave.query.util.Tuple2;
-
-import org.apache.commons.jexl2.parser.ASTReference;
-import org.apache.commons.jexl2.parser.JexlNode;
-import org.apache.commons.jexl2.parser.ParserTreeConstants;
-
-import com.google.common.collect.Iterators;
-import com.google.common.collect.PeekingIterator;
-
-public class ScannerStream extends ASTReference implements IndexStream {
-    protected final PeekingIterator<Tuple2<String,IndexInfo>> itr;
-    protected final StreamContext ctx;
-    protected JexlNode currNode;
-    // The debug delegate is for optionally delegating the contextDebug call
-    protected final IndexStream debugDelegate;
+/**
+ * Basic implementation of an IndexStream for a single term.
+ *
+ * Note that certain cases may create a ScannerStream without an underlying RangeStreamScanner such as the SHARDS_AND_DAYS hint.
+ */
+public class ScannerStream extends BaseIndexStream {
     
-    private ScannerStream(PeekingIterator<Tuple2<String,IndexInfo>> itr, StreamContext ctx, JexlNode currNode, IndexStream debugDelegate) {
-        super(ParserTreeConstants.JJTREFERENCE);
-        this.itr = itr;
-        this.ctx = ctx;
-        this.currNode = currNode;
-        this.debugDelegate = debugDelegate;
+    private ScannerStream(RangeStreamScanner scanSession, EntryParser entryParser, StreamContext ctx, JexlNode currNode, IndexStream debugDelegate) {
+        super(scanSession, entryParser, currNode, ctx, debugDelegate);
     }
     
-    private ScannerStream(Iterator<Tuple2<String,IndexInfo>> itr, StreamContext ctx) {
-        this(Iterators.peekingIterator(itr), ctx, null, null);
+    private ScannerStream(BaseIndexStream itr, StreamContext ctx, JexlNode currNode) {
+        this(itr.rangeStreamScanner, itr.entryParser, ctx, currNode, null);
+    }
+    
+    private ScannerStream(Iterator<Tuple2<String,IndexInfo>> iterator, StreamContext context, JexlNode node, IndexStream debugDelegate) {
+        super(iterator, node, context, debugDelegate);
     }
     
     private ScannerStream(Iterator<Tuple2<String,IndexInfo>> itr, StreamContext ctx, JexlNode currNode) {
-        this(Iterators.peekingIterator(itr), ctx, currNode, null);
-    }
-    
-    private ScannerStream(Iterator<Tuple2<String,IndexInfo>> itr, StreamContext ctx, JexlNode currNode, IndexStream debugDelegate) {
-        this(Iterators.peekingIterator(itr), ctx, currNode, debugDelegate);
-    }
-    
-    @Override
-    public boolean hasNext() {
-        return itr.hasNext();
-    }
-    
-    @Override
-    public Tuple2<String,IndexInfo> peek() {
-        return itr.peek();
-    }
-    
-    @Override
-    public Tuple2<String,IndexInfo> next() {
-        return itr.next();
-    }
-    
-    @Override
-    public void remove() {}
-    
-    @Override
-    public StreamContext context() {
-        return ctx;
-    }
-    
-    @Override
-    public String getContextDebug() {
-        if (debugDelegate == null) {
-            return ctx + ": ScannerStream for " + JexlStringBuildingVisitor.buildQuery(currNode) + " (next = " + (itr.hasNext() ? itr.peek() : null) + ")";
-        } else {
-            return debugDelegate.getContextDebug();
-        }
+        this(itr, ctx, currNode, null);
     }
     
     public static ScannerStream unindexed(JexlNode currNode) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.UNINDEXED, currNode);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.UNINDEXED, currNode);
     }
     
     public static ScannerStream unindexed(JexlNode currNode, IndexStream debugDelegate) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.UNINDEXED, currNode, debugDelegate);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.UNINDEXED, currNode, debugDelegate);
     }
     
     public static ScannerStream noData(JexlNode currNode) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.ABSENT, currNode);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.ABSENT, currNode);
     }
     
     public static ScannerStream noData(JexlNode currNode, IndexStream debugDelegate) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.ABSENT, currNode, debugDelegate);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.ABSENT, currNode, debugDelegate);
     }
     
     public static ScannerStream withData(PeekingIterator<Tuple2<String,IndexInfo>> itr, JexlNode currNode) {
@@ -101,36 +61,39 @@ public class ScannerStream extends ASTReference implements IndexStream {
         return new ScannerStream(itr, StreamContext.VARIABLE, currNode);
     }
     
+    public static ScannerStream variable(BaseIndexStream itr, JexlNode currNode) {
+        return new ScannerStream(itr, StreamContext.VARIABLE, currNode);
+    }
+    
     // exceeded value threshold, so we can evaluate with data but may need special handling
     public static ScannerStream exceededValueThreshold(Iterator<Tuple2<String,IndexInfo>> itr, JexlNode currNode) {
-        
         JexlNode resultNode = JexlNodeFactory.wrap(currNode);
         return new ScannerStream(itr, StreamContext.EXCEEDED_VALUE_THRESHOLD, resultNode);
     }
     
     public static ScannerStream delayedExpression(JexlNode currNode) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.DELAYED_FIELD, currNode);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.DELAYED_FIELD, currNode);
     }
     
     public static ScannerStream unknownField(JexlNode currNode) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.UNKNOWN_FIELD, currNode);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.UNKNOWN_FIELD, currNode);
     }
     
     public static ScannerStream unknownField(JexlNode currNode, IndexStream debugDelegate) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.UNKNOWN_FIELD, currNode, debugDelegate);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.UNKNOWN_FIELD, currNode, debugDelegate);
     }
     
     public static ScannerStream ignored(JexlNode currNode) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.IGNORED, currNode);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.IGNORED, currNode);
     }
     
     public static ScannerStream ignored(JexlNode currNode, IndexStream debugDelegate) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.IGNORED, currNode, debugDelegate);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.IGNORED, currNode, debugDelegate);
     }
     
     // exceeded term threshold, so we cannot evaluate
     public static ScannerStream exceededTermThreshold(JexlNode currNode) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.EXCEEDED_TERM_THRESHOLD, currNode);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.EXCEEDED_TERM_THRESHOLD, currNode);
     }
     
     /**
@@ -143,17 +106,98 @@ public class ScannerStream extends ASTReference implements IndexStream {
         return new ScannerStream(itr, StreamContext.INITIALIZED, currNode);
     }
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.query.index.lookup.IndexStream#currentNode()
+    public static ScannerStream initialized(RangeStreamScanner scannerStream, EntryParser entryParser, JexlNode currNode) {
+        return new ScannerStream(scannerStream, entryParser, StreamContext.INITIALIZED, currNode, null);
+    }
+    
+    /**
+     * Seek this ScannerStream to the specified shard.
+     *
+     * If no underlying RangeStreamScanner exists then the seek operation is delegated to {@link #seekByNext(String)}.
+     *
+     * @param seekShard
+     *            the shard to seek to.
+     * @return the next element great than or equal to the seek shard, or null if all elements were exhausted.
      */
     @Override
-    public JexlNode currentNode() {
-        return currNode;
+    public String seek(String seekShard) {
+        if (rangeStreamScanner != null) {
+            
+            String seekedShard = rangeStreamScanner.seek(seekShard);
+            if (seekedShard == null) {
+                // If the underlying RangeStreamScanner returns null we are done.
+                this.peekedElement = null;
+                this.hasPeeked = false;
+                this.backingIter = Iterators.emptyIterator();
+                return null;
+            } else {
+                
+                resetBackingIterator();
+                
+                if (hasNext()) {
+                    Tuple2<String,IndexInfo> top = peek();
+                    if (top != null) {
+                        seekedShard = top.first();
+                    }
+                }
+                return seekedShard;
+            }
+        } else {
+            return seekByNext(seekShard);
+        }
+    }
+    
+    /**
+     * In the case of {@link RangeStream#createIndexScanList} or a unit test, we need to be able to 'seek' by the backing iterator alone.
+     *
+     * @param seekShard
+     *            the shard to seek to
+     * @return the top shard after seeking
+     */
+    public String seekByNext(String seekShard) {
+        
+        String target = extractDayFromShard(seekShard);
+        
+        // First advance by day.
+        Tuple2<String,IndexInfo> entry = null;
+        while (hasNext()) {
+            entry = peek();
+            if (entry.first().compareTo(target) < 0) {
+                // Continue advancing so long as the top shard sorts before the seekShard
+                next();
+            } else {
+                // If we match or exceed the seekShard, breakout.
+                break;
+            }
+        }
+        
+        // Then advance by shards within a day. The day will sort before day_shard
+        if (entry != null && !ShardEquality.isDay(entry.first()) && entry.first().compareTo(seekShard) <= 0) {
+            // Only drop in here if the top shard is not a day and is less than the seekShard.
+            while (hasNext()) {
+                entry = peek();
+                if (entry.first().compareTo(seekShard) < 0) {
+                    // If the top shard is less than the seekShard keep going.
+                    next();
+                } else {
+                    // If we matched or exceed the seekShard, breakout.
+                    break;
+                }
+            }
+        }
+        
+        return hasNext() ? entry.first() : null;
+    }
+    
+    public String extractDayFromShard(String shard) {
+        int splitIndex = shard.indexOf('_');
+        if (splitIndex > 0) {
+            shard = shard.substring(0, splitIndex);
+        }
+        return shard;
     }
     
     public static IndexStream noOp(JexlNode node) {
-        return new ScannerStream(Collections.<Tuple2<String,IndexInfo>> emptySet().iterator(), StreamContext.NO_OP, node);
+        return new ScannerStream(Collections.emptyIterator(), StreamContext.NO_OP, node);
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardEquality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardEquality.java
@@ -1,0 +1,101 @@
+package datawave.query.index.lookup;
+
+/**
+ * Convenience class that encapsulates some of the basic equality operators plus a few extra.
+ *
+ * Supports equality, greater than, less than operators and also a 'matches within' given the rules of days and shards.
+ *
+ * Some definitions - day ranges are like 20001224 - shard ranges are like 20190314_15
+ *
+ * Shards are sorted lexicographically. Shard _19 sorts before shard _2.
+ */
+public class ShardEquality {
+    
+    // Does A match B?
+    public static boolean matches(String a, String b) {
+        if (a.length() == b.length()) {
+            return a.equals(b);
+        } else {
+            return matchesWithin(a, b) || matchesWithin(b, a);
+        }
+    }
+    
+    public static boolean matchesExactly(String a, String b) {
+        return a.equals(b);
+    }
+    
+    // Does A match within B?
+    public static boolean matchesWithin(String a, String b) {
+        if (isDay(a) && daysMatch(a, b)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+    // Is A before B?
+    public static boolean lessThan(String a, String b) {
+        return a.compareTo(b) < 0;
+    }
+    
+    // Is A before or equal to B?
+    public static boolean lessThanOrEqual(String a, String b) {
+        return a.compareTo(b) <= 0;
+    }
+    
+    // Is A after B?
+    public static boolean greaterThan(String a, String b) {
+        return a.compareTo(b) > 0;
+    }
+    
+    // Is A after or equal to B?
+    public static boolean greaterThanOrEqual(String a, String b) {
+        return a.compareTo(b) >= 0;
+    }
+    
+    // Days are yyyymmdd, shards are yyyymmdd_shardnum.
+    public static boolean isDay(String shard) {
+        return shard.lastIndexOf('_') == -1;
+    }
+    
+    /**
+     * Given the YYYYMMDD_shardNum construct it is faster to determine shard identity with a search that starts from the end of the string
+     * 
+     * @param shard
+     *            a shard
+     * @return true if the shard is not a day
+     */
+    public static boolean isShard(String shard) {
+        return shard.lastIndexOf('_') != -1;
+    }
+    
+    /**
+     * A faster method of determining "a.startsWith(b)" given the YYYYMMDD structure of a shard.
+     *
+     * @param a
+     *            shard A that is a day
+     * @param b
+     *            shard B that could be a day or shard
+     * @return true if shard B starts with shard A
+     */
+    public static boolean daysMatch(String a, String b) {
+        int bIndex = b.lastIndexOf('_');
+        // Check for case where shard B is a day, thus returning -1 for an underscore index
+        if (bIndex == -1) {
+            bIndex = b.length();
+        }
+        
+        // Check for case where A is a day range for a shorter year string than B
+        // i.e., 867 vs. 1776
+        if (bIndex > a.length()) {
+            return false;
+        }
+        
+        for (int ii = bIndex - 1; ii >= 0; ii--) {
+            if (a.charAt(ii) != b.charAt(ii)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
@@ -19,10 +19,14 @@ import org.apache.log4j.Logger;
 
 import com.google.common.collect.Lists;
 
+import static datawave.query.index.lookup.ShardEquality.isDay;
+
 /**
  * Creates a union of global index range streams.
+ *
+ * This implementation of an IndexStream supports seeking to a specific shard. Such calls originate in the {@link Intersection}.
  */
-public class Union implements IndexStream {
+public class Union extends BaseIndexStream {
     protected final PriorityQueue<IndexStream> children;
     protected final JexlNodeSet childNodes;
     protected final StreamContext context;
@@ -76,7 +80,6 @@ public class Union implements IndexStream {
             }
             
             if (stream.hasNext()) {
-                
                 this.children.add(stream);
                 this.childNodes.add(stream.currentNode());
             } else {
@@ -144,7 +147,6 @@ public class Union implements IndexStream {
                 this.context = StreamContext.PRESENT;
                 this.contextDebug = "children are present";
             }
-            
             next();
         }
     }
@@ -183,18 +185,25 @@ public class Union implements IndexStream {
             String streamDayOrShard = children.peek().peek().first();
             if (log.isTraceEnabled())
                 log.trace("we have " + streamDayOrShard + " " + dayOrShard);
+            
             if (!streamDayOrShard.equals(dayOrShard)) {
                 // additional test if dayOrShard is a day
                 if (!(isDay(dayOrShard) && streamDayOrShard.startsWith(dayOrShard))) {
                     break;
                 }
             }
+            
             IndexStream itr = children.poll();
             
             pointers = pointers.union(itr.peek().second(), Lists.newArrayList(delayedNodes.getNodes()));
             itr.next();
-            if (itr.hasNext())
+            if (itr.hasNext()) {
                 children.add(itr);
+            } else {
+                if (log.isTraceEnabled()) {
+                    log.trace("IndexStream exhausted for " + itr.getContextDebug());
+                }
+            }
             childrenAdded = true;
         }
         
@@ -218,25 +227,17 @@ public class Union implements IndexStream {
         return Tuples.tuple(dayOrShard, pointers);
     }
     
-    public static boolean isDay(String dayOrShard) {
-        return (dayOrShard.indexOf('_') < 0);
-    }
-    
-    public static boolean isShard(String dayOrShard) {
-        return !isDay(dayOrShard);
-    }
-    
     @Override
     public void remove() {}
     
     public static class Builder {
         protected boolean built = false;
-        protected IdentityHashMap<IndexStream,Object> children = new IdentityHashMap<>();
+        protected IdentityHashMap<BaseIndexStream,Object> children = new IdentityHashMap<>();
         protected List<ConcurrentScannerInitializer> todo = Lists.newArrayList();
         
         private Builder() {}
         
-        public boolean addChild(IndexStream child) {
+        public boolean addChild(BaseIndexStream child) {
             if (built) {
                 throw new IllegalStateException("Builder already built an Union!");
             } else {
@@ -248,20 +249,19 @@ public class Union implements IndexStream {
             return children.size() + todo.size();
         }
         
-        public ArrayList<IndexStream> children() {
+        public ArrayList<BaseIndexStream> children() {
             return Lists.newArrayList(children.keySet());
         }
         
         public void addChildren(List<ConcurrentScannerInitializer> todo) {
             this.todo.addAll(todo);
-            
         }
         
         public Union build(ExecutorService service) {
             if (!todo.isEmpty()) {
                 
-                Collection<IndexStream> streams = ConcurrentScannerInitializer.initializeScannerStreams(todo, service);
-                for (IndexStream stream : streams) {
+                Collection<BaseIndexStream> streams = ConcurrentScannerInitializer.initializeScannerStreams(todo, service);
+                for (BaseIndexStream stream : streams) {
                     addChild(stream);
                 }
             }
@@ -270,12 +270,11 @@ public class Union implements IndexStream {
         }
         
         public void consume(Builder builder) {
-            for (IndexStream childStream : builder.children()) {
+            for (BaseIndexStream childStream : builder.children()) {
                 addChild(childStream);
             }
             todo.addAll(builder.todo);
         }
-        
     }
     
     public static Builder builder() {
@@ -310,5 +309,89 @@ public class Union implements IndexStream {
     @Override
     public JexlNode currentNode() {
         return currNode;
+    }
+    
+    /**
+     * Seek every IndexStream whose top shard is lower than the specified shard.
+     *
+     * @param seekShard
+     *            the shard to seek to.
+     * @return the lowest shard within this union after seeking
+     */
+    @Override
+    public String seek(String seekShard) {
+        
+        // Guard against the case when a seek range like YYYYMMDD_ is provided.
+        if (seekShard.charAt(seekShard.length() - 1) == '_')
+            seekShard = new String(seekShard.getBytes(), 0, seekShard.length() - 1);
+        
+        // Check the current element first
+        String topShard = isTopElementAMatch(seekShard);
+        if (topShard != null) {
+            // If the top element is a day and we are seeking to a shard range within the day, re-map the top element to the shard range.
+            // Take (A_shard && (B_day || C_day)) for example. The union's top shard is a day, but must be mapped to the same shard as the A term in order for
+            // the intersection to recognize that an intersection is possible.
+            if (!isDay(seekShard) && ShardEquality.matches(this.next.first(), seekShard)) {
+                this.next = new Tuple2<>(seekShard, this.next.second());
+            }
+            
+            return topShard;
+        } else {
+            // If the top element did not match then null it out
+            this.next = null;
+        }
+        
+        List<IndexStream> nextChildren = new ArrayList<>();
+        while (!children.isEmpty()) {
+            
+            IndexStream stream = children.poll();
+            
+            // If the top of the shard-sorted priority queue is beyond the specified shard then we can bail out.
+            String streamDayOrShard = stream.peek().first();
+            
+            // Avoid seeking if the stream shard matches the seek shard, or if the stream shard is greater than the seek shard.
+            if (ShardEquality.matches(streamDayOrShard, seekShard) || ShardEquality.greaterThanOrEqual(streamDayOrShard, seekShard)) {
+                nextChildren.add(stream);
+                continue;
+            }
+            
+            // If the IndexStream has more elements after seeking, add it back into the priority queue.
+            stream.seek(seekShard);
+            if (stream.hasNext()) {
+                nextChildren.add(stream);
+            }
+        }
+        
+        children.addAll(nextChildren);
+        if (!children.isEmpty()) {
+            next = advanceQueue();
+            if (next != null) {
+                return next.first();
+            }
+        }
+        
+        // If no child IndexStreams remain then this union is exhausted.
+        return null;
+    }
+    
+    // Is the top shard greater than or equal to the seek shard
+    public String isTopElementAMatch(String seekShard) {
+        // Check the current element first
+        if (next != null) {
+            
+            String topShard = next.first();
+            
+            // If the top shard exceeds the seek shard then return the top shard
+            if (ShardEquality.greaterThanOrEqual(topShard, seekShard)) {
+                return topShard;
+            }
+            
+            // If the top shard is a day range that matches the seek shard, return the seek shard.
+            if (ShardEquality.matches(topShard, seekShard)) {
+                // Return the existing maximum instead of the day
+                return seekShard;
+            }
+        }
+        return null;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
@@ -5,6 +5,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -24,12 +26,14 @@ import datawave.mr.bulk.RfileScanner;
 import datawave.query.index.lookup.IndexInfo;
 import datawave.query.index.lookup.IndexMatch;
 import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.index.lookup.ShardEquality;
 import datawave.query.tables.stats.ScanSessionStats.TIMERS;
 import datawave.webservice.query.Query;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Column;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -48,10 +52,20 @@ import com.google.common.util.concurrent.MoreExecutors;
 /**
  * Purpose: Extends Scanner session so that we can modify how we build our subsequent ranges. Breaking this out cleans up the code. May require implementation
  * specific details if you are using custom iterators, as we are reinitializing a seek
- * 
+ *
  * Design: Extends Scanner session and only overrides the buildNextRange.
- * 
- * 
+ *
+ * The {@link datawave.query.index.lookup.RangeStream} configures the iterator running against the global index.
+ *
+ * Typically the iterator is a {@link datawave.query.index.lookup.CreateUidsIterator} or variant.
+ *
+ * The iterator returns a tuple of shard - {@link IndexInfo} object pairs, each shard representing and day or shard range.
+ *
+ * Results from the iterator are put onto the currentQueue and then flushed into the resultQueue. Under certain circumstances these results may be modified
+ * final to the prior flush into the resultQueue.
+ *
+ * The RangeStreamScanner supports "seeking" the global index iterator. Because the RangeStreamScanner supports a {@link PeekingIterator} some implementation
+ * details are not immediately obvious. For more information, see {@link #seek(String)}.
  */
 public class RangeStreamScanner extends ScannerSession implements Callable<RangeStreamScanner> {
     
@@ -61,7 +75,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
     // simply compare the strings. no need for a date formatter
     protected static final int dateCfLength = 8;
     protected boolean seenUnexpectedKey = false;
-    protected Queue<Entry<Key,Value>> currentQueue;
+    protected ArrayDeque<Entry<Key,Value>> currentQueue;
     
     protected Entry<Key,Value> prevDay = null;
     
@@ -73,6 +87,10 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
     volatile boolean finished = false;
     
     ExecutorService myExecutor;
+    
+    // If this flag is true, we build the next range using the seekShard.
+    public boolean seeking = false;
+    protected String seekShard = null;
     
     protected ScannerFactory scannerFactory;
     
@@ -135,34 +153,219 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
     
     /**
      * Override this for your specific implementation.
-     * 
+     *
      * In this specific implementation our row key will be the term, the column family will be the field name, and the column family will be the shard,so we
      * should have the following as our last key
-     * 
+     *
      * bar FOO:20130101_0
-     * 
+     *
      * so we should append a null so that we we don't skip shards. similarly, an assumption is made of the key structure within this class.
-     * 
+     *
      * @param lastKey
      * @param previousRange
      */
     @Override
     public Range buildNextRange(final Key lastKey, final Range previousRange) {
-        
         /*
          * This path includes the following key from the shard_id onward. The reason we also append the hex 255 value is because we receive a key not unlike
          * foo:20130101_0. If our next search space is foo:20130101_0\x00 we will hit all data types within that range...again..and again...and again. To
          * account for this, we put \uffff after the null byte so that we start key is technically the last value within the provided shard, moving us to the
          * exact next key within our RangeStream
          */
-        return new Range(new Key(lastKey.getRow(), lastKey.getColumnFamily(), new Text(lastKey.getColumnQualifier() + "\uffff")), true,
-                        previousRange.getEndKey(), previousRange.isEndKeyInclusive());
+        Key startKey = new Key(lastKey.getRow(), lastKey.getColumnFamily(), new Text(lastKey.getColumnQualifier() + "\uffff"));
+        return new Range(startKey, false, previousRange.getEndKey(), previousRange.isEndKeyInclusive());
     }
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.util.Iterator#hasNext()
+    /**
+     * Seek range is built with a start key column qualifier set to the seek shard.
+     *
+     * In a worst case scenario the built seek range is for the very next shard, no differently than {@link #buildNextRange}.
+     *
+     * Best case the seek range lies beyond the data available for this scanner, thus negating any need to continue searching within this range stream.
+     *
+     * @param seekShard
+     *            the shard to seek to
+     * @param range
+     *            the RangeStreamScanner's current range
+     * @return the current range with a modified start key
+     */
+    public Range buildSeekRange(String seekShard, Range range) {
+        
+        // Adjust startKey columnQualifier to be the shard.
+        Key startKey = range.getStartKey();
+        Text row = startKey.getRow();
+        Text cf = startKey.getColumnFamily();
+        startKey = new Key(row, cf, new Text(seekShard));
+        
+        return new Range(startKey, true, range.getEndKey(), range.isEndKeyInclusive());
+    }
+    
+    /**
+     * Seek the underlying iterator to the specified shard.
+     *
+     * First ensures the seek shard does not fall within the currentEntry, resultQueue, or currentQueue.
+     *
+     * The queues are setup not unlike [resultQ.head] - [currentQ.first - currentQ.last] - lastSeenKey
+     *
+     * @param seekShard
+     *            the shard to seek to.
+     * @return the shard we seek'd to.
+     */
+    public String seek(String seekShard) {
+        if (currentEntry == null && resultQueue.isEmpty() && finished) {
+            return null;
+        }
+        
+        String seekedShard = advanceQueues(seekShard);
+        if (seekedShard == null) {
+            
+            this.seekShard = seekShard;
+            this.seeking = true;
+            
+            // Clear queues before calling findTop().
+            this.currentEntry = null;
+            this.resultQueue.clear();
+            this.currentQueue.clear();
+            
+            // Call to hasNext() with empty queues and a null currentEntry triggers a new run of the iterator.
+            if (hasNext()) {
+                // Check to see if the shard exists within the queues.
+                seekedShard = advanceQueues(seekShard);
+            } else {
+                return null;
+            }
+        }
+        return seekedShard;
+    }
+    
+    /**
+     * If the seek shard falls within the bounds of the currentQueue or resultQueue, advance the queues to the shard.
+     *
+     * @param seekShard
+     *            the shard we should advance to
+     * @return the matched shard if exact match, the next highest shard if greater than seekShard, or null if no more elements exist
+     */
+    public String advanceQueues(String seekShard) {
+        
+        // CASE 0: Check the currentEntry first.
+        String topShard = currentEntryMatchesShard(seekShard);
+        if (topShard != null) {
+            return topShard;
+        }
+        
+        // CASE 1: The seek shard is within the bounds of the result queue. Advance the result queue to the seek shard.
+        if (resultQueue.size() > 0) {
+            
+            // If the top shard is a day and we are seeking to a shard within the day, return the shard.
+            String resultQShard = shardFromKey(resultQueue.peek().getKey());
+            if (resultQShard.length() == 8 && seekShard.startsWith(resultQShard)) {
+                return resultQShard;
+            }
+            
+            // If the top shard of the result queue is greater than or equal to the seek shard then we're already at the correct spot.
+            if (ShardEquality.greaterThanOrEqual(resultQShard, seekShard)) {
+                return resultQShard;
+            }
+            
+            // Sanity check to make sure the resultQShard is sorted lower than the seek shard.
+            if (ShardEquality.lessThan(resultQShard, seekShard)) {
+                // Advance the resultQueue to the specified shard.
+                return advanceQueueToShard(resultQueue, seekShard);
+            }
+        }
+        
+        // CASE 2: The seek shard is within the bounds of the current queue.
+        if (currentQueue.size() > 0) {
+            String firstShard = shardFromKey(currentQueue.peekFirst().getKey());
+            String lastShard = shardFromKey(currentQueue.peekLast().getKey());
+            if (ShardEquality.greaterThan(firstShard, seekShard) && ShardEquality.lessThan(lastShard, seekShard)) {
+                // Advance currentQueue to the specified shard.
+                resultQueue.clear();
+                return advanceQueueToShard(currentQueue, seekShard);
+            }
+        }
+        
+        // CASE 3: The seek shard is beyond the bounds of the data currently held by this range stream scanner.
+        return null;
+    }
+    
+    /**
+     * Advance the provided queue to the specified shard. Assumes the shard is already determined to exist within the queue.
+     *
+     * Returns the seek'd shard or the next highest value if the seek shard does not exist.
+     *
+     * If the queue is exhausted then return null.
+     *
+     * @param queue
+     *            either the currentQueue or the resultQueue
+     * @param shard
+     *            shard to seek to
+     * @return the matched shard, the next highest shard, or null
+     */
+    public String advanceQueueToShard(Queue<Entry<Key,Value>> queue, String shard) {
+        Entry<Key,Value> top;
+        String topShard = null;
+        
+        boolean advancing = true;
+        while (advancing) {
+            top = queue.peek();
+            if (top == null)
+                return null;
+            
+            topShard = shardFromKey(top.getKey());
+            
+            if (ShardEquality.greaterThanOrEqual(topShard, shard)) {
+                // Stop advancing if the peeked shard is greater than or equal to the seek shard.
+                advancing = false;
+            } else if (topShard.indexOf('_') == -1 && shard.startsWith(topShard)) {
+                // Check for special case where the top shard is a day.
+                advancing = false;
+            } else {
+                queue.poll();
+            }
+        }
+        return topShard;
+    }
+    
+    /**
+     * Determines if the currentEntry matches the seek shard.
+     *
+     * @param seekShard
+     *            the shard to seek to
+     * @return the matched shard, the next highest shard, or null
+     */
+    public String currentEntryMatchesShard(String seekShard) {
+        if (currentEntry == null) {
+            return null;
+        }
+        
+        String topShard = shardFromKey(currentEntry.getKey());
+        
+        // Is the current entry an exact match?
+        if (topShard.equals(seekShard))
+            return seekShard;
+        
+        // Is the current entry beyond the seek shard?
+        if (ShardEquality.greaterThan(topShard, seekShard))
+            return topShard;
+        
+        // Seek to '20190314', top shard '20190314_0' matches. Return the day range.
+        if (ShardEquality.isDay(seekShard) && topShard.startsWith(seekShard))
+            return seekShard;
+        
+        // Seek to '20190314_0', top shard '20190314' matches. Return the day range.
+        if (ShardEquality.isDay(topShard) && seekShard.startsWith(topShard))
+            return topShard;
+        
+        // Return null to signify no match.
+        return null;
+    }
+    
+    /**
+     * If the currentEntry is null this method will first check the resultQueue for an entry. If the resultQueue is empty then the scanner will submit a new
+     * task which pulls results off the shard index, thus populating the result queue.
+     *
+     * @return true if the scanner has a next element
      */
     @Override
     public boolean hasNext() {
@@ -211,7 +414,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
     
     private void submitTask() {
         // wait on results. submit the task if we can
-        Future<RangeStreamScanner> future = myExecutor.submit(this);
+        Future future = myExecutor.submit(this);
         try {
             future.get();
         } catch (InterruptedException | ExecutionException e) {
@@ -264,21 +467,9 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
             while (kvIter.hasNext()) {
                 Entry<Key,Value> currentKeyValue = kvIter.peek();
                 
-                IndexInfo infos = new IndexInfo();
-                try {
-                    infos.readFields(new DataInputStream(new ByteArrayInputStream(currentKeyValue.getValue().get())));
-                    if (log.isTraceEnabled()) {
-                        for (IndexMatch match : infos.uids()) {
-                            log.trace("match is " + StringUtils.split(match.getUid(), '\u0000')[1]);
-                        }
-                    }
-                } catch (IOException e) {
-                    log.error(e);
-                }
-                
                 // become a pass-through if we've seen an unexpected key.
                 if (seenUnexpectedKey) {
-                    currentQueue.add(currentKeyValue);
+                    currentQueue.add(trimTrailingUnderscore(currentKeyValue));
                     break;
                 }
                 
@@ -290,7 +481,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                     
                     currentDay = getDay(currentKeyValue.getKey());
                     
-                    currentQueue.add(currentKeyValue);
+                    currentQueue.add(trimTrailingUnderscore(currentKeyValue));
                     
                     lastSeenKey = kvIter.next().getKey();
                 } else {
@@ -300,12 +491,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                             log.trace("adding " + currentKeyValue.getKey() + " to queue because it matches" + currentDay);
                         }
                         
-                        IndexInfo info = new IndexInfo();
-                        try {
-                            info.readFields(new DataInputStream(new ByteArrayInputStream(currentKeyValue.getValue().get())));
-                        } catch (IOException e) {
-                            throw new DatawaveFatalQueryException(e);
-                        }
+                        IndexInfo info = readInfoFromValue(currentKeyValue.getValue());
                         
                         if (log.isTraceEnabled()) {
                             log.trace("adding count of " + info.count());
@@ -313,14 +499,13 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                         
                         stats.addValue(info.count());
                         
-                        if (currentQueue.size() <= shardsPerDayThreshold
-                                        || (currentQueue.size() >= shardsPerDayThreshold && stats.getPercentile(50) < MAX_MEDIAN)) {
+                        if (currentQueue.size() <= shardsPerDayThreshold || stats.getPercentile(50) < MAX_MEDIAN) {
                             
                             if (log.isTraceEnabled()) {
                                 log.trace("adding our stats are " + stats.getPercentile(50) + " on " + currentQueue.size());
                             }
                             
-                            currentQueue.add(currentKeyValue);
+                            currentQueue.add(trimTrailingUnderscore(currentKeyValue));
                             
                         } else {
                             if (log.isTraceEnabled()) {
@@ -353,21 +538,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                     log.trace(topKey + " for " + currentDay + " exceeds limit of " + shardsPerDayThreshold + " with " + currentQueue.size());
                 Key newKey = new Key(topKey.getRow(), topKey.getColumnFamily(), new Text(currentDay), topKey.getColumnVisibility(), topKey.getTimestamp());
                 
-                IndexInfo info = new IndexInfo(-1);
-                
-                Value newValue;
-                try {
-                    ByteArrayOutputStream outByteStream = new ByteArrayOutputStream();
-                    DataOutputStream outDataStream = new DataOutputStream(outByteStream);
-                    info.write(outDataStream);
-                    
-                    outDataStream.close();
-                    outByteStream.close();
-                    
-                    newValue = new Value(outByteStream.toByteArray());
-                } catch (IOException e) {
-                    throw new DatawaveFatalQueryException(e);
-                }
+                Value newValue = writeInfoToValue();
                 
                 myEntry = Maps.immutableEntry(newKey, newValue);
                 lastSeenKey = newKey;
@@ -394,6 +565,42 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
         return retrievalCount;
     }
     
+    public IndexInfo readInfoFromValue(Value value) {
+        try {
+            IndexInfo info = new IndexInfo();
+            info.readFields(new DataInputStream(new ByteArrayInputStream(value.get())));
+            if (log.isTraceEnabled()) {
+                for (IndexMatch match : info.uids()) {
+                    log.trace("match is " + StringUtils.split(match.getUid(), '\u0000')[1]);
+                }
+            }
+            return info;
+        } catch (IOException e) {
+            log.error(e);
+            throw new DatawaveFatalQueryException(e);
+        }
+    }
+    
+    public Value writeInfoToValue() {
+        return writeInfoToValue(new IndexInfo(-1));
+    }
+    
+    public Value writeInfoToValue(IndexInfo info) {
+        try {
+            ByteArrayOutputStream outByteStream = new ByteArrayOutputStream();
+            DataOutputStream outDataStream = new DataOutputStream(outByteStream);
+            info.write(outDataStream);
+            
+            outDataStream.close();
+            outByteStream.close();
+            
+            return new Value(outByteStream.toByteArray());
+        } catch (IOException e) {
+            log.error(e);
+            throw new DatawaveFatalQueryException(e);
+        }
+    }
+    
     private int dequeue() {
         return dequeue(false);
     }
@@ -402,7 +609,6 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
         int count = 0;
         
         Queue<Entry<Key,Value>> kvIter = Queues.newArrayDeque(currentQueue);
-        
         currentQueue.clear();
         boolean result = true;
         for (Entry<Key,Value> top : kvIter) {
@@ -465,7 +671,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
     
     /**
      * Get the day from the key
-     * 
+     *
      * @param key
      * @return
      */
@@ -481,6 +687,24 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
         return myDay;
     }
     
+    /**
+     * Get the shard from the accumulo key.
+     *
+     * Strip any trailing underscores from the returned shard.
+     *
+     * @param key
+     *            the key to everything
+     * @return just a shard
+     */
+    public static String shardFromKey(final Key key) {
+        byte[] cq = key.getColumnQualifierData().getBackingArray();
+        if (cq[cq.length - 1] == '_') {
+            return new String(cq, 0, cq.length - 1);
+        } else {
+            return new String(cq, 0, cq.length);
+        }
+    }
+    
     public RangeStreamScanner setShardsPerDayThreshold(int shardsPerDayThreshold) {
         this.shardsPerDayThreshold = shardsPerDayThreshold;
         return this;
@@ -494,9 +718,8 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
     
     /**
      * FindTop -- Follows the logic outlined in the comments, below. Effectively, we continue
-     * 
+     *
      * @throws Exception
-     * 
      */
     protected void findTop() throws Exception {
         if (ranges.isEmpty() && lastSeenKey == null) {
@@ -556,7 +779,12 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                 }
             } else {
                 // adjust the end key range.
-                currentRange = buildNextRange(lastSeenKey, currentRange);
+                if (seeking) {
+                    currentRange = buildSeekRange(seekShard, currentRange);
+                    seeking = false;
+                } else {
+                    currentRange = buildNextRange(lastSeenKey, currentRange);
+                }
                 
                 if (log.isTraceEnabled())
                     log.trace("Building " + currentRange + " from " + lastSeenKey);
@@ -644,6 +872,29 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                 }
             }
             return false;
+        }
+    }
+    
+    // Overloaded
+    public static Entry<Key,Value> trimTrailingUnderscore(Entry<Key,Value> entry) {
+        Key nextKey = trimTrailingUnderscore(entry.getKey());
+        return new AbstractMap.SimpleEntry<>(nextKey, entry.getValue());
+    }
+    
+    /**
+     * It may be possible that a trailing underscore is appended to a day range. Check for and remove any trailing underscores that exist.
+     *
+     * @param key
+     *            the key
+     * @return the key, less any trailing underscores
+     */
+    public static Key trimTrailingUnderscore(Key key) {
+        ByteSequence sequence = key.getColumnQualifierData();
+        if (sequence.byteAt(sequence.length() - 1) == '_') {
+            sequence = sequence.subSequence(0, sequence.length() - 1);
+            return new Key(key.getRow(), key.getColumnFamily(), new Text(sequence.toString()));
+        } else {
+            return key;
         }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/CreateUidsIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/CreateUidsIteratorTest.java
@@ -205,6 +205,7 @@ public class CreateUidsIteratorTest {
     public void testWithCollapse() throws IOException {
         // Setup data for test.
         TreeMap<Key,Value> data = new TreeMap<>();
+        
         List<String> docIds = Arrays.asList("doc1", "doc2", "doc3", "doc4");
         Uid.List.Builder builder = Uid.List.newBuilder();
         builder.addAllUID(docIds);

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
@@ -20,9 +20,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class IntersectionTest {
@@ -277,7 +280,7 @@ public class IntersectionTest {
     }
     
     @Test
-    public void testIntersection_uidAndinfinite() throws ParseException {
+    public void testIntersection_uidAndInfinite() throws ParseException {
         // A && B && C
         ASTJexlScript script = JexlASTHelper.parseJexlQuery("A == '1' && B == '2' && C == '3'");
         
@@ -684,5 +687,393 @@ public class IntersectionTest {
         assertTrue(TreeEqualityVisitor.isEqual(
                         JexlASTHelper.parseJexlQuery("G =='7' && ((A == '1' && C == '3') || (B == '2' && C == '3') || (D == '4' && F == '6'))"),
                         JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+    }
+    
+    @Test
+    public void testSeekBeyondEndOfIntersection() throws ParseException {
+        // A && B && C
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery("A == '1' && B == '2' && C == '3'");
+        
+        // A - uids
+        ScannerStream s1 = buildScannerStream("20090101_1", "A", "1", Arrays.asList("a.b.c"));
+        
+        // B - uids
+        ScannerStream s2 = buildScannerStream("20090101_1", "B", "2", Arrays.asList("a.b.c", "a.b.c.d"));
+        
+        // C - uids
+        ScannerStream s3 = buildScannerStream("20090101_1", "C", "3", Arrays.asList("a.b.c", "az"));
+        
+        List<? extends IndexStream> toMerge = Arrays.asList(s1, s2, s3);
+        
+        Intersection i = new Intersection(toMerge, new IndexInfo());
+        assertTrue(i.hasNext());
+        
+        assertNull(i.seek("20091231_1"));
+        assertFalse(i.hasNext());
+        assertNull(i.next());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfShards_seekBeforeStreamStart() {
+        // Seek to a day range before the IndexStream
+        Intersection intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190202"));
+        assertEquals("20190301_0", intersection.next().first());
+        
+        // Seek to a day-underscore range before the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190202_"));
+        assertEquals("20190301_0", intersection.next().first());
+        
+        // Seek to a shard range before the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190202_0"));
+        assertEquals("20190301_0", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfShards_seekToStreamStart() {
+        // Seek to a day range at the start of the IndexStream
+        Intersection intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190301"));
+        assertEquals("20190301_0", intersection.next().first());
+        
+        // Seek to a day-underscore range at the start of the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190301_"));
+        assertEquals("20190301_0", intersection.next().first());
+        
+        // Seek to a shard range before at the start of the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190301_0"));
+        assertEquals("20190301_0", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfShards_seekToMiddleOfStream() {
+        // Seek to a day range in the middle of the IndexStream
+        Intersection intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190303_0", intersection.seek("20190303"));
+        assertEquals("20190303_0", intersection.next().first());
+        
+        // Seek to a day-underscore range in the middle of the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertEquals("20190303_0", intersection.seek("20190303_"));
+        assertEquals("20190303_0", intersection.next().first());
+        
+        // Seek to a shard range in the middle of the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190303_3", intersection.seek("20190303_3"));
+        assertEquals("20190303_3", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfShards_seekToNonExistentMiddleOfStream() {
+        // Seek to a non-existent day range in the middle of the IndexStream
+        Intersection intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190307_0", intersection.seek("20190305"));
+        assertEquals("20190307_0", intersection.next().first());
+        
+        // Seek to a non-existent day-underscore range to the middle of the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190307_0", intersection.seek("20190305_"));
+        assertEquals("20190307_0", intersection.next().first());
+        
+        // Seek to a non-existent shard range to the middle of of the IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190307_0", intersection.seek("20190305_0"));
+        assertEquals("20190307_0", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfShards_seekToEndOfStream() {
+        // Seek to the last day range in this IndexStream
+        Intersection intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190309_0", intersection.seek("20190309"));
+        assertEquals("20190309_0", intersection.next().first());
+        
+        // Seek to the last day-underscore range in this IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190309_0", intersection.seek("20190309_"));
+        assertEquals("20190309_0", intersection.next().first());
+        
+        // Seek to the last shard range in this IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190309_9", intersection.seek("20190309_9"));
+        assertEquals("20190309_9", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfShards_seekBeyondEndOfStream() {
+        // Seek to a day range beyond the end of this IndexStream
+        Intersection intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertNull(intersection.seek("20190310"));
+        assertFalse(intersection.hasNext());
+        assertNull(intersection.next());
+        
+        // Seek to a day-underscore range beyond the end of this IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertNull(intersection.seek("20190310_"));
+        assertFalse(intersection.hasNext());
+        assertNull(intersection.next());
+        
+        // Seek to a shard range beyond the end of this IndexStream
+        intersection = buildIntersectionOfShards();
+        assertTrue(intersection.hasNext());
+        assertNull(intersection.seek("20190309_99"));
+        assertFalse(intersection.hasNext());
+        assertNull(intersection.next());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfDays_seekBeforeStreamStart() {
+        // Seek to a day range before the IndexStream
+        Intersection intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301", intersection.seek("20190202"));
+        assertEquals("20190301", intersection.next().first());
+        
+        // Seek to a day-underscore range before the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301", intersection.seek("20190202_"));
+        assertEquals("20190301", intersection.next().first());
+        
+        // Seek to a shard range before the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301", intersection.seek("20190202_0"));
+        assertEquals("20190301", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfDays_seekToStreamStart() {
+        // Seek to a day range at the start of the IndexStream
+        Intersection intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301", intersection.seek("20190301"));
+        assertEquals("20190301", intersection.next().first());
+        
+        // Seek to a day-underscore range at the start of the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301", intersection.seek("20190301_"));
+        assertEquals("20190301", intersection.next().first());
+        
+        // Seek to a shard range before at the start of the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190301_0", intersection.seek("20190301_0"));
+        assertEquals("20190301_0", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfDays_seekToMiddleOfStream() {
+        // Seek to a day range in the middle of the IndexStream
+        Intersection intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190303", intersection.seek("20190303"));
+        assertEquals("20190303", intersection.next().first());
+        
+        // Seek to a day-underscore range in the middle of the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertEquals("20190303", intersection.seek("20190303_"));
+        assertEquals("20190303", intersection.next().first());
+        
+        // Seek to a shard range in the middle of the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190303_3", intersection.seek("20190303_3"));
+        assertEquals("20190303_3", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfDays_seekToNonExistentMiddleOfStream() {
+        // Seek to a non-existent day range in the middle of the IndexStream
+        Intersection intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190307", intersection.seek("20190305"));
+        assertEquals("20190307", intersection.next().first());
+        
+        // Seek to a non-existent day-underscore range to the middle of the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190307", intersection.seek("20190305_"));
+        assertEquals("20190307", intersection.next().first());
+        
+        // Seek to a non-existent shard range to the middle of of the IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190307", intersection.seek("20190305_0"));
+        assertEquals("20190307", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfDays_seekToEndOfStream() {
+        // Seek to the last day range in this IndexStream
+        Intersection intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190309", intersection.seek("20190309"));
+        assertEquals("20190309", intersection.next().first());
+        
+        // Seek to the last day-underscore range in this IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190309", intersection.seek("20190309_"));
+        assertEquals("20190309", intersection.next().first());
+        
+        // Seek to the last shard range in this IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertEquals("20190309_9", intersection.seek("20190309_9"));
+        assertEquals("20190309_9", intersection.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testIntersectionOfDays_seekBeyondEndOfStream() {
+        // Seek to a day range beyond the end of this IndexStream
+        Intersection intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertNull(intersection.seek("20190310"));
+        assertFalse(intersection.hasNext());
+        assertNull(intersection.next());
+        
+        // Seek to a day-underscore range beyond the end of this IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertNull(intersection.seek("20190310_"));
+        assertFalse(intersection.hasNext());
+        assertNull(intersection.next());
+        
+        // Seek to a shard range beyond the end of this IndexStream
+        intersection = buildIntersectionOfDays();
+        assertTrue(intersection.hasNext());
+        assertNull(intersection.seek("20190310_0"));
+        assertFalse(intersection.hasNext());
+        assertNull(intersection.next());
+    }
+    
+    @Test
+    public void testTopElementMatch_topIsShard() {
+        Intersection intersection = buildIntersectionOfShards();
+        
+        // Match on same shard
+        assertEquals("20190301_0", intersection.isTopElementAMatch("20190301_0"));
+        
+        // Match on same day
+        assertEquals("20190301_0", intersection.isTopElementAMatch("20190301"));
+        
+        // No match on same day, different shard
+        assertNull(intersection.isTopElementAMatch("20190301_9"));
+        
+        // No match on different day
+        assertNull(intersection.isTopElementAMatch("20190302"));
+    }
+    
+    @Test
+    public void testTopElementMatch_topIsDay() {
+        Intersection intersection = buildIntersectionOfDays();
+        
+        // Match on shard within the day
+        assertEquals("20190301_0", intersection.isTopElementAMatch("20190301_0"));
+        
+        // Match on same day
+        assertEquals("20190301", intersection.isTopElementAMatch("20190301"));
+        
+        // Match on different shard within day
+        assertEquals("20190301_9", intersection.isTopElementAMatch("20190301_9"));
+        
+        // No match on different day
+        assertNull(intersection.isTopElementAMatch("20190302"));
+    }
+    
+    private Intersection buildIntersectionOfShards() {
+        List<String> ignoredDays = Lists.newArrayList("20190304", "20190305", "20190306");
+        SortedSet<String> shards = buildShards(ignoredDays);
+        
+        ScannerStream s1 = buildFullScannerStream(shards, "A", "1");
+        ScannerStream s2 = buildFullScannerStream(shards, "B", "2");
+        
+        return new Intersection(Arrays.asList(s1, s2), new IndexInfo());
+    }
+    
+    private Intersection buildIntersectionOfDays() {
+        List<String> ignoredDays = Lists.newArrayList("20190304", "20190305", "20190306");
+        SortedSet<String> shards = buildDays(ignoredDays);
+        
+        ScannerStream s1 = buildFullScannerStream(shards, "A", "1");
+        ScannerStream s2 = buildFullScannerStream(shards, "B", "2");
+        
+        return new Intersection(Arrays.asList(s1, s2), new IndexInfo());
+    }
+    
+    // Build a set of shards for the first 9 days in march, with the option to ignore days.
+    private SortedSet<String> buildShards(List<String> ignoredDays) {
+        SortedSet<String> shards = new TreeSet<>();
+        for (int ii = 1; ii < 10; ii++) {
+            String day = "2019030" + ii;
+            if (ignoredDays.contains(day)) {
+                continue;
+            }
+            for (int jj = 0; jj < 20; jj++) {
+                shards.add(day + "_" + jj);
+            }
+        }
+        return shards;
+    }
+    
+    // Build a set of day shards for the first 9 days in march, with the option to ignore days.
+    private SortedSet<String> buildDays(List<String> ignoredDays) {
+        SortedSet<String> shards = new TreeSet<>();
+        for (int ii = 1; ii < 10; ii++) {
+            String day = "2019030" + ii;
+            if (ignoredDays.contains(day)) {
+                continue;
+            }
+            shards.add(day);
+        }
+        return shards;
+    }
+    
+    // Build a ScannerStream specifically for testing the ability to seek through the stream.
+    private ScannerStream buildFullScannerStream(SortedSet<String> shards, String field, String value) {
+        JexlNode node = JexlNodeFactory.buildEQNode(field, value);
+        
+        List<Tuple2<String,IndexInfo>> elements = new ArrayList<>();
+        for (String shard : shards) {
+            IndexInfo info = new IndexInfo(-1);
+            info.applyNode(node);
+            elements.add(new Tuple2<>(shard, info));
+        }
+        
+        return ScannerStream.variable(elements.iterator(), node);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -305,6 +306,104 @@ public class RangeStreamTest {
         
         m = new Mutation("oreo");
         m.put(new Text("FOO"), new Text("20190314_1\0" + "datatype1"), new Value(list.toByteArray()));
+        bw.addMutation(m);
+        
+        // ---------------
+        
+        // Terms for high-low cardinality test with query (FOO == 'low_card' && FOO == 'high_card')
+        // Four terms {'highest_card', 'high_card', 'low_card', 'lowest_card'}
+        // Ranges fall across 8 days, each day has up to 50 shards.
+        builder = Uid.List.newBuilder();
+        builder.addUID("a.b.c");
+        builder.setIGNORE(false);
+        builder.setCOUNT(2);
+        list = builder.build();
+        
+        m = new Mutation("lowest_card");
+        m.put(new Text("FOO"), new Text("20190310_1\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190314_22\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_49\0" + "datatype1"), new Value(list.toByteArray()));
+        bw.addMutation(m);
+        
+        m = new Mutation("low_card");
+        m.put(new Text("FOO"), new Text("20190310_1\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190312_1\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190314_22\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_33\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190317_1\0" + "datatype1"), new Value(list.toByteArray()));
+        bw.addMutation(m);
+        
+        builder = Uid.List.newBuilder();
+        builder.addUID("a.b.c");
+        builder.addUID("d.e.f");
+        builder.setIGNORE(false);
+        builder.setCOUNT(2);
+        list = builder.build();
+        
+        m = new Mutation("high_card");
+        for (int day = 0; day < 8; day += 2) {
+            for (int ii = 1; ii < 50; ii++) {
+                m.put(new Text("FOO"), new Text("2019031" + day + "_" + ii + "\0" + "datatype1"), new Value(list.toByteArray()));
+            }
+        }
+        bw.addMutation(m);
+        
+        m = new Mutation("highest_card");
+        for (int day = 0; day < 8; day++) {
+            for (int ii = 1; ii < 50; ii++) {
+                m.put(new Text("FOO"), new Text("2019031" + day + "_" + ii + "\0" + "datatype1"), new Value(list.toByteArray()));
+            }
+        }
+        bw.addMutation(m);
+        
+        // ---------------
+        
+        // Keep it simple, just have one hit.
+        builder = Uid.List.newBuilder();
+        builder.addUID("a.b.c");
+        builder.setIGNORE(true);
+        builder.setCOUNT(5000);
+        list = builder.build();
+        
+        // With shards per day set to zero, these will roll up
+        m = new Mutation("day_ranges");
+        m.put(new Text("FOO"), new Text("20190310_0\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_1\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_2\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_3\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_4\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_5\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_6\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_7\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190310_8\0" + "datatype1"), new Value(list.toByteArray()));
+        
+        m.put(new Text("FOO"), new Text("20190311_0\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190312_0\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190313_0\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190314_0\0" + "datatype1"), new Value(list.toByteArray()));
+        
+        m.put(new Text("FOO"), new Text("20190315_0\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_1\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_2\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_3\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_4\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_5\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_6\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_7\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_8\0" + "datatype1"), new Value(list.toByteArray()));
+        
+        m.put(new Text("FOO"), new Text("20190316_0\0" + "datatype1"), new Value(list.toByteArray()));
+        bw.addMutation(m);
+        
+        builder = Uid.List.newBuilder();
+        builder.addUID("a.b.c");
+        builder.setIGNORE(false);
+        builder.setCOUNT(1);
+        list = builder.build();
+        
+        m = new Mutation("shard_range");
+        m.put(new Text("FOO"), new Text("20190310_21\0" + "datatype1"), new Value(list.toByteArray()));
+        m.put(new Text("FOO"), new Text("20190315_51\0" + "datatype1"), new Value(list.toByteArray()));
         bw.addMutation(m);
         
         // ---------------
@@ -1079,5 +1178,313 @@ public class RangeStreamTest {
         List<Tuple2<String,IndexInfo>> fullFieldIndexScanList = RangeStream.createFullFieldIndexScanList(config, null);
         
         Assert.assertEquals(2, fullFieldIndexScanList.size());
+    }
+    
+    // (A && B)
+    @Test
+    public void testIntersection_HighAndLowCardinality_withSeek() throws Exception {
+        String originalQuery = "(FOO == 'lowest_card' && FOO == 'highest_card')";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        // Create expected ranges verbosely, so it is obvious which shards contribute to the results.
+        Range range1 = makeTestRange("20190310_1", "datatype1\u0000a.b.c");
+        Range range2 = makeTestRange("20190314_22", "datatype1\u0000a.b.c");
+        Range range3 = makeTestRange("20190315_49", "datatype1\u0000a.b.c");
+        Set<Range> expectedRanges = Sets.newHashSet(range1, range2, range3);
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
+    }
+    
+    // (A && (B || C))
+    @Test
+    public void testIntersection_NestedUnionOfHighCardinalityTerm_withSeek() throws Exception {
+        String originalQuery = "(FOO == 'lowest_card' && (FOO == 'high_card' || FOO == 'highest_card'))";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        // Create expected ranges verbosely, so it is obvious which shards contribute to the results.
+        Range range1 = makeTestRange("20190310_1", "datatype1\u0000a.b.c");
+        Range range2 = makeTestRange("20190314_22", "datatype1\u0000a.b.c");
+        Range range3 = makeTestRange("20190315_49", "datatype1\u0000a.b.c");
+        Set<Range> expectedRanges = Sets.newHashSet(range1, range2, range3);
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
+    }
+    
+    // A && (B || C)
+    @Test
+    public void testIntersection_NestedUnionOfLowCardinalityTerm_withSeek() throws Exception {
+        String originalQuery = "(FOO == 'highest_card' && (FOO == 'low_card' || FOO == 'lowest_card'))";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        Range range1 = makeTestRange("20190310_1", "datatype1\u0000a.b.c");
+        Range range2 = makeTestRange("20190312_1", "datatype1\u0000a.b.c");
+        Range range3 = makeTestRange("20190314_22", "datatype1\u0000a.b.c");
+        Range range4 = makeTestRange("20190315_33", "datatype1\u0000a.b.c");
+        Range range5 = makeTestRange("20190315_49", "datatype1\u0000a.b.c");
+        Range range6 = makeTestRange("20190317_1", "datatype1\u0000a.b.c");
+        Set<Range> expectedRanges = Sets.newHashSet(range1, range2, range3, range4, range5, range6);
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
+    }
+    
+    // A || (B && C)
+    @Test
+    public void testUnion_HighCardWithNestedIntersectionOfLowCardTerms_withSeek() throws Exception {
+        String originalQuery = "(FOO == 'low_card' || (FOO == 'high_card' && FOO == 'highest_card'))";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        // Union with the Intersection of the high & highest cardinality terms means we hit every 'high_card' shard.
+        Set<Range> expectedRanges = new HashSet<>();
+        for (int day = 0; day < 8; day += 2) {
+            for (int ii = 1; ii < 50; ii++) {
+                expectedRanges.add(makeTestRange("2019031" + day + "_" + ii, "datatype1\u0000a.b.c"));
+                expectedRanges.add(makeTestRange("2019031" + day + "_" + ii, "datatype1\u0000d.e.f"));
+            }
+        }
+        expectedRanges.add(makeTestRange("20190315_33", "datatype1\u0000a.b.c"));
+        expectedRanges.add(makeTestRange("20190317_1", "datatype1\u0000a.b.c"));
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_OfTwoNestedIntersections_LeftLowCardTerms_withSeek() throws Exception {
+        String originalQuery = "(FOO == 'low_card' && FOO == 'lowest_card') || (FOO == 'high_card' && FOO == 'highest_card')";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        Set<Range> expectedRanges = new HashSet<>();
+        for (int day = 0; day < 8; day += 2) {
+            for (int ii = 1; ii < 50; ii++) {
+                expectedRanges.add(makeTestRange("2019031" + day + "_" + ii, "datatype1\u0000a.b.c"));
+                expectedRanges.add(makeTestRange("2019031" + day + "_" + ii, "datatype1\u0000d.e.f"));
+            }
+        }
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_OfTwoNestedUnions_LeftLowCardTerms_withSeek() throws Exception {
+        String originalQuery = "(FOO == 'low_card' || FOO == 'lowest_card') && (FOO == 'high_card' || FOO == 'highest_card')";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        // Create expected ranges verbosely, so it is obvious which shards contribute to the results.
+        Range range1 = makeTestRange("20190310_1", "datatype1\u0000a.b.c");
+        Range range2 = makeTestRange("20190312_1", "datatype1\u0000a.b.c");
+        Range range3 = makeTestRange("20190314_22", "datatype1\u0000a.b.c");
+        Range range4 = makeTestRange("20190315_33", "datatype1\u0000a.b.c");
+        Range range5 = makeTestRange("20190315_49", "datatype1\u0000a.b.c");
+        Range range6 = makeTestRange("20190317_1", "datatype1\u0000a.b.c");
+        Set<Range> expectedRanges = Sets.newHashSet(range1, range2, range3, range4, range5, range6);
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
+    }
+    
+    // A && B when A term is day ranges and B term is a single shard range within the last day.
+    @Test
+    public void testIntersection_ofDayRangesAndShardRange() throws Exception {
+        String originalQuery = "FOO == 'day_ranges' && FOO == 'shard_range'";
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        // config.setBeginDate(new Date(0));
+        config.setBeginDate(sdf.parse("20190310"));
+        config.setEndDate(sdf.parse("20190320"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1", "datatype2"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("LAUGH", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        config.setShardsPerDayThreshold(2);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        // Create expected ranges verbosely, so it is obvious which shards contribute to the results.
+        Range range1 = makeTestRange("20190310_21", "datatype1\u0000a.b.c");
+        // Fun story. It's hard to roll up to a day range when you seek most of the way through the day and don't have all the shards for the day.
+        // Range range2 = makeTestRange("20190315_51", "datatype1\u0000a.b.c");
+        Set<Range> expectedRanges = Sets.newHashSet(range1);
+        
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        for (QueryPlan queryPlan : queryPlans) {
+            Iterable<Range> ranges = queryPlan.getRanges();
+            for (Range range : ranges) {
+                assertTrue("Tried to remove unexpected range " + range.toString() + "\nfrom expected ranges: " + expectedRanges.toString(),
+                                expectedRanges.remove(range));
+            }
+        }
+        assertTrue("Expected ranges not found in query plan: " + expectedRanges.toString(), expectedRanges.isEmpty());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
@@ -1,0 +1,3202 @@
+package datawave.query.index.lookup;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.Type;
+import datawave.ingest.protobuf.Uid;
+import datawave.query.CloseableIterable;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.jexl.visitors.TreeEqualityVisitor;
+import datawave.query.planner.QueryPlan;
+import datawave.query.tables.ScannerFactory;
+import datawave.query.util.MockMetadataHelper;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static datawave.common.test.utils.query.RangeFactoryForTests.makeDayRange;
+import static datawave.common.test.utils.query.RangeFactoryForTests.makeShardedRange;
+import static datawave.common.test.utils.query.RangeFactoryForTests.makeTestRange;
+import static datawave.util.TableName.SHARD_INDEX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Cover some basic tests involving streams of shards for a basic set of query structures. Only tests for correctness of shard intersection, not that the
+ * underlying IndexInfo objects correctly intersect.
+ *
+ * 6 Basic Types of Query Structures
+ *
+ * 3 Stream Type Combinations (All shards, shards and days, all days)
+ *
+ * 2 Types of Unequal Stream Start/Stop (different start/end day)
+ *
+ * 2 Types of Uneven Stream Start/Stop (same start/end day, different shard)
+ * 
+ * 1 Type of Tick-Tock Shards (alternating shards such that no hits are produced for a day)
+ *
+ * 1 Type of Missing Shards (missing shards should drop terms from query)
+ */
+public class RangeStreamTestX {
+    
+    // A && B
+    // A || B
+    // A && ( B || C )
+    // A || ( B && C )
+    // (A && B) || (C && D)
+    // (A || B) && (C || D)
+    
+    private static InMemoryInstance instance = new InMemoryInstance(RangeStreamTestX.class.toString());
+    private static Connector connector;
+    private ShardQueryConfiguration config;
+    
+    @BeforeClass
+    public static void setupAccumulo() throws Exception {
+        // Zero byte password, so secure it hurts.
+        connector = instance.getConnector("", new PasswordToken(new byte[0]));
+        connector.tableOperations().create(SHARD_INDEX);
+        
+        BatchWriter bw = connector.createBatchWriter(SHARD_INDEX, new BatchWriterConfig().setMaxLatency(10, TimeUnit.SECONDS).setMaxMemory(100000L)
+                        .setMaxWriteThreads(1));
+        
+        // Some values
+        Value valueForShard = buildValueForShard();
+        Value valueForDay = buildValueForDay();
+        
+        // --------------- Hits on every shard for every day
+        Mutation m = new Mutation("all");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Hits on every shard for every day, shards will roll to a day range.
+        m = new Mutation("all_day");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Unequal start, each term misses day 1
+        m = new Mutation("unequal_start");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii > 1) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Unequal start, each term misses day 1, each term rolls to a day range
+        m = new Mutation("unequal_start_day");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii > 1) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Unequal end, each term misses day 5
+        m = new Mutation("unequal_stop");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii < 5) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Unequal end, each term misses day 5
+        m = new Mutation("unequal_stop_day");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii < 5) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Uneven start, each term will miss the first two shards of each day
+        m = new Mutation("uneven_start");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (jj > 0) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Uneven start, each term will miss the first two shards of each day, each term will roll to a day range
+        m = new Mutation("uneven_start_day");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (jj > 0) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Uneven end, each term will miss the last two shards of each day
+        m = new Mutation("uneven_stop");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (jj < 9) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Uneven end, each term will miss the last two shards of each day, each term will roll to a day range.
+        m = new Mutation("uneven_stop_day");
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (jj < 9) {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Tick-tock shard 3, each term takes a turn
+        m = new Mutation("tick_tock");
+        int counter = 0;
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii == 3) {
+                    int mod = counter % 4;
+                    switch (mod) {
+                        case 0:
+                            m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                            break;
+                        case 1:
+                            m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                            break;
+                        case 2:
+                            m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                            break;
+                        case 3:
+                        default:
+                            m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    }
+                } else {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                }
+                counter++;
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Tick-tock shard 3, each term takes a turn, shards roll to days except on day 3.
+        m = new Mutation("tick_tock_day");
+        counter = 0;
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii == 3) {
+                    int mod = counter % 4;
+                    switch (mod) {
+                        case 0:
+                            m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                            break;
+                        case 1:
+                            m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                            break;
+                        case 2:
+                            m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                            break;
+                        case 3:
+                        default:
+                            m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    }
+                    counter++;
+                } else {
+                    m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                    m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                }
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Missing shards for day 3
+        m = new Mutation("missing_shards");
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3) {
+                continue;
+            }
+            for (int jj = 0; jj < 10; jj++) {
+                m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+                m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForShard);
+            }
+        }
+        bw.addMutation(m);
+        
+        // --------------- Missing shards for day 3, existing shards roll to day range
+        m = new Mutation("missing_shards_day");
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3) {
+                continue;
+            }
+            for (int jj = 0; jj < 10; jj++) {
+                m.put(new Text("A"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                m.put(new Text("B"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                m.put(new Text("C"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+                m.put(new Text("D"), new Text("2020010" + ii + "_" + jj + "\0datatype1"), valueForDay);
+            }
+        }
+        bw.addMutation(m);
+        
+        // ---------------
+        
+        bw.flush();
+        bw.close();
+    }
+    
+    private static Value buildValueForShard() {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.addUID("a.b.c");
+        builder.setIGNORE(false);
+        builder.setCOUNT(1);
+        Uid.List list = builder.build();
+        return new Value(list.toByteArray());
+    }
+    
+    // A value that will roll into a day range.
+    private static Value buildValueForDay() {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.setIGNORE(true);
+        builder.setCOUNT(5432);
+        Uid.List list = builder.build();
+        return new Value(list.toByteArray());
+    }
+    
+    @Before
+    public void setupTest() {
+        config = new ShardQueryConfiguration();
+        config.setConnector(connector);
+        config.setShardsPerDayThreshold(20);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards() throws Exception {
+        String query = "A == 'all' && B == 'all'";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && B == 'all'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards_unequalStart() throws Exception {
+        String query = "A == 'all' && B == 'unequal_start'";
+        
+        // B term skips day 1
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 2; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && B == 'unequal_start'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards_unequalStop() throws Exception {
+        String query = "A == 'all' && B == 'unequal_stop'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 4; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && B == 'unequal_stop'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards_unevenStart() throws Exception {
+        String query = "A == 'all' && B == 'uneven_start'";
+        
+        // First shard is skipped for each day in the uneven start case.
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 1; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && B == 'uneven_start'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards_unevenStop() throws Exception {
+        String query = "A == 'all' && B == 'uneven_stop'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 9; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && B == 'uneven_stop'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards_missingShards() throws Exception {
+        String query = "A == 'all' && B == 'missing_shards'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3)
+                continue;
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && B == 'missing_shards'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShards_tickTockShards() throws Exception {
+        String query = "A == 'tick_tock' && B == 'tick_tock'";
+        
+        // No intersection exists between A & B for tick-tock shards for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii != 3) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("(A == 'tick_tock' && B == 'tick_tock')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay() throws Exception {
+        String query = "A == 'all_day' && B == 'all'";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(B == 'all' && ((ASTDelayedPredicate = true) && (A == 'all_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay_unequalStart() throws Exception {
+        String query = "A == 'unequal_start' && B == 'all_day'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 2; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(A == 'unequal_start' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay_unequalStop() throws Exception {
+        String query = "A == 'unequal_stop' && B == 'all_day'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 4; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(A == 'unequal_stop' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay_unevenStart() throws Exception {
+        String query = "A == 'uneven_start' && B == 'all_day'";
+        
+        // Shard 1 is skipped for every day
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 1; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(A == 'uneven_start' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay_unevenStop() throws Exception {
+        String query = "A == 'uneven_stop' && B == 'all_day'";
+        
+        // Shard 9 is skipped for every day
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 9; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(A == 'uneven_stop' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay_missingShards() throws Exception {
+        String query = "A == 'all_day' && B == 'missing_shards'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3)
+                continue;
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'missing_shards'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofShardAndDay_tickTockShards() throws Exception {
+        String query = "A == 'tick_tock' && B == 'tick_tock_day'";
+        
+        // No intersection exists between A & B for tick-tock shards for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii != 3) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("(A == 'tick_tock' && ((ASTDelayedPredicate = true) && (B == 'tick_tock_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays() throws Exception {
+        String query = "A == 'all_day' && B == 'all_day'";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays_unequalStart() throws Exception {
+        String query = "A == 'all_day' && B == 'unequal_start_day'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 2; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'unequal_start_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays_unequalStop() throws Exception {
+        String query = "A == 'all_day' && B == 'unequal_stop_day'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 4; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'unequal_stop_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays_unevenStart() throws Exception {
+        String query = "A == 'all_day' && B == 'uneven_start_day'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'uneven_start_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays_unevenStop() throws Exception {
+        String query = "A == 'all_day' && B == 'uneven_stop_day'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'uneven_stop_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays_missingShards() throws Exception {
+        String query = "A == 'all_day' && B == 'missing_shards_day'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3)
+                continue;
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'missing_shards_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && B
+    @Test
+    public void testIntersection_ofDays_tickTockShards() throws Exception {
+        String query = "A == 'tick_tock_day' && B == 'tick_tock_day'";
+        
+        // No intersection exists between A & B for tick-tock shards for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii != 3) {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'tick_tock_day')) && ((ASTDelayedPredicate = true) && (B == 'tick_tock_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards() throws Exception {
+        String query = "A == 'all' || B == 'all'";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' || B == 'all'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards_unequalStart() throws Exception {
+        String query = "A == 'all' || B == 'unequal_start'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+            }
+        }
+        
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 0; ii < 10; ii++)
+            expectedQueryStrings.add("A == 'all'");
+        
+        for (int ii = 0; ii < 40; ii++)
+            expectedQueryStrings.add("A == 'all' || B == 'unequal_start'");
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards_unequalStop() throws Exception {
+        String query = "A == 'all' || B == 'unequal_stop'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+            }
+        }
+        
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 0; ii < 40; ii++)
+            expectedQueryStrings.add("A == 'all' || B == 'unequal_stop'");
+        
+        for (int ii = 0; ii < 10; ii++)
+            expectedQueryStrings.add("A == 'all'");
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards_unevenStart() throws Exception {
+        String query = "A == 'all' || B == 'uneven_start'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+            }
+        }
+        
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 0; ii < 50; ii++) {
+            int mod = ii % 10;
+            if (mod == 0) {
+                expectedQueryStrings.add("A == 'all'");
+            } else {
+                expectedQueryStrings.add("A == 'all' || B == 'uneven_start'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards_unevenStop() throws Exception {
+        String query = "A == 'all' || B == 'uneven_stop'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+            }
+        }
+        
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 0; ii < 50; ii++) {
+            int mod = ii % 10;
+            if (mod == 9) {
+                expectedQueryStrings.add("A == 'all'");
+            } else {
+                expectedQueryStrings.add("A == 'all' || B == 'uneven_stop'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards_missingShards() throws Exception {
+        String query = "A == 'all' || B == 'missing_shards'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+            }
+        }
+        
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 0; ii < 50; ii++) {
+            if (ii >= 20 && ii < 30) {
+                expectedQueryStrings.add("A == 'all'");
+            } else {
+                expectedQueryStrings.add("A == 'all' || B == 'missing_shards'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShards_tickTockShards() throws Exception {
+        String query = "A == 'tick_tock' || B == 'tick_tock'";
+        
+        // Only hit on B's shards
+        List<Range> expectedRanges = new ArrayList<>();
+        int mod;
+        int counter = 0;
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                if (ii == 3) {
+                    mod = counter % 4;
+                    if (mod == 0 || mod == 1) {
+                        expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    }
+                } else {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                }
+                counter++;
+            }
+        }
+        
+        List<String> expectedQueryStrings = new ArrayList<>();
+        counter = 0;
+        for (int ii = 0; ii < 50; ii++) {
+            if (ii >= 20 && ii < 30) {
+                mod = counter % 4;
+                if (mod == 0) {
+                    expectedQueryStrings.add("A == 'tick_tock'");
+                } else if (mod == 1) {
+                    expectedQueryStrings.add("B == 'tick_tock'");
+                }
+            } else {
+                expectedQueryStrings.add("(A == 'tick_tock' || B == 'tick_tock')");
+            }
+            counter++;
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay() throws Exception {
+        String query = "A == 'all' || B == 'all_day'";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(A == 'all' || ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay_unequalStart() throws Exception {
+        String query = "A == 'all' || B == 'unequal_start_day'";
+        
+        // B term skips day 1
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 1) {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            } else {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'unequal_start_day'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay_unequalStop() throws Exception {
+        String query = "A == 'all' || B == 'unequal_stop_day'";
+        
+        // B term skips day 1
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 5) {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            } else {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'unequal_stop_day'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay_unevenStart() throws Exception {
+        String query = "A == 'all' || B == 'uneven_start_day'";
+        
+        // B term skips day 1
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'uneven_start_day'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay_unevenStop() throws Exception {
+        String query = "A == 'all' || B == 'uneven_stop_day'";
+        
+        // B term skips day 1
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'uneven_stop_day'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay_missingShards() throws Exception {
+        String query = "A == 'all' || B == 'missing_shards_day'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3) {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            } else {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'missing_shards_day'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofShardAndDay_tickTockShards() throws Exception {
+        String query = "A == 'all' || B == 'tick_tock_day'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        
+        expectedRanges.add(makeDayRange("20200101"));
+        expectedRanges.add(makeDayRange("20200102"));
+        expectedRanges.add(makeTestRange("20200103_0", "datatype1\0a.b.c"));
+        expectedRanges.add(makeShardedRange("20200103_1"));
+        expectedRanges.add(makeTestRange("20200103_2", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200103_3", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200103_4", "datatype1\0a.b.c"));
+        expectedRanges.add(makeShardedRange("20200103_5"));
+        expectedRanges.add(makeTestRange("20200103_6", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200103_7", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200103_8", "datatype1\0a.b.c"));
+        expectedRanges.add(makeShardedRange("20200103_9"));
+        expectedRanges.add(makeDayRange("20200104"));
+        expectedRanges.add(makeDayRange("20200105"));
+        
+        expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'tick_tock_day'))");
+        expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'tick_tock_day'))");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all' || B == 'tick_tock_day'");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all' || B == 'tick_tock_day'");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all'");
+        expectedQueryStrings.add("A == 'all' || B == 'tick_tock_day'");
+        expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'tick_tock_day'))");
+        expectedQueryStrings.add("A == 'all' || ((ASTDelayedPredicate = true) && (B == 'tick_tock_day'))");
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays() throws Exception {
+        String query = "A == 'all_day' || B == 'all_day'";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays_unequalStart() throws Exception {
+        String query = "A == 'all_day' || B == 'unequal_start_day'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 1) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'unequal_start_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays_unequalStop() throws Exception {
+        String query = "A == 'all_day' || B == 'unequal_stop_day'";
+        
+        // Day 1 is skipped in the unequal start and Day 5 is skipped in the unequal end
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 5) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'unequal_stop_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays_unevenStart() throws Exception {
+        String query = "A == 'all_day' || B == 'uneven_start_day'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'uneven_start_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays_unevenStop() throws Exception {
+        String query = "A == 'all_day' || B == 'uneven_stop_day'";
+        
+        // First and last shards are skipped for each day in the uneven start/end case.
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'uneven_stop_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays_missingShards() throws Exception {
+        String query = "A == 'all_day' || B == 'missing_shards_day'";
+        
+        // Shards are missing for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'missing_shards_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || B
+    @Test
+    public void testUnion_ofDays_tickTockShards() throws Exception {
+        String query = "A == 'tick_tock_day' || B == 'tick_tock_day'";
+        
+        // No intersection exists between A & B for tick-tock shards for day 3
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii != 3) {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'tick_tock_day')) || ((ASTDelayedPredicate = true) && (B == 'tick_tock_day')))");
+            } else {
+                expectedRanges.add(makeShardedRange("20200103_0"));
+                expectedRanges.add(makeShardedRange("20200103_1"));
+                expectedRanges.add(makeShardedRange("20200103_4"));
+                expectedRanges.add(makeShardedRange("20200103_5"));
+                expectedRanges.add(makeShardedRange("20200103_8"));
+                expectedRanges.add(makeShardedRange("20200103_9"));
+                expectedQueryStrings.add("A == 'tick_tock_day'");
+                expectedQueryStrings.add("B == 'tick_tock_day'");
+                expectedQueryStrings.add("A == 'tick_tock_day'");
+                expectedQueryStrings.add("B == 'tick_tock_day'");
+                expectedQueryStrings.add("A == 'tick_tock_day'");
+                expectedQueryStrings.add("B == 'tick_tock_day'");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'all')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'all')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards_unequalStart() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    expectedQueryStrings.add("A == 'all' && B == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'unequal_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards_unequalStop() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    expectedQueryStrings.add("A == 'all' && B == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'unequal_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards_unevenStart() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 0) {
+                    expectedQueryStrings.add("A == 'all' && B == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'uneven_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards_unevenStop() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 9) {
+                    expectedQueryStrings.add("A == 'all' && B == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'uneven_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards_missingShards() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'missing_shards')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("A == 'all' && B == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'missing_shards')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allShards_tickTockShards() throws Exception {
+        String query = "A == 'all' && (B == 'all' || C == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 2 || jj == 6) {
+                    expectedQueryStrings.add("A == 'all' && (B == 'all' || C == 'tick_tock')");
+                } else {
+                    expectedQueryStrings.add("A == 'all' && B == 'all'");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day'))))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays_unequalStart() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 1) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'unequal_start_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays_unequalStop() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 5) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'unequal_stop_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays_unevenStart() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'uneven_start_day'))))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays_unevenStop() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'uneven_stop_day'))))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays_missingShards() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'missing_shards_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_withNestedUnion_allDays_tickTockShards() throws Exception {
+        String query = "A == 'all_day' && (B == 'all_day' || C == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (((ASTDelayedPredicate = true) && (B == 'all_day')) || C == 'tick_tock'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'all')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'all'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards_unequalStart() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'unequal_start'))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards_unequalStop() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'unequal_stop'))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards_unevenStart() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 0) {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'uneven_start'))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards_unevenStop() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 9) {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'uneven_stop'))");
+                }
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards_missingShards() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'missing_shards')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'missing_shards'))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_dayWithNestedUnionOfShards_tickTockShards() throws Exception {
+        String query = "A == 'all_day' && (B == 'all' || C == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 2 || jj == 6) {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && (B == 'all' || C == 'tick_tock'))");
+                } else {
+                    expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) && B == 'all')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings
+                                .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day')))");
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays_unequalStart() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    expectedQueryStrings.add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'unequal_start_day')))");
+                }
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays_unequalStop() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    expectedQueryStrings.add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'unequal_stop_day')))");
+                }
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays_unevenStart() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings
+                                .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'uneven_start_day')))");
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays_unevenStop() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings
+                                .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'uneven_stop_day')))");
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays_missingShards() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'missing_shards_day')))");
+                }
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A && ( B || C )
+    @Test
+    public void testIntersection_shardWithNestedUnionOfDays_tickTockShards() throws Exception {
+        String query = "A == 'all' && (B == 'all_day' || C == 'tick_tock_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    // Not enough shards to force rolling the C-term to a day range, thus no delay.
+                    expectedQueryStrings.add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || (C == 'tick_tock_day'))");
+                } else {
+                    expectedQueryStrings
+                                    .add("A == 'all' && (((ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'tick_tock_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'all')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'all')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards_unequalStart() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    // Can't intersect B-term with a non-existent C-term. Whole intersection is dropped for day 1.
+                    expectedQueryStrings.add("A == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'unequal_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards_unequalStop() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    // Can't intersect B-term with a non-existent C-term. Whole intersection is dropped for day 5.
+                    expectedQueryStrings.add("A == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'unequal_stop')");
+                }
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards_unevenStart() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 0) {
+                    // Can't intersect B-term with a non-existent C-term. Whole intersection is dropped for first shard of each day.
+                    expectedQueryStrings.add("A == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'uneven_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards_unevenStop() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 9) {
+                    // Can't intersect B-term with a non-existent C-term. Whole intersection is dropped for last shard of each day.
+                    expectedQueryStrings.add("A == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'uneven_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards_missingShards() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'missing_shards')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("A == 'all'");
+                } else {
+                    expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'missing_shards')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allShards_tickTockShards() throws Exception {
+        String query = "A == 'all' || (B == 'all' && C == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 2 || jj == 6) {
+                    expectedQueryStrings.add("A == 'all' || (B == 'all' && C == 'tick_tock')");
+                } else {
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'all_day'))))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays_unequalStart() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 1) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'unequal_start_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays_unequalStop() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 5) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'unequal_stop_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays_unevenStart() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'uneven_start_day'))))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays_unevenStop() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'uneven_stop_day'))))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays_missingShards() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'missing_shards_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_withNestedIntersection_allDays_tickTockShards() throws Exception {
+        String query = "A == 'all_day' || (B == 'all_day' && C == 'tick_tock_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && C == 'tick_tock_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'tick_tock_day'))))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'all')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'all')");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards_unequalStart() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 1) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'unequal_start')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards_unequalStop() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 5) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'unequal_stop')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards_unevenStart() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 0) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'uneven_start')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards_unevenStop() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 0) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'uneven_stop')");
+            }
+        }
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards_missingShards() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'missing_shards')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day'))");
+            } else {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'missing_shards')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_dayWithNestedIntersectionOfShards_tickTockShards() throws Exception {
+        String query = "A == 'all_day' || (B == 'all' && C == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day')) || (B == 'all' && C == 'tick_tock')");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'all_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays_unequalStart() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii != 1) {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'unequal_start_day')))");
+            } else {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays_unequalStop() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii != 5) {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'unequal_stop_day')))");
+            } else {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays_unevenStart() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'uneven_start_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays_unevenStop() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'uneven_stop_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays_missingShards() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 3) {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("A == 'all'");
+                }
+            } else {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'missing_shards_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // A || ( B && C )
+    @Test
+    public void testUnion_shardWithNestedIntersectionOfDays_tickTockShards() throws Exception {
+        String query = "A == 'all' || (B == 'all_day' && C == 'tick_tock_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii != 3) {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && ((ASTDelayedPredicate = true) && (C == 'tick_tock_day')))");
+            } else {
+                for (int jj = 0; jj < 10; jj++) {
+                    if (jj == 2 || jj == 6) {
+                        expectedRanges.add(makeShardedRange("20200103_" + jj));
+                        expectedQueryStrings.add("A == 'all' || (((ASTDelayedPredicate = true) && (B == 'all_day')) && (C == 'tick_tock_day'))");
+                    } else {
+                        expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                        expectedQueryStrings.add("A == 'all'");
+                    }
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'all')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'all')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards_unequalStart() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'unequal_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards_unequalStop() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'unequal_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards_unevenStart() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 0) {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'uneven_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards_unevenStop() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 9) {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'uneven_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards_missingShards() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'missing_shards')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'missing_shards')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allShards_tickTockShards() throws Exception {
+        String query = "(A == 'all' && B == 'all') || (C == 'all' && D == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 3 || jj == 7) {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all') || (C == 'all' && D == 'tick_tock')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && B == 'all')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && (ASTDelayedPredicate = true) && (D == 'all_day'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays_unequalStart() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 1) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && D == 'unequal_start')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays_unequalStop() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 5) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && D == 'unequal_stop')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays_unevenStart() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && D == 'uneven_start')");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays_unevenStop() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && D == 'uneven_stop')");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays_missingShards() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings.add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day'))");
+            } else {
+                expectedQueryStrings
+                                .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && ((ASTDelayedPredicate = true) && (D == 'missing_shards_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_allDays_tickTockShards() throws Exception {
+        String query = "(A == 'all_day' && B == 'all_day') || (C == 'all_day' && D == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((ASTDelayedPredicate = true) && (A == 'all_day') && (ASTDelayedPredicate = true) && (B == 'all_day')) || ((ASTDelayedPredicate = true) && (C == 'all_day') && D == 'tick_tock')");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings
+                                .add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && ((ASTDelayedPredicate = true) && (D == 'all_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays_unequalStart() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && ((ASTDelayedPredicate = true) && (D == 'unequal_start_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays_unequalStop() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && ((ASTDelayedPredicate = true) && (D == 'unequal_stop_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays_unevenStart() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 0) {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && ((ASTDelayedPredicate = true) && (D == 'uneven_start_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays_unevenStop() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 0) {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && ((ASTDelayedPredicate = true) && (D == 'uneven_stop_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays_missingShards() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                } else {
+                    expectedQueryStrings
+                                    .add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && ((ASTDelayedPredicate = true) && (D == 'missing_shards_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A && B) || (C && D)
+    @Test
+    public void testUnion_ofNestedIntersections_distributedDays_tickTockShards() throws Exception {
+        String query = "(A == 'all' && B == 'all_day') || (C == 'all' && D == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 3 || jj == 7) {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day'))) || (C == 'all' && D == 'tick_tock')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' && ((ASTDelayedPredicate = true) && (B == 'all_day')))");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'all')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'all')");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards_unequalStart() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'unequal_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 1) {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && C == 'all'");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'unequal_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards_unequalStop() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'unequal_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 5) {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && C == 'all'");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'unequal_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards_unevenStart() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'uneven_start')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 0) {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && C == 'all'");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'uneven_start')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards_unevenStop() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'uneven_stop')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (jj == 9) {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && C == 'all'");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'uneven_stop')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards_missingShards() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'missing_shards')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii == 3) {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && C == 'all'");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'missing_shards')");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allShards_tickTockShards() throws Exception {
+        String query = "(A == 'all' || B == 'all') && (C == 'all' || D == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 3 || jj == 7) {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && (C == 'all' || D == 'tick_tock')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || B == 'all') && C == 'all'");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || ((ASTDelayedPredicate = true) && (D == 'all_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays_unequalStart() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 1) {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || ((ASTDelayedPredicate = true) && (D == 'unequal_start_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays_unequalStop() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 5) {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || ((ASTDelayedPredicate = true) && (D == 'unequal_stop_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays_unevenStart() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || ((ASTDelayedPredicate = true) && (D == 'uneven_start_day')))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays_unevenStop() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            // if(ii == 5){
+            // expectedQueryStrings.add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')))");
+            // } else {
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || ((ASTDelayedPredicate = true) && (D == 'uneven_stop_day')))");
+            // }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays_missingShards() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'missing_shards_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            if (ii == 3) {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')))");
+            } else {
+                expectedQueryStrings
+                                .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || ((ASTDelayedPredicate = true) && (D == 'missing_shards_day')))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_allDays_tickTockShards() throws Exception {
+        String query = "(A == 'all_day' || B == 'all_day') && (C == 'all_day' || D == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("(((ASTDelayedPredicate = true) && (A == 'all_day')) || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (((ASTDelayedPredicate = true) && (C == 'all_day')) || D == 'tick_tock')");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'all_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all') || (ASTDelayedPredicate = true) && (D == 'all_day'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays_unequalStart() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'unequal_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 1) {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all'))");
+                }
+            } else {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all') || (ASTDelayedPredicate = true) && (D == 'unequal_start_day'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays_unequalStop() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'unequal_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            if (ii == 5) {
+                for (int jj = 0; jj < 10; jj++) {
+                    expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                    expectedQueryStrings.add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all'))");
+                }
+            } else {
+                expectedRanges.add(makeDayRange("2020010" + ii));
+                expectedQueryStrings
+                                .add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all') || (ASTDelayedPredicate = true) && (D == 'unequal_stop_day'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays_unevenStart() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'uneven_start_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all') || (ASTDelayedPredicate = true) && (D == 'uneven_start_day'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays_unevenStop() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'uneven_stop_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            expectedRanges.add(makeDayRange("2020010" + ii));
+            expectedQueryStrings
+                            .add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all') || (ASTDelayedPredicate = true) && (D == 'uneven_stop_day'))");
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays_missingShards() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'missing_shard_day')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                expectedQueryStrings.add("((A == 'all') || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && ((C == 'all'))");
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    // (A || B) && (C || D)
+    @Test
+    public void testIntersection_ofNestedUnions_distributedDays_tickTockShards() throws Exception {
+        String query = "(A == 'all' || B == 'all_day') && (C == 'all' || D == 'tick_tock')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        List<String> expectedQueryStrings = new ArrayList<>();
+        for (int ii = 1; ii <= 5; ii++) {
+            for (int jj = 0; jj < 10; jj++) {
+                expectedRanges.add(makeTestRange("2020010" + ii + "_" + jj, "datatype1\0a.b.c"));
+                if (ii != 3 || jj == 3 || jj == 7) {
+                    expectedQueryStrings.add("(A == 'all' || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && (C == 'all' || D == 'tick_tock')");
+                } else {
+                    expectedQueryStrings.add("(A == 'all' || ((ASTDelayedPredicate = true) && (B == 'all_day'))) && C == 'all'");
+                }
+            }
+        }
+        
+        runTest(query, expectedRanges, expectedQueryStrings);
+    }
+    
+    private void runTest(String query, List<Range> expectedRanges, List<String> expectedQueries) throws Exception {
+        
+        assertEquals("Expected ranges and queries do not match, ranges: " + expectedRanges.size() + " queries: " + expectedQueries.size(),
+                        expectedRanges.size(), expectedQueries.size());
+        
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        // config.setBeginDate(new Date(0));
+        config.setBeginDate(sdf.parse("20200101"));
+        config.setEndDate(sdf.parse("20200105"));
+        
+        config.setDatatypeFilter(Sets.newHashSet("datatype1"));
+        
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("A", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("B", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("C", Sets.newHashSet(new LcNoDiacriticsType()));
+        dataTypes.putAll("D", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setIndexedFields(dataTypes);
+        config.setShardsPerDayThreshold(2);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(dataTypes.keySet());
+        
+        // Run a standard limited-scanner range stream.
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        runTest(rangeStream, script, expectedRanges, expectedQueries);
+        
+        // Run a default range stream.
+        rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(false);
+        runTest(rangeStream, script, expectedRanges, expectedQueries);
+    }
+    
+    private void runTest(RangeStream rangeStream, ASTJexlScript script, List<Range> expectedRanges, List<String> expectedQueries) throws Exception {
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        
+        Iterator<Range> shardIter = expectedRanges.iterator();
+        Iterator<String> queryIter = expectedQueries.iterator();
+        
+        // Should have one range per query plan
+        int counter = 0;
+        for (QueryPlan queryPlan : queryPlans) {
+            
+            // Assert proper range
+            Iterator<Range> rangeIter = queryPlan.getRanges().iterator();
+            Range planRange = rangeIter.next();
+            Range expectedRange = shardIter.next();
+            
+            assertEquals("Query produced unexpected range: " + planRange.toString(), expectedRange, planRange);
+            assertFalse("Query plan had more than one range!", rangeIter.hasNext());
+            
+            // Assert proper query string for this range.
+            
+            ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(queryIter.next());
+            ASTJexlScript planScript = JexlNodeFactory.createScript(queryPlan.getQueryTree());
+            
+            String expectedString = JexlStringBuildingVisitor.buildQuery(expectedScript);
+            String plannedString = JexlStringBuildingVisitor.buildQuery(planScript);
+            
+            // Re-parse to avoid weird cases of DelayedPredicates
+            expectedScript = JexlASTHelper.parseJexlQuery(expectedString);
+            planScript = JexlASTHelper.parseJexlQuery(plannedString);
+            
+            assertTrue("Queries did not match for counter: " + counter + " on shard: " + planRange.toString() + "\nExpected: " + expectedString
+                            + "\nActual  : " + plannedString, TreeEqualityVisitor.isEqual(expectedScript, planScript, new TreeEqualityVisitor.Reason()));
+            counter++;
+        }
+        
+        // Ensure we didn't miss any expected ranges or queries
+        if (shardIter.hasNext())
+            fail("Expected ranges still exist after test: " + shardIter.next());
+        if (queryIter.hasNext())
+            fail("Expected queries still exist after test: " + queryIter.next());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/ScannerStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/ScannerStreamTest.java
@@ -1,0 +1,169 @@
+package datawave.query.index.lookup;
+
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.util.Tuple2;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+public class ScannerStreamTest {
+    
+    private SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+    
+    @Test
+    public void testHasNextPeekIteration() {
+        List<Tuple2<String,IndexInfo>> elements = createIter("20090606", "20090704");
+        ScannerStream stream = buildScannerStream(elements.iterator());
+        
+        while (stream.hasNext()) {
+            stream.peek();
+            stream.next();
+        }
+        assertFalse(stream.hasNext());
+    }
+    
+    // Repeated peek() calls followed by a next() should return the same element.
+    @Test
+    public void testPeekingIteratorContract() {
+        List<Tuple2<String,IndexInfo>> elements = createIter("20090606", "20090606");
+        ScannerStream stream = buildScannerStream(elements.iterator());
+        
+        Tuple2<String,IndexInfo> top = stream.peek();
+        for (int ii = 0; ii < 25; ii++) {
+            assertEquals(top, stream.peek());
+        }
+        assertEquals(top, stream.next());
+    }
+    
+    // It's overkill to create a fresh stream before each seek, but standards.
+    @Test
+    public void testSeekByNext_dayRange() {
+        List<Tuple2<String,IndexInfo>> elements = createIter("20090606", "20090704");
+        
+        // Seek before the start
+        ScannerStream stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090605"));
+        
+        // Seek to the start
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090606"));
+        
+        // Seek to the middle-ish
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090630", stream.seekByNext("20090630"));
+        
+        // Seek to the end
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090704", stream.seekByNext("20090704"));
+        
+        // Seek beyond the end
+        stream = buildScannerStream(elements.iterator());
+        assertNull(stream.seekByNext("20090705"));
+    }
+    
+    // Seek by a day range returned from the CondensedUidIterator. We don't support this
+    // but it might be nice to have built in guards
+    @Test
+    public void testSeekByNext_altDayRange() {
+        List<Tuple2<String,IndexInfo>> elements = createIter("20090606", "20090704");
+        
+        // Seek before the start
+        ScannerStream stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090605_"));
+        
+        // Seek to the start
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090606_"));
+        
+        // Seek to the middle-ish
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090630", stream.seekByNext("20090630_"));
+        
+        // Seek to the end
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090704", stream.seekByNext("20090704_"));
+        
+        // Seek beyond the end
+        stream = buildScannerStream(elements.iterator());
+        assertNull(stream.seekByNext("20090705_"));
+    }
+    
+    @Test
+    public void testSeekByNext_shardRange() {
+        List<Tuple2<String,IndexInfo>> elements = createIter("20090606", "20090704");
+        
+        // Seek before the start
+        ScannerStream stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090605_1"));
+        
+        // Seek to the start
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090606_1"));
+        
+        // Seek to the middle-ish
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090630", stream.seekByNext("20090630_1"));
+        
+        // Seek to the end
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090704", stream.seekByNext("20090704_1"));
+        
+        // Seek beyond the end
+        stream = buildScannerStream(elements.iterator());
+        assertNull(stream.seekByNext("20090705_1"));
+    }
+    
+    @Test
+    public void testSeekByNext_altShardRange() {
+        List<Tuple2<String,IndexInfo>> elements = createIter("20090606", "20090704");
+        
+        // Seek before the start
+        ScannerStream stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090605_11"));
+        
+        // Seek to the start
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090606", stream.seekByNext("20090606_11"));
+        
+        // Seek to the middle-ish
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090630", stream.seekByNext("20090630_11"));
+        
+        // Seek to the end
+        stream = buildScannerStream(elements.iterator());
+        assertEquals("20090704", stream.seekByNext("20090704_11"));
+        
+        // Seek beyond the end
+        stream = buildScannerStream(elements.iterator());
+        assertNull(stream.seekByNext("20090705_11"));
+    }
+    
+    public List<Tuple2<String,IndexInfo>> createIter(String startDate, String endDate) {
+        try {
+            ShardQueryConfiguration config = new ShardQueryConfiguration();
+            config.setBeginDate(sdf.parse(startDate));
+            config.setEndDate(sdf.parse(endDate));
+            
+            JexlNode node = JexlNodeFactory.buildEQNode("FOO", "bar");
+            
+            return RangeStream.createFullFieldIndexScanList(config, node);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
+    public ScannerStream buildScannerStream(Iterator<Tuple2<String,IndexInfo>> iter) {
+        JexlNode node = JexlNodeFactory.buildEQNode("FOO", "bar");
+        return ScannerStream.withData(iter, node);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/ShardEqualityTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/ShardEqualityTest.java
@@ -1,0 +1,102 @@
+package datawave.query.index.lookup;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShardEqualityTest {
+    
+    @Test
+    public void testMatchesWithin() {
+        assertTrue(ShardEquality.matchesWithin("20190314", "20190314"));
+        assertTrue(ShardEquality.matchesWithin("20190314", "20190314_0"));
+        assertTrue(ShardEquality.matchesWithin("20190314", "20190314_15"));
+        
+        assertFalse(ShardEquality.matchesWithin("20190314_0", "20190314"));
+        assertFalse(ShardEquality.matchesWithin("20190314_15", "20190314"));
+        
+        assertFalse(ShardEquality.matchesWithin("20190314", "20190315"));
+        assertFalse(ShardEquality.matchesWithin("20190314", "20190315_0"));
+        assertFalse(ShardEquality.matchesWithin("20190314", "20200202"));
+        assertFalse(ShardEquality.matchesWithin("20190314", "20200202_22"));
+    }
+    
+    @Test
+    public void testLessThan() {
+        // Shards
+        assertTrue(ShardEquality.lessThan("20190314", "20190314_0"));
+        assertTrue(ShardEquality.lessThan("20190314_0", "20190314_1"));
+        assertTrue(ShardEquality.lessThan("20190314_1", "20190314_11"));
+        assertTrue(ShardEquality.lessThan("20190314_1", "20190314_2"));
+        
+        // Days
+        assertTrue(ShardEquality.lessThan("20190314", "20190315_0"));
+        assertTrue(ShardEquality.lessThan("20190314_0", "20190315_1"));
+        assertTrue(ShardEquality.lessThan("20190314_1", "20190315_11"));
+        assertTrue(ShardEquality.lessThan("20190314_1", "20190315_2"));
+    }
+    
+    @Test
+    public void testAfter() {
+        // Shards
+        assertTrue(ShardEquality.greaterThan("20190314_0", "20190314"));
+        assertTrue(ShardEquality.greaterThan("20190314_1", "20190314_0"));
+        assertTrue(ShardEquality.greaterThan("20190314_11", "20190314_1"));
+        assertTrue(ShardEquality.greaterThan("20190314_2", "20190314_1"));
+        
+        // Days
+        assertTrue(ShardEquality.greaterThan("20190315_0", "20190314"));
+        assertTrue(ShardEquality.greaterThan("20190315_1", "20190314_0"));
+        assertTrue(ShardEquality.greaterThan("20190315_11", "20190314_1"));
+        assertTrue(ShardEquality.greaterThan("20190315_2", "20190314_1"));
+    }
+    
+    @Test
+    public void testGreaterThan() {
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314", "20190314"));
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314", "20190301"));
+        assertFalse(ShardEquality.greaterThanOrEqual("20190314", "20190314_17"));
+    }
+    
+    @Test
+    public void testGreaterThanOrEqual() {
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314", "20190314"));
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314", "20190301"));
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314_17", "20190301_17"));
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314_18", "20190301_17"));
+        assertTrue(ShardEquality.greaterThanOrEqual("20190314_100", "20190301_17"));
+        assertFalse(ShardEquality.greaterThanOrEqual("20190314", "20190314_17"));
+    }
+    
+    @Test
+    public void testIsDay() {
+        assertTrue(ShardEquality.isDay("20190314"));
+        assertTrue(ShardEquality.isDay("20200202"));
+        assertTrue(ShardEquality.isDay("99990000"));
+        
+        assertFalse(ShardEquality.isDay("20190314_15"));
+        assertFalse(ShardEquality.isDay("20191224_12"));
+        assertFalse(ShardEquality.isDay("20200101_0"));
+        assertFalse(ShardEquality.isDay("20200101_"));
+    }
+    
+    @Test
+    public void testDaysMatch() {
+        assertTrue(ShardEquality.daysMatch("20190314", "20190314"));
+        assertTrue(ShardEquality.daysMatch("20190314", "20190314_11"));
+        assertFalse(ShardEquality.daysMatch("20190314", "20191224"));
+        assertFalse(ShardEquality.daysMatch("20190314", "20190307_117"));
+        
+        // Test 'non-standard' years, i.e., greater and less than 4 digits
+        // 40k != 2019
+        assertFalse(ShardEquality.daysMatch("400001225", "20190307_117"));
+        assertFalse(ShardEquality.daysMatch("400001225", "20190307"));
+        // 867 A.D. != 2019
+        assertFalse(ShardEquality.daysMatch("8671225", "20190307_117"));
+        assertFalse(ShardEquality.daysMatch("8671225", "20190307"));
+        // 40K != 876 A.D.
+        assertFalse(ShardEquality.daysMatch("8671225", "400001225"));
+        assertFalse(ShardEquality.daysMatch("400001225", "8671225"));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/UnionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/UnionTest.java
@@ -10,13 +10,17 @@ import org.apache.commons.jexl2.parser.JexlNode;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -124,5 +128,335 @@ public class UnionTest {
         expectedIndexInfo.applyNode(JexlNodeFactory.buildEQNode("FIELD", "VALUE"));
         assertEquals(expectedIndexInfo, nextedTuple.second());
         assertFalse(union.hasNext());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfShards_seekBeforeStreamStart() {
+        // Seek to a day range before the IndexStream
+        Union union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190202"));
+        assertEquals("20190301_0", union.next().first());
+        
+        // Seek to a day-underscore range before the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190202_"));
+        assertEquals("20190301_0", union.next().first());
+        
+        // Seek to a shard range before the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190202_0"));
+        assertEquals("20190301_0", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfShards_seekToStreamStart() {
+        // Seek to a day range at the start of the IndexStream
+        Union union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190301"));
+        assertEquals("20190301_0", union.next().first());
+        
+        // Seek to a day-underscore range at the start of the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190301_"));
+        assertEquals("20190301_0", union.next().first());
+        
+        // Seek to a shard range before at the start of the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190301_0"));
+        assertEquals("20190301_0", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfShards_seekToMiddleOfStream() {
+        // Seek to a day range in the middle of the IndexStream
+        Union union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190303_0", union.seek("20190303"));
+        assertEquals("20190303_0", union.next().first());
+        
+        // Seek to a day-underscore range in the middle of the IndexStream
+        union = buildUnionOfShards();
+        assertEquals("20190303_0", union.seek("20190303_"));
+        assertEquals("20190303_0", union.next().first());
+        
+        // Seek to a shard range in the middle of the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190303_3", union.seek("20190303_3"));
+        assertEquals("20190303_3", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfShards_seekToNonExistentMiddleOfStream() {
+        // Seek to a non-existent day range in the middle of the IndexStream
+        Union union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190307_0", union.seek("20190305"));
+        assertEquals("20190307_0", union.next().first());
+        
+        // Seek to a non-existent day-underscore range to the middle of the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190307_0", union.seek("20190305_"));
+        assertEquals("20190307_0", union.next().first());
+        
+        // Seek to a non-existent shard range to the middle of of the IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190307_0", union.seek("20190305_0"));
+        assertEquals("20190307_0", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfShards_seekToEndOfStream() {
+        // Seek to the last day range in this IndexStream
+        Union union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190309_0", union.seek("20190309"));
+        assertEquals("20190309_0", union.next().first());
+        
+        // Seek to the last day-underscore range in this IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190309_0", union.seek("20190309_"));
+        assertEquals("20190309_0", union.next().first());
+        
+        // Seek to the last shard range in this IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertEquals("20190309_9", union.seek("20190309_9"));
+        assertEquals("20190309_9", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfShards_seekBeyondEndOfStream() {
+        // Seek to a day range beyond the end of this IndexStream
+        Union union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertNull(union.seek("20190310"));
+        assertFalse(union.hasNext());
+        assertNull(union.next());
+        
+        // Seek to a day-underscore range beyond the end of this IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertNull(union.seek("20190310_"));
+        assertFalse(union.hasNext());
+        assertNull(union.next());
+        
+        // Seek to a shard range beyond the end of this IndexStream
+        union = buildUnionOfShards();
+        assertTrue(union.hasNext());
+        assertNull(union.seek("20190309_99"));
+        assertFalse(union.hasNext());
+        assertNull(union.next());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfDays_seekBeforeStreamStart() {
+        // Seek to a day range before the IndexStream
+        Union union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190301", union.seek("20190202"));
+        assertEquals("20190301", union.next().first());
+        
+        // Seek to a day-underscore range before the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190301", union.seek("20190202_"));
+        assertEquals("20190301", union.next().first());
+        
+        // Seek to a shard range before the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190301", union.seek("20190202_0"));
+        assertEquals("20190301", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfDays_seekToStreamStart() {
+        // Seek to a day range at the start of the IndexStream
+        Union union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190301", union.seek("20190301"));
+        assertEquals("20190301", union.next().first());
+        
+        // Seek to a day-underscore range at the start of the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190301", union.seek("20190301_"));
+        assertEquals("20190301", union.next().first());
+        
+        // Seek to a shard range before at the start of the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190301_0", union.seek("20190301_0"));
+        assertEquals("20190301_0", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfDays_seekToMiddleOfStream() {
+        // Seek to a day range in the middle of the IndexStream
+        Union union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190303", union.seek("20190303"));
+        assertEquals("20190303", union.next().first());
+        
+        // Seek to a day-underscore range in the middle of the IndexStream
+        union = buildUnionOfDays();
+        assertEquals("20190303", union.seek("20190303_"));
+        assertEquals("20190303", union.next().first());
+        
+        // Seek to a shard range in the middle of the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190303", union.seek("20190303_3"));
+        assertEquals("20190303", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfDays_seekToNonExistentMiddleOfStream() {
+        // Seek to a non-existent day range in the middle of the IndexStream
+        Union union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190307", union.seek("20190305"));
+        assertEquals("20190307", union.next().first());
+        
+        // Seek to a non-existent day-underscore range to the middle of the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190307", union.seek("20190305_"));
+        assertEquals("20190307", union.next().first());
+        
+        // Seek to a non-existent shard range to the middle of of the IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190307", union.seek("20190305_0"));
+        assertEquals("20190307", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfDays_seekToEndOfStream() {
+        // Seek to the last day range in this IndexStream
+        Union union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190309", union.seek("20190309"));
+        assertEquals("20190309", union.next().first());
+        
+        // Seek to the last day-underscore range in this IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190309", union.seek("20190309_"));
+        assertEquals("20190309", union.next().first());
+        
+        // Seek to the last shard range in this IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertEquals("20190309", union.seek("20190309_9"));
+        assertEquals("20190309", union.next().first());
+    }
+    
+    // A && B
+    @Test
+    public void testUnionOfDays_seekBeyondEndOfStream() {
+        // Seek to a day range beyond the end of this IndexStream
+        Union union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertNull(union.seek("20190310"));
+        assertFalse(union.hasNext());
+        assertNull(union.next());
+        
+        // Seek to a day-underscore range beyond the end of this IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertNull(union.seek("20190310_"));
+        assertFalse(union.hasNext());
+        assertNull(union.next());
+        
+        // Seek to a shard range beyond the end of this IndexStream
+        union = buildUnionOfDays();
+        assertTrue(union.hasNext());
+        assertNull(union.seek("20190310_0"));
+        assertFalse(union.hasNext());
+        assertNull(union.next());
+    }
+    
+    private Union buildUnionOfShards() {
+        List<String> ignoredDays = Lists.newArrayList("20190304", "20190305", "20190306");
+        SortedSet<String> shards = buildShards(ignoredDays);
+        
+        ScannerStream s1 = buildFullScannerStream(shards, "A", "1");
+        ScannerStream s2 = buildFullScannerStream(shards, "B", "2");
+        
+        return new Union(Arrays.asList(s1, s2));
+    }
+    
+    private Union buildUnionOfDays() {
+        List<String> ignoredDays = Lists.newArrayList("20190304", "20190305", "20190306");
+        SortedSet<String> shards = buildDays(ignoredDays);
+        
+        ScannerStream s1 = buildFullScannerStream(shards, "A", "1");
+        ScannerStream s2 = buildFullScannerStream(shards, "B", "2");
+        
+        return new Union(Arrays.asList(s1, s2));
+    }
+    
+    // Build a set of shards for the first 9 days in march, with the option to ignore days.
+    private SortedSet<String> buildShards(List<String> ignoredDays) {
+        SortedSet<String> shards = new TreeSet<>();
+        for (int ii = 1; ii < 10; ii++) {
+            String day = "2019030" + ii;
+            if (ignoredDays.contains(day)) {
+                continue;
+            }
+            for (int jj = 0; jj < 20; jj++) {
+                shards.add(day + "_" + jj);
+            }
+        }
+        return shards;
+    }
+    
+    // Build a set of day shards for the first 9 days in march, with the option to ignore days.
+    private SortedSet<String> buildDays(List<String> ignoredDays) {
+        SortedSet<String> shards = new TreeSet<>();
+        for (int ii = 1; ii < 10; ii++) {
+            String day = "2019030" + ii;
+            if (ignoredDays.contains(day)) {
+                continue;
+            }
+            shards.add(day);
+        }
+        return shards;
+    }
+    
+    // Build a ScannerStream specifically for testing the ability to seek through the stream.
+    private ScannerStream buildFullScannerStream(SortedSet<String> shards, String field, String value) {
+        JexlNode node = JexlNodeFactory.buildEQNode(field, value);
+        
+        List<Tuple2<String,IndexInfo>> elements = new ArrayList<>();
+        for (String shard : shards) {
+            IndexInfo info = new IndexInfo(-1);
+            info.applyNode(node);
+            elements.add(new Tuple2<>(shard, info));
+        }
+        
+        return ScannerStream.variable(elements.iterator(), node);
     }
 }


### PR DESCRIPTION
IndexStreams now support seek-like operation on underlying iterators, improves performance of selective query terms on the global index. Seeking to max is adaptive.

Conflicts:
	warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java