### PR TITLE
Bugfix for TermFrequencyIterator

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/key/TFKey.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/key/TFKey.java
@@ -1,5 +1,6 @@
 package datawave.core.iterators.key;
 
+import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.Key;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ public class TFKey {
         this.backing = k.getColumnQualifierData().getBackingArray();
         
         // Find all possible split points
-        for (int i = 0; i < backing.length; i++) {
+        for (int i = 0; i < k.getColumnQualifierData().length(); i++) {
             if (backing[i] == '\u0000')
                 nulls.add(i);
         }

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/key/TFKey.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/key/TFKey.java
@@ -1,0 +1,90 @@
+package datawave.core.iterators.key;
+
+import org.apache.accumulo.core.data.Key;
+
+import java.util.ArrayList;
+
+/**
+ * Utility class that operates on a TermFrequency key's ColumnQualifier
+ */
+public class TFKey {
+    
+    // CQ partitions
+    private String datatype;
+    private String uid;
+    private String value;
+    private String field;
+    private String uidAndValue;
+    
+    private byte[] backing;
+    private ArrayList<Integer> nulls;
+    
+    public void parse(Key k) {
+        this.datatype = null;
+        this.uid = null;
+        this.value = null;
+        this.field = null;
+        this.uidAndValue = null;
+        
+        this.nulls = new ArrayList<>();
+        this.backing = k.getColumnQualifierData().getBackingArray();
+        
+        // Find all possible split points
+        for (int i = 0; i < backing.length; i++) {
+            if (backing[i] == '\u0000')
+                nulls.add(i);
+        }
+    }
+    
+    public String getDatatype() {
+        if (datatype == null) {
+            if (nulls.size() > 1) {
+                int stop = nulls.get(0);
+                datatype = new String(backing, 0, stop);
+            }
+        }
+        return datatype;
+    }
+    
+    public String getUid() {
+        if (uid == null) {
+            if (nulls.size() == 1) {
+                int start = nulls.get(0) + 1;
+                uid = new String(backing, start, (backing.length - start));
+            } else if (nulls.size() > 1) {
+                int start = nulls.get(0) + 1;
+                int stop = nulls.get(1);
+                uid = new String(backing, start, (stop - start));
+            }
+        }
+        return uid;
+    }
+    
+    public String getValue() {
+        if (value == null) {
+            if (nulls.size() >= 3) {
+                int start = nulls.get(1) + 1;
+                int stop = nulls.get(nulls.size() - 1);
+                value = new String(backing, start, (stop - start));
+            }
+        }
+        return value;
+    }
+    
+    public String getField() {
+        if (field == null) {
+            if (nulls.size() >= 3) {
+                int start = nulls.get(nulls.size() - 1) + 1;
+                field = new String(backing, start, (backing.length - start));
+            }
+        }
+        return field;
+    }
+    
+    public String getUidAndValue() {
+        if (uidAndValue == null) {
+            uidAndValue = getUid() + '\u0000' + getValue();
+        }
+        return uidAndValue;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -952,9 +952,13 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
             // getting an additional source deep copy for this function
             final Iterator<Tuple3<Key,Document,Map<String,Object>>> itrWithContext;
             if (this.isTermFrequenciesRequired()) {
+                
+                // The TFFunction can only prune non index-only fields
+                Set<String> tfIndexOnlyFields = Sets.intersection(getTermFrequencyFields(), getIndexOnlyFields());
+                
                 Function<Tuple2<Key,Document>,Tuple3<Key,Document,Map<String,Object>>> tfFunction;
                 tfFunction = TFFactory.getFunction(getScript(documentSource), getContentExpansionFields(), getTermFrequencyFields(), this.getTypeMetadata(),
-                                super.equality, getEvaluationFilter(), sourceDeepCopy.deepCopy(myEnvironment));
+                                super.equality, getEvaluationFilter(), sourceDeepCopy.deepCopy(myEnvironment), tfIndexOnlyFields);
                 
                 itrWithContext = TraceIterators.transform(tupleItr, tfFunction, "Term Frequency Lookup");
             } else {

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TFFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TFFactory.java
@@ -26,7 +26,7 @@ public class TFFactory {
     
     public static com.google.common.base.Function<Tuple2<Key,Document>,Tuple3<Key,Document,Map<String,Object>>> getFunction(ASTJexlScript query,
                     Set<String> contentExpansionFields, Set<String> termFrequencyFields, TypeMetadata typeMetadata, Equality equality,
-                    EventDataQueryFilter evaluationFilter, SortedKeyValueIterator<Key,Value> sourceCopy) {
+                    EventDataQueryFilter evaluationFilter, SortedKeyValueIterator<Key,Value> sourceCopy, Set<String> tfIndexOnlyFields) {
         
         Multimap<String,Class<? extends Type<?>>> fieldMappings = LinkedListMultimap.create();
         for (Entry<String,String> dataType : typeMetadata.fold().entries()) {
@@ -40,7 +40,7 @@ public class TFFactory {
             
         }
         
-        return getFunction(query, contentExpansionFields, termFrequencyFields, fieldMappings, equality, evaluationFilter, sourceCopy);
+        return getFunction(query, contentExpansionFields, termFrequencyFields, fieldMappings, equality, evaluationFilter, sourceCopy, tfIndexOnlyFields);
     }
     
     /**
@@ -53,7 +53,7 @@ public class TFFactory {
      */
     public static com.google.common.base.Function<Tuple2<Key,Document>,Tuple3<Key,Document,Map<String,Object>>> getFunction(ASTJexlScript query,
                     Set<String> contentExpansionFields, Set<String> termFrequencyFields, Multimap<String,Class<? extends Type<?>>> dataTypes,
-                    Equality equality, EventDataQueryFilter evaluationFilter, SortedKeyValueIterator<Key,Value> sourceDeepCopy) {
+                    Equality equality, EventDataQueryFilter evaluationFilter, SortedKeyValueIterator<Key,Value> sourceDeepCopy, Set<String> tfIndexOnlyFields) {
         
         Multimap<String,String> termFrequencyFieldValues = TermOffsetPopulator.getTermFrequencyFieldValues(query, contentExpansionFields, termFrequencyFields,
                         dataTypes);
@@ -61,7 +61,8 @@ public class TFFactory {
         if (termFrequencyFieldValues.isEmpty()) {
             return new EmptyTermFrequencyFunction();
         } else {
-            return new TermOffsetFunction(new TermOffsetPopulator(termFrequencyFieldValues, contentExpansionFields, evaluationFilter, sourceDeepCopy));
+            return new TermOffsetFunction(new TermOffsetPopulator(termFrequencyFieldValues, contentExpansionFields, evaluationFilter, sourceDeepCopy),
+                            tfIndexOnlyFields);
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetFunction.java
@@ -17,10 +17,13 @@ import datawave.query.util.Tuples;
 import org.apache.accumulo.core.data.Key;
 
 public class TermOffsetFunction implements com.google.common.base.Function<Tuple2<Key,Document>,Tuple3<Key,Document,Map<String,Object>>> {
-    private TermOffsetPopulator tfPopulator;
     
-    public TermOffsetFunction(TermOffsetPopulator tfPopulator) {
+    private TermOffsetPopulator tfPopulator;
+    private Set<String> tfIndexOnlyFields;
+    
+    public TermOffsetFunction(TermOffsetPopulator tfPopulator, Set<String> tfIndexOnlyFields) {
         this.tfPopulator = tfPopulator;
+        this.tfIndexOnlyFields = tfIndexOnlyFields;
     }
     
     @Override
@@ -59,7 +62,8 @@ public class TermOffsetFunction implements com.google.common.base.Function<Tuple
         Set<String> docFields = doc.getDictionary().keySet();
         Set<String> tfFields = tfFVs.keySet();
         for (String tfField : tfFields) {
-            if (!docFields.contains(tfField)) {
+            // Can only prune a field if it is not index only
+            if (!docFields.contains(tfField) && !tfIndexOnlyFields.contains(tfField)) {
                 // mark this field for removal prior to building the TermFrequencyIterator
                 fieldsToRemove.add(tfField);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
@@ -149,13 +149,17 @@ public class TermOffsetPopulator {
         
         TermFrequencyIterator tfSource;
         // Do not prune if no fields exist or if the tf fields would prune to nothing. TODO skip tf entirely if this would prune to zero
-        if (fields == null || fields.isEmpty() || fields.size() == termFrequencyFieldValues.size()) {
+        if (fields == null || fields.isEmpty() || fields.size() == termFrequencyFieldValues.keySet().size()) {
             tfSource = new TermFrequencyIterator(termFrequencyFieldValues, keys);
         } else {
             // There are fields to remove, reduce the search space and continue
             Multimap<String,String> tfFVs = HashMultimap.create(termFrequencyFieldValues);
             fields.forEach(tfFVs::removeAll);
             tfSource = new TermFrequencyIterator(tfFVs, keys);
+            
+            if (tfFVs.size() == 0) {
+                log.error("Created a TFIter with no field values. Orig fields: " + termFrequencyFieldValues.keySet() + " fields to remove: " + fields);
+            }
         }
         
         Range range = getRange(keys);

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/key/TFKeyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/key/TFKeyTest.java
@@ -1,0 +1,31 @@
+package datawave.core.iterators.key;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TFKeyTest {
+    
+    @Test
+    public void testParse() {
+        Key k = new Key("row", "tf", "datatype\0uid\0fieldValue\0fieldName");
+        TFKey tfKey = new TFKey();
+        tfKey.parse(k);
+        
+        assertEquals("datatype", tfKey.getDatatype());
+        assertEquals("uid", tfKey.getUid());
+        assertEquals("fieldValue", tfKey.getValue());
+        assertEquals("fieldName", tfKey.getField());
+        assertEquals("uid\0fieldValue", tfKey.getUidAndValue());
+        
+        // Ensure it works when multiple nulls are in the value
+        k = new Key("row", "tf", "datatype\0uid\0fi\0eld\0Va\0lue\0fieldName");
+        tfKey.parse(k);
+        assertEquals("datatype", tfKey.getDatatype());
+        assertEquals("uid", tfKey.getUid());
+        assertEquals("fi\0eld\0Va\0lue", tfKey.getValue());
+        assertEquals("fieldName", tfKey.getField());
+        assertEquals("uid\0fi\0eld\0Va\0lue", tfKey.getUidAndValue());
+    }
+}


### PR DESCRIPTION
Bugfix for TermFrequencyIterator: do not prune index only fields, properly calculate when to seek, do not parse keys with DatawaveKey.