### PR TITLE
Update quickstart to work with Python 2.X and 3.X

### DIFF
--- a/contrib/datawave-quickstart/bin/query.sh
+++ b/contrib/datawave-quickstart/bin/query.sh
@@ -133,7 +133,7 @@ function setQueryIdFromResponse() {
 function prettyPrintJson() {
     local PY=$( which python )
     if [ -n "${PY}" ] ; then
-        echo "${1}" | ${PY} -c 'import sys,json;data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
+        echo "${1}" | ${PY} -c 'from __future__ import print_function;import sys,json;data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
         local exitStatus=$?
         echo
         if [ "${exitStatus}" != "0" ] ; then

--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
@@ -39,7 +39,7 @@ TVMAZE_RESPONSE_STATUS=$( echo ${CURL_RESPONSE} | tr -d '\n' | sed -e 's/.*HTTP_
 [ -z "${TVMAZE_RESPONSE_BODY}" ] && error "Response body is empty!" && exit 1
 
 if [ "${PRETTY}" == true ] ; then
-    echo "${TVMAZE_RESPONSE_BODY}" | python -c 'import sys,json;data=json.loads(sys.stdin.read()); print json.dumps(data, indent=2, sort_keys=True)'
+    echo "${TVMAZE_RESPONSE_BODY}" | python -c 'from __future__ import print_function;import sys,json;data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
 else
     echo "${TVMAZE_RESPONSE_BODY}"
 fi


### PR DESCRIPTION
Fixes #1609 

I made use of Python's built-in `__future__` module to help inherit the new print function introduced in Python 3.x.

This change allows users to use Python 2.x and 3.x in the quickstart. 