### PR TITLE
DRAFT: Update accumulo-2.0 branch to hadoop 3.3.1

### DIFF
--- a/common-test/pom.xml
+++ b/common-test/pom.xml
@@ -41,6 +41,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>
         <dependency>

--- a/contrib/datawave-quickstart/bin/services/hadoop/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/hadoop/bootstrap.sh
@@ -3,7 +3,7 @@
 DW_HADOOP_SERVICE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # You may override DW_HADOOP_DIST_URI in your env ahead of time, and set as file:///path/to/file.tar.gz for local tarball, if needed
-DW_HADOOP_DIST_URI="${DW_HADOOP_DIST_URI:-http://archive.apache.org/dist/hadoop/common/hadoop-3.1.2/hadoop-3.1.2.tar.gz}"
+DW_HADOOP_DIST_URI="${DW_HADOOP_DIST_URI:-http://archive.apache.org/dist/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz}"
 DW_HADOOP_DIST="$( downloadTarball "${DW_HADOOP_DIST_URI}" "${DW_HADOOP_SERVICE_DIR}" && echo "${tarball}" )"
 DW_HADOOP_BASEDIR="hadoop-install"
 DW_HADOOP_SYMLINK="hadoop"
@@ -105,7 +105,7 @@ function hadoopIsRunning() {
 function hadoopStart() {
     hadoopIsRunning && echo "Hadoop is already running" || eval "${DW_HADOOP_CMD_START}"
     echo
-    info "For detailed status visit 'http://localhost:50070/dfshealth.html#tab-overview' in your browser"
+    info "For detailed status visit 'http://localhost:9870/dfshealth.html#tab-overview' in your browser"
     # Wait for Hadoop to come out of safemode
     ${HADOOP_HOME}/bin/hdfs dfsadmin -safemode wait
 }

--- a/contrib/datawave-quickstart/docker/Dockerfile
+++ b/contrib/datawave-quickstart/docker/Dockerfile
@@ -77,7 +77,7 @@ VOLUME ["/opt/datawave/contrib/datawave-quickstart/accumulo/logs"]
 VOLUME ["/opt/datawave/contrib/datawave-quickstart/wildfly/standalone/log"]
 VOLUME ["/opt/datawave/contrib/datawave-quickstart/datawave-ingest/logs"]
 
-EXPOSE 8443 9995 50070 8088 9000 2181
+EXPOSE 8443 9995 9870 8088 9000 2181
 
 WORKDIR /opt/datawave/contrib/datawave-quickstart
 

--- a/contrib/datawave-quickstart/docker/docker-run.sh
+++ b/contrib/datawave-quickstart/docker/docker-run.sh
@@ -58,7 +58,7 @@ VOLUMES="-v ${DATA}:${V_DATA} -v ${M2REPO}:${V_M2REPO} -v ${HLOGS}:${V_HLOGS} -v
 
 # Set port mapping
 
-PORTS="-p 8443:8443 -p 50070:50070 -p 9995:9995"
+PORTS="-p 8443:8443 -p 9870:9870 -p 9995:9995"
 
 # Interpret any remaining args as the CMD to pass in
 

--- a/pom.xml
+++ b/pom.xml
@@ -714,6 +714,11 @@
                 <version>1.1.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.hadoop.thirdparty</groupId>
+                <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.htrace</groupId>
                 <artifactId>htrace-core4</artifactId>
                 <version>${version.htrace}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -587,6 +587,36 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client-api</artifactId>
+                <version>${version.hadoop}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-aws</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client-runtime</artifactId>
+                <version>${version.hadoop}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-aws</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${version.hadoop}</version>
                 <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -709,6 +709,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.hadoop.thirdparty</groupId>
+                <artifactId>hadoop-shaded-guava</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.htrace</groupId>
                 <artifactId>htrace-core4</artifactId>
                 <version>${version.htrace}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <version.googlecode-findbugs>2.0.3</version.googlecode-findbugs>
         <version.googlecode-json-simple>1.1.1</version.googlecode-json-simple>
         <!-- Can download cdh binary from https://www.cloudera.com/documentation/enterprise/release-notes/topics/cdh_vd_cdh_package_tarball_59.html#tarball_59x -->
-        <version.hadoop>3.0.0-cdh6.2.0</version.hadoop>
+        <version.hadoop>3.3.1</version.hadoop>
         <version.htrace>4.0.1-incubating</version.htrace>
         <version.httpcomponents-httpclient>4.5.5</version.httpcomponents-httpclient>
         <version.httpcomponents-httpcore>4.4.8</version.httpcomponents-httpcore>
@@ -112,7 +112,7 @@
         <version.woodstox-core>5.0.3</version.woodstox-core>
         <version.woodstox-stax2>3.1.4</version.woodstox-stax2>
         <version.xerces>2.12.0.SP02</version.xerces>
-        <version.zookeeper>3.4.5-cdh6.3.1</version.zookeeper>
+        <version.zookeeper>3.4.14</version.zookeeper>
         <!-- Unless a version is duplicated multiple times, just place the version on the dependency in dependencyManagement. -->
         <!-- <runOrder>random</runOrder> -->
     </properties>

--- a/warehouse/core/pom.xml
+++ b/warehouse/core/pom.xml
@@ -118,6 +118,10 @@
             <artifactId>hadoop-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
         </dependency>

--- a/warehouse/core/pom.xml
+++ b/warehouse/core/pom.xml
@@ -107,6 +107,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>
         <dependency>

--- a/warehouse/ops-tools/index-validation/pom.xml
+++ b/warehouse/ops-tools/index-validation/pom.xml
@@ -63,6 +63,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+            <version>1.1.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
             <version>4.1.0-incubating</version>

--- a/warehouse/pom.xml
+++ b/warehouse/pom.xml
@@ -246,6 +246,16 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client-api</artifactId>
+                <version>${version.hadoop}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client-runtime</artifactId>
+                <version>${version.hadoop}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${version.hadoop}</version>
                 <exclusions>

--- a/web-services/accumulo/pom.xml
+++ b/web-services/accumulo/pom.xml
@@ -87,6 +87,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
             <scope>provided</scope>

--- a/web-services/atom/pom.xml
+++ b/web-services/atom/pom.xml
@@ -11,6 +11,10 @@
     <name>${project.artifactId}</name>
     <dependencies>
         <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>gov.nsa.datawave.webservices</groupId>
             <artifactId>datawave-ws-common</artifactId>
             <version>${project.version}</version>

--- a/web-services/atom/pom.xml
+++ b/web-services/atom/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>hadoop-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ws.commons.axiom</groupId>
             <artifactId>axiom-api</artifactId>
         </dependency>

--- a/web-services/common-util/pom.xml
+++ b/web-services/common-util/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>hadoop-auth</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
         </dependency>

--- a/web-services/common/pom.xml
+++ b/web-services/common/pom.xml
@@ -98,6 +98,10 @@
             <artifactId>hadoop-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
         </dependency>

--- a/web-services/deploy/application/pom.xml
+++ b/web-services/deploy/application/pom.xml
@@ -199,6 +199,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+            <version>1.1.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
             <scope>runtime</scope>
@@ -586,6 +592,11 @@
                                             <artifactId>hadoop-shaded-guava</artifactId>
                                             <version>1.1.1</version>
                                         </artifactItem>
+                                        <dependency>
+                                            <groupId>org.apache.hadoop.thirdparty</groupId>
+                                            <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+                                            <version>1.1.1</version>
+                                        </dependency>
                                         <artifactItem>
                                             <groupId>org.apache.htrace</groupId>
                                             <artifactId>htrace-core4</artifactId>

--- a/web-services/deploy/application/pom.xml
+++ b/web-services/deploy/application/pom.xml
@@ -193,6 +193,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+            <version>1.1.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
             <scope>runtime</scope>
@@ -574,6 +580,11 @@
                                         <artifactItem>
                                             <groupId>org.apache.hadoop</groupId>
                                             <artifactId>hadoop-common</artifactId>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.apache.hadoop.thirdparty</groupId>
+                                            <artifactId>hadoop-shaded-guava</artifactId>
+                                            <version>1.1.1</version>
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>org.apache.htrace</groupId>

--- a/web-services/deploy/application/src/main/wildfly/overlay/modules/org/apache/hadoop/common/main/module.xml
+++ b/web-services/deploy/application/src/main/wildfly/overlay/modules/org/apache/hadoop/common/main/module.xml
@@ -3,6 +3,7 @@
     <resources>
         <resource-root path="hadoop-auth-${version.hadoop}.jar"/>
         <resource-root path="hadoop-common-${version.hadoop}.jar"/>
+        <resource-root path="hadoop-shaded-guava-1.1.1.jar"/>
         <resource-root path="htrace-core4-${version.htrace}.jar"/>
         <resource-root path="protobuf-java-${version.protobuf}.jar"/>
         <resource-root path="commons-beanutils-${version.commons-beanutils}.jar"/>

--- a/web-services/deploy/application/src/main/wildfly/overlay/modules/org/apache/hadoop/common/main/module.xml
+++ b/web-services/deploy/application/src/main/wildfly/overlay/modules/org/apache/hadoop/common/main/module.xml
@@ -4,6 +4,7 @@
         <resource-root path="hadoop-auth-${version.hadoop}.jar"/>
         <resource-root path="hadoop-common-${version.hadoop}.jar"/>
         <resource-root path="hadoop-shaded-guava-1.1.1.jar"/>
+        <resource-root path="hadoop-shaded-protobuf_3_7-1.1.1.jar"/>
         <resource-root path="htrace-core4-${version.htrace}.jar"/>
         <resource-root path="protobuf-java-${version.protobuf}.jar"/>
         <resource-root path="commons-beanutils-${version.commons-beanutils}.jar"/>

--- a/web-services/map-reduce/pom.xml
+++ b/web-services/map-reduce/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>hadoop-yarn-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-client</artifactId>
             <version>4.1.0</version>

--- a/web-services/modification/pom.xml
+++ b/web-services/modification/pom.xml
@@ -47,6 +47,7 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>

--- a/web-services/security/pom.xml
+++ b/web-services/security/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>deltaspike-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop.thirdparty</groupId>
+            <artifactId>hadoop-shaded-guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.htrace</groupId>
             <artifactId>htrace-core4</artifactId>
         </dependency>


### PR DESCRIPTION
It's maybe odd that my go-to for doing a quick Hadoop install these days is to use the `datawave-quickstart`. I needed to try Hadoop 3.3.1, so I upgraded the Accumulo 2.0 branch to depend on it. Sharing here in case it's useful.