### PR TITLE
Event results should maintain an overall colvis when groupby and redu…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -155,64 +155,48 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     }
     
     protected void writeMetadata(DataOutput out, Boolean reducedResponse) throws IOException {
-        out.writeBoolean(reducedResponse);
-        
-        if (!reducedResponse) {
-            out.writeBoolean(isMetadataSet());
-            if (isMetadataSet()) {
-                byte[] cvBytes = getColumnVisibility().getExpression();
-                
-                WritableUtils.writeVInt(out, cvBytes.length);
-                
-                out.write(cvBytes);
-                out.writeLong(getTimestamp());
-            }
+        out.writeBoolean(isMetadataSet());
+        if (isMetadataSet()) {
+            byte[] cvBytes = getColumnVisibility().getExpression();
+            
+            WritableUtils.writeVInt(out, cvBytes.length);
+            
+            out.write(cvBytes);
+            out.writeLong(getTimestamp());
         }
     }
     
     protected void writeMetadata(Kryo kryo, Output output, Boolean reducedResponse) {
-        output.writeBoolean(reducedResponse);
-        
-        if (!reducedResponse) {
-            output.writeBoolean(isMetadataSet());
-            if (isMetadataSet()) {
-                byte[] cvBytes = getColumnVisibility().getExpression();
-                output.writeInt(cvBytes.length, true);
-                output.writeBytes(cvBytes);
-                output.writeLong(getTimestamp());
-            }
+        output.writeBoolean(isMetadataSet());
+        if (isMetadataSet()) {
+            byte[] cvBytes = getColumnVisibility().getExpression();
+            output.writeInt(cvBytes.length, true);
+            output.writeBytes(cvBytes);
+            output.writeLong(getTimestamp());
         }
     }
     
     protected void readMetadata(DataInput in) throws IOException {
-        boolean reducedResponse = in.readBoolean();
-        
-        if (!reducedResponse) {
-            if (in.readBoolean()) {
-                int cvBytesLength = WritableUtils.readVInt(in);
-                
-                byte[] cvBytes = new byte[cvBytesLength];
-                
-                in.readFully(cvBytes);
-                
-                this.setMetadata(new ColumnVisibility(cvBytes), in.readLong());
-            } else {
-                this.clearMetadata();
-            }
+        if (in.readBoolean()) {
+            int cvBytesLength = WritableUtils.readVInt(in);
+            
+            byte[] cvBytes = new byte[cvBytesLength];
+            
+            in.readFully(cvBytes);
+            
+            this.setMetadata(new ColumnVisibility(cvBytes), in.readLong());
+        } else {
+            this.clearMetadata();
         }
     }
     
     protected void readMetadata(Kryo kryo, Input input) {
-        boolean reducedResponse = input.readBoolean();
-        
-        if (!reducedResponse) {
-            if (input.readBoolean()) {
-                int size = input.readInt(true);
-                
-                this.setMetadata(new ColumnVisibility(input.readBytes(size)), input.readLong());
-            } else {
-                this.clearMetadata();
-            }
+        if (input.readBoolean()) {
+            int size = input.readInt(true);
+            
+            this.setMetadata(new ColumnVisibility(input.readBytes(size)), input.readLong());
+        } else {
+            this.clearMetadata();
         }
     }
     


### PR DESCRIPTION
We have a bug where using a group by query along with a reduced.response parameter results in the overall Event columnVisibility being empty.

The bug fix I did was the path of least risk/resistance. Now, with reduced.response, we will still serialize the field visibilities from the tserver back to the web tier. The transformer on the web side will eliminate them in the actual HTTP responses. 

There's an optimization where we change the Document to always serialize it's top level visibility so that we don't waste cycles serializing the individual field visibilities when using reduced.response. However, that'll take more work and testing. I can open up a follow on ticket to do that if we're interested. For now, this fixes the immediate issue.