### PR TITLE
additional work to stop double wrapping nodes

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EnsureReferenceNodesVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EnsureReferenceNodesVisitor.java
@@ -1,0 +1,381 @@
+package datawave.query.jexl.visitors;
+
+import org.apache.commons.jexl2.parser.ASTAdditiveNode;
+import org.apache.commons.jexl2.parser.ASTAdditiveOperator;
+import org.apache.commons.jexl2.parser.ASTAmbiguous;
+import org.apache.commons.jexl2.parser.ASTAndNode;
+import org.apache.commons.jexl2.parser.ASTArrayAccess;
+import org.apache.commons.jexl2.parser.ASTArrayLiteral;
+import org.apache.commons.jexl2.parser.ASTAssignment;
+import org.apache.commons.jexl2.parser.ASTBitwiseAndNode;
+import org.apache.commons.jexl2.parser.ASTBitwiseComplNode;
+import org.apache.commons.jexl2.parser.ASTBitwiseOrNode;
+import org.apache.commons.jexl2.parser.ASTBitwiseXorNode;
+import org.apache.commons.jexl2.parser.ASTBlock;
+import org.apache.commons.jexl2.parser.ASTConstructorNode;
+import org.apache.commons.jexl2.parser.ASTDivNode;
+import org.apache.commons.jexl2.parser.ASTEQNode;
+import org.apache.commons.jexl2.parser.ASTERNode;
+import org.apache.commons.jexl2.parser.ASTEmptyFunction;
+import org.apache.commons.jexl2.parser.ASTFalseNode;
+import org.apache.commons.jexl2.parser.ASTFloatLiteral;
+import org.apache.commons.jexl2.parser.ASTForeachStatement;
+import org.apache.commons.jexl2.parser.ASTFunctionNode;
+import org.apache.commons.jexl2.parser.ASTGENode;
+import org.apache.commons.jexl2.parser.ASTGTNode;
+import org.apache.commons.jexl2.parser.ASTIdentifier;
+import org.apache.commons.jexl2.parser.ASTIfStatement;
+import org.apache.commons.jexl2.parser.ASTIntegerLiteral;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ASTLENode;
+import org.apache.commons.jexl2.parser.ASTLTNode;
+import org.apache.commons.jexl2.parser.ASTMapEntry;
+import org.apache.commons.jexl2.parser.ASTMapLiteral;
+import org.apache.commons.jexl2.parser.ASTMethodNode;
+import org.apache.commons.jexl2.parser.ASTModNode;
+import org.apache.commons.jexl2.parser.ASTMulNode;
+import org.apache.commons.jexl2.parser.ASTNENode;
+import org.apache.commons.jexl2.parser.ASTNRNode;
+import org.apache.commons.jexl2.parser.ASTNotNode;
+import org.apache.commons.jexl2.parser.ASTNullLiteral;
+import org.apache.commons.jexl2.parser.ASTNumberLiteral;
+import org.apache.commons.jexl2.parser.ASTOrNode;
+import org.apache.commons.jexl2.parser.ASTReference;
+import org.apache.commons.jexl2.parser.ASTReferenceExpression;
+import org.apache.commons.jexl2.parser.ASTReturnStatement;
+import org.apache.commons.jexl2.parser.ASTSizeFunction;
+import org.apache.commons.jexl2.parser.ASTSizeMethod;
+import org.apache.commons.jexl2.parser.ASTStringLiteral;
+import org.apache.commons.jexl2.parser.ASTTernaryNode;
+import org.apache.commons.jexl2.parser.ASTTrueNode;
+import org.apache.commons.jexl2.parser.ASTUnaryMinusNode;
+import org.apache.commons.jexl2.parser.ASTVar;
+import org.apache.commons.jexl2.parser.ASTWhileStatement;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.JexlNodes;
+import org.apache.commons.jexl2.parser.ParserTreeConstants;
+import org.apache.commons.jexl2.parser.SimpleNode;
+
+/**
+ * Some visitors rely on the presence of an {@link org.apache.commons.jexl2.parser.ASTReference} node in the AST.
+ *
+ * Ensure that all {@link org.apache.commons.jexl2.parser.ASTReferenceExpression} nodes have a parent ASTReference.
+ */
+public class EnsureReferenceNodesVisitor extends BaseVisitor {
+    
+    /**
+     * Ensure every ASTReferenceExpression has a parent ASTReferenceNode
+     *
+     * @param node
+     *            an arbitrary JexlNode
+     * @return a valid AST with respect to ReferenceExpressions and References
+     */
+    public static JexlNode ensureReferences(JexlNode node) {
+        EnsureReferenceNodesVisitor visitor = new EnsureReferenceNodesVisitor();
+        node.jjtAccept(visitor, null);
+        return node;
+    }
+    
+    @Override
+    public Object visit(ASTReferenceExpression node, Object data) {
+        
+        if (!isParentAnASTReference(node)) {
+            injectReferenceNode(node);
+        }
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    /**
+     * Determine if a parent is an {@link ASTReference}.
+     *
+     * @param node
+     *            a JexlNode
+     * @return true if this node's parent is an ASTReference
+     */
+    public boolean isParentAnASTReference(JexlNode node) {
+        return node.jjtGetParent() != null && JexlNodes.id(node) == ParserTreeConstants.JJTREFERENCE;
+    }
+    
+    /**
+     * Inject an ASTReference node as this node's parent
+     *
+     * @param node
+     *            a JexlNode
+     * @return the original node
+     */
+    public JexlNode injectReferenceNode(JexlNode node) {
+        JexlNode parent = node.jjtGetParent();
+        JexlNode ref = JexlNodes.makeRef(node);
+        JexlNodes.replaceChild(parent, node, ref);
+        
+        return node;
+    }
+    
+    /*
+     * Pass-through
+     */
+    
+    @Override
+    public Object visit(ASTJexlScript node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTReference node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTOrNode node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAndNode node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNotNode node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    /*
+     * Short circuits
+     */
+    
+    @Override
+    public Object visit(SimpleNode node, Object data) {
+        node.childrenAccept(this, data);
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBlock node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAmbiguous node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTIfStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTWhileStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTForeachStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAssignment node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTTernaryNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseOrNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseXorNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseAndNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTEQNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNENode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTLTNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTGTNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTLENode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTGENode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTERNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNRNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAdditiveNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTAdditiveOperator node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMulNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTDivNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTModNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTUnaryMinusNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTBitwiseComplNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTIdentifier node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNullLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTTrueNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTFalseNode node, Object data) {
+        return data;
+    }
+    
+    public Object visit(ASTIntegerLiteral node, Object data) {
+        return data;
+    }
+    
+    public Object visit(ASTFloatLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTStringLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTArrayLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMapLiteral node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMapEntry node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTEmptyFunction node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTSizeFunction node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTFunctionNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTMethodNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTSizeMethod node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTConstructorNode node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTArrayAccess node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTReturnStatement node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTVar node, Object data) {
+        return data;
+    }
+    
+    @Override
+    public Object visit(ASTNumberLiteral node, Object data) {
+        return data;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -92,6 +92,9 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
             throw new DatawaveFatalQueryException(qe);
         }
         
+        // inject reference nodes when needed
+        script = (T) EnsureReferenceNodesVisitor.ensureReferences(script);
+        
         script = TreeFlatteningRebuildingVisitor.flatten(script);
         return (T) script.jjtAccept(visitor, null);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitor.java
@@ -242,8 +242,15 @@ public class PullupUnexecutableNodesVisitor extends BaseVisitor {
     public Object visit(ASTReference node, Object data) {
         // if a delayed predicate, then change it to a regular reference
         if (ASTDelayedPredicate.instanceOf(node)) {
+            if (node.jjtGetNumChildren() > 1) {
+                log.warn("Tried to pull up a delayed marker that had more than one child.");
+            }
+            
+            // This swap should be safe, the reference node should have a single child that is a reference expression
             JexlNode source = ASTDelayedPredicate.getDelayedPredicateSource(node);
-            JexlNodes.swap(node.jjtGetParent(), node, source);
+            JexlNode wrappedSource = JexlNodes.wrap(source);
+            JexlNodes.swap(node, node.jjtGetChild(0), wrappedSource);
+            
             return source;
         } else if (!ExecutableDeterminationVisitor.isExecutable(node, config, indexedFields, indexOnlyFields, nonEventFields, forFieldIndex, null, helper)) {
             super.visit(node, data);

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitor.java
@@ -243,7 +243,7 @@ public class PullupUnexecutableNodesVisitor extends BaseVisitor {
         // if a delayed predicate, then change it to a regular reference
         if (ASTDelayedPredicate.instanceOf(node)) {
             
-            // continue to pull up delayed markers in the odd case that a double delay ocurred
+            // continue to pull up delayed markers in the odd case that a double delay occurred
             JexlNode marker = node;
             while (ASTDelayedPredicate.instanceOf(marker)) {
                 if (node.jjtGetNumChildren() > 1) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeConjunctionRebuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RangeConjunctionRebuildingVisitor.java
@@ -63,8 +63,8 @@ public class RangeConjunctionRebuildingVisitor extends RebuildingVisitor {
         this.indexOnlyFields = helper.getIndexOnlyFields(config.getDatatypeFilter());
         this.allFields = helper.getAllFields(config.getDatatypeFilter());
         this.scannerFactory = scannerFactory;
-        stats = new IndexStatsClient(this.config.getConnector(), this.config.getIndexStatsTableName());
-        costAnalysis = new CostEstimator(config, scannerFactory, helper);
+        this.stats = new IndexStatsClient(this.config.getConnector(), this.config.getIndexStatsTableName());
+        this.costAnalysis = new CostEstimator(config, scannerFactory, helper);
         this.expandFields = expandFields;
         this.expandValues = expandValues;
     }
@@ -91,6 +91,9 @@ public class RangeConjunctionRebuildingVisitor extends RebuildingVisitor {
                 QueryException qe = new QueryException(DatawaveErrorCode.DATATYPESFORINDEXFIELDS_MULTIMAP_MISSING);
                 throw new DatawaveFatalQueryException(qe);
             }
+            
+            // inject reference nodes when needed
+            script = (T) EnsureReferenceNodesVisitor.ensureReferences(script);
             
             return (T) (script.jjtAccept(visitor, null));
         } else {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RemoveExtraParensVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RemoveExtraParensVisitor.java
@@ -103,11 +103,18 @@ public class RemoveExtraParensVisitor extends BaseVisitor {
     @Override
     public Object visit(ASTReference node, Object data) {
         
+        boolean changed = false;
         while (isDoubleReference(node)) {
             node = (ASTReference) removeMiddleNode(node);
+            changed = true;
         }
         
-        return super.visit(node, data);
+        if (changed && node.jjtGetParent() instanceof ASTReferenceExpression) {
+            // Handle the case when a double ref is eaten, and now we have a double wrap like 'refExpr-ref-refExpr'
+            return visit((ASTReferenceExpression) node.jjtGetParent(), data);
+        } else {
+            return super.visit(node, data);
+        }
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RemoveExtraParensVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RemoveExtraParensVisitor.java
@@ -79,23 +79,25 @@ public class RemoveExtraParensVisitor extends BaseVisitor {
      */
     @Override
     public Object visit(ASTReferenceExpression node, Object data) {
-        
+        // Operate on a plain JexlNode to avoid class cast exception
+        JexlNode target = node;
         boolean changed;
         do {
             changed = false;
             
-            if (isDoubleWrapped(node)) {
-                node = (ASTReferenceExpression) removeDoubleWrap(node);
+            if (isDoubleWrapped(target)) {
+                // Replace this reference expression with the child reference node
+                target = removeDoubleWrap(target);
                 changed = true;
             }
             
-            if (isDoubleReferenceExpression(node)) {
-                node = (ASTReferenceExpression) removeMiddleNode(node);
+            if (isDoubleReferenceExpression(target)) {
+                target = removeMiddleNode(target);
                 changed = true;
             }
         } while (changed);
         
-        return super.visit(node, data);
+        return super.visit(target, data);
     }
     
     @Override
@@ -169,16 +171,11 @@ public class RemoveExtraParensVisitor extends BaseVisitor {
         
         JexlNode parent = node.jjtGetParent();
         JexlNode child = node.jjtGetChild(0);
-        JexlNode target = child.jjtGetChild(0);
         
         // Execute two swaps to clear references to stale nodes
         JexlNodes.swap(parent, node, child);
-        JexlNodes.swap(parent, child, target);
         
-        // All references to the child node should be gone.
-        child = null;
-        
-        return target;
+        return child;
     }
     
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/nodes/QueryPropertyMarkerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/nodes/QueryPropertyMarkerTest.java
@@ -60,4 +60,13 @@ public class QueryPropertyMarkerTest {
     public void verifyEachSubclassHasDistinctLabel() {
         
     }
+    
+    // Test some marker detection scenarios
+    
+    @Test
+    public void testMarkerDetection_delayedExpression() throws ParseException {
+        String query = "((_Delayed_ = true) && (FOO =~ '.*regex.*'))";
+        JexlNode node = JexlASTHelper.parseJexlQuery(query);
+        Assert.assertTrue(ASTDelayedPredicate.instanceOf(node));
+    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
@@ -3,6 +3,7 @@ package datawave.query.jexl.visitors;
 import com.google.common.collect.Sets;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.exceptions.InvalidFieldIndexQueryFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.MockMetadataHelper;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
@@ -165,6 +166,18 @@ public class AllTermsIndexedVisitorTest {
     @Test(expected = DatawaveFatalQueryException.class)
     public void testGreaterThanEqualsWithExtraTerm() throws ParseException {
         String query = "FOO >= '+aE1' || FOO == 'bar'";
+        testIsIndexed(query);
+    }
+    
+    @Test(expected = InvalidFieldIndexQueryFatalQueryException.class)
+    public void testSimpleBoundedRangeCase() throws ParseException {
+        String query = "((_Bounded_ = true) && (FOO >= '2' && FOO <= '5'))";
+        testIsIndexed(query);
+    }
+    
+    @Test(expected = InvalidFieldIndexQueryFatalQueryException.class)
+    public void testSimpleBoundedRangeCaseWithExtraParens() throws ParseException {
+        String query = "(((_Bounded_ = true) && (FOO >= '2' && FOO <= '5')))";
         testIsIndexed(query);
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/EnsureReferenceNodesVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/EnsureReferenceNodesVisitorTest.java
@@ -1,0 +1,60 @@
+package datawave.query.jexl.visitors;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.JexlNodeFactory;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ASTReferenceExpression;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.JexlNodes;
+import org.apache.commons.jexl2.parser.ParserTreeConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EnsureReferenceNodesVisitorTest {
+    
+    @Test
+    public void testInjectReferenceNode() {
+        // Build a simple AST that does not have a reference node
+        JexlNode eqNode = JexlNodeFactory.buildEQNode("F", "v");
+        JexlNode expr = new ASTReferenceExpression(ParserTreeConstants.JJTREFERENCEEXPRESSION);
+        ASTJexlScript script = new ASTJexlScript(ParserTreeConstants.JJTJEXLSCRIPT);
+        JexlNodes.children(expr, eqNode);
+        JexlNodes.children(script, expr);
+        
+        // assert initial tree state
+        assertEquals(1, script.jjtGetNumChildren());
+        JexlNode child = script.jjtGetChild(0);
+        assertEquals(ParserTreeConstants.JJTREFERENCEEXPRESSION, JexlNodes.id(child));
+        assertEquals(1, child.jjtGetNumChildren());
+        JexlNode grandChild = child.jjtGetChild(0);
+        assertEquals(ParserTreeConstants.JJTEQNODE, JexlNodes.id(grandChild));
+        
+        // assert visible query
+        String expectedQuery = "(F == 'v')";
+        String builtQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(script);
+        assertEquals(expectedQuery, builtQuery);
+        
+        // inject reference nodes
+        script = (ASTJexlScript) EnsureReferenceNodesVisitor.ensureReferences(script);
+        
+        // assert lineage
+        assertTrue(JexlASTHelper.validateLineage(script, true));
+        
+        // visible query should not have changed
+        builtQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(script);
+        assertEquals(expectedQuery, builtQuery);
+        
+        // assert that the backing AST now has a reference expression
+        assertEquals(1, script.jjtGetNumChildren());
+        child = script.jjtGetChild(0);
+        assertEquals(ParserTreeConstants.JJTREFERENCE, JexlNodes.id(child));
+        assertEquals(1, child.jjtGetNumChildren());
+        grandChild = child.jjtGetChild(0);
+        assertEquals(ParserTreeConstants.JJTREFERENCEEXPRESSION, JexlNodes.id(grandChild));
+        assertEquals(1, grandChild.jjtGetNumChildren());
+        JexlNode greatGrandChild = grandChild.jjtGetChild(0);
+        assertEquals(ParserTreeConstants.JJTEQNODE, JexlNodes.id(greatGrandChild));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -335,8 +335,8 @@ public class ExpandCompositeTermsTest {
         
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
         
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '"
-                        + Normalizer.NUMBER_NORMALIZER.normalize("12345") + "')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '"
+                        + Normalizer.NUMBER_NORMALIZER.normalize("12345") + "'))";
         String expected = "((((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO <= '020d,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO <= '0335,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO <= '0483,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO <= '050355,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO <= '1f36c71c71c71c71c7,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -963,7 +963,7 @@ public class ExpandCompositeTermsTest {
         
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
         
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))";
         String expected = "((((_Bounded_ = true) && (GEO >= '0202' && GEO < '020e'))) || (((_Bounded_ = true) && (GEO >= '030a' && GEO < '0336'))) || (((_Bounded_ = true) && (GEO >= '0428' && GEO < '0484'))) || (((_Bounded_ = true) && (GEO >= '0500aa' && GEO < '050356'))) || (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO < '1f36c71c71c71c71c8'))))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -987,8 +987,7 @@ public class ExpandCompositeTermsTest {
         indexedFields.add("GEO");
         
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
-        
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
         String expected = "((((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO < '020d,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO < '0335,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO < '0483,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO < '050355,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO < '1f36c71c71c71c71c7,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -1011,7 +1010,7 @@ public class ExpandCompositeTermsTest {
         Set<String> indexedFields = new HashSet<>();
         indexedFields.add("GEO");
         
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
         String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -1036,7 +1035,7 @@ public class ExpandCompositeTermsTest {
         
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
         
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
         String expected = "((((_Bounded_ = true) && (GEO_WKT >= '0202,+AE0' && GEO_WKT < '020d,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO_WKT >= '030a,+AE0' && GEO_WKT < '0335,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO_WKT >= '0428,+AE0' && GEO_WKT < '0483,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO_WKT >= '0500aa,+AE0' && GEO_WKT < '050355,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))) || (((_Bounded_ = true) && (GEO_WKT >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO_WKT < '1f36c71c71c71c71c7,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -1057,7 +1056,7 @@ public class ExpandCompositeTermsTest {
         
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
         
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))";
         String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -1080,7 +1079,7 @@ public class ExpandCompositeTermsTest {
         Set<String> indexedFields = new HashSet<>();
         indexedFields.add("GEO");
         
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
         String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
         
         runTestQuery(query, expected, indexedFields, conf);
@@ -1114,7 +1113,7 @@ public class ExpandCompositeTermsTest {
         
         String normNum = Normalizer.NUMBER_NORMALIZER.normalize("55");
         
-        String query = "(GEO == '0202' || (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) && WKT == '" + normNum + "'";
+        String query = "(GEO == '0202' || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335'))) && WKT == '" + normNum + "'";
         String expected = "((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '0202," + normNum + "')) && ((_Eval_ = true) && (GEO == '0202' && WKT == '"
                         + normNum + "'))) || (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335," + normNum
                         + "')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '" + normNum + "'))))";
@@ -1143,7 +1142,7 @@ public class ExpandCompositeTermsTest {
         
         String normNum = Normalizer.NUMBER_NORMALIZER.normalize("55");
         
-        String query = "(GEO == '0202' || (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) && WKT == '" + normNum + "'";
+        String query = "(GEO == '0202' || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335'))) && WKT == '" + normNum + "'";
         String expected = "(GEO == '0202,+bE5.5' || (((_Bounded_ = true) && (GEO >= '030a,+bE5.5' && GEO <= '0335,+bE5.5')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '+bE5.5'))))";
         
         runTestQuery(query, expected, indexedFields, conf);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitorTest.java
@@ -1,0 +1,57 @@
+package datawave.query.jexl.visitors;
+
+import com.google.common.collect.Sets;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.util.MockMetadataHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class PullupUnexecutableNodesVisitorTest {
+    
+    private Set<String> indexedFields;
+    private Set<String> indexOnlyFields;
+    private Set<String> nonEventFields;
+    private MockMetadataHelper metadataHelper;
+    private ShardQueryConfiguration config;
+    
+    @Before
+    public void before() {
+        indexedFields = Sets.newHashSet("FOO");
+        indexOnlyFields = Sets.newHashSet();
+        nonEventFields = Sets.newHashSet();
+        
+        metadataHelper = new MockMetadataHelper();
+        metadataHelper.setIndexedFields(indexOnlyFields);
+        metadataHelper.setIndexOnlyFields(indexOnlyFields);
+        metadataHelper.setNonEventFields(nonEventFields);
+        
+        config = new ShardQueryConfiguration();
+        config.setIndexedFields(indexedFields);
+    }
+    
+    @Test
+    public void testPullupDelayed() throws ParseException {
+        String query = "!((_Delayed_ = true) && (FOO =~ 'bar.*'))";
+        String expected = "!(FOO =~ 'bar.*')";
+        test(query, expected);
+    }
+    
+    private void test(String query, String expected) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        
+        ASTJexlScript visitedScript = (ASTJexlScript) PullupUnexecutableNodesVisitor.pullupDelayedPredicates(script, true, config, indexedFields,
+                        indexOnlyFields, nonEventFields, metadataHelper);
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        // assertTrue(TreeEqualityVisitor.isEqual(expectedScript, visitedScript));
+        
+        String visitedQueryString = JexlStringBuildingVisitor.buildQueryWithoutParse(visitedScript);
+        assertEquals(expected, visitedQueryString);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/PullupUnexecutableNodesVisitorTest.java
@@ -43,6 +43,13 @@ public class PullupUnexecutableNodesVisitorTest {
         test(query, expected);
     }
     
+    @Test
+    public void testPullUpMultipleDelayed() throws ParseException {
+        String query = "((_Delayed_ = true) && ((_Delayed_ = true) && (FOO == 'bar')))";
+        String expected = "(FOO == 'bar')";
+        test(query, expected);
+    }
+    
     private void test(String query, String expected) throws ParseException {
         ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
         

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RemoveExtraParensVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RemoveExtraParensVisitorTest.java
@@ -1,5 +1,6 @@
 package datawave.query.jexl.visitors;
 
+import com.google.common.collect.Lists;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import org.apache.commons.jexl2.parser.ASTEQNode;
@@ -11,6 +12,8 @@ import org.apache.commons.jexl2.parser.JexlNodes;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -107,6 +110,26 @@ public class RemoveExtraParensVisitorTest {
         assertTrue(TreeEqualityVisitor.isEqual(expected, removed));
         
         assertLineage(removed);
+    }
+    
+    @Test
+    public void testOddRefExprOrder() throws ParseException {
+        JexlNode leftEq = JexlNodeFactory.buildEQNode("F", "v");
+        JexlNode leftNode = JexlNodes.wrap(JexlNodes.makeRef(JexlNodes.wrap(leftEq)));
+        
+        JexlNode rightEq = JexlNodeFactory.buildEQNode("F2", "v2");
+        JexlNode rightNode = JexlNodes.makeRef(JexlNodes.wrap(rightEq));
+        
+        JexlNode union = JexlNodeFactory.createOrNode(Arrays.asList(leftNode, rightNode));
+        
+        String expectedQuery = "((F == 'v') || (F2 == 'v2'))";
+        test(JexlStringBuildingVisitor.buildQueryWithoutParse(union), expectedQuery);
+    }
+    
+    @Test
+    public void testDelayedRegex() throws ParseException {
+        String query = "((_Delayed_ = true) && (FOO =~ '.*regex.*'))";
+        test(query, query);
     }
     
     private void test(String query, String expected) throws ParseException {

--- a/warehouse/query-core/src/test/java/org/apache/commons/jexl2/parser/ASTDelayedPredicateTest.java
+++ b/warehouse/query-core/src/test/java/org/apache/commons/jexl2/parser/ASTDelayedPredicateTest.java
@@ -21,4 +21,28 @@ public class ASTDelayedPredicateTest {
         String delayedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(node);
         assertEquals(expected, delayedQuery);
     }
+    
+    @Test
+    public void testDelayBoundedRange() throws ParseException {
+        String query = "((_Bounded_ = true) && (SIZE >= 3 && SIZE <= 7))";
+        String expected = "((_Delayed_ = true) && (((_Bounded_ = true) && (SIZE >= 3 && SIZE <= 7))))";
+        
+        JexlNode node = JexlASTHelper.parseJexlQuery(query);
+        JexlNode delayed = ASTDelayedPredicate.create(node);
+        
+        String delayedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(delayed);
+        assertEquals(expected, delayedQuery);
+    }
+    
+    @Test
+    public void testDelayOfValueExceededBoundedRange() throws ParseException {
+        String query = "((_Value_ = true) && (((_Bounded_ = true) && (SIZE >= 3 && SIZE <= 7))))";
+        String expected = "((_Delayed_ = true) && (((_Value_ = true) && (((_Bounded_ = true) && (SIZE >= 3 && SIZE <= 7))))))";
+        
+        JexlNode node = JexlASTHelper.parseJexlQuery(query);
+        JexlNode delayed = ASTDelayedPredicate.create(node);
+        
+        String delayedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(delayed);
+        assertEquals(expected, delayedQuery);
+    }
 }


### PR DESCRIPTION
The original implementation for removing extra reference expressions broke a few assumptions made by various visitors. 

- Added a visitor to fix reference expressions that do not have a parent reference node
- Reworked implementation of RemoveExtraParensVisitor
- Simplified delayed predicate pushdown