### PR TITLE
fixes #1123: Fixed the parsing and generation of hit terms

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
@@ -219,27 +219,25 @@ public class LimitFields implements Function<Entry<Key,Document>,Entry<Key,Docum
     }
     
     private Map<String,String> getHitTermMap(Document document) {
-        Attribute<?> attr = document.get(JexlEvaluation.HIT_TERM_FIELD);
         Map<String,String> attrMap = new HashMap<>();
-        if (attr instanceof Attributes) {
-            Attributes attrs = (Attributes) attr;
-            for (Attribute<?> at : attrs.getAttributes()) {
-                if (at instanceof Content) {
-                    Content content = (Content) at;
-                    // split the content into its fieldname:value
-                    String contentString = content.getContent();
-                    String[] fieldValue = new String[] {contentString.substring(0, contentString.indexOf(":")),
-                            contentString.substring(contentString.indexOf(":") + 1)};
-                    attrMap.put(fieldValue[0], fieldValue[1]);
-                }
-            }
-        } else if (attr instanceof Content) {
-            Content content = (Content) attr;
-            // split the content into its fieldname:value
-            String[] fieldValue = Iterables.toArray(Splitter.on(":").omitEmptyStrings().trimResults().split(content.getContent()), String.class);
-            attrMap.put(fieldValue[0], fieldValue[1]);
-        }
+        fillHitTermMap(document.get(JexlEvaluation.HIT_TERM_FIELD), attrMap);
         return attrMap;
+    }
+    
+    private void fillHitTermMap(Attribute<?> attr, Map<String,String> attrMap) {
+        if (attr != null) {
+            if (attr instanceof Attributes) {
+                Attributes attrs = (Attributes) attr;
+                for (Attribute<?> at : attrs.getAttributes()) {
+                    fillHitTermMap(at, attrMap);
+                }
+            } else if (attr instanceof Content) {
+                Content content = (Content) attr;
+                // split the content into its fieldname:value
+                String contentString = content.getContent();
+                attrMap.put(contentString.substring(0, contentString.indexOf(":")), contentString.substring(contentString.indexOf(":") + 1));
+            }
+        }
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveInterpreter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveInterpreter.java
@@ -96,17 +96,8 @@ public class DatawaveInterpreter extends Interpreter {
         
         result = super.visit(node, data);
         
-        if (this.arithmetic instanceof HitListArithmetic) {
-            HitListArithmetic hitListArithmetic = (HitListArithmetic) arithmetic;
-            Set<String> hitSet = hitListArithmetic.getHitSet();
-            if (hitSet != null && result instanceof Collection<?>) {
-                for (Object o : ((Collection<?>) result)) {
-                    if (o instanceof ValueTuple) {
-                        hitListArithmetic.add((ValueTuple) o);
-                    }
-                }
-            }
-        }
+        addHits(result);
+        
         // if the function stands alone, then it needs to return ag boolean
         // if the function is paired with a method that is called on its results (like 'size') then the
         // actual results must be returned.
@@ -329,18 +320,25 @@ public class DatawaveInterpreter extends Interpreter {
                                                 rightInclusive);
                             }
                         }
-                        if (this.arithmetic instanceof HitListArithmetic) {
-                            HitListArithmetic hitListArithmetic = (HitListArithmetic) arithmetic;
-                            Set<String> hitSet = hitListArithmetic.getHitSet();
-                            if (hitSet != null) {
-                                hitSet.addAll((Collection<String>) evaluation);
-                            }
-                        }
+                        addHits(fieldValue);
                     }
                 }
             }
         }
         return evaluation;
+    }
+    
+    private void addHits(Object fieldValue) {
+        if (this.arithmetic instanceof HitListArithmetic && fieldValue != null) {
+            HitListArithmetic hitListArithmetic = (HitListArithmetic) arithmetic;
+            if (fieldValue instanceof Collection<?>) {
+                for (Object o : ((Collection<?>) fieldValue)) {
+                    addHits(o);
+                }
+            } else if (fieldValue instanceof ValueTuple) {
+                hitListArithmetic.add((ValueTuple) fieldValue);
+            }
+        }
     }
     
     public Object visit(ASTAndNode node, Object data) {
@@ -489,7 +487,7 @@ public class DatawaveInterpreter extends Interpreter {
                     }
                 }
             } catch (IOException | URISyntaxException e) {
-                log.warn("Unable to load ExceededOrThreshold Paramters during evaluation", e);
+                log.warn("Unable to load ExceededOrThreshold Parameters during evaluation", e);
             }
         }
         
@@ -558,6 +556,8 @@ public class DatawaveInterpreter extends Interpreter {
         
         if (evaluation.isEmpty())
             return Boolean.FALSE;
+        
+        addHits(evaluation);
         
         return evaluation;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
@@ -1,6 +1,7 @@
 package datawave.query.function;
 
 import com.google.common.collect.Sets;
+import com.google.common.io.Files;
 import datawave.configuration.spring.SpringBean;
 import datawave.helpers.PrintUtility;
 import datawave.ingest.data.TypeRegistry;
@@ -9,6 +10,7 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Attributes;
 import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.tables.ShardQueryLogic;
@@ -34,18 +36,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static datawave.query.QueryTestTableHelper.*;
 
@@ -74,9 +83,9 @@ public abstract class HitsAreAlwaysIncludedTest {
         }
         
         @Override
-        protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
-                        throws Exception {
-            super.runTestQuery(connector, queryString, startDate, endDate, extraParms, goodResults);
+        protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> expectedHits,
+                        Collection<String> goodResults) throws Exception {
+            super.runTestQuery(connector, queryString, startDate, endDate, extraParms, expectedHits, goodResults);
         }
     }
     
@@ -98,9 +107,9 @@ public abstract class HitsAreAlwaysIncludedTest {
         }
         
         @Override
-        protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
-                        throws Exception {
-            super.runTestQuery(connector, queryString, startDate, endDate, extraParms, goodResults);
+        protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> expectedHits,
+                        Collection<String> goodResults) throws Exception {
+            super.runTestQuery(connector, queryString, startDate, endDate, extraParms, expectedHits, goodResults);
         }
     }
     
@@ -147,11 +156,11 @@ public abstract class HitsAreAlwaysIncludedTest {
         deserializer = new KryoDocumentDeserializer();
     }
     
-    protected abstract void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
-                    throws Exception;
+    protected abstract void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> expectedHits,
+                    Collection<String> goodResults) throws Exception;
     
     protected void runTestQuery(Connector connector, String queryString, Date startDate, Date endDate, Map<String,String> extraParms,
-                    Collection<String> goodResults) throws Exception {
+                    Collection<String> expectedHits, Collection<String> goodResults) throws Exception {
         
         QueryImpl settings = new QueryImpl();
         settings.setBeginDate(startDate);
@@ -181,13 +190,17 @@ public abstract class HitsAreAlwaysIncludedTest {
                 for (Attribute attr : attributes.getAttributes()) {
                     if (attr instanceof Content) {
                         Content content = (Content) attr;
-                        Assert.assertTrue(goodResults.contains(content.getContent()));
+                        Assert.assertTrue(expectedHits.remove(content.getContent()));
                     }
                 }
             } else if (hitAttribute instanceof Content) {
                 Content content = (Content) hitAttribute;
-                Assert.assertTrue(goodResults.contains(content.getContent()));
+                Assert.assertTrue(content.getContent() + " is not an expected hit", expectedHits.remove(content.getContent()));
+            } else {
+                Assert.fail("Did not find hit term field");
             }
+            
+            Assert.assertTrue(expectedHits + " expected hits was not empty", expectedHits.isEmpty());
             
             // remove from goodResults as we find the expected return fields
             log.debug("goodResults: " + goodResults);
@@ -218,7 +231,7 @@ public abstract class HitsAreAlwaysIncludedTest {
                 
             }
             
-            Assert.assertTrue(goodResults + " was not empty", goodResults.isEmpty());
+            Assert.assertTrue(goodResults + " good results was not empty", goodResults.isEmpty());
         }
         Assert.assertTrue("No docs were returned!", !docs.isEmpty());
     }
@@ -244,14 +257,15 @@ public abstract class HitsAreAlwaysIncludedTest {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4");
         
         String queryString = "FOO_3_BAR == 'defg<cat>'";
         
         Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
                         "FOO_1.FOO.1.3:good");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3_BAR.FOO.3:defg<cat>");
         
-        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
     }
     
     @Test
@@ -259,12 +273,13 @@ public abstract class HitsAreAlwaysIncludedTest {
         Map<String,String> extraParameters = new HashMap<>();
         
         String queryString = "FOO_3_BAR == 'defg<cat>' and f:options('include.grouping.context', 'true', "
-                        + "'hit.list', 'true', 'limit.fields', 'FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3')";
+                        + "'hit.list', 'true', 'limit.fields', 'FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4')";
         
         Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
                         "FOO_1.FOO.1.3:good");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3_BAR.FOO.3:defg<cat>");
         
-        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
     }
     
     @Test
@@ -272,14 +287,15 @@ public abstract class HitsAreAlwaysIncludedTest {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4");
         
         String queryString = "FOO_3 == 'defg'";
         
         Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
                         "FOO_1.FOO.1.3:good");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3.FOO.3.3:defg");
         
-        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
     }
     
     @Test
@@ -293,8 +309,9 @@ public abstract class HitsAreAlwaysIncludedTest {
         
         Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
                         "FOO_1.FOO.1.3:good");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3_BAR.FOO.3:defg<cat>");
         
-        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
     }
     
     @Test
@@ -302,14 +319,15 @@ public abstract class HitsAreAlwaysIncludedTest {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4");
         
         String queryString = "FOO_3_BAR == 'defg<cat>' and FOO_1 == 'good'";
         
         Set<String> goodResults = Sets.newHashSet("FOO_1_BAR.FOO.3:good<cat>", "FOO_3_BAR.FOO.3:defg<cat>", "FOO_3.FOO.3.3:defg", "FOO_4.FOO.4.3:yes",
                         "FOO_1.FOO.1.3:good");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3_BAR.FOO.3:defg<cat>", "FOO_1.FOO.1.3:good");
         
-        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
     }
     
     @Test
@@ -317,14 +335,96 @@ public abstract class HitsAreAlwaysIncludedTest {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "false");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4");
         
         String queryString = "FOO_3_BAR == 'defg<cat>'";
         
         // there is no grouping context so i can expect only the original term, not the related ones (in the same group)
         Set<String> goodResults = Sets.newHashSet("FOO_3_BAR:defg<cat>");
         
-        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, new HashSet<>(goodResults), goodResults);
+    }
+    
+    @Test
+    public void testHitWithRange() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "false");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4");
+        
+        String queryString = "((BoundedRange = true) && (FOO_1_BAR_1 >= '2021-03-01 00:00:00' && FOO_1_BAR_1 <= '2021-04-01 00:00:00'))";
+        
+        // there is no grouping context so i can expect only the original term, not the related ones (in the same group)
+        Set<String> expectedHits = Sets.newHashSet("FOO_1_BAR_1:Wed Mar 24 16:00:00 GMT 2021");
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR_1:2021-03-24T16:00:00.000Z");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
+    }
+    
+    @Test
+    public void testHitWithDate() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "false");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=2,FOO_4=3,FOO_1_BAR_1=4");
+        
+        String queryString = "FOO_1_BAR_1 == '2021-03-24T16:00:00.000Z'";
+        
+        // there is no grouping context so i can expect only the original term, not the related ones (in the same group)
+        Set<String> expectedHits = Sets.newHashSet("FOO_1_BAR_1:Wed Mar 24 16:00:00 GMT 2021");
+        Set<String> goodResults = Sets.newHashSet("FOO_1_BAR_1:2021-03-24T16:00:00.000Z");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
+    }
+    
+    @Test
+    public void testHitWithExceededOrThreshold() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "false");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=4,FOO_4=3,FOO_1_BAR_1=4");
+        logic.setMaxOrExpansionThreshold(1);
+        ivaratorConfig();
+        
+        String queryString = "FOO_3_BAR == 'defg<cat>' || FOO_3_BAR == 'abcd<cat>'";
+        
+        // there is no grouping context so i can expect only the original term, not the related ones (in the same group)
+        Set<String> goodResults = Sets.newHashSet("FOO_3_BAR:defg<cat>", "FOO_3_BAR:abcd<cat>");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3_BAR:defg<cat>", "FOO_3_BAR:abcd<cat>");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
+    }
+    
+    @Test
+    public void testHitWithFunction() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "false");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "FOO_1_BAR=3,FOO_1=2,FOO_3=2,FOO_3_BAR=4,FOO_4=3,FOO_1_BAR_1=4");
+        logic.setMaxOrExpansionThreshold(1);
+        ivaratorConfig();
+        
+        String queryString = "FOO_3_BAR == 'defg<cat>' || FOO_3_BAR == 'abcd<cat>'";
+        
+        // there is no grouping context so i can expect only the original term, not the related ones (in the same group)
+        Set<String> goodResults = Sets.newHashSet("FOO_3_BAR:defg<cat>", "FOO_3_BAR:abcd<cat>");
+        Set<String> expectedHits = Sets.newHashSet("FOO_3_BAR:defg<cat>", "FOO_3_BAR:abcd<cat>");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, expectedHits, goodResults);
+    }
+    
+    protected void ivaratorConfig() throws IOException {
+        final URL hdfsConfig = this.getClass().getResource("/testhadoop.config");
+        Assert.assertNotNull(hdfsConfig);
+        this.logic.setHdfsSiteConfigURLs(hdfsConfig.toExternalForm());
+        
+        final List<String> dirs = new ArrayList<>();
+        final List<String> fstDirs = new ArrayList<>();
+        Path ivCache = Paths.get(Files.createTempDir().toURI());
+        dirs.add(ivCache.toUri().toString());
+        String uriList = String.join(",", dirs);
+        log.info("hdfs dirs(" + uriList + ")");
+        this.logic.setIvaratorCacheDirConfigs(dirs.stream().map(IvaratorCacheDirConfig::new).collect(Collectors.toList()));
     }
     
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java
@@ -2,6 +2,7 @@ package datawave.query.util;
 
 import datawave.data.ColumnFamilyConstants;
 import datawave.data.hash.UID;
+import datawave.data.type.DateType;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.Type;
 import datawave.ingest.protobuf.Uid;
@@ -27,6 +28,7 @@ public class LimitFieldsTestingIngest {
         SHARD, DOCUMENT;
     }
     
+    private static final Type<?> dateType = new DateType();
     private static final Type<?> lcNoDiacriticsType = new LcNoDiacriticsType();
     
     protected static final String datatype = "test";
@@ -59,6 +61,7 @@ public class LimitFieldsTestingIngest {
             mutation.put(datatype + "\u0000" + myUID, "FOO_3.FOO.3.0" + "\u0000" + "abcd", columnVisibility, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + myUID, "FOO_3_BAR.FOO.0" + "\u0000" + "abcd<cat>", columnVisibility, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + myUID, "FOO_1_BAR.FOO.0" + "\u0000" + "yawn<cat>", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "FOO_1_BAR_1.FOO.0" + "\u0000" + "Wed Mar 24 12:00:00 EDT 2021", columnVisibility, timeStamp, emptyValue);
             
             mutation.put(datatype + "\u0000" + myUID, "FOO_1.FOO.1.1" + "\u0000" + "yawn", columnVisibility, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + myUID, "FOO_4.FOO.4.1" + "\u0000" + "purr", columnVisibility, timeStamp, emptyValue);
@@ -225,6 +228,12 @@ public class LimitFieldsTestingIngest {
             mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
             mutation.put(ColumnFamilyConstants.COLF_I, new Text(datatype), emptyValue);
             mutation.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\u0000" + lcNoDiacriticsType.getClass().getName()), emptyValue);
+            bw.addMutation(mutation);
+            
+            mutation = new Mutation("FOO_1_BAR_1");
+            mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(3L)));
+            mutation.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\u0000" + dateType.getClass().getName()), emptyValue);
             bw.addMutation(mutation);
             
         } finally {

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -148,7 +148,7 @@
         <!-- The max number of terms AFTER all expansions -->
         <property name="maxTermThreshold" value="10" />	<!-- was ${beq.maxTermThreshold} -->
         <!-- The max query depth -->
-        <property name="maxDepthThreshold" value="5" />	<!-- was ${beq.maxDepthThreshold} -->
+        <property name="maxDepthThreshold" value="10" />	<!-- was ${beq.maxDepthThreshold} -->
         <!-- The max unfielded (_ANYFIELD_) expansion per term -->
         <property name="maxUnfieldedExpansionThreshold" value="20" />	<!-- was ${beq.unfieldedExpansionThreshold} -->
         <!-- The max value (regex or range) expansion -->


### PR DESCRIPTION
* Updated LimitFields to correctly parse hit term values
* Updated DatawaveInterpreter to correctly generate hit terms for bounded ranges and large or lists
* Added tests which demonstrated problems and now ensure fixes work