### PR TITLE
Apply UID maximum to removal list

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
@@ -174,8 +174,8 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
                     // set because that will take care of de-duping any duplicate UIDs.
                     long prevCount = uids.size() - uidsToRemove.size();
                     
-                    boolean wasSuccessful = processRemovalUids(v) && processAddedUids(v);
-                    if (!wasSuccessful) {
+                    boolean isUnderMaxThreshold = processRemovalUids(v) && processAddedUids(v);
+                    if (!isUnderMaxThreshold) {
                         enterCountOnlyMode(prevCount);
                     }
                 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
@@ -197,6 +197,14 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
                         } else if (propogate && !uids.contains(uid)) {
                             uidsToRemove.add(uid);
                         }
+
+                        if (uidsToRemove.size() >= maxUids) {
+                            seenIgnore = true;
+                            count = prevCount;
+                            uids.clear();
+                            uidsToRemove.clear();
+                            break;
+                        }
                     }
                     
                     // Add UIDs from the UID list

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
@@ -150,11 +150,11 @@ public class GlobalIndexUidAggregatorExpandedTest {
         
         testCombinations(expectation, value1, value2);
     }
-
+    
     @Test
     public void removeManyFullCompaction() {
         agg = new GlobalIndexUidAggregator(2);
-
+        
         // @formatter:off
         Value value1 = UidTestBuilder.newBuilder()
                 .withUids()
@@ -169,15 +169,15 @@ public class GlobalIndexUidAggregatorExpandedTest {
                 .withCountOnly(0)
                 .build());
         // @formatter:on
-
+        
         isFullCompactionOnlyTest = true;
         testCombinations(expectation, value1, value2);
     }
-
+    
     @Test
     public void removeManyPartialCompaction() {
         agg = new GlobalIndexUidAggregator(2);
-
+        
         // @formatter:off
         Value value1 = UidTestBuilder.newBuilder()
                 .withUids()
@@ -192,10 +192,11 @@ public class GlobalIndexUidAggregatorExpandedTest {
                 .withCountOnly(-4)
                 .build());
         // @formatter:on
-
+        
         isPartialCompactionOnlyTest = true;
         testCombinations(expectation, value1, value2);
     }
+    
     @Test
     public void removeAllAcrossValue() {
         // Do removals of all UIDs in another list work?

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
@@ -150,7 +150,52 @@ public class GlobalIndexUidAggregatorExpandedTest {
         
         testCombinations(expectation, value1, value2);
     }
-    
+
+    @Test
+    public void removeManyFullCompaction() {
+        agg = new GlobalIndexUidAggregator(2);
+
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5") // exceeds the maximum limit
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid100") // not in value1
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+
+        isFullCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+
+    @Test
+    public void removeManyPartialCompaction() {
+        agg = new GlobalIndexUidAggregator(2);
+
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5") // exceeds the maximum limit
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid100") // not in value1
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-4)
+                .build());
+        // @formatter:on
+
+        isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
     @Test
     public void removeAllAcrossValue() {
         // Do removals of all UIDs in another list work?

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregatorExpandedTest.java
@@ -66,11 +66,11 @@ public class GlobalIndexUidAggregatorExpandedTest {
                 .withUids("uid1", "uid2", "uid3")
                 .withRemovals("uid4") // uid4 in other value's list
                 .build();
-        
+
         Value value2 = UidTestBuilder.newBuilder()
                 .withUids("uid4", "uid5", "uid6")
                 .build();
-        
+
         Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
                 .withUids("uid1", "uid2", "uid3", "uid5", "uid6")
                 .withRemovals("uid4")
@@ -148,52 +148,6 @@ public class GlobalIndexUidAggregatorExpandedTest {
                 .build());
         // @formatter:on
         
-        testCombinations(expectation, value1, value2);
-    }
-    
-    @Test
-    public void removeManyFullCompaction() {
-        agg = new GlobalIndexUidAggregator(2);
-        
-        // @formatter:off
-        Value value1 = UidTestBuilder.newBuilder()
-                .withUids()
-                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5") // exceeds the maximum limit
-                .build();
-
-        Value value2 = UidTestBuilder.newBuilder()
-                .withUids("uid100") // not in value1
-                .build();
-
-        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
-                .withCountOnly(0)
-                .build());
-        // @formatter:on
-        
-        isFullCompactionOnlyTest = true;
-        testCombinations(expectation, value1, value2);
-    }
-    
-    @Test
-    public void removeManyPartialCompaction() {
-        agg = new GlobalIndexUidAggregator(2);
-        
-        // @formatter:off
-        Value value1 = UidTestBuilder.newBuilder()
-                .withUids()
-                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5") // exceeds the maximum limit
-                .build();
-
-        Value value2 = UidTestBuilder.newBuilder()
-                .withUids("uid100") // not in value1
-                .build();
-
-        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
-                .withCountOnly(-4)
-                .build());
-        // @formatter:on
-        
-        isPartialCompactionOnlyTest = true;
         testCombinations(expectation, value1, value2);
     }
     
@@ -1102,6 +1056,177 @@ public class GlobalIndexUidAggregatorExpandedTest {
         // @formatter:on
         
         testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void maxRemovalsCauseCountOnlyPartialCompact() {
+        // Test with a single Uid.List with maximum removals
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2") // exceeds the maximum limit
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-2)
+                .build());
+        // @formatter:on
+        
+        isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1);
+    }
+    
+    @Test
+    public void maxRemovalsCauseCountOnlyFullCompact() {
+        // Test with a single Uid.List with maximum removals
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2") // exceeds the maximum limit
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        isFullCompactionOnlyTest = true;
+        testCombinations(expectation, value1);
+    }
+    
+    @Test
+    public void combineMaxRemovalsWithAdditionPartialCompact() {
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5") // exceeds the maximum limit
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid100") // not in value1
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-4)
+                .build());
+        // @formatter:on
+        
+        isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void combineMaxRemovalsWithAdditionFullCompact() {
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2", "uid3", "uid4", "uid5") // exceeds the maximum limit
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid100") // not in value1
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        isFullCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void twoRemovalsExceedMaximum() {
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1")
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid2")
+                .build();
+
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-2)
+                .build());
+        // @formatter:on
+        
+        isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2);
+    }
+    
+    @Test
+    public void netNegativeOneRemains() {
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2") // exceeds the maximum limit
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1") // offsets one of the removals
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids("uid1") // the same uid as value2
+                .build();
+
+        // The removal maximum causes a count-only of -2.  Any UIDs that are added after
+        // the aggregator is in count-only mode offset this count, regardless of value.
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(0)
+                .build());
+        // @formatter:on
+        
+        this.isForwardOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
+    }
+    
+    @Test
+    public void netNegativeOneRemainsReverse() {
+        agg = new GlobalIndexUidAggregator(2);
+        
+        // @formatter:off
+        Value value1 = UidTestBuilder.newBuilder()
+                .withUids("uid1") // offsets one of the forthcoming removals
+                .build();
+
+        Value value2 = UidTestBuilder.newBuilder()
+                .withUids("uid1") // the same uid as value1
+                .build();
+
+        Value value3 = UidTestBuilder.newBuilder()
+                .withUids()
+                .withRemovals("uid1", "uid2") // exceeds the maximum limit, matches an addition
+                .build();
+
+        // The additions of uid1 in both value1 and value2 are de-duplicated.
+        // The two removals force the aggregator into count-only mode, resulting in the previous count
+        // of 1 plus the size of the value3 uids (0) minus the size of value3's removals (-2),
+        // equaling -1.
+        Uid.List expectation = UidTestBuilder.valueToUidList(UidTestBuilder.newBuilder()
+                .withCountOnly(-1)
+                .build());
+        // @formatter:on
+        
+        this.isForwardOnlyTest = true;
+        this.isPartialCompactionOnlyTest = true;
+        testCombinations(expectation, value1, value2, value3);
     }
     
     // For Forward, Partial, and Full see the comments by the boolean field declarations


### PR DESCRIPTION
The purpose of the UID maximum list is to improve storage and latency, at the expense of accuracy.  The removal list is currently exempt from the UID maximum limit.  This PR changes that.  If there are more removal UIDs than the maximum, it's likely that the same key has already exceeded its UID maximum (in another file) and so the removal UIDs are likely to get truncated at a later time anyway.