### PR TITLE
Restrict access by DN in query execution service

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -7,19 +7,20 @@ import datawave.webservice.query.Query;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.iterator.DatawaveTransformIterator;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
-import java.security.Principal;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.inject.Inject;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.springframework.beans.factory.annotation.Required;
+
+import javax.inject.Inject;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     
@@ -35,6 +36,7 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     private long pageByteTrigger = 0;
     private boolean collectQueryMetrics = true;
     private String _connPoolName;
+    private Set<String> authorizedDNs;
     protected Principal principal;
     protected RoleManager roleManager;
     protected MarkingFunctions markingFunctions;
@@ -321,5 +323,15 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     
     public SelectorExtractor getSelectorExtractor() {
         return selectorExtractor;
+    }
+    
+    @Override
+    public Set<String> getAuthorizedDNs() {
+        return authorizedDNs;
+    }
+    
+    @Override
+    public void setAuthorizedDNs(Set<String> authorizedDNs) {
+        this.authorizedDNs = authorizedDNs;
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
@@ -1,9 +1,5 @@
 package datawave.webservice.query.logic;
 
-import java.security.Principal;
-import java.util.List;
-import java.util.Set;
-
 import datawave.audit.SelectorExtractor;
 import datawave.marking.MarkingFunctions;
 import datawave.validation.ParameterValidator;
@@ -15,11 +11,15 @@ import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
-
 import datawave.webservice.result.BaseResponse;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
+
+import java.security.Principal;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidator {
     
@@ -297,4 +297,35 @@ public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidato
      */
     Set<String> getExampleQueries();
     
+    /**
+     * Return the DNs authorized access to this query logic.
+     * 
+     * @return the set of DNs authorized access to this query logic, possibly null or empty
+     */
+    Set<String> getAuthorizedDNs();
+    
+    /**
+     * Set the DNs authorized access to this query logic.
+     * 
+     * @param allowedDNs
+     *            the DNs authorized access
+     */
+    void setAuthorizedDNs(Set<String> allowedDNs);
+    
+    /**
+     * Return whether or not the provided collection of DNs contains at least oneDN that is authorized for access to this query logic. This will return true in
+     * the following cases:
+     * <ul>
+     * <li>The set of authorized DNs for this query logic is null or empty.</li>
+     * <li>The set of authorized DNs is not empty, and the provided collection contains a DN that is also found within the set of authorized DNs.</li>
+     * </ul>
+     * 
+     * @param dns
+     *            the DNs to determine access rights for
+     * @return true if the collection contains at least one DN that has access to this query logic, or false otherwise
+     */
+    default boolean containsDNWithAccess(Collection<String> dns) {
+        Set<String> authorizedDNs = getAuthorizedDNs();
+        return authorizedDNs == null || authorizedDNs.isEmpty() || (dns != null && dns.stream().anyMatch(authorizedDNs::contains));
+    }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -32,6 +32,7 @@ import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.webservice.common.exception.BadRequestException;
 import datawave.webservice.common.exception.DatawaveWebApplicationException;
 import datawave.webservice.common.exception.NoResultsException;
+import datawave.webservice.common.exception.UnauthorizedException;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.QueryImpl.Parameter;
@@ -488,7 +489,17 @@ public class QueryExecutorBean implements QueryExecutor {
             Arrays.sort(dns);
             qd.dnList = Arrays.asList(dns);
             qd.proxyServers = dp.getProxyServers();
+            
+            // Verify that the calling principal has access to the query logic.
+            if (!qd.logic.containsDNWithAccess(qd.dnList)) {
+                UnauthorizedQueryException qe = new UnauthorizedQueryException("User " + qd.userDn + " is not part of the authorized DNs for the query logic "
+                                + queryLogicName, 401);
+                GenericResponse<String> response = new GenericResponse<>();
+                response.addException(qe);
+                throw new UnauthorizedException(qe, response);
+            }
         }
+        
         log.trace(qd.userid + " has authorizations " + ((qd.p instanceof DatawavePrincipal) ? ((DatawavePrincipal) qd.p).getAuthorizations() : ""));
         
         // always check against the max

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -492,8 +492,7 @@ public class QueryExecutorBean implements QueryExecutor {
             
             // Verify that the calling principal has access to the query logic.
             if (!qd.logic.containsDNWithAccess(qd.dnList)) {
-                UnauthorizedQueryException qe = new UnauthorizedQueryException("User " + qd.userDn + " is not part of the authorized DNs for the query logic "
-                                + queryLogicName, 401);
+                UnauthorizedQueryException qe = new UnauthorizedQueryException("None of the DNs used have access to this query logic: " + qd.dnList, 401);
                 GenericResponse<String> response = new GenericResponse<>();
                 response.addException(qe);
                 throw new UnauthorizedException(qe, response);

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
@@ -1,12 +1,6 @@
 package datawave.webservice.query.configuration;
 
-import static org.easymock.EasyMock.expect;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Sets;
 import datawave.webservice.common.audit.Auditor;
 import datawave.webservice.common.connection.AccumuloConnectionFactory.Priority;
 import datawave.webservice.query.Query;
@@ -14,7 +8,6 @@ import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.EasyRoleManager;
 import datawave.webservice.query.logic.QueryLogicTransformer;
 import datawave.webservice.query.logic.RoleManager;
-
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
@@ -23,6 +16,15 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 public class TestBaseQueryLogic {
@@ -69,7 +71,41 @@ public class TestBaseQueryLogic {
         assertNotNull("Iterator should not be null", result3);
     }
     
+    @Test
+    public void testContainsDnWithAccess() {
+        Set<String> dns = Sets.newHashSet("dn=user", "dn=user chain 1", "dn=user chain 2");
+        BaseQueryLogic<Object> logic = new TestQueryLogic<>();
+        
+        // Assert cases given allowedDNs == null. Access should not be blocked at all.
+        assertTrue(logic.containsDNWithAccess(dns));
+        assertTrue(logic.containsDNWithAccess(null));
+        assertTrue(logic.containsDNWithAccess(Collections.emptySet()));
+        
+        // Assert cases given allowedDNs == empty set. Access should not be blocked at all.
+        logic.setAuthorizedDNs(Collections.emptySet());
+        assertTrue(logic.containsDNWithAccess(dns));
+        assertTrue(logic.containsDNWithAccess(null));
+        assertTrue(logic.containsDNWithAccess(Collections.emptySet()));
+        
+        // Assert cases given allowedDNs == non-empty set with matching DN. Access should only be granted where DN is present.
+        logic.setAuthorizedDNs(Sets.newHashSet("dn=user", "dn=other user"));
+        assertTrue(logic.containsDNWithAccess(dns));
+        assertFalse(logic.containsDNWithAccess(null));
+        assertFalse(logic.containsDNWithAccess(Collections.emptySet()));
+        
+        // Assert cases given allowedDNs == non-empty set with no matching DN. All access should be blocked.
+        logic.setAuthorizedDNs(Sets.newHashSet("dn=other user", "dn=other user chain"));
+        assertFalse(logic.containsDNWithAccess(dns));
+        assertFalse(logic.containsDNWithAccess(null));
+        assertFalse(logic.containsDNWithAccess(Collections.emptySet()));
+    }
+    
     private class TestQueryLogic<T> extends BaseQueryLogic<T> {
+        
+        public TestQueryLogic() {
+            super();
+        }
+        
         public TestQueryLogic(BaseQueryLogic<T> other) {
             super(other);
         }

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -3853,8 +3853,8 @@ public class ExtendedQueryExecutorBeanTest {
         // Verify results
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
-        assertEquals("Thrown exception expected to detail reason for access denial",
-                        "None of the DNs used have access to this query logic: [userDN]", result1.getMessage());
+        assertEquals("Thrown exception expected to detail reason for access denial", "None of the DNs used have access to this query logic: [userDN]",
+                        result1.getMessage());
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -3921,8 +3921,8 @@ public class ExtendedQueryExecutorBeanTest {
         // Verify results
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
-        assertEquals("Thrown exception expected to detail reason for access denial",
-                        "None of the DNs used have access to this query logic: [userDN]", result1.getMessage());
+        assertEquals("Thrown exception expected to detail reason for access denial", "None of the DNs used have access to this query logic: [userDN]",
+                        result1.getMessage());
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -3989,8 +3989,8 @@ public class ExtendedQueryExecutorBeanTest {
         // Verify results
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
-        assertEquals("Thrown exception expected to detail reason for access denial",
-                        "None of the DNs used have access to this query logic: [userDN]", result1.getMessage());
+        assertEquals("Thrown exception expected to detail reason for access denial", "None of the DNs used have access to this query logic: [userDN]",
+                        result1.getMessage());
     }
     
     @Test
@@ -4082,8 +4082,8 @@ public class ExtendedQueryExecutorBeanTest {
         // Verify results
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
-        assertEquals("Thrown exception expected to detail reason for access denial",
-                        "None of the DNs used have access to this query logic: [userdn]", result1.getMessage());
+        assertEquals("Thrown exception expected to detail reason for access denial", "None of the DNs used have access to this query logic: [userdn]",
+                        result1.getMessage());
     }
     
     @Test
@@ -4175,8 +4175,8 @@ public class ExtendedQueryExecutorBeanTest {
         // Verify results
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
-        assertEquals("Thrown exception expected to detail reason for access denial",
-                        "None of the DNs used have access to this query logic: [userdn]", result1.getMessage());
+        assertEquals("Thrown exception expected to detail reason for access denial", "None of the DNs used have access to this query logic: [userdn]",
+                        result1.getMessage());
     }
     
     public class TestQuery extends QueryImpl {

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -3854,7 +3854,7 @@ public class ExtendedQueryExecutorBeanTest {
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
         assertEquals("Thrown exception expected to detail reason for access denial",
-                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+                        "None of the DNs used have access to this query logic: [userDN]", result1.getMessage());
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -3922,7 +3922,7 @@ public class ExtendedQueryExecutorBeanTest {
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
         assertEquals("Thrown exception expected to detail reason for access denial",
-                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+                        "None of the DNs used have access to this query logic: [userDN]", result1.getMessage());
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -3990,7 +3990,7 @@ public class ExtendedQueryExecutorBeanTest {
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
         assertEquals("Thrown exception expected to detail reason for access denial",
-                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+                        "None of the DNs used have access to this query logic: [userDN]", result1.getMessage());
     }
     
     @Test
@@ -4083,7 +4083,7 @@ public class ExtendedQueryExecutorBeanTest {
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
         assertEquals("Thrown exception expected to detail reason for access denial",
-                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+                        "None of the DNs used have access to this query logic: [userdn]", result1.getMessage());
     }
     
     @Test
@@ -4176,7 +4176,7 @@ public class ExtendedQueryExecutorBeanTest {
         assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
         assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
         assertEquals("Thrown exception expected to detail reason for access denial",
-                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+                        "None of the DNs used have access to this query logic: [userdn]", result1.getMessage());
     }
     
     public class TestQuery extends QueryImpl {

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -750,6 +750,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(userDNpair);
         expect(this.principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.NONE);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(persister.create(eq(userDNpair.subjectDN()), eq(dnList), eq(marking), eq(queryLogicName), eq(qp), eq(op))).andReturn(this.query);
@@ -923,6 +924,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(userDNpair);
         expect(this.principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.NONE);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(this.principal.getPrimaryUser()).andReturn(dwUser);
@@ -1090,6 +1092,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(userDNpair);
         expect(this.principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0));
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.ACTIVE);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(persister.create(eq(userDNpair.subjectDN()), eq(dnList), eq(marking), eq(queryLogicName), eq(qp), eq(op))).andReturn(this.query);
@@ -1209,6 +1212,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(userDNpair);
         expect(this.principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.NONE);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(this.principal.getPrimaryUser()).andReturn(dwUser);
@@ -1454,6 +1458,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(SubjectIssuerDNPair.of("userDN"));
         expect(this.principal.getDNs()).andReturn(new String[] {"userDN"});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList("userDN"))).andReturn(true);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(this.queryLogic1.getMaxPageSize()).andReturn(10).times(4);
         
@@ -3317,6 +3322,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(userDNpair);
         expect(this.principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.PASSIVE);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(persister.create(eq(userDNpair.subjectDN()), eq(dnList), eq(marking), eq(queryLogicName), eq(qp), eq(op))).andReturn(this.query);
@@ -3448,6 +3454,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getUserDN()).andReturn(userDNpair);
         expect(this.principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.PASSIVE);
         expect(this.queryLogic1.getSelectors(this.query)).andReturn(null);
         expect(auditor.audit(eq(queryParameters))).andReturn(null);
@@ -3569,6 +3576,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(principal.getUserDN()).andReturn(userDNpair);
         expect(principal.getDNs()).andReturn(new String[] {userDN});
         expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(true);
         expect(this.queryLogic1.getAuditType(null)).andReturn(AuditType.ACTIVE);
         expect(this.principal.getAuthorizations()).andReturn((Collection) Arrays.asList(Arrays.asList(queryAuthorizations)));
         expect(this.queryLogic1.getMaxPageSize()).andReturn(10).anyTimes();
@@ -3780,6 +3788,395 @@ public class ExtendedQueryExecutorBeanTest {
         subject.updateQuery(queryId.toString(), queryLogicName, query, queryVisibility, beginDate, endDate, queryAuthorizations, expirationDate, pagesize,
                         pageTimeout, maxResultsOverride, persistenceMode, parameters);
         PowerMock.verifyAll();
+    }
+    
+    @Test
+    public void testDefineQuery_userNotInAllowedDNs() throws Exception {
+        // Set local test input
+        String queryLogicName = "queryLogicName";
+        String query = "query";
+        String queryName = "queryName";
+        String queryVisibility = "A&B";
+        long currentTime = System.currentTimeMillis();
+        Date beginDate = new Date(currentTime - 5000);
+        Date endDate = new Date(currentTime - 1000);
+        String queryAuthorizations = "AUTH_1";
+        Date expirationDate = new Date(currentTime + 9999);
+        int pagesize = 1000;
+        int pageTimeout = -1;
+        Long maxResultsOverride = null;
+        QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String parameters = null;
+        boolean trace = false;
+        // Set expectations
+        
+        MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate,
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
+        
+        ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
+        marking.validate(queryParameters);
+        
+        QueryParameters qp = new QueryParametersImpl();
+        qp.validate(queryParameters);
+        
+        MultivaluedMap<String,String> op = qp.getUnknownParameters(queryParameters);
+        op.putSingle(PrivateAuditConstants.LOGIC_CLASS, queryLogicName);
+        op.putSingle(PrivateAuditConstants.COLUMN_VISIBILITY, queryVisibility);
+        expect(this.queryLogicFactory.getQueryLogic(queryLogicName, this.principal)).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.context.getCallerPrincipal()).andReturn(this.principal).anyTimes();
+        
+        queryLogic1.validate(queryParameters);
+        expect(this.principal.getName()).andReturn("userName Full");
+        expect(this.principal.getShortName()).andReturn("userName");
+        expect(this.principal.getUserDN()).andReturn(SubjectIssuerDNPair.of("userDN"));
+        expect(this.principal.getDNs()).andReturn(new String[] {"userDN"});
+        expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList("userDN"))).andReturn(false);
+        
+        // Run the test
+        PowerMock.replayAll();
+        QueryExecutorBean subject = new QueryExecutorBean();
+        setInternalState(subject, EJBContext.class, context);
+        setInternalState(subject, QueryLogicFactory.class, queryLogicFactory);
+        setInternalState(subject, QueryExpirationConfiguration.class, queryExpirationConf);
+        setInternalState(subject, SecurityMarking.class, new ColumnVisibilitySecurityMarking());
+        setInternalState(subject, QueryParameters.class, new QueryParametersImpl());
+        setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
+        Throwable result1 = null;
+        try {
+            subject.defineQuery(queryLogicName, queryParameters);
+        } catch (DatawaveWebApplicationException e) {
+            result1 = e.getCause();
+        }
+        PowerMock.verifyAll();
+        
+        // Verify results
+        assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
+        assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
+        assertEquals("Thrown exception expected to detail reason for access denial",
+                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+    }
+    
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    public void testCreateQuery_userNotInAllowedDNs() throws Exception {
+        // Set local test input
+        String queryLogicName = "queryLogicName";
+        String query = "query";
+        String queryName = "queryName";
+        String queryVisibility = "A&B";
+        long currentTime = System.currentTimeMillis();
+        Date beginDate = new Date(currentTime - 5000);
+        Date endDate = new Date(currentTime - 1000);
+        String queryAuthorizations = "AUTH_1";
+        Date expirationDate = new Date(currentTime + 9999);
+        int pagesize = 1000;
+        int pageTimeout = -1;
+        Long maxResultsOverride = null;
+        QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String parameters = null;
+        boolean trace = false;
+        // Set expectations
+        
+        MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate,
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
+        
+        ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
+        marking.validate(queryParameters);
+        
+        QueryParameters qp = new QueryParametersImpl();
+        qp.validate(queryParameters);
+        
+        MultivaluedMap<String,String> op = qp.getUnknownParameters(queryParameters);
+        op.putSingle(PrivateAuditConstants.LOGIC_CLASS, queryLogicName);
+        op.putSingle(PrivateAuditConstants.COLUMN_VISIBILITY, queryVisibility);
+        expect(this.queryLogicFactory.getQueryLogic(queryLogicName, this.principal)).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.context.getCallerPrincipal()).andReturn(this.principal).anyTimes();
+        
+        queryLogic1.validate(queryParameters);
+        expect(this.principal.getName()).andReturn("userName Full");
+        expect(this.principal.getShortName()).andReturn("userName");
+        expect(this.principal.getUserDN()).andReturn(SubjectIssuerDNPair.of("userDN"));
+        expect(this.principal.getDNs()).andReturn(new String[] {"userDN"});
+        expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList("userDN"))).andReturn(false);
+        
+        // Run the test
+        PowerMock.replayAll();
+        QueryExecutorBean subject = new QueryExecutorBean();
+        setInternalState(subject, EJBContext.class, context);
+        setInternalState(subject, QueryLogicFactory.class, queryLogicFactory);
+        setInternalState(subject, QueryExpirationConfiguration.class, queryExpirationConf);
+        setInternalState(subject, SecurityMarking.class, new ColumnVisibilitySecurityMarking());
+        setInternalState(subject, QueryParameters.class, new QueryParametersImpl());
+        setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
+        Throwable result1 = null;
+        try {
+            subject.createQuery(queryLogicName, queryParameters);
+        } catch (DatawaveWebApplicationException e) {
+            result1 = e.getCause();
+        }
+        PowerMock.verifyAll();
+        
+        // Verify results
+        assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
+        assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
+        assertEquals("Thrown exception expected to detail reason for access denial",
+                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+    }
+    
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test
+    public void testCreateQueryAndNext_userNotInAllowedDNs() throws Exception {
+        // Set local test input
+        String queryLogicName = "queryLogicName";
+        String query = "query";
+        String queryName = "queryName";
+        String queryVisibility = "A&B";
+        long currentTime = System.currentTimeMillis();
+        Date beginDate = new Date(currentTime - 5000);
+        Date endDate = new Date(currentTime - 1000);
+        String queryAuthorizations = "AUTH_1";
+        Date expirationDate = new Date(currentTime + 9999);
+        int pagesize = 1000;
+        int pageTimeout = -1;
+        Long maxResultsOverride = null;
+        QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String parameters = null;
+        boolean trace = false;
+        // Set expectations
+        
+        MultivaluedMap<String,String> queryParameters = QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate,
+                        queryAuthorizations, expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace);
+        
+        ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
+        marking.validate(queryParameters);
+        
+        QueryParameters qp = new QueryParametersImpl();
+        qp.validate(queryParameters);
+        
+        MultivaluedMap<String,String> op = qp.getUnknownParameters(queryParameters);
+        op.putSingle(PrivateAuditConstants.LOGIC_CLASS, queryLogicName);
+        op.putSingle(PrivateAuditConstants.COLUMN_VISIBILITY, queryVisibility);
+        expect(this.queryLogicFactory.getQueryLogic(queryLogicName, this.principal)).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.context.getCallerPrincipal()).andReturn(this.principal).anyTimes();
+        
+        queryLogic1.validate(queryParameters);
+        expect(this.principal.getName()).andReturn("userName Full");
+        expect(this.principal.getShortName()).andReturn("userName");
+        expect(this.principal.getUserDN()).andReturn(SubjectIssuerDNPair.of("userDN"));
+        expect(this.principal.getDNs()).andReturn(new String[] {"userDN"});
+        expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList("userDN"))).andReturn(false);
+        
+        // Run the test
+        PowerMock.replayAll();
+        QueryExecutorBean subject = new QueryExecutorBean();
+        setInternalState(subject, EJBContext.class, context);
+        setInternalState(subject, QueryLogicFactory.class, queryLogicFactory);
+        setInternalState(subject, QueryExpirationConfiguration.class, queryExpirationConf);
+        setInternalState(subject, SecurityMarking.class, new ColumnVisibilitySecurityMarking());
+        setInternalState(subject, QueryParameters.class, new QueryParametersImpl());
+        setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
+        Throwable result1 = null;
+        try {
+            subject.createQueryAndNext(queryLogicName, queryParameters);
+        } catch (DatawaveWebApplicationException e) {
+            result1 = e.getCause();
+        }
+        PowerMock.verifyAll();
+        
+        // Verify results
+        assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
+        assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
+        assertEquals("Thrown exception expected to detail reason for access denial",
+                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+    }
+    
+    @Test
+    public void testPlanQuery_userNotInAllowedDNs() throws Exception {
+        // Set local test input
+        String queryLogicName = "queryLogicName";
+        String query = "query";
+        String queryName = "queryName";
+        String queryVisibility = "A&B";
+        long currentTime = System.currentTimeMillis();
+        Date beginDate = new Date(currentTime - 5000);
+        Date endDate = new Date(currentTime - 1000);
+        String queryAuthorizations = "AUTH_1";
+        Date expirationDate = new Date(currentTime + 999999);
+        int pagesize = 10;
+        int pageTimeout = -1;
+        QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        boolean trace = false;
+        String userName = "userName";
+        String userSid = "userSid";
+        String userDN = "userdn";
+        SubjectIssuerDNPair userDNpair = SubjectIssuerDNPair.of(userDN);
+        
+        MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
+        queryParameters.putSingle(QueryParameters.QUERY_LOGIC_NAME, queryLogicName);
+        queryParameters.putSingle(QueryParameters.QUERY_STRING, query);
+        queryParameters.putSingle(QueryParameters.QUERY_NAME, queryName);
+        queryParameters.putSingle(QueryParameters.QUERY_BEGIN, QueryParametersImpl.formatDate(beginDate));
+        queryParameters.putSingle(QueryParameters.QUERY_END, QueryParametersImpl.formatDate(endDate));
+        queryParameters.putSingle(QueryParameters.QUERY_EXPIRATION, QueryParametersImpl.formatDate(expirationDate));
+        queryParameters.putSingle(QueryParameters.QUERY_AUTHORIZATIONS, queryAuthorizations);
+        queryParameters.putSingle(QueryParameters.QUERY_PAGESIZE, String.valueOf(pagesize));
+        queryParameters.putSingle(QueryParameters.QUERY_PAGETIMEOUT, String.valueOf(pageTimeout));
+        queryParameters.putSingle(QueryParameters.QUERY_PERSISTENCE, persistenceMode.name());
+        queryParameters.putSingle(QueryParameters.QUERY_TRACE, String.valueOf(trace));
+        queryParameters.putSingle(ColumnVisibilitySecurityMarking.VISIBILITY_MARKING, queryVisibility);
+        queryParameters.putSingle("valid", "param");
+        
+        ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
+        marking.validate(queryParameters);
+        
+        QueryParameters qp = new QueryParametersImpl();
+        qp.validate(queryParameters);
+        
+        MultivaluedMap<String,String> op = qp.getUnknownParameters(queryParameters);
+        op.putSingle(PrivateAuditConstants.LOGIC_CLASS, queryLogicName);
+        op.putSingle(PrivateAuditConstants.COLUMN_VISIBILITY, queryVisibility);
+        op.putSingle(PrivateAuditConstants.USER_DN, userDNpair.subjectDN());
+        
+        // Set expectations of the create logic
+        queryLogic1.validate(queryParameters);
+        expect(this.queryLogicFactory.getQueryLogic(queryLogicName, this.principal)).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.context.getCallerPrincipal()).andReturn(this.principal).anyTimes();
+        expect(this.principal.getName()).andReturn(userName);
+        expect(this.principal.getShortName()).andReturn(userSid);
+        expect(this.principal.getUserDN()).andReturn(userDNpair);
+        expect(this.principal.getDNs()).andReturn(new String[] {userDN});
+        expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(false);
+        
+        // Run the test
+        PowerMock.replayAll();
+        QueryExecutorBean subject = new QueryExecutorBean();
+        setInternalState(subject, EJBContext.class, context);
+        setInternalState(subject, AccumuloConnectionFactory.class, connectionFactory);
+        setInternalState(subject, ResponseObjectFactory.class, responseObjectFactory);
+        setInternalState(subject, CreatedQueryLogicCacheBean.class, qlCache);
+        setInternalState(subject, QueryCache.class, cache);
+        setInternalState(subject, ClosedQueryCache.class, closedCache);
+        setInternalState(subject, Persister.class, persister);
+        setInternalState(subject, QueryLogicFactoryImpl.class, queryLogicFactory);
+        setInternalState(subject, QueryExpirationConfiguration.class, queryExpirationConf);
+        setInternalState(subject, AuditBean.class, auditor);
+        setInternalState(subject, QueryMetricsBean.class, metrics);
+        setInternalState(subject, Multimap.class, traceInfos);
+        setInternalState(subject, SecurityMarking.class, new ColumnVisibilitySecurityMarking());
+        setInternalState(subject, QueryParameters.class, new QueryParametersImpl());
+        setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
+        setInternalState(connectionRequestBean, EJBContext.class, context);
+        setInternalState(subject, AccumuloConnectionRequestBean.class, connectionRequestBean);
+        Throwable result1 = null;
+        try {
+            subject.planQuery(queryLogicName, queryParameters);
+        } catch (DatawaveWebApplicationException e) {
+            result1 = e.getCause();
+        }
+        PowerMock.verifyAll();
+        
+        // Verify results
+        assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
+        assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
+        assertEquals("Thrown exception expected to detail reason for access denial",
+                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
+    }
+    
+    @Test
+    public void testPredictQuery_userNotInAllowedDNs() throws Exception {
+        // Set local test input
+        String queryLogicName = "queryLogicName";
+        String query = "query";
+        String queryName = "queryName";
+        String queryVisibility = "A&B";
+        long currentTime = System.currentTimeMillis();
+        Date beginDate = new Date(currentTime - 5000);
+        Date endDate = new Date(currentTime - 1000);
+        String queryAuthorizations = "AUTH_1";
+        Date expirationDate = new Date(currentTime + 999999);
+        int pagesize = 10;
+        int pageTimeout = -1;
+        QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        boolean trace = false;
+        String userName = "userName";
+        String userSid = "userSid";
+        String userDN = "userdn";
+        SubjectIssuerDNPair userDNpair = SubjectIssuerDNPair.of(userDN);
+        
+        MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
+        queryParameters.putSingle(QueryParameters.QUERY_LOGIC_NAME, queryLogicName);
+        queryParameters.putSingle(QueryParameters.QUERY_STRING, query);
+        queryParameters.putSingle(QueryParameters.QUERY_NAME, queryName);
+        queryParameters.putSingle(QueryParameters.QUERY_BEGIN, QueryParametersImpl.formatDate(beginDate));
+        queryParameters.putSingle(QueryParameters.QUERY_END, QueryParametersImpl.formatDate(endDate));
+        queryParameters.putSingle(QueryParameters.QUERY_EXPIRATION, QueryParametersImpl.formatDate(expirationDate));
+        queryParameters.putSingle(QueryParameters.QUERY_AUTHORIZATIONS, queryAuthorizations);
+        queryParameters.putSingle(QueryParameters.QUERY_PAGESIZE, String.valueOf(pagesize));
+        queryParameters.putSingle(QueryParameters.QUERY_PAGETIMEOUT, String.valueOf(pageTimeout));
+        queryParameters.putSingle(QueryParameters.QUERY_PERSISTENCE, persistenceMode.name());
+        queryParameters.putSingle(QueryParameters.QUERY_TRACE, String.valueOf(trace));
+        queryParameters.putSingle(ColumnVisibilitySecurityMarking.VISIBILITY_MARKING, queryVisibility);
+        queryParameters.putSingle("valid", "param");
+        
+        ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
+        marking.validate(queryParameters);
+        
+        QueryParameters qp = new QueryParametersImpl();
+        qp.validate(queryParameters);
+        
+        MultivaluedMap<String,String> op = qp.getUnknownParameters(queryParameters);
+        op.putSingle(PrivateAuditConstants.LOGIC_CLASS, queryLogicName);
+        op.putSingle(PrivateAuditConstants.COLUMN_VISIBILITY, queryVisibility);
+        op.putSingle(PrivateAuditConstants.USER_DN, userDNpair.subjectDN());
+        
+        // Set expectations of the create logic
+        queryLogic1.validate(queryParameters);
+        expect(this.queryLogicFactory.getQueryLogic(queryLogicName, this.principal)).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.context.getCallerPrincipal()).andReturn(this.principal).anyTimes();
+        expect(this.principal.getName()).andReturn(userName);
+        expect(this.principal.getShortName()).andReturn(userSid);
+        expect(this.principal.getUserDN()).andReturn(userDNpair);
+        expect(this.principal.getDNs()).andReturn(new String[] {userDN});
+        expect(this.principal.getProxyServers()).andReturn(new HashSet<>(0)).anyTimes();
+        expect(this.queryLogic1.containsDNWithAccess(Collections.singletonList(userDN))).andReturn(false);
+        
+        // Run the test
+        PowerMock.replayAll();
+        QueryExecutorBean subject = new QueryExecutorBean();
+        setInternalState(subject, EJBContext.class, context);
+        setInternalState(subject, AccumuloConnectionFactory.class, connectionFactory);
+        setInternalState(subject, ResponseObjectFactory.class, responseObjectFactory);
+        setInternalState(subject, CreatedQueryLogicCacheBean.class, qlCache);
+        setInternalState(subject, QueryCache.class, cache);
+        setInternalState(subject, ClosedQueryCache.class, closedCache);
+        setInternalState(subject, Persister.class, persister);
+        setInternalState(subject, QueryLogicFactoryImpl.class, queryLogicFactory);
+        setInternalState(subject, QueryExpirationConfiguration.class, queryExpirationConf);
+        setInternalState(subject, AuditBean.class, auditor);
+        setInternalState(subject, QueryMetricsBean.class, metrics);
+        setInternalState(subject, Multimap.class, traceInfos);
+        setInternalState(subject, SecurityMarking.class, new ColumnVisibilitySecurityMarking());
+        setInternalState(subject, QueryParameters.class, new QueryParametersImpl());
+        setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
+        setInternalState(connectionRequestBean, EJBContext.class, context);
+        setInternalState(subject, AccumuloConnectionRequestBean.class, connectionRequestBean);
+        Throwable result1 = null;
+        try {
+            subject.predictQuery(queryLogicName, queryParameters);
+        } catch (DatawaveWebApplicationException e) {
+            result1 = e.getCause();
+        }
+        PowerMock.verifyAll();
+        
+        // Verify results
+        assertTrue("QueryException expected to have been thrown", result1 instanceof QueryException);
+        assertEquals("Thrown exception expected to have been due to access denied", "401", ((QueryException) result1).getErrorCode());
+        assertEquals("Thrown exception expected to detail reason for access denial",
+                        "User userdn is not part of the authorized DNs for the query logic queryLogicName", result1.getMessage());
     }
     
     public class TestQuery extends QueryImpl {

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -281,6 +281,7 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
         EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.EMPTY_SET);
         EasyMock.expect(logic.getConnectionPriority()).andReturn(AccumuloConnectionFactory.Priority.NORMAL);
+        EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getCollectQueryMetrics()).andReturn(Boolean.FALSE);
         
@@ -361,6 +362,7 @@ public class QueryExecutorBeanTest {
         
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
         EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.EMPTY_SET);
+        EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getAuditType(EasyMock.<Query> anyObject())).andReturn(AuditType.ACTIVE).anyTimes();
         EasyMock.expect(logic.getSelectors(anyObject())).andReturn(null);
@@ -418,6 +420,7 @@ public class QueryExecutorBeanTest {
         
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
         EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.EMPTY_SET);
+        EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         
         BaseQueryMetric metric = new QueryMetricFactoryImpl().createMetric();
@@ -678,6 +681,7 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
         EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.emptySet());
         EasyMock.expect(logic.getConnectionPriority()).andReturn(AccumuloConnectionFactory.Priority.NORMAL).atLeastOnce();
+        EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getAuditType(q)).andReturn(AuditType.NONE);
         EasyMock.expect(logic.getConnPoolName()).andReturn("connPool1");


### PR DESCRIPTION
Support restricting access to query logics that have defined sets of
authorized DNs to only calling principals with an authorized DN.

Fixes #1027