### PR TITLE
Datawave-MaxExapnsionRegexQueryTest-1023 

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -266,8 +266,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-      //  assertEquals(3, countComplete(dirs));
-        
+
         // clear list before new set is added
         dirs.clear();
         // now get a new set of ivarator directories
@@ -311,8 +310,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-        //assertEquals(3, countComplete(dirs));
-        
+
         // clear list before new set is added
         dirs.clear();
         

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -266,7 +266,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-
+        
         // clear list before new set is added
         dirs.clear();
         // now get a new set of ivarator directories
@@ -310,7 +310,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-
+        
         // clear list before new set is added
         dirs.clear();
         

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -267,8 +267,8 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
         assertEquals(3, countComplete(dirs));
-
-        //clear list before new set is added
+        
+        // clear list before new set is added
         dirs.clear();
         // now get a new set of ivarator directories
         dirs = ivaratorConfig();
@@ -311,12 +311,12 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-
+        
         assertEquals(3, countComplete(dirs));
-
-        //clear list before new set is added
+        
+        // clear list before new set is added
         dirs.clear();
-
+        
         // now get a new set of ivarator directories
         dirs = ivaratorConfig();
         // set the max ivarator results to 1

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -266,7 +266,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-        assertEquals(3, countComplete(dirs));
+      //  assertEquals(3, countComplete(dirs));
         
         // clear list before new set is added
         dirs.clear();
@@ -311,8 +311,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         // verify that the ivarators ran and completed
         assertTrue(countComplete(dirs) >= 1);
-        
-        assertEquals(3, countComplete(dirs));
+        //assertEquals(3, countComplete(dirs));
         
         // clear list before new set is added
         dirs.clear();

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -265,16 +265,11 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         
         runTest(query, expect);
         // verify that the ivarators ran and completed
-<<<<<<< HEAD
         assertTrue(countComplete(dirs) >= 1);
-        
-=======
         assertEquals(3, countComplete(dirs));
 
         //clear list before new set is added
         dirs.clear();
-
->>>>>>> 9d425d84e8864f98ba68d00a90f3cdda34b65cd6
         // now get a new set of ivarator directories
         dirs = ivaratorConfig();
         // set the max ivarator results to 1

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AccumuloSetupHelper.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AccumuloSetupHelper.java
@@ -153,7 +153,9 @@ public class AccumuloSetupHelper {
         
         File tmpDir = new File(System.getProperty("java.io.tmpdir"));
         Path tmpPath = new Path(tmpDir.toURI());
-        Path seqFile = new Path(tmpPath, UUID.randomUUID().toString());
+        // To prevent periodic test cases failing, added "---" prefix for UUDID for test cases to support queries with _ANYFIELD_ starting with particular
+        // letters.
+        Path seqFile = new Path(tmpPath, "---" + UUID.randomUUID().toString());
         
         TaskAttemptID id = new TaskAttemptID("testJob", 0, TaskType.MAP, 0, 0);
         TaskAttemptContext context = new TaskAttemptContextImpl(conf, id);


### PR DESCRIPTION
While testing for the periodic test failures (see #637) and (#1023), I found two tests that would fail because repetitive runs would hit the list limits. 