### PR TITLE
Don't drop UIDs in GlobalIndexUidAggregator

### DIFF
--- a/warehouse/core/src/main/java/datawave/ingest/protobuf/Uid.java
+++ b/warehouse/core/src/main/java/datawave/ingest/protobuf/Uid.java
@@ -73,27 +73,6 @@ public final class Uid {
          * <code>repeated string REMOVEDUID = 4;</code>
          */
         com.google.protobuf.ByteString getREMOVEDUIDBytes(int index);
-        
-        // repeated string QUARANTINEUID = 5;
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        java.util.List<java.lang.String> getQUARANTINEUIDList();
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        int getQUARANTINEUIDCount();
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        java.lang.String getQUARANTINEUID(int index);
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        com.google.protobuf.ByteString getQUARANTINEUIDBytes(int index);
     }
     
     /**
@@ -172,14 +151,6 @@ public final class Uid {
                             rEMOVEDUID_.add(input.readBytes());
                             break;
                         }
-                        case 42: {
-                            if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                                qUARANTINEUID_ = new com.google.protobuf.LazyStringArrayList();
-                                mutable_bitField0_ |= 0x00000010;
-                            }
-                            qUARANTINEUID_.add(input.readBytes());
-                            break;
-                        }
                     }
                 }
             } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -192,9 +163,6 @@ public final class Uid {
                 }
                 if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
                     rEMOVEDUID_ = new com.google.protobuf.UnmodifiableLazyStringList(rEMOVEDUID_);
-                }
-                if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                    qUARANTINEUID_ = new com.google.protobuf.UnmodifiableLazyStringList(qUARANTINEUID_);
                 }
                 this.unknownFields = unknownFields.build();
                 makeExtensionsImmutable();
@@ -323,44 +291,11 @@ public final class Uid {
             return rEMOVEDUID_.getByteString(index);
         }
         
-        // repeated string QUARANTINEUID = 5;
-        public static final int QUARANTINEUID_FIELD_NUMBER = 5;
-        private com.google.protobuf.LazyStringList qUARANTINEUID_;
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        public java.util.List<java.lang.String> getQUARANTINEUIDList() {
-            return qUARANTINEUID_;
-        }
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        public int getQUARANTINEUIDCount() {
-            return qUARANTINEUID_.size();
-        }
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        public java.lang.String getQUARANTINEUID(int index) {
-            return qUARANTINEUID_.get(index);
-        }
-        
-        /**
-         * <code>repeated string QUARANTINEUID = 5;</code>
-         */
-        public com.google.protobuf.ByteString getQUARANTINEUIDBytes(int index) {
-            return qUARANTINEUID_.getByteString(index);
-        }
-        
         private void initFields() {
             iGNORE_ = false;
             cOUNT_ = 0L;
             uID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
             rEMOVEDUID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-            qUARANTINEUID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         }
         
         private byte memoizedIsInitialized = -1;
@@ -396,9 +331,6 @@ public final class Uid {
             for (int i = 0; i < rEMOVEDUID_.size(); i++) {
                 output.writeBytes(4, rEMOVEDUID_.getByteString(i));
             }
-            for (int i = 0; i < qUARANTINEUID_.size(); i++) {
-                output.writeBytes(5, qUARANTINEUID_.getByteString(i));
-            }
             getUnknownFields().writeTo(output);
         }
         
@@ -431,14 +363,6 @@ public final class Uid {
                 }
                 size += dataSize;
                 size += 1 * getREMOVEDUIDList().size();
-            }
-            {
-                int dataSize = 0;
-                for (int i = 0; i < qUARANTINEUID_.size(); i++) {
-                    dataSize += com.google.protobuf.CodedOutputStream.computeBytesSizeNoTag(qUARANTINEUID_.getByteString(i));
-                }
-                size += dataSize;
-                size += 1 * getQUARANTINEUIDList().size();
             }
             size += getUnknownFields().getSerializedSize();
             memoizedSerializedSize = size;
@@ -516,7 +440,8 @@ public final class Uid {
         
         @java.lang.Override
         protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            return new Builder(parent);
+            Builder builder = new Builder(parent);
+            return builder;
         }
         
         /**
@@ -560,8 +485,6 @@ public final class Uid {
                 bitField0_ = (bitField0_ & ~0x00000004);
                 rEMOVEDUID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
                 bitField0_ = (bitField0_ & ~0x00000008);
-                qUARANTINEUID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-                bitField0_ = (bitField0_ & ~0x00000010);
                 return this;
             }
             
@@ -607,11 +530,6 @@ public final class Uid {
                     bitField0_ = (bitField0_ & ~0x00000008);
                 }
                 result.rEMOVEDUID_ = rEMOVEDUID_;
-                if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                    qUARANTINEUID_ = new com.google.protobuf.UnmodifiableLazyStringList(qUARANTINEUID_);
-                    bitField0_ = (bitField0_ & ~0x00000010);
-                }
-                result.qUARANTINEUID_ = qUARANTINEUID_;
                 result.bitField0_ = to_bitField0_;
                 onBuilt();
                 return result;
@@ -652,16 +570,6 @@ public final class Uid {
                     } else {
                         ensureREMOVEDUIDIsMutable();
                         rEMOVEDUID_.addAll(other.rEMOVEDUID_);
-                    }
-                    onChanged();
-                }
-                if (!other.qUARANTINEUID_.isEmpty()) {
-                    if (qUARANTINEUID_.isEmpty()) {
-                        qUARANTINEUID_ = other.qUARANTINEUID_;
-                        bitField0_ = (bitField0_ & ~0x00000010);
-                    } else {
-                        ensureQUARANTINEUIDIsMutable();
-                        qUARANTINEUID_.addAll(other.qUARANTINEUID_);
                     }
                     onChanged();
                 }
@@ -967,103 +875,6 @@ public final class Uid {
                 return this;
             }
             
-            // repeated string QUARANTINEUID = 5;
-            private com.google.protobuf.LazyStringList qUARANTINEUID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-            
-            private void ensureQUARANTINEUIDIsMutable() {
-                if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-                    qUARANTINEUID_ = new com.google.protobuf.LazyStringArrayList(qUARANTINEUID_);
-                    bitField0_ |= 0x00000010;
-                }
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public java.util.List<java.lang.String> getQUARANTINEUIDList() {
-                return java.util.Collections.unmodifiableList(qUARANTINEUID_);
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public int getQUARANTINEUIDCount() {
-                return qUARANTINEUID_.size();
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public java.lang.String getQUARANTINEUID(int index) {
-                return qUARANTINEUID_.get(index);
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public com.google.protobuf.ByteString getQUARANTINEUIDBytes(int index) {
-                return qUARANTINEUID_.getByteString(index);
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public Builder setQUARANTINEUID(int index, java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                ensureQUARANTINEUIDIsMutable();
-                qUARANTINEUID_.set(index, value);
-                onChanged();
-                return this;
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public Builder addQUARANTINEUID(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                ensureQUARANTINEUIDIsMutable();
-                qUARANTINEUID_.add(value);
-                onChanged();
-                return this;
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public Builder addAllQUARANTINEUID(java.lang.Iterable<java.lang.String> values) {
-                ensureQUARANTINEUIDIsMutable();
-                super.addAll(values, qUARANTINEUID_);
-                onChanged();
-                return this;
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public Builder clearQUARANTINEUID() {
-                qUARANTINEUID_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-                bitField0_ = (bitField0_ & ~0x00000010);
-                onChanged();
-                return this;
-            }
-            
-            /**
-             * <code>repeated string QUARANTINEUID = 5;</code>
-             */
-            public Builder addQUARANTINEUIDBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                ensureQUARANTINEUIDIsMutable();
-                qUARANTINEUID_.add(value);
-                onChanged();
-                return this;
-            }
-            
             // @@protoc_insertion_point(builder_scope:datawave.ingest.protobuf.List)
         }
         
@@ -1084,17 +895,15 @@ public final class Uid {
     
     private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
     static {
-        java.lang.String[] descriptorData = {"\n\tUid.proto\022\030datawave.ingest.protobuf\"]\n"
+        java.lang.String[] descriptorData = {"\n\tUid.proto\022\030datawave.ingest.protobuf\"F\n"
                         + "\004List\022\016\n\006IGNORE\030\001 \002(\010\022\r\n\005COUNT\030\002 \002(\004\022\013\n\003"
-                        + "UID\030\003 \003(\t\022\022\n\nREMOVEDUID\030\004 \003(\t\022\025\n\rQUARANT"
-                        + "INEUID\030\005 \003(\tB\034\n\030datawave.ingest.protobuf" + "H\001"};
+                        + "UID\030\003 \003(\t\022\022\n\nREMOVEDUID\030\004 \003(\tB\034\n\030datawav" + "e.ingest.protobufH\001"};
         com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner = new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
             public com.google.protobuf.ExtensionRegistry assignDescriptors(com.google.protobuf.Descriptors.FileDescriptor root) {
                 descriptor = root;
                 internal_static_datawave_ingest_protobuf_List_descriptor = getDescriptor().getMessageTypes().get(0);
                 internal_static_datawave_ingest_protobuf_List_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(
-                                internal_static_datawave_ingest_protobuf_List_descriptor, new java.lang.String[] {"IGNORE", "COUNT", "UID", "REMOVEDUID",
-                                        "QUARANTINEUID",});
+                                internal_static_datawave_ingest_protobuf_List_descriptor, new java.lang.String[] {"IGNORE", "COUNT", "UID", "REMOVEDUID",});
                 return null;
             }
         };

--- a/warehouse/core/src/main/protobuf/Uid.proto
+++ b/warehouse/core/src/main/protobuf/Uid.proto
@@ -11,5 +11,4 @@ message List {
   required uint64 COUNT = 2;
   repeated string UID = 3;
   repeated string REMOVEDUID = 4;
-  repeated string QUARANTINEUID =5;
 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
@@ -1,55 +1,41 @@
 package datawave.ingest.table.aggregator;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 
+import datawave.ingest.protobuf.Uid.List.Builder;
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.log4j.Logger;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import datawave.ingest.protobuf.Uid;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of an Aggregator that aggregates objects of the type Uid.List. This is an optimization for the shardIndex and shardReverseIndex, where the
  * list of UIDs for events will be maintained in the global index for low cardinality terms.
- * 
- * 
- * 
  */
 public class GlobalIndexUidAggregator extends PropogatingCombiner {
-    private static final Logger log = Logger.getLogger(GlobalIndexUidAggregator.class);
-    private Uid.List.Builder builder = Uid.List.newBuilder();
+    private static final Logger log = LoggerFactory.getLogger(GlobalIndexUidAggregator.class);
+    private static final String TIMESTAMPS_IGNORED = "timestampsIgnored";
     
     /**
      * Using a set instead of a list so that duplicate UIDs are filtered out of the list. This might happen in the case of rows with masked fields that share a
      * UID.
      */
-    private HashSet<String> uids = new HashSet<>();
-    
-    public GlobalIndexUidAggregator(int max) {
-        this.maxUids = max;
-    }
-    
-    public GlobalIndexUidAggregator() {
-        this.maxUids = MAX;
-    }
+    private final HashSet<String> uids = new HashSet<>();
     
     /**
      * List of UIDs to remove.
      */
-    private HashSet<String> uidsToRemove = new HashSet<>();
-    
-    /**
-     * List of UIDs to remove.
-     */
-    private HashSet<String> quarantinedIds = new HashSet<>();
-    
-    /**
-     * List of UIDs to remove.
-     */
-    private HashSet<String> releasedUids = new HashSet<>();
+    private final HashSet<String> uidsToRemove = new HashSet<>();
     
     /**
      * flag for whether or not we have seen ignore
@@ -64,7 +50,7 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
     /**
      * Maximum number of UIDs.
      */
-    public int maxUids = MAX;
+    public int maxUids;
     
     /**
      * representative count.
@@ -72,9 +58,17 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
     private long count = 0;
     
     /**
-     * temporary set for removals.
+     * Indicates whether timestamps are "ignored" where it is assumed all keys aggregated by this class share the same timestamp value.
      */
-    protected HashSet<String> tempSet;
+    private boolean timestampsIgnored = true;
+    
+    public GlobalIndexUidAggregator(int max) {
+        this.maxUids = max;
+    }
+    
+    public GlobalIndexUidAggregator() {
+        this.maxUids = MAX;
+    }
     
     /**
      * @return True if we saw a "count only" protobuf during the last reduce operation.
@@ -85,67 +79,67 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
     
     public Value aggregate() {
         
-        // as a backup, we remove the intersection of the UID sets
-        
-        builder.setCOUNT(count);
-        
-        if (seenIgnore || count > maxUids) {
-            builder.setIGNORE(true);
-            builder.clearUID();
-            // if we catch seenIgnore, then there is
-            // no need to propogate removals.
-            propogate = false;
+        Builder builder = Uid.List.newBuilder();
+        builder.setIGNORE(seenIgnore);
+        if (seenIgnore) {
+            // If we're over the max UID size, then the count is simply the sum of counts
+            // as reported by the protocol buffers. If UIDs were duplicated, then this
+            // count might include that info, but there's no way to know since we're not
+            // tracking individual UIDs.
+            builder.setCOUNT(count);
         } else {
-            builder.setIGNORE(false);
-            
-            uidsToRemove.removeAll(quarantinedIds);
-            uidsToRemove.removeAll(releasedUids);
-            quarantinedIds.removeAll(releasedUids);
-            
             uids.removeAll(uidsToRemove);
-            uids.removeAll(quarantinedIds);
-            
-            if (!releasedUids.isEmpty()) {
-                if (log.isDebugEnabled())
-                    log.debug("Adding released UIDS");
-                uids.addAll(releasedUids);
-            }
-            
             builder.addAllUID(uids);
-        }
-        
-        if (log.isDebugEnabled())
-            log.debug("Propogating: " + propogate);
-        
-        // clear all removals
-        builder.clearREMOVEDUID();
-        
-        if (propogate) {
+            // If we're not over the max UID size, then the count is simply the number of
+            // UIDs we have in memory. This will take care of de-duping any UIDs that were
+            // added more than once. Note that we specifically do not account for any UIDs
+            // in uidsToRemove (other than those that were removed from uids above). If we
+            // saw removals for 10 UIDs, we'd have those 10 UIDs in the uidsToRemove list.
+            // Then if the next value contains adds for those 10 UIDs, we would not add
+            // them to the uids set since they're in uidsToRemove, but we would also NOT
+            // remove them from uidsToRemove since we don't know whether or not we'll see
+            // any of those UIDs again and don't want to discard the fact that they are
+            // removed. In that case, we'd have a count of -10 after aggregation if we
+            // subtracted uidsToRemove.size() even though the correct count would be 0.
+            builder.setCOUNT(uids.size());
             
-            builder.addAllREMOVEDUID(uidsToRemove);
-            builder.addAllQUARANTINEUID(quarantinedIds);
+            // Only track REMOVEDUIDs if we're propagating, which means it's a minor or
+            // partial major compaction and therefore the result of aggregation might not
+            // include all possible values for a key. In that case, it's possible the adds
+            // to which these removes apply are in a different file that wasn't involved in
+            // this operation.
+            if (propogate) {
+                builder.addAllREMOVEDUID(uidsToRemove);
+            }
         }
-        if (log.isDebugEnabled())
-            log.debug("Building aggregate. Count is " + count + ", uids.size() is " + uids.size() + ". builder size is " + builder.getUIDList().size());
-        return new Value(builder.build().toByteArray());
         
+        log.trace("Building aggregate. propogate={}, count={}, uids.size()={}, uidsToRemove.size()={}, builder UIDCount={} REMOVEDUIDCount={}", propogate,
+                        count, uids.size(), uidsToRemove.size(), builder.getUIDCount(), builder.getREMOVEDUIDCount());
+        return new Value(builder.build().toByteArray());
     }
     
     /**
-     * We should closely examine the possible use cases to ensure that we have covered all scenarios.
-     * 
-     * Ingest: If we ingest, we would like to aggregate index entries with the same Key. This means that the reducer ( or combiner ) will combine UIDs for a
-     * given index ( on a given shard ). In this case it is unlikey that we have any removals.
-     * 
-     * Deletes: We may have have removals at any point in the RFile read for a given tablet. We need to propogate the removals across compactions, until we have
-     * a full major compaction.
-     * 
-     * If we reach the point where we are merging a UID protobuf, where ignore has been seen, then we do not continue with removals.
+     * Combines UID lists. The {@link Uid.List} protocol buffer contains a count, ignore flag, and lists of UIDs and REMOVEDUIDs. The intent is that the list
+     * can store up to a certain number of UIDs and after that, the lists are no longer tracked (the ignore flag will be set) and only counts are tracked.
+     * REMOVEDUIDs are tracked to handle minor and partial major compactions where this reduce method won't necessarily see all possible values for a given key
+     * (e.g., the UIDs that are being removed might be in a different RFile that isn't involved in the current compaction).
+     *
+     * Aggregation operates in one of two modes depending on whether or not timestamps are ignored. By default, timestamps are ignored since DataWave uses date
+     * to the day as the timestamp in the global term index. When timestamps are ignored, we cannot infer anything about the order of values under aggregation.
+     * Therefore, a decision must be made about how to handle removed UIDs vs added UIDs. In that case, removed UIDs take priority. This means that adding a
+     * UID, then removing it, and adding it back again is not a supported operation. When timestamps are not ignored, then it is assumed that the timestamps are
+     * set properly and values will be processed in order from newest to oldest. In that case, it is possible to add a UID, then remove it, and add it back
+     * again.
+     *
+     * @param key
+     *            the current key
+     * @param iter
+     *            an {@link Iterator} providing the UID lists to be aggregated
+     * @return a new {@link Value} containing the aggregated result
      */
     @Override
     public Value reduce(Key key, Iterator<Value> iter) {
-        if (log.isTraceEnabled())
-            log.trace("has next ? " + iter.hasNext());
+        log.trace("has next ? {}", iter.hasNext());
         while (iter.hasNext()) {
             
             Value value = iter.next();
@@ -156,72 +150,77 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
                 
                 long delta = v.getCOUNT();
                 
-                count += delta;
-                /**
-                 * Fail fast approach.
-                 */
-                if (v.getIGNORE()) {
+                // For best performance, don't attempt to accumulate any individual UIDs (or removals)
+                // if this PB has its ignore flag set or we've seen any other PB with the ignored flag set.
+                if (v.getIGNORE() || seenIgnore) {
                     seenIgnore = true;
-                    if (log.isDebugEnabled())
-                        log.debug("SeenIgnore is true. Skipping collections");
+                    log.debug("SeenIgnore is true. Skipping collections");
+                } else {
+                    // Save a starting count in the event that we go over the max UID count while
+                    // aggregating this protocol buffer. Once we cross the max UID threshold, then we'll
+                    // only use the count reported by the protocol buffer. However, until that point
+                    // we want to count UIDs in the internal set since that will take care of de-duping
+                    // any duplicate UIDs which would be over counted if we just used the protocol buffer
+                    // count.
+                    long prevCount = uids.size();
+                    
+                    // Remove any UIDs in the REMOVEDUID list.
+                    for (String uid : v.getREMOVEDUIDList()) {
+                        // Don't remove the UID if it's in the UID list since that means a newer key
+                        // (larger timestamp value) added the UID and we don't want to undo that add.
+                        // If timestampsIgnored is set, then we are presuming lots of collisions on
+                        // timestamp and the order of incoming values is non-deterministic. In that case
+                        // we give precedence to a removal over an add and mark this UID as removed even
+                        // if it was in the UID list.
+                        //
+                        // If we're not propagating changes then don't bother adding UIDs to the
+                        // REMOVEDUID list. This happens if either we're doing a scan or a full major
+                        // compaction. In those cases, we're guaranteed that we'll see all of the values
+                        // for a given key and therefore there's no need to include removed UIDs in the
+                        // output protocol buffer since the remove have already been applied.
+                        if (timestampsIgnored) {
+                            uids.remove(uid);
+                            if (propogate)
+                                uidsToRemove.add(uid);
+                        } else if (propogate && !uids.contains(uid)) {
+                            uidsToRemove.add(uid);
+                        }
+                    }
+                    
+                    // Add UIDs from the UID list
+                    for (String uid : v.getUIDList()) {
+                        // Don't add a uid that's been removed. This is the same whether or
+                        // not timestamps are ignored since if they are ignored, removals take
+                        // priority and if they are not ignored, then this add is happening
+                        // before a removal and therefore should not take place.
+                        if (!uidsToRemove.contains(uid)) {
+                            // Add the UID iff we are under our MAX. If we reach the max,
+                            // then treat it as though we've seen an ignore--don't try to
+                            // add any more UIDs to the list (or removals from the REMOVEDUIDs
+                            // list) since they won't be included when we aggregate anyway.
+                            if (uids.size() < maxUids) {
+                                uids.add(uid);
+                            } else {
+                                // If aggregating this PB pushed us over the max UID limit,
+                                // then ignore any work we've done integrating this PB so far
+                                // and instead treat it as though its ignore flag had been set.
+                                // Set the count to the number of collected UIDs before we went
+                                // over the max, and then we'll add this PBs delta below.
+                                seenIgnore = true;
+                                count = prevCount;
+                                uids.clear();
+                                uidsToRemove.clear();
+                                break;
+                            }
+                        }
+                    }
                 }
                 
-                // if delta > 0, we are collecting the uid list
-                // in the protobuf into our object's uid list.
-                if (delta > 0) {
-                    
-                    for (String uid : v.getQUARANTINEUIDList()) {
-                        
-                        quarantinedIds.remove(uid);
-                        releasedUids.add(uid);
-                    }
-                    
-                    for (String uid : v.getUIDList()) {
-                        
-                        // check that a removal has not occurred
-                        // if it has, we decrement the count, from above.
-                        if (!uidsToRemove.contains(uid) && !quarantinedIds.contains(uid)) {
-                            
-                            // add the UID iff we are under our MAX
-                            if (uids.size() < maxUids)
-                                uids.add(uid);
-                            
-                        }
-                        
-                    }
-                    
-                    if (log.isDebugEnabled())
-                        log.debug("Adding uids " + delta + " " + count);
-                    
-                    // if our delta is < 0, then we can remove, iff seenIgnore is false. If it is true, there is no need to proceed with removals
-                } else if (delta < 0 && !seenIgnore) {
-                    
-                    // so that we can perform the decrement
-                    for (String uid : v.getREMOVEDUIDList()) {
-                        
-                        uidsToRemove.add(uid);
-                        
-                        if (uids.contains(uid)) {
-                            
-                            uids.remove(uid);
-                        }
-                        
-                    }
-                    
-                    quarantinedIds.addAll(v.getQUARANTINEUIDList());
-                    
-                    /**
-                     * This is added for backwards compatability. The removal list was added to ensure that removals are propogated across compactions. In the
-                     * case where compactions did not occur, and the indices are converted into the newer protobuff, we must use the UID list to maintain
-                     * removals for deltas less than 0
-                     */
-                    for (String uid : v.getUIDList()) {
-                        // add to uidsToRemove, and decrement count if the uid is in UIDS
-                        uidsToRemove.add(uid);
-                        if (uids.contains(uid)) {
-                            uids.remove(uid);
-                        }
-                    }
+                // If we've seen an ignore, then we won't be outputting a UID list and therefore
+                // need to just assume the count in the incoming protocol buffer is correct and
+                // use it.
+                if (seenIgnore) {
+                    count += delta;
                 }
                 
             } catch (InvalidProtocolBufferException e) {
@@ -236,43 +235,54 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
     }
     
     public void reset() {
-        if (log.isDebugEnabled())
-            log.debug("Resetting GlobalIndexUidAggregator");
+        log.debug("Resetting GlobalIndexUidAggregator");
         count = 0;
         seenIgnore = false;
-        builder = Uid.List.newBuilder();
         uids.clear();
         uidsToRemove.clear();
-        releasedUids.clear();
-        quarantinedIds.clear();
     }
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.ingest.table.aggregator.PropogatingAggregator#propogateKey()
-     */
     @Override
     public boolean propogateKey() {
         
-        /**
-         * Changed logic so that if seenIgnore is true and count > MAX, we keep propogate the key
-         */
-        if ((seenIgnore && count > maxUids) || !quarantinedIds.isEmpty())
-            return true;
-        
-        HashSet<String> uidsCopy = new HashSet<>(uids);
-        uidsCopy.removeAll(uidsToRemove);
-        
-        if (log.isDebugEnabled()) {
-            log.debug(count + " " + uids.size() + " " + uidsToRemove.size() + " " + uidsCopy.size() + " removing " + (count == 0 && uidsCopy.isEmpty()));
-        }
-        
-        // if <= 0 and uids is empty, we can safely remove
-        if (count <= 0 && uidsCopy.isEmpty())
-            return false;
-        else
-            return true;
+        // This method is called after reduce and then aggregate, so all of the work to combine has been done.
+        // If the propogate flag is true, then this might have been a partial major compaction, scan, or minor
+        // compaction and we want to keep all keys no matter what. When propogate is false, that means it's a scan or
+        // full major compaction and therefore we can be certain that the aggregated result has combined all possible
+        // values for a given key. In that case, we only need to keep the resulting key/value pair if it has any UIDs
+        // (which means either UIDs in the uid list, or a positive uid count).
+        return propogate || !uids.isEmpty() || count > 0;
     }
     
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        boolean valid = super.validateOptions(options);
+        if (valid) {
+            if (options.containsKey(TIMESTAMPS_IGNORED)) {
+                timestampsIgnored = Boolean.parseBoolean(options.get(TIMESTAMPS_IGNORED));
+            }
+        }
+        return valid;
+    }
+    
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+        GlobalIndexUidAggregator copy = (GlobalIndexUidAggregator) super.deepCopy(env);
+        copy.timestampsIgnored = timestampsIgnored;
+        copy.propogate = propogate;
+        // Not copying other fields that are all cleared in the reset() method.
+        return copy;
+    }
+    
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        super.init(source, options, env);
+        if (options.containsKey(TIMESTAMPS_IGNORED)) {
+            timestampsIgnored = Boolean.parseBoolean(options.get(TIMESTAMPS_IGNORED));
+        }
+    }
+    
+    public static void setTimestampsIgnoredOpt(IteratorSetting is, boolean timestampsIgnored) {
+        is.addOption(TIMESTAMPS_IGNORED, Boolean.toString(timestampsIgnored));
+    }
 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/KeepCountOnlyUidAggregator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/KeepCountOnlyUidAggregator.java
@@ -7,6 +7,15 @@ package datawave.ingest.table.aggregator;
  * The intent of this iterator is to prevent accidental deletion of count only protobufs in case extra deletions occur.
  */
 public class KeepCountOnlyUidAggregator extends GlobalIndexUidAggregator {
+    
+    public KeepCountOnlyUidAggregator(int max) {
+        super(max);
+    }
+    
+    public KeepCountOnlyUidAggregator() {
+        super();
+    }
+    
     @Override
     public boolean propogateKey() {
         return isSeenIgnore() || super.propogateKey();

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
@@ -1,0 +1,1129 @@
+package datawave.ingest.table.aggregator;
+
+import datawave.ingest.protobuf.Uid;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GlobalIndexUidAggregatorExpandedTest {
+    
+    private static final Key KEY = new Key("key");
+    
+    private GlobalIndexUidAggregator agg = new GlobalIndexUidAggregator();
+    
+    // For this set of tests, Forward and Reverse refer to the aggregation order of the
+    // values. This is not to be confused with the ordering of Accumulo Keys.
+    // In this context, Forward means that the values will be aggregated in the same
+    // order that is provided to the test. Reverse means that they will be aggregated in
+    // the reverse order that is provided to the test.
+    private boolean isForwardOnlyTest = false;
+    
+    // For minor compactions and partial major compactions, Accumulo may not have all of
+    // the available Values for a given Key. Additional data may exist in other rfiles.
+    // As a result, the Aggregator must preserve (AKA propagate) certain information, such
+    // as removal markers, in case that information would impact data in those other rfiles.
+    // For scans and full major compactions, on the other hand, Accumulo is guaranteed to
+    // have all available Values for a given Key. With this complete view of the data, it
+    // is possible for the Aggregator to make final decisions and to thus eliminate the
+    // data that would otherwise be preserved, such as removal markers.
+    private boolean isFullCompactionOnlyTest = false;
+    private boolean isPartialCompactionOnlyTest = false;
+    
+    @Before
+    public void setup() {
+        agg.reset();
+    }
+    
+    @Test
+    public void twoSingleUids() {
+        // Do UID lists get combined across values?
+        Value value1 = UidTestBuilder.uidList("uid1");
+        Value value2 = UidTestBuilder.uidList("uid2");
+        
+        // @formatter:off
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removalAcrossValue() {
+        // @formatter:off
+        // Does a UID removal work across Values?
+        // Are UID removals maintained in partial compactions?
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4") // uid4 in other value's list
+                .build();
+        
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .build();
+        
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3", "uid5", "uid6")
+                .withRemovals("uid4")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removalAbsent() {
+        // Are UID removals maintained in partial compactions, without a match?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid7") // uid7 absent from both lists
+                        .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3", "uid4", "uid5", "uid6")
+                        .withRemovals("uid7")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removalsCrissCross() {
+        // Do UID removals work across Values in both directions?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4") // uid4 in other list
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .withRemovals("uid1") // uid1 in other list
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid2", "uid3", "uid5", "uid6")
+                .withRemovals("uid1", "uid4")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removalCrissCrossAndAbsent() {
+        // Does a mixture of a removal-that-hits and a removal-that-doesn't-hit work?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4") // uid4 in other list
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .withRemovals("uid7") // uid7 absent
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3", "uid5", "uid6")
+                .withRemovals("uid4", "uid7")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removeAllAcrossValue() {
+        // Do removals of all UIDs in another list work?
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6") // all UIDs in other list
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removeMultipleAbsent() {
+        // Are multiple removals persisted in partial compactions, even without matching?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid7", "uid8", "uid9") // all UIDs absent
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3", "uid4", "uid5", "uid6")
+                .withRemovals("uid7", "uid8", "uid9") // all UIDs absent
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removeAllAcrossBothValues() {
+        // Do multiple removals wipe UIDs across Values and persist on partial compactions?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6") // all UIDs in other list
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .withRemovals("uid1", "uid2", "uid3") // all UIDs in other list
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5", "uid6")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removeSecondValueUidsPlusAbsent() {
+        // Do multiple removals-that-hit and multiple removals-that-don't-hit work like single removals?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6") // all UIDs in other list
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .withRemovals("uid7", "uid8", "uid9") // all absent
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6", "uid7", "uid8", "uid9")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removeMixture() {
+        // Mixture of hit and non-hit removals within one Value.
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid6", "uid7") // two UIDs in other list, one absent
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .withRemovals("uid8", "uid9") // all absent
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3", "uid5")
+                .withRemovals("uid4", "uid6", "uid7", "uid8", "uid9")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void extraIdInRemovals() {
+        // Another variation of a mixture of hit and non-hit removals within one Value.
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6", "uid7") // all UIDs in other list, one absent
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6", "uid7")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void matchingAndExtraRemovalIds() {
+        // Do extra non-hit-removals persist when mixed with hit-removals?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2", "uid3")
+                .withRemovals("uid4", "uid5", "uid6", "uid7") // all UIDs in other list, one absent
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid4", "uid5", "uid6")
+                .withRemovals("uid1", "uid2", "uid3", "uid8") // all UIDs in other list, one absent
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void loneRemovalId() {
+        // Does a single removal work when seen in the second Value?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid2") // removal of one uid in other list
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1")
+                .withRemovals("uid2")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void loneRemovalExtra() {
+        // Does a non-matching removal persist?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid3") // removal of one UID, not matching other list
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .withRemovals("uid3")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void removalAvoidsExceedingMax() {
+        // With a lowered maximum, is count-only mode avoided with a matching removal?
+        
+        // @formatter:off
+        agg = new GlobalIndexUidAggregator(2);
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3")
+                .withRemovals("uid1") // removal of one UID in other list
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid2", "uid3")
+                .withRemovals("uid1")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void exceedMax() {
+        // In exceeding the maximum, is count-only mode reached?
+        
+        // @formatter:off
+        agg = new GlobalIndexUidAggregator(2);
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void exceedsMaxTwice() {
+        // Do counts add properly in count-only mode?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(6)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void doNotGoNegativeForNamedUids() {
+        // Are removals persisted in partial compaction mode?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid4", "uid5", "uid6", "uid7")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid8")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5", "uid6", "uid7", "uid8")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void unexpectedDataHandling() {
+        // Does a legacy Value (no UIDs, not count-only, yet a count=1) get effectively ignored?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withCountOverride(1)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid3", "uid4")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid2")
+                .withRemovals("uid1", "uid3", "uid4")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void duplicatesRecountedUnderSeenIgnore() {
+        // Does a count-only Value, when seen first, prevent de-duplication of named
+        // UID lists (done for performance optimization)?
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(11)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(15)
+                .build());
+        // @formatter:on
+        
+        // not testing the reversal because its behavior is captured
+        // in testDuplicatesRecountedUnderSeenIgnoreReverse
+        isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void duplicatesRecountedUnderSeenIgnoreReverse() {
+        // Does a count-only Value, when seen last, NOT prevent de-duplication of named
+        // UID lists (done for performance optimization)?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withCountOnly(11)
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(13)
+                .build());
+        // @formatter:on
+        
+        // not testing the reversal because its behavior is captured
+        // in testDuplicatesRecountedUnderSeenIgnore
+        isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void floorOfZeroWhenSeenIgnoreFalse() {
+        // Does count match size of UID list even when there are more removal UIDs than UIDs?
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder().withUids()
+                .withRemovals("uid1", "uid2", "uid3")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void preserveRemovals() {
+        // Does count match size of UID list even when there are propagated removals?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid3", "uid4")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .withRemovals("uid3", "uid4")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void preserveTwoRemovalLists() {
+        // Are removals propagated and the count left at zero?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid3", "uid4")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void shouldDeduplicate() {
+        // Do we avoid temporarily exceeding the (lowered) maximum when re-adding
+        // an already included UID?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1")
+                .withRemovals("uid2")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void shouldDeduplicateVariant() {
+        // Same as testDeduplicates but with a non-matching removal UID:
+        // Do we avoid temporarily exceeding the (lowered) maximum when re-adding
+        // an already included UID?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid4")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .withRemovals("uid4")
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void evaluatesMaxWithEachAddition() {
+        // Does removal after exceeding max simply deduct from the count?
+        
+        // @formatter:off
+        agg = new GlobalIndexUidAggregator(2);
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(2)
+                .build());
+        // @formatter:on
+        
+        // Reverse ordering is tested in testEvaluatesMaxWithEachAdditionReverse
+        isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void evaluatesMaxWithEachAdditionReverse() {
+        // Does removal before exceeding max avoid count-only mode?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withUids("uid2", "uid3")
+                .withRemovals("uid1")
+                .build());
+        // @formatter:on
+        
+        // Reverse ordering is tested in testEvaluatesMaxWithEachAddition
+        isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void seenIgnoreAddsTwoValues() {
+        // Do additions and removals after a count-only Value simply adjust the count?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        // Add two
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        // Net zero
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids("uid4")
+                .withRemovals("uid2") // happens to match prior value's uid2
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(5)
+                .build());
+        // @formatter:on
+        
+        // The behavior for the reverse ordering is captured
+        // in seenIgnoreAddsTwoValuesReverse
+        isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void seenIgnoreAddsTwoValuesReverse() {
+        // uid2 from value2 will be removed because of the removal UID from value1
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid4")
+                .withRemovals("uid2")
+                .build();
+
+        // After value1 and value2 are combined:
+        // uids=uid1,uid4 (count of 2)
+        // removals=uid2
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        // Count-only encountered, so current removal count subtracted from uid count (uid1,uid4 - uid2 = 1)
+        // Add three to it.
+        // Total expected count is 4.
+        Value value3 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(4)
+                .build());
+        // @formatter:on
+        
+        // The behavior for the reverse ordering is captured
+        // in seenIgnoreAddsTwoValues
+        isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void addUidToNegativeCount() {
+        // Will negative count-only, combined with named uid, result in zero?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(-1)
+                .build();
+
+        // Combine -1 (count-only) with a named uid will increment the count
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void negativeCountSetToZeroAfterFullCompaction() {
+        // Will a negative count, combined with a removal, result in a zero count for
+        // full compactions?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(-1)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        isFullCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void negativeCountRemainsAfterPartialCompaction() {
+        // Will a negative count, combined with a removal, result in a negative two count in
+        // propagation scenarios?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(-1)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-2)
+                .build());
+        // @formatter:on
+        
+        isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void anotherNegativeSetToZeroAfterFullCompaction() {
+        // Will a negative count (due to two removals) be changed to a zero
+        // count for full compactions?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(1)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        isFullCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void anotherNegativeRemainsAfterPartialCompaction() {
+        // Will a negative count (due to two removals) propagate
+        // as a negative count for partial compactions?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(1)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-1)
+                .build());
+        // @formatter:on
+        
+        isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void seenIgnoreAddsTwoValuesNoMatch() {
+        // Will count-only take into account the available information when
+        // flipping to seenIgnore?
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids("uid4")
+                .withRemovals("uid3") // does not match prior value's uid list
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(5)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void countOnlyWhenExceedMax() {
+        // Will count-only status continue after decrementing to no longer
+        // exceed maximum?
+        
+        // @formatter:off
+        agg = new GlobalIndexUidAggregator(2);
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1", "uid2")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder().withUids()
+                .withRemovals("uid4")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(2)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void combineCountAndNamedListDeterministic() {
+        // Will a flip to seenIgnore take into account the available
+        // information?
+        // Note this tests both orderings of values (forward and reverse).
+        // 1. either start with a count-only and add two uids
+        // 2. or start with two named uids and add a count-only
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3", "uid4")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(5)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void exceedMaxAddTwoDropOne() {
+        // Will flipping to seen ignore take into account the available information?
+        // Note this tests both orderings of values.
+        // i.e., count = this.uids.size() - this.uidsToRemove.size();
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(3)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid3", "uid4")
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids().withRemovals("uid5")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(4)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void removalToZeroCount() {
+        // Will flipping to seen ignore take into account the available information?
+        // Note this tests both orderings of values.
+        // i.e., count = this.uids.size() - this.uidsToRemove.size();
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(1)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void countOnlyReduced() {
+        // Will flipping to seen ignore take into account the available information?
+        // Note this tests both orderings of values.
+        // i.e., count = this.uids.size() - this.uidsToRemove.size();
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withCountOnly(30)
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(28)
+                .build());
+        // @formatter:on
+        
+        testCombinations(expectation, value1, value2);
+    }
+    
+    // For Forward, Partial, and Full see the comments by the boolean field declarations
+    private void testCombinations(Uid.List expectation, Value... inputValues) {
+        List<Value> input = asList(inputValues);
+        // There should be nothing in the removal UID list after a Full Major Compaction
+        
+        // @formatter:off
+        Uid.List expectNoRemovals = Uid.List.newBuilder()
+                .mergeFrom(expectation)
+                .clearREMOVEDUID()
+                .build();
+        // @formatter:on
+        
+        if (!isFullCompactionOnlyTest) {
+            verify("Forward, Partial Major", expectation, testAsPartialCompaction(input));
+        }
+        
+        if (!isPartialCompactionOnlyTest) {
+            verify("Forward, Full Major", expectNoRemovals, testAsFullMajorCompaction(input));
+        }
+        
+        // See the comment by isForwardOnlyTest declaration
+        if (!isForwardOnlyTest) {
+            // Reverse the ordering of the input and try again
+            // See the comment by isForwardOnlyTest declaration
+            Collections.reverse(input);
+            
+            if (!isFullCompactionOnlyTest) {
+                verify("Reverse, Partial Major", expectation, testAsPartialCompaction(input));
+            }
+            
+            if (!isPartialCompactionOnlyTest) {
+                verify("Reverse, Full Major", expectNoRemovals, testAsFullMajorCompaction(input));
+            }
+        }
+    }
+    
+    private Uid.List testAsPartialCompaction(List<Value> values) {
+        agg.reset();
+        agg.propogate = true;
+        return UidTestBuilder.valueToUidList(agg.reduce(KEY, values.iterator()));
+    }
+    
+    private Uid.List testAsFullMajorCompaction(List<Value> values) {
+        agg.reset();
+        agg.propogate = false;
+        return UidTestBuilder.valueToUidList(agg.reduce(KEY, values.iterator()));
+    }
+    
+    private void verify(String label, Uid.List expectation, Uid.List result) {
+        assertEquals("getIGNORE differs - " + label, expectation.getIGNORE(), result.getIGNORE());
+        
+        for (String expectedUid : expectation.getUIDList()) {
+            assertTrue("UID list missing " + expectedUid + " - " + label, result.getUIDList().contains(expectedUid));
+        }
+        assertEquals("UID count differs - " + label + " " + result.getUIDList(), expectation.getCOUNT(), result.getCOUNT());
+        assertEquals("UID list size differs - " + label, expectation.getUIDList().size(), result.getUIDList().size());
+        // The count and UID List sizes should match unless seenIgnore = true
+        if (!expectation.getIGNORE()) {
+            assertEquals("Invalid test state: expected variable's Uid.List size and getCount differ - " + label, expectation.getCOUNT(), expectation
+                            .getUIDList().size());
+        }
+        
+        for (String expectedRemovalUid : expectation.getREMOVEDUIDList()) {
+            assertTrue("Remove UID list missing " + expectedRemovalUid + " - " + label, result.getREMOVEDUIDList().contains(expectedRemovalUid));
+        }
+        assertEquals("Removed count differs - " + label, expectation.getREMOVEDUIDCount(), result.getREMOVEDUIDCount());
+        assertEquals("Removed UID list size differs - " + label, expectation.getREMOVEDUIDList().size(), result.getREMOVEDUIDList().size());
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorTest.java
@@ -4,22 +4,23 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import datawave.ingest.protobuf.Uid;
 import datawave.ingest.protobuf.Uid.List.Builder;
+
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static datawave.ingest.table.aggregator.UidTestUtils.countOnlyList;
 import static datawave.ingest.table.aggregator.UidTestUtils.legacyRemoveUidList;
-import static datawave.ingest.table.aggregator.UidTestUtils.quarantineUidList;
-import static datawave.ingest.table.aggregator.UidTestUtils.releaseUidList;
 import static datawave.ingest.table.aggregator.UidTestUtils.removeUidList;
 import static datawave.ingest.table.aggregator.UidTestUtils.uidList;
 import static datawave.ingest.table.aggregator.UidTestUtils.valueToUidList;
@@ -33,19 +34,35 @@ public class GlobalIndexUidAggregatorTest {
     
     PropogatingCombiner agg = new GlobalIndexUidAggregator();
     
-    private Uid.List.Builder createNewUidList() {
+    private Builder createNewUidList() {
         return Uid.List.newBuilder();
+    }
+    
+    private Builder createNewUidList(String... uidsToAdd) {
+        Builder b = createNewUidList();
+        b.setIGNORE(false);
+        b.setCOUNT(uidsToAdd.length);
+        Arrays.stream(uidsToAdd).forEach(b::addUID);
+        return b;
+    }
+    
+    private Builder createNewRemoveUidList(String... uidsToRemove) {
+        Builder b = createNewUidList();
+        b.setIGNORE(false);
+        b.setCOUNT(-uidsToRemove.length);
+        Arrays.stream(uidsToRemove).forEach(b::addREMOVEDUID);
+        return b;
+    }
+    
+    private Value toValue(Builder uidListBuilder) {
+        return new Value(uidListBuilder.build().toByteArray());
     }
     
     @Test
     public void testSingleUid() {
         agg.reset();
-        Builder b = createNewUidList();
-        b.setCOUNT(1);
-        b.setIGNORE(false);
-        b.addUID(UUID.randomUUID().toString());
-        Uid.List uidList = b.build();
-        Value val = new Value(uidList.toByteArray());
+        String uuid = UUID.randomUUID().toString();
+        Value val = toValue(createNewUidList(uuid));
         
         Value result = agg.reduce(new Key("key"), Iterators.singletonIterator(val));
         assertNotNull(result);
@@ -60,19 +77,14 @@ public class GlobalIndexUidAggregatorTest {
         List<String> savedUUIDs = new ArrayList<>();
         Collection<Value> values = Lists.newArrayList();
         for (int i = 0; i < GlobalIndexUidAggregator.MAX - 1; i++) {
-            Builder b = createNewUidList();
-            b.setIGNORE(false);
             String uuid = UUID.randomUUID().toString();
-            savedUUIDs.add(uuid);
-            b.setCOUNT(1);
-            b.addUID(uuid);
-            Uid.List uidList = b.build();
-            Value val = new Value(uidList.toByteArray());
+            Value val = toValue(createNewUidList(uuid));
             values.add(val);
+            savedUUIDs.add(uuid);
         }
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
-        assertEquals(false, resultList.getIGNORE());
+        assertFalse(resultList.getIGNORE());
         assertEquals(resultList.getUIDCount(), (GlobalIndexUidAggregator.MAX - 1));
         List<String> resultListUUIDs = resultList.getUIDList();
         for (String s : savedUUIDs)
@@ -85,20 +97,15 @@ public class GlobalIndexUidAggregatorTest {
         List<String> savedUUIDs = new ArrayList<>();
         Collection<Value> values = Lists.newArrayList();
         for (int i = 0; i < GlobalIndexUidAggregator.MAX; i++) {
-            Builder b = createNewUidList();
-            b.setIGNORE(false);
             String uuid = UUID.randomUUID().toString();
-            savedUUIDs.add(uuid);
-            b.setCOUNT(1);
-            b.addUID(uuid);
-            Uid.List uidList = b.build();
-            Value val = new Value(uidList.toByteArray());
+            Value val = toValue(createNewUidList(uuid));
             values.add(val);
+            savedUUIDs.add(uuid);
         }
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
         assertNotNull(resultList);
-        assertEquals(false, resultList.getIGNORE());
+        assertFalse(resultList.getIGNORE());
         assertEquals(resultList.getUIDCount(), (GlobalIndexUidAggregator.MAX));
         List<String> resultListUUIDs = resultList.getUIDList();
         for (String s : savedUUIDs)
@@ -108,22 +115,15 @@ public class GlobalIndexUidAggregatorTest {
     @Test
     public void testMoreThanMax() throws Exception {
         agg.reset();
-        List<String> savedUUIDs = new ArrayList<>();
         Collection<Value> values = Lists.newArrayList();
         for (int i = 0; i < GlobalIndexUidAggregator.MAX + 10; i++) {
-            Builder b = createNewUidList();
-            b.setIGNORE(false);
             String uuid = UUID.randomUUID().toString();
-            savedUUIDs.add(uuid);
-            b.setCOUNT(1);
-            b.addUID(uuid);
-            Uid.List uidList = b.build();
-            Value val = new Value(uidList.toByteArray());
+            Value val = toValue(createNewUidList(uuid));
             values.add(val);
         }
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
-        assertEquals(true, resultList.getIGNORE());
+        assertTrue(resultList.getIGNORE());
         assertEquals(0, resultList.getUIDCount());
         assertEquals(resultList.getCOUNT(), (GlobalIndexUidAggregator.MAX + 10));
     }
@@ -134,39 +134,23 @@ public class GlobalIndexUidAggregatorTest {
         List<String> savedUUIDs = new ArrayList<>();
         Collection<Value> values = Lists.newArrayList();
         for (int i = 0; i < GlobalIndexUidAggregator.MAX / 2; i++) {
-            Builder b = createNewUidList();
-            b.setIGNORE(false);
             String uuid = UUID.randomUUID().toString();
-            savedUUIDs.add(uuid);
-            
-            b.setCOUNT(-1);
-            b.addREMOVEDUID(uuid);
-            Uid.List uidList = b.build();
-            Value val = new Value(uidList.toByteArray());
+            Value val = toValue(createNewRemoveUidList(uuid));
             values.add(val);
+            savedUUIDs.add(uuid);
         }
-        int i = 0;
         
         for (int j = 0; j < 1; j++) {
             for (String uuid : savedUUIDs) {
-                Builder b = createNewUidList();
-                b.setIGNORE(false);
-                if ((i % 2) == 0)
-                    b.setCOUNT(1);
-                else
-                    b.setCOUNT(1);
-                b.addUID(uuid);
-                Uid.List uidList = b.build();
-                Value val = new Value(uidList.toByteArray());
+                Value val = toValue(createNewUidList(uuid));
                 values.add(val);
-                i++;
             }
         }
         
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
-        assertEquals(resultList.getUIDCount(), 0);
-        assertEquals(resultList.getCOUNT(), 0);
+        assertEquals(0, resultList.getUIDCount());
+        assertEquals(0, resultList.getCOUNT());
         
     }
     
@@ -177,20 +161,15 @@ public class GlobalIndexUidAggregatorTest {
         Builder b = createNewUidList();
         b.setIGNORE(true);
         b.setCOUNT(0);
-        Uid.List uidList = b.build();
         Collection<Value> values = Lists.newArrayList();
-        Value val = new Value(uidList.toByteArray());
+        Value val = toValue(b);
         values.add(val);
-        b = createNewUidList();
-        b.setIGNORE(false);
-        b.setCOUNT(1);
-        b.addUID(UUID.randomUUID().toString());
-        uidList = b.build();
-        val = new Value(uidList.toByteArray());
+        String uuid = UUID.randomUUID().toString();
+        val = toValue(createNewUidList(uuid));
         values.add(val);
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
-        assertEquals(true, resultList.getIGNORE());
+        assertTrue(resultList.getIGNORE());
         assertEquals(0, resultList.getUIDCount());
         assertEquals(1, resultList.getCOUNT());
     }
@@ -206,7 +185,7 @@ public class GlobalIndexUidAggregatorTest {
         values.add(val);
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
-        assertEquals(false, resultList.getIGNORE());
+        assertFalse(resultList.getIGNORE());
         assertEquals(0, resultList.getUIDCount());
         assertEquals(0, resultList.getCOUNT());
         
@@ -214,47 +193,586 @@ public class GlobalIndexUidAggregatorTest {
     }
     
     @Test
-    public void testCount() throws Exception {
+    public void testCountUnderMax() throws Exception {
         agg.reset();
-        UUID uuid = UUID.randomUUID();
-        // Collect the same UUID five times.
+        // Collect five random UIDs
         Collection<Value> values = Lists.newArrayList();
         for (int i = 0; i < 5; i++) {
-            Builder b = createNewUidList();
-            b.setCOUNT(1);
-            b.setIGNORE(false);
-            b.addUID(uuid.toString());
-            Uid.List uidList = b.build();
-            Value val = new Value(uidList.toByteArray());
+            String uuid = UUID.randomUUID().toString();
+            Value val = toValue(createNewUidList(uuid));
             values.add(val);
         }
         Value result = agg.reduce(new Key("key"), values.iterator());
         Uid.List resultList = Uid.List.parseFrom(result.get());
         
         assertEquals(5, resultList.getCOUNT());
-        assertEquals(false, resultList.getIGNORE());
-        assertEquals(1, resultList.getUIDCount());
+        assertFalse(resultList.getIGNORE());
+        assertEquals(5, resultList.getUIDCount());
+        assertEquals(5, resultList.getUIDList().size());
         
     }
     
     @Test
-    public void testQuarantineAndRelease() {
-        // First quarantine uid1
-        List<Value> values = asList(uidList("uid1"), quarantineUidList("uid1"));
+    public void testCountWithDuplicates() throws Exception {
+        agg.reset();
+        String uuid = UUID.randomUUID().toString();
+        // Collect the same UUID five times.
+        Collection<Value> values = Lists.newArrayList();
+        for (int i = 0; i < 5; i++) {
+            Value val = toValue(createNewUidList(uuid));
+            values.add(val);
+        }
+        Value result = agg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
         
-        Value firstPassValue = agg(values);
-        Uid.List result = valueToUidList(firstPassValue);
+        assertEquals(1, resultList.getCOUNT());
+        assertFalse(resultList.getIGNORE());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(uuid, resultList.getUID(0));
         
-        assertTrue(result.getQUARANTINEUIDList().contains("uid1"));
-        assertFalse(result.getUIDList().contains("uid1"));
+    }
+    
+    @Test
+    public void testRemoveAndReAddUUID() throws Exception {
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator();
+        IteratorSetting is = new IteratorSetting(19, "test", GlobalIndexUidAggregator.class);
+        GlobalIndexUidAggregator.setTimestampsIgnoredOpt(is, false);
+        GlobalIndexUidAggregator.setCombineAllColumns(is, true);
+        localAgg.validateOptions(is.getOptions());
         
-        // Now release uid1
-        values = asList(firstPassValue, releaseUidList("uid1"));
-        Value secondPassValue = agg(values);
-        result = valueToUidList(secondPassValue);
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
         
-        assertFalse(result.getQUARANTINEUIDList().contains("uid1"));
-        assertTrue(result.getUIDList().contains("uid1"));
+        // Remove UUID2 and then re-add it.
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        // Both uuid1 and uuid2 should be in the UID list. Uuid1 should be there because we
+        // added and never touched it, and uuid2 should be there because the last thing we did
+        // with it was an add (even though there was an older remove for it).
+        Collections.reverse(values);
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(2, resultList.getCOUNT());
+        assertEquals(2, resultList.getUIDCount());
+        assertEquals(2, resultList.getUIDList().size());
+        assertEquals(0, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getUIDList().contains(uuid2));
+    }
+    
+    @Test
+    public void testRemoveAndReAddUUIDWithTimestampsIgnored() throws Exception {
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        
+        // Remove UUID2 and then re-add it.
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        // uuid1 should be in the UID list and uuid2 should be in the REMOVEDUID list. Uuid1
+        // should be there because we added and never touched it. uuid2 should be in the
+        // REMOVEDUID list even though the most recent action was an add because when timestamps
+        // are ignored, a remove takes precedence over any add.
+        Collections.reverse(values);
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid2));
+    }
+    
+    @Test
+    public void testNegativeCountWithPartialMajorCompaction() throws Exception {
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator();
+        IteratorSetting is = new IteratorSetting(19, "test", GlobalIndexUidAggregator.class);
+        GlobalIndexUidAggregator.setTimestampsIgnoredOpt(is, false);
+        GlobalIndexUidAggregator.setCombineAllColumns(is, true);
+        localAgg.validateOptions(is.getOptions());
+        
+        localAgg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        String uuid3 = UUID.randomUUID().toString();
+        String uuid4 = UUID.randomUUID().toString();
+        
+        // Collect the addition of uuid1 and the removal of uuid 2, 3, and 4 together.
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        values.add(toValue(createNewRemoveUidList(uuid3)));
+        values.add(toValue(createNewRemoveUidList(uuid4)));
+        
+        Collections.reverse(values);
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(3, resultList.getREMOVEDUIDCount());
+        assertEquals(3, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid2));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid3));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid4));
+        
+        localAgg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Simulate a partial major compaction by taking the previous combined result (the partial major compaction
+        // output) and include the original adds for uuid2-uuid4.
+        values.add(toValue(createNewUidList(uuid2)));
+        values.add(toValue(createNewUidList(uuid3)));
+        values.add(toValue(createNewUidList(uuid4)));
+        
+        // Don't reverse the collection since we want the adds for uuid2-4 to appear before
+        // the partially compacted protocol buffer. When we're considering timestamps, this
+        // order matters.
+        // Collections.reverse(values);
+        result = localAgg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(3, resultList.getREMOVEDUIDList().size());
+        assertEquals(uuid1, resultList.getUID(0));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid2));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid3));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid4));
+    }
+    
+    @Test
+    public void testNegativeCountWithPartialMajorCompactionAndTimestampsIgnored() throws Exception {
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator();
+        
+        localAgg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        String uuid3 = UUID.randomUUID().toString();
+        String uuid4 = UUID.randomUUID().toString();
+        
+        // Collect the addition of uuid1 and the removal of uuid 2, 3, and 4 together.
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        values.add(toValue(createNewRemoveUidList(uuid3)));
+        values.add(toValue(createNewRemoveUidList(uuid4)));
+        
+        Collections.reverse(values);
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(3, resultList.getREMOVEDUIDCount());
+        assertEquals(3, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid2));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid3));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid4));
+        
+        localAgg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Simulate a partial major compaction by taking the previous combined result (the partial major compaction
+        // output) and include the original adds for uuid2-4
+        values.add(toValue(createNewUidList(uuid2)));
+        values.add(toValue(createNewUidList(uuid3)));
+        values.add(toValue(createNewUidList(uuid4)));
+        
+        // Don't reverse the collection so that the adds for uuid2-4 appear after
+        // the removals. Even though the adds are last, when we're ignoring timestamps
+        // removals take precedence.
+        // Collections.reverse(values);
+        result = localAgg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(3, resultList.getREMOVEDUIDList().size());
+        assertEquals(uuid1, resultList.getUID(0));
+    }
+    
+    @Test
+    public void testRemoveAndReAddUUIDWithPartialMajorCompaction() throws Exception {
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator();
+        IteratorSetting is = new IteratorSetting(19, "test", GlobalIndexUidAggregator.class);
+        GlobalIndexUidAggregator.setTimestampsIgnoredOpt(is, false);
+        GlobalIndexUidAggregator.setCombineAllColumns(is, true);
+        localAgg.validateOptions(is.getOptions());
+        
+        localAgg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        
+        // Collect uuids 1 and 2 together in the UID list...
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        Collections.reverse(values);
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(2, resultList.getCOUNT());
+        assertEquals(2, resultList.getUIDCount());
+        assertEquals(2, resultList.getUIDList().size());
+        assertEquals(0, resultList.getREMOVEDUIDCount());
+        assertEquals(0, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getUIDList().contains(uuid2));
+        
+        localAgg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Simulate a partial major compaction by taking the previous combined result (the partial major compaction
+        // output) and add in a removal for uuid 2.
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        
+        Collections.reverse(values);
+        result = localAgg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertEquals(uuid1, resultList.getUID(0));
+        assertEquals(uuid2, resultList.getREMOVEDUID(0));
+        
+        localAgg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Take the previous combined result (which should have uuid1 in the uid list and uuid2 in the remove list)
+        // and add uuid2 back in. The combined result should have uuid1 in the uid list and uuid2 in the remove list.
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        Collections.reverse(values);
+        result = localAgg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        
+        assertEquals(2, resultList.getCOUNT());
+        assertEquals(2, resultList.getUIDCount());
+        assertEquals(2, resultList.getUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getUIDList().contains(uuid2));
+        assertEquals(0, resultList.getREMOVEDUIDList().size());
+    }
+    
+    @Test
+    public void testRemoveAndReAddUUIDWithTimestampsIgnoredAndPartialMajorCompaction() throws Exception {
+        agg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        
+        // Collect uuids 1 and 2 together in the UID list...
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        Collections.reverse(values);
+        Value result = agg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(2, resultList.getCOUNT());
+        assertEquals(2, resultList.getUIDCount());
+        assertEquals(2, resultList.getUIDList().size());
+        assertEquals(0, resultList.getREMOVEDUIDCount());
+        assertEquals(0, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getUIDList().contains(uuid2));
+        
+        agg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Simulate a partial major compaction by taking the previous combined result (the partial major compaction
+        // output) and add in a removal for uuid 2.
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        
+        Collections.reverse(values);
+        result = agg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertEquals(uuid1, resultList.getUID(0));
+        assertEquals(uuid2, resultList.getREMOVEDUID(0));
+        
+        agg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Take the previous combined result (which should have uuid1 in the uid list and uuid2 in the remove list)
+        // and add uuid2 back in. The combined result should have uuid1 in the uid list and uuid2 in the remove list.
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        Collections.reverse(values);
+        result = agg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid2));
+    }
+    
+    @Test
+    public void testAggregateWithZeroCountAndUUIDs() throws Exception {
+        agg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        
+        // Add uuid1 and remove uuid2 (which hasn't been added yet) to produce a zero count.
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid2)));
+        
+        Collections.reverse(values);
+        Value result = agg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getCOUNT());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid2));
+        
+        agg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Take the previous result (simulating a partial major compaction) and add uuid2 first (before the removal).
+        // We should end up with only uuid1 in the uuid list, and uuid2 in the remove list (if we did a full major
+        // compaction, then uuid1 would be gone from the remove list too).
+        values.add(toValue(createNewUidList(uuid2)));
+        
+        Collections.reverse(values);
+        result = agg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertEquals(uuid1, resultList.getUID(0));
+        assertEquals(uuid2, resultList.getREMOVEDUID(0));
+    }
+    
+    @Test
+    public void testAggregateWithPositiveCountAndUUIDs() throws Exception {
+        agg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        String uuid3 = UUID.randomUUID().toString();
+        
+        // Add uuid2 and uuid3 as well as removing uuid1 (which hasn't been added yet).
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid2)));
+        values.add(toValue(createNewUidList(uuid3)));
+        values.add(toValue(createNewRemoveUidList(uuid1)));
+        
+        Collections.reverse(values);
+        Value result = agg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(2, resultList.getCOUNT());
+        assertEquals(2, resultList.getUIDCount());
+        assertEquals(2, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid2));
+        assertTrue(resultList.getUIDList().contains(uuid3));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid1));
+        
+        agg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Take the previous result (simulating a partial major compaction) and add uuid1 first (before the removal).
+        // We should end up with only uuid2 and uuid3 in the uuid list, and uuid1 in the remove list (if we did a full
+        // major compaction, then uuid1 would be gone from the remove list too).
+        values.add(toValue(createNewRemoveUidList(uuid1)));
+        
+        Collections.reverse(values);
+        result = agg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(2, resultList.getUIDCount());
+        assertEquals(2, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertTrue(resultList.getUIDList().contains(uuid2));
+        assertTrue(resultList.getUIDList().contains(uuid3));
+        assertTrue(resultList.getREMOVEDUIDList().contains(uuid1));
+    }
+    
+    @Test
+    public void testAddUIDTwice() throws Exception {
+        agg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        ArrayList<Value> values = Lists.newArrayList();
+        
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid1)));
+        
+        Value result = agg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getUIDCount());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getCOUNT());
+    }
+    
+    @Test
+    public void testAddUIDThrice() throws Exception {
+        // lowered max to show problem more easily
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator(2);
+        
+        String uuid1 = UUID.randomUUID().toString();
+        ArrayList<Value> values = Lists.newArrayList();
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid1)));
+        
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getUIDCount());
+        assertTrue(resultList.getUIDList().contains(uuid1));
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(1, resultList.getCOUNT());
+    }
+    
+    @Test
+    public void testAddDuplicateUUIDWithSeenIgnore() throws Exception {
+        // lowered max to show problem more easily
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator(2);
+        
+        String uuid1 = UUID.randomUUID().toString();
+        ArrayList<Value> values = Lists.newArrayList();
+        
+        // Add 3 uuids, which will put the protocol buffer over the max and
+        // cause the ignore flag to be set. Then add a duplicate uuid a couple
+        // more times. Once we've exceeded the limit, we don't have a list of
+        // UIDs anymore to check for duplicates so we simply count incoming
+        // UIDs.
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(UUID.randomUUID().toString())));
+        values.add(toValue(createNewUidList(UUID.randomUUID().toString())));
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid1)));
+        
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(0, resultList.getUIDCount());
+        assertEquals(0, resultList.getUIDList().size());
+        assertEquals(5, resultList.getCOUNT());
+    }
+    
+    @Test
+    public void testAddDuplicateUUIDWithSeenIgnoreAndCompaction() throws Exception {
+        // lowered max to show problem more easily
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator(2);
+        
+        String uuid1 = UUID.randomUUID().toString();
+        ArrayList<Value> values = Lists.newArrayList();
+        
+        // Add 3 uuids, which will put the protocol buffer over the max and
+        // cause the ignore flag to be set.
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewUidList(UUID.randomUUID().toString())));
+        values.add(toValue(createNewUidList(UUID.randomUUID().toString())));
+        
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(0, resultList.getUIDCount());
+        assertEquals(0, resultList.getUIDList().size());
+        assertEquals(3, resultList.getCOUNT());
+        
+        // Simulate a compaction
+        localAgg.reset();
+        values.clear();
+        values.add(result);
+        
+        // Now add uuid1 in a new protocol buffer. Even though it's a duplicate,
+        // since we're merging it in to a protocol buffer with the ignore flag
+        // set, we'll simply trust the count (since we don't have any individual
+        // UIDs to check for duplicates).
+        values.add(toValue(createNewUidList(uuid1)));
+        
+        result = localAgg.reduce(new Key("key"), values.iterator());
+        resultList = Uid.List.parseFrom(result.get());
+        assertEquals(0, resultList.getUIDCount());
+        assertEquals(0, resultList.getUIDList().size());
+        assertEquals(4, resultList.getCOUNT());
+    }
+    
+    @Test
+    public void testRemoveAndReAdd() throws Exception {
+        GlobalIndexUidAggregator localAgg = new GlobalIndexUidAggregator();
+        IteratorSetting is = new IteratorSetting(19, "test", GlobalIndexUidAggregator.class);
+        GlobalIndexUidAggregator.setTimestampsIgnoredOpt(is, false);
+        GlobalIndexUidAggregator.setCombineAllColumns(is, true);
+        localAgg.validateOptions(is.getOptions());
+        
+        localAgg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        ArrayList<Value> values = Lists.newArrayList();
+        
+        // When we're considering timestamps, an add of a UID, followed by a removal
+        // of that UID, and then a re-add should result in the UID ending up in the
+        // UID list.
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid1)));
+        
+        Value result = localAgg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(1, resultList.getUIDCount());
+        assertEquals(1, resultList.getUIDList().size());
+        assertEquals(0, resultList.getREMOVEDUIDCount());
+        assertEquals(0, resultList.getREMOVEDUIDList().size());
+        assertEquals(1, resultList.getCOUNT());
+    }
+    
+    @Test
+    public void testRemoveAndReAddWithTimestampsIgnored() throws Exception {
+        agg.reset();
+        
+        String uuid1 = UUID.randomUUID().toString();
+        ArrayList<Value> values = Lists.newArrayList();
+        
+        // The default behavior of the aggregator is that timestamps are ignored. In that case,
+        // a remove takes priority over an add no matter what the order. Therefore, if we
+        // add a UID, then remove it, then re-add it, the expected result is that the UID will
+        // be removed.
+        values.add(toValue(createNewUidList(uuid1)));
+        values.add(toValue(createNewRemoveUidList(uuid1)));
+        values.add(toValue(createNewUidList(uuid1)));
+        
+        Value result = agg.reduce(new Key("key"), values.iterator());
+        Uid.List resultList = Uid.List.parseFrom(result.get());
+        assertEquals(0, resultList.getUIDCount());
+        assertEquals(0, resultList.getUIDList().size());
+        assertEquals(1, resultList.getREMOVEDUIDCount());
+        assertEquals(1, resultList.getREMOVEDUIDList().size());
+        assertEquals(0, resultList.getCOUNT());
     }
     
     @Test

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/UidTestBuilder.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/UidTestBuilder.java
@@ -1,0 +1,69 @@
+package datawave.ingest.table.aggregator;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import datawave.ingest.protobuf.Uid;
+import org.apache.accumulo.core.data.Value;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Common utilities for testing Uid.List functionality.
+ */
+public final class UidTestBuilder {
+    private Uid.List.Builder b;
+    
+    private UidTestBuilder() {
+        b = Uid.List.newBuilder();
+    }
+    
+    public static UidTestBuilder newBuilder() {
+        return new UidTestBuilder();
+    }
+    
+    public UidTestBuilder withCountOnly(int count) {
+        if (b.getUIDList().size() > 0) {
+            throw new IllegalStateException("Setting count-only for named uid list prohibited.");
+        }
+        b.setIGNORE(true);
+        b.setCOUNT(count);
+        return this;
+    }
+    
+    // Only used to represent deprecated data that will no longer be created like this
+    @Deprecated
+    public UidTestBuilder withCountOverride(int count) {
+        b.setCOUNT(count);
+        return this;
+    }
+    
+    public UidTestBuilder withUids(String... uids) {
+        if (b.getIGNORE()) {
+            throw new IllegalStateException("Adding uids to count-only is prohibited.");
+        }
+        b.setIGNORE(false);
+        b.addAllUID(asList(uids));
+        b.setCOUNT(uids.length);
+        return this;
+    }
+    
+    public UidTestBuilder withRemovals(String... uids) {
+        b.addAllREMOVEDUID(asList(uids));
+        return this;
+    }
+    
+    public static Value uidList(String... uids) {
+        return UidTestBuilder.newBuilder().withUids(uids).build();
+    }
+    
+    public static Uid.List valueToUidList(Value value) {
+        try {
+            return Uid.List.parseFrom(value.get());
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException("Failed to parse protobuf", e);
+        }
+    }
+    
+    public Value build() {
+        return new Value(b.build().toByteArray());
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/UidTestUtils.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/UidTestUtils.java
@@ -39,24 +39,6 @@ public final class UidTestUtils {
         return builderToValue(b);
     }
     
-    public static Value releaseUidList(String... uids) {
-        Uid.List.Builder b = Uid.List.newBuilder();
-        b.setIGNORE(false);
-        b.addAllQUARANTINEUID(asList(uids));
-        b.setCOUNT(uids.length);
-        
-        return builderToValue(b);
-    }
-    
-    public static Value quarantineUidList(String... uids) {
-        Uid.List.Builder b = Uid.List.newBuilder();
-        b.setIGNORE(false);
-        b.addAllQUARANTINEUID(asList(uids));
-        b.setCOUNT(-1 * uids.length);
-        
-        return builderToValue(b);
-    }
-    
     public static Value removeUidList(String... uids) {
         Uid.List.Builder b = Uid.List.newBuilder();
         b.setIGNORE(false);

--- a/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorSeekTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorSeekTest.java
@@ -129,7 +129,7 @@ public class PropogatingIteratorSeekTest {
         }
         
         public IteratorUtil.IteratorScope getIteratorScope() {
-            return IteratorUtil.IteratorScope.scan;
+            return IteratorUtil.IteratorScope.minc;
         }
     }
     

--- a/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorTest.java
@@ -31,7 +31,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import datawave.ingest.protobuf.Uid;
 import datawave.ingest.table.aggregator.GlobalIndexUidAggregator;
 
-@SuppressWarnings("deprecation")
+import static org.junit.Assert.assertTrue;
+
 public class PropogatingIteratorTest {
     private static final String SHARD = "20121002_1";
     private static final String FIELD_TO_AGGREGATE = "UUID";
@@ -42,7 +43,7 @@ public class PropogatingIteratorTest {
         
         Assert.assertEquals(uids.length, v.getCOUNT());
         for (String uid : uids) {
-            v.getUIDList().contains(uid);
+            assertTrue(v.getUIDList().contains(uid));
         }
     }
     
@@ -51,7 +52,7 @@ public class PropogatingIteratorTest {
         
         Assert.assertEquals(-uids.length, v.getCOUNT());
         for (String uid : uids) {
-            v.getREMOVEDUIDList().contains(uid);
+            assertTrue(v.getREMOVEDUIDList().contains(uid));
         }
     }
     
@@ -73,9 +74,9 @@ public class PropogatingIteratorTest {
         return builder;
     }
     
-    public class MockIteratorEnvironment implements IteratorEnvironment {
+    public static class MockIteratorEnvironment implements IteratorEnvironment {
         AccumuloConfiguration conf;
-        private boolean major;
+        private final boolean major;
         
         public MockIteratorEnvironment(boolean major) {
             this.conf = AccumuloConfiguration.getDefaultConfiguration();
@@ -126,7 +127,7 @@ public class PropogatingIteratorTest {
         }
         
         @Override
-        public SortedKeyValueIterator<Key,Value> reserveMapFileReader(String arg0) throws IOException {
+        public SortedKeyValueIterator<Key,Value> reserveMapFileReader(String arg0) {
             return null;
         }
     }
@@ -164,7 +165,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -200,7 +201,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -217,9 +218,6 @@ public class PropogatingIteratorTest {
     public void testNullOptions() throws IOException {
         
         PropogatingIterator iter = new PropogatingIterator();
-        Map<String,String> options = Maps.newHashMap();
-        
-        options.put(PropogatingIterator.AGGREGATOR_DEFAULT, GlobalIndexUidAggregator.class.getCanonicalName());
         
         IteratorEnvironment env = new MockIteratorEnvironment(false);
         
@@ -249,8 +247,6 @@ public class PropogatingIteratorTest {
         
         options.put(PropogatingIterator.AGGREGATOR_DEFAULT, GlobalIndexUidAggregator.class.getCanonicalName());
         
-        IteratorEnvironment env = new MockIteratorEnvironment(false);
-        
         iter.init(createSourceWithTestData(), options, null);
         
         iter.seek(new Range(), Collections.emptyList(), false);
@@ -278,11 +274,9 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
-        
-        topKey = iter.getTopKey();
         Assert.assertEquals(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), topKey);
         
     }
@@ -307,7 +301,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -337,7 +331,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -363,7 +357,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -405,7 +399,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -442,7 +436,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -457,8 +451,6 @@ public class PropogatingIteratorTest {
     
     @Test(expected = NullPointerException.class)
     public void testNullOptionsWithInit() throws IOException {
-        Map<String,String> options = Maps.newHashMap();
-        options.put(PropogatingIterator.AGGREGATOR_DEFAULT, GlobalIndexUidAggregator.class.getCanonicalName());
         IteratorEnvironment env = new MockIteratorEnvironment(false);
         new PropogatingIterator().init(createSourceWithTestData(), null, env);
     }
@@ -493,11 +485,9 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
-        
-        topKey = iter.getTopKey();
         Assert.assertEquals(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), topKey);
         
     }
@@ -523,7 +513,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -552,7 +542,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -578,7 +568,7 @@ public class PropogatingIteratorTest {
         
         iter.seek(new Range(), Collections.emptyList(), false);
         
-        Assert.assertTrue(iter.hasTop());
+        assertTrue(iter.hasTop());
         
         Key topKey = iter.getTopKey();
         
@@ -615,7 +605,7 @@ public class PropogatingIteratorTest {
                 
                 List<Entry<Key,Value>> resultList = Lists.newArrayList();
                 
-                Assert.assertTrue(myitr.hasTop());
+                assertTrue(myitr.hasTop());
                 
                 Key topKey = myitr.getTopKey();
                 resultList.add(Maps.immutableEntry(topKey, myitr.getTopValue()));
@@ -644,7 +634,7 @@ public class PropogatingIteratorTest {
     
     @Test
     public void testDeepCopyOnDefaultConstructor() throws IOException {
-        SortedKeyValueIterator source = createSourceWithTestData();
+        SortedKeyValueIterator<Key,Value> source = createSourceWithTestData();
         HashMap<String,String> emptyOptions = new HashMap<>();
         MockIteratorEnvironment env = new MockIteratorEnvironment(true);
         
@@ -656,7 +646,7 @@ public class PropogatingIteratorTest {
     
     @Test
     public void testDeepCopyOnConstructor() throws IOException {
-        SortedKeyValueIterator source = createSourceWithTestData();
+        SortedKeyValueIterator<Key,Value> source = createSourceWithTestData();
         HashMap<String,String> emptyOptions = new HashMap<>();
         MockIteratorEnvironment env = new MockIteratorEnvironment(true);
         


### PR DESCRIPTION
* Ensure that if there is a positive (including 0) count for an incoming
  protocol buffer that we handle UIDs in the REMOVEDUID list as well as
  those in the UID list. This scenario is possible if a partial major
  compaction combines files adding UID(s) to the UID list and adding
  other/different UID(s) to the REMOVEDUID list (where the adds of the
  UIDs being removed are in a different file that isn't involved in the
  major compaction).

* Switch logger to use slf4j and placeholders in the log messages.

* Add test cases for new functionality, and apply IDE clean up.

Fixes #1173