### PR TITLE
Delayed index only field-values are now added to the candidate document.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/function/JexlEvaluation.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/JexlEvaluation.java
@@ -3,6 +3,7 @@ package datawave.query.function;
 import datawave.query.attributes.Attributes;
 import datawave.query.jexl.ArithmeticJexlEngines;
 import datawave.query.jexl.DefaultArithmetic;
+import datawave.query.jexl.DelayedNonEventIndexContext;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.jexl2.JexlArithmetic;
@@ -75,6 +76,11 @@ public class JexlEvaluation implements Predicate<Tuple3<Key,Document,DatawaveJex
         
         boolean matched = isMatched(o);
         
+        // Add delayed info to document
+        if (matched && input.third() instanceof DelayedNonEventIndexContext) {
+            ((DelayedNonEventIndexContext) input.third()).populateDocument(input.second());
+        }
+        
         if (arithmetic instanceof HitListArithmetic) {
             HitListArithmetic hitListArithmetic = (HitListArithmetic) arithmetic;
             if (matched) {
@@ -101,9 +107,7 @@ public class JexlEvaluation implements Predicate<Tuple3<Key,Document,DatawaveJex
             }
             hitListArithmetic.clear();
         }
-        
         return matched;
-        
     }
     
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/DelayedNonEventIndexContext.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/DelayedNonEventIndexContext.java
@@ -2,6 +2,8 @@ package datawave.query.jexl;
 
 import com.google.common.collect.Multimap;
 import datawave.query.attributes.Document;
+import datawave.query.attributes.ValueTuple;
+import datawave.query.collections.FunctionalSet;
 import datawave.query.function.Equality;
 import datawave.query.iterator.NestedIterator;
 import datawave.query.iterator.SeekableIterator;
@@ -130,5 +132,25 @@ public class DelayedNonEventIndexContext extends DatawaveJexlContext {
         }
         
         return documentList;
+    }
+    
+    /**
+     * Add the elements fetched by this context to the main document
+     * 
+     * @param d
+     *            the main document
+     */
+    public void populateDocument(Document d) {
+        for (String field : fetched) {
+            Object obj = get(field);
+            if (obj instanceof FunctionalSet<?>) {
+                FunctionalSet<?> fs = (FunctionalSet<?>) obj;
+                for (Object element : fs) {
+                    if (element instanceof ValueTuple) {
+                        d.put(field, ((ValueTuple) element).getSource());
+                    }
+                }
+            }
+        }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryIteratorIT.java
@@ -1224,6 +1224,16 @@ public class QueryIteratorIT extends EasyMockSupport {
         indexOnly_test(seekRange, query, false, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
     }
     
+    // The term fetched by the delayed context is not added to the returned document.
+    @Test
+    public void test_fetchDelayedIndexOnlyTerm_addTermToHitTerms() throws IOException {
+        options.put(JexlEvaluation.HIT_TERM_FIELD, "true");
+        // build the seek range for a document specific pull
+        Range seekRange = getDocumentRange("123.345.456");
+        String query = "EVENT_FIELD1 == 'a' && ((_Delayed_ = true) && INDEX_ONLY_FIELD1 == 'apple')";
+        indexOnly_test(seekRange, query, false, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+    }
+    
     protected Map.Entry<Key,Map<String,List<String>>> getBaseExpectedEvent(String uid) {
         return getBaseExpectedEvent(DEFAULT_ROW, DEFAULT_DATATYPE, uid);
     }


### PR DESCRIPTION
Index only fields fetched in a delayed fashion are not added to the document returned from the QueryIterator. The query is still functionally correct but HIT_TERMS will fail to report a hit term.