### PR TITLE
Fix circular parent reference

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlNodeFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlNodeFactory.java
@@ -1621,6 +1621,7 @@ public class JexlNodeFactory {
         }
         
         ASTReference ref = new ASTReference(ParserTreeConstants.JJTREFERENCE);
+        ref.jjtSetParent(child.jjtGetParent());
         
         if (child instanceof ASTReferenceExpression) {
             child.jjtSetParent(ref);
@@ -1634,8 +1635,6 @@ public class JexlNodeFactory {
             exp.jjtSetParent(ref);
             ref.jjtAddChild(exp, 0);
         }
-        
-        ref.jjtSetParent(child.jjtGetParent());
         
         return ref;
     }


### PR DESCRIPTION
The parent of the ASTReference returned by
JexlNodeFactory.createExpression(JexlNode child) is set either to itself
or to its child ASTReferenceExpression.

Fix this so that it is set to the original parent of the provided
JexlNode argument.