### PR TITLE
Lazily create ivarator cache dirs

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -277,27 +277,9 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
         pruneIvaratorCacheDirs();
     }
     
-    // this method will prune any ivarator cache directories that are not available on this node
-    private void pruneIvaratorCacheDirs() throws IOException {
-        ivaratorCacheDirConfigs.removeIf(this::pruneIvaratorCacheDir);
-    }
-    
-    private boolean pruneIvaratorCacheDir(IvaratorCacheDirConfig config) {
-        boolean fsExists = false;
-        
-        // first, make sure the cache configuration is valid
-        if (config.isValid()) {
-            Path basePath = new Path(config.getBasePathURI());
-            
-            try {
-                FileSystem fs = this.getFileSystemCache().getFileSystem(basePath.toUri());
-                fsExists = fs.mkdirs(basePath) || fs.exists(basePath);
-            } catch (Exception e) {
-                log.debug("Ivarator Cache Dir does not exist: " + basePath);
-            }
-        }
-        
-        return !fsExists;
+    // this method will prune any ivarator cache directories that do not have a valid configuration.
+    private void pruneIvaratorCacheDirs() {
+        ivaratorCacheDirConfigs.removeIf(config -> !config.isValid());
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -96,13 +96,16 @@ import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.pool.BasePoolableObjectFactory;
 import org.apache.commons.pool.impl.GenericObjectPool;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 
 import javax.annotation.Nullable;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Collection;
@@ -279,7 +282,53 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     // this method will prune any ivarator cache directories that do not have a valid configuration.
     private void pruneIvaratorCacheDirs() {
-        ivaratorCacheDirConfigs.removeIf(config -> !config.isValid());
+        IvaratorCacheDirConfig validConfig = null;
+        for (IvaratorCacheDirConfig config : ivaratorCacheDirConfigs) {
+            if (hasValidBasePath(config)) {
+                validConfig = config;
+                break;
+            }
+        }
+        ivaratorCacheDirConfigs.clear();
+        if (validConfig != null) {
+            ivaratorCacheDirConfigs.add(validConfig);
+        }
+    }
+    
+    private boolean hasValidBasePath(IvaratorCacheDirConfig config) {
+        if (config.isValid()) {
+            try {
+                Path basePath = new Path(config.getBasePathURI());
+                FileSystem fileSystem = this.getFileSystemCache().getFileSystem(basePath.toUri());
+                return isWritablePath(basePath, fileSystem);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
+    }
+    
+    private boolean isWritablePath(Path path, FileSystem fileSystem) {
+        try {
+            FileStatus fileStatus = fileSystem.getFileStatus(path);
+            // If the path exists, verify that it's a directory, not a file.
+            if (fileStatus.isDirectory()) {
+                // Verify that we have write access to the directory.
+                fileSystem.access(path, FsAction.WRITE);
+                return true;
+            }
+            return false;
+        } catch (FileNotFoundException e) {
+            // If the path does not exist, check if the path's parent is a writable directory.
+            Path parent = path.getParent();
+            if (parent != null) {
+                return isWritablePath(parent, fileSystem);
+            }
+            // If the parent is null, we're at the root directory and we do not have write access.
+            return false;
+        } catch (Exception e) {
+            return false;
+        }
     }
     
     @Override
@@ -531,7 +580,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     /**
      * Handle an exception returned from seek or next. This will silently ignore IterationInterruptedException as that happens when the underlying iterator was
      * interrupted because the client is no longer listening.
-     * 
+     *
      * @param e
      */
     private void handleException(Exception e) throws IOException {
@@ -590,7 +639,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     /**
      * Build the document iterator
-     * 
+     *
      * @param documentRange
      * @param seekRange
      * @param columnFamilies
@@ -713,7 +762,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     /**
      * There was a request to create a serial pipeline. The factory may not choose to honor this.
-     * 
+     *
      * @return
      */
     private boolean getSerialPipelineRequest() {
@@ -722,7 +771,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     /**
      * A routine which should always be used to create deep copies of the source. This ensures that we are thread safe when doing these copies.
-     * 
+     *
      * @return
      */
     public SortedKeyValueIterator<Key,Value> getSourceDeepCopy() {
@@ -1157,7 +1206,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     /**
      * If we are performing evaluation (have a query) and are not performing a full-table scan, then we want to instantiate the boolean logic iterators
-     * 
+     *
      * @return Whether or not the boolean logic iterators should be used
      */
     public boolean instantiateBooleanLogic() {
@@ -1216,7 +1265,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     /**
      * Determines if a range is document specific according to the following criteria
-     * 
+     *
      * <pre>
      *     1. Cannot have a null start or end key
      *     2. Cannot span multiple rows
@@ -1355,7 +1404,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     
     /**
      * Determine whether the query can be completely satisfied by the field index
-     * 
+     *
      * @return true if it can be completely satisfied.
      */
     protected boolean isFieldIndexSatisfyingQuery() {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -1032,20 +1032,6 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         return null;
     }
     
-    private boolean isUsable(Path path) throws IOException {
-        try {
-            if (!hdfsFileSystem.getFileSystem(path.toUri()).mkdirs(path)) {
-                throw new IOException("Unable to mkdirs: fs.mkdirs(" + path + ")->false");
-            }
-        } catch (MalformedURLException e) {
-            throw new IOException("Unable to load hadoop configuration", e);
-        } catch (Exception e) {
-            log.warn("Unable to access " + path, e);
-            return false;
-        }
-        return true;
-    }
-    
     /**
      * Create a cache directory path for a specified regex node. If alternatives have been specified, then random alternatives will be attempted until one is
      * found that can be written to.
@@ -1070,10 +1056,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                         path = new Path(path, scanId);
                     }
                     path = new Path(path, subdirectory);
-                    if (isUsable(path)) {
-                        URI uri = path.toUri();
-                        pathAndFs.add(new IvaratorCacheDir(config, hdfsFileSystem.getFileSystem(uri), uri.toString()));
-                    }
+                    URI uri = path.toUri();
+                    pathAndFs.add(new IvaratorCacheDir(config, hdfsFileSystem.getFileSystem(uri), uri.toString()));
                 }
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -1033,8 +1033,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
     }
     
     /**
-     * Create a cache directory path for a specified regex node. If alternatives have been specified, then random alternatives will be attempted until one is
-     * found that can be written to.
+     * Build a list of potential hdfs directories based on each ivarator cache dir configs.
      * 
      * @return A path
      */

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/BufferedFileBackedSortedSet.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/BufferedFileBackedSortedSet.java
@@ -1,7 +1,6 @@
 package datawave.query.util.sortedset;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -113,10 +112,6 @@ public class BufferedFileBackedSortedSet<E> implements SortedSet<E> {
             // go through the handler factories and try to persist the sorted set
             for (int i = 0; i < handlerFactories.size() && !buffer.isPersisted(); i++) {
                 SortedSetFileHandlerFactory handlerFactory = handlerFactories.get(i);
-                
-                // Lazily create the required directories that the files will be written to.
-                // handlerFactory.ensureDirsCreated();
-                
                 SortedSetFileHandler handler = createFileHandler(handlerFactory);
                 
                 // if we have a valid handler, try to persist
@@ -124,7 +119,6 @@ public class BufferedFileBackedSortedSet<E> implements SortedSet<E> {
                     Exception cause = null;
                     for (int attempts = 0; attempts <= numRetries && !buffer.isPersisted(); attempts++) {
                         try {
-                            
                             buffer.persist(handler);
                         } catch (IOException e) {
                             if (attempts == numRetries)

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/BufferedFileBackedSortedSet.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/BufferedFileBackedSortedSet.java
@@ -1,6 +1,7 @@
 package datawave.query.util.sortedset;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -112,6 +113,10 @@ public class BufferedFileBackedSortedSet<E> implements SortedSet<E> {
             // go through the handler factories and try to persist the sorted set
             for (int i = 0; i < handlerFactories.size() && !buffer.isPersisted(); i++) {
                 SortedSetFileHandlerFactory handlerFactory = handlerFactories.get(i);
+                
+                // Lazily create the required directories that the files will be written to.
+                // handlerFactory.ensureDirsCreated();
+                
                 SortedSetFileHandler handler = createFileHandler(handlerFactory);
                 
                 // if we have a valid handler, try to persist
@@ -119,6 +124,7 @@ public class BufferedFileBackedSortedSet<E> implements SortedSet<E> {
                     Exception cause = null;
                     for (int attempts = 0; attempts <= numRetries && !buffer.isPersisted(); attempts++) {
                         try {
+                            
                             buffer.persist(handler);
                         } catch (IOException e) {
                             if (attempts == numRetries)

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/HdfsBackedSortedSet.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/HdfsBackedSortedSet.java
@@ -4,10 +4,13 @@ import datawave.query.iterator.ivarator.IvaratorCacheDir;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.SortedSet;
+
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsStatus;
@@ -162,14 +165,40 @@ public class HdfsBackedSortedSet<E> extends BufferedFileBackedSortedSet<E> imple
             FileSystem fs = getFs();
             Path uniqueDir = getUniqueDir();
             
-            // attempt to create the folder if it doesn't exist
-            if (!fs.exists(uniqueDir) && !fs.mkdirs(uniqueDir))
-                throw new IOException("Unable to create directory [" + uniqueDir + "] in filesystem [" + fs + "]");
+            // Lazily create the required ivarator cache dirs.
+            ensureDirsCreated();
             
             // generate a unique file name
             fileCount++;
             Path file = new Path(uniqueDir, FILENAME_PREFIX + fileCount + '.' + System.currentTimeMillis());
             return new SortedSetHdfsFileHandler(fs, file, persistOptions);
+        }
+        
+        private void ensureDirsCreated() throws IOException {
+            IvaratorCacheDirConfig config = ivaratorCacheDir.getConfig();
+            if (config.isValid()) {
+                ensureCreation(new Path(ivaratorCacheDir.getPathURI()));
+                ensureCreation(getUniqueDir());
+            } else {
+                throw new IOException("Unable to create Ivarator Cache Dir for invalid config: " + config);
+            }
+        }
+        
+        private void ensureCreation(Path path) throws IOException {
+            try {
+                FileSystem fs = getFs();
+                if (!fs.exists(path)) {
+                    // Attempt to create the required directory if it does not exist.
+                    if (!fs.mkdirs(path)) {
+                        throw new IOException("Unable to mkdirs: fs.mkdir(" + path + ")->false");
+                    }
+                }
+            } catch (MalformedURLException e) {
+                throw new IOException("Unable to load hadoop configuration", e);
+            } catch (Exception e) {
+                log.warn("Unable to create directory [" + path + "] in file system [" + getFs() + "]", e);
+                throw new IOException("Unable to create directory [" + path + "] in file system [" + getFs() + "]", e);
+            }
         }
         
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -557,6 +557,17 @@ public class QueryIteratorIT extends EasyMockSupport {
         event_test(seekRange, query, false, null, addEvent(11, "123.345.457"), Arrays.asList(getBaseExpectedEvent("123.345.457")));
     }
     
+    @Test(expected = IOException.class)
+    public void event_bogusIvaratorCacheDir_test() throws IOException {
+        Range seekRange = getShardRange();
+        String query = "((_Value_ = true) && (EVENT_FIELD4 =~ '.*d'))";
+        
+        // setup a bogus ivarator cache dir for the config
+        options.put(IVARATOR_CACHE_DIR_CONFIG, IvaratorCacheDirConfig.toJson(new IvaratorCacheDirConfig("hddfs://bogusPath")));
+        
+        index_test(seekRange, query, false, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+    }
+    
     @Test
     public void index_documentSpecific_test() throws IOException {
         // build the seek range for a document specific pull

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -557,17 +557,6 @@ public class QueryIteratorIT extends EasyMockSupport {
         event_test(seekRange, query, false, null, addEvent(11, "123.345.457"), Arrays.asList(getBaseExpectedEvent("123.345.457")));
     }
     
-    @Test(expected = IOException.class)
-    public void event_bogusIvaratorCacheDir_test() throws IOException {
-        Range seekRange = getShardRange();
-        String query = "((_Value_ = true) && (EVENT_FIELD4 =~ '.*d'))";
-        
-        // setup a bogus ivarator cache dir for the config
-        options.put(IVARATOR_CACHE_DIR_CONFIG, IvaratorCacheDirConfig.toJson(new IvaratorCacheDirConfig("hdfs://bogusPath")));
-        
-        index_test(seekRange, query, false, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
-    }
-    
     @Test
     public void index_documentSpecific_test() throws IOException {
         // build the seek range for a document specific pull


### PR DESCRIPTION
The ivarator cache directories as currently managed result in
directories being created for each QueryIterator even if they are not
actually used for HdfsBackedSortedSets.

Modify this so that the cache directories are lazily created only when
persisting data to the file system.

Note for reviewers, I modified `QueryIterator.pruneIvaratorCacheDirs()` to only remove configurations that are invalid. If there are any additional checks that should be added to this in light of the removal of actually creating the directories, please let me know.

Closes #1059