### PR TITLE
Support custom result limits by DN in Execution service

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -7,13 +7,6 @@ import datawave.webservice.query.Query;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.iterator.DatawaveTransformIterator;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
-import java.security.Principal;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.inject.Inject;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.ScannerBase;
@@ -21,12 +14,21 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.springframework.beans.factory.annotation.Required;
 
+import javax.inject.Inject;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     
     private GenericQueryConfiguration baseConfig;
     private String logicName = "No logicName was set";
     private String logicDescription = "Not configured";
     private AuditType auditType = null;
+    private Map<String,Long> dnResultLimits = null;
     protected long maxResults = -1L;
     protected ScannerBase scanner;
     @SuppressWarnings("unchecked")
@@ -321,5 +323,15 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     
     public SelectorExtractor getSelectorExtractor() {
         return selectorExtractor;
+    }
+    
+    @Override
+    public void setDnResultLimits(Map<String,Long> dnResultLimits) {
+        this.dnResultLimits = dnResultLimits;
+    }
+    
+    @Override
+    public Map<String,Long> getDnResultLimits() {
+        return dnResultLimits;
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
@@ -1,9 +1,5 @@
 package datawave.webservice.query.logic;
 
-import java.security.Principal;
-import java.util.List;
-import java.util.Set;
-
 import datawave.audit.SelectorExtractor;
 import datawave.marking.MarkingFunctions;
 import datawave.validation.ParameterValidator;
@@ -15,11 +11,16 @@ import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
-
 import datawave.webservice.result.BaseResponse;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
+
+import java.security.Principal;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidator {
     
@@ -297,4 +298,36 @@ public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidato
      */
     Set<String> getExampleQueries();
     
+    /**
+     * Set the map of DNs to query result limits. This should override the default limit returned by {@link #getMaxResults()} for any included DNs.
+     *
+     * @param dnResultLimits
+     *            the map of DNs to query result limits
+     */
+    void setDnResultLimits(Map<String,Long> dnResultLimits);
+    
+    /**
+     * Return the map of DNs to result limits.
+     *
+     * @return the map of DNs to query result limits
+     */
+    Map<String,Long> getDnResultLimits();
+    
+    /**
+     * Return the maximum number of results to include for the query for any DN present in the specified collection. If limits are found for multiple DNs in the
+     * collection, the smallest value will be returned. If the provided collection is null or empty, or if no limits are found for any DN, the value of
+     * {@link #getMaxResults()} will be returned.
+     * 
+     * @param dns
+     *            the DNs to determine the maximum number of results to include for the query. It's expected that this list represents all the DNs in the DN
+     *            chain for an individual user.
+     * @return the maximum number of results to include
+     */
+    default long getResultLimit(Collection<String> dns) {
+        Map<String,Long> dnResultLimits = getDnResultLimits();
+        if (dnResultLimits == null || dns == null) {
+            return getMaxResults();
+        }
+        return dns.stream().filter(dnResultLimits::containsKey).map(dnResultLimits::get).min(Long::compareTo).orElseGet(this::getMaxResults);
+    }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
@@ -1,17 +1,5 @@
 package datawave.webservice.query.runner;
 
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import datawave.security.util.AuthorizationsUtil;
 import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.webservice.query.Query;
@@ -30,7 +18,6 @@ import datawave.webservice.query.metric.BaseQueryMetric.Prediction;
 import datawave.webservice.query.metric.QueryMetric;
 import datawave.webservice.query.metric.QueryMetricsBean;
 import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
-
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.thrift.TInfo;
@@ -38,6 +25,18 @@ import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.jboss.logging.NDC;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Object that encapsulates a running query
@@ -65,6 +64,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
     private ExecutorService executor = null;
     private volatile Future<Object> future = null;
     private QueryPredictor predictor = null;
+    private long maxResults = 0;
     
     public RunningQuery() {
         super(new QueryMetricFactoryImpl());
@@ -119,6 +119,11 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
         // If connection is null, then we are likely not going to use this object for query, probably for removing or closing it.
         if (null != connection) {
             setConnection(connection);
+        }
+        this.maxResults = this.logic.getResultLimit(this.settings.getDnList());
+        if (this.maxResults != this.logic.getMaxResults()) {
+            log.info("Maximum results set to " + this.maxResults + " instead of default " + this.logic.getMaxResults() + ", user " + this.settings.getUserDN()
+                            + " has a DN configured with a different limit");
         }
     }
     
@@ -229,7 +234,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
                         this.getMetric().setLifecycle(QueryMetric.Lifecycle.MAXRESULTS);
                         break;
                     }
-                } else if (this.logic.getMaxResults() >= 0 && numResults >= this.logic.getMaxResults()) {
+                } else if (this.maxResults >= 0 && numResults >= this.maxResults) {
                     log.info("Query logic max results has been reached, aborting query.next call");
                     this.getMetric().setLifecycle(QueryMetric.Lifecycle.MAXRESULTS);
                     break;

--- a/web-services/query/src/test/java/datawave/webservice/query/cache/QueryCacheBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/cache/QueryCacheBeanTest.java
@@ -4,16 +4,15 @@ import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.logic.QueryLogic;
 import datawave.webservice.query.runner.RunningQuery;
-
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.util.Pair;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -21,17 +20,12 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.easymock.EasyMock.expect;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.powermock.reflect.Whitebox.setInternalState;
 
 @RunWith(PowerMockRunner.class)
 public class QueryCacheBeanTest {
-    
-    private RunningQuery query = null;
-    
-    private QueryCacheBean bean = null;
-    private String expectedResult = null;
     
     @Mock
     QueryCache altCache;
@@ -45,33 +39,6 @@ public class QueryCacheBeanTest {
     @Mock
     CreatedQueryLogicCacheBean remoteCache;
     
-    @Before
-    public void setup() throws Exception {
-        QueryImpl q = new QueryImpl();
-        q.setQueryLogicName("EventQuery");
-        q.setBeginDate(new Date());
-        q.setEndDate(new Date());
-        q.setExpirationDate(new Date());
-        q.setId(UUID.randomUUID());
-        q.setPagesize(10);
-        q.setQuery("FOO == BAR");
-        q.setQueryName("test query");
-        q.setQueryAuthorizations("ALL");
-        q.setUserDN("some user");
-        
-        query = new RunningQuery(null, AccumuloConnectionFactory.Priority.HIGH, null, q, null, null, new QueryMetricFactoryImpl());
-        bean = new QueryCacheBean();
-        
-        QueryCache cache = new QueryCache();
-        cache.init();
-        cache.put(query.getSettings().getId().toString(), query);
-        CreatedQueryLogicCacheBean qlCache = new CreatedQueryLogicCacheBean();
-        setInternalState(bean, QueryCache.class, cache);
-        setInternalState(bean, CreatedQueryLogicCacheBean.class, qlCache);
-        expectedResult = query.toString();
-    }
-    
-    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
     public void testInit() throws Exception {
         // Run the test
@@ -82,7 +49,7 @@ public class QueryCacheBeanTest {
     
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
-    public void testListRunningQueries() throws Exception {
+    public void testListRunningQueries() {
         // Set expectations
         expect(altCache.iterator()).andReturn((Iterator<RunningQuery>) new HashMap().values().iterator());
         Map<String,Pair<QueryLogic<?>,Connector>> snapshot = new HashMap<>();
@@ -121,9 +88,10 @@ public class QueryCacheBeanTest {
     
     @Test
     public void testCancelUserQuery_HappyPath() throws Exception {
+        
         // Set expectations
         UUID queryId = UUID.randomUUID();
-        expect(this.altCache.get(queryId.toString())).andReturn(this.query);
+        expect(this.altCache.get(queryId.toString())).andReturn(null);
         
         // Run the test
         PowerMock.replayAll();
@@ -137,7 +105,37 @@ public class QueryCacheBeanTest {
     }
     
     @Test
-    public void testGetRunningQueries() {
+    public void testGetRunningQueries() throws Exception {
+        QueryImpl q = new QueryImpl();
+        q.setQueryLogicName("EventQuery");
+        q.setBeginDate(new Date());
+        q.setEndDate(new Date());
+        q.setExpirationDate(new Date());
+        q.setId(UUID.randomUUID());
+        q.setPagesize(10);
+        q.setQuery("FOO == BAR");
+        q.setQueryName("test query");
+        q.setQueryAuthorizations("ALL");
+        q.setUserDN("some user");
+        q.setDnList(Collections.singletonList("some user"));
+        
+        expect(logic.getCollectQueryMetrics()).andReturn(false);
+        expect(logic.getResultLimit(q.getDnList())).andReturn(-1L);
+        expect(logic.getMaxResults()).andReturn(-1L);
+        
+        PowerMock.replayAll();
+        
+        RunningQuery query = new RunningQuery(null, AccumuloConnectionFactory.Priority.HIGH, logic, q, null, null, new QueryMetricFactoryImpl());
+        QueryCacheBean bean = new QueryCacheBean();
+        
+        QueryCache cache = new QueryCache();
+        cache.init();
+        cache.put(query.getSettings().getId().toString(), query);
+        CreatedQueryLogicCacheBean qlCache = new CreatedQueryLogicCacheBean();
+        setInternalState(bean, QueryCache.class, cache);
+        setInternalState(bean, CreatedQueryLogicCacheBean.class, qlCache);
+        String expectedResult = query.toString();
+        
         RunningQueries output = bean.getRunningQueries();
         assertEquals(expectedResult, output.getQueries().get(0));
     }

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -360,6 +360,7 @@ public class ExtendedQueryExecutorBeanTest {
     public void testAdminCancel_LookupAccumuloQuery() throws Exception {
         // Set local test input
         UUID queryId = UUID.randomUUID();
+        List<String> dnList = Collections.singletonList("qwe");
         
         // Set expectations of the create logic
         expect(this.connectionRequestBean.adminCancelConnectionRequest(queryId.toString())).andReturn(false);
@@ -371,6 +372,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.query.getQueryLogicName()).andReturn("ql1").anyTimes();
         expect(this.query.getOwner()).andReturn("qwe").anyTimes();
         expect(this.query.getUserDN()).andReturn("qwe").anyTimes();
+        expect(this.query.getDnList()).andReturn(dnList).anyTimes();
         expect(this.query.getId()).andReturn(queryId).anyTimes();
         expect(this.query.getQuery()).andReturn("qwe").anyTimes();
         expect(this.query.getBeginDate()).andReturn(null).anyTimes();
@@ -385,6 +387,8 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.queryLogicFactory.getQueryLogic("ql1", principal)).andReturn((QueryLogic) this.queryLogic1);
         expect(this.queryLogic1.getConnectionPriority()).andReturn(Priority.NORMAL);
         expect(this.queryLogic1.getCollectQueryMetrics()).andReturn(false);
+        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         cache.put(eq(queryId.toString()), isA(RunningQuery.class));
         cache.remove(queryId.toString());
         this.queryLogic1.close();
@@ -783,6 +787,9 @@ public class ExtendedQueryExecutorBeanTest {
         this.metrics.updateMetric(isA(QueryMetric.class));
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
+        expect(this.query.getDnList()).andReturn(dnList).anyTimes();
+        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic1.setupQuery(this.genericConfiguration);
         expect(this.queryLogic1.getTransformIterator(this.query)).andReturn(this.transformIterator);
@@ -955,6 +962,9 @@ public class ExtendedQueryExecutorBeanTest {
         this.metrics.updateMetric(isA(QueryMetric.class));
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
+        expect(this.query.getDnList()).andReturn(dnList).anyTimes();
+        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic1.setupQuery(this.genericConfiguration);
         expect(this.queryLogic1.getTransformIterator(this.query)).andReturn(this.transformIterator);
@@ -1238,6 +1248,9 @@ public class ExtendedQueryExecutorBeanTest {
         this.metrics.updateMetric(isA(QueryMetric.class));
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
+        expect(this.query.getDnList()).andReturn(dnList).anyTimes();
+        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic1.setupQuery(this.genericConfiguration);
         expect(this.queryLogic1.getTransformIterator(this.query)).andReturn(this.transformIterator);
@@ -2241,7 +2254,7 @@ public class ExtendedQueryExecutorBeanTest {
         String userName = "userName";
         String sid = "sid";
         UUID queryId = UUID.randomUUID();
-        
+        List<String> dnList = Collections.singletonList("userDn");
         HashMap<String,Collection<String>> authsMap = new HashMap<>();
         authsMap.put("USERDN", Arrays.asList("AUTH_1"));
         
@@ -2272,6 +2285,9 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.query.getPageTimeout()).andReturn(-1).anyTimes();
         expect(this.query.getExpirationDate()).andReturn(null).anyTimes();
         expect(this.query.getParameters()).andReturn((Set) Collections.emptySet()).anyTimes();
+        expect(this.query.getDnList()).andReturn(dnList).anyTimes();
+        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         this.cache.put(eq(queryId.toString()), isA(RunningQuery.class));
         
         // Run the test
@@ -2729,7 +2745,8 @@ public class ExtendedQueryExecutorBeanTest {
         qp.setExpirationDate(new Date());
         qp.setQueryName(queryName);
         qp.setUserDN(userDN);
-        qp.setDnList(Collections.singletonList(userDN));
+        List<String> dnList = Collections.singletonList(userDN);
+        qp.setDnList(dnList);
         
         MultivaluedMap<String,String> map = qp.toMap();
         map.putSingle(PrivateAuditConstants.AUDIT_TYPE, AuditType.PASSIVE.name());
@@ -2764,6 +2781,9 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.cache.lock(queryName)).andReturn(true);
         expect(this.queryLogic1.getAuditType(this.query)).andReturn(AuditType.PASSIVE);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
+        expect(this.query.getDnList()).andReturn(dnList).anyTimes();
+        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.query.toMap()).andReturn(map);
         expect(this.query.getColumnVisibility()).andReturn(authorization);
         expect(this.queryLogic1.getSelectors(this.query)).andReturn(null);

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -1,23 +1,6 @@
 package datawave.webservice.query.runner;
 
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.isA;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
+import com.google.common.collect.Lists;
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.security.authorization.DatawaveUser;
 import datawave.security.authorization.DatawaveUser.UserType;
@@ -33,7 +16,6 @@ import datawave.webservice.query.logic.QueryLogic;
 import datawave.webservice.query.metric.QueryMetric;
 import datawave.webservice.query.metric.QueryMetricsBean;
 import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
-
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.Transformer;
@@ -45,6 +27,24 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 public class ExtendedRunningQueryTest {
@@ -121,6 +121,7 @@ public class ExtendedRunningQueryTest {
         
         // Set local test input
         String userDN = "userDN";
+        List<String> dnList = Lists.newArrayList(userDN);
         String userSid = "userSid";
         UUID queryId = UUID.randomUUID();
         String methodAuths = "AUTH_1";
@@ -157,6 +158,7 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getParameters()).andReturn(new HashSet<>());
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths);
         expect(this.query.getUserDN()).andReturn(userDN).times(2);
+        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
@@ -172,6 +174,7 @@ public class ExtendedRunningQueryTest {
         expect(this.queryLogic.getMaxWork()).andReturn(maxWork).anyTimes();
         expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
         expect(this.genericConfiguration.getQueryString()).andReturn(query).once();
+        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
         
         // Run the test
         PowerMock.replayAll();
@@ -200,6 +203,7 @@ public class ExtendedRunningQueryTest {
     public void testNextMaxResults_HappyPathUsingDeprecatedConstructor() throws Exception {
         // Set local test input
         String userDN = "userDN";
+        List<String> dnList = Lists.newArrayList(userDN);
         String userSid = "userSid";
         UUID queryId = UUID.randomUUID();
         String methodAuths = "AUTH_1";
@@ -237,9 +241,11 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getParameters()).andReturn(new HashSet<>());
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths);
         expect(this.query.getUserDN()).andReturn(userDN).times(2);
+        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
+        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
         
         Iterator<Object> iterator = resultObjects.iterator();
         int count = 0;
@@ -283,10 +289,12 @@ public class ExtendedRunningQueryTest {
     public void testNext_NoResultsAfterCancellationUsingDeprecatedConstructor() throws Exception {
         // Set local test input
         String userDN = "userDN";
+        List<String> dnList = Lists.newArrayList(userDN);
         UUID queryId = UUID.randomUUID();
         String methodAuths = "AUTH_1";
         DatawaveUser user = new DatawaveUser(SubjectIssuerDNPair.of("userDN", "issuerDN"), UserType.USER, Collections.singleton(methodAuths), null, null, 0L);
         DatawavePrincipal principal = new DatawavePrincipal(Collections.singletonList(user));
+        long maxResults = 100L;
         
         // Set expectations
         expect(this.queryLogic.getCollectQueryMetrics()).andReturn(true);
@@ -295,6 +303,7 @@ public class ExtendedRunningQueryTest {
         expect(this.exceptionHandler.getThrowable()).andReturn(null).times(3);
         expect(this.query.getId()).andReturn(queryId).times(2);
         expect(this.query.getUserDN()).andReturn(userDN).times(2);
+        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         this.queryMetrics.updateMetric(isA(QueryMetric.class));
@@ -302,6 +311,8 @@ public class ExtendedRunningQueryTest {
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
         expect(this.transformIterator.hasNext()).andReturn(true);
         expect(this.genericConfiguration.getQueryString()).andReturn("query").once();
+        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
+        expect(this.queryLogic.getMaxResults()).andReturn(maxResults);
         
         // Run the test
         PowerMock.replayAll();
@@ -326,10 +337,12 @@ public class ExtendedRunningQueryTest {
     public void testCloseConnection_HappyPath() throws Exception {
         // Set local test input
         String userDN = "userDN";
+        List<String> dnList = Lists.newArrayList(userDN);
         UUID queryId = UUID.randomUUID();
         String methodAuths = "AUTH_1";
         DatawaveUser user = new DatawaveUser(SubjectIssuerDNPair.of("userDN", "issuerDN"), UserType.USER, Collections.singleton(methodAuths), null, null, 0L);
         DatawavePrincipal principal = new DatawavePrincipal(Collections.singletonList(user));
+        long maxResults = 100L;
         
         // Set expectations
         expect(this.transformIterator.getTransformer()).andReturn(transformer);
@@ -339,8 +352,11 @@ public class ExtendedRunningQueryTest {
         expect(this.exceptionHandler.getThrowable()).andReturn(null);
         expect(this.query.getId()).andReturn(queryId).times(2);
         expect(this.query.getUserDN()).andReturn(userDN).times(2);
+        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         expect(this.genericConfiguration.getQueryString()).andReturn("query").once();
+        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
+        expect(this.queryLogic.getMaxResults()).andReturn(maxResults);
         this.queryLogic.setupQuery(this.genericConfiguration);
         this.queryMetrics.updateMetric(isA(QueryMetric.class));
         PowerMock.expectLastCall().times(3);
@@ -357,5 +373,92 @@ public class ExtendedRunningQueryTest {
         PowerMock.verifyAll();
         
         assertSame("Expected status to be closed", status, QueryMetric.Lifecycle.CLOSED);
+    }
+    
+    @SuppressWarnings({"unchecked"})
+    @Test
+    public void testNextWithDnResultLimit_HappyPathUsingDeprecatedConstructor() throws Exception {
+        // Set local test input
+        String userDN = "userDN";
+        List<String> dnList = Lists.newArrayList(userDN);
+        String userSid = "userSid";
+        UUID queryId = UUID.randomUUID();
+        String methodAuths = "AUTH_1";
+        DatawaveUser user = new DatawaveUser(SubjectIssuerDNPair.of("userDN", "issuerDN"), UserType.USER, Collections.singleton(methodAuths), null, null, 0L);
+        DatawavePrincipal principal = new DatawavePrincipal(Collections.singletonList(user));
+        String query = "query";
+        String queryLogicName = "queryLogicName";
+        String queryName = "queryName";
+        long currentTime = System.currentTimeMillis();
+        Date beginDate = new Date(currentTime - 5000);
+        Date endDate = new Date(currentTime - 1000);
+        Date expirationDate = new Date(currentTime + 9999);
+        int pageSize = 5;
+        int maxPageSize = 5;
+        
+        long pageByteTrigger = 4 * 1024L;
+        long maxWork = Long.MAX_VALUE;
+        long maxResults = 10L;
+        long dnResultLimit = 2L;
+        List<Object> resultObjects = Arrays.asList(new Object(), "resultObject1", "resultObject2", "resultObject3", "resultObject4", "resultObject5");
+        
+        // Set expectations
+        expect(this.queryLogic.getCollectQueryMetrics()).andReturn(true);
+        this.query.populateMetric(isA(QueryMetric.class));
+        expect(this.query.getUncaughtExceptionHandler()).andReturn(exceptionHandler).times(5);
+        expect(this.exceptionHandler.getThrowable()).andReturn(null).times(5);
+        expect(this.query.getId()).andReturn(queryId).times(3);
+        expect(this.query.getOwner()).andReturn(userSid);
+        expect(this.query.getQuery()).andReturn(query);
+        expect(this.query.getQueryLogicName()).andReturn(queryLogicName);
+        expect(this.query.getQueryName()).andReturn(queryName);
+        expect(this.query.getBeginDate()).andReturn(beginDate);
+        expect(this.query.getEndDate()).andReturn(endDate);
+        expect(this.query.isMaxResultsOverridden()).andReturn(false).anyTimes();
+        expect(this.query.getExpirationDate()).andReturn(expirationDate);
+        expect(this.query.getParameters()).andReturn(new HashSet<>());
+        expect(this.query.getQueryAuthorizations()).andReturn(methodAuths);
+        expect(this.query.getUserDN()).andReturn(userDN).times(3);
+        expect(this.query.getDnList()).andReturn(dnList);
+        expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
+        this.queryLogic.setupQuery(this.genericConfiguration);
+        expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
+        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(dnResultLimit);
+        
+        Iterator<Object> iterator = resultObjects.iterator();
+        int count = 0;
+        expect(this.transformIterator.hasNext()).andReturn(iterator.hasNext());
+        while (iterator.hasNext() && count < dnResultLimit) {
+            expect(this.transformIterator.hasNext()).andReturn(iterator.hasNext());
+            expect(this.transformIterator.next()).andReturn(iterator.next());
+            count++;
+        }
+        expect(this.transformIterator.getTransformer()).andReturn(transformer).times(count);
+        
+        expect(this.query.getPagesize()).andReturn(pageSize).anyTimes();
+        expect(this.queryLogic.getMaxPageSize()).andReturn(maxPageSize).anyTimes();
+        expect(this.queryLogic.getPageByteTrigger()).andReturn(pageByteTrigger).anyTimes();
+        expect(this.queryLogic.getMaxWork()).andReturn(maxWork).anyTimes();
+        expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
+        expect(this.genericConfiguration.getQueryString()).andReturn(query).once();
+        
+        // Run the test
+        PowerMock.replayAll();
+        RunningQuery subject = new RunningQuery(this.connector, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
+                        new QueryMetricFactoryImpl());
+        
+        ResultsPage result1 = subject.next();
+        
+        String result2 = subject.toString();
+        QueryMetric.Lifecycle status = subject.getMetric().getLifecycle();
+        PowerMock.verifyAll();
+        
+        // Verify results
+        assertNotNull("Expected a non-null page", result1);
+        assertNotNull("Expected a non-null list of results", result1.getResults());
+        assertTrue("Expected DN max results non-null items in the list of results", resultObjects.size() > dnResultLimit);
+        assertSame("Expected status to be MAXRESULTS", status, QueryMetric.Lifecycle.MAXRESULTS);
+        
+        assertNotNull("Expected a non-null toString() representation", result2);
     }
 }

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -226,6 +226,7 @@ public class QueryExecutorBeanTest {
         q.setQueryAuthorizations(StringUtils.join(auths, ","));
         q.setQueryLogicName(queryLogicName);
         q.setUserDN(userDN);
+        q.setDnList(Collections.singletonList(userDN));
         q.setId(UUID.randomUUID());
         
         return q;
@@ -283,7 +284,8 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(logic.getConnectionPriority()).andReturn(AccumuloConnectionFactory.Priority.NORMAL);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getCollectQueryMetrics()).andReturn(Boolean.FALSE);
-        
+        EasyMock.expect(logic.getResultLimit(q.getDnList())).andReturn(-1L);
+        EasyMock.expect(logic.getMaxResults()).andReturn(-1L);
         PowerMock.replayAll();
         
         bean.defineQuery(queryLogicName, p);
@@ -681,6 +683,8 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getAuditType(q)).andReturn(AuditType.NONE);
         EasyMock.expect(logic.getConnPoolName()).andReturn("connPool1");
+        EasyMock.expect(logic.getResultLimit(eq(q.getDnList()))).andReturn(-1L).anyTimes();
+        EasyMock.expect(logic.getMaxResults()).andReturn(-1L).anyTimes();
         
         EasyMock.expect(connectionRequestBean.cancelConnectionRequest(q.getId().toString(), principal)).andReturn(false).anyTimes();
         connectionFactory.returnConnection(EasyMock.isA(Connector.class));

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/RunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/RunningQueryTest.java
@@ -1,25 +1,6 @@
 package datawave.webservice.query.runner;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-import java.util.ArrayList;
-
+import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.security.authorization.DatawaveUser;
 import datawave.security.authorization.DatawaveUser.UserType;
@@ -35,15 +16,33 @@ import datawave.webservice.query.logic.QueryLogic;
 import datawave.webservice.query.logic.TestQueryLogic;
 import datawave.webservice.query.logic.composite.CompositeQueryLogic;
 import datawave.webservice.query.logic.composite.CompositeQueryLogicTest;
-
 import org.apache.accumulo.core.client.Connector;
-import datawave.accumulo.inmemory.InMemoryInstance;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
 
 public class RunningQueryTest {
     
@@ -110,6 +109,8 @@ public class RunningQueryTest {
         TransformIterator iter = new TransformIterator();
         expect(logic.getCollectQueryMetrics()).andReturn(Boolean.FALSE);
         expect(logic.getTransformIterator(settings)).andReturn(iter);
+        expect(logic.getResultLimit(settings.getDnList())).andReturn(-1L);
+        expect(logic.getMaxResults()).andReturn(-1L);
         replay(logic);
         
         RunningQuery query = new RunningQuery(connector, connectionPriority, logic, settings, methodAuths, principal, new QueryMetricFactoryImpl());
@@ -126,6 +127,11 @@ public class RunningQueryTest {
         Connector connector = null;
         DatawaveUser user = new DatawaveUser(userDN, UserType.USER, null, null, null, 0L);
         DatawavePrincipal principal = new DatawavePrincipal(Collections.singletonList(user));
+        
+        expect(logic.getCollectQueryMetrics()).andReturn(false);
+        expect(logic.getResultLimit(settings.getDnList())).andReturn(-1L);
+        expect(logic.getMaxResults()).andReturn(-1L);
+        replay(logic);
         
         RunningQuery query = new RunningQuery(connector, connectionPriority, logic, settings, methodAuths, principal, new QueryMetricFactoryImpl());
         


### PR DESCRIPTION
Allow query logics to be configured with custom limits for specific DNs.
Update the execution service to then use these custom limits instead of
the default maxResults when applicable.

Fixes #1028