### PR TITLE
Support Composite regex expansion combination

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
@@ -12,8 +12,11 @@ import datawave.query.composite.Composite;
 import datawave.query.composite.CompositeRange;
 import datawave.query.composite.CompositeTerm;
 import datawave.query.composite.CompositeUtils;
+import datawave.query.tables.ScannerFactory;
 import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.exceptions.CannotExpandUnfieldedTermFatalException;
 import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.exceptions.DoNotPerformOptimizedQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.LiteralRange;
@@ -22,6 +25,7 @@ import datawave.query.util.MetadataHelper;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTDelayedPredicate;
 import org.apache.commons.jexl2.parser.ASTEQNode;
@@ -30,6 +34,7 @@ import org.apache.commons.jexl2.parser.ASTEvaluationOnly;
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
 import org.apache.commons.jexl2.parser.ASTGENode;
 import org.apache.commons.jexl2.parser.ASTGTNode;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTLENode;
 import org.apache.commons.jexl2.parser.ASTLTNode;
 import org.apache.commons.jexl2.parser.ASTNENode;
@@ -39,7 +44,7 @@ import org.apache.commons.jexl2.parser.ASTOrNode;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ASTReferenceExpression;
 import org.apache.commons.jexl2.parser.JexlNode;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +60,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import static org.apache.commons.jexl2.parser.JexlNodes.children;
 
 /**
@@ -64,7 +71,7 @@ import static org.apache.commons.jexl2.parser.JexlNodes.children;
  */
 public class ExpandCompositeTerms extends RebuildingVisitor {
     
-    private static final Logger log = ThreadConfigurableLogger.getLogger(ExpandCompositeTerms.class);
+    private static final Logger log = getLogger(ExpandCompositeTerms.class);
     
     private final ShardQueryConfiguration config;
     
@@ -104,6 +111,71 @@ public class ExpandCompositeTerms extends RebuildingVisitor {
         }
         
         return (T) script.jjtAccept(visitor, new ExpandData());
+    }
+    
+    /**
+     * Expand all nodes which have multiple dataTypes for the field.
+     *
+     * @param config
+     *            Configuration parameters relevant to our query
+     * @param script
+     *            The jexl node representing the query
+     * @return An expanded version of the passed-in script containing composite nodes
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends JexlNode> T expandTermsWithRegex(ShardQueryConfiguration config, T script, ScannerFactory scannerFactory,
+                    MetadataHelper metadataHelper, Set<String> expansionFields) throws InstantiationException, IllegalAccessException, TableNotFoundException {
+        
+        ExpandCompositeTerms visitor = new ExpandCompositeTerms(config);
+        
+        // need to flatten the tree so i get all and nodes at the same level
+        script = TreeFlatteningRebuildingVisitor.flatten(script);
+        
+        if (null == visitor.config.getCompositeToFieldMap()) {
+            QueryException qe = new QueryException(DatawaveErrorCode.DATATYPESFORINDEXFIELDS_MULTIMAP_MISSING);
+            throw new DatawaveFatalQueryException(qe);
+        }
+        
+        T newTree = (T) script.jjtAccept(visitor, new ExpandData());
+        
+        if (newTree instanceof ASTJexlScript) {
+            Set<String> indexedFields = null;
+            Set<String> indexOnlyFields = null;
+            Set<String> nonEventFields = null;
+            if (config.getMinSelectivity() > 0) {
+                try {
+                    indexedFields = metadataHelper.getIndexedFields(config.getDatatypeFilter());
+                    indexOnlyFields = metadataHelper.getIndexOnlyFields(config.getDatatypeFilter());
+                    nonEventFields = metadataHelper.getNonEventFields(config.getDatatypeFilter());
+                } catch (TableNotFoundException te) {
+                    QueryException qe = new QueryException(DatawaveErrorCode.METADATA_ACCESS_ERROR, te);
+                    throw new DatawaveFatalQueryException(qe);
+                }
+            }
+            
+            final ParallelIndexExpansion regexExpansion = new ParallelIndexExpansion(config, scannerFactory, metadataHelper, expansionFields,
+                            config.isExpandFields(), config.isExpandValues(), config.isExpandUnfieldedNegations());
+            try {
+                T expandedTree = (T) regexExpansion.visit((ASTJexlScript) newTree, null);
+                /**
+                 * Don't promote a tree that isn't executable. If that is the case resort to returning the tree created by the composite expansion.
+                 */
+                if (ExecutableDeterminationVisitor.isExecutable(expandedTree, config, indexedFields, indexOnlyFields, nonEventFields, null, metadataHelper)) {
+                    return (T) expandedTree.jjtAccept(visitor, new ExpandData());
+                }
+            } catch (CannotExpandUnfieldedTermFatalException cee) {
+                /**
+                 * Exceptions in the executor of ParallelIndexExpansion wrap other exceptions. In the case where we have a do not perform query optimization
+                 * exception we want to pass that along. Therefore we will check the cause and return the original DoNotPerformOptimizedQueryException.
+                 */
+                if (null != cee.getCause() && cee.getCause() instanceof DoNotPerformOptimizedQueryException) {
+                    throw (DoNotPerformOptimizedQueryException) cee.getCause();
+                } else {
+                    throw cee;
+                }
+            }
+        }
+        return newTree;
     }
     
     /**
@@ -332,6 +404,9 @@ public class ExpandCompositeTerms extends RebuildingVisitor {
         List<JexlNode> unmodifiedNodes = new ArrayList<>();
         List<JexlNode> modifiedNodes = new ArrayList<>();
         for (JexlNode nonLeafNode : nonLeafNodes) {
+            if (log.isDebugEnabled()) {
+                log.debug("Processing non leaf node {}", JexlStringBuildingVisitor.buildQuery(nonLeafNode));
+            }
             ExpandData eData = new ExpandData();
             
             // add the anded leaf nodes from our ancestors
@@ -749,7 +824,6 @@ public class ExpandCompositeTerms extends RebuildingVisitor {
                 }
                 
                 tempComposites = updateComposites(tempComposites, nodes);
-                
                 // if our updated composites list is empty,
                 // then we failed to update the composites
                 if (tempComposites.isEmpty())

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
@@ -128,7 +128,7 @@ public class ExpandCompositeTerms extends RebuildingVisitor {
         
         ExpandCompositeTerms visitor = new ExpandCompositeTerms(config);
         
-        // need to flatten the tree so i get all and nodes at the same level
+        // CompositeTerm expansion requires a flattened tree
         script = TreeFlatteningRebuildingVisitor.flatten(script);
         
         if (null == visitor.config.getCompositeToFieldMap()) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
@@ -165,8 +165,7 @@ public class ExpandCompositeTerms extends RebuildingVisitor {
                 }
             } catch (CannotExpandUnfieldedTermFatalException cee) {
                 /**
-                 * Exceptions in the executor of ParallelIndexExpansion wrap other exceptions. In the case where we have a do not perform query optimization
-                 * exception we want to pass that along. Therefore we will check the cause and return the original DoNotPerformOptimizedQueryException.
+                 * Propagate the embedded exception if the regex term expansion failed.
                  */
                 if (null != cee.getCause() && cee.getCause() instanceof DoNotPerformOptimizedQueryException) {
                     throw (DoNotPerformOptimizedQueryException) cee.getCause();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -227,7 +227,6 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
             // Get all of the indexed or normalized dataTypes for the field name
             Set<Type<?>> dataTypes = Sets.newHashSet(config.getQueryFieldsDatatypes().get(fieldName));
             dataTypes.addAll(config.getNormalizedFieldsDatatypes().get(fieldName));
-            
             // Catch the case of the user entering FIELD == null
             if (!dataTypes.isEmpty() && null != literal) {
                 try {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1217,14 +1217,13 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             logQuery(queryTree, "Query after forceEvaluationOnly is applied");
         }
         stopwatch.stop();
-       
+        
         if (!disableBoundedLookup) {
             /**
-             * This will allow composite terms to be checked and expanded; however, there are cases where the expansion
-             * cannot occur. For example if you have three fields and the second and third fields are regex. We may be
-             * able to expand the second field and composite a field of A*B*C, where C is a regex with the
-             * ExpandCompositeTerms visitor, at which point ParallelIndexExpansion can then attempt the composite
-             * field expansion of A*B*C, and (hopefully) result in discrete terms.
+             * This will allow composite terms to be checked and expanded; however, there are cases where the expansion cannot occur. For example if you have
+             * three fields and the second and third fields are regex. We may be able to expand the second field and composite a field of A*B*C, where C is a
+             * regex with the ExpandCompositeTerms visitor, at which point ParallelIndexExpansion can then attempt the composite field expansion of A*B*C, and
+             * (hopefully) result in discrete terms.
              */
             queryTree = checkAndExpandCompositeTerms(config, queryTree, timers, scannerFactory, metadataHelper, expansionFields);
             

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeQueryTest.java
@@ -103,6 +103,16 @@ public class CompositeQueryTest extends AbstractFunctionalQuery {
     }
     
     @Test
+    public void testRegexWithRangeLhs() throws Exception {
+        log.info("------  testRegexWithRange  ------");
+        String state = "'Mississippi'";
+        String code = "'uS.*'";
+        
+        String qState = CityField.CODE.name() + RE_OP + code + AND_OP + CityField.STATE + EQ_OP + state;
+        runTest(qState, qState);
+    }
+    
+    @Test
     public void testMultiRegex() throws Exception {
         log.info("------  testMultiRegex  ------");
         String state = "'Miss.*'";

--- a/warehouse/query-core/src/test/java/datawave/query/MultiValueQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MultiValueQueryTest.java
@@ -21,6 +21,7 @@ import static datawave.query.testframework.RawDataManager.AND_OP;
 import static datawave.query.testframework.RawDataManager.EQ_OP;
 import static datawave.query.testframework.RawDataManager.GT_OP;
 import static datawave.query.testframework.RawDataManager.OR_OP;
+import static datawave.query.testframework.RawDataManager.RE_OP;
 
 /**
  * Performs query test for multivalue fields.
@@ -66,6 +67,19 @@ public class MultiValueQueryTest extends AbstractFunctionalQuery {
                 String query = CityField.CITY.name() + EQ_OP + "'" + city.name() + "'" + AND_OP + CityField.STATE.name() + EQ_OP + st;
                 runTest(query, query);
                 return;
+            }
+        }
+    }
+    
+    @Test
+    public void testCompositeRegex() throws Exception {
+        log.debug("------  testCompositeRegex  ------");
+        
+        for (final TestCities city : TestCities.values()) {
+            final String adjustedName = city.name().substring(0, Math.min(city.name().length() - 2, 2));
+            for (final String st : TestStates) {
+                String query = CityField.CITY.name() + RE_OP + "'" + adjustedName + ".*'" + AND_OP + CityField.STATE.name() + EQ_OP + st;
+                runTest(query, query);
             }
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -95,6 +95,10 @@ public class ExpandCompositeTermsTest {
     public void test3() throws Exception {
         String query = "WINNER=='blue' && TEAM=='gold' && NAME=='gold-8' && POINTS==11";
         runTestQuery(query, "WINNER == 'blue' && TEAM_NAME_POINTS == 'gold,gold-8,11'");
+        query = "WINNER=='blue' && TEAM=='gold' && NAME=~'gold-?.*' && POINTS==11";
+        runTestQuery(query, "WINNER == 'blue' && NAME =~ 'gold-?.*' && TEAM_POINTS == 'gold,11'");
+        query = "WINNER=='blue' && TEAM=~'gol.*' && NAME=='gold-8' && POINTS==11";
+        runTestQuery(query, "WINNER == 'blue' && TEAM =~ 'gol.*' && NAME == 'gold-8' && POINTS == 11");
     }
     
     @Test
@@ -172,7 +176,7 @@ public class ExpandCompositeTermsTest {
     @Test
     public void test8() throws Exception {
         String query = "COLOR =~ '.*ed' && (WHEELS == '4' || WHEELS == '+aE4') && (MAKE_COLOR == 'honda' || MAKE == 'honda') && TYPE == 'truck'";
-        String expected = "TYPE == 'truck' && (WHEELS == '4' || WHEELS == '+aE4') && ((COLOR =~ '.*ed' && MAKE_COLOR == 'honda') || (MAKE_COLOR =~ 'honda,.*ed' && ((_Eval_ = true) && (MAKE == 'honda' && COLOR =~ '.*ed'))))";
+        String expected = "TYPE == 'truck' && (WHEELS == '4' || WHEELS == '+aE4') && ((COLOR =~ '.*ed' && MAKE_COLOR == 'honda') || (MAKE_COLOR =~ '\\Qhonda\\E,.*ed' && ((_Eval_ = true) && (MAKE == 'honda' && COLOR =~ '.*ed'))))";
         runTestQuery(query, expected);
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -96,14 +96,14 @@ public class ExpandCompositeTermsTest {
         String query = "WINNER=='blue' && TEAM=='gold' && NAME=='gold-8' && POINTS==11";
         runTestQuery(query, "WINNER == 'blue' && TEAM_NAME_POINTS == 'gold,gold-8,11'");
         /**
-         * As part of boundary value testing we are ensuring that for TEAM_NAME_POINTS we aren't combining
-         * these terms during composite expansion since that would result in [term][regex][term]
+         * As part of boundary value testing we are ensuring that for TEAM_NAME_POINTS we aren't combining these terms during composite expansion since that
+         * would result in [term][regex][term]
          */
         query = "WINNER=='blue' && TEAM=='gold' && NAME=~'gold-?.*' && POINTS==11";
         runTestQuery(query, "WINNER == 'blue' && NAME =~ 'gold-?.*' && TEAM_POINTS == 'gold,11'");
         /**
-         * As part of boundary value testing we are ensuring that for TEAM_POINTS we aren't combining
-         * these terms during composite expansion since that would result in [regex][term]
+         * As part of boundary value testing we are ensuring that for TEAM_POINTS we aren't combining these terms during composite expansion since that would
+         * result in [regex][term]
          */
         query = "WINNER=='blue' && TEAM=~'gol.*' && NAME=='gold-8' && POINTS==11";
         runTestQuery(query, "WINNER == 'blue' && TEAM =~ 'gol.*' && NAME == 'gold-8' && POINTS == 11");
@@ -185,28 +185,26 @@ public class ExpandCompositeTermsTest {
     public void test8() throws Exception {
         String query = "COLOR =~ '.*ed' && (WHEELS == '4' || WHEELS == '+aE4') && (MAKE_COLOR == 'honda' || MAKE == 'honda') && TYPE == 'truck'";
         /**
-         * Since our field is MAKE_COLOR and we have a regex on the rhs, we can quote the left and allow the right
-         * to be expanded. This will allow us to support the case where we have an ASTEQNode that has a period. If
-         * we do not do the escape the RegexAnalyzer will mistakenly assume the period of the original ASTEQNode is
-         * part of a regex.
+         * Since our field is MAKE_COLOR and we have a regex on the rhs, we can quote the left and allow the right to be expanded. This will allow us to support
+         * the case where we have an ASTEQNode that has a period. If we do not do the escape the RegexAnalyzer will mistakenly assume the period of the original
+         * ASTEQNode is part of a regex.
          */
         String expected = "TYPE == 'truck' && (WHEELS == '4' || WHEELS == '+aE4') && ((COLOR =~ '.*ed' && MAKE_COLOR == 'honda') || (MAKE_COLOR =~ '\\Qhonda\\E,.*ed' && ((_Eval_ = true) && (MAKE == 'honda' && COLOR =~ '.*ed'))))";
         runTestQuery(query, expected);
     }
-
+    
     @Test
     public void test8a() throws Exception {
         String query = "COLOR =~ '.*ed' && (WHEELS == '4' || WHEELS == '+aE4') && (MAKE_COLOR == 'honda' || MAKE =~ 'honda.*') && TYPE == 'truck'";
         /**
-         * Unlike test8, we are validating that our composite expansion cannot occur and result in quoted ASTEQNodes
-         * because we don't have one.
+         * Unlike test8, we are validating that our composite expansion cannot occur and result in quoted ASTEQNodes because we don't have one.
          */
         String expected = "COLOR =~ '.*ed' && (WHEELS == '4' || WHEELS == '+aE4') && (MAKE_COLOR == 'honda' || MAKE =~ 'honda.*') && TYPE == 'truck'";
         runTestQuery(query, expected);
-
+        
         /**
-         * Since the field is MAKE_COLOR we can't composite here as the lhs is a regex. This would effectively result
-         * in looking for MAKE=~'honda.*', thus the expand composite terms visitor will not join these terms.
+         * Since the field is MAKE_COLOR we can't composite here as the lhs is a regex. This would effectively result in looking for MAKE=~'honda.*', thus the
+         * expand composite terms visitor will not join these terms.
          */
         query = "COLOR == 'red' && (WHEELS == '4' || WHEELS == '+aE4') && (MAKE_COLOR == 'honda' || MAKE =~ 'honda.*') && TYPE == 'truck'";
         expected = "TYPE == 'truck' && (MAKE_COLOR == 'honda' || MAKE =~ 'honda.*') && (COLOR_WHEELS == 'red,4' || COLOR_WHEELS == 'red,+aE4')";

--- a/warehouse/query-core/src/test/java/datawave/query/planner/CompositeExpansionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/CompositeExpansionTest.java
@@ -1,0 +1,213 @@
+package datawave.query.planner;
+
+import datawave.configuration.spring.SpringBean;
+import datawave.helpers.PrintUtility;
+import datawave.ingest.data.TypeRegistry;
+import datawave.ingest.data.config.ingest.CompositeIngest;
+import datawave.marking.MarkingFunctions;
+import datawave.query.QueryTestTableHelper;
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.Document;
+import datawave.query.attributes.PreNormalizedAttribute;
+import datawave.query.attributes.TypeAttribute;
+import datawave.query.composite.CompositeMetadata;
+import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.language.parser.ParseException;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.tables.edge.BaseEdgeQueryTest;
+import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.CompositeTestingIngest;
+import datawave.query.util.TypeMetadata;
+import datawave.util.TableName;
+import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
+import datawave.webservice.query.QueryImpl;
+import datawave.webservice.query.configuration.GenericQueryConfiguration;
+import datawave.webservice.query.configuration.QueryData;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.log4j.Logger;
+import org.apache.log4j.Level;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.UUID;
+
+@RunWith(Arquillian.class)
+public class CompositeExpansionTest {
+    
+    protected static Connector connector = null;
+    
+    private static final Logger log = Logger.getLogger(CompositeExpansionTest.class);
+    
+    protected Authorizations auths = new Authorizations("ALL");
+    
+    protected Set<Authorizations> authSet = Collections.singleton(auths);
+    
+    @Inject
+    @SpringBean(name = "EventQuery")
+    protected ShardQueryLogic logic;
+    
+    protected KryoDocumentDeserializer deserializer;
+    
+    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        
+        QueryTestTableHelper qtth = new QueryTestTableHelper(CompositeExpansionTest.class.toString(), log);
+        connector = qtth.connector;
+        
+        CompositeTestingIngest.writeItAll(connector, CompositeTestingIngest.WhatKindaRange.SHARD);
+        Authorizations auths = new Authorizations("ALL");
+        PrintUtility.printTable(connector, auths, TableName.SHARD);
+        PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(connector, auths, BaseEdgeQueryTest.MODEL_TABLE_NAME);
+    }
+    
+    @Deployment
+    public static JavaArchive createDeployment() throws Exception {
+        System.setProperty("cdi.bean.context", "queryBeanRefContext.xml");
+        
+        return ShrinkWrap
+                        .create(JavaArchive.class)
+                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
+                                        "datawave.webservice.query.result.event")
+                        .deleteClass(DefaultEdgeEventQueryLogic.class)
+                        .deleteClass(RemoteEdgeDictionary.class)
+                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
+                        .deleteClass(datawave.query.metrics.ShardTableQueryMetricHandler.class)
+                        .addAsManifestResource(
+                                        new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
+                                                        + "</alternatives>"), "beans.xml");
+    }
+    
+    @AfterClass
+    public static void teardown() {
+        TypeRegistry.reset();
+    }
+    
+    @Before
+    public void setup() {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        
+        Logger.getLogger(DefaultQueryPlanner.class).setLevel(Level.TRACE);
+        logic.setFullTableScanEnabled(true);
+        logic.setExpandAllTerms(true);
+        // we will have a higher depth threshold due to this ASTEvaluationOnly marker nodes.
+        // we won't go as high as the default ( 2500 ) but we do need some additional room.
+        logic.setMaxDepthThreshold(10);
+        deserializer = new KryoDocumentDeserializer();
+    }
+    
+    protected void runTestQuery(String expectedQuery, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
+        log.debug("runTestQuery");
+        log.trace("Creating QueryImpl");
+        QueryImpl settings = new QueryImpl();
+        settings.setBeginDate(startDate);
+        settings.setEndDate(endDate);
+        settings.setPagesize(Integer.MAX_VALUE);
+        settings.setQueryAuthorizations(auths.serialize());
+        settings.setQuery(querystr);
+        settings.setParameters(extraParms);
+        settings.setId(UUID.randomUUID());
+        
+        log.debug("query: " + settings.getQuery());
+        log.debug("logic: " + settings.getQueryLogicName());
+        
+        GenericQueryConfiguration config = logic.initialize(connector, settings, authSet);
+        logic.setupQuery(config);
+        
+        String plannedScript = logic.getQueryPlanner().getPlannedScript();
+        Assert.assertTrue("Unexpected query:" + plannedScript + " not " + expectedQuery, plannedScript.equals(expectedQuery));
+    }
+    
+    @Test
+    public void baseExpansion() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        
+        if (log.isDebugEnabled()) {
+            log.debug("testCompositeBaseExpansion");
+        }
+        
+        runTestQuery("MAKE_COLOR == 'FORD" + CompositeIngest.DEFAULT_SEPARATOR + "RED'", "COLOR == 'RED' && MAKE == 'FORD'", format.parse("20091231"),
+                        format.parse("20150101"), extraParameters);
+        
+    }
+    
+    @Test
+    public void regexTrailingWildcardExpansionRhs() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        
+        if (log.isDebugEnabled()) {
+            log.debug("regexTrailingWildcardExpansionRhs");
+        }
+        
+        runTestQuery("MAKE_COLOR == 'FORD􏿿RED' && ((_Eval_ = true) && (MAKE == 'FORD' && COLOR =~ 'RED.*'))", "COLOR =~ 'RED.*' && MAKE == 'FORD'",
+                        format.parse("20091231"), format.parse("20150101"), extraParameters);
+        
+    }
+    
+    @Test
+    public void regexTrailingWildcardExpansionLhs() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        
+        if (log.isDebugEnabled()) {
+            log.debug("regexTrailingWildcardExpansionLhs");
+        }
+        
+        /**
+         * We set expand all terms. If we do not do that, MAKE =~ 'FOR.*' will be delayed. The purpose of this test is to show that the LHS of the composite
+         * expression will be expanded via ParallelIndexExpansion and, if allowed via configuration, placed into the composite term(s).
+         */
+        runTestQuery("MAKE_COLOR == 'FORD" + CompositeIngest.DEFAULT_SEPARATOR + "RED'", "COLOR == 'RED' && MAKE =~ 'FOR.*'", format.parse("20091231"),
+                        format.parse("20150101"), extraParameters);
+        
+    }
+    
+    @Test
+    public void regexTrailingWildcardExpansionBoth() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        
+        if (log.isDebugEnabled()) {
+            log.debug("regexTrailingWildcardExpansionBoth");
+        }
+        /**
+         * Only allowed because full table scans are enabled.
+         */
+        runTestQuery("((_Eval_ = true) && (COLOR =~ 'R.*')) && ((_Eval_ = true) && (MAKE =~ 'F.*'))", "COLOR =~ 'R.*' && MAKE =~ 'F.*'",
+                        format.parse("20091231"), format.parse("20150101"), extraParameters);
+        
+    }
+    
+}

--- a/warehouse/query-core/src/test/java/datawave/query/util/CompositeTestingIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/CompositeTestingIngest.java
@@ -449,7 +449,7 @@ public class CompositeTestingIngest {
             try {
                 JavaRegexAnalyzer regex = new JavaRegexAnalyzer(fieldRegex);
                 regex.applyRegexCaseSensitivity(false);
-                return regex.getRegex();
+                return regex.getRegex().toUpperCase(Locale.ENGLISH);
             } catch (JavaRegexAnalyzer.JavaRegexParseException e) {
                 throw new IllegalArgumentException("Unable to parse regex " + fieldRegex, e);
             }


### PR DESCRIPTION
Works toward Issue #188 . 

Since this is a combined field with ASTEQNodes w/ ERNodes, this will quote the EQNodes so the Regex Analyzer won't treat the EQNodes as regular expression characters ( as they will be escaped ).

Attempts composite term expansion, followed by regex expansion, again followed by composite term expansion. For cases where the regex expansion can help provide eq nodes, we can then attempt composite terms again to locate an optimal index lookup for the composite fields specified in query. 