### PR TITLE
WIP Incorporate Term Frequency Excerpts

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 import datawave.ingest.protobuf.TermWeightPosition;
+import datawave.query.postprocessing.tf.TermOffsetMap;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.LinkedListMultimap;
@@ -25,12 +26,12 @@ public abstract class ContentFunctionEvaluator {
     protected final Set<String> fields;
     protected final int distance;
     protected final String[] terms;
-    protected final Map<String,TermFrequencyList> termOffsetMap;
+    protected final TermOffsetMap termOffsetMap;
     protected final boolean canProcess;
     protected final int maxScore;
     protected Set<String> eventIds;
     
-    public ContentFunctionEvaluator(Set<String> fields, int distance, float maxScore, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public ContentFunctionEvaluator(Set<String> fields, int distance, float maxScore, TermOffsetMap termOffsetMap, String... terms) {
         this.fields = fields;
         this.distance = distance;
         this.maxScore = TermWeightPosition.positionScoreToTermWeightScore(maxScore);
@@ -56,7 +57,7 @@ public abstract class ContentFunctionEvaluator {
      * @param termOffsetMap
      * @param terms
      */
-    protected boolean isValidArguments(int distance, Map<String,TermFrequencyList> termOffsetMap, String[] terms) {
+    protected boolean isValidArguments(int distance, TermOffsetMap termOffsetMap, String[] terms) {
         if (termOffsetMap == null || (distance < 0) || terms.length < 2) {
             return false;
         }
@@ -66,11 +67,12 @@ public abstract class ContentFunctionEvaluator {
     
     /**
      * Evaluate the function based on the list of offset lists. The lists are expected to be ordered, and there is one offset list per term.
-     * 
-     * @param offsets
+     *
+     * @param field the field where the offsets were found
+     * @param offsets the offset lists
      * @return List of offset matching the query, often just the first match for efficiency
      */
-    protected abstract boolean evaluate(List<List<TermWeightPosition>> offsets);
+    protected abstract boolean evaluate(String field, List<List<TermWeightPosition>> offsets);
     
     /**
      * Validate and initialize this class. This will validate the arguments and setup other members.
@@ -107,8 +109,8 @@ public abstract class ContentFunctionEvaluator {
                 
                 return false;
             }
-            
-            TermFrequencyList tfList = termOffsetMap.get(term);
+    
+            TermFrequencyList tfList = termOffsetMap.getTermFrequencyList(term);
             
             if (tfList == null) {
                 if (log.isTraceEnabled()) {
@@ -157,7 +159,7 @@ public abstract class ContentFunctionEvaluator {
             for (String eventId : eventIds) {
                 ListMultimap<String,List<TermWeightPosition>> offsetsByField = LinkedListMultimap.create();
                 for (String term : terms) {
-                    TermFrequencyList tfList = termOffsetMap.get(term);
+                    TermFrequencyList tfList = termOffsetMap.getTermFrequencyList(term);
                     
                     // Invert the map to take all of the offsets for a term within a field
                     // and group the lists together
@@ -217,7 +219,7 @@ public abstract class ContentFunctionEvaluator {
                     }
                     
                     // evaluate the offsets
-                    if (evaluate(offsets)) {
+                    if (evaluate(field, offsets)) {
                         if (log.isTraceEnabled()) {
                             log.trace(logPrefix + " satisfied the content function");
                         }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctions.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import datawave.query.attributes.ValueTuple;
+import datawave.query.postprocessing.tf.TermOffsetMap;
 import datawave.util.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -87,12 +88,12 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> within(int distance, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
-        return new ContentUnorderedEvaluator(Collections.EMPTY_SET, distance, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
+    public static Collection<String> within(int distance, TermOffsetMap termOffsetMap, String... terms) {
+        return new ContentUnorderedEvaluator(Collections.emptySet(), distance, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
     }
     
     /**
-     * Like {@link #within(int, Map, String...)} but limited to only finding a match in a single zone.
+     * Like {@link #within(int, TermOffsetMap, String...)} but limited to only finding a match in a single zone.
      *
      * @param zone
      *            The zone or zones to search within
@@ -103,14 +104,14 @@ public class ContentFunctions {
      * @param terms
      *            The array of terms
      * @return a collection of fields that satisfy the content function
-     * @see #within(int, Map, String...)
+     * @see #within(int, TermOffsetMap, String...)
      */
-    public static Collection<String> within(Object zone, int distance, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> within(Object zone, int distance, TermOffsetMap termOffsetMap, String... terms) {
         return new ContentUnorderedEvaluator(getFields(zone), distance, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
     }
     
     /**
-     * Like {@link #within(int, Map, String...)} but limited to only finding a match in a single zone.
+     * Like {@link #within(int, TermOffsetMap, String...)} but limited to only finding a match in a single zone.
      *
      * @param zones
      *            The zone or zones to search within
@@ -121,9 +122,9 @@ public class ContentFunctions {
      * @param terms
      *            The array of terms
      * @return a collection of fields that satisfy the content function
-     * @see #within(int, Map, String...)
+     * @see #within(int, TermOffsetMap, String...)
      */
-    public static Collection<String> within(Iterable<?> zones, int distance, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> within(Iterable<?> zones, int distance, TermOffsetMap termOffsetMap, String... terms) {
         return new ContentUnorderedEvaluator(getFields(zones), distance, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
     }
     
@@ -137,7 +138,7 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> adjacent(Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> adjacent(TermOffsetMap termOffsetMap, String... terms) {
         return within(terms.length - 1, termOffsetMap, terms);
     }
     
@@ -152,7 +153,7 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> adjacent(Object zone, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> adjacent(Object zone, TermOffsetMap termOffsetMap, String... terms) {
         return within(getFields(zone), terms.length - 1, termOffsetMap, terms);
     }
     
@@ -167,7 +168,7 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> adjacent(Iterable<?> zone, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> adjacent(Iterable<?> zone, TermOffsetMap termOffsetMap, String... terms) {
         return within(getFields(zone), terms.length - 1, termOffsetMap, terms);
     }
     
@@ -180,8 +181,8 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> phrase(Map<String,TermFrequencyList> termOffsetMap, String... terms) {
-        return new ContentOrderedEvaluator(Collections.EMPTY_SET, 1, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
+    public static Collection<String> phrase(TermOffsetMap termOffsetMap, String... terms) {
+        return new ContentOrderedEvaluator(Collections.emptySet(), 1, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
     }
     
     /**
@@ -195,7 +196,7 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> phrase(Object zone, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> phrase(Object zone, TermOffsetMap termOffsetMap, String... terms) {
         return new ContentOrderedEvaluator(getFields(zone), 1, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
     }
     
@@ -210,8 +211,8 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> scoredPhrase(Float minScore, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
-        return new ContentOrderedEvaluator(Collections.EMPTY_SET, 1, minScore, termOffsetMap, terms).evaluate();
+    public static Collection<String> scoredPhrase(Float minScore, TermOffsetMap termOffsetMap, String... terms) {
+        return new ContentOrderedEvaluator(Collections.emptySet(), 1, minScore, termOffsetMap, terms).evaluate();
     }
     
     /**
@@ -227,7 +228,7 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> scoredPhrase(Object zone, Float minScore, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> scoredPhrase(Object zone, Float minScore, TermOffsetMap termOffsetMap, String... terms) {
         return new ContentOrderedEvaluator(getFields(zone), 1, minScore, termOffsetMap, terms).evaluate();
     }
     
@@ -242,7 +243,7 @@ public class ContentFunctions {
      *            The array of terms
      * @return a collection of fields that satisfy the content function
      */
-    public static Collection<String> phrase(Iterable<?> zone, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public static Collection<String> phrase(Iterable<?> zone, TermOffsetMap termOffsetMap, String... terms) {
         return new ContentOrderedEvaluator(getFields(zone), 1, Float.NEGATIVE_INFINITY, termOffsetMap, terms).evaluate();
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentOrderedEvaluator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentOrderedEvaluator.java
@@ -1,6 +1,8 @@
 package datawave.query.jexl.functions;
 
 import datawave.ingest.protobuf.TermWeightPosition;
+import datawave.query.Constants;
+import datawave.query.postprocessing.tf.TermOffsetMap;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
@@ -43,7 +45,7 @@ public class ContentOrderedEvaluator extends ContentFunctionEvaluator {
     private static final int FORWARD = 1;
     private static final int REVERSE = -1;
     
-    public ContentOrderedEvaluator(Set<String> fields, int distance, float maxScore, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+    public ContentOrderedEvaluator(Set<String> fields, int distance, float maxScore, TermOffsetMap termOffsetMap, String... terms) {
         super(fields, distance, maxScore, termOffsetMap, terms);
         if (log.isTraceEnabled()) {
             log.trace("ContentOrderedEvaluatorTreeSet constructor");
@@ -51,7 +53,7 @@ public class ContentOrderedEvaluator extends ContentFunctionEvaluator {
     }
     
     @Override
-    protected boolean evaluate(List<List<TermWeightPosition>> offsets) {
+    protected boolean evaluate(String field, List<List<TermWeightPosition>> offsets) {
         if (offsets.isEmpty() || offsets.size() < terms.length) {
             return false;
         }
@@ -66,12 +68,12 @@ public class ContentOrderedEvaluator extends ContentFunctionEvaluator {
             return false;
         }
         
-        while (!isConverged(termPositions, distance)) {
+        while (!isConverged(field, termPositions, distance)) {
             // look for alternatives that also satisfy convergence within each term before rolling forward. Move at most one term one position until there are
             // no alternatives that satisfy the distance left
             List<NavigableSet<EvaluateTermPosition>> alternativeTermPositions = trimAlternatives(termPositions, distance);
             boolean alternativeConverged = false;
-            while (alternativeTermPositions != null && !(alternativeConverged = isConverged(alternativeTermPositions, distance))) {
+            while (alternativeTermPositions != null && !(alternativeConverged = isConverged(field, alternativeTermPositions, distance))) {
                 alternativeTermPositions = trimAlternatives(alternativeTermPositions, distance);
             }
             
@@ -219,12 +221,13 @@ public class ContentOrderedEvaluator extends ContentFunctionEvaluator {
     
     /**
      * Test if a set of offsets satisfy a distance requirement
-     * 
+     *
+     * @param field the field where the offsets were found
      * @param offsets
      * @param distance
      * @return true if satisfied, false otherwise
      */
-    private boolean isConverged(List<NavigableSet<EvaluateTermPosition>> offsets, int distance) {
+    private boolean isConverged(String field, List<NavigableSet<EvaluateTermPosition>> offsets, int distance) {
         if (offsets.size() == 1) {
             return true;
         }
@@ -233,6 +236,9 @@ public class ContentOrderedEvaluator extends ContentFunctionEvaluator {
         NavigableSet<EvaluateTermPosition> first = offsets.get(0);
         NavigableSet<EvaluateTermPosition> second = offsets.get(secondIndex);
         
+        // The start offset of the phrase if satisfied.
+        int startOffset = first.first().termWeightPosition.getOffset();
+        int endOffset;
         // test that these terms are within distance
         while (first.first().isWithIn(second.first(), distance)) {
             // are there more terms?
@@ -243,6 +249,11 @@ public class ContentOrderedEvaluator extends ContentFunctionEvaluator {
                 second = offsets.get(secondIndex);
             } else {
                 // nope
+                
+                // Establish the end offset of the phrase.
+                endOffset = second.first().termWeightPosition.getOffset();
+                // Record the phrase offsets to fetch excerpts later if desired.
+                termOffsetMap.putPhraseOffset(field, startOffset, endOffset);
                 return true;
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetMap.java
@@ -1,0 +1,79 @@
+package datawave.query.postprocessing.tf;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import datawave.query.jexl.functions.TermFrequencyList;
+import org.javatuples.Pair;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class TermOffsetMap {
+    
+    private final Map<String,TermFrequencyList> termFrequencies = new HashMap<>();
+    
+    private final Multimap<String,Pair<Integer,Integer>> phraseOffsetMap = HashMultimap.create();
+    
+    public TermOffsetMap() {
+    }
+    
+    public TermOffsetMap(Map<String,TermFrequencyList> termFrequencies) {
+        if (termFrequencies != null) {
+            this.termFrequencies.putAll(termFrequencies);
+        }
+    }
+    
+    public void putTermFrequencyList(String field, TermFrequencyList termFrequencyList) {
+        termFrequencies.put(field, termFrequencyList);
+    }
+    
+    public void putAllTermFrequencyLists(Map<String,TermFrequencyList> termOffsetMap) {
+        this.termFrequencies.putAll(termOffsetMap);
+    }
+    
+    public TermFrequencyList getTermFrequencyList(String term) {
+        return termFrequencies.get(term);
+    }
+    
+    public Map<String,TermFrequencyList> getTermFrequencies() {
+        return termFrequencies;
+    }
+    
+    public void putPhraseOffset(String field, int start, int end) {
+        phraseOffsetMap.put(field, Pair.with(start, end));
+    }
+    
+    public Collection<Pair<Integer,Integer>> getPhraseOffsets(String field) {
+        return phraseOffsetMap.get(field);
+    }
+    
+    public Multimap<String,Pair<Integer,Integer>> getPhraseOffsets() {
+        return phraseOffsetMap;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TermOffsetMap that = (TermOffsetMap) o;
+        return Objects.equals(termFrequencies, that.termFrequencies) && Objects.equals(phraseOffsetMap, that.phraseOffsetMap);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(termFrequencies, phraseOffsetMap);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", TermOffsetMap.class.getSimpleName() + "[", "]").add("termFrequencies=" + termFrequencies)
+                        .add("phraseOffsetMap=" + phraseOffsetMap).toString();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
@@ -85,17 +85,17 @@ public class TermOffsetPopulator {
         Map<String,Object> map = new HashMap<>();
         Map<String,TermFrequencyList> termOffsetMap = Maps.newHashMap();
         
-        Map<String,TermFrequencyList> termOffsetMap1 = (Map<String,TermFrequencyList>) (map1.get(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME));
-        Map<String,TermFrequencyList> termOffsetMap2 = (Map<String,TermFrequencyList>) (map2.get(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME));
+        TermOffsetMap termOffsetMap1 = (TermOffsetMap) map1.get(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME);
+        TermOffsetMap termOffsetMap2 = (TermOffsetMap) (map2.get(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME));
         
         if (termOffsetMap1 == null) {
             if (termOffsetMap2 != null) {
-                termOffsetMap.putAll(termOffsetMap2);
+                termOffsetMap.putAll(termOffsetMap2.getTermFrequencies());
             }
         } else {
-            termOffsetMap.putAll(termOffsetMap1);
+            termOffsetMap.putAll(termOffsetMap1.getTermFrequencies());
             if (termOffsetMap2 != null) {
-                for (Map.Entry<String,TermFrequencyList> entry : termOffsetMap2.entrySet()) {
+                for (Map.Entry<String,TermFrequencyList> entry : termOffsetMap2.getTermFrequencies().entrySet()) {
                     String key = entry.getKey();
                     TermFrequencyList list1 = termOffsetMap.get(key);
                     TermFrequencyList list2 = entry.getValue();
@@ -109,7 +109,7 @@ public class TermOffsetPopulator {
         }
         
         // Load the actual map into map that will be put into the JexlContext
-        map.put(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffsetMap);
+        map.put(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, new TermOffsetMap(termOffsetMap));
         
         return map;
     }
@@ -235,7 +235,7 @@ public class TermOffsetPopulator {
         
         // Load the actual map into map that will be put into the JexlContext
         Map<String,Object> map = new HashMap<>();
-        map.put(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffsetMap);
+        map.put(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, new TermOffsetMap(termOffsetMap));
         
         return map;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/function/JexlEvaluationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/JexlEvaluationTest.java
@@ -11,6 +11,7 @@ import datawave.query.attributes.Document;
 import datawave.query.jexl.DatawaveJexlContext;
 import datawave.query.jexl.HitListArithmetic;
 import datawave.query.jexl.functions.TermFrequencyList;
+import datawave.query.postprocessing.tf.TermOffsetMap;
 import datawave.query.util.Tuple3;
 import org.apache.accumulo.core.data.Key;
 import org.junit.Test;
@@ -134,7 +135,7 @@ public class JexlEvaluationTest {
         map.put("dog", buildTfList("TOKFIELD", 3));
         
         DatawaveJexlContext context = new DatawaveJexlContext();
-        context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, map);
+        context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, new TermOffsetMap(map));
         
         Key docKey = new Key("shard", "datatype\0uid");
         

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionsTest.java
@@ -10,6 +10,7 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.functions.TermFrequencyList.Zone;
 import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.postprocessing.tf.TermOffsetMap;
 import datawave.query.util.MockDateIndexHelper;
 import datawave.query.util.MockMetadataHelper;
 import org.apache.commons.jexl2.Expression;
@@ -23,6 +24,7 @@ import org.apache.commons.jexl2.parser.ASTReference;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.log4j.Logger;
+import org.javatuples.Pair;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -31,6 +33,7 @@ import org.junit.Test;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +47,7 @@ public class ContentFunctionsTest {
     private static JexlEngine engine = new DatawaveJexlEngine();
     
     private JexlContext context;
-    private Map<String,TermFrequencyList> termOffSetMap;
+    private TermOffsetMap termOffSetMap;
     
     private String phraseFunction = ContentFunctions.CONTENT_PHRASE_FUNCTION_NAME;
     private String scoredPhraseFunction = ContentFunctions.CONTENT_SCORED_PHRASE_FUNCTION_NAME;
@@ -62,17 +65,17 @@ public class ContentFunctionsTest {
     @Before
     public void setup() {
         this.context = new MapContext();
-        this.termOffSetMap = Maps.newHashMap();
+        this.termOffSetMap = new TermOffsetMap();
     }
     
     /**
-     * Ensures that {@link result} is Boolean and equal to the expected value
+     * Ensures that result is Boolean and equal to the expected value
      * 
      * @param result
      *            The object in question
      * @param expected
      *            The expected result
-     * @return True if {@link result} is Boolean and equal to {@link expected}
+     * @return True if result is Boolean and equal to expected
      */
     public static boolean expect(Object result, Boolean expected) {
         // treat null as false
@@ -162,6 +165,16 @@ public class ContentFunctionsTest {
                         .build();
     }
     
+    private void assertPhraseOffset(String field, int startOffset, int endOffset) {
+        Collection<Pair<Integer,Integer>> phraseOffsets = termOffSetMap.getPhraseOffsets(field);
+        boolean found = phraseOffsets.stream().anyMatch((pair) -> pair.getValue0().equals(startOffset) && pair.getValue1().equals(endOffset));
+        Assert.assertTrue("Expected phrase offset [" + startOffset + ", " + endOffset + "] for field " + field + " but was " + phraseOffsets, found);
+    }
+    
+    private void assertPhraseOffsetsEmpty() {
+        Assert.assertTrue("Expected empty phrase offset map", termOffSetMap.getPhraseOffsets().isEmpty());
+    }
+    
     @Test
     public void testEvaluation1() {
         String query = buildFunction(ContentFunctions.CONTENT_WITHIN_FUNCTION_NAME, "1", Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, "'dog'", "'cat'");
@@ -171,13 +184,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 0, 0));
         list2 = asList(Arrays.asList(5, 6, 7), Arrays.asList(0, 2, 0)); // match (6-2) should match (3+1)
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 3, 4);
     }
     
     @Test
@@ -190,14 +204,15 @@ public class ContentFunctionsTest {
         t2 = asList(Arrays.asList(212, 229, 252, 272), Arrays.asList(0, 0, 0, 0));
         t3 = asList(Arrays.asList(1, 101, 202, 213, 253, 312, 336), Arrays.asList(0, 0, 0, 0, 0, 0, 0));
         
-        termOffSetMap.put("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
-        termOffSetMap.put("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
-        termOffSetMap.put("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
+        termOffSetMap.putTermFrequencyList("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
+        termOffSetMap.putTermFrequencyList("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
+        termOffSetMap.putTermFrequencyList("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 252, 253);
     }
     
     @Test
@@ -210,14 +225,15 @@ public class ContentFunctionsTest {
         t2 = asList(Arrays.asList(212, 229, 252, 272), Arrays.asList(0, 0, 0, 0));
         t3 = asList(Arrays.asList(1, 101, 202, 213, 251, 312, 336), Arrays.asList(0, 0, 0, 0, 0, 0, 0));
         
-        termOffSetMap.put("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
-        termOffSetMap.put("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
-        termOffSetMap.put("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
+        termOffSetMap.putTermFrequencyList("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
+        termOffSetMap.putTermFrequencyList("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
+        termOffSetMap.putTermFrequencyList("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 251, 252);
     }
     
     @Test
@@ -230,14 +246,15 @@ public class ContentFunctionsTest {
         t2 = asList(Arrays.asList(212, 229, 252, 272), Arrays.asList(0, 0, 0, 0));
         t3 = asList(Arrays.asList(1, 101, 202, 213, 252, 312, 336), Arrays.asList(0, 0, 0, 0, 0, 0, 0));
         
-        termOffSetMap.put("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
-        termOffSetMap.put("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
-        termOffSetMap.put("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
+        termOffSetMap.putTermFrequencyList("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
+        termOffSetMap.putTermFrequencyList("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
+        termOffSetMap.putTermFrequencyList("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 252, 252);
     }
     
     @Test
@@ -250,14 +267,15 @@ public class ContentFunctionsTest {
         t2 = asList(Arrays.asList(212, 229, 252, 272), Arrays.asList(0, 0, 0, 0));
         t3 = asList(Arrays.asList(1, 101, 202, 213, 252, 312, 336), Arrays.asList(0, 0, 0, 0, 0, 0, 0));
         
-        termOffSetMap.put("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
-        termOffSetMap.put("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
-        termOffSetMap.put("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
+        termOffSetMap.putTermFrequencyList("a", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t1)));
+        termOffSetMap.putTermFrequencyList("b", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t2)));
+        termOffSetMap.putTermFrequencyList("c", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), t3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 252, 252);
     }
     
     /**
@@ -272,13 +290,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 0, 0));
         list2 = asList(Arrays.asList(5, 6, 7), Arrays.asList(0, 0, 3)); // match (7-3_ should match (3+1)
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", false, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", false, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", false, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", false, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -290,13 +309,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(3, 4, 5);
         
-        termOffSetMap.put("dog's", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog's", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 2, 3);
     }
     
     /**
@@ -319,13 +339,14 @@ public class ContentFunctionsTest {
         list1 = asList(1);
         list2 = asList(2);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 2);
     }
     
     @Test
@@ -337,13 +358,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(5, 6, 7);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -355,13 +377,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(5);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -373,13 +396,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(4), Arrays.asList(1));
         list2 = asList(Arrays.asList(2), Arrays.asList(1)); // (10-6) = (3+1)
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 2, 3);
     }
     
     @Test
@@ -391,13 +415,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = new ArrayList<>();
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -412,14 +437,15 @@ public class ContentFunctionsTest {
         list2 = asList(3, 7, 11);
         list3 = asList(10, 15, 20, 25);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 7, 10);
     }
     
     @Test
@@ -433,14 +459,15 @@ public class ContentFunctionsTest {
         list2 = asList(3, 4, 5);
         list3 = asList(10, 15, 20, 25);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -454,14 +481,15 @@ public class ContentFunctionsTest {
         list2 = asList(3, 4, 5);
         list3 = asList(10, 15, 20, 25);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -475,14 +503,15 @@ public class ContentFunctionsTest {
         list2 = asList(2, 4, 20);
         list3 = asList(6, 8, 15);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 4, 6);
     }
     
     @Test
@@ -494,13 +523,14 @@ public class ContentFunctionsTest {
         list1 = asList(1);
         list2 = asList(2);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 2);
     }
     
     @Test
@@ -512,13 +542,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(5, 6, 7);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -530,13 +561,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(5);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -548,13 +580,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = new ArrayList<>();
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -567,14 +600,15 @@ public class ContentFunctionsTest {
         list2 = asList(3, 7, 11);
         list3 = asList(10, 15, 20, 25);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 9, 11);
     }
     
     @Test
@@ -587,14 +621,15 @@ public class ContentFunctionsTest {
         list2 = asList(3, 4, 5);
         list3 = asList(10, 15, 20, 25);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -606,13 +641,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(3, 4, 5);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 2, 3);
     }
     
     @Test
@@ -624,13 +660,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 1, 0));
         list2 = asList(Arrays.asList(5, 6, 7), Arrays.asList(2, 2, 2));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 2, 5);
     }
     
     @Test
@@ -642,13 +679,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(4, 5, 6);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 3, 4);
     }
     
     @Test
@@ -660,13 +698,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 1, 0));
         list2 = asList(Arrays.asList(5, 6, 7), Arrays.asList(1, 3, 1));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 2, 6);
     }
     
     @Test
@@ -679,14 +718,15 @@ public class ContentFunctionsTest {
         list2 = asList(2);
         list3 = asList(3);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 3);
     }
     
     @Test
@@ -699,14 +739,15 @@ public class ContentFunctionsTest {
         list2 = asList(Arrays.asList(3), Arrays.asList(1)); // ~3-5
         list3 = asList(Arrays.asList(4, 10), Arrays.asList(0, 0));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
-        
+    
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 4);
     }
     
     @Test
@@ -719,14 +760,15 @@ public class ContentFunctionsTest {
         list2 = asList(2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40);
         list3 = asList(41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 39, 41);
     }
     
     @Test
@@ -738,13 +780,14 @@ public class ContentFunctionsTest {
         list1 = asList(3, 4, 5);
         list2 = asList(1, 2);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -756,13 +799,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(3, 4, 5), Arrays.asList(0, 0, 2));
         list2 = asList(Arrays.asList(1, 2), Arrays.asList(0, 1));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -775,14 +819,15 @@ public class ContentFunctionsTest {
         list2 = asList(3);
         list3 = asList(2);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -795,14 +840,15 @@ public class ContentFunctionsTest {
         list2 = asList(Arrays.asList(3), Arrays.asList(1));
         list3 = asList(Arrays.asList(2), Arrays.asList(0));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -815,14 +861,15 @@ public class ContentFunctionsTest {
         list2 = asList(4);
         list3 = asList(3);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -835,14 +882,15 @@ public class ContentFunctionsTest {
         list2 = asList(Arrays.asList(4), Arrays.asList(0));
         list3 = asList(Arrays.asList(3), Arrays.asList(0));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("fish", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -854,13 +902,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(4, 5, 6);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -872,13 +921,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(1, 1, 1));
         list2 = asList(Arrays.asList(4, 5, 6), Arrays.asList(0, 1, 1));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -889,12 +939,13 @@ public class ContentFunctionsTest {
         List<TermWeightPosition> list1;
         list1 = asList(1, 3, 5);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -905,12 +956,13 @@ public class ContentFunctionsTest {
         List<TermWeightPosition> list1;
         list1 = asList(1, 2, 5);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 2);
     }
     
     @Test
@@ -921,12 +973,13 @@ public class ContentFunctionsTest {
         List<TermWeightPosition> list1;
         list1 = asList(1, 4, 5);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 4, 5);
     }
     
     @Test
@@ -937,12 +990,13 @@ public class ContentFunctionsTest {
         List<TermWeightPosition> list1;
         list1 = asList(1, 4);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -953,12 +1007,13 @@ public class ContentFunctionsTest {
         List<TermWeightPosition> list1;
         list1 = asList(1, 3);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 3);
     }
     
     @Test
@@ -969,12 +1024,13 @@ public class ContentFunctionsTest {
         List<TermWeightPosition> list1;
         list1 = asList(Arrays.asList(1, 4), Arrays.asList(0, 1));
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 3);
     }
     
     @Test
@@ -986,13 +1042,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 5);
         list2 = asList(3);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 3);
     }
     
     /**
@@ -1008,13 +1065,14 @@ public class ContentFunctionsTest {
         list1 = asList(1, 2, 3);
         list2 = asList(3, 4, 5);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 3, 3);
     }
     
     @Test
@@ -1027,14 +1085,15 @@ public class ContentFunctionsTest {
         list2 = asList(5, 7, 9);
         list3 = asList(6, 8, 10);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 4, 6);
     }
     
     @Test
@@ -1047,14 +1106,15 @@ public class ContentFunctionsTest {
         list2 = asList(5, 7, 9);
         list3 = asList(6, 8, 10);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1067,14 +1127,15 @@ public class ContentFunctionsTest {
         list2 = asList(4, 7, 8, 10); // rat
         list3 = asList(4, 6); // dog
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 4, 4);
     }
     
     @Test
@@ -1087,14 +1148,15 @@ public class ContentFunctionsTest {
         list2 = asList(5, 7, 9); // rat
         list3 = asList(4, 6, 10); // dog
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1107,14 +1169,15 @@ public class ContentFunctionsTest {
         list2 = asList(1); // rat
         list3 = asList(1); // dog
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 1);
     }
     
     @Test
@@ -1127,14 +1190,15 @@ public class ContentFunctionsTest {
         list2 = asList(Arrays.asList(135), Arrays.asList(6)); // rat
         list3 = asList(Arrays.asList(1), Arrays.asList(1)); // dog
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1147,14 +1211,15 @@ public class ContentFunctionsTest {
         list2 = asList(1); // rat
         list3 = asList(2); // dog
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 2);
     }
     
     @Test
@@ -1166,13 +1231,14 @@ public class ContentFunctionsTest {
         list1 = asList(1); // cat
         list2 = asList(1, 5); // rat
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 1);
     }
     
     @Test
@@ -1184,13 +1250,14 @@ public class ContentFunctionsTest {
         list1 = asList(5); // cat
         list2 = asList(1, 5); // rat
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 5, 5);
     }
     
     @Test
@@ -1203,14 +1270,15 @@ public class ContentFunctionsTest {
         list2 = asList(2);
         list3 = asList(1);
         
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("rat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1222,13 +1290,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 0, 0), Arrays.asList(-0.223f, -1.4339f, -0.0001f));
         list2 = asList(Arrays.asList(3, 4, 5), Arrays.asList(0, 0, 0), Arrays.asList(-0.001f, -1.4339f, -0.2001f));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 3, 3);
     }
     
     @Test
@@ -1240,13 +1309,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 0, 0), Arrays.asList(-0.223f, -1.4339f, -0.0001f));
         list2 = asList(Arrays.asList(3, 4, 5), Arrays.asList(0, 0, 0), Arrays.asList(-0.001f, -1.4339f, -0.2001f));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 3, 3);
     }
     
     @Test
@@ -1258,13 +1328,14 @@ public class ContentFunctionsTest {
         list1 = asList(Arrays.asList(1, 2, 3), Arrays.asList(0, 0, 0), Arrays.asList(-0.223f, -1.4339f, -0.2001f));
         list2 = asList(Arrays.asList(3, 4, 5), Arrays.asList(0, 0, 0), Arrays.asList(-0.001f, -1.4339f, -0.2001f));
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1280,14 +1351,15 @@ public class ContentFunctionsTest {
         list2 = asList(4, 5, 6);
         list3 = asList(11, 12, 14);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 4);
     }
     
     /**
@@ -1304,14 +1376,15 @@ public class ContentFunctionsTest {
         list2 = asList(9, 10, 11);
         list3 = asList(7, 12);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 10, 12);
     }
     
     /**
@@ -1328,14 +1401,15 @@ public class ContentFunctionsTest {
         list2 = asList(3, 9, 10, 12, 13, 20, 23, 25);
         list3 = asList(1, 12, 13, 27);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         Object o = expr.evaluate(context);
         
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1349,23 +1423,28 @@ public class ContentFunctionsTest {
         list2 = asList(4, 5, 6);
         list3 = asList(4, 5, 6);
         
-        termOffSetMap.put("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId + ".1"), list3)));
+        termOffSetMap.putTermFrequencyList("dog", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("bat", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId + ".1"), list3)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         
         Expression expr = engine.createExpression(query1);
         Object o = expr.evaluate(context);
         Assert.assertTrue(expect(o, true));
-        
+        assertPhraseOffset("CONTENT", 1, 4);
+    
+        termOffSetMap.getPhraseOffsets().clear();
         expr = engine.createExpression(query2);
         o = expr.evaluate(context);
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
         
+        termOffSetMap.getPhraseOffsets().clear();
         expr = engine.createExpression(query);
         o = expr.evaluate(context);
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 4);
     }
     
     @Test
@@ -1487,14 +1566,15 @@ public class ContentFunctionsTest {
         list1 = asList(1, 3);
         list2 = asList(2);
         
-        termOffSetMap.put("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
-        termOffSetMap.put("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
-        termOffSetMap.put("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("CONTENT", true, eventId), list1)));
         
         context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
         
         Object o = expr.evaluate(context);
         Assert.assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT", 1, 3);
     }
     
     @Test
@@ -1508,9 +1588,9 @@ public class ContentFunctionsTest {
         list3 = asList(260, 284, 304);
         list4 = asList(1165);
         
-        termOffSetMap.put("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list1)));
-        termOffSetMap.put("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list2)));
-        termOffSetMap.put(
+        termOffSetMap.putTermFrequencyList("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList(
                         "car",
                         new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list3), Maps.immutableEntry(new Zone("META", true, eventId),
                                         list4)));
@@ -1520,6 +1600,7 @@ public class ContentFunctionsTest {
         
         Object o = expr.evaluate(context);
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1534,9 +1615,9 @@ public class ContentFunctionsTest {
         list3 = asList(260, 284, 304);
         list4 = asList(1165);
         
-        termOffSetMap.put("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list1)));
-        termOffSetMap.put("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list2)));
-        termOffSetMap.put(
+        termOffSetMap.putTermFrequencyList("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList(
                         "car",
                         new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list3), Maps.immutableEntry(new Zone("META", true, eventId),
                                         list4)));
@@ -1546,6 +1627,7 @@ public class ContentFunctionsTest {
         
         Object o = expr.evaluate(context);
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
@@ -1560,9 +1642,9 @@ public class ContentFunctionsTest {
         list3 = asList(260, 284, 304);
         list4 = asList(1165);
         
-        termOffSetMap.put("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list1)));
-        termOffSetMap.put("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list2)));
-        termOffSetMap.put(
+        termOffSetMap.putTermFrequencyList("foo", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list1)));
+        termOffSetMap.putTermFrequencyList("bar", new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list2)));
+        termOffSetMap.putTermFrequencyList(
                         "car",
                         new TermFrequencyList(Maps.immutableEntry(new Zone("BODY", true, eventId), list3), Maps.immutableEntry(new Zone("META", true, eventId),
                                         list4)));
@@ -1572,90 +1654,91 @@ public class ContentFunctionsTest {
         
         Object o = expr.evaluate(context);
         Assert.assertTrue(expect(o, false));
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
     public void testDuplicatePhraseOffset() {
         TreeMultimap<Zone,TermWeightPosition> multimap = TreeMultimap.create();
-        
-        Map<String,TermFrequencyList> termList = Maps.newHashMap();
+    
+        TermOffsetMap termOffsetMap = new TermOffsetMap();
         
         multimap.put(genTestZone(), getPosition(19));
-        termList.put("go", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("go", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(20));
         multimap.put(genTestZone(), getPosition(27));
         multimap.put(genTestZone(), getPosition(29));
-        termList.put("and", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("and", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(21));
-        termList.put("tell", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("tell", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(22));
-        termList.put("your", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("your", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(23));
-        termList.put("brother", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("brother", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(20));
         multimap.put(genTestZone(), getPosition(24));
-        termList.put("that", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("that", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(25));
-        termList.put("dinners", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("dinners", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(26));
-        termList.put("ready", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("ready", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(28));
-        termList.put("come", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("come", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(30));
-        termList.put("wash", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("wash", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(31));
-        termList.put("his", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("his", new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(genTestZone(), getPosition(32));
         multimap.put(genTestZone(), getPosition(42));
         multimap.put(genTestZone(), getPosition(52));
-        termList.put("hands", new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList("hands", new TermFrequencyList(multimap));
         
         // ///////////////////////////
         // Phrase functions
         // ///////////////////////////
-        
+    
         // full terms list
-        Assert.assertNotNull(termList.get("his"));
+        Assert.assertNotNull(termOffsetMap.getTermFrequencyList("his"));
         String[] terms = new String[] {"go", "and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and", "wash", "his", "hands"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.phrase("BODY", termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.phrase("BODY", termOffsetMap, terms));
         
         // duplicate consecutive terms fail here
         terms = new String[] {"go", "and", "and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and", "wash", "his", "hands"};
-        Assert.assertEquals(Collections.emptySet(), ContentFunctions.phrase("BODY", termList, terms));
+        Assert.assertEquals(Collections.emptySet(), ContentFunctions.phrase("BODY", termOffsetMap, terms));
         
         // duplicate consecutive terms fail here
         terms = new String[] {"go", "and", "and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come"};
-        Assert.assertEquals(Collections.emptySet(), ContentFunctions.phrase("BODY", termList, terms));
+        Assert.assertEquals(Collections.emptySet(), ContentFunctions.phrase("BODY", termOffsetMap, terms));
         
         // subset(1, end)
         terms = new String[] {"and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and", "wash", "his", "hands"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.phrase("BODY", termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.phrase("BODY", termOffsetMap, terms));
         
         // subset(1,end-5)
         terms = new String[] {"and", "tell", "your", "brother", "that", "dinners", "ready", "and"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.phrase("BODY", termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.phrase("BODY", termOffsetMap, terms));
         
         // ///////////////////////////
         // Within functions
@@ -1663,23 +1746,23 @@ public class ContentFunctionsTest {
         
         // full terms list
         terms = new String[] {"go", "and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and", "wash", "his", "hands"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 14, termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 14, termOffsetMap, terms));
         
         // duplicate consecutive terms fail here
         terms = new String[] {"go", "and", "and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and", "wash", "his", "hands"};
-        Assert.assertEquals(Collections.emptySet(), ContentFunctions.within("BODY", 15, termList, terms));
+        Assert.assertEquals(Collections.emptySet(), ContentFunctions.within("BODY", 15, termOffsetMap, terms));
         
         // placement does not matter
         terms = new String[] {"go", "and", "and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 11, termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 11, termOffsetMap, terms));
         
         // subset(1, end)
         terms = new String[] {"and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and", "wash", "his", "hands"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 12, termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 12, termOffsetMap, terms));
         
         // subset(1,end-5)
         terms = new String[] {"and", "tell", "your", "brother", "that", "dinners", "ready", "and", "come", "and"};
-        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 10, termList, terms));
+        Assert.assertEquals(Collections.singleton("BODY"), ContentFunctions.within("BODY", 10, termOffsetMap, terms));
     }
     
     private Zone genTestZone() {
@@ -1698,42 +1781,42 @@ public class ContentFunctionsTest {
         String[] terms = new String[] {"some", "phrase"};
         
         TreeMultimap<Zone,TermWeightPosition> multimap;
-        Map<String,TermFrequencyList> termList = Maps.newHashMap();
+        TermOffsetMap termOffsetMap = new TermOffsetMap();
         
         // Build term 1 offsets...
         
         multimap = TreeMultimap.create();
         multimap.put(zone1, getPosition(1));
         multimap.put(zone1, getPosition(100));
-        termList.put(terms[0], new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList(terms[0], new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(zone2, getPosition(19));
-        termList.put(terms[0], new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList(terms[0], new TermFrequencyList(multimap));
         
         // Build term 2 offsets...
         
         multimap = TreeMultimap.create();
         multimap.put(zone1, getPosition(10));
         multimap.put(zone1, getPosition(1000));
-        termList.put(terms[1], new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList(terms[1], new TermFrequencyList(multimap));
         
         multimap = TreeMultimap.create();
         multimap.put(zone2, getPosition(20));
         multimap.put(zone2, getPosition(27));
-        termList.put(terms[1], new TermFrequencyList(multimap));
+        termOffsetMap.putTermFrequencyList(terms[1], new TermFrequencyList(multimap));
         
         // The only match, [19, 20], is in ZONE2.
         // Thus, evaluating ZONE1 should return false here (see #1171)...
-        Assert.assertEquals(Collections.emptySet(), ContentFunctions.phrase(zone1.getZone(), termList, terms));
+        Assert.assertEquals(Collections.emptySet(), ContentFunctions.phrase(zone1.getZone(), termOffsetMap, terms));
         
         // Ensure that we do get the hit if we evaluate the other zone
-        Assert.assertEquals(Collections.singleton(zone2.getZone()), ContentFunctions.phrase(zone2.getZone(), termList, terms));
+        Assert.assertEquals(Collections.singleton(zone2.getZone()), ContentFunctions.phrase(zone2.getZone(), termOffsetMap, terms));
         
         // Ensure that we get the hit if we evaluate both zones
-        Assert.assertEquals(Collections.singleton(zone2.getZone()), ContentFunctions.phrase(Arrays.asList(zone1.getZone(), zone2.getZone()), termList, terms));
+        Assert.assertEquals(Collections.singleton(zone2.getZone()), ContentFunctions.phrase(Arrays.asList(zone1.getZone(), zone2.getZone()), termOffsetMap, terms));
         
         // Ensure that we get the hit if we evaluate null zone
-        Assert.assertEquals(Collections.singleton(zone2.getZone()), ContentFunctions.phrase((Object) null, termList, terms));
+        Assert.assertEquals(Collections.singleton(zone2.getZone()), ContentFunctions.phrase((Object) null, termOffsetMap, terms));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentOrderedEvaluatorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentOrderedEvaluatorTest.java
@@ -1,56 +1,39 @@
 package datawave.query.jexl.functions;
 
 import datawave.ingest.protobuf.TermWeightPosition;
+import datawave.query.Constants;
+import datawave.query.postprocessing.tf.TermOffsetMap;
+import org.javatuples.Pair;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class ContentOrderedEvaluatorTest {
     
+    private TermOffsetMap termOffsetMap;
+    private final List<List<TermWeightPosition>> offsets = new ArrayList<>();
+    private String field;
+    private int distance;
+    private String[] terms;
+    
     private WrappedContentOrderedEvaluator evaluator;
     
     @Before
-    public void setup() {}
-    
-    private List<TermWeightPosition> asList(boolean zeroOffsetMatch, List<Integer> offsets, List<Integer> skips) {
-        if (offsets.size() != skips.size()) {
-            Assert.fail("offsets and skips size meed to match");
-        }
-        List<TermWeightPosition> list = new ArrayList<>();
-        for (int i = 0; i < offsets.size(); i++) {
-            list.add(getPosition(offsets.get(i), skips.get(i), zeroOffsetMatch));
-        }
-        return list;
+    public void setup() {
+        termOffsetMap = new TermOffsetMap();
     }
     
-    private List<TermWeightPosition> asList(int... offsets) {
-        return asList(true, offsets);
-    }
-    
-    private List<TermWeightPosition> asList(boolean zeroOffsetMatch, int... offsets) {
-        List<TermWeightPosition> list = new ArrayList<>();
-        for (int offset : offsets) {
-            list.add(getPosition(offset, zeroOffsetMatch));
-        }
-        return list;
-    }
-    
-    private TermWeightPosition getPosition(int offset) {
-        return new TermWeightPosition.Builder().setOffset(offset).build();
-    }
-    
-    private TermWeightPosition getPosition(int offset, boolean zeroOffsetMatch) {
-        return new TermWeightPosition.Builder().setOffset(offset).setZeroOffsetMatch(zeroOffsetMatch).build();
-    }
-    
-    private TermWeightPosition getPosition(int offset, int prevSkips, boolean zeroOffsetMatch) {
-        return new TermWeightPosition.Builder().setOffset(offset).setPrevSkips(prevSkips).setZeroOffsetMatch(zeroOffsetMatch).build();
+    @After
+    public void teardown() {
+        field = null;
+        offsets.clear();
+        terms = null;
     }
     
     /**
@@ -65,22 +48,20 @@ public class ContentOrderedEvaluatorTest {
      */
     @Test
     public void evaluate_traverseFailureFORWARDTest() {
-        
         // offsets[0].size() <= offsets[N-1].size() will trigger forward-order traversal,
         // evaluating the document for the phrase "a b c", starting with 'a' at offset 10
         
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(10, 19);
-        List<TermWeightPosition> offsetsB = asList(11, 20);
-        List<TermWeightPosition> offsetsC = asList(3, 21, 100);
-        
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
-        
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        givenField("CONTENT");
+        givenDistance(1);
+        givenOffsets(10, 19);
+        givenOffsets(11, 20);
+        givenOffsets(3, 21, 100);
+        givenTerms("a", "b", "c");
+    
+        initEvaluator();
+    
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 19, 21);
     }
     
     /**
@@ -95,202 +76,238 @@ public class ContentOrderedEvaluatorTest {
      */
     @Test
     public void evaluate_traverseFailureREVERSETest() {
-        
         // offsets[0].size() > offsets[N-1].size() will trigger reverse-order traversal,
         // evaluating the document for the phrase "c b a", starting with 'c' at offset 21
         
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1, 10, 100);
-        List<TermWeightPosition> offsetsB = asList(2, 20);
-        List<TermWeightPosition> offsetsC = asList(3, 21);
+        givenField("BODY");
+        givenDistance(1);
+        givenOffsets(1, 10, 100);
+        givenOffsets(2, 20);
+        givenOffsets(3, 21);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("BODY", 1, 3);
     }
     
+    /**
+     * Assert that a match for the terms is found for offsets 20->21->22.
+     */
     @Test
     public void evaluate_alternatingExtremesFORWARDTest() {
-        // 20->21->22
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1, 10, 20);
-        List<TermWeightPosition> offsetsB = asList(21, 24, 30);
-        List<TermWeightPosition> offsetsC = asList(3, 8, 12, 19, 22);
-        
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
-        
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        givenField("CONTENT");
+        givenDistance(1);
+        givenOffsets(1, 10, 20);
+        givenOffsets(21, 24, 30);
+        givenOffsets(3, 8, 12, 19, 22);
+        givenTerms("a", "b", "c");
+    
+        initEvaluator();
+    
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 20, 22);
     }
     
+    /**
+     * Assert that a match for the terms is found for offsets 102->101->100.
+     */
     @Test
     public void evaluate_alternatingExtremesREVERSETest() {
-        // 102->101->100
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(100, 200, 300, 500, 601);
-        List<TermWeightPosition> offsetsB = asList(1, 5, 29, 87, 101);
-        List<TermWeightPosition> offsetsC = asList(102, 400, 434);
+        givenField("CONTENT");
+        givenDistance(1);
+        givenOffsets(100, 200, 300, 500, 601);
+        givenOffsets(1, 5, 29, 87, 101);
+        givenOffsets(102, 400, 434);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 100, 102);
     }
     
     @Test
     public void evaluate_notEnoughOffsetsTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
+        givenField("CONTENT");
+        givenDistance(1);
+        givenTerms("a", "b", "c");
         
-        Assert.assertTrue(!evaluator.evaluate(offsets));
+        initEvaluator();
+        
+        assertEvaluate(false);
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
     public void evaluate_pruneAllTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1);
-        List<TermWeightPosition> offsetsB = asList(5);
-        List<TermWeightPosition> offsetsC = asList(11);
+        givenField("BODY");
+        givenDistance(1);
+        givenOffsets(1);
+        givenOffsets(5);
+        givenOffsets(11);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(!evaluator.evaluate(offsets));
+        assertEvaluate(false);
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
     public void evaluate_simpleSuccessDistance1Test() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1);
-        List<TermWeightPosition> offsetsB = asList(2);
-        List<TermWeightPosition> offsetsC = asList(3);
+        givenField("CONTENT");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        givenDistance(1);
+        givenOffsets(1);
+        givenOffsets(2);
+        givenOffsets(3);
+        givenTerms("a", "b", "c");
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
+        initEvaluator();
         
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 1, 3);
     }
     
     @Test
     public void evaluate_simpleSuccessDistance3Test() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1);
-        List<TermWeightPosition> offsetsB = asList(2);
-        List<TermWeightPosition> offsetsC = asList(3);
+        givenField("CONTENT");
+        givenDistance(3);
+        givenOffsets(1);
+        givenOffsets(2);
+        givenOffsets(3);
+        givenTerms("a", "b", "c");
+    
+        initEvaluator();
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
-        
-        evaluator = new WrappedContentOrderedEvaluator(null, 3, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 1, 3);
     }
     
     @Test
     public void evaluate_simpleSuccessDistance3FailTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1);
-        List<TermWeightPosition> offsetsB = asList(5);
-        List<TermWeightPosition> offsetsC = asList(7);
+        givenField("CONTENT");
+        givenDistance(3);
+        givenOffsets(1);
+        givenOffsets(5);
+        givenOffsets(7);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 3, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(!evaluator.evaluate(offsets));
+        assertEvaluate(false);
+        assertPhraseOffsetsEmpty();
     }
     
     @Test
     public void evaluate_pruneTopTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1, 10);
-        List<TermWeightPosition> offsetsB = asList(10, 11);
-        List<TermWeightPosition> offsetsC = asList(4, 12);
+        givenField("CONTENT");
+        givenDistance(1);
+        givenOffsets(1, 10);
+        givenOffsets(10, 11);
+        givenOffsets(4, 12);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 10, 12);
     }
     
     @Test
     public void evaluate_pruneBottomTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1, 3, 8);
-        List<TermWeightPosition> offsetsB = asList(3, 4, 44);
-        List<TermWeightPosition> offsetsC = asList(4, 5, 35);
+        givenField("BODY");
+        givenDistance(1);
+        givenOffsets(1, 3, 8);
+        givenOffsets(3, 4, 44);
+        givenOffsets(4, 5, 35);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("BODY", 3, 4); // TODO - do we want the end offset to be 5 in order to be consecutive?
     }
     
     @Test
     public void evaluate_pruneTopAndBottomTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(3, 4, 5, 6);
-        List<TermWeightPosition> offsetsB = asList(7, 9, 22);
-        List<TermWeightPosition> offsetsC = asList(8, 11, 13);
+        givenField("CONTENT");
+        givenDistance(1);
+        givenOffsets(3, 4, 5, 6);
+        givenOffsets(7, 9, 22);
+        givenOffsets(8, 11, 13);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 1, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 6, 8);
     }
     
     @Test
     public void evaluate_livePruneTest() {
-        List<List<TermWeightPosition>> offsets = new ArrayList<>();
-        List<TermWeightPosition> offsetsA = asList(1, 3);
-        List<TermWeightPosition> offsetsB = asList(2, 4);
-        List<TermWeightPosition> offsetsC = asList(5, 6);
+        givenField("CONTENT");
+        givenDistance(2);
+        givenOffsets(1, 3);
+        givenOffsets(2, 4);
+        givenOffsets(5, 6);
+        givenTerms("a", "b", "c");
         
-        offsets.add(offsetsA);
-        offsets.add(offsetsB);
-        offsets.add(offsetsC);
+        initEvaluator();
         
-        evaluator = new WrappedContentOrderedEvaluator(null, 2, new HashMap<>(), "a", "b", "c");
-        
-        Assert.assertTrue(evaluator.evaluate(offsets));
+        assertEvaluate(true);
+        assertPhraseOffsetsContain("CONTENT", 3, 5);
+    }
+    
+    
+    private void givenField(String field) {
+        this.field = field;
+    }
+    
+    private void givenOffsets(int... offsets) {
+        List<TermWeightPosition> list = new ArrayList<>();
+        for (int offset : offsets) {
+            list.add(new TermWeightPosition.Builder().setOffset(offset).setZeroOffsetMatch(true).build());
+        }
+        this.offsets.add(list);
+    }
+    
+    private void givenDistance(int distance) {
+        this.distance = distance;
+    }
+    
+    private void givenTerms(String... terms) {
+        this.terms = terms;
+    }
+    
+    private void initEvaluator() {
+        evaluator = new WrappedContentOrderedEvaluator(null, distance, termOffsetMap, terms);
+    }
+    
+    private void assertEvaluate(boolean expected) {
+        Assert.assertEquals("Expected evaluate() to return " + expected, expected, evaluator.evaluate(field, offsets));
+    }
+    
+    private void assertPhraseOffsetsContain(String field, int startOffset, int endOffset) {
+        Collection<Pair<Integer,Integer>> phraseOffsets = termOffsetMap.getPhraseOffsets(field);
+        boolean found = phraseOffsets.stream().anyMatch((pair) -> pair.getValue0().equals(startOffset) && pair.getValue1().equals(endOffset));
+        Assert.assertTrue("Expected phrase offset [" + startOffset + ", " + endOffset + "] for field " + field, found);
+    }
+    
+    private void assertPhraseOffsetsEmpty() {
+        Assert.assertTrue("Expected empty phrase offset map", termOffsetMap.getPhraseOffsets().isEmpty());
     }
     
     private static class WrappedContentOrderedEvaluator extends ContentOrderedEvaluator {
-        public WrappedContentOrderedEvaluator(Set<String> fields, int distance, Map<String,TermFrequencyList> termOffsetMap, String... terms) {
+        public WrappedContentOrderedEvaluator(Set<String> fields, int distance, TermOffsetMap termOffsetMap, String... terms) {
             super(fields, distance, Float.MIN_VALUE, termOffsetMap, terms);
         }
         
         @Override
-        protected boolean evaluate(List<List<TermWeightPosition>> offsets) {
-            return super.evaluate(offsets);
+        protected boolean evaluate(String field, List<List<TermWeightPosition>> offsets) {
+            return super.evaluate(field, offsets);
         }
     }
 }


### PR DESCRIPTION
This pull request is for the current work of incorporating Term Frequency Excerpts (TFEs) into query results, and is currently still a WIP. One of the primary requirements for being able to retrieve TFEs is to identify and track the start and end offsets for each phrase that is a match for the target fields.

I have modified the termOffsetMap var to be a TermOffsetMap object that will both contain the term frequency lists and track phrase offsets. Currently phrase offsets are being tracked for all content:phrase functions and content:within functions, and I have updated tests to verify the results.

I am primarily asking reviewers to take a second glance at the test assertions to see if there are any phrase offsets oddities that do not look correct, or any edge cases that need to be tested against. 