### PR TITLE
Ensure unique_by_xxx functions are allowed

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctionsDescriptor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctionsDescriptor.java
@@ -135,7 +135,9 @@ public class QueryFunctionsDescriptor implements JexlFunctionArgumentDescriptorF
             if (numArgs % 2 != 0) {
                 throw new IllegalArgumentException("Expected even number of arguments to options function");
             }
-        } else if (name.equals(QueryFunctions.UNIQUE_FUNCTION) || name.equals(QueryFunctions.GROUPBY_FUNCTION)) {
+        } else if (name.equals(QueryFunctions.UNIQUE_FUNCTION) || name.equals(QueryFunctions.UNIQUE_BY_DAY_FUNCTION)
+                        || name.equals(QueryFunctions.UNIQUE_BY_HOUR_FUNCTION) || name.equals(QueryFunctions.UNIQUE_BY_MINUTE_FUNCTION)
+                        || name.equals(QueryFunctions.GROUPBY_FUNCTION)) {
             if (numArgs == 0) {
                 throw new IllegalArgumentException("Expected at least one argument to the " + name + " function");
             }

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -37,6 +37,9 @@
         <bean class="datawave.query.language.functions.jexl.Jexl"/>
         <bean class="datawave.query.language.functions.jexl.Options"/>
         <bean class="datawave.query.language.functions.jexl.Unique"/>
+        <bean class="datawave.query.language.functions.jexl.UniqueByDay"/>
+        <bean class="datawave.query.language.functions.jexl.UniqueByHour"/>
+        <bean class="datawave.query.language.functions.jexl.UniqueByMinute"/>
         <bean class="datawave.query.language.functions.jexl.Geowave.Contains"/>
         <bean class="datawave.query.language.functions.jexl.Geowave.CoveredBy"/>
         <bean class="datawave.query.language.functions.jexl.Geowave.Covers"/>


### PR DESCRIPTION
Ensure that UniqueFunctionsDescriptor.java and QueryLogicFactory.xml
support the unique_by_day, unique_by_hour, and unique_by_minute
functions.

Fixes #1375