### PR TITLE
Verify lineage for QueryOptionsFromQueryVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
@@ -76,7 +76,8 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
     }
     
     /**
-     * If the passed OR node contains a f:options
+     * If the passed OR node contains a f:options, descend the tree with a List in the passed userdata. The function args will be collected into the List when
+     * visiting the child ASTStringLiteral nodes.
      *
      * @param node
      *            the {@link ASTOrNode}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
@@ -2,38 +2,65 @@ package datawave.query.jexl.visitors;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
-import datawave.query.Constants;
 import datawave.query.QueryParameters;
-import datawave.query.jexl.functions.QueryFunctions;
 import datawave.query.attributes.UniqueFields;
 import datawave.query.attributes.UniqueGranularity;
+import datawave.query.jexl.functions.QueryFunctions;
+import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
 import org.apache.commons.jexl2.parser.ASTIdentifier;
+import org.apache.commons.jexl2.parser.ASTOrNode;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ASTReferenceExpression;
 import org.apache.commons.jexl2.parser.ASTStringLiteral;
 import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.JexlNodes;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.apache.commons.jexl2.parser.ParserTreeConstants.JJTANDNODE;
+import static org.apache.commons.jexl2.parser.ParserTreeConstants.JJTORNODE;
 
 /**
- * Visits the query tree and if there is a f:options function, extracts the parameters into a Map
- *
+ * Visits the query tree and extracts the parameters from any options functions present and adds them to the provided data {@link Map}. Any options function
+ * nodes will be subsequently deleted and remaining AND/OR nodes will be optimized to account for the potential removal of their children. The supported options
+ * are as followed:
+ * <ul>
+ * <li>{@code f:options()}: Expects a comma-delimited list of key/value pairs, e.g. {@code f:options('hit.list','true','limit.fields','FOO_1_BAR=3)}</li>
+ * <li>{@code f:groupby()}: Expects a comma-delimited list of fields to group by, e.g. {@code f:groupby('field1','field2',field3')}</li>
+ * <li>{@code f:unique()}: Expects a comma-delimited list of fields to be unique and their granularity levels, e.g.
+ * {@code f:unique('field1[ALL]','field2[DAY]','field3[MINUTE,SECOND]')}</li>
+ * <li>{@code f:unique_by_day()}: Expects a comma-delimited list of fields to be unique with a granularity level of by DAY, e.g.
+ * {@code unique_by_day('field1','field2')}</li>
+ * <li>{@code f:unique_by_minute()}: Expects a comma-delimited list of fields to be unique with a granularity level of by MINUTE, e.g.
+ * {@code unique_by_minute('field1','field2')}</li>
+ * <li>{@code f:unique_by_second()}: Expects a comma-delimited list of fields to be unique with a granularity level of by SECOND, e.g.
+ * {@code unique_by_second('field1','field2')}</li>
+ * </ul>
  */
 public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
+    
+    private static final Joiner JOINER = Joiner.on(',').skipNulls();
     
     private static final Set<String> RESERVED = ImmutableSet.of(QueryFunctions.QUERY_FUNCTION_NAMESPACE, QueryFunctions.OPTIONS_FUNCTION,
                     QueryFunctions.UNIQUE_FUNCTION, QueryFunctions.UNIQUE_BY_DAY_FUNCTION, QueryFunctions.UNIQUE_BY_HOUR_FUNCTION,
                     QueryFunctions.UNIQUE_BY_MINUTE_FUNCTION, QueryFunctions.GROUPBY_FUNCTION);
     
+    @SuppressWarnings("unchecked")
+    public static <T extends JexlNode> T collect(T node, Object data) {
+        QueryOptionsFromQueryVisitor visitor = new QueryOptionsFromQueryVisitor();
+        return (T) node.jjtAccept(visitor, data);
+    }
+    
     /**
-     * If the passed userData is a Map, type cast and call the method to begin collection of the function arguments
+     * If the passed data is a {@link Map}, type cast and call the method to begin collection of the function arguments
      * 
      * @param node
-     *            potentially a f:options function node
+     *            potentially an f:options function node
      * @param data
      *            userData
      * @return the rebuilt node
@@ -49,14 +76,58 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
     }
     
     /**
-     * If this is the f:options function, descend the tree with a List in the passed userdata. The function args will be collected into the List when visiting
-     * the child ASTStringLiteral nodes
+     * If the passed OR node contains a f:options
+     *
+     * @param node
+     *            the {@link ASTOrNode}
+     * @param data
+     *            the data
+     * @return the rebuilt node, or null if all children of the node were deleted
+     */
+    @Override
+    public Object visit(ASTOrNode node, Object data) {
+        return visitJunction(node, data, () -> new ASTOrNode(JJTORNODE));
+    }
+    
+    @Override
+    public Object visit(ASTAndNode node, Object data) {
+        return visitJunction(node, data, () -> new ASTAndNode(JJTANDNODE));
+    }
+    
+    private Object visitJunction(JexlNode node, Object data, Supplier<JexlNode> creator) {
+        // Visit each child, and keep only the non-null ones.
+        List<JexlNode> children = new ArrayList<>();
+        for (JexlNode child : JexlNodes.children(node)) {
+            Object copy = child.jjtAccept(this, data);
+            if (copy != null) {
+                children.add((JexlNode) copy);
+            }
+        }
+        
+        // If there are no children, return null and effectively delete the junction.
+        if (children.isEmpty()) {
+            return null;
+        } else if (children.size() == 1) {
+            // If there is one child, delete the junction and return the child.
+            return children.get(0);
+        } else {
+            // If there are multiple children, return a new junction with the children.
+            JexlNode copy = creator.get();
+            copy.image = node.image;
+            JexlNodes.children(copy, children.toArray(new JexlNode[0]));
+            return copy;
+        }
+    }
+    
+    /**
+     * If this is a function that contains key/value options, descend the tree with a {@link List} as the data. The function args will be collected into the
+     * list when visiting the child {@link ASTStringLiteral} nodes.
      * 
      * @param node
-     *            the function node potentially for f:options
+     *            the {@link ASTFunctionNode} that potentially contains parsable function options
      * @param optionsMap
-     *            a Map to return option key/values
-     * @return the rebuilt node
+     *            a {@link Map} that any parsed options key/values will be added to
+     * @return null if this is a function with any key/value options, or the rebuilt node
      */
     private Object visit(ASTFunctionNode node, Map<String,String> optionsMap) {
         // if this is the f:options function, create a List for the userData to be passed to the child nodes
@@ -77,7 +148,7 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
                     // Get the list of declared fields and join them into a comma-delimited string.
                     List<String> fieldList = new ArrayList<>();
                     this.visit(node, fieldList);
-                    String fieldString = String.join(Constants.COMMA, fieldList);
+                    String fieldString = JOINER.join(fieldList);
                     
                     // Parse the unique fields.
                     UniqueFields uniqueFields = UniqueFields.from(fieldString);
@@ -105,7 +176,7 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
                 case QueryFunctions.GROUPBY_FUNCTION: {
                     List<String> optionsList = new ArrayList<>();
                     this.visit(node, optionsList);
-                    optionsMap.put(QueryParameters.GROUP_FIELDS, Joiner.on(',').join(optionsList));
+                    optionsMap.put(QueryParameters.GROUP_FIELDS, JOINER.join(optionsList));
                     return null;
                 }
             }
@@ -113,30 +184,14 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
         return super.visit(node, optionsMap);
     }
     
-    /**
-     * Find all unique fields declared in the provided node and add them to the provided {@link UniqueFields} with the specified transformer.
-     * 
-     * @param node
-     *            the node to find fields in
-     * @param uniqueFields
-     *            the unique fields instance to modify
-     * @param transformer
-     *            the transformer to add any identified fields with.
-     */
+    // Find all unique fields declared in the provided node and add them to the provided {@link UniqueFields} with the specified transformer.
     private void putFieldsFromChildren(JexlNode node, UniqueFields uniqueFields, UniqueGranularity transformer) {
         List<String> fields = new ArrayList<>();
         this.visit(node, fields);
         fields.forEach((field) -> uniqueFields.put(field, transformer));
     }
     
-    /**
-     * Update the {@value QueryParameters#UNIQUE_FIELDS} option to include the given unique fields.
-     * 
-     * @param optionsMap
-     *            the options map
-     * @param uniqueFields
-     *            the unique fields to include
-     */
+    // Update the {@value QueryParameters#UNIQUE_FIELDS} option to include the given unique fields.
     private void updateUniqueFieldsOption(Map<String,String> optionsMap, UniqueFields uniqueFields) {
         // Combine with any previously found unique fields.
         if (optionsMap.containsKey(QueryParameters.UNIQUE_FIELDS)) {
@@ -147,67 +202,45 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
     }
     
     /**
-     * if the passed data is a List, call the method that collects the node image strings
+     * If the passed data is a {@link List}, add the node's image to the list.
      * 
      * @param node
-     *            a string literal
+     *            the {@link ASTStringLiteral} node
      * @param data
-     *            userData
+     *            the data, possible a {@link List}
      * @return the rebuilt node
      */
     @Override
     public Object visit(ASTStringLiteral node, Object data) {
-        if (data instanceof List) {
-            return this.visit(node, (List) data);
-        }
+        addImageToListData(node, data);
         return super.visit(node, data);
     }
     
     /**
-     * collect the node.image strings into the passed List
-     * 
-     * @param node
-     *            the ASTLiteralNode that is a child of the f:options function
-     * @param list
-     *            a list for collecting the child image strings (the property key/values)
-     * @return
-     */
-    private Object visit(ASTStringLiteral node, List<String> list) {
-        list.add(node.image);
-        return super.visit(node, list);
-    }
-    
-    /**
-     * if the passed data is a List, call the method that collects the node image strings
+     * If the passed data is a {@link List}, and the node's image is not in the {@link #RESERVED} set, add the node's image to the list.
      *
      * @param node
-     *            an identifier
+     *            the {@link ASTIdentifier} node
      * @param data
-     *            userData
+     *            the data, possibly a {@link List}
      * @return the rebuilt node
      */
     @Override
     public Object visit(ASTIdentifier node, Object data) {
+        // Check if the current node is a child of the f:options function.
         if (!RESERVED.contains(node.image)) {
-            if (data instanceof List) {
-                return this.visit(node, (List) data);
-            }
+            addImageToListData(node, data);
         }
         return super.visit(node, data);
     }
     
-    /**
-     * collect the node.image strings into the passed List
-     *
-     * @param node
-     *            the ASTIdentifier that is a child of the f:options function
-     * @param list
-     *            a list for collecting the child image strings (the property key/values)
-     * @return
-     */
-    private Object visit(ASTIdentifier node, List<String> list) {
-        list.add(node.image);
-        return super.visit(node, list);
+    // If the given data is a list, add the node's image to it.
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void addImageToListData(JexlNode node, Object data) {
+        if (data instanceof List) {
+            List list = (List) data;
+            list.add(node.image);
+        }
     }
     
     /**
@@ -215,8 +248,10 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
      * generate a parseException in the jexl Parser unless the empty ASTReference node is also removed by returning null here.
      * 
      * @param node
+     *            the {@link ASTReference} node
      * @param data
-     * @return
+     *            the data
+     * @return the rebuilt node if it has children, or null otherwise
      */
     @Override
     public Object visit(ASTReference node, Object data) {
@@ -231,8 +266,10 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
      * would generate a parseException in the jexl Parser unless the empty ASTReferenceExpression node is also removed by returning null here.
      *
      * @param node
+     *            the {@link ASTReferenceExpression} node
      * @param data
-     * @return
+     *            the data
+     * @return the rebuilt node if it has children, or null otherwise
      */
     @Override
     public Object visit(ASTReferenceExpression node, Object data) {
@@ -240,12 +277,6 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
         if (n.jjtGetNumChildren() == 0)
             return null;
         return n;
-        
     }
     
-    @SuppressWarnings("unchecked")
-    public static <T extends JexlNode> T collect(T node, Object data) {
-        QueryOptionsFromQueryVisitor visitor = new QueryOptionsFromQueryVisitor();
-        return (T) node.jjtAccept(visitor, data);
-    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitorTest.java
@@ -2,9 +2,10 @@ package datawave.query.jexl.visitors;
 
 import datawave.query.QueryParameters;
 import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.junit.After;
+import org.apache.log4j.Logger;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -15,16 +16,18 @@ import static org.junit.Assert.assertTrue;
 
 public class QueryOptionsFromQueryVisitorTest {
     
+    private static final Logger log = Logger.getLogger(QueryOptionsFromQueryVisitorTest.class);
+    
     private final Map<String,String> optionsMap = new HashMap<>();
     
     @Test
     public void testOptionsFunction() throws ParseException {
         // Verify that an empty options function adds no parameters.
-        findQueryOptions("f:options()");
+        assertResult("f:options()", "");
         assertTrue(optionsMap.isEmpty());
         
         // Verify any specified options are added as separate parameters.
-        findQueryOptions("f:options('include.grouping.context','true','hit.list','true','limit.fields','FOO_1_BAR=3,FOO_1=2')");
+        assertResult("f:options('include.grouping.context','true','hit.list','true','limit.fields','FOO_1_BAR=3,FOO_1=2')", "");
         assertOption("include.grouping.context", "true");
         assertOption("hit.list", "true");
         assertOption("limit.fields", "FOO_1_BAR=3,FOO_1=2");
@@ -33,100 +36,148 @@ public class QueryOptionsFromQueryVisitorTest {
     @Test
     public void testGroupByFunction() throws ParseException {
         // Verify that an empty groupby functions results in an empty parameter value.
-        findQueryOptions("f:groupby()");
+        assertResult("f:groupby()", "");
         assertOption(QueryParameters.GROUP_FIELDS, "");
         
-        findQueryOptions("f:groupby('field1','field2','field3')");
+        assertResult("f:groupby('field1','field2','field3')", "");
         assertOption(QueryParameters.GROUP_FIELDS, "field1,field2,field3");
     }
     
     @Test
     public void testUniqueFunction() throws ParseException {
         // Verify an empty function results in an empty parameter value.
-        findQueryOptions("f:unique_by_day()");
+        assertResult("f:unique_by_day()", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "");
         
         // Verify that fields of no specified granularity are added with the default ALL granularity.
-        findQueryOptions("f:unique('field1','field2','field3')");
+        assertResult("f:unique('field1','field2','field3')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[ALL],field2[ALL],field3[ALL]");
         
         // Verify that fields with DAY granularity are added as such.
-        findQueryOptions("f:unique('field1[DAY]','field2[DAY]','field3[DAY]')");
+        assertResult("f:unique('field1[DAY]','field2[DAY]','field3[DAY]')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[DAY],field2[DAY],field3[DAY]");
         
         // Verify that fields with HOUR granularity are added as such.
-        findQueryOptions("f:unique('field1[HOUR]','field2[HOUR]','field3[HOUR]')");
+        assertResult("f:unique('field1[HOUR]','field2[HOUR]','field3[HOUR]')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[HOUR],field2[HOUR],field3[HOUR]");
         
         // Verify that fields with MINUTE granularity are added as such.
-        findQueryOptions("f:unique('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')");
+        assertResult("f:unique('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[MINUTE],field2[MINUTE],field3[MINUTE]");
         
         // Verify that fields from multiple unique functions are merged together.
-        findQueryOptions("f:unique('field1','field2') AND f:unique('field2[DAY]','field3[DAY]') AND f:unique('field4')");
+        assertResult("f:unique('field1','field2') AND f:unique('field2[DAY]','field3[DAY]') AND f:unique('field4')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[ALL],field2[ALL,DAY],field3[DAY],field4[ALL]");
         
         // Verify more complex fields with multiple granularity levels are merged together.
-        findQueryOptions("f:unique('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')");
+        assertResult("f:unique('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[DAY],field2[DAY,HOUR],field3[HOUR,MINUTE],field4[ALL,MINUTE],field5[ALL]");
         
         // Lucene will parse comma-delimited granularity levels into separate strings. Ensure it still parses correctly.
-        findQueryOptions("f:unique('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')");
+        assertResult("f:unique('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[DAY],field2[DAY,HOUR],field3[HOUR,MINUTE],field4[ALL,MINUTE],field5[ALL]");
     }
     
     @Test
     public void testUniqueByDay() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        findQueryOptions("f:unique_by_day()");
+        assertResult("f:unique_by_day()", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "");
         
         // Verify fields are added with the DAY granularity.
-        findQueryOptions("f:unique_by_day('field1','field2','field3')");
+        assertResult("f:unique_by_day('field1','field2','field3')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[DAY],field2[DAY],field3[DAY]");
         
         // Verify fields from multiple functions are merged.
-        findQueryOptions("f:unique('field1','field2[HOUR]') AND f:unique_by_day('field1','field2','field3') AND f:unique_by_day('field4')");
+        assertResult("f:unique('field1','field2[HOUR]') AND f:unique_by_day('field1','field2','field3') AND f:unique_by_day('field4')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[ALL,DAY],field2[DAY,HOUR],field3[DAY],field4[DAY]");
     }
     
     @Test
     public void testUniqueByHour() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        findQueryOptions("f:unique_by_hour()");
+        assertResult("f:unique_by_hour()", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "");
         
         // Verify fields are added with the HOUR granularity.
-        findQueryOptions("f:unique_by_hour('field1','field2','field3')");
+        assertResult("f:unique_by_hour('field1','field2','field3')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[HOUR],field2[HOUR],field3[HOUR]");
         
         // Verify fields from multiple functions are merged.
-        findQueryOptions("f:unique('field1','field2[DAY]') AND f:unique_by_hour('field1','field2','field3') AND f:unique_by_hour('field4')");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_hour('field1','field2','field3') AND f:unique_by_hour('field4')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[ALL,HOUR],field2[DAY,HOUR],field3[HOUR],field4[HOUR]");
     }
     
     @Test
     public void testUniqueByMinute() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        findQueryOptions("f:unique_by_minute()");
+        assertResult("f:unique_by_minute()", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "");
         
         // Verify fields are added with the MINUTE granularity.
-        findQueryOptions("f:unique_by_minute('field1','field2','field3')");
+        assertResult("f:unique_by_minute('field1','field2','field3')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[MINUTE],field2[MINUTE],field3[MINUTE]");
         
         // Verify fields from multiple functions are merged.
-        findQueryOptions("f:unique('field1','field2[DAY]') AND f:unique_by_minute('field1','field2','field3') AND f:unique_by_minute('field4')");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_minute('field1','field2','field3') AND f:unique_by_minute('field4')", "");
         assertOption(QueryParameters.UNIQUE_FIELDS, "field1[ALL,MINUTE],field2[DAY,MINUTE],field3[MINUTE],field4[MINUTE]");
     }
     
-    private void findQueryOptions(String query) throws ParseException {
-        optionsMap.clear();
-        JexlNode node = JexlASTHelper.parseJexlQuery(query);
-        QueryOptionsFromQueryVisitor.collect(node, optionsMap);
+    @Test
+    public void testNonFunctionNodesWithJunctions() throws ParseException {
+        // Verify that only the function node is removed.
+        assertResult("f:unique_by_minute('field1') AND FOO == 'bar'", "FOO == 'bar'");
+        assertOption(QueryParameters.UNIQUE_FIELDS, "field1[MINUTE]");
+        
+        // Verify that only the function node is removed.
+        assertResult("f:unique_by_minute('field1') AND (FOO == 'bar' AND BAT == 'foo')", "(FOO == 'bar' AND BAT == 'foo')");
+        assertOption(QueryParameters.UNIQUE_FIELDS, "field1[MINUTE]");
+        
+        // Verify that only the function node is removed.
+        assertResult("f:unique_by_minute('field1') OR FOO == 'bar'", "FOO == 'bar'");
+        assertOption(QueryParameters.UNIQUE_FIELDS, "field1[MINUTE]");
+        
+        // Verify that AND nodes are cleaned up.
+        assertResult("(FOO == 'bar' OR (BAR == 'foo' AND f:groupby('field1','field2')))", "(FOO == 'bar' OR (BAR == 'foo'))");
+        assertOption(QueryParameters.GROUP_FIELDS, "field1,field2");
+        
+        // Verify that OR nodes are cleaned up.
+        assertResult("(FOO == 'bar' AND (BAR == 'foo' OR f:groupby('field1','field2')))", "(FOO == 'bar' AND (BAR == 'foo'))");
+        assertOption(QueryParameters.GROUP_FIELDS, "field1,field2");
     }
     
     private void assertOption(String option, String value) {
         assertEquals(value, optionsMap.get(option));
+    }
+    
+    private void assertResult(String original, String expected) throws ParseException {
+        optionsMap.clear();
+        
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        
+        ASTJexlScript result = QueryOptionsFromQueryVisitor.collect(originalScript, optionsMap);
+        
+        assertScriptEquality(result, expected);
+        assertLineage(result);
+        
+        assertScriptEquality(originalScript, original);
+        assertLineage(originalScript);
+        
+        assertTrue(TreeEqualityVisitor.isEqual(expectedScript, result));
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expected));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
+        }
+        assertTrue(comparison.getReason(), comparison.isEqual());
+    }
+    
+    private void assertLineage(JexlNode node) {
+        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
 }


### PR DESCRIPTION
Write tests for QueryOptionsFromQueryVisitor to verify that it returns a
query with a valid lineage. Additionally, update the documentation, and
ensure that any AND/OR nodes with subsequently deleted children are
cleaned up.

Part of #880