### PR TITLE
weeded out Attribute methods that pass and don't use 'reducedResponse…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -156,7 +156,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         metadata = null;
     }
     
-    protected void writeMetadata(DataOutput out, Boolean reducedResponse) throws IOException {
+    protected void writeMetadata(DataOutput out) throws IOException {
         out.writeBoolean(isMetadataSet());
         if (isMetadataSet()) {
             byte[] cvBytes = getColumnVisibility().getExpression();
@@ -168,7 +168,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         }
     }
     
-    protected void writeMetadata(Kryo kryo, Output output, Boolean reducedResponse) {
+    protected void writeMetadata(Kryo kryo, Output output) {
         output.writeBoolean(isMetadataSet());
         if (isMetadataSet()) {
             byte[] cvBytes = getColumnVisibility().getExpression();
@@ -318,9 +318,9 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         }
     }
     
-    public abstract void write(DataOutput output, boolean reducedResponse) throws IOException;
+    public abstract void write(DataOutput output) throws IOException;
     
-    public abstract void write(Kryo kryo, Output output, Boolean reducedResponse);
+    public abstract void write(Kryo kryo, Output output);
     
     public abstract Object getData();
     

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
@@ -110,11 +110,6 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
         WritableUtils.writeVInt(out, _count);
         out.writeBoolean(trackSizes);
         // Write out the number of Attributes we're going to store
@@ -125,7 +120,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
             WritableUtils.writeString(out, attr.getClass().getName());
             
             // Defer to the concrete instance to write() itself
-            attr.write(out, reducedResponse);
+            attr.write(out);
         }
     }
     
@@ -283,11 +278,6 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
         output.writeInt(this._count, true);
         output.writeBoolean(this.trackSizes);
         // Write out the number of Attributes we're going to store
@@ -298,7 +288,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
             output.writeString(attr.getClass().getName());
             
             // Defer to the concrete instance to write() itself
-            attr.write(kryo, output, reducedResponse);
+            attr.write(kryo, output);
         }
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
@@ -62,12 +62,7 @@ public class Cardinality extends Attribute<Cardinality> {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, content.fieldName);
         WritableUtils.writeString(out, content.lower);
         WritableUtils.writeString(out, content.upper);
@@ -150,12 +145,7 @@ public class Cardinality extends Attribute<Cardinality> {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         output.writeString(this.content.fieldName);
         output.writeString(this.content.lower);
         output.writeString(this.content.upper);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
@@ -52,12 +52,7 @@ public class Content extends Attribute<Content> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, content);
     }
@@ -109,12 +104,7 @@ public class Content extends Attribute<Content> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         
         output.writeString(this.content);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DateContent.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DateContent.java
@@ -102,12 +102,7 @@ public class DateContent extends Attribute<DateContent> implements Serializable 
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, normalizer.parseToString(this.value.getTime()));
     }
     
@@ -160,12 +155,7 @@ public class DateContent extends Attribute<DateContent> implements Serializable 
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(normalizer.parseToString(this.value.getTime()));
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DiacriticContent.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DiacriticContent.java
@@ -51,12 +51,7 @@ public class DiacriticContent extends Attribute<DiacriticContent> implements Ser
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, content);
     }
@@ -108,12 +103,7 @@ public class DiacriticContent extends Attribute<DiacriticContent> implements Ser
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         
         output.writeString(this.content);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -226,7 +226,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
     }
     
     public void put(String key, Attribute<?> value) {
-        put(key, value, false, false);
+        put(key, value, false);
     }
     
     /**
@@ -235,7 +235,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
      * @param key
      * @param value
      */
-    public void replace(String key, Attribute<?> value, Boolean includeGroupingContext, boolean reducedResponse) {
+    public void replace(String key, Attribute<?> value, Boolean includeGroupingContext) {
         dict.put(key, value);
     }
     
@@ -247,7 +247,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
      * @param key
      * @param value
      */
-    public void put(String key, Attribute<?> value, Boolean includeGroupingContext, boolean reducedResponse) {
+    public void put(String key, Attribute<?> value, Boolean includeGroupingContext) {
         
         if (0 == value.size()) {
             if (log.isTraceEnabled()) {
@@ -359,25 +359,16 @@ public class Document extends AttributeBag<Document> implements Serializable {
     
     public void put(Entry<String,Attribute<? extends Comparable<?>>> entry, Boolean includeGroupingContext) {
         // No grouping context in the document.
-        this.put(entry.getKey(), entry.getValue(), includeGroupingContext, false);
-    }
-    
-    public void put(Entry<String,Attribute<? extends Comparable<?>>> entry, Boolean includeGroupingContext, boolean reducedResponse) {
-        // No grouping context in the document.
-        this.put(entry.getKey(), entry.getValue(), includeGroupingContext, reducedResponse);
+        this.put(entry.getKey(), entry.getValue(), includeGroupingContext);
     }
     
     public void putAll(Iterator<Entry<String,Attribute<? extends Comparable<?>>>> iterator, Boolean includeGroupingContext) {
-        putAll(iterator, includeGroupingContext, false);
-    }
-    
-    public void putAll(Iterator<Entry<String,Attribute<? extends Comparable<?>>>> iterator, Boolean includeGroupingContext, boolean reducedResponse) {
         if (null == iterator) {
             return;
         }
         
         while (iterator.hasNext()) {
-            put(iterator.next(), includeGroupingContext, reducedResponse);
+            put(iterator.next(), includeGroupingContext);
         }
     }
     
@@ -520,11 +511,6 @@ public class Document extends AttributeBag<Document> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
         WritableUtils.writeVInt(out, _count);
         out.writeBoolean(trackSizes);
         WritableUtils.writeVLong(out, _bytes);
@@ -753,11 +739,6 @@ public class Document extends AttributeBag<Document> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
         output.writeInt(this._count, true);
         output.writeBoolean(trackSizes);
         output.writeLong(this._bytes, true);
@@ -772,7 +753,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
             
             Attribute<?> attribute = entry.getValue();
             output.writeString(attribute.getClass().getName());
-            attribute.write(kryo, output, reducedResponse);
+            attribute.write(kryo, output);
         }
         
         output.writeLong(this.shardTimestamp);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DocumentKey.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DocumentKey.java
@@ -85,12 +85,7 @@ public class DocumentKey extends Attribute<DocumentKey> implements Serializable 
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, getShardId());
         WritableUtils.writeString(out, getDataType());
@@ -133,12 +128,7 @@ public class DocumentKey extends Attribute<DocumentKey> implements Serializable 
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         
         output.writeString(this.getShardId());
         output.writeString(this.getDataType());

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/GeoPoint.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/GeoPoint.java
@@ -60,12 +60,7 @@ public class GeoPoint extends Attribute<GeoPoint> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, this.point);
     }
@@ -134,12 +129,7 @@ public class GeoPoint extends Attribute<GeoPoint> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         
         output.writeString(this.point);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Geometry.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Geometry.java
@@ -73,12 +73,7 @@ public class Geometry extends Attribute<Geometry> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeCompressedByteArray(out, write());
     }
@@ -151,12 +146,7 @@ public class Geometry extends Attribute<Geometry> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         byte[] wellKnownBinary = write();
         output.write(wellKnownBinary.length);
         output.write(wellKnownBinary);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/IpAddress.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/IpAddress.java
@@ -61,12 +61,7 @@ public class IpAddress extends Attribute<IpAddress> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, this.value.toString());
     }
@@ -121,12 +116,7 @@ public class IpAddress extends Attribute<IpAddress> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         
         output.writeString(this.value.toString());
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Latitude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Latitude.java
@@ -61,12 +61,7 @@ public class Latitude extends Attribute<Latitude> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, this.latitude);
     }
@@ -134,12 +129,7 @@ public class Latitude extends Attribute<Latitude> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         
         output.writeString(this.latitude);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Longitude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Longitude.java
@@ -61,12 +61,7 @@ public class Longitude extends Attribute<Longitude> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         
         WritableUtils.writeString(out, this.longitude);
     }
@@ -134,12 +129,7 @@ public class Longitude extends Attribute<Longitude> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         
         output.writeString(this.longitude);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
@@ -107,12 +107,7 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, normalizedValue);
     }
     
@@ -168,12 +163,7 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         
         output.writeString(this.normalizedValue);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/PreNormalizedAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/PreNormalizedAttribute.java
@@ -77,12 +77,7 @@ public class PreNormalizedAttribute extends Attribute<PreNormalizedAttribute> im
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         
         output.writeString(this.value);
     }
@@ -95,12 +90,7 @@ public class PreNormalizedAttribute extends Attribute<PreNormalizedAttribute> im
     
     @Override
     public void write(DataOutput output) throws IOException {
-        write(output, false);
-    }
-    
-    @Override
-    public void write(DataOutput output, boolean reducedResponse) throws IOException {
-        super.writeMetadata(output, reducedResponse);
+        super.writeMetadata(output);
         
         WritableUtils.writeString(output, this.value);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -57,13 +57,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
     
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-    
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
         WritableUtils.writeString(out, datawaveType.getClass().toString());
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, datawaveType.getDelegateAsString());
     }
     
@@ -127,13 +122,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
     
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-    
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
         output.writeString(datawaveType.getClass().getName());
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         
         output.writeString(this.datawaveType.getDelegateAsString());
     }

--- a/warehouse/query-core/src/main/java/datawave/query/function/DataTypeAsField.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/DataTypeAsField.java
@@ -29,7 +29,7 @@ public class DataTypeAsField implements Function<Entry<Key,Document>,Entry<Key,D
     @Override
     public Entry<Key,Document> apply(Entry<Key,Document> from) {
         Content dataType = extractDataType(from.getKey(), from.getValue().isToKeep());
-        from.getValue().put(key, dataType, false, false);
+        from.getValue().put(key, dataType, false);
         return from;
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/function/DocumentProjection.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/DocumentProjection.java
@@ -93,7 +93,7 @@ public class DocumentProjection implements DocumentPermutation {
                         Document newSubDoc = trim((Document) attr);
                         
                         if (0 < newSubDoc.size()) {
-                            newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext, this.reducedResponse);
+                            newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext);
                         }
                         
                         continue;
@@ -101,7 +101,7 @@ public class DocumentProjection implements DocumentPermutation {
                         Attributes subAttrs = trim((Attributes) attr, fieldName);
                         
                         if (0 < subAttrs.size()) {
-                            newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext, this.reducedResponse);
+                            newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext);
                         }
                         
                         continue;
@@ -109,7 +109,7 @@ public class DocumentProjection implements DocumentPermutation {
                 }
                 
                 // We just want to add this subtree
-                newDoc.put(fieldName, (Attribute<?>) attr.copy(), this.includeGroupingContext, this.reducedResponse);
+                newDoc.put(fieldName, (Attribute<?>) attr.copy(), this.includeGroupingContext);
                 
             } else if (!projection.isUseBlacklist()) {
                 // Blacklist will completely exclude a subtree, whereas a whitelist
@@ -119,7 +119,7 @@ public class DocumentProjection implements DocumentPermutation {
                     Document newSubDoc = trim((Document) attr);
                     
                     if (0 < newSubDoc.size()) {
-                        newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext, this.reducedResponse);
+                        newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext);
                     }
                 } else if (attr instanceof Attributes) {
                     // Since Document instances can be nested under attributes and vice-versa
@@ -128,7 +128,7 @@ public class DocumentProjection implements DocumentPermutation {
                     Attributes subAttrs = trim((Attributes) attr, fieldName);
                     
                     if (0 < subAttrs.size()) {
-                        newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext, this.reducedResponse);
+                        newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext);
                     }
                 }
             }

--- a/warehouse/query-core/src/main/java/datawave/query/function/FacetedGrouping.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/FacetedGrouping.java
@@ -142,7 +142,7 @@ public class FacetedGrouping implements Function<Entry<Key,Document>,Entry<Key,D
         if (log.isTraceEnabled())
             log.trace("entries" + newDocumentAttributes.entries());
         for (Entry<String,Attribute<?>> newAttr : newDocumentAttributes.entries()) {
-            currentDoc.replace(newAttr.getKey(), newAttr.getValue(), false, false);
+            currentDoc.replace(newAttr.getKey(), newAttr.getValue(), false);
         }
         if (log.isTraceEnabled())
             log.trace("currentDoc" + currentDoc);

--- a/warehouse/query-core/src/main/java/datawave/query/function/GroupFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/GroupFields.java
@@ -81,7 +81,7 @@ public class GroupFields implements Function<Entry<Key,Document>,Entry<Key,Docum
             for (Entry<String,Integer> groupFieldCountEntry : groupFieldsMap.entrySet()) {
                 Attribute<?> removedAttr = doc.remove(groupFieldCountEntry.getKey());
                 log.debug("removed from document:" + groupFieldCountEntry.getKey());
-                doc.put(groupFieldCountEntry.getKey(), new Numeric(groupFieldCountEntry.getValue(), doc.getMetadata(), removedAttr.isToKeep()), true, false);
+                doc.put(groupFieldCountEntry.getKey(), new Numeric(groupFieldCountEntry.getValue(), doc.getMetadata(), removedAttr.isToKeep()), true);
                 log.debug("added to document:" + groupFieldCountEntry.getKey() + " with count of " + groupFieldCountEntry.getValue());
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/function/KryoCVAwareSerializableSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/KryoCVAwareSerializableSerializer.java
@@ -25,7 +25,7 @@ public class KryoCVAwareSerializableSerializer extends KryoSerializableSerialize
     @Override
     public void write(Kryo kryo, Output output, KryoSerializable object) {
         if (object instanceof Document) {
-            ((Document) object).write(kryo, output, getReducedResponse());
+            ((Document) object).write(kryo, output);
         } else {
             object.write(kryo, output);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
@@ -251,7 +251,7 @@ public class LimitFields implements Function<Entry<Key,Document>,Entry<Key,Docum
         if (!limitedFieldCounts.entrySet().isEmpty()) {
             ColumnVisibility docVisibility = doc.getColumnVisibility();
             for (Entry<String,Integer> limitedFieldCountEntry : limitedFieldCounts.entrySet()) {
-                doc.put(limitedFieldCountEntry.getKey(), new Numeric(limitedFieldCountEntry.getValue(), doc.getMetadata(), doc.isToKeep()), true, false);
+                doc.put(limitedFieldCountEntry.getKey(), new Numeric(limitedFieldCountEntry.getValue(), doc.getMetadata(), doc.isToKeep()), true);
             }
         }
     }

--- a/warehouse/query-core/src/main/java/datawave/query/function/RemoveGroupingContext.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/RemoveGroupingContext.java
@@ -34,7 +34,7 @@ public class RemoveGroupingContext implements Function<Entry<Key,Document>,Entry
         }
         // put them all back without the grouping context
         for (Entry<String,Attribute<? extends Comparable<?>>> goner : toRemove) {
-            entry.getValue().put(goner.getKey(), goner.getValue(), false, false);
+            entry.getValue().put(goner.getKey(), goner.getValue(), false);
         }
         return entry;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/function/serializer/WritableDocumentSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/serializer/WritableDocumentSerializer.java
@@ -26,7 +26,7 @@ public class WritableDocumentSerializer extends DocumentSerializer {
         DataOutputStream dos = new DataOutputStream(baos);
         
         try {
-            doc.write(dos, reducedResponse);
+            doc.write(dos);
         } catch (IOException e) {
             throw new RuntimeException("Could not convert Document through write().", e);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ContentTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ContentTransform.java
@@ -36,7 +36,7 @@ public class ContentTransform extends DocumentTransform.DefaultDocumentTransform
                     Attribute<?> contentField = document.remove(contentFieldName);
                     if (contentField.getData().toString().equalsIgnoreCase("true")) {
                         Content c = new Content(uid, contentField.getMetadata(), document.isToKeep());
-                        document.put(contentFieldName, c, false, this.reducedResponse);
+                        document.put(contentFieldName, c, false);
                     }
                 }
             }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/FieldMappingTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/FieldMappingTransform.java
@@ -29,7 +29,7 @@ public class FieldMappingTransform extends DocumentTransform.DefaultDocumentTran
                 if (!document.containsKey(primaryField)) {
                     for (String secondaryField : this.primaryToSecondaryFieldMap.get(primaryField)) {
                         if (document.containsKey(secondaryField)) {
-                            document.put(primaryField, document.get(secondaryField), false, this.reducedResponse);
+                            document.put(primaryField, document.get(secondaryField), false);
                             break;
                         }
                     }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
@@ -327,7 +327,7 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
                 attribute.setColumnVisibility(entry.getValue().getColumnVisibility());
                 // call copy() on the GroupingTypeAttribute to get a plain TypeAttribute
                 // instead of a GroupingTypeAttribute that is package protected and won't serialize
-                theDocument.put(name + "." + Integer.toHexString(context).toUpperCase(), (TypeAttribute) attribute.copy(), true, false);
+                theDocument.put(name + "." + Integer.toHexString(context).toUpperCase(), (TypeAttribute) attribute.copy(), true);
             }
             context++;
         }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
@@ -550,7 +550,7 @@ public class UniqueTransformTest {
         }
         
         InputDocumentBuilder withKeyValue(String key, String value) {
-            document.put(key, new DiacriticContent(value, document.getMetadata(), true), true, false);
+            document.put(key, new DiacriticContent(value, document.getMetadata(), true), true);
             return this;
         }
         


### PR DESCRIPTION
I noticed that the Attribute hierarchy of classes have methods that pass boolean reducedResponse as a parameter, 
but I found no methods there that actually use that parameter. I removed those methods and changed every calling method.

this passes the build with mvn -V -B -e -Pdev,examples,assemble,spotbugs -Ddeploy -Ddist -T1C clean verify


FWIW, to reduce pain for others, I will restore and deprecate the methods I removed. For now, its easier for me to trace tests using json serialization if I don't have all the spurious use of the reducedResponse flag.