### PR TITLE
Issue1445 - Support injection of Scheduler choice and remove 'check for test mode' from PushdownScheduler

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -93,7 +93,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private int collapseUidsThreshold = -1;
     // Should this query dedupe terms within ANDs and ORs
     private boolean enforceUniqueTermsWithinExpressions = false;
-    private boolean sequentialScheduler = false;
     private boolean collectTimingDetails = false;
     private boolean logTimingDetails = false;
     private boolean sendTimingToStatsd = true;
@@ -404,7 +403,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setCollapseUidsThreshold(other.getCollapseUidsThreshold());
         this.setEnforceUniqueTermsWithinExpressions(other.getEnforceUniqueTermsWithinExpressions());
         this.setParseTldUids(other.getParseTldUids());
-        this.setSequentialScheduler(other.getSequentialScheduler());
         this.setCollectTimingDetails(other.getCollectTimingDetails());
         this.setLogTimingDetails(other.getLogTimingDetails());
         this.setSendTimingToStatsd(other.getSendTimingToStatsd());
@@ -1921,14 +1919,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     
     public void setEnforceUniqueTermsWithinExpressions(boolean enforceUniqueTermsWithinExpressions) {
         this.enforceUniqueTermsWithinExpressions = enforceUniqueTermsWithinExpressions;
-    }
-    
-    public boolean getSequentialScheduler() {
-        return sequentialScheduler;
-    }
-    
-    public void setSequentialScheduler(boolean sequentialScheduler) {
-        this.sequentialScheduler = sequentialScheduler;
     }
     
     public boolean getLimitAnyFieldLookups() {

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/SchedulerProducer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/SchedulerProducer.java
@@ -1,0 +1,47 @@
+package datawave.query.scheduler;
+
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+import datawave.query.util.MetadataHelperFactory;
+import org.apache.accumulo.core.client.Instance;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.Credentials;
+import org.apache.accumulo.core.client.impl.Tables;
+import org.apache.accumulo.core.client.impl.TabletLocator;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.conf.AccumuloConfiguration;
+
+public abstract class SchedulerProducer {
+    
+    public abstract Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scan, MetadataHelperFactory metadataHelperFactory)
+                    throws TableNotFoundException;
+    
+    public static class Pushdown extends SchedulerProducer {
+        
+        @Override
+        public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory)
+                        throws TableNotFoundException {
+            PushdownScheduler scheduler = new PushdownScheduler(config, scannerFactory, metadataHelperFactory);
+            
+            Instance instance = config.getConnector().getInstance();
+            String tableName = config.getShardTableName();
+            String tableId = Tables.getTableId(instance, tableName);
+            Credentials credentials = new Credentials(config.getConnector().whoami(), new PasswordToken(config.getAccumuloPassword()));
+            TabletLocator tabletLocator = TabletLocator.getLocator(new ClientContext(instance, credentials, AccumuloConfiguration.getDefaultConfiguration()),
+                            tableId);
+            
+            scheduler.setTableId(tableId);
+            scheduler.setTabletLocator(tabletLocator);
+            return scheduler;
+        }
+    }
+    
+    public static class Sequential extends SchedulerProducer {
+        
+        @Override
+        public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory) {
+            return new SequentialScheduler(config, scannerFactory);
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/SchedulerProducer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/SchedulerProducer.java
@@ -12,11 +12,26 @@ import org.apache.accumulo.core.client.impl.TabletLocator;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 
+/**
+ * Supplies a {@code Scheduler}, either a {@code SequentialScheduler} or a {@code PushdownScheduler} The {@code SchedulerProducer.Pushdown} is coded as the
+ * default for {@code ShardQueryLogic} and can be changed in the spring configuration file, or with an explicit call to set a different one.
+ */
 public abstract class SchedulerProducer {
     
+    /**
+     *
+     * @param config
+     * @param scan
+     * @param metadataHelperFactory
+     * @return the Scheduler
+     * @throws TableNotFoundException
+     */
     public abstract Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scan, MetadataHelperFactory metadataHelperFactory)
                     throws TableNotFoundException;
     
+    /**
+     * Supplies a {@code PushdownScheduler}
+     */
     public static class Pushdown extends SchedulerProducer {
         
         @Override
@@ -37,6 +52,9 @@ public abstract class SchedulerProducer {
         }
     }
     
+    /**
+     * Supplies a {@code SequentialScheduler}
+     */
     public static class Sequential extends SchedulerProducer {
         
         @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/CountingShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/CountingShardQueryLogic.java
@@ -10,6 +10,7 @@ import datawave.webservice.query.Query;
 import datawave.webservice.query.logic.QueryLogicTransformer;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.log4j.Logger;
 
@@ -46,10 +47,10 @@ public class CountingShardQueryLogic extends ShardQueryLogic {
     }
     
     @Override
-    public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory) {
-        PushdownScheduler scheduler = new PushdownScheduler(config, scannerFactory, this.metadataHelperFactory);
+    public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory) throws TableNotFoundException {
+        
+        PushdownScheduler scheduler = (PushdownScheduler) schedulerProducer.getScheduler(config, scannerFactory, metadataHelperFactory);
         scheduler.addSetting(new IteratorSetting(config.getBaseIteratorPriority() + 50, "counter", ResultCountingIterator.class.getName()));
         return scheduler;
     }
-    
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -995,10 +995,23 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         
     }
     
+    /**
+     * Sets the {@code SchedulerProducer} type
+     * 
+     * @param schedulerProducer
+     */
     public void setSchedulerProducer(SchedulerProducer schedulerProducer) {
         this.schedulerProducer = schedulerProducer;
     }
     
+    /**
+     * uses the {@code SchedulerProducer} to supply the configured type of {@code Scheduler}
+     * 
+     * @param config
+     * @param scannerFactory
+     * @return
+     * @throws TableNotFoundException
+     */
     protected Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory) throws TableNotFoundException {
         return schedulerProducer.getScheduler(config, scannerFactory, metadataHelperFactory);
     }
@@ -1923,14 +1936,6 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     
     public void setLimitTermExpansionToModel(boolean shouldLimitTermExpansionToModel) {
         getConfig().setLimitTermExpansionToModel(shouldLimitTermExpansionToModel);
-    }
-    
-    public boolean getSequentialScheduler() {
-        return getConfig().getSequentialScheduler();
-    }
-    
-    public void setSequentialScheduler(boolean sequentialScheduler) {
-        getConfig().setSequentialScheduler(sequentialScheduler);
     }
     
     public boolean getParseTldUids() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -33,9 +33,8 @@ import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.planner.MetadataHelperQueryModelProvider;
 import datawave.query.planner.QueryModelProvider;
 import datawave.query.planner.QueryPlanner;
-import datawave.query.scheduler.PushdownScheduler;
 import datawave.query.scheduler.Scheduler;
-import datawave.query.scheduler.SequentialScheduler;
+import datawave.query.scheduler.SchedulerProducer;
 import datawave.query.tables.stats.ScanSessionStats;
 import datawave.query.transformer.DocumentTransformer;
 import datawave.query.transformer.EventQueryDataDecoratorTransformer;
@@ -168,6 +167,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     protected CloseableIterable<QueryData> queries = null;
     protected QueryModel queryModel = null;
     protected ScannerFactory scannerFactory = null;
+    protected SchedulerProducer schedulerProducer = new SchedulerProducer.Pushdown();
     protected Scheduler scheduler = null;
     protected EventQueryDataDecoratorTransformer eventQueryDataDecoratorTransformer = null;
     private ShardQueryConfiguration config;
@@ -219,6 +219,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         this.setQueryModel(other.getQueryModel());
         this.setScannerFactory(other.getScannerFactory());
         this.setScheduler(other.getScheduler());
+        this.setSchedulerProducer(other.schedulerProducer);
         this.setEventQueryDataDecoratorTransformer(other.getEventQueryDataDecoratorTransformer());
         
         log.trace("copy CTOR setting metadataHelperFactory to " + other.getMetadataHelperFactory());
@@ -994,12 +995,12 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         
     }
     
-    protected Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory) {
-        if (config.getSequentialScheduler()) {
-            return new SequentialScheduler(config, scannerFactory);
-        } else {
-            return new PushdownScheduler(config, scannerFactory, this.metadataHelperFactory);
-        }
+    public void setSchedulerProducer(SchedulerProducer schedulerProducer) {
+        this.schedulerProducer = schedulerProducer;
+    }
+    
+    protected Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory) throws TableNotFoundException {
+        return schedulerProducer.getScheduler(config, scannerFactory, metadataHelperFactory);
     }
     
     public EventQueryDataDecoratorTransformer getEventQueryDataDecoratorTransformer() {

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeQueryTest.java
@@ -1,5 +1,6 @@
 package datawave.query;
 
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -10,6 +11,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -32,6 +34,11 @@ public class CompositeQueryTest extends AbstractFunctionalQuery {
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
     
     private static final Logger log = Logger.getLogger(CompositeQueryTest.class);
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/CompoundJexlQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompoundJexlQueryTest.java
@@ -1,5 +1,6 @@
 package datawave.query;
 
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -10,6 +11,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -31,6 +33,11 @@ public class CompoundJexlQueryTest extends AbstractFunctionalQuery {
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
     
     private static final Logger log = Logger.getLogger(CompoundJexlQueryTest.class);
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/CountQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CountQueryTest.java
@@ -1,5 +1,6 @@
 package datawave.query;
 
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.CountingShardQueryLogic;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;

--- a/warehouse/query-core/src/test/java/datawave/query/DataTypeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/DataTypeQueryTest.java
@@ -1,6 +1,7 @@
 package datawave.query;
 
 import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.BaseRawData;
@@ -12,6 +13,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -41,6 +43,11 @@ public class DataTypeQueryTest extends AbstractFunctionalQuery {
     private static final List<String> TEST_NUMS = Arrays.asList("100", "110", "120");
     private static final List<CityEntry> TEST_DATATYPES = Arrays.asList(CityEntry.generic, CityEntry.usa, CityEntry.dup_usa);
     private static final List<String> INVALID_DATATYPES = Arrays.asList("invalid-one", "invalid-two");
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/DelayedIndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/DelayedIndexOnlyQueryTest.java
@@ -1,6 +1,7 @@
 package datawave.query;
 
 import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -9,6 +10,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,6 +29,11 @@ public class DelayedIndexOnlyQueryTest extends AbstractFunctionalQuery {
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
     
     private static final Logger log = Logger.getLogger(DelayedIndexOnlyQueryTest.class);
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/ExpansionThresholdQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ExpansionThresholdQueryTest.java
@@ -2,6 +2,7 @@ package datawave.query;
 
 import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.planner.QueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -12,6 +13,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -34,6 +36,11 @@ public class ExpansionThresholdQueryTest extends AbstractFunctionalQuery {
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
     
     private static final Logger log = Logger.getLogger(ExpansionThresholdQueryTest.class);
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/FilterFieldsQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FilterFieldsQueryTest.java
@@ -1,6 +1,7 @@
 package datawave.query;
 
 import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -14,6 +15,7 @@ import datawave.query.testframework.QueryJexl;
 import datawave.query.testframework.QueryLogicTestHarness;
 import datawave.query.testframework.ResponseFieldChecker;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,6 +44,11 @@ public class FilterFieldsQueryTest extends AbstractFunctionalQuery {
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
     
     private static final Logger log = Logger.getLogger(FilterFieldsQueryTest.class);
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/FilterFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FilterFunctionQueryTest.java
@@ -2,6 +2,7 @@ package datawave.query;
 
 import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.exceptions.InvalidQueryException;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -13,6 +14,7 @@ import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -40,6 +42,11 @@ public class FilterFunctionQueryTest extends AbstractFunctionalQuery {
     private static final String IsNotNull = "filter:isNotNull(";
     private static final String MatchesAtLeastCountOf = "filter:matchesAtLeastCountOf(";
     private static final String Occurrence = "filter:occurrence(";
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -19,6 +19,7 @@ import datawave.query.attributes.TypeAttribute;
 import datawave.query.function.JexlEvaluation;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.DateIndexHelperFactory;
 import datawave.query.util.MetadataHelperFactory;
@@ -143,6 +144,7 @@ public class IfThisTestFailsThenHitTermsAreBroken {
         log.info("using tempFolder " + tempDir);
         
         logic = new ShardQueryLogic();
+        logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         logic.setMetadataTableName(QueryTestTableHelper.MODEL_TABLE_NAME);
         logic.setTableName(TableName.SHARD);
         logic.setIndexTableName(TableName.SHARD_INDEX);

--- a/warehouse/query-core/src/test/java/datawave/query/IndexHoleQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexHoleQueryTest.java
@@ -2,6 +2,7 @@ package datawave.query;
 
 import datawave.query.config.IndexHole;
 import datawave.query.exceptions.FullTableScansDisallowedException;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFields;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
@@ -14,6 +15,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.ShardIdValues;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,6 +45,11 @@ public class IndexHoleQueryTest extends AbstractFunctionalQuery {
         String[] dateHole = new String[] {BaseShardIdRange.DATE_2015_0404.getDateStr(), BaseShardIdRange.DATE_2015_0505.getDateStr()};
         IndexHole hole = new IndexHole(dateHole, new String[] {"us", "ut"});
         INDEX_HOLE.add(hole);
+    }
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
     }
     
     @BeforeClass

--- a/warehouse/query-core/src/test/java/datawave/query/IndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexOnlyQueryTest.java
@@ -1,6 +1,7 @@
 package datawave.query;
 
 import datawave.query.exceptions.FullTableScansDisallowedException;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -9,6 +10,7 @@ import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -26,6 +28,11 @@ public class IndexOnlyQueryTest extends AbstractFunctionalQuery {
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
     
     private static final Logger log = Logger.getLogger(IndexOnlyQueryTest.class);
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
+    }
     
     @BeforeClass
     public static void filterSetup() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
@@ -26,6 +26,7 @@ import datawave.policy.IngestPolicyEnforcer;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.InvalidQueryException;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.MockStatusReporter;
 import datawave.query.model.QueryModel;
 import datawave.query.planner.DefaultQueryPlanner;
@@ -58,6 +59,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -188,6 +190,11 @@ public class MixedGeoAndGeoWaveTest {
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");
+    }
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
     }
     
     @BeforeClass

--- a/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
@@ -19,6 +19,7 @@ import datawave.query.attributes.TypeAttribute;
 import datawave.query.function.JexlEvaluation;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.DateIndexHelperFactory;
 import datawave.query.util.MetadataHelperFactory;
@@ -146,6 +147,7 @@ public abstract class UseOccurrenceToCountInJexlContextTest {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         
         logic = new ShardQueryLogic();
+        logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         logic.setMetadataTableName(QueryTestTableHelper.METADATA_TABLE_NAME);
         logic.setTableName(TableName.SHARD);
         logic.setIndexTableName(TableName.SHARD_INDEX);

--- a/warehouse/query-core/src/test/java/datawave/query/cardinality/TestCardinalityWithQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/cardinality/TestCardinalityWithQuery.java
@@ -6,6 +6,7 @@ import datawave.ingest.protobuf.Uid;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.querymetric.QueryMetricFactoryImpl;
 import datawave.query.QueryTestTableHelper;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.transformer.DocumentTransformer;
 import datawave.query.util.DateIndexHelperFactory;
@@ -94,6 +95,7 @@ public class TestCardinalityWithQuery {
         temporaryFolder = tempDir.newFolder().toPath();
         
         logic = new ShardQueryLogic();
+        logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         logic.setMarkingFunctions(new MarkingFunctions.Default());
         logic.setResponseObjectFactory(new DefaultResponseObjectFactory());
         logic.setMetadataHelperFactory(new MetadataHelperFactory());

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -62,7 +62,6 @@ public class ShardQueryConfigurationTest {
         Assert.assertEquals(Long.MAX_VALUE, config.getMaxIndexScanTimeMillis());
         Assert.assertFalse(config.getCollapseUids());
         Assert.assertFalse(config.getParseTldUids());
-        Assert.assertFalse(config.getSequentialScheduler());
         Assert.assertFalse(config.getCollectTimingDetails());
         Assert.assertFalse(config.getLogTimingDetails());
         Assert.assertTrue(config.getSendTimingToStatsd());
@@ -456,7 +455,7 @@ public class ShardQueryConfigurationTest {
      */
     @Test
     public void testCheckForNewAdditions() throws IOException {
-        int expectedObjectCount = 182;
+        int expectedObjectCount = 181;
         ShardQueryConfiguration config = ShardQueryConfiguration.create();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(mapper.writeValueAsString(config));

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionQueryTest.java
@@ -28,6 +28,7 @@ import datawave.ingest.table.config.TableConfigHelper;
 import datawave.policy.IngestPolicyEnforcer;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.MockStatusReporter;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.ShardQueryLogic;
@@ -61,6 +62,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -139,6 +141,11 @@ public class ContentFunctionQueryTest {
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");
+    }
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
     }
     
     @BeforeClass

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/nodes/ExceededOrThresholdMarkerJexlNodeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/nodes/ExceededOrThresholdMarkerJexlNodeTest.java
@@ -27,6 +27,7 @@ import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.jexl.visitors.PushdownLargeFieldedListsVisitor;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.MockStatusReporter;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.ShardQueryLogic;
@@ -59,6 +60,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -189,6 +191,11 @@ public class ExceededOrThresholdMarkerJexlNodeTest {
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");
+    }
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
     }
     
     @BeforeClass

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -16,6 +16,7 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.nodes.ExceededOrThresholdMarkerJexlNode;
 import datawave.query.jexl.nodes.ExceededValueThresholdMarkerJexlNode;
 import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.WiseGuysIngest;
@@ -151,6 +152,7 @@ public abstract class ExecutableExpansionVisitorTest {
         logic.setFullTableScanEnabled(false);
         logic.setMaxDepthThreshold(11);
         logic.setMaxTermThreshold(12);
+        logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         deserializer = new KryoDocumentDeserializer();
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
@@ -14,6 +14,7 @@ import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
 import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.GeoWaveQueryInfoVisitor;
@@ -152,6 +153,11 @@ public class GeoSortedQueryDataTest {
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");
+    }
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
     }
     
     @BeforeClass

--- a/warehouse/query-core/src/test/java/datawave/query/planner/MultiValueCompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/MultiValueCompositeIndexTest.java
@@ -24,6 +24,7 @@ import datawave.ingest.table.config.TableConfigHelper;
 import datawave.policy.IngestPolicyEnforcer;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.MockStatusReporter;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
@@ -55,6 +56,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -194,6 +196,11 @@ public class MultiValueCompositeIndexTest {
         // Test Data with 1 wkt and 2 numbers
         testData.add(new TestData(Collections.singletonList("POINT (0 0)"), Arrays.asList(11, 22)));
         
+    }
+    
+    @Before
+    public void setup() {
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
     }
     
     @BeforeClass

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
@@ -12,6 +12,7 @@ import datawave.query.attributes.TypeAttribute;
 import datawave.query.composite.CompositeMetadata;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.language.parser.ParseException;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.BaseEdgeQueryTest;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
@@ -144,6 +145,7 @@ public abstract class ValueToAttributesTest {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         
         logic.setFullTableScanEnabled(true);
+        logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         deserializer = new KryoDocumentDeserializer();
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/scheduler/TestSchedulerProducer.java
+++ b/warehouse/query-core/src/test/java/datawave/query/scheduler/TestSchedulerProducer.java
@@ -5,13 +5,17 @@ import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.MetadataHelperFactory;
 
+/**
+ * Supplies a {@code Scheduler}, either a {@code SequentialScheduler} or a {@code PushdownScehduler} that is configured for unit tests. The
+ * {@code TestSchedulerProducer.Pushdown} is codes as the default for {@code ShardQueryLogic} in unit tests, and can be changed in the spring configuration
+ * file, or with an explicit call to set a different one.
+ */
 public abstract class TestSchedulerProducer extends SchedulerProducer {
-
+    
+    /**
+     * Supplies a {@code PushdownScheduler} that is configured to use the @{code InMemoryTabletLocator} for unit tests
+     */
     public static class Pushdown extends TestSchedulerProducer {
-        
-        public Pushdown() {
-            super();
-        }
         
         @Override
         public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory) {
@@ -23,11 +27,10 @@ public abstract class TestSchedulerProducer extends SchedulerProducer {
         }
     }
     
+    /**
+     * Supplies a {@code SequentialScheduler}
+     */
     public static class Sequential extends TestSchedulerProducer {
-        
-        public Sequential() {
-            super();
-        }
         
         @Override
         public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory) {

--- a/warehouse/query-core/src/test/java/datawave/query/scheduler/TestSchedulerProducer.java
+++ b/warehouse/query-core/src/test/java/datawave/query/scheduler/TestSchedulerProducer.java
@@ -1,0 +1,37 @@
+package datawave.query.scheduler;
+
+import datawave.accumulo.inmemory.impl.InMemoryTabletLocator;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+import datawave.query.util.MetadataHelperFactory;
+
+public abstract class TestSchedulerProducer extends SchedulerProducer {
+
+    public static class Pushdown extends TestSchedulerProducer {
+        
+        public Pushdown() {
+            super();
+        }
+        
+        @Override
+        public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory) {
+            
+            PushdownScheduler scheduler = new PushdownScheduler(config, scannerFactory, metadataHelperFactory);
+            scheduler.setTableId(config.getIndexTableName());
+            scheduler.setTabletLocator(new InMemoryTabletLocator());
+            return scheduler;
+        }
+    }
+    
+    public static class Sequential extends TestSchedulerProducer {
+        
+        public Sequential() {
+            super();
+        }
+        
+        @Override
+        public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory) {
+            return new SequentialScheduler(config, scannerFactory);
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/scheduler/TestSchedulerProducer.java
+++ b/warehouse/query-core/src/test/java/datawave/query/scheduler/TestSchedulerProducer.java
@@ -21,7 +21,7 @@ public abstract class TestSchedulerProducer extends SchedulerProducer {
         public Scheduler getScheduler(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelperFactory metadataHelperFactory) {
             
             PushdownScheduler scheduler = new PushdownScheduler(config, scannerFactory, metadataHelperFactory);
-            scheduler.setTableId(config.getIndexTableName());
+            scheduler.setTableId(config.getTableName());
             scheduler.setTabletLocator(new InMemoryTabletLocator());
             return scheduler;
         }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
@@ -6,6 +6,7 @@ import datawave.marking.MarkingFunctions;
 import datawave.query.Constants;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.DataTypeHadoopConfig;
@@ -84,7 +85,7 @@ public class IndexQueryLogicTest extends AbstractFunctionalQuery {
         this.logic.setMetadataHelperFactory(new MetadataHelperFactory());
         this.logic.setQueryPlanner(new DefaultQueryPlanner());
         this.logic.setResponseObjectFactory(new DefaultResponseObjectFactory());
-        
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         // init must set auths
         testInit();
         

--- a/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetedQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetedQueryLogicTest.java
@@ -9,6 +9,7 @@ import datawave.query.RebuildingScannerTestHelper.TEARDOWN;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Attributes;
 import datawave.query.attributes.Document;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -96,6 +97,7 @@ public class FacetedQueryLogicTest extends AbstractFunctionalQuery {
         facetLogic.setMinimumFacet(1);
         
         this.logic = facetLogic;
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         QueryTestTableHelper.configureLogicToScanTables(this.logic);
         
         this.logic.setFullTableScanEnabled(false);

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -18,6 +18,7 @@ import datawave.query.jexl.nodes.ExceededValueThresholdMarkerJexlNode;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
 import datawave.query.jexl.visitors.TreeFlatteningRebuildingVisitor;
 import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.scheduler.TestSchedulerProducer;
 import datawave.query.tables.CountingShardQueryLogic;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.testframework.QueryLogicTestHarness.DocumentChecker;
@@ -178,6 +179,7 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         this.logic.setLogTimingDetails(true);
         this.logic.setMinimumSelectivity(0.03D);
         this.logic.setMaxIndexScanTimeMillis(5000);
+        this.logic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         
         // count logic
         countLogic.setIncludeDataTypeAsField(true);
@@ -188,6 +190,7 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         countLogic.setMetadataHelperFactory(new MetadataHelperFactory());
         countLogic.setQueryPlanner(new DefaultQueryPlanner());
         countLogic.setResponseObjectFactory(new DefaultResponseObjectFactory());
+        countLogic.setSchedulerProducer(new TestSchedulerProducer.Pushdown());
         
         QueryTestTableHelper.configureLogicToScanTables(countLogic);
         

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -101,7 +101,9 @@
         <property name="roleManager" ref="easyRoleManager" />
         <property name="markingFunctions" ref="markingFunctions" />
     </bean>
-    
+
+    <bean id="testSchedulerProducer" scope="prototype" class="datawave.query.scheduler.TestSchedulerProducer$Pushdown"/>
+
     <bean id="BaseEventQuery" parent="baseQueryLogic" scope="prototype" class="datawave.query.tables.ShardQueryLogic" abstract="true">
         <property name="tableName" value="shard" />
         <property name="dateIndexTableName" value="dateIndex" />
@@ -119,6 +121,7 @@
         <!-- property name="accumuloPassword" value="${accumulo.user.password}" />	 -->
         <property name="collapseUids" value="true" />	<!-- was ${query.collapse.uids} -->
         <property name="useEnrichers" value="true" />
+        <property name="schedulerProducer" ref="testSchedulerProducer" />
         <property name="contentFieldNames">
             <list value-type="java.lang.String">
                 <value>CONTENT</value>

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -122,6 +122,8 @@
         <property name="markingFunctions" ref="markingFunctions" />
     </bean>
 
+    <bean id="schedulerProducer" scope="prototype" class="datawave.query.scheduler.SchedulerProducer$Pushdown"/>
+
     <bean id="BaseEventQuery" parent="baseQueryLogic" class="datawave.query.tables.ShardQueryLogic" abstract="true">
         <property name="accumuloPassword" value="${accumulo.user.password}" />
         <property name="tableName" value="${shard.table.name}" />
@@ -146,6 +148,7 @@
         <property name="maxIndexScanTimeMillis" value="${query.max.index.scan.ms}" />
         <property name="collapseUids" value="${query.collapse.uids}" />
         <property name="collapseUidsThreshold" value="${query.collapse.uids.threshold}"/>
+        <property name="schedulerProducer" ref="schedulerProducer" />
         <property name="useEnrichers" value="true" />
         <property name="contentFieldNames">
             <list value-type="java.lang.String">


### PR DESCRIPTION
Makes the choice of Pushdown or Sequential Scheduler configurable in the QueryLogic.
The 'test' version of the PushdownScheduler is configured to use InMemoryAccumulo so that the actual production class no longer needs to check whether it is in a 'test' mode or not.