### PR TITLE
Allow Ivarators to take advantage of document range when possible.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/key/FiKey.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/key/FiKey.java
@@ -1,0 +1,57 @@
+package datawave.core.iterators.key;
+
+import org.apache.hadoop.io.Text;
+
+/**
+ * Class that lazily parses the elements from a field index key's column qualifier, with some methods to support seeking.
+ *
+ * FI key structure like shard:fi\0FIELD:value\0datatype\0uid
+ */
+public class FiKey {
+    
+    // the value\0datatype\0uid
+    private String cq;
+    
+    private String value;
+    private String datatype;
+    private String uid;
+    
+    // index of the nulls for easier parsing
+    private int lastNull = 0;
+    private int firstNull = 0;
+    
+    public void parse(Text columnQualifier) {
+        this.cq = columnQualifier.toString();
+        // Avoid values with nulls by traversing backwards
+        this.lastNull = cq.lastIndexOf('\u0000');
+        this.firstNull = cq.lastIndexOf('\u0000', lastNull - 1);
+        this.value = null;
+        this.datatype = null;
+        this.uid = null;
+    }
+    
+    public String getValue() {
+        if (value == null) {
+            value = cq.substring(0, firstNull);
+        }
+        return value;
+    }
+    
+    public String getDatatype() {
+        if (datatype == null) {
+            datatype = cq.substring(firstNull + 1, lastNull);
+        }
+        return datatype;
+    }
+    
+    public String getUid() {
+        if (uid == null) {
+            uid = cq.substring(lastNull + 1);
+        }
+        return uid;
+    }
+    
+    public boolean uidStartsWith(String uid) {
+        return getUid().startsWith(uid);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexlTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexlTest.java
@@ -1,0 +1,49 @@
+package datawave.core.iterators;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DatawaveFieldIndexCachingIteratorJexlTest {
+    
+    @Test
+    public void testUidMatching() {
+        DatawaveFieldIndexCachingIteratorJexl iter = new DatawaveFieldIndexFilterIteratorJexl();
+        
+        Key tldKey = new Key("shard", "fi\0FIELD", "value\0datatype\0uid");
+        Key childKey = new Key("shard", "fi\0FIELD", "value\0datatype\0uid.2");
+        Key grandchildKey = new Key("shard", "fi\0FIELD", "value\0datatype\0uid.2.5");
+        
+        // tld uid matches
+        String uid = "uid";
+        assertTrue(iter.uidMatches(uid, tldKey));
+        assertTrue(iter.uidMatches(uid, childKey));
+        assertTrue(iter.uidMatches(uid, grandchildKey));
+        
+        // child uid matches
+        uid = "uid.2";
+        assertFalse(iter.uidMatches(uid, tldKey));
+        assertTrue(iter.uidMatches(uid, childKey));
+        assertTrue(iter.uidMatches(uid, grandchildKey));
+        
+        // grandchild uid matches
+        uid = "uid.2.5";
+        assertFalse(iter.uidMatches(uid, tldKey));
+        assertFalse(iter.uidMatches(uid, childKey));
+        assertTrue(iter.uidMatches(uid, grandchildKey));
+        
+        // alternate child uid should not match
+        uid = "uid.7";
+        assertFalse(iter.uidMatches(uid, tldKey));
+        assertFalse(iter.uidMatches(uid, childKey));
+        assertFalse(iter.uidMatches(uid, grandchildKey));
+        
+        // alternate grandchild uid should not match either
+        uid = "uid.6.9";
+        assertFalse(iter.uidMatches(uid, tldKey));
+        assertFalse(iter.uidMatches(uid, childKey));
+        assertFalse(iter.uidMatches(uid, grandchildKey));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/DatawaveFieldIndexListIteratorJexlTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/DatawaveFieldIndexListIteratorJexlTest.java
@@ -1,0 +1,87 @@
+package datawave.core.iterators;
+
+import datawave.query.IvaratorReloadTest;
+import datawave.query.iterator.ivarator.IvaratorCacheDir;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.io.Text;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatawaveFieldIndexListIteratorJexlTest {
+    
+    @ClassRule
+    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    
+    private List<IvaratorCacheDir> cacheDirs;
+    
+    @Before
+    public void setup() throws IOException {
+        File cacheDir = temporaryFolder.newFolder();
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(cacheDir.toURI().toString());
+        FileSystem fs = FileSystem.get(cacheDir.toURI(), new Configuration());
+        File queryDirFile = new File(cacheDir, "query");
+        queryDirFile.deleteOnExit();
+        Assert.assertTrue(queryDirFile.mkdirs());
+        String queryDir = queryDirFile.toURI().toString();
+        cacheDirs = Collections.singletonList(new IvaratorCacheDir(config, fs, queryDir));
+    }
+    
+    @Test
+    public void testBuildingOfBoundedRanges() {
+        DatawaveFieldIndexListIteratorJexl.Builder<?> builder = DatawaveFieldIndexListIteratorJexl.builder();
+        builder.withFieldName("FIELDNAME");
+        builder.withIvaratorCacheDirs(cacheDirs);
+        DatawaveFieldIndexListIteratorJexl iter = builder.build();
+        
+        Text row = new Text("20200314_1");
+        Text fiName = new Text("fi\u0000FIELDNAME");
+        Text value = new Text("fieldvalue");
+        Range range = iter.buildBoundingRange(row, fiName, value);
+        
+        Key start = new Key(new Text("20200314_1"), new Text("fi\u0000FIELDNAME"), new Text("fieldvalue\0"));
+        Key end = new Key(new Text("20200314_1"), new Text("fi\u0000FIELDNAME"), new Text("fieldvalue\1"));
+        Range expected = new Range(start, true, end, false);
+        
+        assertEquals(expected, range);
+    }
+    
+    @Test
+    public void testBuildingOfBoundedRangesWithinADocumentSpecificContext() throws Exception {
+        DatawaveFieldIndexListIteratorJexl.Builder<?> builder = DatawaveFieldIndexListIteratorJexl.builder();
+        builder.withFieldName("FIELDNAME");
+        builder.withIvaratorCacheDirs(cacheDirs);
+        builder.withIvaratorSourcePool(IvaratorReloadTest.createIvaratorSourcePool(1));
+        DatawaveFieldIndexListIteratorJexl iter = builder.build();
+        
+        // Simulate a seek to a document specific range
+        Key start = new Key(new Text("20200314_1"), new Text("datatype\0uid0"));
+        Key end = start.followingKey(PartialKey.ROW_COLFAM);
+        Range seekRange = new Range(start, true, end, false);
+        iter.seek(seekRange, DatawaveFieldIndexCachingIteratorJexl.EMPTY_COL_FAMS, true);
+        
+        Text row = new Text("20200314_1");
+        Text fiName = new Text("fi\u0000FIELDNAME");
+        Range range = iter.buildBoundingRange(row, fiName, "fieldvalue", "datatype", "uid0");
+        
+        start = new Key(new Text("20200314_1"), new Text("fi\u0000FIELDNAME"), new Text("fieldvalue\0datatype\0uid0"));
+        end = new Key(new Text("20200314_1"), new Text("fi\u0000FIELDNAME"), new Text("fieldvalue\0datatype\0uid0\0"));
+        Range expected = new Range(start, true, end, false);
+        
+        assertEquals(expected, range);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/key/FiKeyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/key/FiKeyTest.java
@@ -1,0 +1,57 @@
+package datawave.core.iterators.key;
+
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class FiKeyTest {
+    
+    @Test
+    public void testParseValue() {
+        Text columnQualifier = new Text("value\0datatype\0uid");
+        FiKey fiKey = new FiKey();
+        fiKey.parse(columnQualifier);
+        assertEquals("value", fiKey.getValue());
+        
+        // validate the fiKey returns the same object once cached
+        assertSame(fiKey.getValue(), fiKey.getValue());
+    }
+    
+    @Test
+    public void testParseDatatype() {
+        Text columnQualifier = new Text("value\0datatype\0uid");
+        FiKey fiKey = new FiKey();
+        fiKey.parse(columnQualifier);
+        assertEquals("datatype", fiKey.getDatatype());
+        
+        // validate the fiKey returns the same object once cached
+        assertSame(fiKey.getDatatype(), fiKey.getDatatype());
+    }
+    
+    @Test
+    public void testParseUid() {
+        Text columnQualifier = new Text("value\0datatype\0uid");
+        FiKey fiKey = new FiKey();
+        fiKey.parse(columnQualifier);
+        assertEquals("uid", fiKey.getUid());
+        
+        // validate the fiKey returns the same object once cached
+        assertSame(fiKey.getUid(), fiKey.getUid());
+    }
+    
+    @Test
+    public void testUidStartsWith() {
+        Text columnQualifier = new Text("value\0datatype\0uid.1.2");
+        FiKey fiKey = new FiKey();
+        fiKey.parse(columnQualifier);
+        assertEquals("uid.1.2", fiKey.getUid());
+        assertTrue(fiKey.uidStartsWith("uid"));
+        assertTrue(fiKey.uidStartsWith("uid.1"));
+        assertTrue(fiKey.uidStartsWith("uid.1.2"));
+        assertFalse(fiKey.uidStartsWith("uid.9"));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -565,8 +565,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         // define the base hit for an index only test.
         List<Map.Entry<Key,Map<String,List<String>>>> expectedHits = new ArrayList<>();
         Map.Entry<Key,Map<String,List<String>>> hit = getBaseExpectedEvent("123.345.456");
-        // Note: INDEX_ONLY_FIELD1 is not added to the hit because it is evaluated in a separate context
-        // and not aggregated into the main context.
+        hit.getValue().put("INDEX_ONLY_FIELD1", Arrays.asList(new String[] {"apple"}));
         expectedHits.add(hit);
         
         indexOnly_test(seekRange, query, source, expectedHits);
@@ -583,8 +582,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         // define the base hit for an index only test.
         List<Map.Entry<Key,Map<String,List<String>>>> expectedHits = new ArrayList<>();
         Map.Entry<Key,Map<String,List<String>>> hit = getBaseExpectedEvent("123.345.456");
-        // Note: INDEX_ONLY_FIELD1 is not added to the hit because it is evaluated in a separate context
-        // and not aggregated into the main context.
+        hit.getValue().put("INDEX_ONLY_FIELD1", Arrays.asList(new String[] {"apple"}));
         expectedHits.add(hit);
         
         indexOnly_test(seekRange, query, source, expectedHits);
@@ -1513,7 +1511,7 @@ public class QueryIteratorIT extends EasyMockSupport {
         // build the seek range for a document specific pull
         Range seekRange = getDocumentRange("123.345.456");
         String query = "EVENT_FIELD1 == 'a' && ((_Delayed_ = true) && INDEX_ONLY_FIELD1 == 'apple')";
-        indexOnly_test(seekRange, query, false, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+        indexOnly_test(seekRange, query, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
     }
     
     protected Map.Entry<Key,Map<String,List<String>>> getBaseExpectedEvent(String uid) {

--- a/warehouse/query-core/src/test/java/datawave/query/tld/TLDQueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tld/TLDQueryIteratorIT.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,8 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("z");
         expectedDocument.getValue().put("TF_FIELD3", tfField1Hits);
         
-        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", false, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", configureTestData(11), Arrays.asList(expectedDocument),
+                        configureTLDTestData(11), Collections.EMPTY_LIST);
     }
     
     @Test
@@ -72,7 +74,8 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("z");
         expectedDocument.getValue().put("TF_FIELD3", tfField1Hits);
         
-        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", false, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", configureTLDTestData(11), Arrays.asList(expectedDocument),
+                        configureTLDTestData(11), Collections.EMPTY_LIST);
     }
     
     /**


### PR DESCRIPTION
- parse out datatype and uid when handed a document range
- List ivarator builds bounding ranges with datatype and uid

Note: Filter, Range, and Regex ivarators not modified to take advantage of the doc range. 