### PR TITLE
Enforce timeouts for regex term expansion

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/LookupTermsFromRegex.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/LookupTermsFromRegex.java
@@ -122,7 +122,7 @@ public class LookupTermsFromRegex extends RegexIndexLookup {
             }
         }
         
-        if (!fields.isEmpty()) {
+        if (!fields.isEmpty() && !forwardMap.isEmpty()) {
             for (String key : forwardMap.keySet()) {
                 Collection<Range> ranges = forwardMap.get(key);
                 try {
@@ -161,7 +161,7 @@ public class LookupTermsFromRegex extends RegexIndexLookup {
         }
         
         sessions.clear();
-        if (!reverseFields.isEmpty()) {
+        if (!reverseFields.isEmpty() && !reverseMap.isEmpty()) {
             for (String key : reverseMap.keySet()) {
                 Collection<Range> ranges = reverseMap.get(key);
                 if (log.isTraceEnabled()) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnfieldedTermsVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnfieldedTermsVisitor.java
@@ -335,7 +335,8 @@ public class FixUnfieldedTermsVisitor extends ParallelIndexExpansion {
             lookup.setLimitToTerms(true);
             ((FieldNameLookup) lookup).setTypeFilterSet(config.getDatatypeFilter());
         }
-        return new IndexLookupCallable(lookup, node, false, true, keepOriginalNode);
+        
+        return new IndexLookupCallable(lookup, node, true, true, keepOriginalNode);
     }
     
     /**


### PR DESCRIPTION
Enforce timeouts for regex term expansion, execute scans only if terms exist in forward/reverse maps.