### PR TITLE
Make TreeEqualityVisitor accept JexlNodes for comparison

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ConjunctionEliminationVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ConjunctionEliminationVisitor.java
@@ -225,7 +225,7 @@ public class ConjunctionEliminationVisitor extends RebuildingVisitor {
     // Return whether or not the two JEXL queries are equivalent.
     private boolean isEquivalent(JexlNode node, ASTJexlScript script) throws ParseException {
         ASTJexlScript nodeScript = getScript(node);
-        return TreeEqualityVisitor.isEqual(nodeScript, script, new TreeEqualityVisitor.Reason());
+        return TreeEqualityVisitor.isEqual(nodeScript, script);
     }
     
     // Return the Jexl node as a script.

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/DisjunctionEliminationVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/DisjunctionEliminationVisitor.java
@@ -228,7 +228,7 @@ public class DisjunctionEliminationVisitor extends RebuildingVisitor {
     // Return whether or not the two JEXL queries are equivalent.
     private boolean isEquivalent(JexlNode node, ASTJexlScript script) throws ParseException {
         ASTJexlScript nodeScript = getScript(node);
-        return TreeEqualityVisitor.isEqual(nodeScript, script, new TreeEqualityVisitor.Reason());
+        return TreeEqualityVisitor.isEqual(nodeScript, script);
     }
     
     // Return the JEXL node as a script.

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/TreeEqualityVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/TreeEqualityVisitor.java
@@ -62,27 +62,70 @@ import org.apache.log4j.Logger;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
 
 /**
- * Determine whether two trees are equivalent, accounting for arbitrary order within subtrees
+ * Determine whether two trees are equivalent, accounting for arbitrary order within subtrees.
  */
 public class TreeEqualityVisitor implements ParserVisitor {
     private static final Logger log = ThreadConfigurableLogger.getLogger(TreeEqualityVisitor.class);
     
     private boolean equal = true;
     
-    public TreeEqualityVisitor() {
-        this.equal = true;
+    public final static class Comparison {
+        
+        private static final Comparison IS_EQUAL = new Comparison(true, null);
+        
+        private static Comparison notEqual(String reason) {
+            return new Comparison(false, reason);
+        }
+        
+        private final boolean equal;
+        private final String reason;
+        
+        private Comparison(boolean equal, String reason) {
+            this.equal = equal;
+            this.reason = reason;
+        }
+        
+        public boolean isEqual() {
+            return equal;
+        }
+        
+        public String getReason() {
+            return reason;
+        }
     }
     
-    public static class Reason {
-        public String reason = null;
+    /**
+     * Return whether or not the provided query trees are considered equivalent.
+     * 
+     * @param first
+     *            the first query tree
+     * @param second
+     *            the second query tree
+     * @return true if the query trees are considered equivalent, or false otherwise
+     */
+    public static boolean isEqual(JexlNode first, JexlNode second) {
+        return checkEquality(first, second).isEqual();
     }
     
-    public static boolean isEqual(ASTJexlScript script1, ASTJexlScript script2, Reason reason) {
-        TreeEqualityVisitor visitor = new TreeEqualityVisitor();
-        
-        reason.reason = (String) (script1.jjtAccept(visitor, script2));
-        
-        return visitor.equal;
+    /**
+     * Compare the provided query trees for equivalency and return the resulting comparison.
+     * 
+     * @param first
+     *            the first query tree
+     * @param second
+     *            the second query tree
+     * @return the comparison result
+     */
+    public static Comparison checkEquality(JexlNode first, JexlNode second) {
+        if (first != null && second != null) {
+            TreeEqualityVisitor visitor = new TreeEqualityVisitor();
+            String reason = (String) first.jjtAccept(visitor, second);
+            return visitor.equal ? Comparison.IS_EQUAL : Comparison.notEqual(reason);
+        } else if (first == null && second == null) {
+            return Comparison.IS_EQUAL;
+        } else {
+            return Comparison.notEqual("One tree is null: " + first + " vs " + second);
+        }
     }
     
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IndexInfoTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IndexInfoTest.java
@@ -117,8 +117,7 @@ public class IndexInfoTest {
         assertEquals(1, merged.uids().size());
         assertEquals(expectedSorted, merged.uids());
         
-        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode())));
     }
     
     @Test
@@ -149,8 +148,7 @@ public class IndexInfoTest {
         
         assertEquals(1, merged.uids().size());
         assertEquals(expectedSorted, merged.uids());
-        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode())));
     }
     
     @Test
@@ -184,8 +182,7 @@ public class IndexInfoTest {
         
         assertEquals(1, merged.uids().size());
         assertEquals(expectedSorted, merged.uids());
-        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode())));
     }
     
     @Test
@@ -219,8 +216,7 @@ public class IndexInfoTest {
         
         assertEquals(1, merged.uids().size());
         assertEquals(expectedSorted, merged.uids());
-        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlNodeFactory.createScript(origQueryTree), JexlNodeFactory.createScript(merged.getNode())));
     }
     
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
@@ -251,10 +251,9 @@ public class IntersectionTest {
         assertEquals(ii.second().uids.iterator().next().uid, "a.b.c");
         assertEquals(ii.second().uids.iterator().next().type, IndexMatchType.AND);
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(ii.second().uids.iterator().next().getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(ii.second().uids.iterator().next().getNode())));
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -273,7 +272,7 @@ public class IntersectionTest {
         Intersection i = new Intersection(toMerge, new IndexInfo());
         assertFalse(i.hasNext());
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -316,13 +315,13 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         m = all.get(1);
         assertEquals(m.uid, "a.b.z");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -364,13 +363,13 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.OR);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         m = all.get(1);
         assertEquals(m.uid, "a.b.z");
         assertEquals(m.type, IndexMatchType.OR);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -416,13 +415,13 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         m = all.get(1);
         assertEquals(m.uid, "a.b.z");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -473,25 +472,21 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3'"), JexlNodeFactory.createScript(m.getNode())));
         m = all.get(1);
         assertEquals(m.uid, "a.b.z");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3'"), JexlNodeFactory.createScript(m.getNode())));
         m = all.get(2);
         assertEquals(m.uid, "x.y.z");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("B == '2' && C == '3'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("B == '2' && C == '3'"), JexlNodeFactory.createScript(m.getNode())));
         m = all.get(3);
         assertEquals(m.uid, "x.y.z.1");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("B == '2' && C == '3'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("B == '2' && C == '3'"), JexlNodeFactory.createScript(m.getNode())));
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -541,9 +536,9 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(m.getNode())));
         
-        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(script, JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -604,12 +599,11 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3' && G == '7'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3' && G == '7'"), JexlNodeFactory.createScript(m.getNode())));
         
         assertTrue(TreeEqualityVisitor.isEqual(
                         JexlASTHelper.parseJexlQuery("G =='7' && ((A == '1' && C == '3') || (B == '2' && C == '3') || (D == '4' && F == '6'))"),
-                        JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+                        JexlNodeFactory.createScript(i.currentNode())));
     }
     
     @Test
@@ -673,16 +667,14 @@ public class IntersectionTest {
         m = all.get(0);
         assertEquals(m.uid, "a.b.c");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3' && G == '7'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("A == '1' && C == '3' && G == '7'"), JexlNodeFactory.createScript(m.getNode())));
         m = all.get(1);
         assertEquals(m.uid, "x.y.z.1");
         assertEquals(m.type, IndexMatchType.AND);
-        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("B == '2' && C == '3' && G == '7'"), JexlNodeFactory.createScript(m.getNode()),
-                        new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery("B == '2' && C == '3' && G == '7'"), JexlNodeFactory.createScript(m.getNode())));
         
         assertTrue(TreeEqualityVisitor.isEqual(
                         JexlASTHelper.parseJexlQuery("G =='7' && ((A == '1' && C == '3') || (B == '2' && C == '3') || (D == '4' && F == '6'))"),
-                        JexlNodeFactory.createScript(i.currentNode()), new TreeEqualityVisitor.Reason()));
+                        JexlNodeFactory.createScript(i.currentNode())));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
@@ -181,15 +181,13 @@ public class AllTermsIndexedVisitorTest {
     }
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
@@ -96,15 +96,13 @@ public class BooleanOptimizationRebuildingVisitorTest {
     }
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ConjunctionEliminationVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ConjunctionEliminationVisitorTest.java
@@ -140,15 +140,12 @@ public class ConjunctionEliminationVisitorTest {
     
     private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
-            log.error("Expected: " + expected);
-            log.error("Actual: " + JexlStringBuildingVisitor.buildQuery(actualScript));
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexCleanupVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexCleanupVisitorTest.java
@@ -64,15 +64,13 @@ public class DateIndexCleanupVisitorTest {
     }
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DisjunctionEliminationVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DisjunctionEliminationVisitorTest.java
@@ -131,15 +131,12 @@ public class DisjunctionEliminationVisitorTest {
     
     private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
-            log.error("Expected: " + expected);
-            log.error("Actual: " + JexlStringBuildingVisitor.buildQuery(actualScript));
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -1263,13 +1263,12 @@ public class ExpandCompositeTermsTest {
     
     private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -481,15 +481,13 @@ public class ExpandMultiNormalizedTermsTest {
     }
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
@@ -42,13 +42,12 @@ public class FixNegativeNumbersVisitorTest {
     
     private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actual, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
@@ -107,15 +107,12 @@ public class FunctionIndexQueryExpansionVisitorTest {
     
     private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
-            log.error("Expected: " + expected);
-            log.error("Actual:   " + JexlStringBuildingVisitor.buildQueryWithoutParse(actualScript));
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
@@ -75,15 +75,13 @@ public class GeoWavePruningVisitorTest {
     }
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IsNotNullIntentVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IsNotNullIntentVisitorTest.java
@@ -51,15 +51,13 @@ public class IsNotNullIntentVisitorTest {
     }
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -7,7 +7,7 @@ import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NoOpType;
 import datawave.data.type.Type;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.jexl.visitors.TreeEqualityVisitor.Reason;
+import datawave.query.jexl.visitors.TreeEqualityVisitor.Comparison;
 import datawave.query.model.QueryModel;
 import datawave.query.util.MockMetadataHelper;
 import org.apache.commons.jexl2.parser.ASTEQNode;
@@ -359,15 +359,12 @@ public class QueryModelVisitorTest {
     
     private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        Reason reason = new Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
-            log.error("Expected " + JexlStringBuildingVisitor.buildQuery(expectedScript));
-            log.error("Actual   " + JexlStringBuildingVisitor.buildQuery(actualScript));
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual   " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
@@ -92,14 +92,12 @@ public class RegexFunctionVisitorTest {
     
     private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        ASTJexlScript actualScript = JexlASTHelper.parseJexlQuery(JexlStringBuildingVisitor.buildQuery(actual));
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeEqualityVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeEqualityVisitorTest.java
@@ -1,0 +1,91 @@
+package datawave.query.jexl.visitors;
+
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TreeEqualityVisitorTest {
+    
+    @Test
+    public void testNonEqualType() throws ParseException {
+        assertNotEquivalent("FOO == 'bar'", "BAT == 'one' || BAR == 'two'",
+                        "Did not find a matching child for EQNode in [OrNode]: Classes differ: ASTEQNode vs ASTOrNode");
+    }
+    
+    @Test
+    public void testNonEqualValue() throws ParseException {
+        ASTJexlScript first = JexlASTHelper.parseJexlQuery("FOO == 'bar'");
+        first.jjtSetValue("somevalue");
+        ASTJexlScript second = JexlASTHelper.parseJexlQuery("FOO == 'bar'");
+        assertNotEquivalent(first, second, "Node values differ: somevalue vs null");
+    }
+    
+    @Test
+    public void testNonEqualImage() throws ParseException {
+        assertNotEquivalent("FOO == 'bar'", "FOO == 'bat'",
+                        "Did not find a matching child for EQNode in [EQNode]: Did not find a matching child for StringLiteral in [StringLiteral]: Node images differ: bar vs bat");
+    }
+    
+    @Test
+    public void testNonEqualChildrenSize() throws ParseException {
+        assertNotEquivalent(
+                        "[1, 2, 3, 4]",
+                        "[1, 2]",
+                        "Did not find a matching child for ArrayLiteral in [ArrayLiteral]: Num children differ: [NumberLiteral, NumberLiteral, NumberLiteral, NumberLiteral] vs [NumberLiteral, NumberLiteral]");
+    }
+    
+    @Test
+    public void testNonEqualChildren() throws ParseException {
+        assertNotEquivalent(
+                        "[1, 2]",
+                        "[1, 3]",
+                        "Did not find a matching child for ArrayLiteral in [ArrayLiteral]: Did not find a matching child for NumberLiteral in [NumberLiteral]: Node images differ: 2 vs 3");
+    }
+    
+    @Test
+    public void testEqualTreesWithIdenticalNodeOrder() throws ParseException {
+        assertEquivalent("FOO == 'one' && BAT == 'two' && BAT == 'three'", "FOO == 'one' && BAT == 'two' && BAT == 'three'");
+    }
+    
+    @Test
+    public void testEqualTreesWithDifferentNodeOrder() throws ParseException {
+        assertEquivalent("FOO == 'one' && BAT == 'two' && BAT == 'three'", "BAT == 'two' && FOO == 'one' && BAT == 'three'");
+    }
+    
+    @Test
+    public void testEqualTreesWithDifferentWrapping() throws ParseException {
+        assertEquivalent("FOO == 'bar'", "((FOO == 'bar'))");
+    }
+    
+    @Test
+    public void testEqualTreesWithDifferentNodeOrderAndDifferentWrapping() throws ParseException {
+        assertEquivalent("FOO == 'one' && BAT == 'two' && BAT == 'three'", "((BAT == 'two' && FOO == 'one') && BAT == 'three')");
+    }
+    
+    private void assertEquivalent(String first, String second) throws ParseException {
+        ASTJexlScript firstScript = JexlASTHelper.parseJexlQuery(first);
+        ASTJexlScript secondScript = JexlASTHelper.parseJexlQuery(second);
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(firstScript, secondScript);
+        assertTrue(comparison.isEqual());
+        assertNull(comparison.getReason());
+    }
+    
+    private void assertNotEquivalent(String first, String second, String expectedReason) throws ParseException {
+        ASTJexlScript firstScript = JexlASTHelper.parseJexlQuery(first);
+        ASTJexlScript secondScript = JexlASTHelper.parseJexlQuery(second);
+        assertNotEquivalent(firstScript, secondScript, expectedReason);
+    }
+    
+    private void assertNotEquivalent(JexlNode first, JexlNode second, String expectedReason) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(first, second);
+        assertFalse(comparison.isEqual());
+        assertEquals(expectedReason, comparison.getReason());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitorTest.java
@@ -195,18 +195,17 @@ public class TreeFlatteningRebuildingVisitorTest {
         assertScriptEquality(originalScript, original);
         assertLineage(originalScript);
         
-        assertTrue(TreeEqualityVisitor.isEqual(expectedScript, flattened, new TreeEqualityVisitor.Reason()));
+        assertTrue(TreeEqualityVisitor.isEqual(expectedScript, flattened));
     }
     
     private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actual, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UniqueExpressionTermsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UniqueExpressionTermsVisitorTest.java
@@ -256,13 +256,12 @@ public class UniqueExpressionTermsVisitorTest {
     
     private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actualScript, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetCheckTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetCheckTest.java
@@ -244,13 +244,12 @@ public class FacetCheckTest {
     
     private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
         ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedScript, actual, reason);
-        if (!equal) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
             log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
             log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
         }
-        assertTrue(reason.reason, equal);
+        assertTrue(comparison.getReason(), comparison.isEqual());
     }
     
     private void assertLineage(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -585,11 +585,9 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         expectedTree = TreeFlatteningRebuildingVisitor.flattenAll(expectedTree);
         ASTJexlScript queryTree = JexlASTHelper.parseJexlQuery(query);
         queryTree = TreeFlatteningRebuildingVisitor.flattenAll(queryTree);
-        TreeEqualityVisitor.Reason reason = new TreeEqualityVisitor.Reason();
-        boolean equal = TreeEqualityVisitor.isEqual(expectedTree, queryTree, reason);
-        
-        if (!equal) {
-            throw new ComparisonFailure(reason.reason, expected, query);
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedTree, queryTree);
+        if (!comparison.isEqual()) {
+            throw new ComparisonFailure(comparison.getReason(), expected, query);
         }
     }
     


### PR DESCRIPTION
The TreeEqualityVisitor currently only accepts two ASTJexlAcripts as
arguments for comparison. This forces developers to do more work to
utilize the TreeEqualityVisitor in tests.

Make the following changes:
* Modify the TreeEqualityVisitor to accept JexlNodes instead of
  ASTJexlScripts.
* Add a static TreeEqualityVisitor.isEqual method that does not require
  an instantiated Reason to be passed in.
* Add field equal to TreeEqualityVisitor.Reason so that the Reason class
  may be returned and used both to assert equality and to get the reason
  why two trees may not be equal.
* Add unit tests for the TreeEqualityVisitor.

Fixes #914