### PR TITLE
Refactor DefaultQueryPlanner into discrete methods

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/exceptions/InvalidQueryTreeException.java
+++ b/warehouse/query-core/src/main/java/datawave/query/exceptions/InvalidQueryTreeException.java
@@ -1,0 +1,23 @@
+package datawave.query.exceptions;
+
+/**
+ * Thrown when an invalid query tree is encountered
+ */
+public class InvalidQueryTreeException extends Exception {
+    
+    public InvalidQueryTreeException() {
+        super();
+    }
+    
+    public InvalidQueryTreeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    public InvalidQueryTreeException(String message) {
+        super(message);
+    }
+    
+    public InvalidQueryTreeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/validate/ASTValidator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/validate/ASTValidator.java
@@ -1,0 +1,118 @@
+package datawave.query.jexl.visitors.validate;
+
+import datawave.query.exceptions.InvalidQueryTreeException;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.jexl.visitors.RebuildingVisitor;
+import datawave.query.jexl.visitors.TreeFlatteningRebuildingVisitor;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.log4j.Logger;
+
+/**
+ * Validates an AST with respect to some basic assumptions. Intended to be called after a given visitor is done visiting a query tree.
+ *
+ * <pre>
+ *     1. Proper lineage with respect to parent-child pointers
+ *     2. The tree is flattened
+ * </pre>
+ */
+public class ASTValidator {
+    
+    private static final Logger log = Logger.getLogger(ASTValidator.class);
+    
+    // this is a static utility class
+    private ASTValidator() {}
+    
+    /**
+     * Determines if the provided AST meets all basic assumptions. Intended to be called outside of normal visitor validation
+     *
+     * @param root
+     *            an arbitrary JexlNode
+     * @return true if the tree is valid, otherwise throws an exception
+     */
+    public static boolean isValid(JexlNode root) throws InvalidQueryTreeException {
+        return isValid(root, null, true);
+    }
+    
+    /**
+     * Determines if the provided AST meets all basic assumptions of validity. Intended to be called after a visitor is done visiting a query tree.
+     *
+     * @param root
+     *            an arbitrary JexlNode
+     * @param sourceVisitor
+     *            the visitor calling this method
+     * @return true if the AST is valid, otherwise
+     */
+    public static boolean isValid(JexlNode root, String sourceVisitor) throws InvalidQueryTreeException {
+        return isValid(root, sourceVisitor, true);
+    }
+    
+    /**
+     * Determines if the AST meets all basic assumptions of validity. Throws an exception if the AST if not valid.
+     *
+     * @param root
+     *            an arbitrary JexlNode
+     * @param sourceVisitor
+     *            the visitor calling this method, may be null if called outside normal scope
+     * @param logDiffs
+     *            boolean to control logging any detected diffs
+     * @param failHard
+     *            boolean to throw an exception if the tree fails validation
+     * @return true if the AST is valid, otherwise throws an exception
+     */
+    public static boolean isValid(JexlNode root, String sourceVisitor, boolean failHard) throws InvalidQueryTreeException {
+        
+        log.info("Validating tree after visiting " + sourceVisitor);
+        
+        boolean isLineageValid = isLineageValid(root);
+        boolean isTreeFlattened = isTreeFlattened(root);
+        
+        //  @formatter:off
+        boolean isValid = isLineageValid && isTreeFlattened;
+        //  @formatter:on
+        
+        if (!isValid) {
+            
+            if (!isLineageValid)
+                log.error("Valid Lineage: " + isLineageValid);
+            if (!isTreeFlattened)
+                log.error("Valid flatten: " + isTreeFlattened);
+            
+            log.error(sourceVisitor + " produced an invalid query tree, see logs for details.");
+            if (failHard) {
+                if (sourceVisitor != null) {
+                    throw new InvalidQueryTreeException(sourceVisitor + " produced an invalid query tree, see logs for details.");
+                } else {
+                    throw new InvalidQueryTreeException("Invalid query tree detected outside of normal scope, see logs for details");
+                }
+            }
+        }
+        return isValid;
+    }
+    
+    /**
+     * Validate the lineage of all nodes under this root
+     *
+     * @param root
+     *            an arbitrary JexlNode
+     * @return true if all parent-child relationships are valid
+     */
+    private static boolean isLineageValid(JexlNode root) {
+        // Do not fail hard
+        return JexlASTHelper.validateLineage(root, false);
+    }
+    
+    /**
+     * Determine if this AST is flattened
+     *
+     * @param root
+     *            an arbitrary JexlNode
+     * @return true if the tree is flattened
+     */
+    private static boolean isTreeFlattened(JexlNode root) {
+        JexlNode copy = RebuildingVisitor.copy(root);
+        String original = JexlStringBuildingVisitor.buildQueryWithoutParse(copy);
+        String flattened = JexlStringBuildingVisitor.buildQueryWithoutParse(TreeFlatteningRebuildingVisitor.flatten(copy));
+        return original.equals(flattened);
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/validate/ASTValidator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/validate/ASTValidator.java
@@ -54,8 +54,6 @@ public class ASTValidator {
      *            an arbitrary JexlNode
      * @param sourceVisitor
      *            the visitor calling this method, may be null if called outside normal scope
-     * @param logDiffs
-     *            boolean to control logging any detected diffs
      * @param failHard
      *            boolean to throw an exception if the tree fails validation
      * @return true if the AST is valid, otherwise throws an exception

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -695,7 +695,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (optionsMap.containsKey(QueryParameters.SHARDS_AND_DAYS)) {
             queryTree = timedAddShardsAndDaysFromOptions(timers, queryTree, optionsMap);
         }
-
+        
         // flatten the tree
         queryTree = timedFlatten(timers, queryTree);
         
@@ -769,8 +769,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         
         return queryTree;
     }
-
-
+    
     protected ASTJexlScript processTree(final ASTJexlScript originalQueryTree, ShardQueryConfiguration config, Query settings, MetadataHelper metadataHelper,
                     ScannerFactory scannerFactory, QueryData queryData, QueryStopwatch timers, QueryModel queryModel) throws DatawaveQueryException {
         ASTJexlScript queryTree = originalQueryTree;
@@ -1147,13 +1146,13 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     protected ASTJexlScript timedFlatten(QueryStopwatch timers, ASTJexlScript script) throws DatawaveQueryException {
         return visitorManager.timedVisit(timers, "Flatten", () -> (TreeFlatteningRebuildingVisitor.flatten(script)));
     }
-
-
-    protected ASTJexlScript timedAddShardsAndDaysFromOptions(QueryStopwatch timers, ASTJexlScript script, Map<String, String> optionsMap) throws DatawaveQueryException {
+    
+    protected ASTJexlScript timedAddShardsAndDaysFromOptions(QueryStopwatch timers, ASTJexlScript script, Map<String,String> optionsMap)
+                    throws DatawaveQueryException {
         String shardsAndDays = optionsMap.get(QueryParameters.SHARDS_AND_DAYS);
         return visitorManager.timedVisit(timers, "Add SHARDS_AND_DAYS From Options", () -> (AddShardsAndDaysVisitor.update(script, shardsAndDays)));
     }
-
+    
     protected ASTJexlScript timedApplyRules(QueryStopwatch timers, ASTJexlScript script, ShardQueryConfiguration config, MetadataHelper metadataHelper,
                     ScannerFactory scannerFactory) throws DatawaveQueryException {
         return visitorManager.timedVisit(timers, "Apply Pushdown Rules", () -> (applyRules(script, scannerFactory, metadataHelper, config)));

--- a/warehouse/query-core/src/main/java/datawave/query/planner/TimedVisitorManager.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/TimedVisitorManager.java
@@ -1,0 +1,90 @@
+package datawave.query.planner;
+
+import datawave.query.exceptions.DatawaveQueryException;
+import datawave.query.exceptions.InvalidQueryTreeException;
+import datawave.query.jexl.visitors.validate.ASTValidator;
+import datawave.query.util.QueryStopwatch;
+import datawave.util.time.TraceStopwatch;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+
+import static datawave.query.planner.DefaultQueryPlanner.logQuery;
+
+/**
+ * Handles boilerplate code execution for operations like timing a visit call, logging the query tree, and eventualy validating the resulting query tree.
+ */
+class TimedVisitorManager {
+    
+    private boolean isDebugEnabled; // log query tree after visit?
+    private boolean validateAst; // validate the query tree after visit?
+    
+    // default, do not log, do not validate
+    public TimedVisitorManager() {
+        this(false, false);
+    }
+    
+    /**
+     * Sets flags to log the query or validate the query
+     *
+     * @param isDebugEnabled
+     *            set this flag to log the query
+     * @param validateAst
+     *            set this flag to validate the query
+     */
+    public TimedVisitorManager(boolean isDebugEnabled, boolean validateAst) {
+        this.isDebugEnabled = isDebugEnabled;
+        this.validateAst = validateAst;
+    }
+    
+    /**
+     * Wrap visitor execution with a timer and debug msg
+     *
+     * @param timers
+     *            a {@link QueryStopwatch}
+     * @param stageName
+     *            the name for this operation, for example "Fix Not Null Intent" or "Expand Regex Nodes"
+     * @param visitorManager
+     *            an interface that allows us to pass a lambda operation {@link VisitorManager}
+     * @return the query tree, a {@link ASTJexlScript}
+     * @throws DatawaveQueryException
+     *             if something goes wrong
+     */
+    public ASTJexlScript timedVisit(QueryStopwatch timers, String stageName, VisitorManager visitorManager) throws DatawaveQueryException {
+        
+        ASTJexlScript script;
+        TraceStopwatch stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - " + stageName);
+        
+        try {
+            script = visitorManager.apply();
+            
+            if (isDebugEnabled) {
+                logQuery(script, "Query after visit: " + stageName);
+            }
+            
+            if (validateAst) {
+                try {
+                    ASTValidator.isValid(script);
+                } catch (InvalidQueryTreeException e) {
+                    throw new DatawaveQueryException(e);
+                }
+            }
+        } finally {
+            stopwatch.stop();
+        }
+        return script;
+    }
+    
+    // no timers, only validate
+    public ASTJexlScript validateAndVisit(VisitorManager visitorManager) throws DatawaveQueryException {
+        ASTJexlScript script = visitorManager.apply();
+        
+        if (validateAst) {
+            try {
+                ASTValidator.isValid(script);
+            } catch (InvalidQueryTreeException e) {
+                throw new DatawaveQueryException(e);
+            }
+        }
+        
+        return script;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/TimedVisitorManager.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/TimedVisitorManager.java
@@ -62,7 +62,7 @@ class TimedVisitorManager {
             
             if (validateAst) {
                 try {
-                    ASTValidator.isValid(script);
+                    ASTValidator.isValid(script, stageName);
                 } catch (InvalidQueryTreeException e) {
                     throw new DatawaveQueryException(e);
                 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/VisitorManager.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/VisitorManager.java
@@ -1,0 +1,11 @@
+package datawave.query.planner;
+
+import datawave.query.exceptions.DatawaveQueryException;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+
+/**
+ * An interface that lets us pass a lambda operation to the {@link TimedVisitorManager}
+ */
+public interface VisitorManager {
+    ASTJexlScript apply() throws DatawaveQueryException;
+}


### PR DESCRIPTION
This is a proof of concept merge request. The goal is to eliminate boilerplate code in the DefaultQueryPlanner while also providing more options to override and extend specific operations.