### PR TITLE
WIP: Update ShardQueryConfiguration.java

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -530,6 +530,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setModelTableName(other.getModelTableName());
         this.setLimitTermExpansionToModel(other.isExpansionLimitedToModelContents());
         this.setQuery(null == other.getQuery() ? null : other.getQuery().duplicate(other.getQuery().getQueryName()));
+        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(this.queryTree());
         this.setCompressServerSideResults(other.isCompressServerSideResults());
         this.setIndexOnlyFilterFunctionsEnabled(other.isIndexOnlyFilterFunctionsEnabled());
         this.setCompositeFilterFunctionsEnabled(other.isCompositeFilterFunctionsEnabled());

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -531,7 +531,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setModelTableName(other.getModelTableName());
         this.setLimitTermExpansionToModel(other.isExpansionLimitedToModelContents());
         this.setQuery(null == other.getQuery() ? null : other.getQuery().duplicate(other.getQuery().getQueryName()));
-        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(this.queryTree()));
+        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(other.queryTree()));
         this.setCompressServerSideResults(other.isCompressServerSideResults());
         this.setIndexOnlyFilterFunctionsEnabled(other.isIndexOnlyFilterFunctionsEnabled());
         this.setCompositeFilterFunctionsEnabled(other.isCompositeFilterFunctionsEnabled());

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -531,7 +531,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setModelTableName(other.getModelTableName());
         this.setLimitTermExpansionToModel(other.isExpansionLimitedToModelContents());
         this.setQuery(null == other.getQuery() ? null : other.getQuery().duplicate(other.getQuery().getQueryName()));
-        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(this.queryTree());
+        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(this.queryTree()));
         this.setCompressServerSideResults(other.isCompressServerSideResults());
         this.setIndexOnlyFilterFunctionsEnabled(other.isIndexOnlyFilterFunctionsEnabled());
         this.setCompositeFilterFunctionsEnabled(other.isCompositeFilterFunctionsEnabled());

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -19,6 +19,7 @@ import datawave.query.function.DocumentPermutation;
 import datawave.query.iterator.QueryIterator;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.jexl.visitors.RebuildingVisitor;
 import datawave.query.jexl.visitors.whindex.WhindexVisitor;
 import datawave.query.model.QueryModel;
 import datawave.query.tables.ShardQueryLogic;

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -531,7 +531,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setModelTableName(other.getModelTableName());
         this.setLimitTermExpansionToModel(other.isExpansionLimitedToModelContents());
         this.setQuery(null == other.getQuery() ? null : other.getQuery().duplicate(other.getQuery().getQueryName()));
-        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(other.queryTree()));
+        this.setQueryTree(null == other.getQueryTree() ? null : (ASTJexlScript) RebuildingVisitor.copy(other.getQueryTree()));
         this.setCompressServerSideResults(other.isCompressServerSideResults());
         this.setIndexOnlyFilterFunctionsEnabled(other.isIndexOnlyFilterFunctionsEnabled());
         this.setCompositeFilterFunctionsEnabled(other.isCompositeFilterFunctionsEnabled());


### PR DESCRIPTION
The copy constructor ignored queryTree which can impact query logics that make use of it.