### PR TITLE
 Add timestamped job cache for deletion purposes

### DIFF
--- a/common-test/src/main/java/datawave/common/test/utils/FileUtils.java
+++ b/common-test/src/main/java/datawave/common/test/utils/FileUtils.java
@@ -1,0 +1,94 @@
+package datawave.common.test.utils;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class FileUtils {
+    
+    /**
+     * Delete all files under a directory.
+     *
+     * @param filePath
+     *            Local directory to delete
+     * @throws IOException
+     *             An exception is thrown if an I/O issue occurs while deleting
+     */
+    public static void deletePath(String filePath) throws IOException {
+        try (Stream<Path> allTmpPaths = java.nio.file.Files.walk(Paths.get(filePath), Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)) {
+            
+            // @formatter:off
+            Collection<Path> deletePaths = allTmpPaths
+                    .sorted(Comparator.reverseOrder())
+                    .collect(Collectors.toList());
+            // @formatter:on
+            
+            for (Path tmpPath : deletePaths) {
+                Files.delete(tmpPath);
+            }
+        }
+    }
+    
+    /**
+     * Create a temporary file at a certain path depth for test purposes.
+     *
+     * @param baseDir
+     *            The top level parent directory where the files will be created
+     * @param depth
+     *            The depth from the top level parent where the file will be created
+     * @param filePrefix
+     *            The file name before the depth level is appended
+     * @param fileSuffix
+     *            The file extension
+     * @throws IOException
+     *             An exception is thrown if an I/O issue occurs while creating file.
+     */
+    public static String createTemporaryFile(String baseDir, int depth, String filePrefix, String fileSuffix) throws IOException {
+        StringJoiner pathMaker = new StringJoiner(FileSystems.getDefault().getSeparator()).add(baseDir);
+        
+        // @formatter:off
+        IntStream.range(1, depth + 1)
+                .mapToObj(String::valueOf)
+                .forEach(pathMaker::add);
+        // @formatter:on
+        
+        return createTemporaryFile(pathMaker.add(filePrefix + depth + "." + fileSuffix).toString());
+    }
+    
+    /**
+     * Create a temporary file
+     *
+     * @param tmpFile
+     *            The file to create
+     * @return The file that was created.
+     * @throws IOException
+     *             An exception is thrown if an I/O issue occurs while deleting
+     */
+    public static String createTemporaryFile(String tmpFile) throws IOException {
+        Path filePath = Paths.get(tmpFile);
+        createTemporaryDir(filePath.getParent().toFile().getAbsolutePath());
+        return Files.createFile(filePath).toFile().getAbsolutePath();
+    }
+    
+    /**
+     * Create a temporary directory
+     *
+     * @param tmpDir
+     *            The directory to create
+     * @return The directory that was created.
+     * @throws IOException
+     *             An exception is thrown if an I/O issue occurs while deleting
+     */
+    public static String createTemporaryDir(String tmpDir) throws IOException {
+        return Files.createDirectories(Paths.get(tmpDir)).toFile().getAbsolutePath();
+    }
+}

--- a/warehouse/common/pom.xml
+++ b/warehouse/common/pom.xml
@@ -47,6 +47,12 @@
             <artifactId>easymock</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.18.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/warehouse/common/src/main/java/datawave/common/io/FilesFinder.java
+++ b/warehouse/common/src/main/java/datawave/common/io/FilesFinder.java
@@ -1,0 +1,129 @@
+package datawave.common.io;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.http.util.Args;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitOption;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class FilesFinder {
+    
+    /**
+     * Takes a classpath's value and resolves relative paths and returns a list of paths
+     *
+     * @param classpath
+     *            Classpath value to read to gather file paths
+     * @param delim
+     *            Delimiter to use to split environment variable value.
+     * @return A collection of files
+     */
+    public static Collection<String> getFilesFromClasspath(String classpath, String delim) {
+        // @formatter:off
+        return Arrays
+                .stream(classpath.split(delim))
+                .filter(path -> !path.isEmpty())
+                .map(FilesFinder::convertToCanonicalPath)
+                .sorted()
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    /**
+     * Traverses a directory path for a files that match a pattern up to a max depth and returns a list of paths
+     *
+     * @param path
+     *            Path to search
+     * @param filePattern
+     *            Pattern to match
+     * @param maxDepth
+     *            Maximum file tree depth to search
+     * @return A collection of files
+     * @throws IOException
+     *             If an error occurs while traversing the input directory
+     */
+    public static Collection<String> getFilesFromPattern(String path, String filePattern, int maxDepth) throws IOException {
+        Path dirPath = Paths.get(Args.notBlank(path, "Path must not be null or blank"));
+        
+        if (!java.nio.file.Files.isDirectory(dirPath, LinkOption.NOFOLLOW_LINKS)) {
+            throw new IllegalArgumentException("Input path " + path + " must be a directory");
+        }
+        
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + filePattern);
+        try (Stream<Path> filesWalked = java.nio.file.Files.walk(dirPath, maxDepth, FileVisitOption.FOLLOW_LINKS)) {
+            // @formatter:off
+            return filesWalked
+                    .filter(java.nio.file.Files::isReadable)
+                    .filter(java.nio.file.Files::isRegularFile)
+                    .filter(matcher::matches)
+                    .map(Path::toString)
+                    .sorted()
+                    .collect(Collectors.toList());
+            // @formatter:on
+        }
+    }
+    
+    /**
+     * Verify absolute path
+     *
+     * @param pathEntry
+     *            Path entry
+     * @return Resolved path entry
+     */
+    private static String convertToCanonicalPath(String pathEntry) {
+        File filePath = new File(pathEntry);
+        
+        if (!filePath.exists()) {
+            throw new IllegalArgumentException(pathEntry + " does not exist on file system.");
+        }
+        
+        try {
+            return filePath.getCanonicalPath();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to convert " + pathEntry + " to a canonical path.", e);
+        }
+    }
+    
+    /**
+     * Will search the source path for files that match the pattern
+     *
+     * @param fileSystem
+     *            The file system
+     * @param sourcePath
+     *            The source path to list
+     * @param pattern
+     *            The pattern to evaluate matching files
+     * @return An array of files status objects representing matching files.
+     */
+    public static FileStatus[] listPath(FileSystem fileSystem, org.apache.hadoop.fs.Path sourcePath, Pattern pattern) {
+        try {
+            return fileSystem.listStatus(sourcePath, getPathNameFilter(pattern));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to list files from " + sourcePath + " of pattern" + pattern, e);
+        }
+    }
+    
+    /**
+     * Will create a PathFilter based on a pattern
+     *
+     * @param pattern
+     *            A pattern to filter matches
+     * @return A path filter that will evaluate files based on a pattern
+     */
+    private static PathFilter getPathNameFilter(Pattern pattern) {
+        return path -> pattern.matcher(path.getName()).matches();
+    }
+    
+}

--- a/warehouse/common/src/main/java/datawave/common/io/HadoopFileSystemUtils.java
+++ b/warehouse/common/src/main/java/datawave/common/io/HadoopFileSystemUtils.java
@@ -1,0 +1,63 @@
+package datawave.common.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+/* Helper class for hadoop file system operations */
+public class HadoopFileSystemUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HadoopFileSystemUtils.class);
+    
+    private HadoopFileSystemUtils() {}
+    
+    /**
+     * Find the hadoop file system associated with the file path
+     *
+     * @param hadoopConfs
+     *            A collection of hadoop configurations
+     * @param filePath
+     *            A file path
+     * @return An optional that contains a file system for the file path or an empty optional
+     */
+    public static Optional<FileSystem> getFileSystem(Collection<Configuration> hadoopConfs, Path filePath) {
+        for (Configuration conf : hadoopConfs) {
+            try {
+                return Optional.of(filePath.getFileSystem(conf));
+            } catch (IOException e) {
+                LOGGER.debug("Unable to create filesystem for path {} and configuration {} ", filePath, conf, e);
+            }
+        }
+        return Optional.empty();
+    }
+    
+    /**
+     * Returns a runnable method for copying files to hdfs
+     *
+     * @param fileSystem
+     *            The file system to copy files
+     * @param srcPath
+     *            The source path to copy
+     * @param dstPath
+     *            The destination path
+     * @param replicationCnt
+     *            The number of replications
+     * @return A runnable method that will copy files.
+     */
+    public static Runnable getCopyFromLocalFileRunnable(FileSystem fileSystem, Path srcPath, Path dstPath, short replicationCnt) {
+        return () -> {
+            try {
+                fileSystem.copyFromLocalFile(false, true, srcPath, dstPath);
+                fileSystem.setReplication(dstPath, replicationCnt);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to upload " + srcPath + " to " + dstPath, e);
+            }
+        };
+    }
+}

--- a/warehouse/common/src/test/java/datawave/common/io/FilesFinderTest.java
+++ b/warehouse/common/src/test/java/datawave/common/io/FilesFinderTest.java
@@ -1,0 +1,121 @@
+package datawave.common.io;
+
+import com.google.common.io.Files;
+
+import datawave.common.test.utils.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import java.util.stream.Stream;
+
+import static datawave.common.test.utils.FileUtils.createTemporaryFile;
+
+public class FilesFinderTest {
+    private static final String TEMP_DIR = Files.createTempDir().getAbsolutePath();
+    private static final String CLASSPATH_DELIMITER = ":";
+    private static final String FILE_PREFIX = "File";
+    
+    private static String TEST_LEVEL0_PROP_FILE;
+    private static String TEST_LEVEL1_JAR_FILE;
+    private static String TEST_LEVEL1_XML_FILE;
+    private static String TEST_LEVEL2_XML_FILE;
+    
+    @BeforeClass
+    public static void setup() throws IOException {
+        TEST_LEVEL0_PROP_FILE = createTemporaryFile(TEMP_DIR, 0, FILE_PREFIX, "properties");
+        TEST_LEVEL1_JAR_FILE = createTemporaryFile(TEMP_DIR, 1, FILE_PREFIX, "jar");
+        TEST_LEVEL1_XML_FILE = createTemporaryFile(TEMP_DIR, 1, FILE_PREFIX, "xml");
+        TEST_LEVEL2_XML_FILE = createTemporaryFile(TEMP_DIR, 2, FILE_PREFIX, "xml");
+    }
+    
+    @AfterClass
+    public static void tearDown() throws IOException {
+        FileUtils.deletePath(TEMP_DIR);
+    }
+    
+    @Test
+    public void testGetFilesFromClasspath() {
+        Collection<String> expectedFiles = sortedList(TEST_LEVEL1_XML_FILE, TEST_LEVEL2_XML_FILE);
+        StringJoiner joiner = new StringJoiner(CLASSPATH_DELIMITER);
+        expectedFiles.forEach(joiner::add);
+        
+        Collection<String> filesFound = FilesFinder.getFilesFromClasspath(joiner.toString(), CLASSPATH_DELIMITER);
+        Assert.assertEquals(expectedFiles, filesFound);
+    }
+    
+    @Test
+    public void testGetFilesFromClasspathWithRelativePaths() {
+        Collection<String> expectedFiles = sortedList(TEST_LEVEL0_PROP_FILE, TEST_LEVEL1_JAR_FILE);
+        String baseDir = TEMP_DIR + "/1/2/";
+        String testPaths = baseDir + "../../" + FILE_PREFIX + "0.properties:" + baseDir + "../../1/" + FILE_PREFIX + "1.jar";
+        
+        Collection<String> filesFound = FilesFinder.getFilesFromClasspath(testPaths, CLASSPATH_DELIMITER);
+        Assert.assertEquals(expectedFiles, filesFound);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetFilesFromClasspathWithRelativePathFailures() {
+        String testPaths = "../../" + FILE_PREFIX + "0.properties:../../1/" + FILE_PREFIX + "1.jar";
+        FilesFinder.getFilesFromClasspath(testPaths, CLASSPATH_DELIMITER);
+    }
+    
+    @Test
+    public void testGetFilesFromPattern() throws IOException {
+        Collection<String> expectedFiles = sortedList(TEST_LEVEL1_XML_FILE, TEST_LEVEL2_XML_FILE);
+        Collection<String> filesFound = FilesFinder.getFilesFromPattern(TEMP_DIR, "**.xml", Integer.MAX_VALUE);
+        Assert.assertEquals(expectedFiles, filesFound);
+    }
+    
+    @Test
+    public void testGetFilesFromPatternByDepth() throws IOException {
+        Collection<String> expectedFiles = Stream.of(TEST_LEVEL1_XML_FILE).collect(Collectors.toList());
+        Collection<String> filesFound = FilesFinder.getFilesFromPattern(TEMP_DIR, "**.xml", 2);
+        Assert.assertEquals(expectedFiles, filesFound);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetFilesFromPatternWithNonDirectory() throws IOException {
+        FilesFinder.getFilesFromPattern("File.out", "**", Integer.MAX_VALUE);
+    }
+    
+    @Test
+    public void testArtifactsInDirectoryThatMatchPattern() throws IOException {
+        Collection<String> expectedFiles = Stream.of("1").collect(Collectors.toList());
+        
+        FileSystem fileSystem = FileSystem.getLocal(new Configuration());
+        Pattern numDirPattern = Pattern.compile("\\d{1}");
+        FileStatus[] fileStatuses = FilesFinder.listPath(fileSystem, new Path(TEMP_DIR), numDirPattern);
+        
+        // @formatter:off
+        Collection<String> filesFound = Arrays
+                .stream(fileStatuses)
+                .map(FileStatus::getPath)
+                .map(Path::getName)
+                .collect(Collectors.toList());
+        // @formatter: on
+
+        Assert.assertEquals(expectedFiles, filesFound);
+    }
+
+    private Collection<String> sortedList(String ... elements) {
+        // @formatter:off
+        return Arrays
+                .stream(elements)
+                .sorted()
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+}

--- a/warehouse/common/src/test/java/datawave/common/io/HadoopFileSystemUtilsTest.java
+++ b/warehouse/common/src/test/java/datawave/common/io/HadoopFileSystemUtilsTest.java
@@ -1,0 +1,96 @@
+package datawave.common.io;
+
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class HadoopFileSystemUtilsTest {
+    private static final Configuration TEST_CONF_A = getConfiguration("A");
+    private static final Configuration TEST_CONF_B = getConfiguration("B");
+    private static final Path TEST_PATH_A = new HadoopTestPath("A/file/path");
+    private static final Path TEST_PATH_B = new HadoopTestPath("B/file/path");
+    private static final String HADOOP_TEST_SCHEME_KEY = "SCHEME";
+    
+    private static final Map<Configuration,FileSystem> CONF_TO_FS = Maps.newHashMap();
+    
+    @BeforeClass
+    public static void setup() throws IOException {
+        CONF_TO_FS.put(TEST_CONF_A, FileSystem.get(TEST_CONF_A));
+        CONF_TO_FS.put(TEST_CONF_B, FileSystem.get(TEST_CONF_B));
+    }
+    
+    @AfterClass
+    public static void tearDown() throws IOException {
+        for (FileSystem fs : CONF_TO_FS.values()) {
+            fs.close();
+        }
+    }
+    
+    /**
+     * Create a test configuration with a scheme key/value pair
+     *
+     * @param testScheme
+     *            A scheme value to simulate a different hdfs file system
+     * @return A configuration
+     */
+    private static Configuration getConfiguration(String testScheme) {
+        Configuration conf = new Configuration();
+        conf.set(HADOOP_TEST_SCHEME_KEY, testScheme);
+        return conf;
+    }
+    
+    @Test
+    public void testWhenPathsFindAMatchingFileSystem() {
+        Collection<Configuration> testConfs = Stream.of(TEST_CONF_A, TEST_CONF_B).collect(Collectors.toList());
+        
+        // @formatter:off
+        Assert.assertTrue(Stream.of(TEST_PATH_B, TEST_PATH_A)
+                .map(path -> HadoopFileSystemUtils.getFileSystem(testConfs, path))
+                .allMatch(Optional::isPresent));
+        // @formatter:on
+        
+    }
+    
+    @Test
+    public void testNoFileSystemFoundForPath() {
+        Collection<Configuration> testConfs = Stream.of(TEST_CONF_A).collect(Collectors.toList());
+        
+        // @formatter:off
+        Assert.assertTrue(Stream.of(TEST_PATH_B)
+                .map(path -> HadoopFileSystemUtils.getFileSystem(testConfs, path))
+                .noneMatch(Optional::isPresent));
+        // @formatter:on
+    }
+    
+    /** A test helper class to simulate assigning filesystem objects by scheme of output path */
+    private static class HadoopTestPath extends Path {
+        private static final String UNKNOWN_SCHEME = "UNKNOWN";
+        private final String scheme;
+        
+        public HadoopTestPath(String pathString) throws IllegalArgumentException {
+            super(pathString);
+            this.scheme = pathString.substring(0, pathString.indexOf("/"));
+        }
+        
+        @Override
+        public FileSystem getFileSystem(Configuration conf) throws IOException {
+            String confType = conf.get(HADOOP_TEST_SCHEME_KEY, UNKNOWN_SCHEME);
+            if (!confType.equals(scheme)) {
+                throw new IOException("No fileSystem found with scheme");
+            }
+            return CONF_TO_FS.get(conf);
+        }
+    }
+}

--- a/warehouse/common/src/test/resources/log4j.properties
+++ b/warehouse/common/src/test/resources/log4j.properties
@@ -1,10 +1,6 @@
-log4j.rootCategory=INFO, CONSOLE
+log4j.rootCategory=DEBUG, CONSOLE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.Threshold=trace
+log4j.appender.CONSOLE.Threshold=DEBUG
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%-5p [%C{1}:%M] %m%n
-
-log4j.logger.datawave.util.flag=info
-log4j.logger.org.apache.zookeeper=warn
-log4j.logger.org.apache.curator=warn

--- a/warehouse/ingest-core/pom.xml
+++ b/warehouse/ingest-core/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>commons-jexl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-annotations</artifactId>
         </dependency>

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/ConfigurationFileHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/ConfigurationFileHelper.java
@@ -3,6 +3,8 @@ package datawave.ingest.util;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.hadoop.conf.Configuration;
@@ -15,13 +17,18 @@ import org.apache.hadoop.fs.Path;
  */
 public class ConfigurationFileHelper {
     private static final org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(ConfigurationFileHelper.class);
+    private static final String HADOOP_CONF_SUFFIX = "-site.xml";
     
     /**
+     * Create hadoop configuration from hadoop configuration directory
      * 
      * @param configDirectory
+     *            Hadoop configuration directory
      * @param configSuffix
+     *            Suffix to filter files to add to the configuration
      * @param loadDefaults
-     * @return
+     *            Will load configuration with default parameters
+     * @return A hadoop configuration
      */
     public static Configuration getConfigurationFromFiles(String configDirectory, String configSuffix, boolean loadDefaults) {
         Configuration conf = new Configuration(loadDefaults);
@@ -30,10 +37,14 @@ public class ConfigurationFileHelper {
     }
     
     /**
+     * Add resources to hadoop configuration
      * 
      * @param conf
+     *            A hadoop configuration object
      * @param configDirectory
+     *            A hadoop configuration directory
      * @param configSuffix
+     *            A suffix to filter results
      */
     public static void setConfigurationFromFiles(Configuration conf, String configDirectory, String configSuffix) {
         File directory = new File(configDirectory);
@@ -45,5 +56,21 @@ public class ConfigurationFileHelper {
                 log.error("Could not add config file to configuration: " + configFile, ex);
             }
         }
+    }
+    
+    /**
+     * Create a configuration for each hadoop configuration directory specified
+     *
+     * @param confDirs
+     *            A collection of hadoop configuration directories
+     * @return A collection of hadoop configuration objects
+     */
+    public static Collection<Configuration> getHadoopConfs(Collection<String> confDirs) {
+        // @formatter:off
+        return confDirs
+                .stream()
+                .map(dir -> ConfigurationFileHelper.getConfigurationFromFiles(dir, HADOOP_CONF_SUFFIX, false))
+                .collect(Collectors.toList());
+        // @formatter:on
     }
 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/JobCacheFactory.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/JobCacheFactory.java
@@ -1,0 +1,194 @@
+package datawave.ingest.util.cache;
+
+import com.google.common.collect.Maps;
+import datawave.common.io.FilesFinder;
+import datawave.ingest.util.cache.delete.DeleteJobCache;
+import datawave.ingest.util.cache.lease.JobCacheLockFactory;
+import datawave.ingest.util.cache.load.LoadJobCache;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.http.util.Args;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** The JobCacheFactory will expose the basic functionality to interact and use the job cache */
+public class JobCacheFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobCacheFactory.class);
+    public static final Comparator<Path> PATH_COMPARATOR = Comparator.comparing(x -> x.toUri().getPath());
+    public static final String DW_JOB_CACHE_TIMESTAMP_DIR_PREFIX = "datawave.job.cache.timestamp.dir.prefix";
+    public static final String DW_JOB_CACHE_TIMESTAMP_PATTERN = "datawave.job.cache.timestamp.pattern";
+    public static final String DW_JOB_CACHE_BASE_PATH = "datawave.job.cache.base.path";
+    public static final String DW_JOB_CACHE_LOCK_FACTORY_MODE = "datawave.job.cache.lock.factory.mode";
+    
+    private final FileSystemPath jobCacheBasePath;
+    private final Pattern timestampPattern;
+    private final JobCacheLockFactory lockFactory;
+    private final String timestampDirPrefix;
+    private final Map<String,String> jobIdToCacheId = Maps.newHashMap();
+    
+    public JobCacheFactory(Configuration conf) throws IOException {
+        Path basePath = new Path(Args.notNull(conf.get(DW_JOB_CACHE_BASE_PATH), DW_JOB_CACHE_BASE_PATH));
+        jobCacheBasePath = new FileSystemPath(basePath.getFileSystem(conf), basePath);
+        
+        timestampPattern = Pattern.compile(Args.notNull(conf.get(DW_JOB_CACHE_TIMESTAMP_PATTERN), DW_JOB_CACHE_TIMESTAMP_PATTERN));
+        timestampDirPrefix = Args.notNull(conf.get(DW_JOB_CACHE_TIMESTAMP_DIR_PREFIX), DW_JOB_CACHE_TIMESTAMP_DIR_PREFIX);
+        
+        String lockFactoryMode = Args.notNull(conf.get(DW_JOB_CACHE_LOCK_FACTORY_MODE), DW_JOB_CACHE_LOCK_FACTORY_MODE);
+        lockFactory = JobCacheLockFactory.getLockFactory(lockFactoryMode);
+        lockFactory.init(conf);
+    }
+    
+    /**
+     * Will attempt to find the most recent unlocked job cache.
+     *
+     * @param jobId
+     *            The unique identifier for the job.
+     * @return The path of the most recent active job cache.
+     * @throws Exception
+     *             if no unlocked cache is found.
+     */
+    public Path getJobCache(String jobId) throws Exception {
+        for (FileSystemPath jobCache : getCacheCandidates(jobCacheBasePath, timestampPattern, 0)) {
+            String lockIdPath = getLockIdPath(jobCache.getOutputPath().getName(), jobId);
+            if (lockFactory.acquireLock(lockIdPath)) {
+                jobIdToCacheId.put(jobId, lockIdPath);
+                LOGGER.info("{} will be assigned to cache {}", jobId, lockIdPath);
+                return jobCache.getOutputPath();
+            }
+        }
+        throw new Exception("Unable to find an active cache in " + jobCacheBasePath.getOutputPath());
+    }
+    
+    /**
+     * Will attempt to release the lock associated with this job id.
+     *
+     * @param jobId
+     *            The unique identifier for the job.
+     * @return Whether the release of the lease was successful.
+     */
+    public boolean releaseId(String jobId) {
+        return jobIdToCacheId.containsKey(jobId) && lockFactory.releaseLock(jobIdToCacheId.get(jobId));
+    }
+    
+    /**
+     * Will load a new job cache in the specified paths.
+     *
+     * @param baseCachePaths
+     *            The base cache paths for each active system.
+     * @param filesToLoad
+     *            The files to load to the cache.
+     * @param cacheReplicationCnt
+     *            The replication factor.
+     * @param executorThreads
+     *            The number of executor threads.
+     */
+    public void loadNewJobCache(Collection<FileSystemPath> baseCachePaths, Collection<String> filesToLoad, short cacheReplicationCnt, int executorThreads) {
+        LoadJobCache.load(baseCachePaths, filesToLoad, true, cacheReplicationCnt, executorThreads, LoadJobCache.getJobCacheTimestampDir(timestampDirPrefix), "");
+    }
+    
+    /**
+     * Will attempt to delete the cachePath specified if it is not active or locked.
+     *
+     * @param cachePath
+     *            An object that holds the cache path and its associated file system.
+     */
+    public void deleteJobCache(FileSystemPath cachePath) {
+        DeleteJobCache.deleteCacheIfNotActive(Collections.singleton(cachePath), lockFactory);
+    }
+    
+    /**
+     * Find all the job cache's status under the system's base cache path
+     *
+     * @param baseCachePath
+     *            An object that contains the job cache base path and its associated file system.
+     * @return A collection objects representing the status for each job cache.
+     */
+    public Collection<JobCacheStatus> getJobCacheStatuses(FileSystemPath baseCachePath) {
+        // @formatter:off
+        return getCacheCandidates(baseCachePath, timestampPattern, 0)
+                .stream()
+                .map(this::getJobCacheStatus)
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    /**
+     * Will attempt to release all locks for each cache id stored.
+     */
+    public void close() {
+        jobIdToCacheId.clear();
+        lockFactory.close();
+    }
+    
+    /**
+     * Find job cache paths that pass the input criteria.
+     *
+     * @param cacheBasePath
+     *            An object that contains the job cache base path and its associated file system.
+     * @param pattern
+     *            A pattern that will be used to filter job cache paths.
+     * @param keepNumVersions
+     *            The number of versions to skip(this is used primarily when deleting)
+     * @return A collection of job cache paths sorted in reverse order.
+     */
+    public static Collection<FileSystemPath> getCacheCandidates(FileSystemPath cacheBasePath, Pattern pattern, int keepNumVersions) {
+        Path cachePath = cacheBasePath.getOutputPath();
+        FileSystem fileSystem = cacheBasePath.getFileSystem();
+        
+        FileStatus[] pathStatus = FilesFinder.listPath(fileSystem, cachePath, pattern);
+        
+        // @formatter:off
+        return Arrays
+                .stream(pathStatus)
+                .filter(FileStatus::isDirectory)
+                .map(FileStatus::getPath)
+                .sorted(PATH_COMPARATOR.reversed())
+                .skip(keepNumVersions)
+                .map(deleteCachePath -> new FileSystemPath(fileSystem, deleteCachePath))
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    JobCacheLockFactory getLockFactory() {
+        return lockFactory;
+    }
+    
+    /**
+     * Find the job cache status for this job cache path
+     *
+     * @param cachePath
+     *            An object that contains the job cache path and its associated file system.
+     * @return An object that represents the status of the job cache.
+     */
+    private JobCacheStatus getJobCacheStatus(FileSystemPath cachePath) {
+        String lockIdPath = getLockIdPath(cachePath.getOutputPath().getName());
+        return new JobCacheStatus(cachePath, lockFactory.getCacheStatus(lockIdPath));
+    }
+    
+    /**
+     * Form the lock id by joining the passed in array with file.separator as the delimiter.
+     *
+     * @param lockIdElements
+     *            An array of lock id components that when joined form the lock id.
+     * @return A String representing the lock id.
+     */
+    String getLockIdPath(String... lockIdElements) {
+        StringJoiner joiner = new StringJoiner(File.separator);
+        Arrays.stream(lockIdElements).forEach(joiner::add);
+        return joiner.toString();
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/JobCacheStatus.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/JobCacheStatus.java
@@ -1,0 +1,42 @@
+package datawave.ingest.util.cache;
+
+import datawave.ingest.util.cache.lease.LockCacheStatus;
+import datawave.ingest.util.cache.path.FileSystemPath;
+
+import java.util.Objects;
+
+/** A job cache status is made up of its path and its lock attributes */
+public class JobCacheStatus {
+    
+    private final LockCacheStatus lockCacheStatus;
+    private final FileSystemPath cachePath;
+    
+    public JobCacheStatus(FileSystemPath cachePath, LockCacheStatus lockCacheStatus) {
+        this.cachePath = cachePath;
+        this.lockCacheStatus = lockCacheStatus;
+    }
+    
+    public LockCacheStatus getLockCacheStatus() {
+        return lockCacheStatus;
+    }
+    
+    public FileSystemPath getCachePath() {
+        return cachePath;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+        
+        JobCacheStatus that = (JobCacheStatus) obj;
+        return this.cachePath.equals(that.cachePath) && this.lockCacheStatus.equals(that.lockCacheStatus);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(cachePath, lockCacheStatus);
+    }
+    
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/CacheLockConverter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/CacheLockConverter.java
@@ -1,0 +1,12 @@
+package datawave.ingest.util.cache.converter;
+
+import com.beust.jcommander.IStringConverter;
+import datawave.ingest.util.cache.lease.JobCacheLockFactory;
+
+/** JCommander converter class to convert a command line string to the JobCacheLockFactory object */
+public class CacheLockConverter implements IStringConverter<JobCacheLockFactory> {
+    @Override
+    public JobCacheLockFactory convert(String value) {
+        return JobCacheLockFactory.getLockFactory(value);
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/DeleteModeConverter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/DeleteModeConverter.java
@@ -1,0 +1,20 @@
+package datawave.ingest.util.cache.converter;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/** JCommander converter class to convert a command line string to the DeleteJobCacheMode object */
+public class DeleteModeConverter implements IStringConverter<DeleteJobCacheMode> {
+    @Override
+    public DeleteJobCacheMode convert(String value) {
+        Optional<DeleteJobCacheMode> mode = DeleteJobCacheMode.getDeleteCacheMode(DeleteJobCacheMode.Mode.valueOf(value));
+        if (!mode.isPresent()) {
+            throw new ParameterException(value + " is not a valid mode. " + Arrays.toString(DeleteJobCacheMode.Mode.values()));
+        }
+        return mode.get();
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/HadoopPathConverter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/HadoopPathConverter.java
@@ -1,0 +1,19 @@
+package datawave.ingest.util.cache.converter;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * JCommander converter class to convert a command line string to the Path object
+ */
+public class HadoopPathConverter implements IStringConverter<Path> {
+    @Override
+    public Path convert(String value) {
+        try {
+            return new Path(value);
+        } catch (IllegalArgumentException iae) {
+            throw new ParameterException(value + " could not be converted to a Path ", iae);
+        }
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/LoadModeConverter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/LoadModeConverter.java
@@ -1,0 +1,20 @@
+package datawave.ingest.util.cache.converter;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import datawave.ingest.util.cache.load.mode.LoadJobCacheMode;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/** JCommander converter class to convert a command line string to the LoadJobCacheMode object */
+public class LoadModeConverter implements IStringConverter<LoadJobCacheMode> {
+    @Override
+    public LoadJobCacheMode convert(String value) {
+        Optional<LoadJobCacheMode> mode = LoadJobCacheMode.getLoadCacheMode(LoadJobCacheMode.Mode.valueOf(value));
+        if (!mode.isPresent()) {
+            throw new ParameterException(value + " is not a valid mode. " + Arrays.toString(LoadJobCacheMode.Mode.values()));
+        }
+        return mode.get();
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/RegexPatternConverter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/RegexPatternConverter.java
@@ -1,0 +1,15 @@
+package datawave.ingest.util.cache.converter;
+
+import com.beust.jcommander.IStringConverter;
+
+import java.util.regex.Pattern;
+
+/**
+ * JCommander converter class to convert a command line string to the Path object
+ */
+public class RegexPatternConverter implements IStringConverter<Pattern> {
+    @Override
+    public Pattern convert(String value) {
+        return Pattern.compile(value);
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/ShortConverter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/converter/ShortConverter.java
@@ -1,0 +1,16 @@
+package datawave.ingest.util.cache.converter;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+
+/** JCommander converter class to convert a command line string to the Short object */
+public class ShortConverter implements IStringConverter<Short> {
+    @Override
+    public Short convert(String value) {
+        try {
+            return Short.parseShort(value);
+        } catch (NumberFormatException nfe) {
+            throw new ParameterException(value + " could not be converted to a short ", nfe);
+        }
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/DeleteJobCache.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/DeleteJobCache.java
@@ -1,0 +1,73 @@
+package datawave.ingest.util.cache.delete;
+
+import com.google.common.base.Predicates;
+import datawave.ingest.util.cache.lease.JobCacheLockFactory;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/** This class will be responsible for deleting job caches */
+public class DeleteJobCache {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteJobCache.class);
+    
+    /**
+     * Find job cache directories that are candidates for deletion.
+     *
+     * @param deletePaths
+     *            Job cache paths that should be deleted.
+     * @param keepPaths
+     *            Job cache paths that should be kept.
+     * @return A collection of job cache directories to attempt to delete.
+     */
+    public static Collection<Path> getDeletionCandidates(Collection<Path> deletePaths, Collection<Path> keepPaths) {
+        // @formatter:off
+        return deletePaths
+                .stream()
+                .filter(Predicates.not(keepPaths::contains))
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    /**
+     * Attempts to delete inactive job cache directories.
+     *
+     * @param jobCachePaths
+     *            A collection of job cache directories where deletion will be attempted.
+     * @param lockFactory
+     *            A factory to determine caches that are still active or locked.
+     */
+    public static void deleteCacheIfNotActive(Collection<FileSystemPath> jobCachePaths, JobCacheLockFactory lockFactory) {
+        // @formatter:off
+        jobCachePaths
+                .stream()
+                .filter(jobCache -> lockFactory.acquireLock(jobCache.getOutputPath().getName(), lockFactory.getCacheAvailablePredicate()))
+                .filter(DeleteJobCache::deleteCache)
+                .forEach(jobCache -> lockFactory.releaseLock(jobCache.getOutputPath().getName()));
+        // @formatter:on
+    }
+    
+    /**
+     * Deletes the job cache directory.
+     *
+     * @param jobCachePath
+     *            An object that contains the job cache path and its associated file system.
+     * @return A boolean representing if the cache was deleted successfully.
+     */
+    private static boolean deleteCache(FileSystemPath jobCachePath) {
+        FileSystem fileSystem = jobCachePath.getFileSystem();
+        Path cachePath = jobCachePath.getOutputPath();
+        
+        try {
+            LOGGER.info("Deleting cache {} ", cachePath);
+            return fileSystem.delete(cachePath, true);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to delete " + cachePath, e);
+        }
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/DeleteJobCacheLauncher.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/DeleteJobCacheLauncher.java
@@ -1,0 +1,115 @@
+package datawave.ingest.util.cache.delete;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import datawave.ingest.util.ConfigurationFileHelper;
+import datawave.ingest.util.cache.converter.CacheLockConverter;
+import datawave.ingest.util.cache.converter.DeleteModeConverter;
+import datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode;
+import datawave.ingest.util.cache.delete.mode.DeleteModeOptions;
+import datawave.ingest.util.cache.delete.mode.OldInactiveMode;
+import datawave.ingest.util.cache.lease.JobCacheZkLockFactory;
+import datawave.ingest.util.cache.lease.JobCacheLockFactory;
+import datawave.ingest.util.cache.lease.LockFactoryModeOptions;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Delete job cache launcher will delete specified or old/inactive job cache directories.
+ */
+
+public class DeleteJobCacheLauncher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteJobCacheLauncher.class);
+    
+    @Parameter(names = {"--delete-mode"}, description = "Mode to determine how to delete job cache directories.", converter = DeleteModeConverter.class)
+    DeleteJobCacheMode deleteMode = new OldInactiveMode();
+    
+    @Parameter(names = {"--lock-mode"}, description = "Mode to determine what the locking mechanism.", converter = CacheLockConverter.class)
+    JobCacheLockFactory lockFactory = new JobCacheZkLockFactory();
+    
+    @Parameter(names = {"--hadoop-conf-dirs"}, description = "The hadoop configuration directories")
+    List<String> hadoopConfDirs = Arrays.asList(System.getenv("INGEST_HADOOP_CONF"), System.getenv("WAREHOUSE_HADOOP_CONF"));
+    
+    @Parameter(names = {"-h", "-help", "--help", "-?"}, help = true, description = "Prints job options.")
+    boolean help;
+    
+    /**
+     * Will delete job cache paths based on the deletion mode specified.
+     *
+     * @param deleteModeOptions
+     *            Mode options that will determine which job caches to delete.
+     * @param lockModeOptions
+     *            Mode options that will determine the locking mechanism to use.
+     */
+    public void run(DeleteModeOptions deleteModeOptions, LockFactoryModeOptions lockModeOptions) {
+        Collection<Configuration> hadoopConfs = ConfigurationFileHelper.getHadoopConfs(hadoopConfDirs);
+        Collection<FileSystemPath> deletionCandidates = deleteMode.getDeletionCandidates(hadoopConfs, deleteModeOptions);
+        
+        try {
+            lockFactory.init(lockModeOptions.getConf());
+            LOGGER.info("Attempting to delete inactive caches {}", listToString(deletionCandidates));
+            if (!deletionCandidates.isEmpty()) {
+                DeleteJobCache.deleteCacheIfNotActive(deletionCandidates, lockFactory);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unable to delete caches " + listToString(deletionCandidates), e);
+        } finally {
+            lockFactory.close();
+            deletionCandidates.forEach(FileSystemPath::close);
+        }
+    }
+    
+    /**
+     * Will transform a collection of objects to single string representation for logging.
+     *
+     * @param collection
+     *            Collection of objects to transform to a string.
+     * @return A string representing the collection separating with a comma delimiter.
+     */
+    public static String listToString(Collection<?> collection) {
+        // @formatter:off
+        return collection
+                .stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(","));
+        // @formatter:on
+    }
+    
+    public static void main(String[] args) throws Exception {
+        LOGGER.info("Starting delete job cache utility");
+        DeleteJobCacheLauncher launcher = new DeleteJobCacheLauncher();
+        DeleteModeOptions deleteModeOptions = new DeleteModeOptions();
+        LockFactoryModeOptions lockModeOptions = new LockFactoryModeOptions();
+        
+        // @formatter:off
+        JCommander jCommander = JCommander
+                .newBuilder()
+                .addObject(launcher)
+                .addObject(deleteModeOptions)
+                .addObject(lockModeOptions)
+                .build();
+        // @formatter:on
+        
+        try {
+            jCommander.parse(args);
+            if (launcher.help) {
+                jCommander.usage();
+            } else {
+                launcher.run(deleteModeOptions, lockModeOptions);
+            }
+        } catch (ParameterException e) {
+            System.err.println(e.getMessage());
+            jCommander.usage();
+            System.exit(-1);
+        }
+        LOGGER.info("Finished delete job cache utility");
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/DeleteJobCacheMode.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/DeleteJobCacheMode.java
@@ -1,0 +1,54 @@
+package datawave.ingest.util.cache.delete.mode;
+
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
+/** Interface that will be used to determine method to inactive job caches */
+public interface DeleteJobCacheMode {
+    ServiceLoader<DeleteJobCacheMode> serviceLoader = ServiceLoader.load(DeleteJobCacheMode.class);
+    
+    /**
+     * Find mode that will determine which timestamp cache directories to delete.
+     *
+     * @param mode
+     *            Enum that specifies method to find cache candidates for deletion.
+     * @return An optional for DeleteJobCacheMode object
+     */
+    static Optional<DeleteJobCacheMode> getDeleteCacheMode(Mode mode) {
+        // @formatter:off
+        return StreamSupport.stream(serviceLoader.spliterator(), false)
+                .filter(deleteMode -> deleteMode.getMode().equals(mode))
+                .findFirst();
+        // @formatter:on
+    }
+    
+    /**
+     * Get enum representing mode specified
+     *
+     * @return A mode to find cache directories to delete
+     */
+    Mode getMode();
+    
+    /**
+     * Get job cache candidates for deletion
+     *
+     * @param hadoopConfs
+     *            Hadoop configuration used to search for correct file system
+     * @param options
+     *            Mode options necessary for finding deletion candidates
+     * @return A collection of candidates for deletion
+     */
+    Collection<FileSystemPath> getDeletionCandidates(Collection<Configuration> hadoopConfs, DeleteModeOptions options);
+    
+    /**
+     * Mode enum for specifying the method to find files to delete
+     */
+    enum Mode {
+        DELETES_SPECIFIED, OLD_INACTIVE
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/DeleteModeOptions.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/DeleteModeOptions.java
@@ -1,0 +1,50 @@
+package datawave.ingest.util.cache.delete.mode;
+
+import com.beust.jcommander.Parameter;
+import com.google.common.collect.Lists;
+import datawave.ingest.util.cache.converter.HadoopPathConverter;
+import datawave.ingest.util.cache.converter.RegexPatternConverter;
+import org.apache.hadoop.fs.Path;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** JCommander options class that will evaluate command line delete mode options. */
+public class DeleteModeOptions {
+    @Parameter(names = {"--delete-paths"}, description = "A list of timestamp job cache paths to delete.", converter = HadoopPathConverter.class)
+    List<Path> deletePaths = Lists.newArrayList();
+    
+    @Parameter(names = {"--job-cache-paths"}, description = "The parent job cache directories to evaluate.", converter = HadoopPathConverter.class)
+    List<Path> jobCachePaths;
+    
+    @Parameter(names = {"--keep-num-versions"}, description = "The number of old cache directories to keep.")
+    int keepNumVersions = 1;
+    
+    @Parameter(names = {"--keep-paths"}, description = "A list of timestamp directories to keep.", converter = HadoopPathConverter.class)
+    List<Path> keepPaths = Lists.newArrayList();
+    
+    @Parameter(names = {"--timestamp-pattern"}, description = "The timestamp pattern.", converter = RegexPatternConverter.class)
+    Pattern timestampPattern = Pattern.compile("jobCache_\\d{14}");
+    
+    public Collection<Path> getDeletePaths() {
+        return deletePaths;
+    }
+    
+    public Collection<Path> getJobCachePaths() {
+        return jobCachePaths;
+    }
+    
+    public int getKeepNumVersions() {
+        return keepNumVersions;
+    }
+    
+    public Collection<Path> getKeepPaths() {
+        return keepPaths;
+    }
+    
+    public Pattern getTimestampPattern() {
+        return timestampPattern;
+    }
+    
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/DeletesSpecifiedMode.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/DeletesSpecifiedMode.java
@@ -1,0 +1,31 @@
+package datawave.ingest.util.cache.delete.mode;
+
+import datawave.ingest.util.cache.delete.DeleteJobCache;
+import datawave.ingest.util.cache.delete.DeleteJobCacheLauncher;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+/** Delete job cache mode that will attempt to delete caches specified by the user */
+public class DeletesSpecifiedMode implements DeleteJobCacheMode {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeletesSpecifiedMode.class);
+    
+    @Override
+    public Collection<FileSystemPath> getDeletionCandidates(Collection<Configuration> hadoopConfs, DeleteModeOptions options) {
+        Collection<Path> deletePaths = options.getDeletePaths();
+        Collection<Path> keepPaths = options.getKeepPaths();
+        
+        LOGGER.debug("{} mode. Delete paths: {} , Keep paths: {}", Mode.DELETES_SPECIFIED, deletePaths, keepPaths);
+        Collection<Path> deleteCandidates = DeleteJobCache.getDeletionCandidates(deletePaths, keepPaths);
+        return FileSystemPath.getFileSystemPaths(deleteCandidates, hadoopConfs);
+    }
+    
+    @Override
+    public Mode getMode() {
+        return Mode.DELETES_SPECIFIED;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/OldInactiveMode.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/delete/mode/OldInactiveMode.java
@@ -1,0 +1,43 @@
+package datawave.ingest.util.cache.delete.mode;
+
+import com.google.common.base.Predicates;
+import datawave.ingest.util.cache.JobCacheFactory;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** Delete job cache mode that will attempt to delete caches that are old and inactive */
+public class OldInactiveMode implements DeleteJobCacheMode {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OldInactiveMode.class);
+    
+    @Override
+    public Collection<FileSystemPath> getDeletionCandidates(Collection<Configuration> hadoopConfs, DeleteModeOptions options) {
+        Collection<FileSystemPath> jobCachePaths = FileSystemPath.getFileSystemPaths(options.getJobCachePaths(), hadoopConfs);
+        Collection<Path> keepPaths = options.getKeepPaths();
+        Pattern timestampPattern = options.getTimestampPattern();
+        int keepNumVersions = options.getKeepNumVersions();
+        
+        LOGGER.debug("{} mode. Job base path: {} , Keep paths: {} , pattern: {} and num versions {}", Mode.OLD_INACTIVE, jobCachePaths, keepPaths,
+                        timestampPattern, keepNumVersions);
+        
+        // @formatter:off
+        return jobCachePaths
+                .stream()
+                .map(jobCachePath -> JobCacheFactory.getCacheCandidates(jobCachePath, timestampPattern, keepNumVersions))
+                .flatMap(Collection::stream)
+                .filter(Predicates.not(fsPath -> keepPaths.contains(fsPath.getOutputPath())))
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    @Override
+    public DeleteJobCacheMode.Mode getMode() {
+        return Mode.OLD_INACTIVE;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/JobCacheLockFactory.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/JobCacheLockFactory.java
@@ -1,0 +1,106 @@
+package datawave.ingest.util.cache.lease;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+public interface JobCacheLockFactory extends AutoCloseable {
+    ServiceLoader<JobCacheLockFactory> serviceLoader = ServiceLoader.load(JobCacheLockFactory.class);
+    
+    /**
+     * Get the lock factory that is associated with the input mode.
+     *
+     * @param inputMode
+     *            User input mode associated with a lock factory
+     * @return A JobCacheLockFactory
+     */
+    static JobCacheLockFactory getLockFactory(String inputMode) {
+        // @formatter:off
+        Optional<JobCacheLockFactory> optLockFactory = StreamSupport
+                .stream(serviceLoader.spliterator(), false)
+                .filter(lockFactoryMode -> lockFactoryMode.getMode().name().equals(inputMode))
+                .findFirst();
+        // @formatter:on
+        
+        if (!optLockFactory.isPresent()) {
+            throw new IllegalArgumentException(inputMode + " is not a valid mode. " + Arrays.toString(Mode.values()));
+        }
+        return optLockFactory.get();
+    }
+    
+    /**
+     * Acquire a lock based on the id.
+     *
+     * @param id
+     *            An id that represents a resource to lock
+     * @return True if a lock was acquired.
+     */
+    boolean acquireLock(String id);
+    
+    /**
+     * Acquire a lock based on the id and the availability of the cache
+     *
+     * @param id
+     *            An id that represents a resource to lock.
+     * @param cacheAvailablePredicate
+     *            A predicate function to determine if the cache is available.
+     * @return True if a lock was acquired.
+     */
+    boolean acquireLock(String id, Predicate<String> cacheAvailablePredicate);
+    
+    /**
+     * Will close all resources used by the locking factory
+     */
+    void close();
+    
+    /**
+     * Predicate to determine if the cache is available for acquiring locks
+     *
+     * @return A predicate function that takes a string as input
+     */
+    Predicate<String> getCacheAvailablePredicate();
+    
+    /**
+     * Get cache status for the given id
+     * 
+     * @param id
+     *            An cache id
+     *
+     * @return An object representing the cache lock attributes.
+     */
+    LockCacheStatus getCacheStatus(String id);
+    
+    /**
+     * Get cache status for the given id
+     * 
+     * @param conf
+     *            The configuration to extract property values
+     */
+    default void init(Configuration conf) {}
+    
+    /**
+     * Release lock for id if possible
+     *
+     * @param id
+     *            An id that represents a resource to lock
+     * @return True if the lock was released.
+     */
+    boolean releaseLock(String id);
+    
+    /**
+     * Get enum representing mode specified
+     *
+     * @return A mode to specify type of lock factory
+     */
+    JobCacheLockFactory.Mode getMode();
+    
+    /** Mode enum for specifying the method to find files to load */
+    enum Mode {
+        ZOOKEEPER, NO_OP
+    }
+    
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/JobCacheNoOpLockFactory.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/JobCacheNoOpLockFactory.java
@@ -1,0 +1,40 @@
+package datawave.ingest.util.cache.lease;
+
+import java.util.function.Predicate;
+
+public class JobCacheNoOpLockFactory implements JobCacheLockFactory {
+    
+    @Override
+    public boolean acquireLock(String id) {
+        return true;
+    }
+    
+    @Override
+    public boolean acquireLock(String id, Predicate<String> cacheAvailablePredicate) {
+        return true;
+    }
+    
+    @Override
+    public boolean releaseLock(String id) {
+        return true;
+    }
+    
+    @Override
+    public Mode getMode() {
+        return Mode.NO_OP;
+    }
+    
+    @Override
+    public void close() {}
+    
+    @Override
+    public Predicate<String> getCacheAvailablePredicate() {
+        return input -> true;
+    }
+    
+    @Override
+    public LockCacheStatus getCacheStatus(String id) {
+        return null;
+    }
+    
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/JobCacheZkLockFactory.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/JobCacheZkLockFactory.java
@@ -1,0 +1,277 @@
+package datawave.ingest.util.cache.lease;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.utils.CloseableUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/** Factory class to handle job cache leases. */
+public class JobCacheZkLockFactory implements JobCacheLockFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobCacheZkLockFactory.class);
+    
+    public static final String DW_JOB_CACHE_ZOOKEEPER_TIMEOUT = "datawave.job.cache.zk.timeout.ms";
+    public static final String DW_JOB_CACHE_ZOOKEEPER_RETRY_CNT = "datawave.job.cache.zk.retry.cnt";
+    public static final String DW_JOB_CACHE_ZOOKEEPER_RETRY_TIMEOUT = "datawave.job.cache.zk.retry.timeout.ms";
+    public static final String DW_JOB_CACHE_ZOOKEEPER_NAMESPACE = "datawave.job.cache.zk.namespace";
+    public static final String DW_JOB_CACHE_ZOOKEEPER_NODES = "datawave.job.cache.zk.nodes";
+    private static final int ZOOKEEPER_TIME_BEFORE_RETRY_MS = 30;
+    private static final int ZOOKEEPER_ACQUIRE_LOCK_TIMEOUT = 30;
+    private static final int ZOOKEEPER_RETRY_CONNECTION_CNT = 3;
+    
+    private static final String ZOOKEEPER_LEASE_DIR = "/leases";
+    
+    private CuratorFramework client;
+    private final Map<String,InterProcessSemaphoreMutex> jobIdToLeases = Maps.newHashMap();
+    private int lockTimeoutInMs;
+    
+    public JobCacheZkLockFactory() {}
+    
+    public JobCacheZkLockFactory(String namespace, String zookeepers, int lockTimeoutInMs, int retryCnt, int retryTimeoutInMS) {
+        init(namespace, zookeepers, lockTimeoutInMs, retryCnt, retryTimeoutInMS);
+    }
+    
+    @Override
+    public void init(Configuration conf) {
+        int lockTimeout = conf.getInt(DW_JOB_CACHE_ZOOKEEPER_TIMEOUT, ZOOKEEPER_TIME_BEFORE_RETRY_MS);
+        int retryCnt = conf.getInt(DW_JOB_CACHE_ZOOKEEPER_RETRY_CNT, ZOOKEEPER_RETRY_CONNECTION_CNT);
+        int retryTimeout = conf.getInt(DW_JOB_CACHE_ZOOKEEPER_RETRY_TIMEOUT, ZOOKEEPER_ACQUIRE_LOCK_TIMEOUT);
+        String namespace = conf.get(DW_JOB_CACHE_ZOOKEEPER_NAMESPACE);
+        String zookeepers = conf.get(DW_JOB_CACHE_ZOOKEEPER_NODES);
+        init(namespace, zookeepers, lockTimeout, retryCnt, retryTimeout);
+    }
+    
+    @Override
+    public boolean acquireLock(String id) {
+        return acquireLock(id, this::isCacheLocked);
+    }
+    
+    @Override
+    public boolean acquireLock(String id, Predicate<String> cacheCheck) {
+        if (cacheCheck.test(getCacheId(id))) {
+            LOGGER.warn("Unable to acquire job lease for {} since cache is locked or active if deleting", id);
+            return false;
+        }
+        
+        InterProcessSemaphoreMutex lock = new InterProcessSemaphoreMutex(client, getLockPath(id));
+        try {
+            if (lock.acquire(lockTimeoutInMs, TimeUnit.MILLISECONDS)) {
+                jobIdToLeases.put(id, lock);
+                return true;
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to acquire lock for " + id, e);
+        }
+        
+        return false;
+    }
+    
+    @Override
+    public boolean releaseLock(String id) {
+        if (jobIdToLeases.containsKey(id) && releaseLock(id, jobIdToLeases.get(id))) {
+            jobIdToLeases.remove(id);
+            return true;
+        }
+        return false;
+    }
+    
+    @Override
+    public Mode getMode() {
+        return Mode.ZOOKEEPER;
+    }
+    
+    @Override
+    public void close() {
+        jobIdToLeases.forEach(this::releaseLock);
+        jobIdToLeases.clear();
+        CloseableUtils.closeQuietly(client);
+    }
+    
+    @Override
+    public Predicate<String> getCacheAvailablePredicate() {
+        return id -> isCacheLocked(id) || isCacheActive(id);
+    }
+    
+    @Override
+    public LockCacheStatus getCacheStatus(String id) {
+        Collection<String> jobIds = getJobIds(id);
+        return new LockCacheStatus(isCacheLocked(id), jobIds);
+    }
+    
+    /**
+     * Get the curator framework.
+     *
+     * @return The curator framework object
+     */
+    CuratorFramework getCurator() {
+        return client;
+    }
+    
+    /**
+     * Convert id to zookeeper node path
+     *
+     * @param id
+     *            A cache id.
+     * @return A string representing the a zookeeper path
+     */
+    String getLockPath(String id) {
+        return id.startsWith(File.separator) ? id : File.separator + id;
+    }
+    
+    /**
+     * Initializes Zookeeper curator framework.
+     *
+     * @param namespace
+     *            The namespace that will appended to each curator framework call.
+     * @param zookeepers
+     *            The zookeepers.
+     * @param lockTimeoutInMs
+     *            The timeout to use when acquiring a lock.
+     * @param retryCnt
+     *            The number of attempts to retry to reconnect.
+     * @param retryTimeoutInMS
+     *            The timeout while attempting to reconnect.
+     */
+    private void init(String namespace, String zookeepers, int lockTimeoutInMs, int retryCnt, int retryTimeoutInMS) {
+        // @formatter:off
+        client = CuratorFrameworkFactory
+                .builder()
+                .connectString(zookeepers)
+                .retryPolicy(new RetryNTimes(retryCnt, retryTimeoutInMS))
+                .namespace(namespace)
+                .build();
+        // @formatter:on
+        client.start();
+        this.lockTimeoutInMs = lockTimeoutInMs;
+    }
+    
+    /**
+     * Find any jobIds that are active for this cacheId
+     *
+     * @param cacheId
+     *            A cache id.
+     * @return A collection of active job ids.
+     */
+    private Collection<String> getJobIds(String cacheId) {
+        Collection<String> jobIds = Lists.newArrayList();
+        try {
+            // @formatter:off
+            jobIds = client.getChildren().forPath(getLockPath(cacheId))
+                    .stream()
+                    .map(childId -> cacheId + File.separator + childId)
+                    .filter(this::doesLeaseExist)
+                    .collect(Collectors.toList());
+            // @formatter:on
+        } catch (Exception e) {
+            LOGGER.debug("Could not find zookeeper children for " + cacheId, e);
+        }
+        return jobIds;
+    }
+    
+    /**
+     * Tests to see if there are still active leases under this cache id.
+     *
+     * @param cacheId
+     *            A cache id.
+     * @return True if the cache is still active.
+     */
+    private boolean isCacheActive(String cacheId) {
+        return !getJobIds(cacheId).isEmpty();
+    }
+    
+    /**
+     * Convert jobId to cacheId.
+     *
+     * @param id
+     *            An id.
+     * @return The parent(cache) id.
+     */
+    private String getCacheId(String id) {
+        String lockPath = getLockPath(id);
+        int endIndex = lockPath.lastIndexOf("/");
+        return (endIndex == 0) ? lockPath : lockPath.substring(0, endIndex);
+    }
+    
+    /**
+     * Tests to see if the timestamp cache(not the job id) is locked by another process.
+     *
+     * @param cacheId
+     *            A cache id.
+     * @return True if the parent(cache) id is locked.
+     */
+    private boolean isCacheLocked(String cacheId) {
+        return doesLeaseExist(cacheId);
+    }
+    
+    /**
+     * Get the zookeeper node for the lease directory if it exists.
+     *
+     * @param zkNodePath
+     *            The zookeeper node path.
+     * @return Returns null if the path does not exist or an Stat object.
+     */
+    private Stat getZNodeStat(String zkNodePath) {
+        try {
+            return client.checkExists().forPath(getLockPath(zkNodePath) + ZOOKEEPER_LEASE_DIR);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to check existence for " + zkNodePath, e);
+        }
+    }
+    
+    /**
+     * Determines if a lease exists for the zookeeper node path
+     *
+     * @param zkNodePath
+     *            The zookeeper node path.
+     * @return True if a lease exists for this node path
+     */
+    private boolean doesLeaseExist(String zkNodePath) {
+        Stat zkNodeStat = getZNodeStat(zkNodePath);
+        return zkNodeStat != null && zkNodeStat.getNumChildren() > 0;
+    }
+    
+    /**
+     * Manual cleanup of unlocked nodes is only needed before Zookeeper 3.5. This is automatically done in 3.5
+     *
+     * @param path
+     *            Zookeeper node path to delete.
+     * @throws Exception
+     *             if unable to delete zookeeper nodes
+     */
+    private void manuallyCleanupZKnode(String path) throws Exception {
+        client.delete().guaranteed().deletingChildrenIfNeeded().forPath(getLockPath(path));
+    }
+    
+    /**
+     * Release lock for id if possible
+     *
+     * @param id
+     *            A cache id.
+     * @param lease
+     *            The lease associated with the id.
+     * @return True if the lock was released.
+     */
+    private boolean releaseLock(String id, InterProcessSemaphoreMutex lease) {
+        try {
+            lease.release();
+            manuallyCleanupZKnode(id);
+        } catch (Exception e) {
+            LOGGER.warn("Unable to release lock for " + id, e);
+            return false;
+        }
+        return true;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/LockCacheStatus.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/LockCacheStatus.java
@@ -1,0 +1,43 @@
+package datawave.ingest.util.cache.lease;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class LockCacheStatus {
+    private final boolean cacheActive;
+    private final boolean cacheLocked;
+    private final Collection<String> jobIds;
+    
+    public LockCacheStatus(boolean cacheLocked, Collection<String> jobIds) {
+        this.cacheLocked = cacheLocked;
+        this.cacheActive = !jobIds.isEmpty();
+        this.jobIds = jobIds;
+    }
+    
+    public boolean isCacheActive() {
+        return cacheActive;
+    }
+    
+    public boolean isCacheLocked() {
+        return cacheLocked;
+    }
+    
+    public Collection<String> getJobIds() {
+        return jobIds;
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+        
+        LockCacheStatus that = (LockCacheStatus) obj;
+        return this.cacheActive == that.cacheActive && this.cacheLocked == that.cacheLocked && (this.jobIds.equals(that.jobIds));
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(cacheActive, cacheLocked, jobIds);
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/LockFactoryModeOptions.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/lease/LockFactoryModeOptions.java
@@ -1,0 +1,58 @@
+package datawave.ingest.util.cache.lease;
+
+import com.beust.jcommander.Parameter;
+import org.apache.hadoop.conf.Configuration;
+
+import static datawave.ingest.util.cache.lease.JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_NAMESPACE;
+import static datawave.ingest.util.cache.lease.JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_NODES;
+import static datawave.ingest.util.cache.lease.JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_RETRY_CNT;
+import static datawave.ingest.util.cache.lease.JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_RETRY_TIMEOUT;
+import static datawave.ingest.util.cache.lease.JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_TIMEOUT;
+
+public class LockFactoryModeOptions {
+    
+    @Parameter(names = {"--cache-namespace"}, description = "Zookeeper namespace to check for active jobs")
+    String cacheNamespace = "datawave/jobCache";
+    
+    @Parameter(names = {"--lock-timeout-in-ms"}, description = "Zookeeper timeout for acquiring lock")
+    int lockTimeoutInMs = 30;
+    
+    @Parameter(names = {"--lock-retry-timeout-in-ms"}, description = "Zookeeper timeout for retrying connection ")
+    int lockRetryTimeoutInMs = 30;
+    
+    @Parameter(names = {"--lock-retry-count"}, description = "Zookeeper retry connection attempts ")
+    int lockRetryCount = 30;
+    
+    @Parameter(names = {"--zookeepers"}, description = "Zookeeper instances.", required = true)
+    String zookeepers;
+    
+    public String getNamespace() {
+        return cacheNamespace;
+    }
+    
+    public int getLockTime() {
+        return lockTimeoutInMs;
+    }
+    
+    public int getLockRetryTimeout() {
+        return lockRetryTimeoutInMs;
+    }
+    
+    public int getLockRetryCount() {
+        return lockRetryCount;
+    }
+    
+    public String getZookeepers() {
+        return zookeepers;
+    }
+    
+    public Configuration getConf() {
+        Configuration conf = new Configuration();
+        conf.setInt(DW_JOB_CACHE_ZOOKEEPER_TIMEOUT, lockTimeoutInMs);
+        conf.setInt(DW_JOB_CACHE_ZOOKEEPER_RETRY_CNT, lockRetryCount);
+        conf.setInt(DW_JOB_CACHE_ZOOKEEPER_RETRY_TIMEOUT, lockRetryTimeoutInMs);
+        conf.set(DW_JOB_CACHE_ZOOKEEPER_NAMESPACE, cacheNamespace);
+        conf.set(DW_JOB_CACHE_ZOOKEEPER_NODES, zookeepers);
+        return conf;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/LoadJobCache.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/LoadJobCache.java
@@ -1,0 +1,174 @@
+package datawave.ingest.util.cache.load;
+
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static datawave.common.io.HadoopFileSystemUtils.getCopyFromLocalFileRunnable;
+
+/** Loads hdfs cache from a collection of local files */
+public class LoadJobCache {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadJobCache.class);
+    private static final String LOADING_PREFIX = "LOADING_";
+    public static final String JOB_CACHE_TIMESTAMP_FORMAT = "yyyyMMddHHmmss";
+    public static final DateTimeFormatter JOB_CACHE_FORMATER = DateTimeFormatter.ofPattern(JOB_CACHE_TIMESTAMP_FORMAT).withZone(ZoneOffset.UTC);
+    
+    public static String getJobCacheTimestampDir(String prefix) {
+        return prefix + LoadJobCache.JOB_CACHE_FORMATER.format(LocalDateTime.now());
+    }
+    
+    /**
+     * Create a timestamped hdfs directory and copy local files to it.
+     *
+     * @param fileSystemPaths
+     *            An object that contains the path and its associated file system
+     * @param filesToLoad
+     *            A collection of files to load cache
+     * @param finalizeLoad
+     *            Controls when to finalize cache by setting the replication and moving to its final path
+     * @param cacheReplicationCnt
+     *            The number of replicas to create for each cache file
+     * @param executorThreads
+     *            The number of threads to use to load the cache
+     * @param timestampDir
+     *            The timestamped directory for the cache
+     * @param optionalSubDir
+     *            Optional subdirectory to provide a more granular cache structure
+     */
+    public static void load(Collection<FileSystemPath> fileSystemPaths, Collection<String> filesToLoad, boolean finalizeLoad, short cacheReplicationCnt,
+                    int executorThreads, String timestampDir, String optionalSubDir) {
+        ExecutorService executorService = Executors.newFixedThreadPool(Math.min(filesToLoad.size(), executorThreads));
+        
+        Consumer<FileSystemPath> loadCache = getLoadCacheConsumer(filesToLoad, executorService, timestampDir, optionalSubDir, cacheReplicationCnt);
+        Consumer<FileSystemPath> finalizeCache = getFinalizeCacheConsumer(timestampDir);
+        Consumer<FileSystemPath> deleteCache = getDeleteCacheConsumer(timestampDir);
+        
+        try {
+            load(fileSystemPaths, finalizeLoad, loadCache, finalizeCache, deleteCache);
+        } finally {
+            executorService.shutdown();
+        }
+        
+    }
+    
+    /**
+     * Create a timestamped hdfs directory and copy local files to it.
+     *
+     * @param fileSystemPaths
+     *            An object that contains the path and its associated file system
+     * @param finalizeLoad
+     *            A boolean to determine if the cache should be finalized
+     * @param loadCache
+     *            A Consumer method that will load the cache
+     * @param finalizeCache
+     *            A Consumer method that will finalize the cache
+     * @param deleteCache
+     *            A Consumer method that will delete the cache on error
+     */
+    public static void load(Collection<FileSystemPath> fileSystemPaths, boolean finalizeLoad, Consumer<FileSystemPath> loadCache,
+                    Consumer<FileSystemPath> finalizeCache, Consumer<FileSystemPath> deleteCache) {
+        try {
+            fileSystemPaths.forEach(loadCache);
+            if (finalizeLoad) {
+                fileSystemPaths.forEach(finalizeCache);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unable to load job cache. Deleting temporary directories. ", e);
+            fileSystemPaths.forEach(deleteCache);
+        }
+    }
+    
+    /**
+     * Create a consumer that will delete temporary cache artifacts upon error.
+     *
+     * @param timestampDir
+     *            A timestamp directory that will reflect when the cache was loaded
+     * @return A consumer that will delete the cache.
+     */
+    static Consumer<FileSystemPath> getDeleteCacheConsumer(String timestampDir) {
+        return (FileSystemPath fsPath) -> {
+            Path uploadWorkingDir = new Path(fsPath.getOutputPath(), LOADING_PREFIX + timestampDir);
+            FileSystem cacheFs = fsPath.getFileSystem();
+            
+            try {
+                cacheFs.delete(uploadWorkingDir, true);
+            } catch (IOException e) {
+                LOGGER.error("Unable to delete temporary directory " + uploadWorkingDir, e);
+            }
+        };
+    }
+    
+    /**
+     * Create a consumer that will finalize the cache directory.
+     *
+     * @param timestampDir
+     *            A timestamp directory that will reflect when the cache was loaded
+     * @return A consumer that will finalize the cache
+     */
+    static Consumer<FileSystemPath> getFinalizeCacheConsumer(String timestampDir) {
+        return (FileSystemPath fsPath) -> {
+            Path jobCacheDir = new Path(fsPath.getOutputPath(), timestampDir);
+            Path uploadWorkingDir = new Path(jobCacheDir.getParent(), LOADING_PREFIX + jobCacheDir.getName());
+            FileSystem cacheFs = fsPath.getFileSystem();
+            
+            try {
+                cacheFs.rename(uploadWorkingDir, jobCacheDir);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to rename " + uploadWorkingDir + "  to " + jobCacheDir, e);
+            }
+        };
+    }
+    
+    /**
+     * Create a consumer that will load local files to the hdfs cache.
+     *
+     * @param filesToLoad
+     *            A collection of local files to load.
+     * @param executorService
+     *            A executor service to help parallelize the upload
+     * @param optionalSubDir
+     *            An optional sub directory timestamp directory
+     * @param cacheReplicationCnt
+     *            The replication count for each file in the cache
+     * @return A consumer that will load the cache.
+     */
+    static Consumer<FileSystemPath> getLoadCacheConsumer(Collection<String> filesToLoad, ExecutorService executorService, String timestampDir,
+                    String optionalSubDir, short cacheReplicationCnt) {
+        return (FileSystemPath fsPath) -> {
+            Path jobCacheDir = new Path(fsPath.getOutputPath(), timestampDir);
+            Path uploadWorkingDir = new Path(jobCacheDir.getParent(), LOADING_PREFIX + jobCacheDir.getName());
+            Path loadingDir = StringUtils.isBlank(optionalSubDir) ? uploadWorkingDir : new Path(uploadWorkingDir, optionalSubDir);
+            FileSystem cacheFs = fsPath.getFileSystem();
+            
+            try {
+                cacheFs.mkdirs(loadingDir);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to make directory " + loadingDir, e);
+            }
+            
+            // @formatter:off
+            Collection<CompletableFuture<Void>> loadFileFutures = filesToLoad
+                    .stream()
+                    .map(path -> getCopyFromLocalFileRunnable(cacheFs, new Path(path), loadingDir, cacheReplicationCnt))
+                    .map(runnable -> CompletableFuture.runAsync(runnable, executorService))
+                    .collect(Collectors.toList());
+            // @formatter:on
+            loadFileFutures.forEach(CompletableFuture::join);
+            LOGGER.info("Loaded files to {}", loadingDir);
+        };
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/LoadJobCacheLauncher.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/LoadJobCacheLauncher.java
@@ -1,0 +1,101 @@
+package datawave.ingest.util.cache.load;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.google.common.collect.Lists;
+import datawave.ingest.util.ConfigurationFileHelper;
+import datawave.ingest.util.cache.converter.HadoopPathConverter;
+import datawave.ingest.util.cache.converter.ShortConverter;
+import datawave.ingest.util.cache.load.mode.ClasspathMode;
+import datawave.ingest.util.cache.load.mode.LoadJobCacheMode;
+import datawave.ingest.util.cache.converter.LoadModeConverter;
+import datawave.ingest.util.cache.load.mode.LoadModeOptions;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Load job cache launcher will copy local configuration and jars file to a configurable timestamped location in hdfs
+ */
+public class LoadJobCacheLauncher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadJobCacheLauncher.class);
+    
+    @Parameter(names = {"--cache-replication-cnt"}, description = "The number of replicas for loaded cache files.", converter = ShortConverter.class)
+    short cacheReplicationCnt = 3;
+    
+    @Parameter(names = {"--finalize-load"}, description = "Finalize loading by moving working path to its final path.", arity = 1)
+    boolean finalizeLoad = true;
+    
+    @Parameter(names = {"--executor-thread-cnt"}, description = "Number of cpu threads to use for loading the cache.")
+    int executorThreadCnt = 30;
+    
+    @Parameter(names = {"--hadoop-conf-dirs"}, description = "The hadoop configuration directories")
+    List<String> hadoopConfDirs = Arrays.asList(System.getenv("INGEST_HADOOP_CONF"), System.getenv("WAREHOUSE_HADOOP_CONF"));
+    
+    @Parameter(names = {"-h", "-help", "--help", "-?"}, help = true, description = "Prints job options.")
+    boolean help;
+    
+    @Parameter(names = {"--load-mode"}, description = "Mode to determine how to find files to load the cache.", converter = LoadModeConverter.class)
+    LoadJobCacheMode loadMode = new ClasspathMode();
+    
+    @Parameter(names = {"--output-paths"}, description = "The output directories to load", converter = HadoopPathConverter.class, required = true)
+    List<Path> outputPaths;
+    
+    @Parameter(names = {"--sub-dir"}, description = "A optional subdirectory to add to the cache directory.")
+    String subDir;
+    
+    @Parameter(names = {"--timestamp-dir"}, description = "The timestamp cache directory name.")
+    String timestampDir = LoadJobCache.getJobCacheTimestampDir("jobCache_");
+    
+    /**
+     * Will load job cache from specified arguments
+     *
+     * @param options
+     *            Mode options that will determine the files to load to cache
+     */
+    public void run(LoadModeOptions options) {
+        Collection<FileSystemPath> fsPaths = Lists.newArrayList();
+        Collection<Configuration> hadoopConfs = ConfigurationFileHelper.getHadoopConfs(hadoopConfDirs);
+        
+        try {
+            fsPaths = FileSystemPath.getFileSystemPaths(outputPaths, hadoopConfs);
+            Collection<String> filesToUpload = loadMode.getFilesToLoad(options);
+            if (!filesToUpload.isEmpty()) {
+                LOGGER.info("Loading job cache with timestamp directory {}", timestampDir);
+                LoadJobCache.load(fsPaths, filesToUpload, finalizeLoad, cacheReplicationCnt, executorThreadCnt, timestampDir, subDir);
+            } else {
+                LOGGER.warn("No files were found to load cache for mode {} with options {} ", loadMode.getMode(), options);
+            }
+        } finally {
+            fsPaths.forEach(FileSystemPath::close);
+        }
+    }
+    
+    public static void main(String[] args) throws Exception {
+        LOGGER.info("Starting load job cache utility");
+        LoadJobCacheLauncher launcher = new LoadJobCacheLauncher();
+        LoadModeOptions loadModeOptions = new LoadModeOptions();
+        
+        JCommander jCommander = JCommander.newBuilder().addObject(launcher).addObject(loadModeOptions).build();
+        try {
+            jCommander.parse(args);
+            if (launcher.help) {
+                jCommander.usage();
+            } else {
+                launcher.run(loadModeOptions);
+            }
+        } catch (ParameterException e) {
+            System.err.println(e.getMessage());
+            jCommander.usage();
+            System.exit(-1);
+        }
+        LOGGER.info("Finished load job cache utility");
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/ClasspathMode.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/ClasspathMode.java
@@ -1,0 +1,22 @@
+package datawave.ingest.util.cache.load.mode;
+
+import datawave.common.io.FilesFinder;
+import org.apache.http.util.Args;
+
+import java.util.Collection;
+
+/** This mode will find files to load based on the classpath and a relative path resolver */
+public class ClasspathMode implements LoadJobCacheMode {
+    public static final String CLASSPATH_DELIM = ":";
+    
+    @Override
+    public Collection<String> getFilesToLoad(LoadModeOptions options) {
+        String classpath = Args.notNull(options.getClasspath(), "Classpath");
+        return FilesFinder.getFilesFromClasspath(classpath, CLASSPATH_DELIM);
+    }
+    
+    @Override
+    public Mode getMode() {
+        return Mode.CLASSPATH;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/FilePatternMode.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/FilePatternMode.java
@@ -1,0 +1,37 @@
+package datawave.ingest.util.cache.load.mode;
+
+import com.google.common.collect.Lists;
+import datawave.common.io.FilesFinder;
+import datawave.ingest.util.cache.load.LoadJobCacheLauncher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/** This mode will find files to load based on the input path, pattern and depth specified */
+public class FilePatternMode implements LoadJobCacheMode {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadJobCacheLauncher.class);
+    
+    @Override
+    public Collection<String> getFilesToLoad(LoadModeOptions options) {
+        Collection<String> filesToLoad = Lists.newArrayList();
+        
+        String inputPath = options.getInputPath();
+        String filePattern = options.getFilePattern();
+        int maxDepth = options.getMaxDepth();
+        
+        try {
+            filesToLoad = FilesFinder.getFilesFromPattern(inputPath, filePattern, maxDepth);
+        } catch (IOException e) {
+            LOGGER.error("Unable to get files to load from path " + inputPath + " and pattern " + filePattern, e);
+        }
+        
+        return filesToLoad;
+    }
+    
+    @Override
+    public Mode getMode() {
+        return Mode.FILE_PATTERN;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/LoadJobCacheMode.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/LoadJobCacheMode.java
@@ -1,0 +1,47 @@
+package datawave.ingest.util.cache.load.mode;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
+/** Interface to support the different modes available for loading the job cache. */
+public interface LoadJobCacheMode {
+    ServiceLoader<LoadJobCacheMode> serviceLoader = ServiceLoader.load(LoadJobCacheMode.class);
+    
+    /**
+     * Find mode that will determine how to find files to load cache
+     *
+     * @param mode
+     *            Enum that specifies method to find files to load cache
+     * @return An optional of LoadJobCacheMode
+     */
+    static Optional<LoadJobCacheMode> getLoadCacheMode(Mode mode) {
+        // @formatter:off
+        return StreamSupport.stream(serviceLoader.spliterator(), false)
+                .filter(loaderMode -> loaderMode.getMode().equals(mode))
+                .findFirst();
+        // @formatter:on
+    }
+    
+    /**
+     * Get enum representing mode specified
+     *
+     * @return A mode to find cache files to load
+     */
+    Mode getMode();
+    
+    /**
+     * Get files to load to cache
+     *
+     * @param options
+     *            Mode options necessary for finding local files
+     * @return A collection of files to load
+     */
+    Collection<String> getFilesToLoad(LoadModeOptions options);
+    
+    /** Mode enum for specifying the method to find files to load */
+    enum Mode {
+        CLASSPATH, FILE_PATTERN
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/LoadModeOptions.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/load/mode/LoadModeOptions.java
@@ -1,0 +1,37 @@
+package datawave.ingest.util.cache.load.mode;
+
+import com.beust.jcommander.Parameter;
+
+/** JCommander options class that will define the mode options for LoadJobCacheLauncher */
+public class LoadModeOptions {
+    
+    private static final String DATAWAVE_HOME = System.getenv().getOrDefault("DATAWAVE_HOME", "/opt/datawave-ingest/current/");
+    
+    @Parameter(names = {"--classpath"}, description = "Classpath value.")
+    String classpath;
+    
+    @Parameter(names = {"--file-pattern"}, description = "In file pattern mode, the pattern of files to upload.")
+    String filePattern = "**";
+    
+    @Parameter(names = {"--input-path"}, description = "In file pattern mode, the directory to search for files.")
+    String inputPath = DATAWAVE_HOME + "lib/";
+    
+    @Parameter(names = {"--max-depth"}, description = "In file pattern mode, the maximum depth for a directory search.")
+    int maxDepth = Integer.MAX_VALUE;
+    
+    public String getClasspath() {
+        return classpath;
+    }
+    
+    public String getFilePattern() {
+        return filePattern;
+    }
+    
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+    
+    public String getInputPath() {
+        return inputPath;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/path/FileSystemPath.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/cache/path/FileSystemPath.java
@@ -1,0 +1,96 @@
+package datawave.ingest.util.cache.path;
+
+import datawave.common.io.HadoopFileSystemUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Class that will map an output path to its file system specified by the passed in configurations */
+public class FileSystemPath implements AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemPath.class);
+    
+    private final Path outputPath;
+    private final FileSystem fileSystem;
+    
+    public FileSystemPath(FileSystem fileSystem, Path outputPath) {
+        this.fileSystem = fileSystem;
+        this.outputPath = outputPath;
+    }
+    
+    public FileSystemPath(Path outputPath, Collection<Configuration> confs) {
+        Optional<FileSystem> optFs = HadoopFileSystemUtils.getFileSystem(confs, outputPath);
+        if (!optFs.isPresent()) {
+            throw new IllegalArgumentException("Unable to create filesystem for " + outputPath + " with " + confs);
+        }
+        
+        this.fileSystem = optFs.get();
+        this.outputPath = outputPath;
+    }
+    
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+    
+    public Path getOutputPath() {
+        return outputPath;
+    }
+    
+    @Override
+    public void close() {
+        try {
+            fileSystem.close();
+        } catch (IOException e) {
+            LOGGER.warn("Unable to close " + fileSystem, e);
+        }
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (obj.getClass() != this.getClass()) {
+            return false;
+        }
+        
+        FileSystemPath that = ((FileSystemPath) obj);
+        String thatOutputPath = that.getOutputPath().toUri().getPath();
+        String thisOutputPath = outputPath.toUri().getPath();
+        
+        return thisOutputPath.equals(thatOutputPath) && this.getFileSystem().equals(that.fileSystem);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(outputPath.toUri().getPath());
+    }
+    
+    @Override
+    public String toString() {
+        return "Path: " + outputPath.toUri().getPath();
+    }
+    
+    /**
+     * Will associate a file system to each input path
+     *
+     * @param paths
+     *            Input paths to associate with a file system.
+     * @param confs
+     *            Hadoop configuration object used to find available file systems.
+     * @return A collection of object that associate the path to its file system.
+     */
+    public static Collection<FileSystemPath> getFileSystemPaths(Collection<Path> paths, Collection<Configuration> confs) {
+        // @formatter:off
+        return paths
+                .stream()
+                .map(path -> new FileSystemPath(path, confs))
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+}

--- a/warehouse/ingest-core/src/main/resources/META-INF/services/datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode
+++ b/warehouse/ingest-core/src/main/resources/META-INF/services/datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode
@@ -1,0 +1,2 @@
+datawave.ingest.util.cache.delete.mode.DeletesSpecifiedMode
+datawave.ingest.util.cache.delete.mode.OldInactiveMode

--- a/warehouse/ingest-core/src/main/resources/META-INF/services/datawave.ingest.util.cache.lease.JobCacheLockFactory
+++ b/warehouse/ingest-core/src/main/resources/META-INF/services/datawave.ingest.util.cache.lease.JobCacheLockFactory
@@ -1,0 +1,2 @@
+datawave.ingest.util.cache.lease.JobCacheZkLockFactory
+datawave.ingest.util.cache.lease.JobCacheNoOpLockFactory

--- a/warehouse/ingest-core/src/main/resources/META-INF/services/datawave.ingest.util.cache.load.mode.LoadJobCacheMode
+++ b/warehouse/ingest-core/src/main/resources/META-INF/services/datawave.ingest.util.cache.load.mode.LoadJobCacheMode
@@ -1,0 +1,2 @@
+datawave.ingest.util.cache.load.mode.ClasspathMode
+datawave.ingest.util.cache.load.mode.FilePatternMode

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/JobCacheFactoryTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/JobCacheFactoryTest.java
@@ -1,0 +1,212 @@
+package datawave.ingest.util.cache;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import datawave.common.test.utils.FileUtils;
+import datawave.ingest.util.cache.lease.JobCacheLockFactory;
+import datawave.ingest.util.cache.lease.JobCacheZkLockFactory;
+import datawave.ingest.util.cache.lease.LockCacheStatus;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static datawave.common.test.utils.FileUtils.createTemporaryDir;
+
+public class JobCacheFactoryTest {
+    private static final String TEMP_DIR = Files.createTempDir().getAbsolutePath();
+    private static final String ZOOKEEPER_CACHE_NAMESPACE = "test/jobCache";
+    private static final String JOB_CACHE_TIMESTAMP_FORMAT = "yyyyMMddHHmmssSSS";
+    private static final DateTimeFormatter JOB_CACHE_FORMATER = DateTimeFormatter.ofPattern(JOB_CACHE_TIMESTAMP_FORMAT);
+    private static final String JOB_CACHE_PREFIX = "jobCache_";
+    private static final Pattern JOB_CACHE_PATTERN = Pattern.compile(JOB_CACHE_PREFIX + "\\d{" + JOB_CACHE_TIMESTAMP_FORMAT.length() + "}");
+    private static final String TEST_JOB_ID1 = "testJobId1";
+    private static final String TEST_JOB_ID2 = "testJobId2";
+    
+    private static TestingServer TESTING_SERVER;
+    private static String TEST_ZOOKEEPERS;
+    private static String CACHE_TIMESTAMP_A;
+    private static String CACHE_TIMESTAMP_B;
+    private static String CACHE_TIMESTAMP_C;
+    private static String CACHE_TIMESTAMP_D;
+    
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        InstanceSpec instanceSpec = InstanceSpec.newInstanceSpec();
+        TESTING_SERVER = new TestingServer(instanceSpec, true);
+        TEST_ZOOKEEPERS = instanceSpec.getConnectString();
+        CACHE_TIMESTAMP_A = getTimestampPath();
+        CACHE_TIMESTAMP_B = getTimestampPath();
+        CACHE_TIMESTAMP_C = getTimestampPath();
+        CACHE_TIMESTAMP_D = getTimestampPath();
+    }
+    
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        TESTING_SERVER.close();
+        FileUtils.deletePath(TEMP_DIR);
+    }
+    
+    private static String getTimestampPath() throws IOException, InterruptedException {
+        // @formatter:off
+        String cacheDir =  new StringJoiner(File.separator)
+                .add(TEMP_DIR)
+                .add(JOB_CACHE_PREFIX+JOB_CACHE_FORMATER.format(LocalDateTime.now()))
+                .toString();
+        // @formatter:on
+        
+        TimeUnit.MILLISECONDS.sleep(10);
+        return createTemporaryDir(cacheDir);
+    }
+    
+    private JobCacheFactory jobCacheFactory;
+    
+    @Before
+    public void setup() throws IOException, InstantiationException, IllegalAccessException, ClassNotFoundException {
+        Configuration conf = new Configuration();
+        conf.set(JobCacheFactory.DW_JOB_CACHE_BASE_PATH, TEMP_DIR);
+        conf.set(JobCacheFactory.DW_JOB_CACHE_LOCK_FACTORY_MODE, JobCacheLockFactory.Mode.ZOOKEEPER.name());
+        conf.set(JobCacheFactory.DW_JOB_CACHE_TIMESTAMP_DIR_PREFIX, JOB_CACHE_PREFIX);
+        conf.set(JobCacheFactory.DW_JOB_CACHE_TIMESTAMP_PATTERN, JOB_CACHE_PATTERN.pattern());
+        
+        conf.set(JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_TIMEOUT, "30");
+        conf.set(JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_RETRY_CNT, "3");
+        conf.set(JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_RETRY_TIMEOUT, "30");
+        conf.set(JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_NODES, TEST_ZOOKEEPERS);
+        conf.set(JobCacheZkLockFactory.DW_JOB_CACHE_ZOOKEEPER_NAMESPACE, ZOOKEEPER_CACHE_NAMESPACE);
+        
+        jobCacheFactory = new JobCacheFactory(conf);
+    }
+    
+    @After
+    public void tearDown() {
+        jobCacheFactory.close();
+    }
+    
+    @Test
+    public void shouldFindLatestAvailableCache() throws Exception {
+        Path expectedJobCache = new Path(CACHE_TIMESTAMP_B);
+        
+        acquireLock("", CACHE_TIMESTAMP_C, CACHE_TIMESTAMP_D);
+        Path jobCache = jobCacheFactory.getJobCache(TEST_JOB_ID1);
+        Assert.assertEquals(expectedJobCache.getName(), jobCache.getName());
+    }
+    
+    @Test(expected = Exception.class)
+    public void shouldThrowExceptionWhenNoCacheIsAvailable() throws Exception {
+        acquireLock("", CACHE_TIMESTAMP_A, CACHE_TIMESTAMP_B, CACHE_TIMESTAMP_C, CACHE_TIMESTAMP_D);
+        jobCacheFactory.getJobCache(TEST_JOB_ID1);
+    }
+    
+    @Test
+    public void shouldReleaseLock() throws Exception {
+        JobCacheLockFactory lockFactory = jobCacheFactory.getLockFactory();
+        
+        Path jobCache = jobCacheFactory.getJobCache(TEST_JOB_ID1);
+        LockCacheStatus status = lockFactory.getCacheStatus(jobCache.getName());
+        Assert.assertTrue(status.isCacheActive());
+        Assert.assertTrue(status.getJobIds().contains(getLockPath(jobCache.getName(), TEST_JOB_ID1)));
+        
+        Assert.assertTrue(jobCacheFactory.releaseId(TEST_JOB_ID1));
+        status = lockFactory.getCacheStatus(jobCache.getName());
+        Assert.assertFalse(status.isCacheActive());
+        Assert.assertFalse(status.getJobIds().contains(getLockPath(jobCache.getName(), TEST_JOB_ID1)));
+        
+    }
+    
+    @Test
+    public void shouldReportStatusOnAllCaches() throws IOException {
+        Collection<JobCacheStatus> expectedStatuses = Lists.newArrayList();
+        expectedStatuses.add(getCacheStatus(CACHE_TIMESTAMP_D, false, TEST_JOB_ID2));
+        expectedStatuses.add(getCacheStatus(CACHE_TIMESTAMP_C, true));
+        expectedStatuses.add(getCacheStatus(CACHE_TIMESTAMP_B, false));
+        expectedStatuses.add(getCacheStatus(CACHE_TIMESTAMP_A, false, TEST_JOB_ID1, TEST_JOB_ID2));
+        
+        acquireLock(TEST_JOB_ID1, CACHE_TIMESTAMP_A);
+        acquireLock(TEST_JOB_ID2, CACHE_TIMESTAMP_A);
+        acquireLock("", CACHE_TIMESTAMP_C);
+        acquireLock(TEST_JOB_ID2, CACHE_TIMESTAMP_D);
+        
+        FileSystemPath baseCachePath = new FileSystemPath(FileSystem.getLocal(new Configuration()), new Path(TEMP_DIR));
+        Collection<JobCacheStatus> cacheStatuses = jobCacheFactory.getJobCacheStatuses(baseCachePath);
+        
+        Assert.assertEquals(expectedStatuses, cacheStatuses);
+    }
+    
+    @Test
+    public void shouldFindNoCandidatesSincePatternNotFound() throws IOException {
+        FileSystemPath jobCachePath = new FileSystemPath(FileSystem.getLocal(new Configuration()), new Path(TEMP_DIR));
+        Pattern missPattern = Pattern.compile("missCache_\\d{17}");
+        Collection<FileSystemPath> foundCandidates = JobCacheFactory.getCacheCandidates(jobCachePath, missPattern, 0);
+        Assert.assertTrue(foundCandidates.isEmpty());
+    }
+    
+    @Test
+    public void shouldKeepNumberOfVersionsSpecified() throws IOException {
+        Collection<FileSystemPath> expectedCandidates = convertToFileSystemPaths(CACHE_TIMESTAMP_A);
+        FileSystemPath jobCachePath = new FileSystemPath(FileSystem.getLocal(new Configuration()), new Path(TEMP_DIR));
+        Collection<FileSystemPath> foundCandidates = JobCacheFactory.getCacheCandidates(jobCachePath, JOB_CACHE_PATTERN, 3);
+        Assert.assertEquals(expectedCandidates, foundCandidates);
+    }
+    
+    private Collection<FileSystemPath> convertToFileSystemPaths(String... paths) throws IOException {
+        FileSystem fileSystem = FileSystem.getLocal(new Configuration());
+        // @formatter:off
+        return Arrays.stream(paths)
+                .map(Path::new)
+                .map(path -> new FileSystemPath(fileSystem, path))
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    private void acquireLock(String jobId, String... caches) {
+        JobCacheLockFactory lockFactory = jobCacheFactory.getLockFactory();
+        // @formatter:off
+        Arrays.stream(caches)
+                .map(this::getTimestampName)
+                .map(cacheName -> getLockPath(cacheName, jobId))
+                .forEach(lockFactory::acquireLock);
+        // @formatter:on
+    }
+    
+    private JobCacheStatus getCacheStatus(String timestampPath, boolean locked, String... jobIds) throws IOException {
+        FileSystemPath cachePath = new FileSystemPath(FileSystem.getLocal(new Configuration()), new Path(timestampPath));
+        String timestampName = getTimestampName(timestampPath);
+        
+        // @formatter:off
+        Collection<String> lockJobIds =
+                Arrays.stream(jobIds)
+                        .map(jobId -> getLockPath(timestampName, jobId))
+                        .collect(Collectors.toList());
+        // @formatter:on
+        return new JobCacheStatus(cachePath, new LockCacheStatus(locked, lockJobIds));
+    }
+    
+    private String getLockPath(String cache, String jobId) {
+        return (jobId.isEmpty()) ? cache : cache + File.separator + jobId;
+    }
+    
+    private String getTimestampName(String timestampPath) {
+        return timestampPath.substring(timestampPath.lastIndexOf(File.separator) + 1);
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/converter/CacheLockConverterTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/converter/CacheLockConverterTest.java
@@ -1,0 +1,27 @@
+package datawave.ingest.util.cache.converter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static datawave.ingest.util.cache.lease.JobCacheLockFactory.Mode.NO_OP;
+import static datawave.ingest.util.cache.lease.JobCacheLockFactory.Mode.ZOOKEEPER;
+
+public class CacheLockConverterTest {
+    private static final CacheLockConverter LOCK_CONVERTER = new CacheLockConverter();
+    
+    @Test
+    public void testZookeeperMode() {
+        Assert.assertEquals(LOCK_CONVERTER.convert(ZOOKEEPER.name()).getMode(), ZOOKEEPER);
+    }
+    
+    @Test
+    public void testNoOpMode() {
+        Assert.assertEquals(LOCK_CONVERTER.convert(NO_OP.name()).getMode(), NO_OP);
+        
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidMode() {
+        LOCK_CONVERTER.convert("INVALID");
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/converter/DeleteModeConverterTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/converter/DeleteModeConverterTest.java
@@ -1,0 +1,26 @@
+package datawave.ingest.util.cache.converter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode.Mode.DELETES_SPECIFIED;
+import static datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode.Mode.OLD_INACTIVE;
+
+public class DeleteModeConverterTest {
+    private static final DeleteModeConverter MODE_CONVERTER = new DeleteModeConverter();
+    
+    @Test
+    public void testDeletesSpecifiedMode() {
+        Assert.assertEquals(MODE_CONVERTER.convert(DELETES_SPECIFIED.name()).getMode(), DELETES_SPECIFIED);
+    }
+    
+    @Test
+    public void testOldInactiveMode() {
+        Assert.assertEquals(MODE_CONVERTER.convert(OLD_INACTIVE.name()).getMode(), OLD_INACTIVE);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidMode() {
+        MODE_CONVERTER.convert("INVALID");
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/converter/LoadModeConverterTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/converter/LoadModeConverterTest.java
@@ -1,0 +1,26 @@
+package datawave.ingest.util.cache.converter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static datawave.ingest.util.cache.load.mode.LoadJobCacheMode.Mode.CLASSPATH;
+import static datawave.ingest.util.cache.load.mode.LoadJobCacheMode.Mode.FILE_PATTERN;
+
+public class LoadModeConverterTest {
+    private static final LoadModeConverter MODE_CONVERTER = new LoadModeConverter();
+    
+    @Test
+    public void testClasspathMode() {
+        Assert.assertEquals(MODE_CONVERTER.convert(CLASSPATH.name()).getMode(), CLASSPATH);
+    }
+    
+    @Test
+    public void testFilePatternMode() {
+        Assert.assertEquals(MODE_CONVERTER.convert(FILE_PATTERN.name()).getMode(), FILE_PATTERN);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidMode() {
+        MODE_CONVERTER.convert("INVALID");
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/delete/DeleteJobCacheTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/delete/DeleteJobCacheTest.java
@@ -1,0 +1,122 @@
+package datawave.ingest.util.cache.delete;
+
+import com.google.common.io.Files;
+import datawave.common.test.utils.FileUtils;
+import datawave.ingest.util.cache.JobCacheFactory;
+import datawave.ingest.util.cache.lease.JobCacheNoOpLockFactory;
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static datawave.common.test.utils.FileUtils.createTemporaryFile;
+
+public class DeleteJobCacheTest {
+    private static final String TEMP_DIR = Files.createTempDir().getAbsolutePath();
+    
+    public static final String JOB_CACHE_TIMESTAMP_FORMAT = "yyyyMMddHHmmssSSS";
+    public static final DateTimeFormatter JOB_CACHE_FORMATER = DateTimeFormatter.ofPattern(JOB_CACHE_TIMESTAMP_FORMAT);
+    public static final String JOB_CACHE_PREFIX = "jobCache_";
+    public static final Pattern JOB_CACHE_PATTERN = Pattern.compile(JOB_CACHE_PREFIX + "\\d{" + JOB_CACHE_TIMESTAMP_FORMAT.length() + "}");
+    
+    private static String CACHE_TIMESTAMP_DIR_A;
+    private static String CACHE_TIMESTAMP_DIR_B;
+    private static String CACHE_TIMESTAMP_DIR_C;
+    private static String CACHE_TIMESTAMP_DIR_D;
+    
+    @BeforeClass
+    public static void setup() throws IOException, InterruptedException {
+        CACHE_TIMESTAMP_DIR_A = getTimeStampDir();
+        CACHE_TIMESTAMP_DIR_B = getTimeStampDir();
+        CACHE_TIMESTAMP_DIR_C = getTimeStampDir();
+        CACHE_TIMESTAMP_DIR_D = getTimeStampDir();
+    }
+    
+    @AfterClass
+    public static void tearDown() throws IOException {
+        FileUtils.deletePath(TEMP_DIR);
+    }
+    
+    private static String getTimeStampDir() throws IOException, InterruptedException {
+        // @formatter:off
+        String jarFile =  new StringJoiner(File.separator)
+                .add(TEMP_DIR)
+                .add(JOB_CACHE_PREFIX+JOB_CACHE_FORMATER.format(LocalDateTime.now()))
+                .add("File.jar")
+                .toString();
+        // @formatter:on
+        
+        TimeUnit.MILLISECONDS.sleep(10);
+        return new File(createTemporaryFile(jarFile)).getParent();
+    }
+    
+    @Test
+    public void shouldGivePriorityToKeepList() {
+        Collection<Path> deletePaths = convertToPaths(CACHE_TIMESTAMP_DIR_C, CACHE_TIMESTAMP_DIR_D);
+        Collection<Path> keepPaths = convertToPaths(CACHE_TIMESTAMP_DIR_D);
+        Collection<Path> expectedCandidates = convertToPaths(CACHE_TIMESTAMP_DIR_C);
+        
+        Collection<Path> deletionCandidates = DeleteJobCache.getDeletionCandidates(deletePaths, keepPaths);
+        Assert.assertEquals(expectedCandidates, deletionCandidates);
+    }
+    
+    @Test
+    public void shouldDeleteCacheCandidates() throws IOException {
+        Collection<FileSystemPath> expectedDeletedCaches = convertToFileSystemPaths(CACHE_TIMESTAMP_DIR_B, CACHE_TIMESTAMP_DIR_A);
+        Collection<FileSystemPath> expectedRemainingCaches = convertToFileSystemPaths(CACHE_TIMESTAMP_DIR_D, CACHE_TIMESTAMP_DIR_C);
+        FileSystemPath jobCachePath = new FileSystemPath(FileSystem.getLocal(new Configuration()), new Path(TEMP_DIR));
+        
+        Collection<FileSystemPath> deletionCandidates = JobCacheFactory.getCacheCandidates(jobCachePath, JOB_CACHE_PATTERN, 2);
+        Assert.assertEquals(deletionCandidates, expectedDeletedCaches);
+        
+        DeleteJobCache.deleteCacheIfNotActive(deletionCandidates, new JobCacheNoOpLockFactory());
+        Assert.assertTrue(expectedDeletedCaches.stream().allMatch(this::cacheDoesNotExist));
+        
+        Collection<FileSystemPath> remainingCaches = JobCacheFactory.getCacheCandidates(jobCachePath, JOB_CACHE_PATTERN, 0);
+        Assert.assertEquals(expectedRemainingCaches, remainingCaches);
+    }
+    
+    private boolean cacheDoesNotExist(FileSystemPath fileSystemPath) {
+        FileSystem fileSystem = fileSystemPath.getFileSystem();
+        Path cachePath = fileSystemPath.getOutputPath();
+        
+        try {
+            return !fileSystem.exists(cachePath);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+    
+    private Collection<FileSystemPath> convertToFileSystemPaths(String... paths) throws IOException {
+        FileSystem fileSystem = FileSystem.getLocal(new Configuration());
+        // @formatter:off
+        return Arrays.stream(paths)
+                .map(Path::new)
+                .map(path -> new FileSystemPath(fileSystem, path))
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    private Collection<Path> convertToPaths(String... paths) {
+        // @formatter:off
+        return Arrays.stream(paths)
+                .map(Path::new)
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/lease/JobCacheZkLockFactoryTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/lease/JobCacheZkLockFactoryTest.java
@@ -1,0 +1,147 @@
+package datawave.ingest.util.cache.lease;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class JobCacheZkLockFactoryTest {
+    private static final String TIMESTAMP_ID = "timestamp";
+    private static final String ZNODE_JOB_ID_1 = TIMESTAMP_ID + "/jobId1";
+    private static final String ZNODE_JOB_ID_2 = TIMESTAMP_ID + "/jobId2";
+    private static final String ZOOKEEPER_LEASE_DIR = "/leases";
+    private static final String ZOOKEEPER_CACHE_NAMESPACE = "test/jobCache";
+    
+    private static final int ZOOKEEPER_LOCK_TIMEOUT_MS = 30;
+    private static final int ZOOKEEPER_RETRY_TIMEOUT_MS = 30;
+    private static final int ZOOKEEPER_RETRY_CNT = 3;
+    
+    private static String zookeepers;
+    private static TestingServer testingServer;
+    
+    private CuratorFramework client;
+    private JobCacheZkLockFactory lockFactory;
+    
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        InstanceSpec instanceSpec = InstanceSpec.newInstanceSpec();
+        testingServer = new TestingServer(instanceSpec, true);
+        zookeepers = instanceSpec.getConnectString();
+    }
+    
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        testingServer.close();
+    }
+    
+    @Before
+    public void setup() {
+        lockFactory = getNewLockFactory();
+        client = lockFactory.getCurator();
+    }
+    
+    @After
+    public void tearDown() {
+        lockFactory.close();
+    }
+    
+    /*
+     * Extra: Test setup features like retry timeout and locking.
+     */
+    
+    @Test
+    public void shouldAcquireLock() throws Exception {
+        Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_1));
+        verifyLockFileWasCreated(ZNODE_JOB_ID_1);
+    }
+    
+    @Test
+    public void shouldNotAcquireLockDueToCacheLocked() {
+        Assert.assertTrue(lockFactory.acquireLock(TIMESTAMP_ID));
+        Assert.assertFalse(lockFactory.acquireLock(ZNODE_JOB_ID_1));
+    }
+    
+    @Test
+    public void shouldAcquireJobIdLockWhenCacheIsActive() {
+        Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_1));
+        Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_2));
+    }
+    
+    @Test
+    public void shouldNotAcquireCacheLockWhenCacheIsActive() {
+        Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_1));
+        Assert.assertFalse(lockFactory.acquireLock(TIMESTAMP_ID, lockFactory.getCacheAvailablePredicate()));
+    }
+    
+    @Test
+    public void shouldReleaseLock() throws Exception {
+        try (JobCacheZkLockFactory secondaryLockFactory = getNewLockFactory()) {
+            
+            Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_1));
+            Assert.assertFalse(secondaryLockFactory.acquireLock(ZNODE_JOB_ID_1));
+            
+            Assert.assertTrue(lockFactory.releaseLock(ZNODE_JOB_ID_1));
+            Assert.assertTrue(secondaryLockFactory.acquireLock(ZNODE_JOB_ID_1));
+        }
+        verifyLockFileWasReleased(ZNODE_JOB_ID_1);
+        
+    }
+    
+    @Test
+    public void shouldCleanupReleasedZookeeperNode() throws Exception {
+        try (JobCacheZkLockFactory secondaryLockFactory = getNewLockFactory()) {
+            Assert.assertTrue(secondaryLockFactory.acquireLock(ZNODE_JOB_ID_2));
+            verifyLockFileWasCreated(ZNODE_JOB_ID_2);
+            Assert.assertTrue(secondaryLockFactory.releaseLock(ZNODE_JOB_ID_2));
+        }
+        
+        verifyLockFileWasReleased(ZNODE_JOB_ID_2);
+    }
+    
+    @Test
+    public void shouldShowActiveCacheWithTwoJobIds() {
+        Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_1));
+        Assert.assertTrue(lockFactory.acquireLock(ZNODE_JOB_ID_2));
+        LockCacheStatus status = lockFactory.getCacheStatus(TIMESTAMP_ID);
+        Assert.assertTrue(status.isCacheActive());
+        Assert.assertFalse(status.isCacheLocked());
+        Assert.assertTrue(status.getJobIds().contains(ZNODE_JOB_ID_1));
+        Assert.assertTrue(status.getJobIds().contains(ZNODE_JOB_ID_2));
+    }
+    
+    @Test
+    public void shouldShowInActiveCacheWithNoJobIds() {
+        LockCacheStatus status = lockFactory.getCacheStatus(ZNODE_JOB_ID_1);
+        Assert.assertFalse(status.isCacheActive());
+        Assert.assertFalse(status.isCacheLocked());
+        Assert.assertEquals(status.getJobIds().size(), 0);
+    }
+    
+    @Test
+    public void shouldShowLockedCacheWithNoJobIds() {
+        Assert.assertTrue(lockFactory.acquireLock(TIMESTAMP_ID));
+        LockCacheStatus status = lockFactory.getCacheStatus(TIMESTAMP_ID);
+        Assert.assertFalse(status.isCacheActive());
+        Assert.assertTrue(status.isCacheLocked());
+        Assert.assertEquals(status.getJobIds().size(), 0);
+    }
+    
+    private JobCacheZkLockFactory getNewLockFactory() {
+        return new JobCacheZkLockFactory(ZOOKEEPER_CACHE_NAMESPACE, zookeepers, ZOOKEEPER_LOCK_TIMEOUT_MS, ZOOKEEPER_RETRY_CNT, ZOOKEEPER_RETRY_TIMEOUT_MS);
+    }
+    
+    private void verifyLockFileWasCreated(String id) throws Exception {
+        Assert.assertEquals(client.checkExists().forPath(lockFactory.getLockPath(id) + ZOOKEEPER_LEASE_DIR).getNumChildren(), 1);
+    }
+    
+    private void verifyLockFileWasReleased(String id) throws Exception {
+        Assert.assertNull(client.checkExists().forPath(lockFactory.getLockPath(id)));
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/load/LoadJobCacheTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/util/cache/load/LoadJobCacheTest.java
@@ -1,0 +1,130 @@
+package datawave.ingest.util.cache.load;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import datawave.common.io.FilesFinder;
+import java.io.File;
+import java.io.IOException;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import datawave.ingest.util.cache.path.FileSystemPath;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static datawave.common.test.utils.FileUtils.createTemporaryFile;
+import static datawave.common.test.utils.FileUtils.deletePath;
+import static datawave.ingest.util.cache.load.LoadJobCache.getDeleteCacheConsumer;
+import static datawave.ingest.util.cache.load.LoadJobCache.getLoadCacheConsumer;
+
+public class LoadJobCacheTest {
+    private static final String TEMP_DIR = Files.createTempDir().getAbsolutePath();
+    private static final String JOB_CACHE_DIR = LoadJobCache.getJobCacheTimestampDir("jobCache_");
+    private static final String FILE_PREFIX = "File";
+    
+    private static Collection<FileSystemPath> CACHE_PATHS = Lists.newArrayList();
+    private static Collection<String> FILES_TO_LOAD = Lists.newArrayList();
+    
+    @BeforeClass
+    public static void setupClass() throws IOException {
+        // @formatter: off
+        FILES_TO_LOAD = Stream.of(createTemporaryFile(TEMP_DIR, 0, FILE_PREFIX, "properties"), createTemporaryFile(TEMP_DIR, 1, FILE_PREFIX, "jar"),
+                        createTemporaryFile(TEMP_DIR, 1, FILE_PREFIX, "xml"), createTemporaryFile(TEMP_DIR, 2, FILE_PREFIX, "xml"))
+                        .collect(Collectors.toList());
+        // @formatter: on
+        
+        Collection<Configuration> confs = Stream.of(new Configuration()).collect(Collectors.toList());
+        
+        CACHE_PATHS = Stream
+                        .of(new org.apache.hadoop.fs.Path(TEMP_DIR + File.separator + "output1"),
+                                        new org.apache.hadoop.fs.Path(TEMP_DIR + File.separator + "output2")).map(path -> new FileSystemPath(path, confs))
+                        .collect(Collectors.toList());
+        // @formatter: on
+    }
+    
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        deletePath(TEMP_DIR);
+    }
+    
+    @After
+    public void tearDown() throws IOException {
+        for (FileSystemPath delPath : CACHE_PATHS) {
+            deletePath(delPath.getOutputPath().toString());
+        }
+    }
+    
+    @Test
+    public void testLoadJobCache() throws IOException {
+        LoadJobCache.load(CACHE_PATHS, FILES_TO_LOAD, true, (short) 3, 2, JOB_CACHE_DIR, "");
+        verifyResults(getOutputPaths(""));
+    }
+    
+    @Test
+    public void testLoadJobCacheWithSubDir() throws IOException {
+        LoadJobCache.load(CACHE_PATHS, FILES_TO_LOAD, true, (short) 3, 2, JOB_CACHE_DIR, "subDir");
+        verifyResults(getOutputPaths("subDir"));
+    }
+    
+    @Test
+    public void testCacheCleanupOnError() {
+        ExecutorService executorService = Executors.newFixedThreadPool(1);
+        try {
+            LoadJobCache.load(CACHE_PATHS, true, getLoadCacheConsumer(FILES_TO_LOAD, executorService, JOB_CACHE_DIR, "", (short) 3),
+                            getFinalizerThatThrowsError(), getDeleteCacheConsumer(JOB_CACHE_DIR));
+        } finally {
+            executorService.shutdown();
+        }
+        Assert.assertTrue(getOutputPaths("").stream().map(File::new).noneMatch(File::exists));
+    }
+    
+    private static Consumer<FileSystemPath> getFinalizerThatThrowsError() {
+        return (FileSystemPath fsPath) -> {
+            throw new RuntimeException("Test exception check");
+        };
+    }
+    
+    private void verifyResults(Collection<String> outputPaths) throws IOException {
+        for (String outputPath : outputPaths) {
+            // @formatter:off
+            Collection<String> filesFound =
+                    FilesFinder.getFilesFromPattern(outputPath, "**", Integer.MAX_VALUE)
+                    .stream()
+                    .sorted()
+                    .collect(Collectors.toList());
+            // @formatter:on
+            Collection<String> filesExpected = getExpectedOutput(outputPath);
+            Assert.assertEquals(filesExpected, filesFound);
+        }
+    }
+    
+    private Collection<String> getExpectedOutput(String outputPath) {
+        // @formatter:off
+        return FILES_TO_LOAD
+                .stream()
+                .map(path -> path.substring(path.lastIndexOf("/")))
+                .map(fileName -> new File(outputPath, fileName))
+                .map(File::getAbsolutePath)
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+    
+    private Collection<String> getOutputPaths(String optionalSubDir) {
+        // @formatter:off
+        return CACHE_PATHS
+                .stream()
+                .map(FileSystemPath::getOutputPath)
+                .map(outputPath -> outputPath + "/" + JOB_CACHE_DIR + "/" + optionalSubDir)
+                .collect(Collectors.toList());
+        // @formatter:on
+    }
+}

--- a/warehouse/ingest-core/src/test/resources/META-INF/services/datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode
+++ b/warehouse/ingest-core/src/test/resources/META-INF/services/datawave.ingest.util.cache.delete.mode.DeleteJobCacheMode
@@ -1,0 +1,2 @@
+datawave.ingest.util.cache.delete.mode.DeletesSpecifiedMode
+datawave.ingest.util.cache.delete.mode.OldInactiveMode

--- a/warehouse/ingest-core/src/test/resources/META-INF/services/datawave.ingest.util.cache.lease.JobCacheLockFactory
+++ b/warehouse/ingest-core/src/test/resources/META-INF/services/datawave.ingest.util.cache.lease.JobCacheLockFactory
@@ -1,0 +1,2 @@
+datawave.ingest.util.cache.lease.JobCacheNoOpLockFactory
+datawave.ingest.util.cache.lease.JobCacheZkLockFactory

--- a/warehouse/ingest-core/src/test/resources/META-INF/services/datawave.ingest.util.cache.load.mode.LoadJobCacheMode
+++ b/warehouse/ingest-core/src/test/resources/META-INF/services/datawave.ingest.util.cache.load.mode.LoadJobCacheMode
@@ -1,0 +1,2 @@
+datawave.ingest.util.cache.load.mode.ClasspathMode
+datawave.ingest.util.cache.load.mode.FilePatternMode

--- a/warehouse/ingest-scripts/src/main/resources/bin/ingest/delete-timestamp-job-cache.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/ingest/delete-timestamp-job-cache.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [[ `uname` == "Darwin" ]]; then
+        READLINK_CMD="python -c 'import os,sys;print os.path.realpath(sys.argv[1])'"
+else
+        READLINK_CMD="readlink -f"
+fi
+THIS_SCRIPT=`eval $READLINK_CMD $0`
+THIS_DIR="${THIS_SCRIPT%/*}"
+cd $THIS_DIR
+
+. ../ingest/ingest-env.sh
+. ../ingest/ingest-libs.sh
+
+CLASSPATH=$CLASSPATH:`$HADOOP_HOME/bin/hadoop classpath`
+HADOOP_NATIVE_LIB_DIR="$INGEST_HADOOP_HOME/lib/native"
+JAVA_OPTS="${JAVA_OPTS} -Djava.library.path=${HADOOP_NATIVE_LIB_DIR}"
+
+export HADOOP_CLASSPATH=$CLASSPATH
+export INGEST_HADOOP_CONF
+export WAREHOUSE_HADOOP_CONF
+
+$JAVA_HOME/bin/java $JAVA_OPTS -cp $CLASSPATH datawave.ingest.util.cache.delete.DeleteJobCacheLauncher "$@" 2>&1 < /dev/null

--- a/warehouse/ingest-scripts/src/main/resources/bin/ingest/load-timestamp-job-cache.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/ingest/load-timestamp-job-cache.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ `uname` == "Darwin" ]]; then
+	READLINK_CMD="python -c 'import os,sys;print os.path.realpath(sys.argv[1])'"
+else
+	READLINK_CMD="readlink -f"
+fi
+THIS_SCRIPT=`eval $READLINK_CMD $0`
+THIS_DIR="${THIS_SCRIPT%/*}"
+cd $THIS_DIR
+
+. ../ingest/ingest-env.sh
+
+#read from the datawave metadata table to create the edge key version file and save it locally with the rest of the config files
+./create-edgekey-version-cache.sh --update ../../config
+
+. ../ingest/ingest-libs.sh
+
+JOB_CACHE_CLASSPATH="--classpath ${CLASSPATH}"
+CLASSPATH=$CLASSPATH:`$HADOOP_HOME/bin/hadoop classpath`
+HADOOP_NATIVE_LIB_DIR="$INGEST_HADOOP_HOME/lib/native"
+JAVA_OPTS="${JAVA_OPTS} -Djava.library.path=${HADOOP_NATIVE_LIB_DIR}"
+
+export HADOOP_CLASSPATH=$CLASSPATH
+export INGEST_HADOOP_CONF
+export WAREHOUSE_HADOOP_CONF
+
+$JAVA_HOME/bin/java $JAVA_OPTS -cp $CLASSPATH datawave.ingest.util.cache.load.LoadJobCacheLauncher ${JOB_CACHE_CLASSPATH} "$@" 2>&1 < /dev/null &
+


### PR DESCRIPTION
This pull request will add functionality for loading/deleting job caches with a timestamp. This will not replace the ingest job cache loading because of concerns about the frequency it hits zookeeper(locking mechanism). This will be used primarily for deletion jobs that run less frequently.