### PR TITLE
fixes #1594: Updated unique transform to avoid resetting bloom filter

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/transformer/UniqueTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/UniqueTransform.java
@@ -79,11 +79,16 @@ public class UniqueTransform extends DocumentTransform.DefaultDocumentTransform 
     }
     
     public void updateConfig(UniqueFields uniqueFields, QueryModel model) {
-        this.uniqueFields = uniqueFields;
-        this.uniqueFields.deconstructIdentifierFields();
-        this.bloom = BloomFilter.create(new ByteFunnel(), 500000, 1e-15);
-        if (log.isTraceEnabled()) {
-            log.trace("unique fields: " + this.uniqueFields.getFields());
+        if (this.uniqueFields != uniqueFields) {
+            uniqueFields.deconstructIdentifierFields();
+            if (!this.uniqueFields.equals(uniqueFields)) {
+                this.uniqueFields = uniqueFields;
+                log.info("Resetting unique fields on the unique transform");
+                this.bloom = BloomFilter.create(new ByteFunnel(), 500000, 1e-15);
+                if (log.isTraceEnabled()) {
+                    log.trace("unique fields: " + this.uniqueFields.getFields());
+                }
+            }
         }
         if (model != null) {
             modelMapping = HashMultimap.create();

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
@@ -493,7 +493,7 @@ public class UniqueTransformTest {
     }
     
     private void assertUniqueDocuments() {
-        List<Document> actual = getUniqueDocuments(inputDocuments);
+        List<Document> actual = getUniqueDocumentsWithUpdateConfigCalls(inputDocuments);
         Collections.sort(expectedUniqueDocuments);
         Collections.sort(actual);
         assertEquals("Unique documents do not match expected", expectedUniqueDocuments, actual);
@@ -506,6 +506,22 @@ public class UniqueTransformTest {
         Iterator<Map.Entry<Key,Document>> resultIterator = Iterators.transform(inputIterator, uniqueTransform);
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(resultIterator, Spliterator.ORDERED), false).filter(Objects::nonNull)
                         .map(Map.Entry::getValue).collect(Collectors.toList());
+    }
+    
+    private List<Document> getUniqueDocumentsWithUpdateConfigCalls(List<Document> documents) {
+        Transformer<Document,Map.Entry<Key,Document>> docToEntry = document -> Maps.immutableEntry(document.getMetadata(), document);
+        TransformIterator<Document,Map.Entry<Key,Document>> inputIterator = new TransformIterator<>(documents.iterator(), docToEntry);
+        UniqueTransform uniqueTransform = getUniqueTransform();
+        Iterator<Map.Entry<Key,Document>> resultIterator = Iterators.transform(inputIterator, uniqueTransform);
+        ArrayList<Document> docs = new ArrayList<>();
+        while (resultIterator.hasNext()) {
+            Map.Entry<Key,Document> next = resultIterator.next();
+            if (next != null) {
+                docs.add(next.getValue());
+                updateUniqueTransform(uniqueTransform);
+            }
+        }
+        return docs;
     }
     
     private void assertOrderedFieldSets() {
@@ -527,6 +543,10 @@ public class UniqueTransformTest {
     
     private UniqueTransform getUniqueTransform() {
         return new UniqueTransform(uniqueFields);
+    }
+    
+    private void updateUniqueTransform(UniqueTransform uniqueTransform) {
+        uniqueTransform.updateConfig(uniqueFields, null);
     }
     
     private InputDocumentBuilder givenInputDocument() {


### PR DESCRIPTION
when update config is called if nothing actually changed.