### PR TITLE
Add ability to override query node processor in LuceneToJexlQueryParser

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlQueryParser.java
@@ -72,7 +72,7 @@ public class LuceneToJexlQueryParser implements QueryParser {
             Locale.setDefault(Locale.US);
             AccumuloSyntaxParser syntaxParser = new AccumuloSyntaxParser();
             syntaxParser.enable_tracing();
-
+            
             QueryNodeProcessor processor = getQueryNodeProcessor();
             QueryBuilder builder = new JexlTreeBuilder(allowedFunctions);
             
@@ -84,12 +84,12 @@ public class LuceneToJexlQueryParser implements QueryParser {
         }
         return parsedQuery;
     }
-
+    
     private QueryNodeProcessor getQueryNodeProcessor() {
         QueryConfigHandler queryConfigHandler = new QueryConfigHandler();
-
+        
         queryConfigHandler.set(ConfigurationKeys.ANALYZER, analyzer);
-
+        
         queryConfigHandler.set(ConfigurationKeys.ENABLE_POSITION_INCREMENTS, positionIncrementsEnabled);
         queryConfigHandler.set(TOKENIZED_FIELDS, tokenizedFields);
         queryConfigHandler.set(TOKENIZE_UNFIELDED_QUERIES, tokenizeUnfieldedQueries);
@@ -97,13 +97,13 @@ public class LuceneToJexlQueryParser implements QueryParser {
         queryConfigHandler.set(ALLOWED_FIELDS, allowedFields);
         queryConfigHandler.set(ALLOW_ANY_FIELD_QUERIES, allowAnyFieldQueries);
         queryConfigHandler.set(USE_SLOP_FOR_TOKENIZED_TERMS, useSlopForTokenizedTerms);
-
+        
         queryConfigHandler.set(ConfigurationKeys.ALLOW_LEADING_WILDCARD, allowLeadingWildCard);
-
+        
         QueryNodeProcessor processor = queryNodeProcessorFactory.create(queryConfigHandler);
         return processor;
     }
-
+    
     public boolean isTokenizeUnfieldedQueries() {
         return tokenizeUnfieldedQueries;
     }
@@ -175,15 +175,15 @@ public class LuceneToJexlQueryParser implements QueryParser {
     public void setAnalyzer(Analyzer analyzer) {
         this.analyzer = analyzer;
     }
-
+    
     public QueryNodeProcessorFactory getQueryNodeProcessorFactory() {
         return queryNodeProcessorFactory;
     }
-
+    
     public void setQueryNodeProcessorFactory(QueryNodeProcessorFactory queryNodeProcessorFactory) {
         this.queryNodeProcessorFactory = queryNodeProcessorFactory;
     }
-
+    
     public List<JexlQueryFunction> getAllowedFunctions() {
         return allowedFunctions;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlQueryParser.java
@@ -12,10 +12,9 @@ import datawave.query.language.parser.ParseException;
 import datawave.query.language.parser.QueryParser;
 import datawave.query.language.parser.lucene.AccumuloSyntaxParser;
 import datawave.query.language.parser.lucene.QueryConfigHandler;
-import datawave.query.language.processor.lucene.CustomQueryNodeProcessorPipeline;
 import datawave.query.language.tree.QueryNode;
 import datawave.query.language.tree.ServerHeadNode;
-
+import datawave.query.language.processor.lucene.QueryNodeProcessorFactory;
 import org.apache.lucene.analysis.Analyzer;
 import datawave.ingest.data.tokenize.StandardAnalyzer;
 import org.apache.lucene.queryparser.flexible.core.builders.QueryBuilder;
@@ -38,6 +37,7 @@ public class LuceneToJexlQueryParser implements QueryParser {
     private Boolean allowAnyFieldQueries = true;
     private List<JexlQueryFunction> allowedFunctions = JexlTreeBuilder.DEFAULT_ALLOWED_FUNCTION_LIST;
     private Analyzer analyzer = new StandardAnalyzer();
+    private QueryNodeProcessorFactory queryNodeProcessorFactory = new QueryNodeProcessorFactory();
     
     public LuceneToJexlQueryParser() {
         Collections.addAll(tokenizedFields, DEFAULT_TOKENIZED_FIELDS);
@@ -72,22 +72,8 @@ public class LuceneToJexlQueryParser implements QueryParser {
             Locale.setDefault(Locale.US);
             AccumuloSyntaxParser syntaxParser = new AccumuloSyntaxParser();
             syntaxParser.enable_tracing();
-            
-            QueryConfigHandler queryConfigHandler = new QueryConfigHandler();
-            
-            queryConfigHandler.set(ConfigurationKeys.ANALYZER, analyzer);
-            
-            queryConfigHandler.set(ConfigurationKeys.ENABLE_POSITION_INCREMENTS, positionIncrementsEnabled);
-            queryConfigHandler.set(TOKENIZED_FIELDS, tokenizedFields);
-            queryConfigHandler.set(TOKENIZE_UNFIELDED_QUERIES, tokenizeUnfieldedQueries);
-            queryConfigHandler.set(SKIP_TOKENIZE_UNFIELDED_FIELDS, skipTokenizeUnfieldedFields);
-            queryConfigHandler.set(ALLOWED_FIELDS, allowedFields);
-            queryConfigHandler.set(ALLOW_ANY_FIELD_QUERIES, allowAnyFieldQueries);
-            queryConfigHandler.set(USE_SLOP_FOR_TOKENIZED_TERMS, useSlopForTokenizedTerms);
-            
-            queryConfigHandler.set(ConfigurationKeys.ALLOW_LEADING_WILDCARD, allowLeadingWildCard);
-            
-            QueryNodeProcessor processor = new CustomQueryNodeProcessorPipeline(queryConfigHandler);
+
+            QueryNodeProcessor processor = getQueryNodeProcessor();
             QueryBuilder builder = new JexlTreeBuilder(allowedFunctions);
             
             org.apache.lucene.queryparser.flexible.core.nodes.QueryNode queryTree = syntaxParser.parse(query, "");
@@ -98,7 +84,26 @@ public class LuceneToJexlQueryParser implements QueryParser {
         }
         return parsedQuery;
     }
-    
+
+    private QueryNodeProcessor getQueryNodeProcessor() {
+        QueryConfigHandler queryConfigHandler = new QueryConfigHandler();
+
+        queryConfigHandler.set(ConfigurationKeys.ANALYZER, analyzer);
+
+        queryConfigHandler.set(ConfigurationKeys.ENABLE_POSITION_INCREMENTS, positionIncrementsEnabled);
+        queryConfigHandler.set(TOKENIZED_FIELDS, tokenizedFields);
+        queryConfigHandler.set(TOKENIZE_UNFIELDED_QUERIES, tokenizeUnfieldedQueries);
+        queryConfigHandler.set(SKIP_TOKENIZE_UNFIELDED_FIELDS, skipTokenizeUnfieldedFields);
+        queryConfigHandler.set(ALLOWED_FIELDS, allowedFields);
+        queryConfigHandler.set(ALLOW_ANY_FIELD_QUERIES, allowAnyFieldQueries);
+        queryConfigHandler.set(USE_SLOP_FOR_TOKENIZED_TERMS, useSlopForTokenizedTerms);
+
+        queryConfigHandler.set(ConfigurationKeys.ALLOW_LEADING_WILDCARD, allowLeadingWildCard);
+
+        QueryNodeProcessor processor = queryNodeProcessorFactory.create(queryConfigHandler);
+        return processor;
+    }
+
     public boolean isTokenizeUnfieldedQueries() {
         return tokenizeUnfieldedQueries;
     }
@@ -170,7 +175,15 @@ public class LuceneToJexlQueryParser implements QueryParser {
     public void setAnalyzer(Analyzer analyzer) {
         this.analyzer = analyzer;
     }
-    
+
+    public QueryNodeProcessorFactory getQueryNodeProcessorFactory() {
+        return queryNodeProcessorFactory;
+    }
+
+    public void setQueryNodeProcessorFactory(QueryNodeProcessorFactory queryNodeProcessorFactory) {
+        this.queryNodeProcessorFactory = queryNodeProcessorFactory;
+    }
+
     public List<JexlQueryFunction> getAllowedFunctions() {
         return allowedFunctions;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/QueryNodeProcessorFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/QueryNodeProcessorFactory.java
@@ -1,0 +1,10 @@
+package datawave.query.language.processor.lucene;
+
+import org.apache.lucene.queryparser.flexible.core.config.QueryConfigHandler;
+import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessor;
+
+public class QueryNodeProcessorFactory {
+    public QueryNodeProcessor create(QueryConfigHandler configHandler) {
+        return new CustomQueryNodeProcessorPipeline(configHandler);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -585,18 +585,20 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo\\ Foo.*'", parser.parse("FOO:bar BAZ:/Foo\\/Foo\\ Foo.*/").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo Foo.*?'", parser.parse("FOO:bar BAZ:/Foo\\/Foo Foo.*?/").getOriginalQuery());
     }
-
+    
     private static class TestQueryNodeProcessorFactory extends QueryNodeProcessorFactory {
         @Override
         public QueryNodeProcessor create(QueryConfigHandler configHandler) {
             return new QueryNodeProcessorPipeline(configHandler);
         }
     }
-
+    
     @Test
     public void testCustomQueryNodeProcessor() throws ParseException {
         String query = "TOKFIELD:\"quick wi-fi fox\"";
-        Assert.assertEquals("(content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi-fi', 'fox') || content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi', 'fi', 'fox'))", parseQuery(query));
+        Assert.assertEquals(
+                        "(content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi-fi', 'fox') || content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi', 'fi', 'fox'))",
+                        parseQuery(query));
         parser.setQueryNodeProcessorFactory(new TestQueryNodeProcessorFactory());
         Assert.assertEquals("content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi-fi', 'fox')", parseQuery(query));
     }

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -2,10 +2,28 @@ package datawave.query.language.parser.jexl;
 
 import com.google.common.collect.Sets;
 import datawave.query.language.parser.ParseException;
+import datawave.query.language.processor.lucene.CustomAnalyzerQueryNodeProcessor;
+import datawave.query.language.processor.lucene.CustomFieldLimiterNodeProcessor;
+import datawave.query.language.processor.lucene.CustomWildcardQueryNodeProcessor;
+import datawave.query.language.processor.lucene.QueryNodeProcessorFactory;
 import datawave.query.language.tree.QueryNode;
 import datawave.query.language.tree.ServerHeadNode;
 import datawave.query.Constants;
 
+import org.apache.lucene.queryparser.flexible.core.config.QueryConfigHandler;
+import org.apache.lucene.queryparser.flexible.core.processors.NoChildOptimizationQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessorPipeline;
+import org.apache.lucene.queryparser.flexible.core.processors.RemoveDeletedQueryNodesProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.AllowLeadingWildcardProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.BooleanSingleChildOptimizationQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.DefaultPhraseSlopQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.FuzzyQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.MatchAllDocsQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.MultiFieldQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.MultiTermRewriteMethodProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.RemoveEmptyNonLeafQueryNodeProcessor;
+import org.apache.lucene.queryparser.flexible.standard.processors.TermRangeQueryNodeProcessor;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -566,6 +584,21 @@ public class TestLuceneToJexlQueryParser {
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo Foo.*?'", parser.parse("FOO:bar BAZ:Foo\\/Foo\\ Foo*").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo\\ Foo.*'", parser.parse("FOO:bar BAZ:/Foo\\/Foo\\ Foo.*/").getOriginalQuery());
         Assert.assertEquals("FOO == 'bar' && BAZ =~ 'Foo/Foo Foo.*?'", parser.parse("FOO:bar BAZ:/Foo\\/Foo Foo.*?/").getOriginalQuery());
+    }
+
+    private static class TestQueryNodeProcessorFactory extends QueryNodeProcessorFactory {
+        @Override
+        public QueryNodeProcessor create(QueryConfigHandler configHandler) {
+            return new QueryNodeProcessorPipeline(configHandler);
+        }
+    }
+
+    @Test
+    public void testCustomQueryNodeProcessor() throws ParseException {
+        String query = "TOKFIELD:\"quick wi-fi fox\"";
+        Assert.assertEquals("(content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi-fi', 'fox') || content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi', 'fi', 'fox'))", parseQuery(query));
+        parser.setQueryNodeProcessorFactory(new TestQueryNodeProcessorFactory());
+        Assert.assertEquals("content:phrase(TOKFIELD, termOffsetMap, 'quick', 'wi-fi', 'fox')", parseQuery(query));
     }
     
 }


### PR DESCRIPTION
When implementing query handling strategies that differ from what's implemented in `LuceneToJexlQueryParser` it is necessary to override the `CustomQueryNodeProcessorPipeline` which is currently hard-coded. 

This change introduces a `QueryNodeProcessorPipelineFactory` that can be overridden and injected into `LuceneToJexlQueryParser` to change the way in which lucene `QueryNode`'s will be transformed into JEXL expressions. 