### PR TITLE
Filter indexed, index-only, and term frequency fields to just the fields present in the query when possible.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -3,7 +3,6 @@ package datawave.query.iterator;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -298,7 +298,7 @@ public class QueryOptions implements OptionDescriber {
     protected List<String> documentPermutationClasses = new ArrayList<>();
     protected List<DocumentPermutation> documentPermutations = null;
     
-    protected long startTime = 0l;
+    protected long startTime = 0L;
     protected long endTime = System.currentTimeMillis();
     protected TimeFilter timeFilter = null;
     

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryFieldsVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryFieldsVisitor.java
@@ -1,0 +1,344 @@
+package datawave.query.jexl.visitors;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.functions.JexlFunctionArgumentDescriptorFactory;
+import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
+import datawave.query.jexl.nodes.ExceededOrThresholdMarkerJexlNode;
+import datawave.query.util.MetadataHelper;
+import org.apache.commons.jexl2.parser.ASTAdditiveNode;
+import org.apache.commons.jexl2.parser.ASTAdditiveOperator;
+import org.apache.commons.jexl2.parser.ASTAmbiguous;
+import org.apache.commons.jexl2.parser.ASTArrayAccess;
+import org.apache.commons.jexl2.parser.ASTArrayLiteral;
+import org.apache.commons.jexl2.parser.ASTAssignment;
+import org.apache.commons.jexl2.parser.ASTBitwiseAndNode;
+import org.apache.commons.jexl2.parser.ASTBitwiseComplNode;
+import org.apache.commons.jexl2.parser.ASTBitwiseOrNode;
+import org.apache.commons.jexl2.parser.ASTBitwiseXorNode;
+import org.apache.commons.jexl2.parser.ASTBlock;
+import org.apache.commons.jexl2.parser.ASTConstructorNode;
+import org.apache.commons.jexl2.parser.ASTDivNode;
+import org.apache.commons.jexl2.parser.ASTEQNode;
+import org.apache.commons.jexl2.parser.ASTERNode;
+import org.apache.commons.jexl2.parser.ASTEmptyFunction;
+import org.apache.commons.jexl2.parser.ASTFalseNode;
+import org.apache.commons.jexl2.parser.ASTFloatLiteral;
+import org.apache.commons.jexl2.parser.ASTForeachStatement;
+import org.apache.commons.jexl2.parser.ASTFunctionNode;
+import org.apache.commons.jexl2.parser.ASTGENode;
+import org.apache.commons.jexl2.parser.ASTGTNode;
+import org.apache.commons.jexl2.parser.ASTIdentifier;
+import org.apache.commons.jexl2.parser.ASTIfStatement;
+import org.apache.commons.jexl2.parser.ASTIntegerLiteral;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ASTLENode;
+import org.apache.commons.jexl2.parser.ASTLTNode;
+import org.apache.commons.jexl2.parser.ASTMapEntry;
+import org.apache.commons.jexl2.parser.ASTMapLiteral;
+import org.apache.commons.jexl2.parser.ASTMethodNode;
+import org.apache.commons.jexl2.parser.ASTModNode;
+import org.apache.commons.jexl2.parser.ASTMulNode;
+import org.apache.commons.jexl2.parser.ASTNENode;
+import org.apache.commons.jexl2.parser.ASTNRNode;
+import org.apache.commons.jexl2.parser.ASTNullLiteral;
+import org.apache.commons.jexl2.parser.ASTNumberLiteral;
+import org.apache.commons.jexl2.parser.ASTReference;
+import org.apache.commons.jexl2.parser.ASTReturnStatement;
+import org.apache.commons.jexl2.parser.ASTSizeFunction;
+import org.apache.commons.jexl2.parser.ASTSizeMethod;
+import org.apache.commons.jexl2.parser.ASTStringLiteral;
+import org.apache.commons.jexl2.parser.ASTTernaryNode;
+import org.apache.commons.jexl2.parser.ASTTrueNode;
+import org.apache.commons.jexl2.parser.ASTUnaryMinusNode;
+import org.apache.commons.jexl2.parser.ASTVar;
+import org.apache.commons.jexl2.parser.ASTWhileStatement;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Return a set of all fields present in the query
+ */
+public class QueryFieldsVisitor extends BaseVisitor {
+    
+    private final MetadataHelper helper;
+    
+    public static Set<String> parseQueryFields(String query, MetadataHelper helper) {
+        try {
+            ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+            return parseQueryFields(script, helper);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return Collections.emptySet();
+    }
+    
+    public static Set<String> parseQueryFields(ASTJexlScript script, MetadataHelper helper) {
+        QueryFieldsVisitor visitor = new QueryFieldsVisitor(helper);
+        return (Set<String>) script.jjtAccept(visitor, new HashSet<>());
+    }
+    
+    public QueryFieldsVisitor(MetadataHelper helper) {
+        this.helper = helper;
+    }
+    
+    private Object parseSingleField(JexlNode node, Object data) {
+        String field = JexlASTHelper.getIdentifier(node);
+        ((Set<String>) data).add(field);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAssignment node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTEQNode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTNENode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTLTNode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTGTNode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTLENode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTGENode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTERNode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTNRNode node, Object data) {
+        return parseSingleField(node, data);
+    }
+    
+    @Override
+    public Object visit(ASTIdentifier node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    /**
+     * Have to handle JexlArg, GeoFunctions, and GeoWaveFunctions
+     * 
+     * @param node
+     * @param data
+     * @return
+     */
+    @Override
+    public Object visit(ASTFunctionNode node, Object data) {
+        JexlArgumentDescriptor desc = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(node);
+        Set<String> fields = desc.fields(helper, null);
+        ((Set<String>) data).addAll(fields);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTReference node, Object data) {
+        // Special handling for node with json-encoded params
+        if (ExceededOrThresholdMarkerJexlNode.instanceOf(node, ExceededOrThresholdMarkerJexlNode.class)) {
+            String field = ExceededOrThresholdMarkerJexlNode.getField(node);
+            if (field != null) {
+                ((Set<String>) data).add(field);
+            }
+            return data;
+        }
+        
+        return super.visit(node, data);
+    }
+    
+    // Short circuits
+    
+    @Override
+    public Object visit(ASTBlock node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAmbiguous node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTIfStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTWhileStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTForeachStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTTernaryNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseOrNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseXorNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseAndNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAdditiveNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAdditiveOperator node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMulNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTDivNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTModNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTUnaryMinusNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseComplNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNullLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTTrueNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTFalseNode node, Object data) {
+        return data;
+    }
+    
+    public Object visit(ASTIntegerLiteral node, Object data) {
+        return data;
+    }
+    
+    public Object visit(ASTFloatLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTStringLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTArrayLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMapLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMapEntry node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTEmptyFunction node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTSizeFunction node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMethodNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTSizeMethod node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTConstructorNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTArrayAccess node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTReturnStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTVar node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNumberLiteral node, Object data) {
+        return data;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -67,6 +67,7 @@ import datawave.query.jexl.visitors.PushFunctionsIntoExceededValueRanges;
 import datawave.query.jexl.visitors.PushdownLowSelectivityNodesVisitor;
 import datawave.query.jexl.visitors.PushdownMissingIndexRangeNodesVisitor;
 import datawave.query.jexl.visitors.PushdownUnexecutableNodesVisitor;
+import datawave.query.jexl.visitors.QueryFieldsVisitor;
 import datawave.query.jexl.visitors.QueryModelVisitor;
 import datawave.query.jexl.visitors.QueryOptionsFromQueryVisitor;
 import datawave.query.jexl.visitors.QueryPruningVisitor;
@@ -438,7 +439,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         
         if (!config.isGeneratePlanOnly()) {
             while (null == cfg) {
-                cfg = getQueryIterator(metadataHelper, config, settings, "", false);
+                cfg = getQueryIterator(metadataHelper, config, settings, newQueryString, false);
             }
             configureIterator(config, cfg, newQueryString, isFullTable);
         }
@@ -507,7 +508,8 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         addOption(cfg, QueryOptions.GROUP_FIELDS_BATCH_SIZE, config.getGroupFieldsBatchSizeAsString(), true);
         addOption(cfg, QueryOptions.UNIQUE_FIELDS, config.getUniqueFieldsAsString(), true);
         addOption(cfg, QueryOptions.HIT_LIST, Boolean.toString(config.isHitList()), false);
-        addOption(cfg, QueryOptions.TERM_FREQUENCY_FIELDS, Joiner.on(',').join(config.getQueryTermFrequencyFields()), false);
+        Set<String> queryFields = QueryFieldsVisitor.parseQueryFields(newQueryString, metadataHelper);
+        addOption(cfg, QueryOptions.TERM_FREQUENCY_FIELDS, Joiner.on(',').join(filterFields(config.getQueryTermFrequencyFields(), queryFields)), false);
         addOption(cfg, QueryOptions.TERM_FREQUENCIES_REQUIRED, Boolean.toString(config.isTermFrequenciesRequired()), true);
         addOption(cfg, QueryOptions.QUERY, newQueryString, false);
         addOption(cfg, QueryOptions.QUERY_ID, config.getQuery().getId().toString(), false);
@@ -1762,10 +1764,11 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     }
     
     protected Future<IteratorSetting> loadQueryIterator(final MetadataHelper metadataHelper, final ShardQueryConfiguration config, final Query settings,
-                    final String queryString, final Boolean isFullTable) throws DatawaveQueryException {
+                    final String queryString, final Set<String> queryFields, final Boolean isFullTable) throws DatawaveQueryException {
         
         return builderThread.submit(() -> {
             // VersioningIterator is typically set at 20 on the table
+                        
                         IteratorSetting cfg = new IteratorSetting(config.getBaseIteratorPriority() + 40, "query", getQueryIteratorClass());
                         
                         addOption(cfg, Constants.RETURN_TYPE, config.getReturnType().toString(), false);
@@ -1818,13 +1821,13 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
                         configureAdditionalOptions(config, cfg);
                         
                         try {
-                            addOption(cfg, QueryOptions.INDEX_ONLY_FIELDS,
-                                            QueryOptions.buildFieldStringFromSet(metadataHelper.getIndexOnlyFields(config.getDatatypeFilter())), true);
+                            addOption(cfg, QueryOptions.INDEX_ONLY_FIELDS, QueryOptions.buildFieldStringFromSet(filterFields(
+                                            metadataHelper.getIndexOnlyFields(config.getDatatypeFilter()), queryFields)), true);
                             addOption(cfg, QueryOptions.COMPOSITE_FIELDS,
                                             QueryOptions.buildFieldStringFromSet(metadataHelper.getCompositeToFieldMap(config.getDatatypeFilter()).keySet()),
                                             true);
-                            addOption(cfg, QueryOptions.INDEXED_FIELDS,
-                                            QueryOptions.buildFieldStringFromSet(metadataHelper.getIndexedFields(config.getDatatypeFilter())), true);
+                            addOption(cfg, QueryOptions.INDEXED_FIELDS, QueryOptions.buildFieldStringFromSet(filterFields(
+                                            metadataHelper.getIndexedFields(config.getDatatypeFilter()), queryFields)), true);
                         } catch (TableNotFoundException e) {
                             QueryException qe = new QueryException(DatawaveErrorCode.INDEX_ONLY_FIELDS_RETRIEVAL_ERROR, e);
                             throw new DatawaveQueryException(qe);
@@ -1869,6 +1872,38 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     }
     
     /**
+     * Extract fields from a query string
+     *
+     * @param query
+     *            the query represented as a string
+     * @return a set of all fields in the query
+     */
+    private Set<String> getQueryFields(String query) {
+        Set<String> queryFields = new HashSet<>();
+        if (org.apache.commons.lang3.StringUtils.isNotBlank(query)) {
+            queryFields = QueryFieldsVisitor.parseQueryFields(query, metadataHelper);
+        }
+        return queryFields;
+    }
+    
+    /**
+     * Filter a set of fields by the fields present in the query
+     * 
+     * @param fieldsToFilter
+     *            the set of fields to filter
+     * @param queryFields
+     *            set of fields present in the query
+     * @return the intersection of query fields and an arbitrary set of fields
+     */
+    private Set<String> filterFields(Set<String> fieldsToFilter, Set<String> queryFields) {
+        if (queryFields.isEmpty()) {
+            return fieldsToFilter;
+        } else {
+            return Sets.intersection(queryFields, fieldsToFilter);
+        }
+    }
+    
+    /**
      * Get the list of ivarator cache dirs, randomizing the order (while respecting priority) so that the tservers spread out the disk usage.
      */
     private List<IvaratorCacheDirConfig> getShuffledIvaratoCacheDirConfigs(ShardQueryConfiguration config) {
@@ -1890,8 +1925,10 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     
     protected IteratorSetting getQueryIterator(MetadataHelper metadataHelper, ShardQueryConfiguration config, Query settings, String queryString,
                     Boolean isFullTable) throws DatawaveQueryException {
-        if (null == settingFuture)
-            settingFuture = loadQueryIterator(metadataHelper, config, settings, queryString, isFullTable);
+        if (null == settingFuture) {
+            Set<String> queryFields = getQueryFields(queryString);
+            settingFuture = loadQueryIterator(metadataHelper, config, settings, queryString, queryFields, isFullTable);
+        }
         if (settingFuture.isDone())
             try {
                 return settingFuture.get();

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryFieldsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryFieldsVisitorTest.java
@@ -1,0 +1,190 @@
+package datawave.query.jexl.visitors;
+
+import com.google.common.collect.Sets;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.util.MockMetadataHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryFieldsVisitorTest {
+    
+    private static MockMetadataHelper helper = new MockMetadataHelper();
+    
+    @BeforeClass
+    public static void setup() {
+        helper.addNormalizers("FOO", Collections.singleton(new LcNoDiacriticsType()));
+        helper.addNormalizers("FOO2", Collections.singleton(new LcNoDiacriticsType()));
+        helper.addNormalizers("FOO3", Collections.singleton(new LcNoDiacriticsType()));
+        helper.addNormalizers("FOO4", Collections.singleton(new LcNoDiacriticsType()));
+    }
+    
+    @Test
+    public void testEQ() throws ParseException {
+        String query = "FOO == 'bar'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testNE() throws ParseException {
+        String query = "FOO != 'bar'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testLT() throws ParseException {
+        String query = "FOO < 'bar'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testGT() throws ParseException {
+        String query = "FOO > 'bar'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testLE() throws ParseException {
+        String query = "FOO <= 'bar'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testGE() throws ParseException {
+        String query = "FOO >= 'bar'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testER() throws ParseException {
+        String query = "FOO =~ 'ba.*'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testNR() throws ParseException {
+        String query = "FOO !~ 'ba.*'";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testMultiFieldedUnion() throws ParseException {
+        String query = "FOO == 'bar' || FOO2 == 'baz'";
+        test(query, Sets.newHashSet("FOO", "FOO2"));
+    }
+    
+    @Test
+    public void testMultiFieldedIntersection() throws ParseException {
+        String query = "FOO == 'bar' && FOO2 == 'baz'";
+        test(query, Sets.newHashSet("FOO", "FOO2"));
+    }
+    
+    @Test
+    public void testIntersectionOfNestedUnions() throws ParseException {
+        String query = "(FOO == 'bar' || FOO2 == 'baz') && (FOO3 == 'xray' || FOO4 == 'zed')";
+        test(query, Sets.newHashSet("FOO", "FOO2", "FOO3", "FOO4"));
+    }
+    
+    @Test
+    public void testUnionOfNestedIntersection() throws ParseException {
+        String query = "(FOO == 'tank' && FOO2 == 'man') || (FOO3 == 'thanks ' && FOO4 == 'man')";
+        test(query, Sets.newHashSet("FOO", "FOO2", "FOO3", "FOO4"));
+    }
+    
+    // Some functions
+    
+    @Test
+    public void testContentFunction_phrase() throws ParseException {
+        String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz')";
+        test(query, Collections.singleton("FOO"));
+        
+        // Multi-fielded
+        query = "content:phrase((FOO|FOO2), termOffsetMap, 'bar', 'baz')";
+        test(query, Sets.newHashSet("FOO", "FOO2"));
+        
+        // Fields within intersection
+        query = "(content:phrase(termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testContentFunction_adjacent() throws ParseException {
+        String query = "content:adjacent(FOO, termOffsetMap, 'bar', 'baz')";
+        test(query, Collections.singleton("FOO"));
+        
+        // Fields within intersection
+        query = "(content:adjacent(termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testContentFunction_within() throws ParseException {
+        String query = "content:within(FOO, 5, termOffsetMap, 'bar', 'baz')";
+        test(query, Collections.singleton("FOO"));
+        
+        // Fields within intersection
+        query = "(content:within(5, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    // Filter functions
+    
+    @Test
+    public void testFilterIncludeRegex() throws ParseException {
+        String query = "filter:includeRegex(FOO, 'bar.*')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testFilterExcludeRegex() throws ParseException {
+        String query = "filter:excludeRegex(FOO, 'bar.*')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    // Geowave functions
+    @Test
+    public void testGeoWaveFunction_intersects() throws ParseException {
+        String query = "geowave:intersects(FOO, 'POINT(4 4)')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testGeoWaveFunction_overlaps() throws ParseException {
+        String query = "geowave:overlaps(FOO, 'POINT(5 5)')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    @Test
+    public void testGeoWaveFunction_intersectsAndOverlaps() throws ParseException {
+        String query = "geowave:intersects(FOO, 'POINT(4 4)') || geowave:overlaps(FOO, 'POINT(5 5)')";
+        test(query, Collections.singleton("FOO"));
+    }
+    
+    // Misc. tests
+    
+    @Test
+    public void testAnyFieldAndNoField() throws ParseException {
+        String query = "_ANYFIELD_ == 'bar' && _NOFIELD_ == 'baz'";
+        test(query, Sets.newHashSet("_ANYFIELD_", "_NOFIELD_"));
+    }
+    
+    @Test
+    public void testExceededOrThresholdMarker() throws ParseException {
+        // shamelessly lifted from ExecutableExpansionVisitorTest
+        String query = "FOO == 'capone' && (((_List_ = true) && (((id = 'some-bogus-id') && (field = 'FOO2') && (params = '{\"values\":[\"a\",\"b\",\"c\"]}')))))";
+        test(query, Sets.newHashSet("FOO", "FOO2"));
+    }
+    
+    private void test(String query, Set<String> fields) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+        Set<String> parsedFields = QueryFieldsVisitor.parseQueryFields(script, helper);
+        assertEquals(fields, parsedFields);
+    }
+}


### PR DESCRIPTION
This change reduces the size of the serialized query iterator sent to the tablet servers.