### PR TITLE
Move #NO_EXPANSION to query functions

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsDescriptor.java
@@ -42,7 +42,6 @@ public class EvaluationPhaseFilterFunctionsDescriptor implements JexlFunctionArg
     public static final String MATCHES_AT_LEAST_COUNT_OF = "matchesAtLeastCountOf";
     public static final String TIME_FUNCTION = "timeFunction";
     public static final String COMPARE = "compare";
-    public static final String NO_EXPANSION = "noExpansion";
     
     /**
      * This is the argument descriptor which can be used to normalize and optimize function node queries

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctions.java
@@ -34,6 +34,7 @@ public class QueryFunctions {
     public static final String EXCERPT_FIELDS_FUNCTION = "excerpt_fields";
     public static final String MATCH_REGEX = "matchRegex";
     public static final String INCLUDE_TEXT = "includeText";
+    public static final String NO_EXPANSION = "noExpansion";
     
     protected static Logger log = Logger.getLogger(QueryFunctions.class);
     

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctionsDescriptor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctionsDescriptor.java
@@ -197,7 +197,7 @@ public class QueryFunctionsDescriptor implements JexlFunctionArgumentDescriptorF
             case QueryFunctions.EXCERPT_FIELDS_FUNCTION:
             case QueryFunctions.MATCH_REGEX:
             case QueryFunctions.INCLUDE_TEXT:
-	    case QueryFunctions.NO_EXPANSION:
+            case QueryFunctions.NO_EXPANSION:
                 if (numArgs == 0) {
                     throw new IllegalArgumentException("Expected at least one argument to the " + name + " function");
                 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctionsDescriptor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/QueryFunctionsDescriptor.java
@@ -197,6 +197,7 @@ public class QueryFunctionsDescriptor implements JexlFunctionArgumentDescriptorF
             case QueryFunctions.EXCERPT_FIELDS_FUNCTION:
             case QueryFunctions.MATCH_REGEX:
             case QueryFunctions.INCLUDE_TEXT:
+	    case QueryFunctions.NO_EXPANSION:
                 if (numArgs == 0) {
                     throw new IllegalArgumentException("Expected at least one argument to the " + name + " function");
                 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/NoExpansionFunctionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/NoExpansionFunctionVisitor.java
@@ -1,8 +1,8 @@
 package datawave.query.jexl.visitors;
 
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.jexl.functions.EvaluationPhaseFilterFunctionsDescriptor;
 import datawave.query.jexl.functions.FunctionJexlNodeVisitor;
+import datawave.query.jexl.functions.QueryFunctions;
 import org.apache.commons.jexl2.parser.ASTAndNode;
 import org.apache.commons.jexl2.parser.ASTFunctionNode;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
@@ -55,7 +55,7 @@ public class NoExpansionFunctionVisitor extends RebuildingVisitor {
         FunctionJexlNodeVisitor visitor = new FunctionJexlNodeVisitor();
         node.jjtAccept(visitor, null);
         
-        if (visitor.namespace().equals("filter") && visitor.name().equalsIgnoreCase(EvaluationPhaseFilterFunctionsDescriptor.NO_EXPANSION)) {
+        if (visitor.namespace().equals(QueryFunctions.QUERY_FUNCTION_NAMESPACE) && visitor.name().equalsIgnoreCase(QueryFunctions.NO_EXPANSION)) {
             
             noExpansionFields.addAll(visitor.args().stream().map(JexlASTHelper::getIdentifier).collect(Collectors.toSet()));
             

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ValidateFilterFunctionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ValidateFilterFunctionVisitor.java
@@ -64,7 +64,7 @@ import org.apache.log4j.Logger;
 import java.util.Set;
 
 import static datawave.query.jexl.functions.EvaluationPhaseFilterFunctions.EVAL_PHASE_FUNCTION_NAMESPACE;
-import static datawave.query.jexl.functions.EvaluationPhaseFilterFunctionsDescriptor.NO_EXPANSION;
+import static datawave.query.jexl.functions.QueryFunctions.NO_EXPANSION;
 
 /**
  * Verifies that no filter function is run against an index-only field

--- a/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/NoExpansion.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/functions/jexl/NoExpansion.java
@@ -36,6 +36,6 @@ public class NoExpansion extends JexlQueryFunction {
     @Override
     public String toString() {
         List<String> params = getParameterList();
-        return "filter:noExpansion(" + String.join("", params) + ")";
+        return "f:noExpansion(" + String.join("", params) + ")";
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/NoExpansionFunctionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/NoExpansionFunctionVisitorTest.java
@@ -16,7 +16,7 @@ public class NoExpansionFunctionVisitorTest {
     
     @Test
     public void testSimpleParseFunctionInConjunction() {
-        String query = "FOO == 'bar' && filter:noExpansion(FOO)";
+        String query = "FOO == 'bar' && f:noExpansion(FOO)";
         String expected = "FOO == 'bar'";
         Set<String> expectedFields = Sets.newHashSet("FOO");
         test(query, expected, expectedFields);
@@ -24,7 +24,7 @@ public class NoExpansionFunctionVisitorTest {
     
     @Test
     public void testSimpleParseFunctionInDisjunction() {
-        String query = "FOO == 'bar' || filter:noExpansion(FOO)";
+        String query = "FOO == 'bar' || f:noExpansion(FOO)";
         String expected = "FOO == 'bar'";
         Set<String> expectedFields = Sets.newHashSet("FOO");
         test(query, expected, expectedFields);
@@ -32,7 +32,7 @@ public class NoExpansionFunctionVisitorTest {
     
     @Test
     public void testParseMultipleFields() {
-        String query = "FOO == 'bar' && filter:noExpansion(FOO,FOO2,FOO3)";
+        String query = "FOO == 'bar' && f:noExpansion(FOO,FOO2,FOO3)";
         String expected = "FOO == 'bar'";
         Set<String> expectedFields = Sets.newHashSet("FOO", "FOO2", "FOO3");
         test(query, expected, expectedFields);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -386,7 +386,7 @@ public class QueryModelVisitorTest {
     
     @Test
     public void testModelExpansionWithNoExpansionFunction() {
-        // model contains expansions for both FIELD_A and FIELD_B, presence of filter:noExpansion(FIELD_B) prevents
+        // model contains expansions for both FIELD_A and FIELD_B, presence of f:noExpansion(FIELD_B) prevents
         // that portion of the model expansion.
         QueryModel model = new QueryModel();
         model.addTermToModel("FIELD_A", "FIELD_AA");
@@ -400,30 +400,30 @@ public class QueryModelVisitorTest {
         testNoExpansion(query, expected, model, Collections.emptySet());
         
         // only FIELD_B is expanded
-        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && filter:noExpansion(FIELD_A)";
+        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && f:noExpansion(FIELD_A)";
         expected = "FIELD_A == 'bar' && (FIELD_BB == 'baz' || FIELD_BC == 'baz')";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_A"));
         
         // only FIELD_A is expanded
-        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && filter:noExpansion(FIELD_B)";
+        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && f:noExpansion(FIELD_B)";
         expected = "(FIELD_AB == 'bar' || FIELD_AA == 'bar') && FIELD_B == 'baz'";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_B"));
         
         // neither field is expanded
-        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && filter:noExpansion(FIELD_A,FIELD_B)";
+        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && f:noExpansion(FIELD_A,FIELD_B)";
         expected = "FIELD_A == 'bar' && FIELD_B == 'baz'";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_A", "FIELD_B"));
         
         // both fields are expanded, NoExpansion function specified a field that does not exist in the query
-        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && filter:noExpansion(FIELD_X,FIELD_Y)";
+        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && f:noExpansion(FIELD_X,FIELD_Y)";
         expected = "(FIELD_AA == 'bar' || FIELD_AB == 'bar') && (FIELD_BB == 'baz' || FIELD_BC == 'baz')";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_X", "FIELD_Y"));
         
-        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && filter:noExpansion(FIELD_X,FIELD_Y,FIELD_A)";
+        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && f:noExpansion(FIELD_X,FIELD_Y,FIELD_A)";
         expected = "FIELD_A == 'bar' && (FIELD_BB == 'baz' || FIELD_BC == 'baz')";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_A", "FIELD_X", "FIELD_Y"));
         
-        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && filter:noExpansion(FIELD_A,FIELD_X,FIELD_Y)";
+        query = "FIELD_A == 'bar' && FIELD_B == 'baz' && f:noExpansion(FIELD_A,FIELD_X,FIELD_Y)";
         expected = "FIELD_A == 'bar' && (FIELD_BB == 'baz' || FIELD_BC == 'baz')";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_A", "FIELD_X", "FIELD_Y"));
     }
@@ -435,7 +435,7 @@ public class QueryModelVisitorTest {
         model.addTermToModel("FIELD_A", "FIELD_B");
         model.addTermToModel("FIELD_A", "FIELD_C");
         
-        String query = "FIELD_A == 'bar' && filter:noExpansion(FIELD_C)";
+        String query = "FIELD_A == 'bar' && f:noExpansion(FIELD_C)";
         String expected = "(FIELD_B == 'bar' || FIELD_C == 'bar')";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_C"));
     }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -446,7 +446,7 @@ public class QueryModelVisitorTest {
         model.addTermToModel("FIELD_A", "FIELD_B");
         model.addTermToModel("FIELD_A", "FIELD_C");
         
-        String query = "filter:includeRegex(FIELD_A, 'ba.*') && filter:noExpansion(FIELD_A)";
+        String query = "filter:includeRegex(FIELD_A, 'ba.*') && f:noExpansion(FIELD_A)";
         String expected = "filter:includeRegex(FIELD_A, 'ba.*')";
         testNoExpansion(query, expected, model, Sets.newHashSet("FIELD_A"));
     }

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlParser.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlParser.java
@@ -56,7 +56,7 @@ public class TestLuceneToJexlParser {
     public void testParseFunction_NoExpansion() throws ParseException {
         LuceneToJexlQueryParser parser = getQueryParser();
         QueryNode node = parser.parse("FIELD:SOMETHING AND #NOEXPANSION(FIELD)");
-        Assert.assertEquals("FIELD == 'SOMETHING' && filter:noExpansion(FIELD)", node.getOriginalQuery());
+        Assert.assertEquals("FIELD == 'SOMETHING' && f:noExpansion(FIELD)", node.getOriginalQuery());
     }
     
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTestWithModel.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTestWithModel.java
@@ -602,7 +602,7 @@ public abstract class GroupingTestWithModel {
         runTestToComparePlans(queryString, expectedPlan, startDate, endDate, extraParameters, NEVER, RebuildingScannerTestHelper.INTERRUPT.NEVER);
         
         // case where #NO_EXPANSION is specified in the query string itself
-        queryString = "COLOR == 'blue' && filter:noExpansion(COLOR)";
+        queryString = "COLOR == 'blue' && f:noExpansion(COLOR)";
         expectedPlan = "COLOR == 'blue'";
         runTestToComparePlans(queryString, expectedPlan, startDate, endDate, extraParameters, NEVER, RebuildingScannerTestHelper.INTERRUPT.NEVER);
         
@@ -615,14 +615,14 @@ public abstract class GroupingTestWithModel {
         // case where #NO_EXPANSION is specified in both query parameters and the query string
         extraParameters.clear();
         extraParameters.put(QueryParameters.NO_EXPANSION_FIELDS, "COLOR");
-        queryString = "COLOR == 'blue' && filter:noExpansion(COLOR)";
+        queryString = "COLOR == 'blue' && f:noExpansion(COLOR)";
         expectedPlan = "COLOR == 'blue'";
         runTestToComparePlans(queryString, expectedPlan, startDate, endDate, extraParameters, NEVER, RebuildingScannerTestHelper.INTERRUPT.NEVER);
         
         // case where #NO_EXPANSION in query params is the wrong field and query string function is the correct one
         extraParameters.clear();
         extraParameters.put(QueryParameters.NO_EXPANSION_FIELDS, "HUE");
-        queryString = "COLOR == 'blue' && filter:noExpansion(COLOR)";
+        queryString = "COLOR == 'blue' && f:noExpansion(COLOR)";
         expectedPlan = "COLOR == 'blue'";
         runTestToComparePlans(queryString, expectedPlan, startDate, endDate, extraParameters, NEVER, RebuildingScannerTestHelper.INTERRUPT.NEVER);
     }


### PR DESCRIPTION
Move #NO_EXPANSION from filter functions to query functions.

Resolves #1615