### PR TITLE
Bump infinispan-core from 9.4.21.Final to 11.0.6.Final in /warehouse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <version.commons-collections>4.3</version.commons-collections>
         <version.commons-configuration>1.10</version.commons-configuration>
         <version.commons-configuration2>2.7</version.commons-configuration2>
-        <version.commons-io>2.6</version.commons-io>
+        <version.commons-io>2.7</version.commons-io>
         <version.commons-jexl>2.1.1</version.commons-jexl>
         <version.commons-lang>2.6</version.commons-lang>
         <version.commons-logging>1.2</version.commons-logging>

--- a/warehouse/pom.xml
+++ b/warehouse/pom.xml
@@ -339,7 +339,7 @@
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>
-                <version>9.4.21.Final</version>
+                <version>11.0.6.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.javatuples</groupId>


### PR DESCRIPTION
[Bump infinispan-core from 9.4.21.Final to 11.0.6.Final in /warehouse](https://github.com/NationalSecurityAgency/datawave/commit/3d22ed8683ebd9aa7da0061099984195fa0c2de8)