### PR TITLE
fixes #1372: handle evaluation only fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.microservice.base-rest-responses>1.2</version.microservice.base-rest-responses>
         <version.microservice.common-utils>1.0</version.microservice.common-utils>
         <version.microservice.dictionary-api>1.0</version.microservice.dictionary-api>
-        <version.microservice.metadata-utils>1.8.2</version.microservice.metadata-utils>
+        <version.microservice.metadata-utils>1.9</version.microservice.metadata-utils>
         <version.microservice.metrics-reporter>1.2</version.microservice.metrics-reporter>
         <version.microservice.query-metric-api>1.4.8</version.microservice.query-metric-api>
         <version.microservice.type-utils>1.8</version.microservice.type-utils>

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1302,7 +1302,6 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         // Verify that the query does not contain fields we've never seen
         // before
         Set<String> specialFields = Sets.newHashSet(QueryOptions.DEFAULT_DATATYPE_FIELDNAME, Constants.ANY_FIELD, Constants.NO_FIELD);
-        specialFields.addAll(config.getEvaluationOnlyFields());
         Set<String> nonexistentFields = FieldMissingFromSchemaVisitor.getNonExistentFields(metadataHelper, script, config.getDatatypeFilter(), specialFields);
         
         if (log.isDebugEnabled()) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -477,7 +477,9 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     protected MetadataHelper prepareMetadataHelper(Connector connection, String metadataTableName, Set<Authorizations> auths, boolean rawTypes) {
         if (log.isTraceEnabled())
             log.trace("prepareMetadataHelper with " + connection);
-        return metadataHelperFactory.createMetadataHelper(connection, metadataTableName, auths, rawTypes);
+        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connection, metadataTableName, auths, rawTypes);
+        helper.setEvaluationOnlyFields(config.getEvaluationOnlyFields());
+        return helper;
     }
     
     public MetadataHelperFactory getMetadataHelperFactory() {


### PR DESCRIPTION
    * Updated metadata utils to 1.9
    * Updated the shard query logic to set the evaluation only fields on the metadata helper
    * Updated the test case to appropriately test evaluation only fields
