### PR TITLE
Cache decisions for ColumnVisibility filters

### DIFF
--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
@@ -63,4 +63,9 @@ public class AgeOffConfigParams {
      * Exclude schema components from age-off
      */
     public static final String EXCLUDE_DATA = "excludeData";
+
+    /**
+     * How many column visibilities should be cached. Parsing column visibilities is an expensive operation, so cache the decision.
+     */
+    public static final String COLUMN_VISIBILITY_CACHE_SIZE = "columnVisibilityCacheSize";
 }

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/AgeOffConfigParams.java
@@ -65,7 +65,7 @@ public class AgeOffConfigParams {
     public static final String EXCLUDE_DATA = "excludeData";
 
     /**
-     * How many column visibilities should be cached. Parsing column visibilities is an expensive operation, so cache the decision.
+     * Enable caching the previous column visibility.
      */
-    public static final String COLUMN_VISIBILITY_CACHE_SIZE = "columnVisibilityCacheSize";
+    public static final String COLUMN_VISIBILITY_CACHE_ENABLED = "columnVisibilityCacheEnabled";
 }

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package datawave.iterators.filter;
 
 import org.apache.accumulo.core.data.Key;

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
@@ -9,6 +9,7 @@ import org.apache.accumulo.core.data.Value;
 /**
  * This subclass of the {@code RegexFilterBase} class is used to filter based on the column visibility of the {@code Key} object {@code k}.
  */
+@Deprecated
 public class ColumnVisibilityAndFilter extends TokenFilterBase {
 
     /**

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
@@ -6,19 +6,21 @@ package datawave.iterators.filter;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
+import java.util.Arrays;
+
 /**
  * This subclass of the {@code RegexFilterBase} class is used to filter based on the column visibility of the {@code Key} object {@code k}.
  */
 public class ColumnVisibilityAndFilter extends TokenFilterBase {
 
     /**
-     * This method returns a {@code Iterator<String>} iterator of tokens containing the column column visibility parts for {@code Key} object {@code k}
+     * Determine if the key's column visibility matches the regex defined by {@link AgeOffConfigParams#MATCHPATTERN}
      *
      * @param k
      *            {@code Key} object containing the row, column family, and column qualifier.
      * @param v
      *            {@code Value} object containing the value corresponding to the {@code Key: k}
-     * @return {@code String} object containing the column visibility of {@code k}
+     * @return true if the provided key's column visibility matches the configured {@link TokenFilterBase}'s pattern
      */
     @Override
     public boolean hasToken(Key k, Value v, byte[][] testTokens) {
@@ -28,11 +30,19 @@ public class ColumnVisibilityAndFilter extends TokenFilterBase {
 
         byte[] cv = k.getColumnVisibilityData().getBackingArray();
 
-        int start = -1;
-        int end = -1;
+        if (prevCVBytes == null) {
+            prevCVBytes = cv; // first time, record cv
+        } else if (Arrays.equals(prevCVBytes, cv)) {
+            // ruleApplied was reset before the call to hasToken
+            setRuleApplied(true);
+            return prevDecision; // return cached decision
+        } else {
+            prevCVBytes = cv; // new cv found, record it
+        }
 
         // find the start of the first token to test
-        start = findNextNonDelimiter(cv, end + 1);
+        int start = findNextNonDelimiter(cv, 0);
+        int end = -1;
 
         // while not past the end and our test token was not found
         while (start < cv.length && numFound < found.length) {
@@ -63,7 +73,8 @@ public class ColumnVisibilityAndFilter extends TokenFilterBase {
             }
         }
 
-        return numFound == found.length;
+        prevDecision = numFound == found.length;
+        return prevDecision;
     }
 
 }

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityAndFilter.java
@@ -6,8 +6,6 @@ package datawave.iterators.filter;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
-import java.util.Arrays;
-
 /**
  * This subclass of the {@code RegexFilterBase} class is used to filter based on the column visibility of the {@code Key} object {@code k}.
  */
@@ -29,16 +27,6 @@ public class ColumnVisibilityAndFilter extends TokenFilterBase {
         int numFound = 0;
 
         byte[] cv = k.getColumnVisibilityData().getBackingArray();
-
-        if (prevCVBytes == null) {
-            prevCVBytes = cv; // first time, record cv
-        } else if (Arrays.equals(prevCVBytes, cv)) {
-            // ruleApplied was reset before the call to hasToken
-            setRuleApplied(true);
-            return prevDecision; // return cached decision
-        } else {
-            prevCVBytes = cv; // new cv found, record it
-        }
 
         // find the start of the first token to test
         int start = findNextNonDelimiter(cv, 0);
@@ -73,8 +61,7 @@ public class ColumnVisibilityAndFilter extends TokenFilterBase {
             }
         }
 
-        prevDecision = numFound == found.length;
-        return prevDecision;
+        return numFound == found.length;
     }
 
 }

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityOrFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityOrFilter.java
@@ -6,8 +6,6 @@ package datawave.iterators.filter;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
-import java.util.Arrays;
-
 /**
  * This subclass of the {@code RegexFilterBase} class is used to filter based on the column visibility of the {@code Key} object {@code k}.
  */
@@ -27,16 +25,6 @@ public class ColumnVisibilityOrFilter extends TokenFilterBase {
         boolean found = false;
 
         byte[] cv = k.getColumnVisibilityData().getBackingArray();
-
-        if (prevCVBytes == null) {
-            prevCVBytes = cv; // first time, record cv
-        } else if (Arrays.equals(prevCVBytes, cv)) {
-            // ruleApplied was reset before the call to hasToken
-            setRuleApplied(true);
-            return prevDecision; // return cached decision
-        } else {
-            prevCVBytes = cv; // new cv found, record it
-        }
 
         // find the start of the first token to test
         int start = findNextNonDelimiter(cv, 0);
@@ -64,8 +52,7 @@ public class ColumnVisibilityOrFilter extends TokenFilterBase {
             }
         }
 
-        prevDecision = found;
-        return prevDecision;
+        return found;
     }
 
 }

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityOrFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityOrFilter.java
@@ -6,9 +6,7 @@ package datawave.iterators.filter;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
-/**
- * This subclass of the {@code RegexFilterBase} class is used to filter based on the column visibility of the {@code Key} object {@code k}.
- */
+@Deprecated
 public class ColumnVisibilityOrFilter extends TokenFilterBase {
 
     /**

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenFilterBase.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenFilterBase.java
@@ -24,13 +24,17 @@ public abstract class TokenFilterBase extends AppliedRule {
     private byte[][] patternBytes;
     private boolean ruleApplied;
 
+    // record if the column visibility contained the tokens specified by the filter
+    protected byte[] prevCVBytes;
+    protected boolean prevDecision;
+
     // These are the possible delimiters in a column visibility exception for the double quote. NOTE, this is fragile
     // but currently there is no way to get this list out of the accumulo ColumnVisibility class.
     private static final byte[] DELIMITERS = "|&()".getBytes();
 
     /**
-     * This method is to be implemented by sub-classes of this class. It should return the tokens that needs to be tested against a test token for the instance
-     * of this class.
+     * This method is to be implemented by sub-classes of this class. Child classes should test the provided tokens against the provided key's column visibility
+     * and return true if the pattern was satisfied.
      *
      * @param k
      *            {@code Key} object containing the row, column family, and column qualifier.
@@ -38,7 +42,7 @@ public abstract class TokenFilterBase extends AppliedRule {
      *            {@code Value} object containing the value corresponding to the {@code Key: k}
      * @param testTokens
      *            the tokens to search for (or vs and rules defined by the underlying class)
-     * @return {@code boolean} True of the test token was found
+     * @return {@code boolean} True if the key satisfies the pattern(s)
      */
     public abstract boolean hasToken(Key k, Value v, byte[][] testTokens);
 
@@ -128,6 +132,12 @@ public abstract class TokenFilterBase extends AppliedRule {
             }
         }
         ruleApplied = false;
+        prevCVBytes = null;
+        prevDecision = false;
+    }
+
+    protected void setRuleApplied(boolean ruleApplied) {
+        this.ruleApplied = ruleApplied;
     }
 
     @Override

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenizingFilterBase.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenizingFilterBase.java
@@ -103,7 +103,8 @@ public abstract class TokenizingFilterBase extends AppliedRule {
             //  @formatter:off
             cvCache = Caffeine.newBuilder()
                             .maximumSize(size)
-                            .expireAfterAccess(30, TimeUnit.MINUTES)
+                            .expireAfterWrite(5, TimeUnit.MINUTES)
+                            .expireAfterAccess(5, TimeUnit.MINUTES)
                             .build();
             //  @formatter:on
         }
@@ -173,5 +174,9 @@ public abstract class TokenizingFilterBase extends AppliedRule {
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "[size=" + (scanTrie == null ? null : scanTrie.size()) + "]";
+    }
+
+    public Cache<byte[],Long> getCvCache() {
+        return cvCache;
     }
 }

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityAndFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityAndFilterTest.java
@@ -1,0 +1,125 @@
+package datawave.iterators.filter;
+
+import datawave.iterators.filter.ageoff.AgeOffPeriod;
+import datawave.iterators.filter.ageoff.FilterOptions;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for the {@link ColumnVisibilityAndFilter}
+ */
+public class ColumnVisibilityAndFilterTest {
+
+    private ColumnVisibilityAndFilter filter;
+    private AgeOffPeriod period;
+
+    private final Value value = new Value();
+
+    private long start;
+
+    private Key a;
+    private Key b;
+    private Key c;
+    private Key AandB;
+    private Key BandC;
+
+    private Key AorBandBorC;
+
+    @Before
+    public void setup() {
+        start = System.currentTimeMillis();
+        period = new AgeOffPeriod(start, 60, "ms");
+    }
+
+    private void createKeysWithTimeStamp(long ts) {
+        a = createKey("(A)", ts);
+        b = createKey("(B)", ts);
+        c = createKey("(C)", ts);
+
+        AandB = createKey("(A&B)", ts);
+        BandC = createKey("(B&C)", ts);
+
+        AorBandBorC = createKey("(A|B)&(B|C)", ts);
+    }
+
+    private Key createKey(String viz, long ts) {
+        return new Key("row", "cf", "cq", viz, ts);
+    }
+
+    private void createFilter(String pattern, long ttl) {
+        FilterOptions filterOptions = new FilterOptions();
+        filterOptions.setOption(AgeOffConfigParams.MATCHPATTERN, pattern);
+        filterOptions.setTTL(ttl);
+        filterOptions.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
+
+        filter = new ColumnVisibilityAndFilter();
+        filter.init(filterOptions);
+    }
+
+    @Test
+    public void testSingleMatchPattern() {
+        createFilter("A", 60);
+        createKeysWithTimeStamp(start - 45);
+
+        assertKeyAccepted(a);
+        assertRuleAppliedState(true);
+
+        assertKeyAccepted(b);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(c);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(AandB);
+        assertRuleAppliedState(true);
+
+        assertKeyAccepted(BandC);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(AorBandBorC);
+        assertRuleAppliedState(true);
+    }
+
+    @Test
+    public void testMultiPattern() {
+        createFilter("A,B", 60);
+        createKeysWithTimeStamp(start - 45);
+
+        assertKeyAccepted(a);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(b);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(c);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(AandB);
+        assertRuleAppliedState(true);
+
+        assertKeyAccepted(BandC);
+        assertRuleAppliedState(false);
+
+        assertKeyAccepted(AorBandBorC);
+        assertRuleAppliedState(true);
+    }
+
+    private void assertKeyAccepted(Key k) {
+        assertTrue(filter.accept(period, k, value));
+    }
+
+    private void assertKeyRejected(Key k) {
+        assertFalse(filter.accept(period, k, value));
+    }
+
+    private void assertRuleAppliedState(boolean state) {
+        assertEquals(state, filter.isFilterRuleApplied());
+    }
+
+}

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityAndFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityAndFilterTest.java
@@ -138,7 +138,7 @@ public class ColumnVisibilityAndFilterTest {
         // issue a cleanup call to reduce the cache to the last
         // accessed key
         filter.getCvCache().cleanUp();
-        assertEquals(1, filter.getCvCache().estimatedSize());
+        assertTrue(filter.getCvCache().estimatedSize() < 6);
     }
 
     private void assertKeyAccepted(Key k) {

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityOrFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityOrFilterTest.java
@@ -1,180 +1,89 @@
 package datawave.iterators.filter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
 import org.junit.Before;
 import org.junit.Test;
-
-import datawave.iterators.filter.ageoff.AgeOffPeriod;
-import datawave.iterators.filter.ageoff.FilterOptions;
 
 /**
  * Test for the {@link ColumnVisibilityOrFilter}
  */
-public class ColumnVisibilityOrFilterTest {
+public class ColumnVisibilityOrFilterTest extends VisibilityFilterTest {
 
-    private ColumnVisibilityOrFilter filter;
-    private ColumnVisibilityOrFilter filterWithCache;
-
-    private AgeOffPeriod period;
-    private final Value value = new Value();
-    private long start;
-
-    private Key keyA;
-    private Key keyAandB;
-    private Key keyAorB;
-    private Key keyX;
-    private Key keyXorY;
+    private final int max = 5;
 
     @Before
     public void setup() {
-        start = System.currentTimeMillis();
-        period = new AgeOffPeriod(start, 60L, "ms");
+        createAgeOffPeriod(100L, 50L);
+        createFilters("A,B", 50L, 25);
     }
 
-    private void createKeysWithTimeStamp(long ts) {
-        keyA = createKey("(A)", ts);
-        keyAandB = createKey("(A&B)", ts);
-        keyAorB = createKey("(A|B)", ts);
-
-        keyX = createKey("(X)", ts);
-        keyXorY = createKey("(X|Y)", ts);
-    }
-
-    private Key createKey(String viz, long ts) {
-        return new Key("row", "cf", "cq", viz, ts);
-    }
-
-    private void createFilter(String pattern, long ttl) {
-        FilterOptions filterOptions = new FilterOptions();
-        filterOptions.setOption(AgeOffConfigParams.MATCHPATTERN, pattern);
-        filterOptions.setTTL(ttl);
-        filterOptions.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
-
+    private void createFilters(String pattern, long ttl, int size) {
         filter = new ColumnVisibilityOrFilter();
-        filter.init(filterOptions);
-    }
-
-    private void createFilter(String pattern, long ttl, int size) {
-        FilterOptions filterOptions = new FilterOptions();
-        filterOptions.setOption(AgeOffConfigParams.MATCHPATTERN, pattern);
-        filterOptions.setTTL(ttl);
-        filterOptions.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
-        filterOptions.setOption(AgeOffConfigParams.COLUMN_VISIBILITY_CACHE_SIZE, String.valueOf(size));
+        filter.init(createOptions(pattern, ttl));
 
         filterWithCache = new ColumnVisibilityOrFilter();
-        filterWithCache.init(filterOptions);
+        filterWithCache.init(createOptions(pattern, ttl, size));
     }
 
     @Test
-    public void testKeysWithinAgeOffPeriod() {
-        // for keys within the AgeOffPeriod
-        createKeysWithTimeStamp(start - 45L);
-        createFilter("A", 60L);
-        createFilter("A", 60L, 50);
+    public void testVisibilityFullMatchTimeStampMatch() {
+        Key key = createKey("(A|B)", 75L);
 
-        // rule is applied to key that has the target column visibility and falls within the time range
-        assertKeyAccepted(keyA);
-        assertRuleAppliedState(true);
-
-        assertKeyAccepted(keyAandB);
-        assertRuleAppliedState(true);
-
-        assertKeyAccepted(keyAorB);
-        assertRuleAppliedState(true);
-
-        // rule is NOT applied to key that has different column visibility and falls within the time range
-        assertKeyAccepted(keyX);
-        assertRuleAppliedState(false);
-
-        assertKeyAccepted(keyXorY);
-        assertRuleAppliedState(false);
+        for (int i = 0; i < max; i++) {
+            assertKeyAccepted(key);
+            assertRuleAppliedState(true);
+        }
     }
 
     @Test
-    public void testKeysOutsideOfAgeOffPeriod() {
-        // for keys that fall outside the AgeOffPeriod
-        createKeysWithTimeStamp(start - 85L);
-        createFilter("A", 60L);
-        createFilter("A", 60L, 50);
+    public void testVisibilityPartialMatchTimeStampMatch() {
+        Key key = createKey("(A)", 75L);
 
-        // rule is applied to key that has the target column visibility and falls within the time range
-        assertKeyRejected(keyA);
-        assertRuleAppliedState(true);
-
-        assertKeyRejected(keyAandB);
-        assertRuleAppliedState(true);
-
-        assertKeyRejected(keyAorB);
-        assertRuleAppliedState(true);
-
-        // rule is NOT applied to key that has different column visibility and falls within the time range
-        assertKeyAccepted(keyX);
-        assertRuleAppliedState(false);
-
-        assertKeyAccepted(keyXorY);
-        assertRuleAppliedState(false);
+        for (int i = 0; i < max; i++) {
+            assertKeyAccepted(key);
+            assertRuleAppliedState(true);
+        }
     }
 
     @Test
-    public void testMultiFilterWithinAgeOffPeriod() {
-        // for keys within the AgeOffPeriod
-        createKeysWithTimeStamp(start - 45L);
-        createFilter("A,Y", 60L);
-        createFilter("A,Y", 60L, 50);
+    public void testVisibilityFullMatchTimeStampMiss() {
+        Key key = createKey("(A|B)", 25L);
 
-        // rule is applied to key that has the target column visibility and falls within the time range
-        assertKeyAccepted(keyA);
-        assertRuleAppliedState(true);
+        for (int i = 0; i < max; i++) {
+            assertKeyRejected(key);
+            assertRuleAppliedState(true);
+        }
+    }
 
-        assertKeyAccepted(keyAandB);
-        assertRuleAppliedState(true);
+    @Test
+    public void testVisibilityMissTimeStampMatch() {
+        Key key = createKey("(X&Y)", 75L);
 
-        assertKeyAccepted(keyAorB);
-        assertRuleAppliedState(true);
+        for (int i = 0; i < max; i++) {
+            assertKeyAccepted(key);
+            assertRuleAppliedState(false);
+        }
+    }
 
-        // rule is NOT applied to key that has different column visibility and falls within the time range
-        assertKeyAccepted(keyX);
-        assertRuleAppliedState(false);
+    @Test
+    public void testVisibilityMissTimeStampMiss() {
+        Key key = createKey("(X&Y)", 25L);
 
-        assertKeyAccepted(keyXorY);
-        assertRuleAppliedState(true); // Y portion matches
+        for (int i = 0; i < max; i++) {
+            assertKeyAccepted(key);
+            assertRuleAppliedState(false);
+        }
     }
 
     @Test
     public void testFilterWithDifferentTimeStampsAndDifferentCacheSizes() {
-        Key first = createKey("(A)", start + 75L);
-        Key second = createKey("(A)", start - 75L);
-
-        createFilter("A,B", 60L);
-        createFilter("A,B", 60L, 50);
+        Key first = createKey("(A)", 75L);
+        Key second = createKey("(A)", 25L);
 
         assertKeyAccepted(first);
         assertRuleAppliedState(true);
         assertKeyRejected(second);
         assertRuleAppliedState(true);
-
-        filterWithCache.getCvCache().cleanUp();
-        assertEquals(1, filterWithCache.getCvCache().estimatedSize());
-    }
-
-    private void assertKeyAccepted(Key k) {
-        assertTrue(filter.accept(period, k, value));
-        assertTrue(filterWithCache.accept(period, k, value));
-    }
-
-    private void assertKeyRejected(Key k) {
-        assertFalse(filter.accept(period, k, value));
-        assertFalse(filterWithCache.accept(period, k, value));
-    }
-
-    private void assertRuleAppliedState(boolean state) {
-        assertEquals(state, filter.isFilterRuleApplied());
-        assertEquals(state, filterWithCache.isFilterRuleApplied());
     }
 
 }

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityOrFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityOrFilterTest.java
@@ -1,0 +1,102 @@
+package datawave.iterators.filter;
+
+import datawave.iterators.filter.ageoff.AgeOffPeriod;
+import datawave.iterators.filter.ageoff.FilterOptions;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for the {@link ColumnVisibilityOrFilter}
+ */
+public class ColumnVisibilityOrFilterTest {
+
+    private ColumnVisibilityOrFilter filter;
+
+    private AgeOffPeriod period;
+
+    private Key keyA;
+    private Key keyAandB;
+    private Key keyAorB;
+    private Key keyX;
+    private Key keyXorY;
+
+    private Value value = new Value();
+
+    private long start;
+
+    @Before
+    public void setup() {
+        start = System.currentTimeMillis();
+
+        FilterOptions filterOptions = new FilterOptions();
+        filterOptions.setOption(AgeOffConfigParams.MATCHPATTERN, "A");
+        filterOptions.setTTL(60L);
+        filterOptions.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
+
+        filter = new ColumnVisibilityOrFilter();
+        filter.init(filterOptions);
+
+        period = new AgeOffPeriod(start, 60, "ms");
+    }
+
+    private void createKeysWithTimeStamp(long ts) {
+        keyA = new Key("row", "cf", "cq", "(A)", ts);
+        keyAandB = new Key("row", "cf", "cq", "(A&B)", ts);
+        keyAorB = new Key("row", "cf", "cq", "(A|B)", ts);
+
+        keyX = new Key("row", "cf", "cq", "(X)", ts);
+        keyXorY = new Key("row", "cf", "cq", "(X|Y)", ts);
+    }
+
+    @Test
+    public void testKeysWithinAgeOffPeriod() {
+        // for keys within the AgeOffPeriod
+        createKeysWithTimeStamp(start - 45);
+
+        // rule is applied to key that has the target column visibility and falls within the time range
+        assertTrue(filter.accept(period, keyA, value));
+        assertTrue(filter.isFilterRuleApplied());
+
+        assertTrue(filter.accept(period, keyAandB, value));
+        assertTrue(filter.isFilterRuleApplied());
+
+        assertTrue(filter.accept(period, keyAorB, value));
+        assertTrue(filter.isFilterRuleApplied());
+
+        // rule is NOT applied to key that has different column visibility and falls within the time range
+        assertTrue(filter.accept(period, keyX, value));
+        assertFalse(filter.isFilterRuleApplied());
+
+        assertTrue(filter.accept(period, keyXorY, value));
+        assertFalse(filter.isFilterRuleApplied());
+    }
+
+    @Test
+    public void testKeysOutsideOfAgeOffPeriod() {
+        // for keys that fall outside the AgeOffPeriod
+        createKeysWithTimeStamp(start - 85);
+
+        // rule is applied to key that has the target column visibility and falls within the time range
+        assertFalse(filter.accept(period, keyA, value));
+        assertTrue(filter.isFilterRuleApplied());
+
+        assertFalse(filter.accept(period, keyAandB, value));
+        assertTrue(filter.isFilterRuleApplied());
+
+        assertFalse(filter.accept(period, keyAorB, value));
+        assertTrue(filter.isFilterRuleApplied());
+
+        // rule is NOT applied to key that has different column visibility and falls within the time range
+        assertTrue(filter.accept(period, keyX, value));
+        assertFalse(filter.isFilterRuleApplied());
+
+        assertTrue(filter.accept(period, keyXorY, value));
+        assertFalse(filter.isFilterRuleApplied());
+    }
+
+}

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityOrFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityOrFilterTest.java
@@ -1,15 +1,16 @@
 package datawave.iterators.filter;
 
-import datawave.iterators.filter.ageoff.AgeOffPeriod;
-import datawave.iterators.filter.ageoff.FilterOptions;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import datawave.iterators.filter.ageoff.AgeOffPeriod;
+import datawave.iterators.filter.ageoff.FilterOptions;
 
 /**
  * Test for the {@link ColumnVisibilityOrFilter}
@@ -31,7 +32,7 @@ public class ColumnVisibilityOrFilterTest {
     @Before
     public void setup() {
         start = System.currentTimeMillis();
-        period = new AgeOffPeriod(start, 60, "ms");
+        period = new AgeOffPeriod(start, 60L, "ms");
     }
 
     private void createKeysWithTimeStamp(long ts) {
@@ -60,8 +61,8 @@ public class ColumnVisibilityOrFilterTest {
     @Test
     public void testKeysWithinAgeOffPeriod() {
         // for keys within the AgeOffPeriod
-        createKeysWithTimeStamp(start - 45);
-        createFilter("A", 60);
+        createKeysWithTimeStamp(start - 45L);
+        createFilter("A", 60L);
 
         // rule is applied to key that has the target column visibility and falls within the time range
         assertKeyAccepted(keyA);
@@ -84,8 +85,8 @@ public class ColumnVisibilityOrFilterTest {
     @Test
     public void testKeysOutsideOfAgeOffPeriod() {
         // for keys that fall outside the AgeOffPeriod
-        createKeysWithTimeStamp(start - 85);
-        createFilter("A", 60);
+        createKeysWithTimeStamp(start - 85L);
+        createFilter("A", 60L);
 
         // rule is applied to key that has the target column visibility and falls within the time range
         assertKeyRejected(keyA);
@@ -108,8 +109,8 @@ public class ColumnVisibilityOrFilterTest {
     @Test
     public void testMultiFilterWithinAgeOffPeriod() {
         // for keys within the AgeOffPeriod
-        createKeysWithTimeStamp(start - 45);
-        createFilter("A,Y", 60);
+        createKeysWithTimeStamp(start - 45L);
+        createFilter("A,Y", 60L);
 
         // rule is applied to key that has the target column visibility and falls within the time range
         assertKeyAccepted(keyA);

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityTokenizingFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/ColumnVisibilityTokenizingFilterTest.java
@@ -1,0 +1,88 @@
+package datawave.iterators.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import datawave.iterators.filter.ageoff.AgeOffPeriod;
+import datawave.iterators.filter.ageoff.FilterOptions;
+
+public class ColumnVisibilityTokenizingFilterTest {
+
+    private ColumnVisibilityTokenizingFilter filter;
+    private AgeOffPeriod period;
+    private final Value value = new Value();
+
+    @Before
+    public void before() {
+        period = new AgeOffPeriod(100L, 50L, "ms");
+    }
+
+    private Key createKey(String viz, long ts) {
+        return new Key("row", "cf", "cq", viz, ts);
+    }
+
+    private void createFilter(String pattern, long ttl) {
+        FilterOptions options = new FilterOptions();
+        options.setOption(AgeOffConfigParams.MATCHPATTERN, pattern);
+        options.setTTL(ttl);
+        options.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
+
+        filter = new ColumnVisibilityTokenizingFilter();
+        filter.init(options);
+    }
+
+    @Test
+    public void testMatchingVisibilityAndTimeStamp() {
+        Key key = createKey("(A)", 75L);
+        createFilter("\"A\": 50ms", 50L);
+
+        assertKeyAccepted(key);
+        assertRuleAppliedState(true);
+    }
+
+    @Test
+    public void testMatchingVisibilityAndExcludeTimeStamp() {
+        Key key = createKey("(A)", 25L);
+        createFilter("\"A\": 50ms", 50L);
+
+        assertKeyRejected(key);
+        assertRuleAppliedState(true);
+    }
+
+    @Test
+    public void testExclusionVisibilityAndMatchingTimeStamp() {
+        Key key = createKey("(X)", 75L);
+        createFilter("\"A\": 50ms", 50L);
+
+        assertKeyAccepted(key);
+        assertRuleAppliedState(false);
+    }
+
+    @Test
+    public void testExclusionVisibilityAndTimeStamp() {
+        Key key = createKey("(X)", 25L);
+        createFilter("\"A\": 50ms", 50L);
+
+        assertKeyAccepted(key);
+        assertRuleAppliedState(false);
+    }
+
+    private void assertKeyAccepted(Key key) {
+        assertTrue(filter.accept(period, key, value));
+    }
+
+    private void assertKeyRejected(Key key) {
+        assertFalse(filter.accept(period, key, value));
+    }
+
+    private void assertRuleAppliedState(boolean state) {
+        assertEquals(state, filter.isFilterRuleApplied());
+    }
+
+}

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/VisibilityFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/VisibilityFilterTest.java
@@ -1,0 +1,176 @@
+package datawave.iterators.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import datawave.iterators.filter.ageoff.AgeOffPeriod;
+import datawave.iterators.filter.ageoff.AppliedRule;
+import datawave.iterators.filter.ageoff.FilterOptions;
+
+/**
+ * Common methods useful for ColumnVisibilityFilter tests
+ */
+public class VisibilityFilterTest {
+
+    protected AgeOffPeriod period;
+    protected AppliedRule filter;
+    protected AppliedRule filterWithCache;
+
+    protected final Value value = new Value();
+
+    /**
+     * Create a {@link Key} with the specified visibility and timestamp
+     *
+     * @param visibility
+     *            the visibility
+     * @param timestamp
+     *            the timestamp
+     * @return a Key
+     */
+    protected Key createKey(String visibility, long timestamp) {
+        return new Key("row", "cf", "cq", visibility, timestamp);
+    }
+
+    /**
+     * Create an {@link AgeOffPeriod} using a starting timestamp and ttl in milliseconds
+     *
+     * @param start
+     *            the starting timestamp
+     * @param ttl
+     *            the ttl in milliseconds
+     */
+    protected void createAgeOffPeriod(long start, long ttl) {
+        period = new AgeOffPeriod(start, ttl, "ms");
+    }
+
+    /**
+     * Create a {@link FilterOptions} with a pattern and TTL
+     *
+     * @param pattern
+     *            the pattern
+     * @param ttl
+     *            the ttl
+     * @return an instance of FilterOptions
+     */
+    protected FilterOptions createOptions(String pattern, long ttl) {
+        return createOptions(pattern, ttl, 0);
+    }
+
+    /**
+     * Create a {@link FilterOptions} with a pattern, ttl, and column visibility cache size
+     *
+     * @param pattern
+     *            the pattern
+     * @param ttl
+     *            the ttl
+     * @param cacheSize
+     *            the size of the column visibility cache
+     * @return an instance of FilterOptions
+     */
+    protected FilterOptions createOptions(String pattern, long ttl, int cacheSize) {
+        FilterOptions filterOptions = new FilterOptions();
+        filterOptions.setOption(AgeOffConfigParams.MATCHPATTERN, pattern);
+        filterOptions.setTTL(ttl);
+        filterOptions.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
+
+        if (cacheSize > 0) {
+            filterOptions.setOption(AgeOffConfigParams.COLUMN_VISIBILITY_CACHE_SIZE, String.valueOf(cacheSize));
+        }
+
+        return filterOptions;
+    }
+
+    /**
+     * Asserts that a key is accepted by a filter with and without column visibility caching enabled
+     *
+     * @param k
+     *            a key
+     */
+    protected void assertKeyAccepted(Key k) {
+        assertTrue(filter.accept(period, k, value));
+        assertTrue(filterWithCache.accept(period, k, value));
+    }
+
+    /**
+     * Asserts that a key is rejected by a filter with and without column visibility caching enabled
+     *
+     * @param k
+     *            a key
+     */
+    protected void assertKeyRejected(Key k) {
+        assertFalse(filter.accept(period, k, value));
+        assertFalse(filterWithCache.accept(period, k, value));
+    }
+
+    /**
+     * Asserts that the filter rule is applied (or not), with and without column visibility caching enabled
+     *
+     * @param state
+     *            the expected boolean state
+     */
+    protected void assertRuleAppliedState(boolean state) {
+        assertEquals(state, filter.isFilterRuleApplied());
+        assertEquals(state, filterWithCache.isFilterRuleApplied());
+    }
+
+    /**
+     * Record how long it takes to apply a filter to a list of keys. Default number of iterations is 10,000.
+     *
+     * @param filter
+     *            the filter
+     * @param keys
+     *            the list of keys
+     * @return the time in milliseconds it took to traverse the keys
+     */
+    protected long throughput(AppliedRule filter, List<Key> keys) {
+        return throughput(filter, keys, 1_000);
+    }
+
+    /**
+     * Record how long it takes to apply a filter to a list of keys for the provided number of iterations
+     *
+     * @param filter
+     *            the filter
+     * @param keys
+     *            the list of keys
+     * @param max
+     *            the number of iterations
+     * @return the time in milliseconds it took to traverse the keys
+     */
+    protected long throughput(AppliedRule filter, List<Key> keys, int max) {
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < max; i++) {
+            for (Key key : keys) {
+                filter.accept(period, key, value);
+            }
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    /**
+     * Build a list of keys using the provided visibility and timestamp. For testing filter throughput.
+     *
+     * @param size
+     *            the number of keys to create
+     * @param visibility
+     *            the visibility of the keys
+     * @param timestamp
+     *            the timestamp of the keys
+     * @return a list of keys
+     */
+    protected List<Key> buildListOfSize(int size, String visibility, long timestamp) {
+        List<Key> keys = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            keys.add(createKey(visibility, timestamp));
+        }
+        return keys;
+    }
+
+}

--- a/warehouse/age-off/src/test/java/datawave/iterators/filter/VisibilityFilterTest.java
+++ b/warehouse/age-off/src/test/java/datawave/iterators/filter/VisibilityFilterTest.java
@@ -60,30 +60,26 @@ public class VisibilityFilterTest {
      * @return an instance of FilterOptions
      */
     protected FilterOptions createOptions(String pattern, long ttl) {
-        return createOptions(pattern, ttl, 0);
+        return createOptions(pattern, ttl, false);
     }
 
     /**
-     * Create a {@link FilterOptions} with a pattern, ttl, and column visibility cache size
+     * Create a {@link FilterOptions} with a pattern, ttl, and column visibility cache
      *
      * @param pattern
      *            the pattern
      * @param ttl
      *            the ttl
-     * @param cacheSize
-     *            the size of the column visibility cache
+     * @param enableCache
+     *            enable the column visibility cache
      * @return an instance of FilterOptions
      */
-    protected FilterOptions createOptions(String pattern, long ttl, int cacheSize) {
+    protected FilterOptions createOptions(String pattern, long ttl, boolean enableCache) {
         FilterOptions filterOptions = new FilterOptions();
         filterOptions.setOption(AgeOffConfigParams.MATCHPATTERN, pattern);
         filterOptions.setTTL(ttl);
         filterOptions.setTTLUnits(AgeOffTtlUnits.MILLISECONDS);
-
-        if (cacheSize > 0) {
-            filterOptions.setOption(AgeOffConfigParams.COLUMN_VISIBILITY_CACHE_SIZE, String.valueOf(cacheSize));
-        }
-
+        filterOptions.setOption(AgeOffConfigParams.COLUMN_VISIBILITY_CACHE_ENABLED, String.valueOf(enableCache));
         return filterOptions;
     }
 


### PR DESCRIPTION
- The TokenFilterBase now has a column visibility cache to reduce the time spent parsing visibilities. 
- The cache has a default size of 50 but the size can be overridden using the COLUMN_VISIBILITY_CACHE_SIZE age off parameter. 
- added unit tests for the ColumnVisibilityOrFilter and ColumnVisibilityAndFilter

Addresses https://github.com/NationalSecurityAgency/datawave/issues/1579