### PR TITLE
Deprecate unused Lucene-related classes

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/AccumuloQueryTreeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/AccumuloQueryTreeBuilder.java
@@ -16,6 +16,7 @@ import org.apache.lucene.queryparser.flexible.core.nodes.SlopQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.TokenizedPhraseQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.nodes.TermRangeQueryNode;
 
+@Deprecated
 public class AccumuloQueryTreeBuilder extends QueryTreeBuilder {
     public AccumuloQueryTreeBuilder() {
         setBuilder(TermRangeQueryNode.class, new RangeQueryNodeBuilder());

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/BooleanQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/BooleanQueryNodeBuilder.java
@@ -46,6 +46,7 @@ import org.apache.lucene.search.Query;
  * <br>
  * It takes in consideration if the children is a {@link ModifierQueryNode} to define the {@link BooleanClause}.
  */
+@Deprecated
 public class BooleanQueryNodeBuilder implements QueryBuilder {
     
     public datawave.query.language.tree.QueryNode build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FieldQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FieldQueryNodeBuilder.java
@@ -35,6 +35,7 @@ import org.apache.lucene.search.TermQuery;
 /**
  * Builds a {@link TermQuery} object from a {@link FieldQueryNode} object.
  */
+@Deprecated
 public class FieldQueryNodeBuilder implements QueryBuilder {
     
     private static final String WHITE_SPACE_ESCAPE_STRING = "~~";

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FunctionQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FunctionQueryNodeBuilder.java
@@ -46,6 +46,7 @@ import org.apache.lucene.search.TermQuery;
 /**
  * Builds a {@link TermQuery} object from a {@link FieldQueryNode} object.
  */
+@Deprecated
 public class FunctionQueryNodeBuilder implements QueryBuilder {
     
     private Map<String,LuceneQueryFunction> allowedFunctionMap = Collections.synchronizedMap(new HashMap<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FuzzyQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/FuzzyQueryNodeBuilder.java
@@ -26,6 +26,7 @@ import org.apache.lucene.search.FuzzyQuery;
 /**
  * Builds a {@link FuzzyQuery} object from a {@link FuzzyQueryNode} object.
  */
+@Deprecated
 public class FuzzyQueryNodeBuilder implements QueryBuilder {
     
     public FuzzyQuery build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/GroupQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/GroupQueryNodeBuilder.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.Query;
  * Builds no object, it only returns the {@link Query} object set on the {@link GroupQueryNode} object using a {@link QueryTreeBuilder#QUERY_TREE_BUILDER_TAGID}
  * tag.
  */
+@Deprecated
 public class GroupQueryNodeBuilder implements QueryBuilder {
     
     public datawave.query.language.tree.QueryNode build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/ModifierQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/ModifierQueryNodeBuilder.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.Query;
  * Builds no object, it only returns the {@link Query} object set on the {@link ModifierQueryNode} object using a
  * {@link QueryTreeBuilder#QUERY_TREE_BUILDER_TAGID} tag.
  */
+@Deprecated
 public class ModifierQueryNodeBuilder implements QueryBuilder {
     
     public datawave.query.language.tree.QueryNode build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/PhraseQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/PhraseQueryNodeBuilder.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.PhraseQuery;
 /**
  * Builds a {@link PhraseQuery} object from a {@link TokenizedPhraseQueryNode} object.
  */
+@Deprecated
 public class PhraseQueryNodeBuilder implements QueryBuilder {
     
     public datawave.query.language.tree.QueryNode build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/RangeQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/RangeQueryNodeBuilder.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.TermRangeQuery;
 /**
  * Builds a {@link TermRangeQuery} object from a {@link RangeQueryNode} object.
  */
+@Deprecated
 public class RangeQueryNodeBuilder implements QueryBuilder {
     
     public datawave.query.language.tree.QueryNode build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/SlopQueryNodeBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/builder/lucene/SlopQueryNodeBuilder.java
@@ -32,6 +32,7 @@ import org.apache.lucene.search.Query;
  * This builder basically reads the {@link Query} object set on the {@link SlopQueryNode} child using {@link QueryTreeBuilder#QUERY_TREE_BUILDER_TAGID} and
  * applies the slop value defined in the {@link SlopQueryNode}.
  */
+@Deprecated
 public class SlopQueryNodeBuilder implements QueryBuilder {
     
     public datawave.query.language.tree.QueryNode build(QueryNode queryNode) throws QueryNodeException {

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/AbstractEvaluationPhaseFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/AbstractEvaluationPhaseFunction.java
@@ -12,6 +12,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public abstract class AbstractEvaluationPhaseFunction extends LuceneQueryFunction {
     private boolean includeIfMatch;
     

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/EvaluationOnly.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/EvaluationOnly.java
@@ -10,6 +10,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class EvaluationOnly extends LuceneQueryFunction {
     private LuceneToJexlQueryParser parser;
     

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Exclude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Exclude.java
@@ -2,6 +2,7 @@ package datawave.query.language.functions.lucene;
 
 import datawave.query.language.functions.QueryFunction;
 
+@Deprecated
 public class Exclude extends AbstractEvaluationPhaseFunction {
     public Exclude() {
         super("exclude", false);

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/GetAllMatches.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/GetAllMatches.java
@@ -12,6 +12,7 @@ import datawave.webservice.query.exception.DatawaveErrorCode;
 import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
+@Deprecated
 public class GetAllMatches extends LuceneQueryFunction {
     public GetAllMatches() {
         super("getAllMatches", new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/GroupBy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/GroupBy.java
@@ -12,6 +12,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class GroupBy extends LuceneQueryFunction {
     public GroupBy() {
         super(QueryFunctions.GROUPBY_FUNCTION, new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Include.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Include.java
@@ -2,6 +2,7 @@ package datawave.query.language.functions.lucene;
 
 import datawave.query.language.functions.QueryFunction;
 
+@Deprecated
 public class Include extends AbstractEvaluationPhaseFunction {
     public Include() {
         super("include", true);

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/IsNotNull.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/IsNotNull.java
@@ -13,6 +13,7 @@ import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.BooleanQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
+@Deprecated
 public class IsNotNull extends LuceneQueryFunction {
     public IsNotNull() {
         super("isnotnull", new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/IsNull.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/IsNull.java
@@ -13,6 +13,7 @@ import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.BooleanQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
+@Deprecated
 public class IsNull extends LuceneQueryFunction {
     public IsNull() {
         super("isnull", new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/LuceneQueryFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/LuceneQueryFunction.java
@@ -8,6 +8,7 @@ import datawave.query.search.WildcardFieldedFilter;
 
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
+@Deprecated
 public abstract class LuceneQueryFunction implements QueryFunction {
     
     protected String name = null;

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Occurrence.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Occurrence.java
@@ -12,6 +12,7 @@ import datawave.webservice.query.exception.DatawaveErrorCode;
 import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
+@Deprecated
 public class Occurrence extends LuceneQueryFunction {
     public Occurrence() {
         super("occurrence", new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Options.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Options.java
@@ -12,6 +12,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class Options extends LuceneQueryFunction {
     public Options() {
         super(QueryFunctions.OPTIONS_FUNCTION, new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Text.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Text.java
@@ -2,6 +2,7 @@ package datawave.query.language.functions.lucene;
 
 import datawave.query.language.functions.QueryFunction;
 
+@Deprecated
 public class Text extends AbstractEvaluationPhaseFunction {
     public Text() {
         super("text", true);

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Unique.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/lucene/Unique.java
@@ -12,6 +12,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class Unique extends LuceneQueryFunction {
     public Unique() {
         super(QueryFunctions.UNIQUE_FUNCTION, new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlUUIDQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlUUIDQueryParser.java
@@ -12,6 +12,7 @@ import datawave.query.search.FieldedTerm;
 import datawave.query.search.RangeFieldedTerm;
 import datawave.query.search.WildcardFieldedTerm;
 
+@Deprecated
 public class LuceneToJexlUUIDQueryParser extends LuceneToJexlQueryParser {
     private List<UUIDType> uuidTypes = new ArrayList<>();
     private LuceneQueryParser luceneParser = new LuceneQueryParser();

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/lucene/LuceneQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/lucene/LuceneQueryParser.java
@@ -30,6 +30,7 @@ import org.apache.lucene.queryparser.flexible.core.builders.QueryBuilder;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessor;
 
+@Deprecated
 public class LuceneQueryParser implements QueryParser {
     private static Logger log = Logger.getLogger(LuceneQueryParser.class.getName());
     private Map<String,String> filters = new HashMap<>();

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/lucene/LuceneUUIDQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/lucene/LuceneUUIDQueryParser.java
@@ -12,6 +12,7 @@ import datawave.query.search.WildcardFieldedTerm;
 
 import org.apache.log4j.Logger;
 
+@Deprecated
 public class LuceneUUIDQueryParser extends LuceneQueryParser {
     private static Logger log = Logger.getLogger(LuceneUUIDQueryParser.class.getName());
     private List<UUIDType> uuidTypes = new ArrayList<>();


### PR DESCRIPTION
There are several classes related to Lucene parsing that are no longer
in used, and have been superseded by similar classes in neighboring
jexl packages.

Deprecate the unused classes.

Fixes #1200