### PR TITLE
Support specifying NOEXPANSION fields as parameter

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/QueryParameters.java
+++ b/warehouse/query-core/src/main/java/datawave/query/QueryParameters.java
@@ -141,6 +141,12 @@ public class QueryParameters {
     public static final String GROUP_FIELDS = "group.fields";
     public static final String GROUP_FIELDS_BATCH_SIZE = "group.fields.batch.size";
     public static final String UNIQUE_FIELDS = "unique.fields";
+    
+    /**
+     * Used to specify fields that are excluded from query model expansion.
+     */
+    public static final String NOEXPANSION_FIELDS = "noexpansion.fields";
+    
     /**
      * Used to cause Documents to contain a list of selectors that hit;
      */

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryOptionsSwitch.java
@@ -45,6 +45,11 @@ public class QueryOptionsSwitch {
                 case QueryParameters.UNIQUE_FIELDS:
                     UniqueFields uniqueFields = UniqueFields.from(value);
                     config.setUniqueFields(uniqueFields);
+                    break;
+                case QueryParameters.NOEXPANSION_FIELDS:
+                    String[] fields = StringUtils.split(value, Constants.PARAM_VALUE_SEP);
+                    config.setNoExpansionFields(Sets.newHashSet(fields));
+                    break;
             }
         }
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -821,6 +821,17 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
             config.setHierarchyFieldOptions(options);
         }
         
+        // Get the NOEXPANSION_FIELDS parameter if given
+        String noExpansionFieldsStr = settings.findParameter(QueryParameters.NOEXPANSION_FIELDS).getParameterValue().trim();
+        if (org.apache.commons.lang.StringUtils.isNotBlank(noExpansionFieldsStr)) {
+            List<String> noExpansionFields = Arrays.asList(StringUtils.split(noExpansionFieldsStr, Constants.PARAM_VALUE_SEP));
+            
+            // Only set the noexpansion fields if we were actually given some
+            if (!noExpansionFields.isEmpty()) {
+                config.setNoExpansionFields(new HashSet<>(noExpansionFields));
+            }
+        }
+        
         // Get the query profile to allow us to select the tune profile of the query
         String queryProfile = settings.findParameter(QueryParameters.QUERY_PROFILE).getParameterValue().trim();
         if ((org.apache.commons.lang.StringUtils.isNotBlank(queryProfile))) {


### PR DESCRIPTION
Support specifying #NOEXPANSION fields as either a query parameter or as
a parameter within the options function.

Resolves #1331