### PR TITLE
Hittermtype

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/HitTermType.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/HitTermType.java
@@ -1,0 +1,13 @@
+package datawave.query.attributes;
+
+import datawave.data.type.StringType;
+
+import java.util.function.Predicate;
+
+public class HitTermType extends StringType {
+
+    public static final boolean matches(Attribute<?> attr) {
+        return attr instanceof TypeAttribute && ((TypeAttribute) attr).getType() instanceof HitTermType;
+    }
+
+}

--- a/warehouse/query-core/src/main/java/datawave/query/function/JexlEvaluation.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/JexlEvaluation.java
@@ -1,10 +1,14 @@
 package datawave.query.function;
 
+import datawave.data.type.StringType;
 import datawave.query.attributes.Attributes;
+import datawave.query.attributes.HitTermType;
+import datawave.query.attributes.TypeAttribute;
 import datawave.query.attributes.ValueTuple;
 import datawave.query.jexl.ArithmeticJexlEngines;
 import datawave.query.jexl.DefaultArithmetic;
 import datawave.query.jexl.DelayedNonEventIndexContext;
+import datawave.query.util.TypeMetadata;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.jexl2.JexlArithmetic;
@@ -108,9 +112,11 @@ public class JexlEvaluation implements Predicate<Tuple3<Key,Document,DatawaveJex
                     if (cv != null) {
                         // unused
                         long timestamp = document.getTimestamp(); // will force an update to make the metadata valid
-                        Content content = new Content(term, document.getMetadata(), document.isToKeep());
-                        content.setColumnVisibility(cv);
-                        attributes.add(content);
+                        HitTermType type = new HitTermType();
+                        type.setDelegate(term);
+                        TypeAttribute typeAttribute = new TypeAttribute(type, document.getMetadata(), document.isToKeep());
+                        typeAttribute.setColumnVisibility(cv);
+                        attributes.add(typeAttribute);
                         
                     }
                 }

--- a/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
@@ -14,7 +14,9 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Attributes;
 import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
+import datawave.query.attributes.HitTermType;
 import datawave.query.attributes.Numeric;
+import datawave.query.attributes.TypeAttribute;
 import datawave.util.StringUtils;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -231,10 +233,9 @@ public class LimitFields implements Function<Entry<Key,Document>,Entry<Key,Docum
                 for (Attribute<?> at : attrs.getAttributes()) {
                     fillHitTermMap(at, attrMap);
                 }
-            } else if (attr instanceof Content) {
-                Content content = (Content) attr;
+            } else if (HitTermType.matches(attr)) {
                 // split the content into its fieldname:value
-                String contentString = content.getContent();
+                String contentString = ((TypeAttribute)attr).getType().toString();
                 attrMap.put(contentString.substring(0, contentString.indexOf(":")), contentString.substring(contentString.indexOf(":") + 1));
             }
         }

--- a/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedCommonalityTokenTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedCommonalityTokenTest.java
@@ -8,6 +8,7 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Attributes;
 import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
+import datawave.query.attributes.HitTermType;
 import datawave.query.function.JexlEvaluation;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.tables.ShardQueryLogic;
@@ -178,14 +179,14 @@ public abstract class HitsAreAlwaysIncludedCommonalityTokenTest {
             if (hitAttribute instanceof Attributes) {
                 Attributes attributes = (Attributes) hitAttribute;
                 for (Attribute attr : attributes.getAttributes()) {
-                    if (attr instanceof Content) {
-                        Content content = (Content) attr;
-                        Assert.assertTrue(goodResults.contains(content.getContent()));
+                    if (HitTermType.matches(attr)) {
+                        String content = attr.toString();
+                        Assert.assertTrue(goodResults.contains(content));
                     }
                 }
-            } else if (hitAttribute instanceof Content) {
-                Content content = (Content) hitAttribute;
-                Assert.assertTrue(goodResults.contains(content.getContent()));
+            } else if (HitTermType.matches(hitAttribute)) {
+//                Content content = (Content) hitAttribute;
+                Assert.assertTrue(goodResults.contains(hitAttribute.toString()));
             }
             
             // remove from goodResults as we find the expected return fields

--- a/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
@@ -8,8 +8,9 @@ import datawave.ingest.data.TypeRegistry;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Attributes;
-import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
+import datawave.query.attributes.HitTermType;
+import datawave.query.attributes.TypeAttribute;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.tables.ShardQueryLogic;
@@ -187,14 +188,14 @@ public abstract class HitsAreAlwaysIncludedTest {
             if (hitAttribute instanceof Attributes) {
                 Attributes attributes = (Attributes) hitAttribute;
                 for (Attribute attr : attributes.getAttributes()) {
-                    if (attr instanceof Content) {
-                        Content content = (Content) attr;
-                        Assert.assertTrue(expectedHits.remove(content.getContent()));
+                    if (HitTermType.matches(attr)) {
+                        TypeAttribute content = (TypeAttribute) attr;
+                        Assert.assertTrue(expectedHits.remove(content.toString()));
                     }
                 }
-            } else if (hitAttribute instanceof Content) {
-                Content content = (Content) hitAttribute;
-                Assert.assertTrue(content.getContent() + " is not an expected hit", expectedHits.remove(content.getContent()));
+            } else if (hitAttribute instanceof TypeAttribute) {
+                TypeAttribute attr = (TypeAttribute) hitAttribute;
+                Assert.assertTrue(attr + " is not an expected hit", expectedHits.remove(attr.toString()));
             } else {
                 Assert.fail("Did not find hit term field");
             }

--- a/warehouse/query-core/src/test/java/datawave/query/function/JexlEvaluationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/JexlEvaluationTest.java
@@ -155,7 +155,7 @@ public class JexlEvaluationTest {
         boolean foundPhrase = false;
         Attributes attrs = (Attributes) d.get("HIT_TERM");
         for (Attribute<?> attr : attrs.getAttributes()) {
-            if (attr.getData().equals("TOKFIELD:big red dog")) {
+            if (attr.toString().equals("TOKFIELD:big red dog")) {
                 foundPhrase = true;
             }
         }


### PR DESCRIPTION
I will also make this same PR against the integration branch. This fixes a problem where Content was probably not the best choice as a type for the hit terms, and also the accumulo key added to the value of the Content type was not making thru the serialization / deserialization stages, so it was never seen.
The new HitTermType could/should go in the datawave-type-utils project at some point, but that module may be harder to make a new release of.