### PR TITLE
Fix CustomAnalyzerQueryNodeProcessor to avoid dropping tokens when generating a query that contains synonyms.

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParser.java
@@ -1,11 +1,14 @@
 package datawave.query.language.parser.jexl;
 
 import com.google.common.collect.Sets;
+import datawave.ingest.data.tokenize.StandardAnalyzer;
+import datawave.ingest.data.tokenize.TokenSearch;
 import datawave.query.Constants;
 import datawave.query.language.parser.ParseException;
 import datawave.query.language.processor.lucene.QueryNodeProcessorFactory;
 import datawave.query.language.tree.QueryNode;
 import datawave.query.language.tree.ServerHeadNode;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.flexible.core.config.QueryConfigHandler;
 import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessor;
 import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessorPipeline;
@@ -627,5 +630,17 @@ public class TestLuceneToJexlQueryParser {
     public void testParseIncludeFunctionPartOfUnion() throws ParseException {
         testFunction("(filter:includeRegex(f1, 'r1') || filter:includeRegex(f2, 'r2'))", "#include(OR, f1, r1, f2, r2)");
         testFunction("filter:includeRegex(f1, 'r1')", "#include(f1, r1)");
+    }
+    
+    @Test
+    public void testSynonymTokenization() throws ParseException {
+        TokenSearch searchUtil = TokenSearch.Factory.newInstance();
+        Analyzer analyzer = new StandardAnalyzer(searchUtil);
+        parser.setAnalyzer(analyzer);
+        // this isn't the most realistic test, but it does verify that we don't lose the rest of the token stream
+        // when the first token emitted is the same as the input token.
+        Assert.assertEquals("(TOKFIELD == '/home/datawave/README.md' || "
+                        + "content:phrase(TOKFIELD, termOffsetMap, '/home/datawave/readme.md', 'home/datawave/readme.md', "
+                        + "'home', 'datawave/readme.md', 'datawave', 'readme.md', 'readme', 'md'))", parseQuery("TOKFIELD:\"/home/datawave/README.md\""));
     }
 }

--- a/warehouse/query-core/src/test/resources/datawave/ingest/data/tokenize/stopwords.txt
+++ b/warehouse/query-core/src/test/resources/datawave/ingest/data/tokenize/stopwords.txt
@@ -1,0 +1,5 @@
+a
+an
+and
+of
+the


### PR DESCRIPTION
Identified an issue where the custom query node processor would drop tokens when the first token produced is the same as the string being tokenized. This is a common case when the Analyzer used performs query expansion by adding synonyms.

Reproduced the issue with a unit test and then applied fixes. This will slightly change behavior when dealing with slop, but practically this will make little difference because we avoid slop in general because it does not preserve word order.

Also fixes a minor issue where the `NODE_PROCESSED` tag wasn't being checked properly. We were only checking for null, not actually checking the Boolean value. As a result a NODE_PROCESSED tag with a value of false would have been treated as being true.

Cleaned up a couple warnings as well. 