### PR TITLE
Fix lineage for FixUnindexedNumericTerms

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnindexedNumericTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FixUnindexedNumericTerms.java
@@ -8,7 +8,6 @@ import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlASTHelper.IdentifierOpLiteral;
 import datawave.query.jexl.JexlNodeFactory;
-import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
 
@@ -21,17 +20,15 @@ import org.apache.commons.jexl2.parser.ASTLTNode;
 import org.apache.commons.jexl2.parser.ASTNENode;
 import org.apache.commons.jexl2.parser.ASTNRNode;
 import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.JexlNodes;
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.log4j.Logger;
 
 import com.google.common.base.Preconditions;
 
 /**
- * When we have an unindexed field that appears numeric in nature, then convert the string literals to numeric literals.
- *
+ * When we have an unindexed field that appears numeric in nature, convert the string literals to numeric literals.
  */
 public class FixUnindexedNumericTerms extends RebuildingVisitor {
-    private static final Logger log = ThreadConfigurableLogger.getLogger(FixUnindexedNumericTerms.class);
     
     private final ShardQueryConfiguration config;
     
@@ -62,54 +59,54 @@ public class FixUnindexedNumericTerms extends RebuildingVisitor {
     
     @Override
     public Object visit(ASTEQNode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTNENode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTERNode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTLTNode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTLENode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTGTNode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
     @Override
     public Object visit(ASTGENode node, Object data) {
-        return expandNodeForNormalizers(node, data);
+        return expandNodeForNormalizers(node);
     }
     
-    protected JexlNode expandNodeForNormalizers(JexlNode node, Object data) {
+    protected JexlNode expandNodeForNormalizers(JexlNode node) {
         IdentifierOpLiteral op = JexlASTHelper.getIdentifierOpLiteral(node);
         if (op == null) {
-            return node;
+            return copy(node);
         }
         
         final String fieldName = op.deconstructIdentifier();
         Object literal = op.getLiteralValue();
         
-        // Get all of the normalizers for the field name
+        // Get all the normalizers for the field name
         Collection<Type<?>> normalizers = config.getQueryFieldsDatatypes().get(fieldName);
         
         // Catch the case of the user entering FIELD == null
@@ -122,7 +119,8 @@ public class FixUnindexedNumericTerms extends RebuildingVisitor {
         }
         
         // Return a copy of the node with a potentially converted literal
-        return JexlNodeFactory.buildUntypedNewLiteralNode(node, fieldName, literal);
+        JexlNode copy = copy(node);
+        return JexlNodeFactory.buildUntypedNewLiteralNode(copy, fieldName, literal);
     }
     
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixUnindexedNumericTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixUnindexedNumericTermsTest.java
@@ -1,0 +1,139 @@
+package datawave.query.jexl.visitors;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import datawave.IdentityDataType;
+import datawave.data.type.Type;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.apache.log4j.Logger;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertTrue;
+
+public class FixUnindexedNumericTermsTest {
+    
+    private static final Logger log = Logger.getLogger(FixUnindexedNumericTermsTest.class);
+    
+    private Multimap<String,Type<?>> datatypes;
+    
+    private ShardQueryConfiguration config;
+    
+    @Before
+    public void setUp() throws Exception {
+        datatypes = HashMultimap.create();
+        config = EasyMock.mock(ShardQueryConfiguration.class);
+        expect(config.getQueryFieldsDatatypes()).andReturn(datatypes).anyTimes();
+        replay(config);
+    }
+    
+    @Test
+    public void testNullValues() throws ParseException {
+        assertResult("FOO == null", "FOO == null");
+        assertResult("FOO == 'null'", "FOO == 'null'");
+    }
+    
+    @Test
+    public void testEQNode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO == '10' && BAR == 2 && INDEXED_A == '10' && INDEXED_B == 2", "FOO == 10 && BAR == 2 && INDEXED_A == '10' && INDEXED_B == 2");
+    }
+    
+    @Test
+    public void testNENode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO != '10' && BAR != 2 && INDEXED_A != '10' && INDEXED_B != 2", "FOO != 10 && BAR != 2 && INDEXED_A != '10' && INDEXED_B != 2");
+    }
+    
+    @Test
+    public void testERNode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO =~ '10' && BAR =~ 2 && INDEXED_A =~ '10' && INDEXED_B =~ 2", "FOO =~ 10 && BAR =~ 2 && INDEXED_A =~ '10' && INDEXED_B =~ 2");
+    }
+    
+    @Test
+    public void testNRNode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO !~ '10' && BAR !~ 2 && INDEXED_A !~ '10' && INDEXED_B !~ 2", "FOO !~ 10 && BAR !~ 2 && INDEXED_A !~ '10' && INDEXED_B !~ 2");
+    }
+    
+    @Test
+    public void testLTNode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO < '10' && BAR < 2 && INDEXED_A < '10' && INDEXED_B < 2", "FOO < 10 && BAR < 2 && INDEXED_A < '10' && INDEXED_B < 2");
+    }
+    
+    @Test
+    public void testLENode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO <= '10' && BAR <= 2 && INDEXED_A <= '10' && INDEXED_B <= 2", "FOO <= 10 && BAR <= 2 && INDEXED_A <= '10' && INDEXED_B <= 2");
+    }
+    
+    @Test
+    public void testGTNode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO > '10' && BAR > 2 && INDEXED_A > '10' && INDEXED_B > 2", "FOO > 10 && BAR > 2 && INDEXED_A > '10' && INDEXED_B > 2");
+    }
+    
+    @Test
+    public void testGENode() throws ParseException {
+        givenIndexedField("INDEXED_A");
+        givenIndexedField("INDEXED_B");
+        
+        assertResult("FOO >= '10' && BAR >= 2 && INDEXED_A >= '10' && INDEXED_B >= 2", "FOO >= 10 && BAR >= 2 && INDEXED_A >= '10' && INDEXED_B >= 2");
+    }
+    
+    private void givenIndexedField(String field) {
+        datatypes.put(field, new IdentityDataType());
+    }
+    
+    private void assertResult(String original, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
+        ASTJexlScript actual = FixUnindexedNumericTerms.fixNumerics(config, originalScript);
+        
+        assertScriptEquality(actual, expected);
+        assertLineage(actual);
+        
+        assertScriptEquality(originalScript, original);
+        assertLineage(originalScript);
+        
+        assertTrue(TreeEqualityVisitor.isEqual(expectedScript, actual));
+    }
+    
+    private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
+        if (!comparison.isEqual()) {
+            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
+            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
+        }
+        assertTrue(comparison.getReason(), comparison.isEqual());
+    }
+    
+    private void assertLineage(JexlNode node) {
+        assertTrue(JexlASTHelper.validateLineage(node, true));
+    }
+}


### PR DESCRIPTION
FixUnindexedNumericTerms does not return a query tree with a valid
lineage. Ensure that lineage is properly established, and add unit tests
to verify this.

Part of #880.