### PR TITLE
fixes #1010 fix SpringCDIExtension applicationContext and serialization/deserialization of DatawavePrincipals

### DIFF
--- a/web-services/common/src/main/java/datawave/configuration/spring/SpringCDIExtension.java
+++ b/web-services/common/src/main/java/datawave/configuration/spring/SpringCDIExtension.java
@@ -86,7 +86,7 @@ public class SpringCDIExtension implements Extension {
         
         String cdiSpringConfigs = System.getProperty("cdi.spring.configs");
         if (cdiSpringConfigs != null) {
-            springContext = new ClassPathXmlApplicationContext(cdiSpringConfigs);
+            springContext = new ClassPathXmlApplicationContext(cdiSpringConfigs.split(","));
         } else {
             String beanRefContext = System.getProperty("cdi.bean.context", "beanRefContext.xml");
             ClassPathXmlApplicationContext bootstrap = new ClassPathXmlApplicationContext("classpath*:" + beanRefContext);

--- a/web-services/map-reduce-embedded/pom.xml
+++ b/web-services/map-reduce-embedded/pom.xml
@@ -25,10 +25,6 @@
             <artifactId>cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-commons</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.3_spec</artifactId>
         </dependency>

--- a/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedCallerPrincipalProducer.java
+++ b/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedCallerPrincipalProducer.java
@@ -7,7 +7,11 @@ import javax.enterprise.inject.Produces;
 import javax.interceptor.Interceptor;
 
 import datawave.security.authorization.DatawavePrincipal;
-import org.infinispan.commons.util.Base64;
+import org.apache.commons.codec.binary.Base64;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 
 /**
  * Caller principal producer supplied just for Embedded mode (e.g., inside of MapReduce jars). This archive should not be included for normal web applications.
@@ -31,8 +35,21 @@ public class EmbeddedCallerPrincipalProducer {
     
     private void initializeCallerPrincipal() {
         String encodedCallerPrincipal = System.getProperty("caller.principal");
-        if (encodedCallerPrincipal == null)
-            throw new IllegalStateException("System property caller.principal must be set to a serialized, gzip'd, base64 encoded principal.");
-        callerPrincipal = (DatawavePrincipal) Base64.decodeToObject(encodedCallerPrincipal);
+        if (encodedCallerPrincipal == null) {
+            throw new IllegalStateException("System property caller.principal must be set to a serialized, base64 encoded principal.");
+        }
+        ByteArrayInputStream bais = new ByteArrayInputStream(Base64.decodeBase64(encodedCallerPrincipal));
+        try {
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            callerPrincipal = (DatawavePrincipal) ois.readObject();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        } finally {
+            try {
+                bais.close();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
     }
 }

--- a/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedCallerPrincipalProducer.java
+++ b/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedCallerPrincipalProducer.java
@@ -38,18 +38,12 @@ public class EmbeddedCallerPrincipalProducer {
         if (encodedCallerPrincipal == null) {
             throw new IllegalStateException("System property caller.principal must be set to a serialized, base64 encoded principal.");
         }
-        ByteArrayInputStream bais = new ByteArrayInputStream(Base64.decodeBase64(encodedCallerPrincipal));
-        try {
-            ObjectInputStream ois = new ObjectInputStream(bais);
+        byte[] decodedCallerPrincipal = Base64.decodeBase64(encodedCallerPrincipal);
+        
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(decodedCallerPrincipal); ObjectInputStream ois = new ObjectInputStream(bais)) {
             callerPrincipal = (DatawavePrincipal) ois.readObject();
         } catch (Exception e) {
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                bais.close();
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
         }
     }
 }

--- a/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedServerPrincipalProducer.java
+++ b/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedServerPrincipalProducer.java
@@ -38,18 +38,12 @@ public class EmbeddedServerPrincipalProducer {
         if (encodedServerPrincipal == null) {
             throw new IllegalStateException("System property server.principal must be set to a serialized, base64 encoded principal.");
         }
-        ByteArrayInputStream bais = new ByteArrayInputStream(Base64.decodeBase64(encodedServerPrincipal));
-        try {
-            ObjectInputStream ois = new ObjectInputStream(bais);
+        byte[] decodedServerPrincipal = Base64.decodeBase64(encodedServerPrincipal);
+        
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(decodedServerPrincipal); ObjectInputStream ois = new ObjectInputStream(bais)) {
             serverPrincipal = (DatawavePrincipal) ois.readObject();
         } catch (Exception e) {
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                bais.close();
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
         }
     }
 }

--- a/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedServerPrincipalProducer.java
+++ b/web-services/map-reduce-embedded/src/main/java/datawave/security/system/EmbeddedServerPrincipalProducer.java
@@ -7,7 +7,11 @@ import javax.enterprise.inject.Produces;
 import javax.interceptor.Interceptor;
 
 import datawave.security.authorization.DatawavePrincipal;
-import org.infinispan.commons.util.Base64;
+import org.apache.commons.codec.binary.Base64;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 
 /**
  * Server principal producer supplied just for Embedded mode (e.g., inside of MapReduce jars). This archive should not be included for normal web applications.
@@ -31,8 +35,21 @@ public class EmbeddedServerPrincipalProducer {
     
     private void initializeServerPrincipal() {
         String encodedServerPrincipal = System.getProperty("server.principal");
-        if (encodedServerPrincipal == null)
-            throw new IllegalStateException("System property server.principal must be set to a serialized, gzip'd, base64 encoded principal.");
-        serverPrincipal = (DatawavePrincipal) Base64.decodeToObject(encodedServerPrincipal);
+        if (encodedServerPrincipal == null) {
+            throw new IllegalStateException("System property server.principal must be set to a serialized, base64 encoded principal.");
+        }
+        ByteArrayInputStream bais = new ByteArrayInputStream(Base64.decodeBase64(encodedServerPrincipal));
+        try {
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            serverPrincipal = (DatawavePrincipal) ois.readObject();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        } finally {
+            try {
+                bais.close();
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
     }
 }

--- a/web-services/map-reduce/src/main/java/datawave/webservice/mr/bulkresults/map/BulkResultsFileOutputMapper.java
+++ b/web-services/map-reduce/src/main/java/datawave/webservice/mr/bulkresults/map/BulkResultsFileOutputMapper.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,10 +26,10 @@ import datawave.webservice.util.ProtostuffMessageBodyWriter;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.log4j.Logger;
-import org.infinispan.commons.util.Base64;
 import org.jboss.weld.environment.se.Weld;
 import org.springframework.util.Assert;
 
@@ -182,11 +183,11 @@ public class BulkResultsFileOutputMapper extends ApplicationContextAwareMapper<K
         Marshaller m = ctx.createMarshaller();
         m.marshal(q, writer);
         // Probably need to base64 encode it so that it will not mess up the Hadoop Configuration object
-        return Base64.encodeBytes(writer.toString().getBytes());
+        return new String(Base64.encodeBase64(writer.toString().getBytes()), Charset.forName("UTF-8"));
     }
     
     public static Query deserializeQuery(String base64EncodedQuery, Class<? extends Query> queryImplClass) throws JAXBException {
-        String query = new String(Base64.decode(base64EncodedQuery));
+        String query = new String(Base64.decodeBase64(base64EncodedQuery), Charset.forName("UTF-8"));
         JAXBContext ctx = JAXBContext.newInstance(queryImplClass);
         Unmarshaller u = ctx.createUnmarshaller();
         return (Query) u.unmarshal(new StringReader(query));

--- a/web-services/map-reduce/src/main/java/datawave/webservice/mr/configuration/BulkResultsJobConfiguration.java
+++ b/web-services/map-reduce/src/main/java/datawave/webservice/mr/configuration/BulkResultsJobConfiguration.java
@@ -306,20 +306,12 @@ public class BulkResultsJobConfiguration extends MapReduceJobConfiguration imple
     }
     
     private String encodePrincipal(DatawavePrincipal principal) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = null;
-        try {
-            oos = new ObjectOutputStream(baos);
+        
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            
             // create a copy because this DatawavePrincipal might be CDI injected and have a reference to Weld
             oos.writeObject(new DatawavePrincipal(principal.getProxiedUsers(), principal.getCreationTime()));
             return Base64.encodeBase64String(baos.toByteArray());
-        } finally {
-            if (oos != null) {
-                oos.close();
-            }
-            if (baos != null) {
-                baos.close();
-            }
         }
     }
     


### PR DESCRIPTION
SpringCDIExtension not properly initializing the ClassPathXmlApplicationContext -- must split the resource string on commas

This was noticed when a running QueryLogic reached a point in the DocumentTransformer where it was adding cardinality information and called Document.getTimestamp() whiched caused a metadata update and a reference to MarkingFunctions which had to be resolved through Weld/CDI/Spring and failed.

CallerPrincipal and ServerPrincipal encode/decode isn't working

Also -- use an Apache Base64 class for encoding/decoding instead of infinispan