### PR TITLE
Handle exception thrown when retrieving excerpts for TLDEventQuery

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
@@ -175,7 +175,17 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
             excerptIterator.seek(range, Collections.emptyList(), false);
             if (excerptIterator.hasTop()) {
                 Key topKey = excerptIterator.getTopKey();
-                return topKey.getColumnQualifier().toString().split(Constants.NULL)[1];
+                String[] parts = topKey.getColumnQualifier().toString().split(Constants.NULL);
+                // The column qualifier is expected to be field\0phrase.
+                if (parts.length == 2) {
+                    return parts[1];
+                } else {
+                    if (log.isTraceEnabled()) {
+                        log.trace(TermFrequencyExcerptIterator.class.getSimpleName() + " returned top key with incorrectly-formatted column qualifier in key: "
+                                        + topKey + " when scanning for excerpt [" + start + "," + end + "] for field " + field + " within range " + range);
+                    }
+                    return null;
+                }
             } else {
                 return null;
             }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
@@ -180,10 +180,8 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
                 if (parts.length == 2) {
                     return parts[1];
                 } else {
-                    if (log.isTraceEnabled()) {
-                        log.trace(TermFrequencyExcerptIterator.class.getSimpleName() + " returned top key with incorrectly-formatted column qualifier in key: "
-                                        + topKey + " when scanning for excerpt [" + start + "," + end + "] for field " + field + " within range " + range);
-                    }
+                    log.warn(TermFrequencyExcerptIterator.class.getSimpleName() + " returned top key with incorrectly-formatted column qualifier in key: "
+                                    + topKey + " when scanning for excerpt [" + start + "," + end + "] for field " + field + " within range " + range);
                     return null;
                 }
             } else {


### PR DESCRIPTION
An ArrayIndexOutOfBoundsException can be thrown when attempting to
retrieve excerpts for a TLDEventQuery. Ensure this scenario does not
result in an exception, and log relevant details.

This PR may be updated with additional fixes. 