### PR TITLE
Wait for ingest servers to stop before killing jobs

### DIFF
--- a/warehouse/ingest-scripts/src/main/resources/bin/ingest/stop-ingest-servers.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/ingest/stop-ingest-servers.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+if [[ `uname` == "Darwin" ]]; then
+        THIS_SCRIPT=`python -c 'import os,sys;print os.path.realpath(sys.argv[1])' $0`
+else
+        THIS_SCRIPT=`readlink -f $0`
+fi
+
+THIS_DIR="${THIS_SCRIPT%/*}"
+cd $THIS_DIR
+
+. ../util/pid-functions.sh
+
 function usage
 {
     echo -e "usage: stop-ingest-servers.sh [options] where options include:\n
@@ -6,6 +18,8 @@ function usage
     \t-signal\tSignal command to send as first arg to kill
     \t-help\tprint this message\n"
 }
+
+MAX_SLEEP_TIME_SECS="${MAX_SLEEP_TIME_SECS:-30}"
 
 BULK_SCRIPT="bulk-ingest-server.sh"
 BULK_TEXT="bulk"
@@ -69,6 +83,7 @@ do
      else
         echo "stopping ${!text} ingest server $SIGNAL"
         kill $SIGNAL $PID
+        pid::waitForDeath ${PID} ${MAX_SLEEP_TIME_SECS}
      fi
 done
 

--- a/warehouse/ingest-scripts/src/main/resources/bin/util/pid-functions.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/util/pid-functions.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+PID_FUNCTIONS_DEFINED="${PID_FUNCTIONS_DEFINED}"
+[[ -n "${PID_FUNCTIONS_DEFINED}" ]] && return # already sourced
+
+#######################################
+# Waits for a PID to terminate up to a given threshold
+# Arguments:
+#  1) The PID to wait for
+#  2) The max time (in seconds) to wait
+#######################################
+function pid::waitForDeath() {
+  local _pid=$1
+  local _maxTimeToWait=$2
+
+  if [[ -z "${_pid}" ]] || [[ -z "${_maxTimeToWait}" ]]; then
+    echo "Expected <pid> <maxTimeToWaitSecs>"
+    return 1
+  fi
+
+  local _sleepTime=1
+  local _totalWaitTime=0
+
+  while (( _totalWaitTime < _maxTimeToWait )) && kill -0 "${_pid}" 2>/dev/null; do
+    sleep ${_sleepTime}
+    _totalWaitTime=$(( _totalWaitTime + _sleepTime ))
+  done
+
+  if (( _totalWaitTime >= _maxTimeToWait )); then
+    echo "Exceeded max wait time. Process ${_pid} may still be running."
+    return 2
+  else
+    return 0
+  fi
+}
+
+PID_FUNCTIONS_DEFINED="true"


### PR DESCRIPTION
We sometimes have YARN ingest jobs that start while we are in the process of shutting down. It looks like the cause of this is due to stop-ingest-servers.sh invoking kill, which is async, and then immediately calling KillJobsByRegex to stop the YARN jobs. 

This modification makes the stop-ingest-servers.sh script block up to 30 seconds (can be overridden) to allow the ingest-servers to actually come down before issuing the KillJobsByRegex. In testing, the script doesn't block for a noticeable amount of time.