### PR TITLE
Removed duplication of data in the logic members with those in the configuration.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -70,7 +70,7 @@ import com.google.common.collect.Sets;
 public class DiscoveryLogic extends ShardIndexQueryTable {
     
     private static final Logger log = Logger.getLogger(DiscoveryLogic.class);
-
+    
     public static final String SEPARATE_COUNTS_BY_COLVIS = "separate.counts.by.colvis";
     public static final String SHOW_REFERENCE_COUNT = "show.reference.count";
     public static final String REVERSE_INDEX = "reverse.index";

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -70,13 +70,13 @@ import com.google.common.collect.Sets;
 public class DiscoveryLogic extends ShardIndexQueryTable {
     
     private static final Logger log = Logger.getLogger(DiscoveryLogic.class);
-    
+
     public static final String SEPARATE_COUNTS_BY_COLVIS = "separate.counts.by.colvis";
     public static final String SHOW_REFERENCE_COUNT = "show.reference.count";
     public static final String REVERSE_INDEX = "reverse.index";
     
-    private Boolean separateCountsByColVis = false;
-    private Boolean showReferenceCount = false;
+    private static Boolean separateCountsByColVis = DiscoveryQueryConfiguration.getSeparateCountsByColVis();
+    private static Boolean showReferenceCount = DiscoveryQueryConfiguration.getShowReferenceCount();
     private MetadataHelper metadataHelper;
     
     public DiscoveryLogic() {

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -68,15 +68,14 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 public class DiscoveryLogic extends ShardIndexQueryTable {
-
-
+    
     private static final Logger log = Logger.getLogger(DiscoveryLogic.class);
-
+    
     DiscoveryQueryConfiguration config = new DiscoveryQueryConfiguration();
     public static final String SEPARATE_COUNTS_BY_COLVIS = "separate.counts.by.colvis";
     public static final String SHOW_REFERENCE_COUNT = "show.reference.count";
     public static final String REVERSE_INDEX = "reverse.index";
-
+    
     private MetadataHelper metadataHelper;
     
     public DiscoveryLogic() {
@@ -224,7 +223,7 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
                             config.getLiterals(), config.getPatterns(), config.getRanges(), true);
             iterators.add(transformScanner(bs));
         }
-
+        
         this.iterator = concat(iterators.iterator());
     }
     
@@ -495,40 +494,40 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
         params.add(SEPARATE_COUNTS_BY_COLVIS);
         return params;
     }
-
+    
     public Boolean getSeparateCountsByColVis() {
-
+        
         if (config != null) {
             return config.getSeparateCountsByColVis();
         }
-
+        
         return false;
-
+        
     }
-
+    
     public void setSeparateCountsByColVis(Boolean separateCountsByColVis) {
-
+        
         if (config != null) {
             config.setSeparateCountsByColVis(separateCountsByColVis);
         }
-
+        
     }
-
+    
     public Boolean getShowReferenceCount() {
-
+        
         if (config != null) {
             return config.getShowReferenceCount();
         }
-
+        
         return false;
     }
-
+    
     public void setShowReferenceCount(Boolean showReferenceCount) {
-
+        
         if (config != null) {
             config.setShowReferenceCount(showReferenceCount);
         }
-
+        
     }
-
+    
 }

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -71,7 +71,7 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
     
     private static final Logger log = Logger.getLogger(DiscoveryLogic.class);
     
-    DiscoveryQueryConfiguration config = new DiscoveryQueryConfiguration();
+    DiscoveryQueryConfiguration config;
     public static final String SEPARATE_COUNTS_BY_COLVIS = "separate.counts.by.colvis";
     public static final String SHOW_REFERENCE_COUNT = "show.reference.count";
     public static final String REVERSE_INDEX = "reverse.index";
@@ -89,6 +89,8 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
     @Override
     public GenericQueryConfiguration initialize(AccumuloClient client, Query settings, Set<Authorizations> auths) throws Exception {
         DiscoveryQueryConfiguration config = new DiscoveryQueryConfiguration(this, settings);
+        
+        this.config = config;
         
         this.scannerFactory = new ScannerFactory(client);
         

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -68,15 +68,15 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 public class DiscoveryLogic extends ShardIndexQueryTable {
-    
+
+
     private static final Logger log = Logger.getLogger(DiscoveryLogic.class);
-    
+
+    DiscoveryQueryConfiguration config = new DiscoveryQueryConfiguration();
     public static final String SEPARATE_COUNTS_BY_COLVIS = "separate.counts.by.colvis";
     public static final String SHOW_REFERENCE_COUNT = "show.reference.count";
     public static final String REVERSE_INDEX = "reverse.index";
-    
-    private static Boolean separateCountsByColVis = DiscoveryQueryConfiguration.getSeparateCountsByColVis();
-    private static Boolean showReferenceCount = DiscoveryQueryConfiguration.getShowReferenceCount();
+
     private MetadataHelper metadataHelper;
     
     public DiscoveryLogic() {
@@ -116,13 +116,13 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
         // Check if user would like counts separated by column visibility
         if (null != settings.findParameter(SEPARATE_COUNTS_BY_COLVIS)
                         && !settings.findParameter(SEPARATE_COUNTS_BY_COLVIS).getParameterValue().trim().isEmpty()) {
-            separateCountsByColVis = Boolean.valueOf(settings.findParameter(SEPARATE_COUNTS_BY_COLVIS).getParameterValue().trim());
+            boolean separateCountsByColVis = Boolean.parseBoolean(settings.findParameter(SEPARATE_COUNTS_BY_COLVIS).getParameterValue().trim());
             config.setSeparateCountsByColVis(separateCountsByColVis);
         }
         
         // Check if user would like to show reference counts instead of term counts
         if (null != settings.findParameter(SHOW_REFERENCE_COUNT) && !settings.findParameter(SHOW_REFERENCE_COUNT).getParameterValue().trim().isEmpty()) {
-            showReferenceCount = Boolean.valueOf(settings.findParameter(SHOW_REFERENCE_COUNT).getParameterValue().trim());
+            Boolean showReferenceCount = Boolean.valueOf(settings.findParameter(SHOW_REFERENCE_COUNT).getParameterValue().trim());
             config.setShowReferenceCount(showReferenceCount);
         }
         
@@ -224,10 +224,7 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
                             config.getLiterals(), config.getPatterns(), config.getRanges(), true);
             iterators.add(transformScanner(bs));
         }
-        
-        config.setSeparateCountsByColVis(separateCountsByColVis);
-        config.setShowReferenceCount(showReferenceCount);
-        
+
         this.iterator = concat(iterators.iterator());
     }
     
@@ -498,21 +495,40 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
         params.add(SEPARATE_COUNTS_BY_COLVIS);
         return params;
     }
-    
+
     public Boolean getSeparateCountsByColVis() {
-        return separateCountsByColVis;
+
+        if (config != null) {
+            return config.getSeparateCountsByColVis();
+        }
+
+        return false;
+
     }
-    
+
     public void setSeparateCountsByColVis(Boolean separateCountsByColVis) {
-        this.separateCountsByColVis = separateCountsByColVis;
+
+        if (config != null) {
+            config.setSeparateCountsByColVis(separateCountsByColVis);
+        }
+
     }
-    
+
     public Boolean getShowReferenceCount() {
-        return showReferenceCount;
+
+        if (config != null) {
+            return config.getShowReferenceCount();
+        }
+
+        return false;
     }
-    
+
     public void setShowReferenceCount(Boolean showReferenceCount) {
-        this.showReferenceCount = showReferenceCount;
+
+        if (config != null) {
+            config.setShowReferenceCount(showReferenceCount);
+        }
+
     }
-    
+
 }

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -499,36 +499,25 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
     
     public Boolean getSeparateCountsByColVis() {
         
-        if (config != null) {
-            return config.getSeparateCountsByColVis();
-        }
-        
-        return false;
+        return config.getSeparateCountsByColVis();
         
     }
     
     public void setSeparateCountsByColVis(Boolean separateCountsByColVis) {
         
-        if (config != null) {
-            config.setSeparateCountsByColVis(separateCountsByColVis);
-        }
+        config.setSeparateCountsByColVis(separateCountsByColVis);
         
     }
     
     public Boolean getShowReferenceCount() {
         
-        if (config != null) {
-            return config.getShowReferenceCount();
-        }
+        return config.getShowReferenceCount();
         
-        return false;
     }
     
     public void setShowReferenceCount(Boolean showReferenceCount) {
         
-        if (config != null) {
-            config.setShowReferenceCount(showReferenceCount);
-        }
+        config.setShowReferenceCount(showReferenceCount);
         
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
@@ -13,16 +13,15 @@ import com.google.common.collect.Multimap;
 public class DiscoveryQueryConfiguration extends ShardIndexQueryConfiguration {
     private Multimap<String,String> literals, patterns;
     private Multimap<String,LiteralRange<String>> ranges;
-    private  Boolean separateCountsByColVis = false;
-    private  Boolean showReferenceCount = false;
-
-    public DiscoveryQueryConfiguration() {
-    }
-
+    private Boolean separateCountsByColVis = false;
+    private Boolean showReferenceCount = false;
+    
+    public DiscoveryQueryConfiguration() {}
+    
     public DiscoveryQueryConfiguration(ShardIndexQueryTable logic, Query query) {
         super(logic, query);
     }
-
+    
     public Multimap<String,String> getLiterals() {
         return literals;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
@@ -16,8 +16,6 @@ public class DiscoveryQueryConfiguration extends ShardIndexQueryConfiguration {
     private Boolean separateCountsByColVis = false;
     private Boolean showReferenceCount = false;
     
-    public DiscoveryQueryConfiguration() {}
-    
     public DiscoveryQueryConfiguration(ShardIndexQueryTable logic, Query query) {
         super(logic, query);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
@@ -13,13 +13,16 @@ import com.google.common.collect.Multimap;
 public class DiscoveryQueryConfiguration extends ShardIndexQueryConfiguration {
     private Multimap<String,String> literals, patterns;
     private Multimap<String,LiteralRange<String>> ranges;
-    private static Boolean separateCountsByColVis = false;
-    private static Boolean showReferenceCount = false;
-    
+    private  Boolean separateCountsByColVis = false;
+    private  Boolean showReferenceCount = false;
+
+    public DiscoveryQueryConfiguration() {
+    }
+
     public DiscoveryQueryConfiguration(ShardIndexQueryTable logic, Query query) {
         super(logic, query);
     }
-    
+
     public Multimap<String,String> getLiterals() {
         return literals;
     }
@@ -44,11 +47,11 @@ public class DiscoveryQueryConfiguration extends ShardIndexQueryConfiguration {
         this.patterns = patterns;
     }
     
-    public static Boolean getSeparateCountsByColVis() {
+    public Boolean getSeparateCountsByColVis() {
         return separateCountsByColVis;
     }
     
-    public static Boolean getShowReferenceCount() {
+    public Boolean getShowReferenceCount() {
         return showReferenceCount;
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryQueryConfiguration.java
@@ -13,8 +13,8 @@ import com.google.common.collect.Multimap;
 public class DiscoveryQueryConfiguration extends ShardIndexQueryConfiguration {
     private Multimap<String,String> literals, patterns;
     private Multimap<String,LiteralRange<String>> ranges;
-    private Boolean separateCountsByColVis = false;
-    private Boolean showReferenceCount = false;
+    private static Boolean separateCountsByColVis = false;
+    private static Boolean showReferenceCount = false;
     
     public DiscoveryQueryConfiguration(ShardIndexQueryTable logic, Query query) {
         super(logic, query);
@@ -44,11 +44,11 @@ public class DiscoveryQueryConfiguration extends ShardIndexQueryConfiguration {
         this.patterns = patterns;
     }
     
-    public Boolean getSeparateCountsByColVis() {
+    public static Boolean getSeparateCountsByColVis() {
         return separateCountsByColVis;
     }
     
-    public Boolean getShowReferenceCount() {
+    public static Boolean getShowReferenceCount() {
         return showReferenceCount;
     }
     


### PR DESCRIPTION
… from DiscoveryLogic.java. I replaced the variables with separateCountsByColVis = DiscoveryQueryConfiguration.getSeparateCountsByColVis() and DiscoveryQueryConfiguration.getShowReferenceCount(). This was to avoid duplication of data in the logic members with those in the conifgurtion.