### PR TITLE
Add custom assertions for JexlNode instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <version.accumulo>1.9.2</version.accumulo>
         <version.arquillian>1.4.1.Final</version.arquillian>
         <version.arquillian-weld-ee-embedded>1.0.0.Final</version.arquillian-weld-ee-embedded>
+        <version.assertj>3.20.2</version.assertj>
         <version.avro>1.8.2</version.avro>
         <version.caffeine>2.7.0</version.caffeine>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
@@ -965,6 +966,12 @@
                 <version>${version.curator}</version>
                 <scope>test</scope>
                 <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.easymock</groupId>

--- a/warehouse/query-core/pom.xml
+++ b/warehouse/query-core/pom.xml
@@ -122,6 +122,10 @@
             <artifactId>lucene-queryparser</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
         </dependency>

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -1550,25 +1550,29 @@ public class JexlASTHelper {
     public static class LineageValidation {
         
         private final List<String> violations = new ArrayList<>();
-    
+        
         /**
          * Returns whether a valid lineage was confirmed.
+         * 
          * @return true if no violations were found, or false otherwise
          */
         public boolean isValid() {
             return violations.isEmpty();
         }
-    
+        
         /**
          * Add a message describing an encountered violation.
-         * @param message the description message
+         * 
+         * @param message
+         *            the description message
          */
         public void addViolation(String message) {
             violations.add(message);
         }
-    
+        
         /**
          * Return a string containing each violation message on a new line.
+         * 
          * @return the formatted string, or null if there are no violations.
          */
         public String getFormattedViolations() {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -68,7 +68,6 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
-import javax.sound.sampled.Line;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -1550,15 +1550,27 @@ public class JexlASTHelper {
     public static class LineageValidation {
         
         private final List<String> violations = new ArrayList<>();
-        
+    
+        /**
+         * Returns whether a valid lineage was confirmed.
+         * @return true if no violations were found, or false otherwise
+         */
         public boolean isValid() {
             return violations.isEmpty();
         }
-        
+    
+        /**
+         * Add a message describing an encountered violation.
+         * @param message the description message
+         */
         public void addViolation(String message) {
             violations.add(message);
         }
-        
+    
+        /**
+         * Return a string containing each violation message on a new line.
+         * @return the formatted string, or null if there are no violations.
+         */
         public String getFormattedViolations() {
             if (isValid()) {
                 return null;

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/AllTermsIndexedVisitorTest.java
@@ -5,20 +5,17 @@ import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.MockMetadataHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
-
 public class AllTermsIndexedVisitorTest {
     
-    private static final Logger log = Logger.getLogger(AllTermsIndexedVisitorTest.class);
     private static final Set<String> indexedFields = Sets.newHashSet("FOO", "FOO2", "FOO3");
     private static MockMetadataHelper helper;
     private static ShardQueryConfiguration config;
@@ -173,24 +170,9 @@ public class AllTermsIndexedVisitorTest {
         JexlNode result = AllTermsIndexedVisitor.isIndexed(original, config, helper);
         
         // Verify the resulting script has a valid lineage.
-        assertLineage(result);
+        JexlNodeAssert.assertThat(result).hasValidLineage();
         
         // Verify the original script was not modified and has a valid lineage.
-        assertScriptEquality(original, query);
-        assertLineage(original);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(original).isEqualTo(query).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BooleanOptimizationRebuildingVisitorTest.java
@@ -1,18 +1,13 @@
 package datawave.query.jexl.visitors;
 
-import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
 import static datawave.query.jexl.JexlASTHelper.parseJexlQuery;
-import static org.junit.Assert.assertTrue;
 
 public class BooleanOptimizationRebuildingVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(BooleanOptimizationRebuildingVisitorTest.class);
     
     @Test
     public void testConjunction() throws ParseException {
@@ -86,26 +81,7 @@ public class BooleanOptimizationRebuildingVisitorTest {
         
         ASTJexlScript resultScript = BooleanOptimizationRebuildingVisitor.optimize(originalScript);
         
-        // Verify the resulting script is as expected, and has a valid lineage.
-        assertScriptEquality(resultScript, expected);
-        assertLineage(resultScript);
-        
-        // Verify the original script was not modified, and has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(resultScript).isEqualTo(expected).hasValidLineage();
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/CaseSensitivityVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/CaseSensitivityVisitorTest.java
@@ -2,6 +2,7 @@ package datawave.query.jexl.visitors;
 
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.util.MockMetadataHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.junit.Before;
@@ -10,12 +11,11 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static datawave.query.jexl.JexlASTHelper.parseJexlQuery;
-import static org.junit.Assert.assertEquals;
 
 public class CaseSensitivityVisitorTest {
     
-    private MockMetadataHelper helper = new MockMetadataHelper();
-    private ShardQueryConfiguration config = new ShardQueryConfiguration();
+    private final MockMetadataHelper helper = new MockMetadataHelper();
+    private final ShardQueryConfiguration config = new ShardQueryConfiguration();
     
     @Before
     public void beforeTest() {
@@ -59,7 +59,6 @@ public class CaseSensitivityVisitorTest {
         
         CaseSensitivityVisitor.upperCaseIdentifiers(config, helper, script);
         
-        String result = JexlStringBuildingVisitor.buildQuery(script);
-        assertEquals(expected, result);
+        JexlNodeAssert.assertThat(script).hasExactQueryString(expected);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ConjunctionEliminationVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ConjunctionEliminationVisitorTest.java
@@ -1,17 +1,12 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 public class ConjunctionEliminationVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(ConjunctionEliminationVisitorTest.class);
     
     // A is not reducible.
     @Test
@@ -130,25 +125,9 @@ public class ConjunctionEliminationVisitorTest {
         ASTJexlScript visitedScript = ConjunctionEliminationVisitor.optimize(originalScript);
         
         // Verify the script is as expected, and has a valid lineage.
-        assertScriptEquality(visitedScript, expected);
-        assertLineage(visitedScript);
+        JexlNodeAssert.assertThat(visitedScript).isEqualTo(expected).hasValidLineage();
         
         // Verify the original script was not modified, and still has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexCleanupVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexCleanupVisitorTest.java
@@ -1,18 +1,14 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
 import static datawave.query.Constants.SHARD_DAY_HINT;
-import static org.junit.Assert.assertTrue;
 
 public class DateIndexCleanupVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(DateIndexCleanupVisitorTest.class);
     
     @Test
     public void testConjunction() throws ParseException {
@@ -54,26 +50,7 @@ public class DateIndexCleanupVisitorTest {
         
         ASTJexlScript cleaned = DateIndexCleanupVisitor.cleanup(script);
         
-        // Verify the result script is as expected, with a valid lineage.
-        assertScriptEquality(cleaned, expected);
-        assertLineage(cleaned);
-        
-        // Verify the original script was not modified, and has a valid lineage.
-        assertScriptEquality(script, original);
-        assertLineage(script);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(cleaned).isEqualTo(expected).hasValidLineage();
+        JexlNodeAssert.assertThat(script).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DateIndexQueryExpansionVisitorTest.java
@@ -3,12 +3,12 @@ package datawave.query.jexl.visitors;
 import datawave.helpers.PrintUtility;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.DateIndexTestIngest;
 import datawave.query.util.DateIndexHelper;
 import datawave.query.util.DateIndexHelperFactory;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.MetadataHelperFactory;
+import datawave.test.JexlNodeAssert;
 import datawave.util.TableName;
 import datawave.util.time.DateHelper;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -21,8 +21,7 @@ import datawave.accumulo.inmemory.InMemoryInstance;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.log4j.Logger;
-import org.junit.Assert;
+import org.apache.commons.jexl2.parser.ParseException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -33,20 +32,17 @@ import java.util.TimeZone;
 
 /**
  * Test the function index query expansion
- *
- *
  */
 public class DateIndexQueryExpansionVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(DateIndexQueryExpansionVisitorTest.class);
     
     Authorizations auths = new Authorizations("HUSH");
     
     private static Connector connector = null;
     
-    protected ShardQueryLogic logic = null;
-    
-    private MetadataHelper helper;
+    private Date startDate;
+    private Date endDate;
+    private MetadataHelper metadataHelper;
+    private DateIndexHelper dateIndexHelper;
     
     @BeforeClass
     public static void before() throws Exception {
@@ -57,113 +53,86 @@ public class DateIndexQueryExpansionVisitorTest {
     
     @Before
     public void setupTests() throws Exception {
-        
-        this.helper = new MetadataHelperFactory().createMetadataHelper(connector, TableName.DATE_INDEX, Collections.singleton(auths));
-        
-        this.createTables();
-        
+        this.metadataHelper = new MetadataHelperFactory().createMetadataHelper(connector, TableName.DATE_INDEX, Collections.singleton(auths));
+        this.deleteAndCreateTable();
         DateIndexTestIngest.writeItAll(connector);
         PrintUtility.printTable(connector, auths, TableName.DATE_INDEX);
+        dateIndexHelper = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX, Collections.singleton(auths), 2,
+                        0.9f);
+    }
+    
+    private void deleteAndCreateTable() throws AccumuloException, AccumuloSecurityException, TableNotFoundException, TableExistsException {
+        TableOperations tops = connector.tableOperations();
+        if (tops.exists(TableName.DATE_INDEX)) {
+            tops.delete(TableName.DATE_INDEX);
+        }
+        tops.create(TableName.DATE_INDEX);
     }
     
     @Test
     public void testDateIndexExpansion() throws Exception {
+        givenStartDate("20100701");
+        givenEndDate("20100710");
+        
         String originalQuery = "filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000')";
         String expectedQuery = "(filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000') && (SHARDS_AND_DAYS = '20100703_0,20100704_0,20100704_2,20100705_1'))";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         
-        Date startDate = DateHelper.parse("20100701");
-        Date endDate = DateHelper.parse("20100710");
-        
-        ShardQueryConfiguration config = new ShardQueryConfiguration();
-        config.setBeginDate(startDate);
-        config.setEndDate(endDate);
-        DateIndexHelper helper2 = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX,
-                        Collections.singleton(auths), 2, 0.9f);
-        ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        
-        Assert.assertEquals(expectedQuery, newQuery);
+        assertExpansion(originalQuery, expectedQuery);
     }
     
     @Test
     public void testDateIndexExpansionWithTimeTravel() throws Exception {
+        givenStartDate("20100701");
+        givenEndDate("20100710");
+        dateIndexHelper.setTimeTravel(true);
+        
         String originalQuery = "filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000')";
         String expectedQuery = "(filter:betweenDates(UPTIME, '20100704_200000', '20100704_210000') && (SHARDS_AND_DAYS = '20100702_0,20100703_0,20100704_0,20100704_2,20100705_1'))";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         
-        Date startDate = DateHelper.parse("20100701");
-        Date endDate = DateHelper.parse("20100710");
-        
-        ShardQueryConfiguration config = new ShardQueryConfiguration();
-        config.setBeginDate(startDate);
-        config.setEndDate(endDate);
-        
-        DateIndexHelper helper2 = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX,
-                        Collections.singleton(auths), 2, 0.9f);
-        helper2.setTimeTravel(true);
-        
-        ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        
-        Assert.assertEquals(expectedQuery, newQuery);
+        assertExpansion(originalQuery, expectedQuery);
     }
     
     @Test
     public void testDateIndexExpansion1() throws Exception {
+        givenStartDate("20100101");
+        givenEndDate("20100102");
+        
         String originalQuery = "filter:betweenDates(UPTIME, '20100101', '20100101')";
         String expectedQuery = "(filter:betweenDates(UPTIME, '20100101', '20100101') && (SHARDS_AND_DAYS = '20100101_1,20100102_2,20100102_4,20100102_5'))";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         
-        Date startDate = DateHelper.parse("20100101");
-        Date endDate = DateHelper.parse("20100102");
-        
-        ShardQueryConfiguration config = new ShardQueryConfiguration();
-        config.setBeginDate(startDate);
-        config.setEndDate(endDate);
-        DateIndexHelper helper2 = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX,
-                        Collections.singleton(auths), 2, 0.9f);
-        
-        ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
-        
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        
-        Assert.assertEquals(expectedQuery, newQuery);
+        assertExpansion(originalQuery, expectedQuery);
     }
     
     @Test
     public void testDateIndexExpansion2() throws Exception {
+        givenStartDate("20100101_200000");
+        givenEndDate("20100102_210000");
+        
         String originalQuery = "filter:betweenDates(UPTIME, '20100101_200000', '20100101_210000')";
         String expectedQuery = "(filter:betweenDates(UPTIME, '20100101_200000', '20100101_210000') && (SHARDS_AND_DAYS = '20100101_1,20100102_2,20100102_4,20100102_5'))";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
-        Date startDate = DateHelper.parse("20100101_200000");
-        Date endDate = DateHelper.parse("20100102_210000");
+        
+        assertExpansion(originalQuery, expectedQuery);
+    }
+    
+    private void givenStartDate(String startDate) {
+        this.startDate = DateHelper.parse(startDate);
+    }
+    
+    private void givenEndDate(String endDate) {
+        this.endDate = DateHelper.parse(endDate);
+    }
+    
+    private void assertExpansion(String original, String expected) throws ParseException {
+        ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
         
         ShardQueryConfiguration config = new ShardQueryConfiguration();
         config.setBeginDate(startDate);
         config.setEndDate(endDate);
-        DateIndexHelper helper2 = new DateIndexHelperFactory().createDateIndexHelper().initialize(connector, TableName.DATE_INDEX,
-                        Collections.singleton(auths), 2, 0.9f);
         
-        ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
+        ASTJexlScript result = FunctionIndexQueryExpansionVisitor.expandFunctions(config, metadataHelper, dateIndexHelper, originalScript);
         
-        String newQuery = JexlStringBuildingVisitor.buildQuery(newScript);
-        
-        Assert.assertEquals(expectedQuery, newQuery);
+        JexlNodeAssert.assertThat(result).isEqualTo(expected).hasValidLineage();
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
     
-    private void createTables() throws AccumuloSecurityException, AccumuloException, TableNotFoundException, TableExistsException {
-        TableOperations tops = connector.tableOperations();
-        deleteAndCreateTable(tops, TableName.DATE_INDEX);
-    }
-    
-    private void deleteAndCreateTable(TableOperations tops, String tableName) throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
-                    TableExistsException {
-        if (tops.exists(tableName)) {
-            tops.delete(tableName);
-        }
-        tops.create(tableName);
-    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DisjunctionEliminationVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/DisjunctionEliminationVisitorTest.java
@@ -1,17 +1,12 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 public class DisjunctionEliminationVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(DisjunctionEliminationVisitorTest.class);
     
     // A is not reducible.
     @Test
@@ -121,25 +116,9 @@ public class DisjunctionEliminationVisitorTest {
         ASTJexlScript visitedScript = DisjunctionEliminationVisitor.optimize(originalScript);
         
         // Verify the script is as expected, and has a valid lineage.
-        assertScriptEquality(visitedScript, expected);
-        assertLineage(visitedScript);
+        JexlNodeAssert.assertThat(visitedScript).isEqualTo(expected).hasValidLineage();
         
         // Verify the original script was not modified, and still has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -14,10 +14,9 @@ import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.DateIndexHelper;
 import datawave.query.util.MockMetadataHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,12 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class ExpandCompositeTermsTest {
-    
-    private static final Logger log = Logger.getLogger(ExpandCompositeTermsTest.class);
     
     private static final Set<String> INDEX_FIELDS = Sets.newHashSet("MAKE", "COLOR", "WHEELS", "TEAM", "NAME", "POINTS");
     
@@ -1230,11 +1224,11 @@ public class ExpandCompositeTermsTest {
         ASTJexlScript expand = FunctionIndexQueryExpansionVisitor.expandFunctions(conf, helper, DateIndexHelper.getInstance(), original);
         expand = ExpandCompositeTerms.expandTerms(conf, expand);
         
-        assertQueryStringEquality(expand, expected);
-        assertLineage(expand);
+        // Verify the script is as expected, and has a valid lineage.
+        JexlNodeAssert.assertThat(expand).isEqualTo(expected).hasValidLineage();
         
-        assertScriptEquality(original, query);
-        assertLineage(original);
+        // Verify the original script was not modified, and still has a valid lineage.
+        JexlNodeAssert.assertThat(original).isEqualTo(query).hasValidLineage();
     }
     
     void workIt(String query) throws Exception {
@@ -1254,25 +1248,6 @@ public class ExpandCompositeTermsTest {
         PrintingVisitor.printQuery(script);
         System.err.println(JexlStringBuildingVisitor.buildQuery(script));
         System.err.println();
-    }
-    
-    private void assertQueryStringEquality(ASTJexlScript actualScript, String expected) {
-        String actual = JexlStringBuildingVisitor.buildQuery(actualScript);
-        assertEquals(expected, actual);
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
     
     private static class MockDiscreteIndexType extends BaseType<String> implements DiscreteIndexType<String> {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -12,21 +12,16 @@ import datawave.data.type.Type;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.MockMetadataHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class ExpandMultiNormalizedTermsTest {
     
-    private static final Logger log = Logger.getLogger(ExpandMultiNormalizedTermsTest.class);
     private ShardQueryConfiguration config;
     private MockMetadataHelper helper;
     
@@ -454,43 +449,18 @@ public class ExpandMultiNormalizedTermsTest {
         ASTJexlScript smashed = TreeFlatteningRebuildingVisitor.flatten(queryTree);
         ASTJexlScript script = ExpandMultiNormalizedTerms.expandTerms(config, helper, smashed);
         
-        String originalRoundTrip = JexlStringBuildingVisitor.buildQuery(queryTree);
-        String smashedRoundTrip = JexlStringBuildingVisitor.buildQuery(smashed);
-        String visitedRountTrip = JexlStringBuildingVisitor.buildQuery(script);
-        
-        assertEquals(originalRoundTrip, smashedRoundTrip);
-        assertEquals(smashedRoundTrip, visitedRountTrip);
-        assertLineage(script);
-        
-        // Verify the original input script was not modified, and still has a valid lineage.
-        assertScriptEquality(queryTree, query);
-        assertLineage(queryTree);
+        JexlNodeAssert.assertThat(script).isEqualTo(smashed).isEqualTo(queryTree).hasValidLineage();
+        JexlNodeAssert.assertThat(queryTree).isEqualTo(query).hasValidLineage();
     }
     
     private void expandTerms(String original, String expected) throws ParseException {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(original);
         ASTJexlScript expanded = ExpandMultiNormalizedTerms.expandTerms(config, helper, script);
         
-        // Verify the resulting script is as expected, with a valid lineage.
-        assertScriptEquality(expanded, expected);
-        assertLineage(expanded);
+        // Verify the script is as expected, and has a valid lineage.
+        JexlNodeAssert.assertThat(expanded).isEqualTo(expected).hasValidLineage();
         
-        // Verify the original input script was not modified, and still has a valid lineage.
-        assertScriptEquality(script, original);
-        assertLineage(script);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        // Verify the original script was not modified, and still has a valid lineage.
+        JexlNodeAssert.assertThat(script).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldToFieldComparisonVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldToFieldComparisonVisitorTest.java
@@ -16,26 +16,30 @@ public class FieldToFieldComparisonVisitorTest {
     
     @Test
     public void testEq() throws ParseException {
-        ASTJexlScript query = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("FOO == BAR"));
-        JexlNodeAssert.assertThat(query).isEqualTo("((_Eval_ = true) && (FOO == BAR))").matches(ASTEvaluationOnly::instanceOf);
+        String query = "((_Eval_ = true) && (FOO == BAR))";
+        ASTJexlScript script = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("FOO == BAR"));
+        JexlNodeAssert.assertThat(script).isEqualTo(query).matches(ASTEvaluationOnly::instanceOf);
     }
     
     @Test
     public void testEqDoNothing() throws ParseException {
-        ASTJexlScript query = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("FOO == 'bar'"));
-        JexlNodeAssert.assertThat(query).isEqualTo("FOO == 'bar'").matches(notASTEvaluationOnlyInstance);
+        String query = "FOO == 'bar'";
+        ASTJexlScript script = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("FOO == 'bar'"));
+        JexlNodeAssert.assertThat(script).isEqualTo(query).matches(notASTEvaluationOnlyInstance);
     }
     
     @Test
     public void testEqDoNothingFieldsToLiteral() throws ParseException {
-        ASTJexlScript query = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("(FOO || BAR).min().hashCode() == 0"));
-        JexlNodeAssert.assertThat(query).isEqualTo("(FOO || BAR).min().hashCode() == 0").matches(notASTEvaluationOnlyInstance);
+        String query = "(FOO || BAR).min().hashCode() == 0";
+        ASTJexlScript script = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("(FOO || BAR).min().hashCode() == 0"));
+        JexlNodeAssert.assertThat(script).isEqualTo(query).matches(notASTEvaluationOnlyInstance);
     }
     
     @Test
     public void testEqDoNothing2() throws ParseException {
-        ASTJexlScript query = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("(UUID =~ 'C.*?' || UUID =~ 'S.*?')"));
-        JexlNodeAssert.assertThat(query).isEqualTo("(UUID =~ 'C.*?' || UUID =~ 'S.*?')").matches(notASTEvaluationOnlyInstance);
+        String query = "(UUID =~ 'C.*?' || UUID =~ 'S.*?')";
+        ASTJexlScript script = FieldToFieldComparisonVisitor.forceEvaluationOnly(JexlASTHelper.parseJexlQuery("(UUID =~ 'C.*?' || UUID =~ 'S.*?')"));
+        JexlNodeAssert.assertThat(script).isEqualTo(query).matches(notASTEvaluationOnlyInstance);
     }
     
     @Test(expected = ParseException.class)

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldToFieldComparisonVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldToFieldComparisonVisitorTest.java
@@ -5,12 +5,9 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
 public class FieldToFieldComparisonVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(FieldToFieldComparisonVisitorTest.class);
     
     @Test
     public void testEQ() throws ParseException {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
@@ -1,56 +1,32 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTNumberLiteral;
 import org.apache.commons.jexl2.parser.ASTUnaryMinusNode;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class FixNegativeNumbersVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(FixNegativeNumbersVisitorTest.class);
     
     @Test
     public void testUnaryMinusModeConvertedToNumberLiteral() throws ParseException {
         String query = "FOO == -1";
         ASTJexlScript queryScript = JexlASTHelper.parseJexlQuery(query);
         
-        // Verify the script was parsed with an unary minus node.
-        assertTrue(queryScript.jjtGetChild(0).jjtGetChild(1) instanceof ASTUnaryMinusNode);
+        // Verify the script was parsed with a unary minus node.
+        JexlNodeAssert.assertThat(queryScript).child(0).child(1).isInstanceOf(ASTUnaryMinusNode.class);
         
         ASTJexlScript fixed = FixNegativeNumbersVisitor.fix(queryScript);
-        JexlNode convertedNode = fixed.jjtGetChild(0).jjtGetChild(1);
         
         // Verify the unary minus mode was converted to a number literal.
-        assertTrue(convertedNode instanceof ASTNumberLiteral);
-        assertEquals("-1", convertedNode.jjtGetValue());
-        assertEquals(query, JexlStringBuildingVisitor.buildQuery(fixed));
+        JexlNodeAssert.assertThat(fixed).child(0).child(1).isInstanceOf(ASTNumberLiteral.class).hasValue("-1");
         
-        // Verify the resulting script has a valid lineage.
-        assertLineage(fixed);
+        // Verify the resulting script has a valid lineage and the same query string.
+        JexlNodeAssert.assertThat(fixed).hasExactQueryString(query).hasValidLineage();
         
         // Verify the original script was not modified, and has a valid lineage.
-        assertScriptEquality(queryScript, query);
-        assertLineage(queryScript);
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(queryScript).isEqualTo(query).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FixNegativeNumbersVisitorTest.java
@@ -15,7 +15,7 @@ public class FixNegativeNumbersVisitorTest {
         String query = "FOO == -1";
         ASTJexlScript queryScript = JexlASTHelper.parseJexlQuery(query);
         
-        // Verify the script was parsed with a unary minus node.
+        // Verify the script was parsed with a single unary minus node.
         JexlNodeAssert.assertThat(queryScript).child(0).child(1).isInstanceOf(ASTUnaryMinusNode.class);
         
         ASTJexlScript fixed = FixNegativeNumbersVisitor.fix(queryScript);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionIndexQueryExpansionVisitorTest.java
@@ -11,15 +11,14 @@ import datawave.query.util.MetadataHelper;
 import datawave.query.util.MetadataHelperFactory;
 import datawave.query.util.MockDateIndexHelper;
 import datawave.query.util.MockMetadataHelper;
+import datawave.test.JexlNodeAssert;
 import datawave.util.TableName;
 import datawave.util.time.DateHelper;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,11 +26,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertTrue;
-
 public class FunctionIndexQueryExpansionVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(FunctionIndexQueryExpansionVisitorTest.class);
     
     private ShardQueryConfiguration config;
     
@@ -97,25 +92,9 @@ public class FunctionIndexQueryExpansionVisitorTest {
         ASTJexlScript actualScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, metadataHelper, dateIndexHelper, originalScript);
         
         // Verify the script is as expected, and has a valid lineage.
-        assertScriptEquality(actualScript, expected);
-        assertLineage(actualScript);
+        JexlNodeAssert.assertThat(actualScript).isEqualTo(expected).hasValidLineage();
         
         // Verify that the original script was not modified.
-        assertScriptEquality(originalScript, originalQuery);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(originalQuery).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/GeoWavePruningVisitorTest.java
@@ -4,22 +4,19 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.ASTReferenceExpression;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
 import static datawave.query.jexl.functions.GeoWaveFunctionsDescriptorTest.convertFunctionToIndexQuery;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class GeoWavePruningVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(GeoWavePruningVisitorTest.class);
     
     @Test
     public void testNonIntersectingTermIsPruned() throws ParseException {
@@ -60,8 +57,7 @@ public class GeoWavePruningVisitorTest {
         ASTJexlScript actualScript = GeoWavePruningVisitor.pruneTree(originalScript, prunedTerms, null);
         
         // Verify the result is as expected, with a valid lineage.
-        assertScriptEquality(actualScript, expected);
-        assertLineage(actualScript);
+        JexlNodeAssert.assertThat(actualScript).isEqualTo(expected).hasValidLineage();
         
         // Verify there are no empty wrapped nodes.
         assertNoChildlessReferences(actualScript);
@@ -70,22 +66,7 @@ public class GeoWavePruningVisitorTest {
         assertEquals(prunedTerms, expectedPrunedTerms);
         
         // Verify the original script was not modified, and has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
     
     private void assertNoChildlessReferences(JexlNode node) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IsNotNullIntentVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IsNotNullIntentVisitorTest.java
@@ -1,6 +1,7 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
@@ -10,8 +11,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
 public class IsNotNullIntentVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(IsNotNullIntentVisitorTest.class);
     
     @Test
     public void testMatchAnythingRegex() throws ParseException {
@@ -41,26 +40,7 @@ public class IsNotNullIntentVisitorTest {
         ASTJexlScript originalScript = JexlASTHelper.parseJexlQuery(original);
         ASTJexlScript actual = IsNotNullIntentVisitor.fixNotNullIntent(originalScript);
         
-        // Verify the resulting script is as expected and has a valid lineage.
-        assertScriptEquality(actual, expected);
-        assertLineage(actual);
-        
-        // Verify the original script was not modified and has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(actual).isEqualTo(expected).hasValidLineage();
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -7,15 +7,13 @@ import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NoOpType;
 import datawave.data.type.Type;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.jexl.visitors.TreeEqualityVisitor.Comparison;
 import datawave.query.model.QueryModel;
 import datawave.query.util.MockMetadataHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTEQNode;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ASTReference;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,8 +26,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class QueryModelVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(QueryModelVisitor.class);
     
     private QueryModel model;
     private Set<String> allFields;
@@ -347,27 +343,11 @@ public class QueryModelVisitorTest {
         ASTJexlScript actualScript = QueryModelVisitor.applyModel(originalScript, model, allFields);
         
         // Verify the resulting script is as expected with a valid lineage.
-        assertScriptEquality(actualScript, expected);
-        assertLineage(actualScript);
+        JexlNodeAssert.assertThat(actualScript).isEqualTo(expected).hasValidLineage();
         
         // Verify the original script was not modified, and has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
         
         return actualScript;
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexFunctionVisitorTest.java
@@ -3,21 +3,17 @@ package datawave.query.jexl.visitors;
 import com.google.common.collect.Sets;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
-
 public class RegexFunctionVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(RegexFunctionVisitorTest.class);
     
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -82,25 +78,9 @@ public class RegexFunctionVisitorTest {
         JexlNode actual = RegexFunctionVisitor.expandRegex(null, null, indexOnlyFields, originalScript);
         
         // Verify the resulting script is as expected, with a valid lineage.
-        assertScriptEquality(actual, expected);
-        assertLineage(actual);
+        JexlNodeAssert.assertThat(actual).isEqualTo(expected).hasValidLineage();
         
         // Verify the original script was not modified and has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(JexlNode actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeFlatteningRebuildingVisitorTest.java
@@ -3,24 +3,20 @@ package datawave.query.jexl.visitors;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTEQNode;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.commons.jexl2.parser.Parser;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.StringReader;
 import java.util.Collections;
 
-import static org.junit.Assert.assertTrue;
-
 public class TreeFlatteningRebuildingVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(TreeFlatteningRebuildingVisitorTest.class);
     
     @Test
     public void dontFlattenASTDelayedPredicateAndTest() throws Exception {
@@ -189,26 +185,7 @@ public class TreeFlatteningRebuildingVisitorTest {
         
         ASTJexlScript flattened = TreeFlatteningRebuildingVisitor.flattenAll(originalScript);
         
-        assertScriptEquality(flattened, expected);
-        assertLineage(flattened);
-        
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-        
-        assertTrue(TreeEqualityVisitor.isEqual(expectedScript, flattened));
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(flattened).isEqualTo(expectedScript).hasValidLineage();
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeWrappingRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/TreeWrappingRebuildingVisitorTest.java
@@ -1,17 +1,12 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
 public class TreeWrappingRebuildingVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(TreeWrappingRebuildingVisitorTest.class);
     
     /**
      * Test that a new, top-level, unwrapped OR node is wrapped.
@@ -43,26 +38,8 @@ public class TreeWrappingRebuildingVisitorTest {
         
         ASTJexlScript flattened = TreeWrappingRebuildingVisitor.wrap(originalScript);
         
-        assertScriptEquality(flattened, expected);
-        assertLineage(flattened);
+        JexlNodeAssert.assertThat(flattened).isEqualTo(expectedScript).hasValidLineage();
         
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-        
-        assertTrue(TreeEqualityVisitor.isEqual(expectedScript, flattened));
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actual, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actual);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + JexlStringBuildingVisitor.buildQuery(expectedScript) + "\n" + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + JexlStringBuildingVisitor.buildQuery(actual) + "\n" + PrintingVisitor.formattedQueryString(actual));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UniqueExpressionTermsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UniqueExpressionTermsVisitorTest.java
@@ -1,18 +1,12 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
+import datawave.test.JexlNodeAssert;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
-import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 public class UniqueExpressionTermsVisitorTest {
-    
-    private static final Logger log = Logger.getLogger(UniqueExpressionTermsVisitorTest.class);
     
     @Test
     public void testSingleTerm() throws ParseException {
@@ -245,26 +239,9 @@ public class UniqueExpressionTermsVisitorTest {
         ASTJexlScript visitedScript = UniqueExpressionTermsVisitor.enforce(originalScript);
         
         // Verify the script is as expected, and has a valid lineage.
-        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(visitedScript));
-        assertScriptEquality(visitedScript, expected);
-        assertLineage(visitedScript);
+        JexlNodeAssert.assertThat(visitedScript).isEqualTo(expected).hasValidLineage();
         
         // Verify the original script was not modified, and still has a valid lineage.
-        assertScriptEquality(originalScript, original);
-        assertLineage(originalScript);
-    }
-    
-    private void assertScriptEquality(ASTJexlScript actualScript, String expected) throws ParseException {
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
-        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedScript, actualScript);
-        if (!comparison.isEqual()) {
-            log.error("Expected " + PrintingVisitor.formattedQueryString(expectedScript));
-            log.error("Actual " + PrintingVisitor.formattedQueryString(actualScript));
-        }
-        assertTrue(comparison.getReason(), comparison.isEqual());
-    }
-    
-    private void assertLineage(JexlNode node) {
-        assertTrue(JexlASTHelper.validateLineage(node, true));
+        JexlNodeAssert.assertThat(originalScript).isEqualTo(original).hasValidLineage();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/test/JexlNodeAssert.java
+++ b/warehouse/query-core/src/test/java/datawave/test/JexlNodeAssert.java
@@ -157,9 +157,7 @@ public class JexlNodeAssert extends AbstractAssert<JexlNodeAssert,JexlNode> {
      */
     public JexlNodeAssert hasNoChildren() {
         isNotNull();
-        if (actual.jjtGetNumChildren() != 0) {
-            failWithMessage("Expected no children, but had children %s", formatChildren(actual));
-        }
+        hasNumChildren(0);
         return this;
     }
     
@@ -233,7 +231,7 @@ public class JexlNodeAssert extends AbstractAssert<JexlNodeAssert,JexlNode> {
         isNotNull();
         JexlASTHelper.LineageValidation validation = JexlASTHelper.validateLineageVerbosely(actual, false);
         if (!validation.isValid()) {
-            failWithMessage("Expected a valid lineage, but found the following conflicts: \n" + validation.getFormattedInvalidations());
+            failWithMessage("Expected a valid lineage, but found the following conflicts: \n" + validation.getFormattedViolations());
         }
         return this;
     }

--- a/warehouse/query-core/src/test/java/datawave/test/JexlNodeAssert.java
+++ b/warehouse/query-core/src/test/java/datawave/test/JexlNodeAssert.java
@@ -1,0 +1,335 @@
+package datawave.test;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.jexl.visitors.PrintingVisitor;
+import datawave.query.jexl.visitors.TreeEqualityVisitor;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.commons.jexl2.parser.ParseException;
+import org.assertj.core.api.AbstractAssert;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * This class provides the ability to perform a number of assertions specific to {@link JexlNode} instances, and is intended to be used for testing purposes.
+ */
+public class JexlNodeAssert extends AbstractAssert<JexlNodeAssert,JexlNode> {
+    
+    /**
+     * Return a new {@link JexlNodeAssert} that will perform assertions on the specified node.
+     * 
+     * @param node
+     *            the node
+     * @return a new {@link JexlNodeAssert} for the node
+     */
+    public static JexlNodeAssert assertThat(JexlNode node) {
+        return new JexlNodeAssert(node, JexlNodeAssert.class);
+    }
+    
+    protected JexlNodeAssert(JexlNode node, Class<?> selfType) {
+        super(node, selfType);
+    }
+    
+    /**
+     * Verifies that the actual node's image is null
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNullImage() {
+        isNotNull();
+        if (actual.image != null) {
+            failWithMessage("Expected image to be null, but was %s", actual.image);
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's image is not null.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNonNullImage() {
+        isNotNull();
+        if (actual.image == null) {
+            failWithMessage("Expected image to not be null");
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's image is equal to the given one.
+     * 
+     * @param image
+     *            the image
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasImage(String image) {
+        isNotNull();
+        if (!Objects.equals(actual.image, image)) {
+            failWithMessage("Expected image to be %s but was %s", image, actual.image);
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's value is null.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNullValue() {
+        isNotNull();
+        if (actual.jjtGetValue() != null) {
+            failWithMessage("Expected value to be null, but was %s", actual.jjtGetValue());
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's value is not null.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNonNullValue() {
+        isNotNull();
+        if (actual.jjtGetValue() == null) {
+            failWithMessage("Expected value to not be null");
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's value is equal to the given one.
+     * 
+     * @param value
+     *            the value
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasValue(Object value) {
+        isNotNull();
+        if (!Objects.equals(actual.jjtGetValue(), value)) {
+            failWithMessage("Expected value to be %s, but was %s", value, actual.jjtGetValue());
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's parent is null.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNullParent() {
+        isNotNull();
+        if (actual.jjtGetParent() != null) {
+            failWithMessage("Expected parent to be null");
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's parent is not null.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNonNullParent() {
+        isNotNull();
+        if (actual.jjtGetParent() == null) {
+            failWithMessage("Expected parent to not be null, but was %s", actual.jjtGetParent());
+        }
+        return this;
+    }
+    
+    /**
+     * Returns a new {@link JexlNodeAssert} that will perform assertions on the actual node's parent.
+     * 
+     * @return the new {@link JexlNodeAssert} for the parent
+     */
+    public JexlNodeAssert parent() {
+        isNotNull();
+        return assertThat(actual.jjtGetParent());
+    }
+    
+    /**
+     * Verifies that the actual node has no children.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNoChildren() {
+        isNotNull();
+        if (actual.jjtGetNumChildren() != 0) {
+            failWithMessage("Expected no children, but had children %s", formatChildren(actual));
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node has the given number of children.
+     * 
+     * @param numChildren
+     *            the number of children
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasNumChildren(int numChildren) {
+        isNotNull();
+        if (actual.jjtGetNumChildren() != numChildren) {
+            failWithMessage("Expected %d children, but had %d", numChildren, actual.jjtGetNumChildren());
+            
+        }
+        return this;
+    }
+    
+    /**
+     * Returns a new {@link JexlNodeAssert} that will perform assertions on the specified child.
+     * 
+     * @param child
+     *            the child
+     * @return the new {@link JexlNodeAssert} for the child
+     */
+    public JexlNodeAssert child(int child) {
+        isNotNull();
+        return assertThat(actual.jjtGetChild(child));
+    }
+    
+    /**
+     * Verifies that the actual node's query string as supplied by {@link JexlStringBuildingVisitor#buildQuery(JexlNode)} is an exact match to the given one.
+     * 
+     * @param query
+     *            the query string
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasExactQueryString(String query) {
+        isNotNull();
+        String queryString = getQueryString(actual);
+        if (!queryString.equals(query)) {
+            failWithMessage("Expected query string to be %s, but was %s", query, queryString);
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node's query string as supplied by {@link JexlStringBuildingVisitor#buildQuery(JexlNode)} contains the given expression within
+     * it as a substring.
+     * 
+     * @param expression
+     *            the query expression
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert containsWithinQueryString(String expression) {
+        isNotNull();
+        String queryString = getQueryString(actual);
+        if (!queryString.contains(expression)) {
+            failWithMessage("Expected query to contain expression %s, query: %s", expression, queryString);
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node has a valid lineage as determined by {@link JexlASTHelper#validateLineageVerbosely(JexlNode, boolean)}.
+     * 
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert hasValidLineage() {
+        isNotNull();
+        JexlASTHelper.LineageValidation validation = JexlASTHelper.validateLineageVerbosely(actual, false);
+        if (!validation.isValid()) {
+            failWithMessage("Expected a valid lineage, but found the following conflicts: \n" + validation.getFormattedInvalidations());
+        }
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node is equal to the given query string as determined by a {@link TreeEqualityVisitor} comparison. The query string will be
+     * parsed to a query tree that will always have a root {@link ASTJexlScript} node.
+     * 
+     * @param query
+     *            the query
+     * @return this {@link JexlNodeAssert}
+     * @throws ParseException
+     *             if the given query string cannot be parsed to a {@link ASTJexlScript}
+     */
+    public JexlNodeAssert isEqualTo(String query) throws ParseException {
+        return isEqualTo(query, false);
+    }
+    
+    /**
+     * Verifies that the actual node is equal to the given node as determined by a {@link TreeEqualityVisitor} comparison.
+     * 
+     * @param node
+     *            the node
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert isEqualTo(JexlNode node) {
+        return isEqualTo(node, false);
+    }
+    
+    /**
+     * Verifies that the actual node is equal to the given query string as determined by a {@link TreeEqualityVisitor} comparison. The query string will be
+     * parsed to a query tree that will always have a root {@link ASTJexlScript} node. If the assertion fails and printQueries is true, both the actual node and
+     * parsed node will be printed to the system output via {@link PrintingVisitor#printQuery(String)} for debugging purposes.
+     * 
+     * @param query
+     *            the query
+     * @return this {@link JexlNodeAssert}
+     * @throws ParseException
+     *             if the given query string cannot be parsed to a {@link ASTJexlScript}
+     */
+    public JexlNodeAssert isEqualTo(String query, boolean printQueries) throws ParseException {
+        isNotNull();
+        ASTJexlScript expected = JexlASTHelper.parseJexlQuery(query);
+        assertEqual(actual, expected, printQueries);
+        return this;
+    }
+    
+    /**
+     * Verifies that the actual node is equal to the given node as determined by a {@link TreeEqualityVisitor} comparison. If the assertion fails and
+     * printQueries is true, both the actual node and parsed node will be printed to the system output via {@link PrintingVisitor#printQuery(String)} for
+     * debugging purposes.
+     * 
+     * @param node
+     *            the node
+     * @return this {@link JexlNodeAssert}
+     */
+    public JexlNodeAssert isEqualTo(JexlNode node, boolean printQueries) {
+        if (node != actual) {
+            if (node == null || actual == null) {
+                failWithMessage("Expected actual to be " + getQueryString(node) + " but was " + getQueryString(actual));
+            } else {
+                assertEqual(actual, node, printQueries);
+            }
+        }
+        return this;
+    }
+    
+    // Return a comma-delimited list of the node's children.
+    private String formatChildren(JexlNode node) {
+        return Arrays.toString(getChildren(node));
+    }
+    
+    // Return a copy of the node's children array.
+    private JexlNode[] getChildren(JexlNode node) {
+        int numChildren = node.jjtGetNumChildren();
+        JexlNode[] children = new JexlNode[numChildren];
+        for (int i = 0; i < numChildren; i++) {
+            children[i] = node.jjtGetChild(i);
+        }
+        return children;
+    }
+    
+    // Return the query tree's query string, or "null" if the query tree is null.
+    private String getQueryString(JexlNode node) {
+        return node != null ? JexlStringBuildingVisitor.buildQuery(node) : "null";
+    }
+    
+    // Assert whether the two nodes are equal.
+    private void assertEqual(JexlNode actual, JexlNode expected, boolean printQueries) {
+        TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expected, actual);
+        if (!comparison.isEqual()) {
+            failWithMessage("Expected actual to be " + getQueryString(expected) + " but was non-equal: " + comparison.getReason());
+            if (printQueries) {
+                PrintingVisitor.printQuery(actual);
+                PrintingVisitor.printQuery(expected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use the AssertJ library to create a set of assertions in JexlNodeAssert 
that can be used against JexlNode instances in unit tests. Update existing
unit tests to use these assertions where possible in order to remove areas
of repeated code.