### PR TITLE
Add visibility/authorization validation to unit test framework

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/BooksQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/BooksQueryTest.java
@@ -45,7 +45,7 @@ public class BooksQueryTest extends AbstractFunctionalQuery {
             Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
             FieldConfig indexes = new BooksFieldIndex();
             ConfigData cfgData = new ConfigData(BooksField.BOOKS_DATE.name(), BooksField.ISBN_13.name(), BooksField.getHeaders(),
-                            BooksDataType.getVisibility(), BooksField.getFieldsMetadata());
+                            BooksDataType.getDefaultVisibility(), BooksField.getFieldsMetadata());
             
             DataTypeHadoopConfig books = new BooksDataType(BooksEntry.tech.getDataType(), BooksEntry.tech.getIngestFile(), indexes, cfgData);
             dataTypes.add(books);

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionIndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionIndexOnlyQueryTest.java
@@ -137,7 +137,7 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
     // ============================================
     // implemented abstract methods
     protected void testInit() {
-        this.auths = CitiesDataType.getTestAuths();
+        this.auths = CitiesDataType.getExpansionAuths();
         this.documentKey = CitiesDataType.CityField.EVENT_ID.name();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -9,6 +9,8 @@ import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.MaxExpandCityFields;
+
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -364,8 +366,9 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
     
     // ============================================
     // implemented abstract methods
+    @Override
     protected void testInit() {
-        this.auths = CitiesDataType.getTestAuths();
+        this.auths = CitiesDataType.getExpansionAuths();
         this.documentKey = CitiesDataType.CityField.EVENT_ID.name();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/QueryAuthsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryAuthsTest.java
@@ -26,7 +26,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -50,12 +49,6 @@ public class QueryAuthsTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
-        // Set<String> virt = new HashSet<>(Arrays.asList(CityField.CITY.name(), CityField.CONTINENT.name()));
-        // generic.removeVirtualField(virt);
-        // generic.addIndexField(CityField.CODE.name());
-        // for (String idx : generic.getIndexFields()) {
-        // generic.addReverseIndexField(idx);
-        // }
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
         
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/QueryAuthsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryAuthsTest.java
@@ -1,0 +1,225 @@
+package datawave.query;
+
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.Attributes;
+import datawave.query.attributes.Document;
+import datawave.query.attributes.TimingMetadata;
+import datawave.query.testframework.AbstractFunctionalQuery;
+import datawave.query.testframework.AccumuloSetup;
+import datawave.query.testframework.BaseRawData;
+import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CitiesDataType.CityEntry;
+import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.DataTypeHadoopConfig;
+import datawave.query.testframework.FieldConfig;
+import datawave.query.testframework.FileType;
+import datawave.query.testframework.GenericCityFields;
+import datawave.query.testframework.QueryLogicTestHarness;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.core.security.VisibilityEvaluator;
+import org.apache.accumulo.core.security.VisibilityParseException;
+import org.apache.log4j.Logger;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static datawave.query.testframework.RawDataManager.EQ_OP;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class QueryAuthsTest extends AbstractFunctionalQuery {
+    
+    @ClassRule
+    public static AccumuloSetup accumuloSetup = new AccumuloSetup();
+    
+    private static final Logger log = Logger.getLogger(QueryAuthsTest.class);
+    
+    @BeforeClass
+    public static void filterSetup() throws Exception {
+        Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
+        FieldConfig generic = new GenericCityFields();
+        // Set<String> virt = new HashSet<>(Arrays.asList(CityField.CITY.name(), CityField.CONTINENT.name()));
+        // generic.removeVirtualField(virt);
+        // generic.addIndexField(CityField.CODE.name());
+        // for (String idx : generic.getIndexFields()) {
+        // generic.addReverseIndexField(idx);
+        // }
+        dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
+        
+        accumuloSetup.setData(FileType.CSV, dataTypes);
+        connector = accumuloSetup.loadTables(log);
+    }
+    
+    public QueryAuthsTest() {
+        super(CitiesDataType.getManager());
+    }
+    
+    @Test
+    public void testAuthsEuro() throws Exception {
+        log.info("----- testAuths Euro -----");
+        String city = "'paris'";
+        String query = CityField.CITY.name() + EQ_OP + city;
+        
+        Set<Authorizations> euroAuths = Collections.singleton(new Authorizations("Euro"));
+        List<String> expectedEuro = new ArrayList<>();
+        expectedEuro.add("par-ita-11");
+        expectedEuro.add("par-fra-lle-7");
+        
+        final List<QueryLogicTestHarness.DocumentChecker> queryChecker = new ArrayList<>();
+        final VisibilityChecker checker = new VisibilityChecker("Euro");
+        queryChecker.add(checker);
+        Date[] startEndDate = this.dataManager.getShardStartEndDate();
+        runTestQuery(expectedEuro, query, startEndDate[0], startEndDate[1], Collections.emptyMap(), queryChecker, euroAuths);
+    }
+    
+    @Test
+    public void testAuthsMulti() throws Exception {
+        log.info("----- testAuths Multi -----");
+        String city = "'paris'";
+        String query = CityField.CITY.name() + EQ_OP + city;
+        
+        Set<Authorizations> multiAuths = Collections.singleton(new Authorizations("Euro", "NA"));
+        
+        final Collection<String> expected = getExpectedKeyResponse(query);
+        final List<QueryLogicTestHarness.DocumentChecker> queryChecker = new ArrayList<>();
+        final VisibilityChecker checker = new VisibilityChecker("Euro", "NA");
+        queryChecker.add(checker);
+        Date[] startEndDate = this.dataManager.getShardStartEndDate();
+        runTestQuery(expected, query, startEndDate[0], startEndDate[1], Collections.emptyMap(), queryChecker, multiAuths);
+    }
+    
+    @Test
+    public void testAuthsEmpty() throws Exception {
+        log.info("----- testAuths Empty -----");
+        String city = "'paris'";
+        String query = CityField.CITY.name() + EQ_OP + city;
+        
+        Set<Authorizations> emptyAuths = Collections.singleton(new Authorizations());
+        
+        Date[] startEndDate = this.dataManager.getShardStartEndDate();
+        runTestQuery(Collections.emptyList(), query, startEndDate[0], startEndDate[1], Collections.emptyMap(), Collections.emptyList(), emptyAuths);
+    }
+    
+    @Test
+    public void testAuthsEmptyIntersection() throws Exception {
+        log.info("----- testAuths Empty Intersection -----");
+        String city = "'paris'";
+        String query = CityField.CITY.name() + EQ_OP + city;
+        
+        Set<Authorizations> emptyIntersectionAuths = new HashSet<>();
+        emptyIntersectionAuths.add(new Authorizations("NA"));
+        emptyIntersectionAuths.add(new Authorizations("Euro"));
+        
+        Date[] startEndDate = this.dataManager.getShardStartEndDate();
+        runTestQuery(Collections.emptyList(), query, startEndDate[0], startEndDate[1], Collections.emptyMap(), Collections.emptyList(), emptyIntersectionAuths);
+    }
+    
+    @Test
+    public void testAuthsEuroIntersection() throws Exception {
+        log.info("----- testAuths Euro Intersection -----");
+        String city = "'paris'";
+        String query = CityField.CITY.name() + EQ_OP + city;
+        
+        Set<Authorizations> euroIntersectionAuths = new HashSet<>();
+        euroIntersectionAuths.add(new Authorizations("NA", "Euro"));
+        euroIntersectionAuths.add(new Authorizations("Euro"));
+        
+        List<String> expectedEuro = new ArrayList<>();
+        expectedEuro.add("par-ita-11");
+        expectedEuro.add("par-fra-lle-7");
+        
+        final List<QueryLogicTestHarness.DocumentChecker> queryChecker = new ArrayList<>();
+        final VisibilityChecker checker = new VisibilityChecker("Euro");
+        queryChecker.add(checker);
+        Date[] startEndDate = this.dataManager.getShardStartEndDate();
+        runTestQuery(expectedEuro, query, startEndDate[0], startEndDate[1], Collections.emptyMap(), queryChecker, euroIntersectionAuths);
+    }
+    
+    // ============================================
+    // implemented abstract methods
+    protected void testInit() {
+        this.auths = CitiesDataType.getTestAuths();
+        this.documentKey = CityField.EVENT_ID.name();
+    }
+    
+    /**
+     * Ensure that the visibilities returned match the auths that were specified for the query.
+     */
+    private static class VisibilityChecker implements QueryLogicTestHarness.DocumentChecker {
+        
+        private final String[] validVisibilities;
+        private final Authorizations auths;
+        private final VisibilityEvaluator filter;
+        
+        public VisibilityChecker(String... visibilities) {
+            this.validVisibilities = visibilities;
+            this.auths = new Authorizations(validVisibilities);
+            this.filter = new VisibilityEvaluator(this.auths);
+        }
+        
+        @Override
+        public void assertValid(Document doc) {
+            if (doc instanceof TimingMetadata) {
+                return;
+            }
+            
+            Map<String,Attribute<? extends Comparable<?>>> dict = doc.getDictionary();
+            
+            for (Map.Entry<String,Attribute<? extends Comparable<?>>> entry : dict.entrySet()) {
+                String fieldName = entry.getKey();
+                if (fieldName.equals(BaseRawData.EVENT_DATATYPE)) {
+                    // does not include a visibility, why?
+                    continue;
+                }
+                
+                Attribute<?> attr = entry.getValue();
+                
+                if (attr instanceof Document) {
+                    assertValid((Document) attr);
+                } else if (attr instanceof Attributes) {
+                    assertValid((Attributes) attr, fieldName);
+                } else {
+                    assertValid(attr, fieldName);
+                }
+            }
+            
+        }
+        
+        protected void assertValid(Attributes attrs, String fieldName) {
+            for (Attribute<? extends Comparable<?>> attr : attrs.getAttributes()) {
+                if (attr instanceof Document) {
+                    assertValid((Document) attr);
+                } else if (attr instanceof Attributes) {
+                    assertValid((Attributes) attr, fieldName);
+                } else {
+                    assertValid(attr, fieldName);
+                }
+            }
+        }
+        
+        protected void assertValid(Attribute<? extends Comparable<?>> attr, String fieldName) {
+            final ColumnVisibility cv = attr.getColumnVisibility();
+            if (log.isDebugEnabled()) {
+                log.debug("field: '" + fieldName + "' value: '" + attr.getData().toString() + "' visibility:" + cv.toString());
+            }
+            
+            try {
+                assertTrue("Should not filter visibility: " + cv.toString(), filter.evaluate(cv));
+            } catch (VisibilityParseException vpe) {
+                fail("Could not parse visibility for field: " + fieldName + " visibility: " + cv.toString() + " exception: " + vpe.getMessage());
+            }
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetedQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetedQueryLogicTest.java
@@ -57,7 +57,7 @@ public class FacetedQueryLogicTest extends AbstractFunctionalQuery {
     private static final Logger log = Logger.getLogger(FacetedQueryLogicTest.class);
     
     public FacetedQueryLogicTest() {
-        super(CarsDataType.getManager());
+        super(CitiesDataType.getManager());
     }
     
     @BeforeClass
@@ -74,6 +74,7 @@ public class FacetedQueryLogicTest extends AbstractFunctionalQuery {
         dataTypes.add(new FacetedCitiesDataType(CitiesDataType.CityEntry.rome, generic));
         
         accumuloSetup.setData(FileType.CSV, dataTypes);
+        accumuloSetup.setAuthorizations(CitiesDataType.getTestAuths());
         connector = accumuloSetup.loadTables(log, TEARDOWN.EVERY_OTHER, INTERRUPT.NEVER);
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -391,9 +391,37 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
      */
     protected void runTestQuery(Collection<String> expected, String queryStr, Date startDate, Date endDate, Map<String,String> options,
                     List<DocumentChecker> checkers) throws Exception {
+        runTestQuery(expected, queryStr, startDate, endDate, options, checkers, this.authSet);
+    }
+    
+    /**
+     * Executes the query and performs validation of the results.
+     *
+     * @param expected
+     *            expected results from the query
+     * @param queryStr
+     *            execution query string
+     * @param startDate
+     *            start date for query (inclusive)
+     * @param endDate
+     *            end date for query (exclusive)
+     * @param options
+     *            optional parameters to query
+     * @param checkers
+     *            optional list of assert checker methods
+     * @param authSet
+     *            optional set of authorizations to use. If null or empty, will use default auths.
+     */
+    protected void runTestQuery(Collection<String> expected, String queryStr, Date startDate, Date endDate, Map<String,String> options,
+                    List<DocumentChecker> checkers, Set<Authorizations> authSet) throws Exception {
         if (log.isDebugEnabled()) {
             log.debug("  query[" + queryStr + "]  start(" + YMD_DateFormat.format(startDate) + ")  end(" + YMD_DateFormat.format(endDate) + ")");
         }
+        
+        if (authSet == null || authSet.isEmpty()) {
+            authSet = this.authSet;
+        }
+        
         QueryImpl q = new QueryImpl();
         q.setBeginDate(startDate);
         q.setEndDate(endDate);
@@ -407,7 +435,7 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
             QueryMetricFactory queryMetricFactory = (metricFactory == null) ? new QueryMetricFactoryImpl() : metricFactory;
             new RunningQuery(connector, AccumuloConnectionFactory.Priority.NORMAL, this.logic, q, "", principal, queryMetricFactory);
         } else {
-            GenericQueryConfiguration config = this.logic.initialize(connector, q, this.authSet);
+            GenericQueryConfiguration config = this.logic.initialize(connector, q, authSet);
             this.logic.setupQuery(config);
             if (log.isDebugEnabled()) {
                 log.debug("Plan: " + config.getQueryString());

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AccumuloSetup.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AccumuloSetup.java
@@ -15,6 +15,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -65,6 +66,7 @@ public class AccumuloSetup extends ExternalResource {
     private Collection<DataTypeHadoopConfig> dataTypes;
     private Set<String> shardIds;
     private FileType fileFormat;
+    private Authorizations auths = AbstractDataTypeConfig.getTestAuths();
     
     public AccumuloSetup() {
         this(false);
@@ -137,6 +139,11 @@ public class AccumuloSetup extends ExternalResource {
         }
     }
     
+    /** Override the default authorizations used for printing the contents of tables */
+    public void setAuthorizations(Authorizations auths) {
+        this.auths = auths;
+    }
+    
     /**
      * Creates the Accumulo shard ids and ingests the data into the tables. Uses a CSV file for loading test data.
      *
@@ -183,15 +190,15 @@ public class AccumuloSetup extends ExternalResource {
             }
         }
         
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), QueryTestTableHelper.METADATA_TABLE_NAME);
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), TableName.SHARD);
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), TableName.SHARD_INDEX);
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), TableName.SHARD_RINDEX);
+        PrintUtility.printTable(connector, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
+        PrintUtility.printTable(connector, auths, TableName.SHARD);
+        PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(connector, auths, TableName.SHARD_RINDEX);
         
         // TODO: elsewhere?
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), QueryTestTableHelper.FACET_TABLE_NAME);
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), QueryTestTableHelper.FACET_METADATA_TABLE_NAME);
-        PrintUtility.printTable(connector, AbstractDataTypeConfig.getTestAuths(), QueryTestTableHelper.FACET_HASH_TABLE_NAME);
+        PrintUtility.printTable(connector, auths, QueryTestTableHelper.FACET_TABLE_NAME);
+        PrintUtility.printTable(connector, auths, QueryTestTableHelper.FACET_METADATA_TABLE_NAME);
+        PrintUtility.printTable(connector, auths, QueryTestTableHelper.FACET_HASH_TABLE_NAME);
         
         return connector;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/CitiesDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/CitiesDataType.java
@@ -7,6 +7,9 @@ import datawave.ingest.csv.config.helper.ExtendedCSVHelper;
 import datawave.ingest.data.config.CSVHelper;
 import datawave.ingest.data.config.ingest.BaseIngestHelper;
 import datawave.ingest.input.reader.EventRecordReader;
+import datawave.marking.MarkingFunctions;
+
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -237,6 +240,28 @@ public class CitiesDataType extends AbstractDataTypeConfig {
         this.hConf.set(this.dataType + "." + CityField.CODE.name() + BaseIngestHelper.FIELD_TYPE, LcNoDiacriticsType.class.getName());
         
         log.debug(this.toString());
+    }
+    
+    private static final String[] AUTH_VALUES = new String[] {"Euro", "NA"};
+    private static final Authorizations TEST_AUTHS = new Authorizations(AUTH_VALUES);
+    private static final Authorizations EXPANSION_AUTHS = new Authorizations("ct-a", "b-ct", "not-b-ct");
+    
+    public static Authorizations getTestAuths() {
+        return TEST_AUTHS;
+    }
+    
+    public static Authorizations getExpansionAuths() {
+        return EXPANSION_AUTHS;
+    }
+    
+    @Override
+    public String getSecurityMarkingFieldNames() {
+        return CityField.ACCESS.name();
+    }
+    
+    @Override
+    public String getSecurityMarkingFieldDomains() {
+        return MarkingFunctions.Default.COLUMN_VISIBILITY;
     }
     
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/ExtendedTestCSVIngestHelper.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/ExtendedTestCSVIngestHelper.java
@@ -1,0 +1,23 @@
+package datawave.query.testframework;
+
+import datawave.ingest.csv.config.helper.ExtendedCSVIngestHelper;
+
+import com.google.common.collect.Multimap;
+import datawave.ingest.data.RawRecordContainer;
+import datawave.ingest.data.config.NormalizedContentInterface;
+
+/** Patches the ExtendedCSVIngestHelper to add visibility markings to the fields based on the contents of the event */
+public class ExtendedTestCSVIngestHelper extends ExtendedCSVIngestHelper {
+    @Override
+    public Multimap<String,NormalizedContentInterface> getEventFields(RawRecordContainer event) {
+        Multimap<String,NormalizedContentInterface> normalizedFields = super.getEventFields(event);
+        
+        if (null != event.getSecurityMarkings() && !event.getSecurityMarkings().isEmpty()) {
+            for (NormalizedContentInterface nci : normalizedFields.values()) {
+                nci.setMarkings(event.getSecurityMarkings());
+            }
+        }
+        
+        return normalizedFields;
+    }
+}


### PR DESCRIPTION
Currently the unit test framework doesn't do anything to validate the operations of authorizations and visibilities. This PR changes the `CitiesDataType` to use its [ACCESS](https://github.com/NationalSecurityAgency/datawave/blob/afbdc0546c23562dfa5e66a193a094f574200609/warehouse/query-core/src/test/java/datawave/query/testframework/CitiesDataType.java#L87) field to populate the `columnVisibility` security marking in events and then adds a test to validate that they are operating  correctly.

Minor modifications are made elsewhere, such as other tests in datawave-query-core, in order to work with this new approach.

As a part of this work, it was necessary to produce an `ExtendedTestCSVIngestHelper` in order to properly propagate security markings to the `NormalizedContentInterface` instances generated by the `ExtendedCSVIngestHelper` produced when reading events from a sequence file in the [CSVTestFileLoader](https://github.com/NationalSecurityAgency/datawave/blob/afbdc0546c23562dfa5e66a193a094f574200609/warehouse/query-core/src/test/java/datawave/query/testframework/CSVTestFileLoader.java#L33)