### PR TITLE
Fix bug when delayed index streams are added to the query plan multiple times

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/BaseIndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/BaseIndexStream.java
@@ -98,6 +98,11 @@ public abstract class BaseIndexStream implements IndexStream {
     }
     
     @Override
+    public Tuple2<String,IndexInfo> next(String context) {
+        return next();
+    }
+    
+    @Override
     public void remove() {}
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ConcurrentScannerInitializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ConcurrentScannerInitializer.java
@@ -35,7 +35,7 @@ public class ConcurrentScannerInitializer implements Callable<BaseIndexStream> {
     public BaseIndexStream call() throws Exception {
         if (stream.context() == StreamContext.INITIALIZED) {
             if (stream.hasNext()) {
-                return ScannerStream.variable(stream, stream.currentNode());
+                return ScannerStream.withData(stream, stream.currentNode());
             } else {
                 return ScannerStream.noData(stream.currentNode());
             }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
@@ -29,6 +29,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -596,5 +597,12 @@ public class IndexInfo implements Writable, UidIntersector {
     
     public void setNode(JexlNode currNode) {
         myNode = currNode;
+        
+        // need to update the nodes for the underlying index matches in order
+        // to persist delayed terms. In the case of a document specific range
+        // the query plan is pulled from indexMatch.getNode()
+        for (IndexMatch uid : uids) {
+            uid.set(myNode);
+        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
@@ -29,7 +29,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
@@ -82,7 +82,10 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
     String seek(String seekShard);
     
     /**
-     * In certain cases a next call must be made within a context
+     * Additional context is required for nested unions that have a VARIABLE stream context.
+     * <p>
+     * The active terms in a union may hit on a later shard than the provided shard; in this case any delayed terms need to be returned in order to maintain as
+     * much of the original query as possible.
      *
      * @param context
      *            a shard

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
@@ -30,7 +30,7 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
          */
         VARIABLE,
         /**
-         * No op expression indicates that an expression is kept as a placeholder
+         * NO_OP marks a node as a placeholder when it is consumed by a parent of the same node type
          */
         NO_OP,
         /**

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
@@ -34,7 +34,7 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
          */
         NO_OP,
         /**
-         * Delayed expression
+         * DELAYED_FIELD means this term or junction of terms is delayed
          */
         DELAYED_FIELD,
         /**

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
@@ -80,4 +80,13 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
      * @return the top shard after seeking, or null if no more values exist
      */
     String seek(String seekShard);
+    
+    /**
+     * In certain cases a next call must be made within a context
+     *
+     * @param context
+     *            a shard
+     * @return the next result
+     */
+    Tuple2<String,IndexInfo> next(String context);
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStream.java
@@ -21,22 +21,18 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
          * PRESENT indicates that a given field and term has data in the global index.
          */
         PRESENT,
-        
         /**
          * ABSENT means that we expected data to exist, but did not find any.
          */
         ABSENT,
-        
         /**
-         * VARIABLE indicates that this particular stream will have some delayed and non delayed predicates
+         * VARIABLE indicates that this index stream has a mix of delayed and non-delayed terms
          */
         VARIABLE,
-        
         /**
-         * No op expression used to indicate that an expression is kept as a place holder.
+         * No op expression indicates that an expression is kept as a placeholder
          */
         NO_OP,
-        
         /**
          * Delayed expression
          */
@@ -45,22 +41,19 @@ public interface IndexStream extends PeekingIterator<Tuple2<String,IndexInfo>> {
          * UNINDEXED means that the given field is not present for any value in the index.
          */
         UNINDEXED,
-        
         /**
          * UKNOWN_FIELD means that the field has never been tracked by the system.
          */
         UNKNOWN_FIELD,
-        
         /**
-         * EXCEEDED_THRESHOLD means that a we exceeded a term threshold somewhere
+         * EXCEEDED_TERM_THRESHOLD means that we exceeded a term threshold somewhere
          */
         EXCEEDED_TERM_THRESHOLD,
-        
         /**
-         * EXCEEDED_THRESHOLD means that a we exceeded a value threshold somewhere
+         * EXCEEDED_VALUE_THRESHOLD means that we exceeded a value threshold somewhere. The RangeStream will generate a list of day ranges that covers the date
+         * range of the query.
          */
         EXCEEDED_VALUE_THRESHOLD,
-        
         /**
          * At some point in the processing chain, we determined that a node (range or regex) did not need to be expanded to satisfy the query using the field
          * index

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStreamComparator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStreamComparator.java
@@ -4,6 +4,8 @@ import java.util.Comparator;
 
 /**
  * Intended for use in the {@link Intersection} to order IndexStreams
+ * <p>
+ * IndexStreams are ordered first by stream context, then by implementing subclass
  */
 public class IndexStreamComparator implements Comparator<IndexStream> {
     
@@ -28,6 +30,17 @@ public class IndexStreamComparator implements Comparator<IndexStream> {
      * @return an integer id for the provided index stream
      */
     private int id(IndexStream stream) {
+        return getContextId(stream) + getClassId(stream);
+    }
+    
+    /**
+     * Secondary sort by class
+     *
+     * @param stream
+     *            an IndexStream
+     * @return an integer value between 1 and 4, inclusive
+     */
+    private int getClassId(IndexStream stream) {
         if (stream instanceof ScannerStream) {
             return 1;
         } else if (stream instanceof Intersection) {
@@ -36,6 +49,42 @@ public class IndexStreamComparator implements Comparator<IndexStream> {
             return 3;
         } else {
             return 4;
+        }
+    }
+    
+    /**
+     * Primary sort by IndexStream context
+     *
+     * @param stream
+     *            an IndexStream
+     * @return an integer value between 10 and 110, inclusive
+     */
+    private int getContextId(IndexStream stream) {
+        switch (stream.context()) {
+            case ABSENT: // ABSENT returns first so we can short-circuit intersections
+                return 10;
+            case PRESENT: // PRESENT provides the best chance for a shard to anchor on
+                return 20;
+            case VARIABLE: // mix of PRESENT and some form of DELAYED
+                return 30;
+            case EXCEEDED_VALUE_THRESHOLD: // from here on down, all forms of DELAYED
+                return 40;
+            case EXCEEDED_TERM_THRESHOLD:
+                return 50;
+            case IGNORED:
+                return 60;
+            case UNINDEXED:
+                return 70;
+            case DELAYED_FIELD:
+                return 80;
+            case UNKNOWN_FIELD:
+                return 90;
+            case NO_OP:
+                return 100;
+            case INITIALIZED:
+                return 110;
+            default:
+                throw new IllegalStateException("cannot get context id for context: " + stream.context());
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStreamComparator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStreamComparator.java
@@ -16,6 +16,9 @@ public class IndexStreamComparator implements Comparator<IndexStream> {
         
         int result = Integer.compare(leftId, rightId);
         if (result == 0) {
+            // a TreeMultimap is an implementation of a SortedKeySortedSetMultimap
+            // element uniqueness is NOT determined by the stream class and context
+            // return a 1 to insert this "equivalent" element after an existing element
             return 1;
         } else {
             return result;

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStreamComparator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexStreamComparator.java
@@ -1,0 +1,41 @@
+package datawave.query.index.lookup;
+
+import java.util.Comparator;
+
+/**
+ * Intended for use in the {@link Intersection} to order IndexStreams
+ */
+public class IndexStreamComparator implements Comparator<IndexStream> {
+    
+    @Override
+    public int compare(IndexStream left, IndexStream right) {
+        int leftId = id(left);
+        int rightId = id(right);
+        
+        int result = Integer.compare(leftId, rightId);
+        if (result == 0) {
+            return 1;
+        } else {
+            return result;
+        }
+    }
+    
+    /**
+     * Map an IndexStream's class to an integer id
+     *
+     * @param stream
+     *            an IndexStream
+     * @return an integer id for the provided index stream
+     */
+    private int id(IndexStream stream) {
+        if (stream instanceof ScannerStream) {
+            return 1;
+        } else if (stream instanceof Intersection) {
+            return 2;
+        } else if (stream instanceof Union) {
+            return 3;
+        } else {
+            return 4;
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Intersection.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Intersection.java
@@ -91,7 +91,7 @@ public class Intersection extends BaseIndexStream {
     private Tuple2<String,IndexInfo> next;
     
     protected UidIntersector uidIntersector;
-    protected static IndexStreamComparator streamComparator = new IndexStreamComparator();
+    private static final IndexStreamComparator streamComparator = new IndexStreamComparator();
     
     private static final Logger log = Logger.getLogger(Intersection.class);
     

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Intersection.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Intersection.java
@@ -193,8 +193,13 @@ public class Intersection extends BaseIndexStream {
             // just because index streams are present, does not mean they actually intersect
             next();
             if (next != null) {
-                this.context = StreamContext.PRESENT;
-                this.contextDebug = "children intersect";
+                if (delayedNodes.isEmpty()) {
+                    this.context = StreamContext.PRESENT;
+                    this.contextDebug = "children intersect";
+                } else {
+                    this.context = StreamContext.VARIABLE;
+                    this.contextDebug = "children are a mix of delayed and non-delayed terms";
+                }
             } else {
                 this.context = StreamContext.ABSENT;
                 this.contextDebug = "children did not intersect";

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -327,9 +327,11 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                     return ScannerStream.noData(union.currentNode(), union);
                 case IGNORED:
                     return ScannerStream.ignored(union.currentNode(), union);
+                case PRESENT:
+                case VARIABLE:
+                case DELAYED_FIELD:
                 case EXCEEDED_TERM_THRESHOLD:
                 case EXCEEDED_VALUE_THRESHOLD:
-                case PRESENT:
                     return union;
                 case UNINDEXED:
                     return ScannerStream.unindexed(union.currentNode(), union);

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -389,6 +389,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                 case EXCEEDED_TERM_THRESHOLD:
                 case EXCEEDED_VALUE_THRESHOLD:
                 case PRESENT:
+                case VARIABLE:
                     return build;
                 case UNINDEXED:
                     return ScannerStream.unindexed(build.currentNode(), build);

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -2,7 +2,6 @@ package datawave.query.index.lookup;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -338,8 +337,8 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                     return ScannerStream.ignored(union.currentNode(), union);
                 case DELAYED_FIELD:
                     return ScannerStream.delayedExpression(union.currentNode());
-                case PRESENT: //
-                case VARIABLE: // variable state becoming delayed means we can no longer prune the non-delayed terms from a query
+                case PRESENT:
+                case VARIABLE:
                 case EXCEEDED_TERM_THRESHOLD:
                 case EXCEEDED_VALUE_THRESHOLD:
                     return union;
@@ -696,7 +695,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
             
             // create a list of tuples for each shard
             if (log.isDebugEnabled()) {
-                LiteralRange range = JexlASTHelper.findRange().indexedOnly(config.getDatatypeFilter(), metadataHelper).getRange(node);
+                LiteralRange<?> range = JexlASTHelper.findRange().indexedOnly(config.getDatatypeFilter(), metadataHelper).getRange(node);
                 if (range != null) {
                     log.debug("{\"" + range.getFieldName() + "\": \"" + range.getLower() + " - " + range.getUpper() + "\"} requires a full field index scan.");
                 } else {

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -327,9 +327,10 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                     return ScannerStream.noData(union.currentNode(), union);
                 case IGNORED:
                     return ScannerStream.ignored(union.currentNode(), union);
-                case PRESENT:
-                case VARIABLE:
+                case VARIABLE: // variable state becoming delayed means we can no longer prune the non-delayed terms from a query
                 case DELAYED_FIELD:
+                    return ScannerStream.delayedExpression(union.currentNode());
+                case PRESENT:
                 case EXCEEDED_TERM_THRESHOLD:
                 case EXCEEDED_VALUE_THRESHOLD:
                     return union;

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
@@ -61,6 +61,7 @@ public class Union extends BaseIndexStream {
             if (stream.hasNext()) {
                 switch (stream.context()) {
                     case PRESENT:
+                    case VARIABLE:
                     case EXCEEDED_VALUE_THRESHOLD:
                         // index streams with data are always added
                         this.children.add(stream);
@@ -82,7 +83,6 @@ public class Union extends BaseIndexStream {
                     delayedNodes.add(stream.currentNode());
                     continue;
                 case IGNORED:
-                case VARIABLE:
                 case DELAYED_FIELD:
                 case UNKNOWN_FIELD:
                 case EXCEEDED_TERM_THRESHOLD:

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
@@ -59,10 +59,16 @@ public class Union extends BaseIndexStream {
             }
             
             if (stream.hasNext()) {
-                // index streams with data are always added
-                this.children.add(stream);
-                this.childNodes.add(stream.currentNode());
-                continue;
+                switch (stream.context()) {
+                    case PRESENT:
+                    case EXCEEDED_VALUE_THRESHOLD:
+                        // index streams with data are always added
+                        this.children.add(stream);
+                        this.childNodes.add(stream.currentNode());
+                        continue;
+                    default:
+                        throw new IllegalStateException("Unexpected stream context " + stream.context());
+                }
             }
             
             switch (stream.context()) {

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/Union.java
@@ -2,6 +2,7 @@ package datawave.query.index.lookup;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -43,110 +44,92 @@ public class Union extends BaseIndexStream {
         this.children = new PriorityQueue(16, PeekOrdering.make(new TupleComparator<>()));
         this.childNodes = new JexlNodeSet();
         this.delayedNodes = new JexlNodeSet();
-        int childrenCount = 0;
-        boolean childrenIgnored = false;
-        boolean unindexedField = false;
-        boolean delayedField = false;
-        boolean exceededTermThreshold = false;
-        boolean exceededValueThreshold = false;
+        
+        boolean delayedFromUnindexed = false;
+        
         for (IndexStream stream : children) {
             
             if (log.isDebugEnabled()) {
                 childrenContextDebug.add(stream.getContextDebug());
             }
             
-            childrenCount++;
             if (log.isTraceEnabled()) {
-                log.trace("Union of " + stream.currentNode() + " " + stream.hasNext() + " " + JexlStringBuildingVisitor.buildQuery(stream.currentNode()));
-                log.trace("Union of " + stream + " " + stream.context());
-            }
-            
-            if (StreamContext.NO_OP == stream.context())
-                continue;
-            if (StreamContext.EXCEEDED_VALUE_THRESHOLD == stream.context()) {
-                exceededValueThreshold = true;
-            } else if (StreamContext.EXCEEDED_TERM_THRESHOLD == stream.context()) {
-                exceededTermThreshold = true;
-            } else if (StreamContext.UNINDEXED == stream.context()) {
-                this.childNodes.add(stream.currentNode());
-                this.delayedNodes.add(stream.currentNode());
-                unindexedField = true;
-                continue;
-            } else if (StreamContext.DELAYED_FIELD == stream.context()) {
-                this.childNodes.add(stream.currentNode());
-                this.delayedNodes.add(stream.currentNode());
-                delayedField = true;
-                continue;
+                log.trace("Union child " + JexlStringBuildingVisitor.buildQuery(stream.currentNode()) + " - " + stream.context() + " hasNext: "
+                                + stream.hasNext());
             }
             
             if (stream.hasNext()) {
+                // index streams with data are always added
                 this.children.add(stream);
                 this.childNodes.add(stream.currentNode());
-            } else {
-                switch (stream.context()) {
-                
-                    case INITIALIZED:
-                        // this should never be returned
-                        throw new RuntimeException("Invalid state in RangeStream");
-                    case IGNORED:
-                        childrenIgnored = true;
-                        this.childNodes.add(stream.currentNode());
-                        this.delayedNodes.add(stream.currentNode());
-                        break;
-                    case EXCEEDED_VALUE_THRESHOLD:
-                    case EXCEEDED_TERM_THRESHOLD:
-                        if (log.isTraceEnabled())
-                            log.trace("Adding current node to stream");
-                        /*
-                         * Helpful for debugging
-                         */
-                        this.childNodes.add(stream.currentNode());
-                        break;
-                    case VARIABLE:
-                    case UNKNOWN_FIELD:
-                        this.delayedNodes.add(stream.currentNode());
-                    case ABSENT:
-                    case PRESENT:
-                    default:
-                        break;
-                }
+                continue;
+            }
+            
+            switch (stream.context()) {
+                case NO_OP:
+                case ABSENT:
+                    // these index streams are dropped from the union
+                    continue;
+                case UNINDEXED:
+                    // a non-indexed field present in a top level union results in a non-executable query
+                    delayedFromUnindexed = true;
+                    delayedNodes.add(stream.currentNode());
+                    continue;
+                case IGNORED:
+                case VARIABLE:
+                case DELAYED_FIELD:
+                case UNKNOWN_FIELD:
+                case EXCEEDED_TERM_THRESHOLD:
+                    // these nodes need to be persisted via the set of delayedNodes
+                    delayedNodes.add(stream.currentNode());
+                    continue;
+                case INITIALIZED:
+                    throw new RuntimeException("Invalid state in RangeStream");
+                default:
+                    throw new IllegalStateException("[Union] unhandled stream context: " + stream.context());
             }
         }
-        if (log.isTraceEnabled())
-            log.trace("children count is " + childrenCount + " " + childNodes.size() + " " + this.children.size());
-        if (childNodes.size() == 1)
-            currNode = JexlNodeFactory.createUnwrappedOrNode(this.childNodes.getNodes());
-        else
-            currNode = JexlNodeFactory.createOrNode(this.childNodes.getNodes());
         
-        if (this.children.isEmpty()) {
-            if (childrenIgnored || childrenCount == 0) {
-                this.context = StreamContext.IGNORED;
-                this.contextDebug = "no children";
-            } else if (unindexedField) {
-                this.context = StreamContext.UNINDEXED;
-                this.contextDebug = "unindexed child";
-            } else if (delayedField) {
-                this.context = StreamContext.DELAYED_FIELD;
-                this.contextDebug = "delayed child";
-            } else {
-                this.context = StreamContext.ABSENT;
-                this.contextDebug = "no children";
-            }
+        // build the union based on updated information from the child index streams
+        JexlNodeSet nodes = new JexlNodeSet();
+        if (!childNodes.isEmpty()) {
+            nodes.addAll(childNodes);
+        }
+        if (!delayedNodes.isEmpty()) {
+            nodes.addAll(delayedNodes);
+        }
+        
+        if (nodes.size() == 1) {
+            currNode = nodes.iterator().next();
         } else {
-            if (exceededTermThreshold) {
-                this.context = StreamContext.EXCEEDED_TERM_THRESHOLD;
-                this.contextDebug = "ExceededTermThreshold child";
-            } else if (exceededValueThreshold) {
-                this.context = StreamContext.EXCEEDED_VALUE_THRESHOLD;
-                this.contextDebug = "ExceededValueThreshold child";
-            } else if (unindexedField) {
-                this.context = StreamContext.UNINDEXED;
-                this.contextDebug = "Unindexed child";
-            } else {
-                this.context = StreamContext.PRESENT;
-                this.contextDebug = "children are present";
-            }
+            currNode = JexlNodeFactory.createOrNode(nodes.getNodes());
+        }
+        
+        if (log.isTraceEnabled()) {
+            log.trace("union has " + childNodes.size() + " active children and " + delayedNodes.size() + " delayed children");
+        }
+        
+        if (delayedFromUnindexed) {
+            this.context = StreamContext.UNINDEXED;
+            this.contextDebug = "child contains an unindexed field";
+        } else if (!childNodes.isEmpty() && !delayedNodes.isEmpty()) {
+            // set this union's context based on the state of child index streams
+            this.context = StreamContext.VARIABLE;
+            this.contextDebug = "children are a mix of delayed and non-delayed";
+        } else if (!childNodes.isEmpty() && delayedNodes.isEmpty()) {
+            this.context = StreamContext.PRESENT;
+            this.contextDebug = "children are all present";
+        } else if (childNodes.isEmpty() && !delayedNodes.isEmpty()) {
+            this.context = StreamContext.DELAYED_FIELD;
+            this.contextDebug = "children are all delayed";
+        } else {
+            // both are empty
+            this.context = StreamContext.ABSENT;
+            this.contextDebug = "children are all absent";
+        }
+        
+        // advance the queue if we have active index streams
+        if (!this.children.isEmpty()) {
             next();
         }
     }
@@ -180,7 +163,6 @@ public class Union extends BaseIndexStream {
         if (log.isTraceEnabled())
             log.trace("advancing " + pointers.getNode() + " " + children.peek().context());
         
-        boolean childrenAdded = false;
         /**
          * Since children is a PriorityQueue sorted by shard and its possible for a day_shard to call next() and then return a day. That iterator will sort to
          * the front. This may cause a break in the end loop condition before all iterators have had a chance to be evaluated. Until all iterators have been
@@ -208,7 +190,7 @@ public class Union extends BaseIndexStream {
             
             IndexStream itr = children.poll();
             
-            pointers = pointers.union(itr.peek().second(), Lists.newArrayList(delayedNodes.getNodes()));
+            pointers = pointers.union(itr.peek().second(), Collections.emptyList());
             itr.next();
             if (itr.hasNext()) {
                 // add this to the processed list so other iterators have a chance to be first even if this one comes back earlier in the stack
@@ -218,7 +200,6 @@ public class Union extends BaseIndexStream {
                     log.trace("IndexStream exhausted for " + itr.getContextDebug());
                 }
             }
-            childrenAdded = true;
             
             // repopulate children with all processed children
             if (children.isEmpty() && !processedChildren.isEmpty()) {
@@ -227,12 +208,14 @@ public class Union extends BaseIndexStream {
             }
         }
         
+        // build set of nodes, to include any delayed nodes in this union
         JexlNodeSet nodeSet = new JexlNodeSet();
         if (pointers.myNode != null)
             nodeSet.add(pointers.myNode);
         if (delayedNodes != null && !delayedNodes.isEmpty())
             nodeSet.addAll(delayedNodes);
         
+        // rebuild current node
         currNode = null;
         if (nodeSet.size() == 1) {
             currNode = nodeSet.iterator().next();
@@ -240,7 +223,10 @@ public class Union extends BaseIndexStream {
             currNode = JexlNodeFactory.createUnwrappedOrNode(nodeSet.getNodes());
         }
         
-        if (!childrenAdded) {
+        // update pointers with the current node
+        if (!delayedNodes.isEmpty()) {
+            // pointers is composed of all live index streams, but we need to add in
+            // any delayed nodes
             pointers.setNode(currNode);
         }
         

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -30,7 +30,6 @@ import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.exceptions.InvalidQueryException;
 import datawave.query.exceptions.NoResultsException;
 import datawave.query.function.JexlEvaluation;
-import datawave.query.index.lookup.IndexStream.StreamContext;
 import datawave.query.index.lookup.RangeStream;
 import datawave.query.iterator.CloseableListIterable;
 import datawave.query.iterator.QueryIterator;

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2437,6 +2437,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             // check for the case where we cannot handle an ivarator but the query requires an ivarator
             if (IvaratorRequiredVisitor.isIvaratorRequired(queryTree) && !config.canHandleExceededValueThreshold()) {
                 log.debug("Needs full table scan because we exceeded the value threshold and config.canHandleExceededValueThreshold() is false");
+                needsFullTable = true;
             }
             
             stopwatch.stop();

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IndexStreamComparatorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IndexStreamComparatorTest.java
@@ -1,0 +1,225 @@
+package datawave.query.index.lookup;
+
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.util.Tuple2;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeSet;
+
+import static datawave.query.index.lookup.IndexStream.StreamContext;
+import static datawave.query.index.lookup.IndexStream.StreamContext.ABSENT;
+import static datawave.query.index.lookup.IndexStream.StreamContext.DELAYED_FIELD;
+import static datawave.query.index.lookup.IndexStream.StreamContext.EXCEEDED_TERM_THRESHOLD;
+import static datawave.query.index.lookup.IndexStream.StreamContext.EXCEEDED_VALUE_THRESHOLD;
+import static datawave.query.index.lookup.IndexStream.StreamContext.IGNORED;
+import static datawave.query.index.lookup.IndexStream.StreamContext.PRESENT;
+import static datawave.query.index.lookup.IndexStream.StreamContext.UNINDEXED;
+import static datawave.query.index.lookup.IndexStream.StreamContext.UNKNOWN_FIELD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IndexStreamComparatorTest {
+    
+    private final String key = "shard";
+    private final TreeSet<String> shards = Sets.newTreeSet(Arrays.asList("20220101_1", "20220101_2", "20220101_3", "20220101_4"));
+    
+    private final IndexStreamComparator comparator = new IndexStreamComparator();
+    
+    @Test
+    public void testIntersectionOfScannerStreams() {
+        test(s1(), s2(), s3()); // all present
+        test(s1(), s2(), ignored()); // present and ignored
+        test(s1(), s2(), unindexed()); // present and unindexed
+        test(absent(), s1(), s2()); // present and absent -- shouldn't happen but record expected output
+        test(s1(), s2(), delayed()); // present and delayed
+        test(s1(), s2(), unknown()); // present and unknown field
+        test(s1(), s2(), exceededTerm()); // present and exceeded term threshold
+        test(s1(), s2(), exceededValue()); // present and exceeded value threshold
+    }
+    
+    // terms with PRESENT should sort before unions
+    @Test
+    public void testIntersectionWithNestedUnions() {
+        
+        // present and union(PRESENT)
+        test(s1(), union(s1(), s2()));
+        
+        // present and union(VARIABLE)
+        test(s1(), union(s1(), ignored()));
+        test(s1(), union(s1(), unindexed()));
+        test(s1(), union(s1(), absent()));
+        test(s1(), union(s1(), delayed()));
+        test(s1(), union(s1(), unknown()));
+        test(s1(), union(s1(), exceededTerm()));
+        test(s1(), union(s1(), exceededValue()));
+        
+        // present and union(DELAYED)
+        test(s1(), union(ignored(), ignored()));
+        test(s1(), union(unindexed(), unindexed()));
+        test(union(absent(), absent()), s1());
+        test(s1(), union(delayed(), delayed()));
+        test(s1(), union(unknown(), unknown()));
+        test(s1(), union(exceededTerm(), exceededTerm()));
+        test(s1(), union(exceededValue(), exceededValue()));
+        
+        // present and union(VARIABLE) and union(DELAYED)
+        test(s1(), union(s1(), ignored()), union(ignored(), ignored()));
+        test(s1(), union(s1(), unindexed()), union(unindexed(), unindexed()));
+        test(union(absent(), absent()), s1(), union(s1(), absent()));
+        test(s1(), union(s1(), delayed()), union(delayed(), delayed()));
+        test(s1(), union(s1(), unknown()), union(unknown(), unknown()));
+        test(s1(), union(s1(), exceededTerm()), union(exceededTerm(), exceededTerm()));
+        test(s1(), union(s1(), exceededValue()), union(exceededValue(), exceededValue()));
+    }
+    
+    // unions with a context of PRESENT should sort before VARIABLE
+    @Test
+    public void testIntersectionOfAllUnions() {
+        // union(VARIABLE) and union(DELAYED)
+        test(union(s1(), ignored()), union(ignored(), ignored()));
+        test(union(s1(), unindexed()), union(unindexed(), unindexed()));
+        test(union(absent(), absent()), union(s1(), absent()));
+        test(union(s1(), delayed()), union(delayed(), delayed()));
+        test(union(s1(), unknown()), union(unknown(), unknown()));
+        test(union(s1(), exceededTerm()), union(exceededTerm(), exceededTerm()));
+        test(union(s1(), exceededValue()), union(exceededValue(), exceededValue()));
+    }
+    
+    @Test
+    public void testIntersectionsWithNestedUnionsWithNestedIntersections() {
+        // A && (B || (C && D))
+        test(s1(), union(s2(), intersection(s1(), s2())));
+        
+        // A && (B || (C && D)) && delayed(C)
+        test(s1(), union(s2(), intersection(s1(), s2())), delayed());
+        
+        // A && (B || (C && D)) && (B || (delayed(C) && D))
+        test(s1(), union(s2(), intersection(s1(), s2())), union(s2(), intersection(s1(), delayed())));
+        
+        // A && (B || C) && (C || (D && delayed))
+        test(s1(), union(s2(), s3()), union(s1(), intersection(s2(), delayed())));
+    }
+    
+    /**
+     * Given a collection of IndexStreams assert that proper order is maintained through a variety of iterations
+     * <p>
+     * The order of input index streams is the expected order
+     *
+     * @param streams
+     *            a collection of IndexStreams, in expected order
+     */
+    private void test(BaseIndexStream... streams) {
+        TreeMultimap<String,IndexStream> map = TreeMultimap.create(Ordering.natural(), comparator);
+        List<BaseIndexStream> inputs = new ArrayList<>(Arrays.asList(streams));
+        
+        for (int i = 0; i < 10; i++) {
+            Collections.shuffle(inputs);
+            map.clear();
+            map.putAll(key, inputs);
+            
+            Iterator<IndexStream> iter = map.get(key).iterator();
+            
+            for (BaseIndexStream stream : streams) {
+                assertTrue("input streams had next, but intersection did not", iter.hasNext());
+                IndexStream is = iter.next();
+                assertEquals("IndexStream class did not match", is.getClass(), stream.getClass());
+                assertEquals("IndexStream context did not match", is.context(), stream.context());
+            }
+            
+            assertFalse(iter.hasNext());
+        }
+    }
+    
+    private ScannerStream s1() {
+        return buildScannerStream("F1", "a", PRESENT);
+    }
+    
+    private ScannerStream s2() {
+        return buildScannerStream("F2", "b", PRESENT);
+    }
+    
+    private ScannerStream s3() {
+        return buildScannerStream("F3", "c", PRESENT);
+    }
+    
+    private ScannerStream ignored() {
+        return buildScannerStream("F3", "c", IGNORED);
+    }
+    
+    private ScannerStream unindexed() {
+        return buildScannerStream("F4", "d", UNINDEXED);
+    }
+    
+    private ScannerStream absent() {
+        return buildScannerStream("F5", "e", ABSENT);
+    }
+    
+    private ScannerStream delayed() {
+        return buildScannerStream("F6", "f", DELAYED_FIELD);
+    }
+    
+    private ScannerStream unknown() {
+        return buildScannerStream("F7", "g", UNKNOWN_FIELD);
+    }
+    
+    private ScannerStream exceededTerm() {
+        return buildScannerStream("F8", "h", EXCEEDED_TERM_THRESHOLD);
+    }
+    
+    private ScannerStream exceededValue() {
+        return buildScannerStream("F9", "i", EXCEEDED_VALUE_THRESHOLD);
+    }
+    
+    private ScannerStream buildScannerStream(String field, String value, StreamContext context) {
+        JexlNode node = JexlNodeFactory.buildEQNode(field, value);
+        
+        List<Tuple2<String,IndexInfo>> elements = new ArrayList<>();
+        for (String shard : shards) {
+            IndexInfo info = new IndexInfo(-1);
+            info.applyNode(node);
+            elements.add(new Tuple2<>(shard, info));
+        }
+        
+        // build correct scanner stream type based on context
+        switch (context) {
+            case PRESENT:
+                return ScannerStream.withData(elements.iterator(), node);
+            case IGNORED:
+                return ScannerStream.ignored(node);
+            case UNINDEXED:
+                return ScannerStream.unindexed(node);
+            case ABSENT:
+                return ScannerStream.noData(node);
+            case DELAYED_FIELD:
+                return ScannerStream.delayedExpression(node);
+            case UNKNOWN_FIELD:
+                return ScannerStream.unknownField(node);
+            case EXCEEDED_TERM_THRESHOLD:
+                return ScannerStream.exceededTermThreshold(node);
+            case EXCEEDED_VALUE_THRESHOLD:
+                return ScannerStream.exceededValueThreshold(elements.iterator(), node);
+            default:
+                throw new IllegalStateException("unknown context: " + context);
+        }
+        
+    }
+    
+    private Intersection intersection(BaseIndexStream... streams) {
+        return new Intersection(Arrays.asList(streams), new IndexInfo());
+    }
+    
+    private Union union(BaseIndexStream... streams) {
+        return new Union(Arrays.asList(streams));
+    }
+    
+}

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
@@ -2,7 +2,9 @@ package datawave.query.index.lookup;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
+import com.google.common.collect.TreeMultimap;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
@@ -16,6 +18,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1005,6 +1008,75 @@ public class IntersectionTest {
         
         // No match on different day
         assertNull(intersection.isTopElementAMatch("20190302"));
+    }
+    
+    // test some ordering
+    
+    @Test
+    public void testTreeMultiMapOrdering() {
+        List<String> ignoredDays = Lists.newArrayList("20190304", "20190305", "20190306");
+        SortedSet<String> shards = buildShards(ignoredDays);
+        
+        ScannerStream s1 = buildFullScannerStream(shards, "A", "1");
+        ScannerStream s2 = buildFullScannerStream(shards, "B", "2");
+        ScannerStream s3 = buildFullScannerStream(shards, "C", "3");
+        Intersection intersection = new Intersection(Arrays.asList(s2, s3), new IndexInfo());
+        Union union = new Union(Arrays.asList(s2, s3));
+        
+        TreeMultimap<String,IndexStream> map = TreeMultimap.create(Ordering.natural(), new IndexStreamComparator());
+        map.put("s1", s1);
+        map.put("s1", s2);
+        map.put("s1", intersection);
+        map.put("s1", union);
+        
+        Iterator<IndexStream> iter = map.get("s1").iterator();
+        assertTrue(iter.next() instanceof ScannerStream);
+        assertTrue(iter.next() instanceof ScannerStream);
+        assertTrue(iter.next() instanceof Intersection);
+        assertTrue(iter.next() instanceof Union);
+        assertFalse(iter.hasNext());
+        
+        // -------------------------------------
+        map.clear();
+        map.put("s1", union);
+        map.put("s1", s1);
+        map.put("s1", intersection);
+        map.put("s1", s2);
+        
+        iter = map.get("s1").iterator();
+        assertTrue(iter.next() instanceof ScannerStream);
+        assertTrue(iter.next() instanceof ScannerStream);
+        assertTrue(iter.next() instanceof Intersection);
+        assertTrue(iter.next() instanceof Union);
+        assertFalse(iter.hasNext());
+        
+        // -------------------------------------
+        
+        map.clear();
+        map.put("s1", s1);
+        map.put("s1", intersection);
+        iter = map.get("s1").iterator();
+        assertTrue(iter.next() instanceof ScannerStream);
+        assertTrue(iter.next() instanceof Intersection);
+        
+        // -------------------------------------
+        
+        map.clear();
+        map.put("s1", s1);
+        map.put("s1", union);
+        iter = map.get("s1").iterator();
+        assertTrue(iter.next() instanceof ScannerStream);
+        assertTrue(iter.next() instanceof Union);
+        
+        // -------------------------------------
+        
+        map.clear();
+        map.put("s1", union);
+        map.put("s1", intersection);
+        iter = map.get("s1").iterator();
+        assertTrue(iter.next() instanceof Intersection);
+        assertTrue(iter.next() instanceof Union);
+        
     }
     
     private Intersection buildIntersectionOfShards() {

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IntersectionTest.java
@@ -226,7 +226,7 @@ public class IntersectionTest {
         JexlNode n1 = JexlNodeFactory.buildEQNode(field, value);
         ii1.applyNode(n1);
         Iterator<Tuple2<String,IndexInfo>> i1 = Arrays.asList(new Tuple2<>(shard, ii1)).iterator();
-        return ScannerStream.variable(i1, n1);
+        return ScannerStream.withData(i1, n1);
     }
     
     @Test
@@ -1066,6 +1066,6 @@ public class IntersectionTest {
             elements.add(new Tuple2<>(shard, info));
         }
         
-        return ScannerStream.variable(elements.iterator(), node);
+        return ScannerStream.withData(elements.iterator(), node);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -1,0 +1,180 @@
+package datawave.query.index.lookup;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.Type;
+import datawave.ingest.protobuf.Uid;
+import datawave.query.CloseableIterable;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.jexl.visitors.TreeEqualityVisitor;
+import datawave.query.planner.QueryPlan;
+import datawave.query.tables.ScannerFactory;
+import datawave.query.util.MockMetadataHelper;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static datawave.query.index.lookup.IndexStream.StreamContext.INITIALIZED;
+import static datawave.util.TableName.SHARD_INDEX;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test for asserting correct query plans coming off the RangeStream
+ * <p>
+ * Underlying index streams are assumed to have data based on the field
+ * 
+ * <pre>
+ *     FOO  - has data, doc range
+ *     FOO2 - has data, alternate doc range
+ *     FOO3 - has data, shard range
+ *     FOO4 - has no data
+ * </pre>
+ */
+public class RangeStreamQueryTest {
+    
+    private static InMemoryInstance instance = new InMemoryInstance(RangeStreamQueryTest.class.toString());
+    private static Connector connector;
+    private ShardQueryConfiguration config;
+    
+    @BeforeClass
+    public static void setupAccumulo() throws Exception {
+        connector = instance.getConnector("", new PasswordToken(new byte[0]));
+        connector.tableOperations().create(SHARD_INDEX);
+        
+        BatchWriter bw = connector.createBatchWriter(SHARD_INDEX, new BatchWriterConfig().setMaxLatency(10, TimeUnit.SECONDS).setMaxMemory(100000L)
+                        .setMaxWriteThreads(1));
+        
+        Value shardValue = buildShardRange();
+        Value docValue = buildDocRange("a.b.c");
+        Value docValue2 = buildDocRange("x.y.z");
+        
+        Text cq = new Text("20200101_7\0datatype");
+        
+        Mutation m = new Mutation("bar");
+        m.put(new Text("FOO"), cq, docValue);
+        m.put(new Text("FOO2"), cq, docValue2);
+        m.put(new Text("FOO3"), cq, shardValue);
+        bw.addMutation(m);
+        
+        m = new Mutation("baz");
+        m.put(new Text("FOO"), cq, docValue);
+        m.put(new Text("FOO2"), cq, docValue2);
+        m.put(new Text("FOO3"), cq, shardValue);
+        bw.addMutation(m);
+        
+        bw.flush();
+        bw.close();
+    }
+    
+    private static Value buildDocRange(String uid) {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.addUID(uid);
+        builder.setIGNORE(false);
+        builder.setCOUNT(1);
+        Uid.List list = builder.build();
+        return new Value(list.toByteArray());
+    }
+    
+    private static Value buildShardRange() {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.setIGNORE(true);
+        builder.setCOUNT(31);
+        Uid.List list = builder.build();
+        return new Value(list.toByteArray());
+    }
+    
+    @Before
+    public void setupTest() {
+        config = new ShardQueryConfiguration();
+        config.setConnector(connector);
+        config.setShardsPerDayThreshold(20);
+    }
+    
+    @Test
+    public void testSimpleQueries() throws Exception {
+        test("FOO == 'bar'");
+        test("FOO == 'baz'");
+        test("FOO2 == 'bar'");
+        test("FOO2 == 'baz'");
+        test("FOO3 == 'bar'");
+        test("FOO3 == 'baz'");
+    }
+    
+    @Test
+    public void testSimpleQueriesWithDelayedTerms() throws Exception {
+        test("FOO == 'bar' && !(FOO == null)");
+        test("FOO == 'bar' && FOO3 == 'baz' && !(FOO == null)");
+        test("(FOO == 'bar' || FOO3 == 'baz') && !(FOO == null)");
+        test("(FOO == 'bar' || FOO3 == 'baz') && FOO == 'bar' && !(FOO == null)");
+        test("(FOO == 'bar' || FOO3 == 'baz') && (FOO == 'bar' || FOO3 == 'bar') && !(FOO == null)");
+        
+        test("FOO == 'bar' && (!(FOO == null) || !(FOO == null))");
+        test("FOO == 'bar' && FOO3 == 'baz' && (!(FOO == null) || !(FOO == null))");
+        test("(FOO == 'bar' || FOO3 == 'baz') && (!(FOO == null) || !(FOO == null))");
+        test("(FOO == 'bar' || FOO3 == 'baz') && FOO == 'bar' && (!(FOO == null) || !(FOO == null))");
+        test("(FOO == 'bar' || FOO3 == 'baz') && (FOO == 'bar' || FOO3 == 'bar') && (!(FOO == null) || !(FOO == null))");
+    }
+    
+    @Test
+    public void testLargerQueriesWithDelayedTerms() throws Exception {
+        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && !(FOO == null)");
+        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && filter:includeRegex(FOO2, 'ba.*')");
+        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && (filter:includeRegex(FOO, 'ba.*') || filter:includeRegex(FOO2, 'ba.*'))");
+        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && (!(FOO == null) || !(FOO2 == null)) && (filter:includeRegex(FOO, 'ba.*') || filter:includeRegex(FOO2, 'ba.*'))");
+    }
+    
+    private void test(String query) throws Exception {
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        config.setBeginDate(sdf.parse("20200101"));
+        config.setEndDate(sdf.parse("20200102"));
+        
+        config.setDatatypeFilter(Collections.singleton("datatype"));
+        
+        Multimap<String,Type<?>> fieldToDataType = HashMultimap.create();
+        fieldToDataType.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+        fieldToDataType.putAll("FOO2", Sets.newHashSet(new LcNoDiacriticsType()));
+        fieldToDataType.putAll("FOO3", Sets.newHashSet(new LcNoDiacriticsType()));
+        
+        config.setQueryFieldsDatatypes(fieldToDataType);
+        config.setIndexedFields(fieldToDataType);
+        config.setShardsPerDayThreshold(2);
+        
+        MockMetadataHelper helper = new MockMetadataHelper();
+        helper.setIndexedFields(fieldToDataType.keySet());
+        
+        // Run a standard limited-scanner range stream.
+        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        rangeStream.setLimitScanners(true);
+        
+        CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
+        assertTrue(INITIALIZED.equals(rangeStream.context()) || (IndexStream.StreamContext.PRESENT.equals(rangeStream.context())));
+        
+        QueryPlan plan = queryPlans.iterator().next();
+        assertNotNull("expected a query plan, but was null for query: " + query, plan);
+        
+        ASTJexlScript planned = JexlNodeFactory.createScript(plan.getQueryTree());
+        ASTJexlScript expected = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        assertTrue(JexlStringBuildingVisitor.buildQueryWithoutParse(planned), TreeEqualityVisitor.isEqual(expected, planned));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -24,6 +24,7 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.hadoop.io.Text;
+import org.apache.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -56,6 +57,8 @@ import static org.junit.Assert.fail;
  */
 @Category(IntegrationTest.class)
 public class RangeStreamQueryTest {
+    
+    private static final Logger log = Logger.getLogger(RangeStreamQueryTest.class);
     
     private static InMemoryInstance instance = new InMemoryInstance(RangeStreamQueryTest.class.toString());
     private static Connector connector;
@@ -155,7 +158,7 @@ public class RangeStreamQueryTest {
     
     @AfterClass
     public static void afterClass() {
-        System.out.println("Queries run: " + count);
+        log.info("ran " + count + " queries");
     }
     
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -404,7 +404,7 @@ public class RangeStreamQueryTest {
         script = JexlASTHelper.parseAndFlattenJexlQuery(query);
         CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
         
-        // call to 'iterator()' may modify the stream context
+        // a stream context of VARIABLE will change to PRESENT for intersections and ABSENT for unions
         Iterator<QueryPlan> queryPlanIter = queryPlans.iterator();
         
         // check for a top level union and a delayed term. These queries are not executable

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.common.test.integration.IntegrationTest;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.Type;
 import datawave.ingest.protobuf.Uid;
@@ -24,36 +25,53 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.hadoop.io.Text;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-import static datawave.query.index.lookup.IndexStream.StreamContext.INITIALIZED;
 import static datawave.util.TableName.SHARD_INDEX;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration test for asserting correct query plans coming off the RangeStream
  * <p>
  * Underlying index streams are assumed to have data based on the field
- * 
- * <pre>
- *     FOO  - has data, doc range
- *     FOO2 - has data, alternate doc range
- *     FOO3 - has data, shard range
- *     FOO4 - has no data
- * </pre>
  */
+@Category(IntegrationTest.class)
 public class RangeStreamQueryTest {
     
     private static InMemoryInstance instance = new InMemoryInstance(RangeStreamQueryTest.class.toString());
     private static Connector connector;
     private ShardQueryConfiguration config;
+    
+    private MockMetadataHelper helper;
+    private Multimap<String,Type<?>> fieldToDataType;
+    
+    private ASTJexlScript script;
+    private RangeStream rangeStream;
+    private final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+    
+    private static int count = 0;
+    
+    // is the query a top level union or a top level intersection?
+    public enum QUERY_CONTEXT {
+        UNION, INTERSECTION
+    }
+    
+    // is the term added to the query an anchor term or is it delayed?
+    public enum TERM_CONTEXT {
+        ANCHOR, DELAYED
+    }
     
     @BeforeClass
     public static void setupAccumulo() throws Exception {
@@ -69,16 +87,22 @@ public class RangeStreamQueryTest {
         
         Text cq = new Text("20200101_7\0datatype");
         
-        Mutation m = new Mutation("bar");
-        m.put(new Text("FOO"), cq, docValue);
-        m.put(new Text("FOO2"), cq, docValue2);
+        Mutation m = new Mutation("shard");
+        m.put(new Text("FOO"), cq, shardValue);
+        m.put(new Text("FOO2"), cq, shardValue);
         m.put(new Text("FOO3"), cq, shardValue);
         bw.addMutation(m);
         
-        m = new Mutation("baz");
+        m = new Mutation("uid");
         m.put(new Text("FOO"), cq, docValue);
+        m.put(new Text("FOO2"), cq, docValue);
+        m.put(new Text("FOO3"), cq, docValue);
+        bw.addMutation(m);
+        
+        m = new Mutation("uid2");
+        m.put(new Text("FOO"), cq, docValue2);
         m.put(new Text("FOO2"), cq, docValue2);
-        m.put(new Text("FOO3"), cq, shardValue);
+        m.put(new Text("FOO3"), cq, docValue2);
         bw.addMutation(m);
         
         bw.flush();
@@ -103,78 +127,283 @@ public class RangeStreamQueryTest {
     }
     
     @Before
-    public void setupTest() {
-        config = new ShardQueryConfiguration();
-        config.setConnector(connector);
-        config.setShardsPerDayThreshold(20);
-    }
-    
-    @Test
-    public void testSimpleQueries() throws Exception {
-        test("FOO == 'bar'");
-        test("FOO == 'baz'");
-        test("FOO2 == 'bar'");
-        test("FOO2 == 'baz'");
-        test("FOO3 == 'bar'");
-        test("FOO3 == 'baz'");
-    }
-    
-    @Test
-    public void testSimpleQueriesWithDelayedTerms() throws Exception {
-        test("FOO == 'bar' && !(FOO == null)");
-        test("FOO == 'bar' && FOO3 == 'baz' && !(FOO == null)");
-        test("(FOO == 'bar' || FOO3 == 'baz') && !(FOO == null)");
-        test("(FOO == 'bar' || FOO3 == 'baz') && FOO == 'bar' && !(FOO == null)");
-        test("(FOO == 'bar' || FOO3 == 'baz') && (FOO == 'bar' || FOO3 == 'bar') && !(FOO == null)");
+    public void setupTest() throws ParseException {
+        helper = new MockMetadataHelper();
+        helper.setIndexedFields(Sets.newHashSet("FOO", "FOO2", "FOO3"));
         
-        test("FOO == 'bar' && (!(FOO == null) || !(FOO == null))");
-        test("FOO == 'bar' && FOO3 == 'baz' && (!(FOO == null) || !(FOO == null))");
-        test("(FOO == 'bar' || FOO3 == 'baz') && (!(FOO == null) || !(FOO == null))");
-        test("(FOO == 'bar' || FOO3 == 'baz') && FOO == 'bar' && (!(FOO == null) || !(FOO == null))");
-        test("(FOO == 'bar' || FOO3 == 'baz') && (FOO == 'bar' || FOO3 == 'bar') && (!(FOO == null) || !(FOO == null))");
-    }
-    
-    @Test
-    public void testLargerQueriesWithDelayedTerms() throws Exception {
-        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && !(FOO == null)");
-        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && filter:includeRegex(FOO2, 'ba.*')");
-        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && (filter:includeRegex(FOO, 'ba.*') || filter:includeRegex(FOO2, 'ba.*'))");
-        test("FOO == 'bar' && FOO3 == 'baz' && FOO3 == 'bar' && (!(FOO == null) || !(FOO2 == null)) && (filter:includeRegex(FOO, 'ba.*') || filter:includeRegex(FOO2, 'ba.*'))");
-    }
-    
-    private void test(String query) throws Exception {
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-        
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
-        config.setBeginDate(sdf.parse("20200101"));
-        config.setEndDate(sdf.parse("20200102"));
-        
-        config.setDatatypeFilter(Collections.singleton("datatype"));
-        
-        Multimap<String,Type<?>> fieldToDataType = HashMultimap.create();
+        fieldToDataType = HashMultimap.create();
         fieldToDataType.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
         fieldToDataType.putAll("FOO2", Sets.newHashSet(new LcNoDiacriticsType()));
         fieldToDataType.putAll("FOO3", Sets.newHashSet(new LcNoDiacriticsType()));
         
+        config = new ShardQueryConfiguration();
+        config.setConnector(connector);
+        config.setBeginDate(sdf.parse("20200101"));
+        config.setEndDate(sdf.parse("20200102"));
+        config.setDatatypeFilter(Collections.singleton("datatype"));
         config.setQueryFieldsDatatypes(fieldToDataType);
         config.setIndexedFields(fieldToDataType);
         config.setShardsPerDayThreshold(2);
+    }
+    
+    @AfterClass
+    public static void afterClass() {
+        System.out.println("Queries run: " + count);
+    }
+    
+    @Test
+    public void testSimpleQueries() throws Exception {
+        test("FOO3 == 'shard'");
+        test("FOO3 == 'uid'");
+    }
+    
+    @Test
+    public void testQueriesWithFilterIsNulls() throws Exception {
+        test("FOO == null", TERM_CONTEXT.DELAYED);
+        test("(FOO == null && FOO2 == null)", TERM_CONTEXT.DELAYED);
+        test("(FOO == null || FOO2 == null)", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithFilterIsNotNulls() throws Exception {
+        test("!(FOO == null)", TERM_CONTEXT.DELAYED);
+        test("(!(FOO == null) && !(FOO2 == null))", TERM_CONTEXT.DELAYED);
+        test("(!(FOO == null) || !(FOO2 == null))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithFilterIncludeRegex() throws Exception {
+        test("filter:includeRegex(FOO, 'ba.*')", TERM_CONTEXT.DELAYED);
+        test("(filter:includeRegex(FOO, 'ba.*') && filter:includeRegex(FOO2, 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(filter:includeRegex(FOO, 'ba.*') || filter:includeRegex(FOO2, 'ba.*'))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithFilterExcludeRegex() throws Exception {
+        test("filter:excludeRegex(FOO, 'ba.*')", TERM_CONTEXT.DELAYED);
+        test("(filter:excludeRegex(FOO, 'ba.*') && filter:excludeRegex(FOO2, 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(filter:excludeRegex(FOO, 'ba.*') || filter:excludeRegex(FOO2, 'ba.*'))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithExceededValueMarkers() throws Exception {
+        // the range stream creates a stream of day shards for these terms, thus they are treated as anchor terms
+        test("((_Value_ = true) && (FOO =~ 'ba.*'))");
+        test("(((_Value_ = true) && (FOO =~ 'ba.*')) && ((_Value_ = true) && (FOO2 =~ 'ba.*')))");
+        test("(((_Value_ = true) && (FOO =~ 'ba.*')) || ((_Value_ = true) && (FOO2 =~ 'ba.*')))");
+    }
+    
+    @Test
+    public void testQueriesWithExceededTermMarkers() throws Exception {
+        test("((_Term_ = true) && (FOO =~ 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(((_Term_ = true) && (FOO =~ 'ba.*')) && ((_Term_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+        test("(((_Term_ = true) && (FOO =~ 'ba.*')) || ((_Term_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithDelayedRegexNodes() throws Exception {
+        test("((_Delayed_ = true) && (FOO =~ 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(((_Delayed_ = true) && (FOO =~ 'ba.*')) && ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+        test("(((_Delayed_ = true) && (FOO =~ 'ba.*')) || ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithBoundedRangeMarkers() throws Exception {
+        test("((_Bounded_ = true) && (FOO > '3' && FOO < 7))", TERM_CONTEXT.DELAYED);
+        test("(((_Bounded_ = true) && (FOO > '3' && FOO < 7)) && ((_Bounded_ = true) && (FOO2 > '3' && FOO2 < 7)))", TERM_CONTEXT.DELAYED);
+        test("(((_Bounded_ = true) && (FOO > '3' && FOO < 7)) || ((_Bounded_ = true) && (FOO2 > '3' && FOO2 < 7)))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithMixedDelays() throws Exception {
+        test("(!(FOO == null) && filter:includeRegex(FOO, 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(!(FOO == null) && filter:includeRegex(FOO, 'ba.*') && ((_Delayed_ = true) && (FOO =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+        test("(!(FOO == null) || filter:includeRegex(FOO, 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(!(FOO == null) || filter:includeRegex(FOO, 'ba.*') || ((_Delayed_ = true) && (FOO =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithMixedMarkers() throws Exception {
+        test("(((_Value_ = true) && (FOO =~ 'ba.*')) && ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))");
+        test("(((_Value_ = true) && (FOO =~ 'ba.*')) || ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+    }
+    
+    @Test
+    public void testQueriesWithMixedMarkersAndAnchors() throws Exception {
+        // each intersection should pivot on the anchor term and add in the delayed markers
+        test("(FOO3 == 'shard' && !(FOO == null) && filter:includeRegex(FOO, 'ba.*'))");
+        test("(FOO3 == 'shard' && !(FOO == null) && filter:includeRegex(FOO, 'ba.*') && ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))");
+        test("(FOO3 == 'shard' && ((_Value_ = true) && (FOO =~ 'ba.*')) && ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))");
         
-        MockMetadataHelper helper = new MockMetadataHelper();
-        helper.setIndexedFields(fieldToDataType.keySet());
+        // each whole union should be added into queries with top level intersections
+        test("(FOO3 == 'shard' || !(FOO == null) || filter:includeRegex(FOO, 'ba.*'))", TERM_CONTEXT.DELAYED);
+        test("(FOO3 == 'shard' || !(FOO == null) || filter:includeRegex(FOO, 'ba.*') || ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+        test("(FOO3 == 'shard' || ((_Value_ = true) && (FOO =~ 'ba.*')) || ((_Delayed_ = true) && (FOO2 =~ 'ba.*')))", TERM_CONTEXT.DELAYED);
+    }
+    
+    // default term context to ANCHOR
+    private void test(String append) throws Exception {
+        test(append, TERM_CONTEXT.ANCHOR);
+    }
+    
+    private void test(String append, TERM_CONTEXT termContext) throws Exception {
+        testIntersections(append, termContext);
+        testUnions(append, termContext);
+    }
+    
+    private void testIntersections(String append, TERM_CONTEXT termContext) throws Exception {
+        String[] queries = {
+                // single terms
+                "FOO == 'shard'",
+                "FOO == 'uid'",
+                // two terms: shard-shard, shard-uid, uid-shard, uid-uid
+                "FOO == 'shard' && FOO2 == 'shard'",
+                "FOO == 'shard' && FOO2 == 'uid'",
+                "FOO == 'uid' && FOO2 == 'shard'",
+                "FOO == 'uid' && FOO2 == 'uid'",
+                // two terms, one side is a nested union
+                "FOO == 'shard' && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "FOO == 'shard' && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "FOO == 'shard' && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "FOO == 'shard' && (FOO2 == 'uid' || FOO3 == 'uid')",
+                "FOO == 'uid' && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "FOO == 'uid' && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "FOO == 'uid' && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "FOO == 'uid' && (FOO2 == 'uid' || FOO3 == 'uid')",
+                // three terms, one term is a nested union
+                "FOO == 'shard' && FOO2 == 'shard' && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "FOO == 'shard' && FOO2 == 'shard' && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "FOO == 'shard' && FOO2 == 'shard' && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "FOO == 'shard' && FOO2 == 'shard' && (FOO2 == 'uid' || FOO3 == 'uid')",
+                "FOO == 'uid' && FOO2 == 'uid' && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "FOO == 'uid' && FOO2 == 'uid' && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "FOO == 'uid' && FOO2 == 'uid' && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "FOO == 'uid' && FOO2 == 'uid' && (FOO2 == 'uid' || FOO3 == 'uid')",
+                // three terms, two terms are a nested union
+                "FOO == 'shard' && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "FOO == 'shard' && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "FOO == 'shard' && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "FOO == 'shard' && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'uid' || FOO3 == 'uid')",
+                "FOO == 'uid' && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "FOO == 'uid' && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "FOO == 'uid' && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "FOO == 'uid' && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'uid' || FOO3 == 'uid')",
+                // three terms, all terms nested unions
+                "(FOO == 'shard' || FOO3 == 'shard') && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "(FOO == 'shard' || FOO3 == 'shard') && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "(FOO == 'shard' || FOO3 == 'shard') && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "(FOO == 'shard' || FOO3 == 'shard') && (FOO == 'shard' || FOO2 == 'shard') && (FOO2 == 'uid' || FOO3 == 'uid')",
+                "(FOO == 'uid' || FOO3 == 'uid') && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'shard' || FOO3 == 'shard')",
+                "(FOO == 'uid' || FOO3 == 'uid') && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'shard' || FOO3 == 'uid')",
+                "(FOO == 'uid' || FOO3 == 'uid') && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'uid' || FOO3 == 'shard')",
+                "(FOO == 'uid' || FOO3 == 'uid') && (FOO == 'uid' || FOO2 == 'uid') && (FOO2 == 'uid' || FOO3 == 'uid')"};
+        
+        for (String query : queries) {
+            query += " && " + append;
+            test(query, query, QUERY_CONTEXT.INTERSECTION, termContext);
+        }
+    }
+    
+    private void testUnions(String append, TERM_CONTEXT termContext) throws Exception {
+        String[] queries = {
+                // single terms
+                "FOO == 'shard'",
+                "FOO == 'uid'",
+                // two terms: shard-shard, shard-uid, uid-shard, uid-uid
+                "FOO == 'shard' || FOO2 == 'shard'",
+                "FOO == 'shard' || FOO2 == 'uid'",
+                "FOO == 'uid' || FOO2 == 'shard'",
+                "FOO == 'uid' || FOO2 == 'uid'",
+                // two terms, one side is a nested intersection
+                "FOO == 'shard' || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "FOO == 'shard' || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "FOO == 'shard' || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "FOO == 'shard' || (FOO2 == 'uid' && FOO3 == 'uid')",
+                "FOO == 'uid' || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "FOO == 'uid' || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "FOO == 'uid' || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "FOO == 'uid' || (FOO2 == 'uid' && FOO3 == 'uid')",
+                // three terms, one term is a nested intersection
+                "FOO == 'shard' || FOO2 == 'shard' || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "FOO == 'shard' || FOO2 == 'shard' || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "FOO == 'shard' || FOO2 == 'shard' || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "FOO == 'shard' || FOO2 == 'shard' || (FOO2 == 'uid' && FOO3 == 'uid')",
+                "FOO == 'uid' || FOO2 == 'uid' || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "FOO == 'uid' || FOO2 == 'uid' || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "FOO == 'uid' || FOO2 == 'uid' || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "FOO == 'uid' || FOO2 == 'uid' || (FOO2 == 'uid' && FOO3 == 'uid')",
+                // three terms, two terms are a nested intersection
+                "FOO == 'shard' || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "FOO == 'shard' || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "FOO == 'shard' || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "FOO == 'shard' || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'uid' && FOO3 == 'uid')",
+                "FOO == 'uid' || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "FOO == 'uid' || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "FOO == 'uid' || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "FOO == 'uid' || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'uid' && FOO3 == 'uid')",
+                // three terms, all terms nested intersection
+                "(FOO == 'shard' && FOO3 == 'shard') || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "(FOO == 'shard' && FOO3 == 'shard') || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "(FOO == 'shard' && FOO3 == 'shard') || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "(FOO == 'shard' && FOO3 == 'shard') || (FOO == 'shard' && FOO2 == 'shard') || (FOO2 == 'uid' && FOO3 == 'uid')",
+                "(FOO == 'uid' && FOO3 == 'uid') || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'shard' && FOO3 == 'shard')",
+                "(FOO == 'uid' && FOO3 == 'uid') || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'shard' && FOO3 == 'uid')",
+                "(FOO == 'uid' && FOO3 == 'uid') || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'uid' && FOO3 == 'shard')",
+                "(FOO == 'uid' && FOO3 == 'uid') || (FOO == 'uid' && FOO2 == 'uid') || (FOO2 == 'uid' && FOO3 == 'uid')"};
+        
+        for (String query : queries) {
+            query += " || " + append;
+            test(query, query, QUERY_CONTEXT.UNION, termContext);
+        }
+    }
+    
+    private void test(String query, String expected, QUERY_CONTEXT queryContext, TERM_CONTEXT termContext) throws Exception {
         
         // Run a standard limited-scanner range stream.
-        RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
+        count++;
+        rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
         rangeStream.setLimitScanners(true);
         
+        script = JexlASTHelper.parseAndFlattenJexlQuery(query);
         CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
-        assertTrue(INITIALIZED.equals(rangeStream.context()) || (IndexStream.StreamContext.PRESENT.equals(rangeStream.context())));
         
-        QueryPlan plan = queryPlans.iterator().next();
+        // call to 'iterator()' will modify the stream context
+        Iterator<QueryPlan> queryPlanIter = queryPlans.iterator();
+        
+        switch (rangeStream.context()) {
+            case PRESENT:
+            case INITIALIZED:
+            case EXCEEDED_VALUE_THRESHOLD:
+                // these are good
+                break;
+            case UNINDEXED:
+            case EXCEEDED_TERM_THRESHOLD:
+                // top level unions with a delayed term cannot be executed. Capture that case here.
+                if (termContext.equals(TERM_CONTEXT.DELAYED) && queryContext.equals(QUERY_CONTEXT.UNION)) {
+                    queryPlans.close();
+                    rangeStream.close();
+                    return;
+                }
+                break;
+            default:
+                queryPlans.close();
+                rangeStream.close();
+                fail("RangeStream context was: " + rangeStream.context() + " for query: " + query);
+                return;
+        }
+        
+        assertTrue(query + " did not produce any query plans", queryPlanIter.hasNext());
+        
+        QueryPlan plan = queryPlanIter.next();
         assertNotNull("expected a query plan, but was null for query: " + query, plan);
         
-        ASTJexlScript planned = JexlNodeFactory.createScript(plan.getQueryTree());
-        ASTJexlScript expected = JexlASTHelper.parseAndFlattenJexlQuery(query);
-        assertTrue(JexlStringBuildingVisitor.buildQueryWithoutParse(planned), TreeEqualityVisitor.isEqual(expected, planned));
+        ASTJexlScript plannedScript = JexlNodeFactory.createScript(plan.getQueryTree());
+        ASTJexlScript expectedScript = JexlASTHelper.parseAndFlattenJexlQuery(expected);
+        if (!TreeEqualityVisitor.isEqual(expectedScript, plannedScript)) {
+            fail("Expected [" + JexlStringBuildingVisitor.buildQuery(expectedScript) + "] but got [" + JexlStringBuildingVisitor.buildQuery(plannedScript)
+                            + "]");
+        }
+        queryPlans.close();
+        rangeStream.close();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -409,7 +409,7 @@ public class RangeStreamQueryTest {
         
         // check for a top level union and a delayed term. These queries are not executable
         if (queryContext == QUERY_CONTEXT.UNION && (termContext.equals(DELAYED) || termContext.equals(DELAYED_UNION) || termContext.equals(DELAYED_INTERSECT))) {
-            assertFalse("top level union and delayed term should have produced no query plans, but got one", queryPlanIter.hasNext());
+            assertFalse("top level union and delayed term should have produced no query plans, but got one for query " + query, queryPlanIter.hasNext());
             queryPlans.close();
             rangeStream.close();
             return;

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
@@ -38,7 +38,13 @@ import org.junit.Test;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static datawave.common.test.utils.query.RangeFactoryForTests.makeTestRange;

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
@@ -1161,8 +1161,9 @@ public class RangeStreamTest {
         RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector()), helper).setLimitScanners(true);
         rangeStream.streamPlans(script);
         // streamPlans(script) to populate the StreamContext.
-        assertTrue(rangeStream.iterator().hasNext());
-        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
+        assertFalse(rangeStream.iterator().hasNext());
+        assertEquals(IndexStream.StreamContext.DELAYED_FIELD, rangeStream.context());
+        // a non-existent field in a top level union means we cannot run this query. Logic changes if this union is nested within an intersection
     }
     
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
@@ -1105,9 +1105,13 @@ public class RangeStreamTest {
         
         RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector()), helper).setLimitScanners(true);
         CloseableIterable<QueryPlan> queryPlans = rangeStream.streamPlans(script);
-        // streamPlans(script) to populate the StreamContext.
+        
+        assertEquals(IndexStream.StreamContext.VARIABLE, rangeStream.context());
+        Iterator<QueryPlan> iter = queryPlans.iterator();
         assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
-        for (QueryPlan queryPlan : queryPlans) {
+        
+        while (iter.hasNext()) {
+            QueryPlan queryPlan = iter.next();
             for (Range range : queryPlan.getRanges()) {
                 assertTrue("Tried to remove unexpected range " + range.toString() + " from expected ranges: " + expectedRanges.toString(),
                                 expectedRanges.remove(range));

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
@@ -1161,8 +1161,8 @@ public class RangeStreamTest {
         RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector()), helper).setLimitScanners(true);
         rangeStream.streamPlans(script);
         // streamPlans(script) to populate the StreamContext.
-        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
         assertTrue(rangeStream.iterator().hasNext());
+        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
     }
     
     @Test
@@ -1186,8 +1186,8 @@ public class RangeStreamTest {
         RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector()), helper).setLimitScanners(true);
         rangeStream.streamPlans(script);
         // streamPlans(script) to populate the StreamContext.
-        assertEquals(IndexStream.StreamContext.PRESENT, rangeStream.context());
         assertFalse(rangeStream.iterator().hasNext());
+        assertEquals(IndexStream.StreamContext.ABSENT, rangeStream.context());
     }
     
     @Test
@@ -1576,8 +1576,8 @@ public class RangeStreamTest {
         // Create expected ranges verbosely, so it is obvious which shards contribute to the results.
         Range range1 = makeTestRange("20190310_21", "datatype1\u0000a.b.c");
         // Fun story. It's hard to roll up to a day range when you seek most of the way through the day and don't have all the shards for the day.
-        // Range range2 = makeTestRange("20190315_51", "datatype1\u0000a.b.c");
-        Set<Range> expectedRanges = Sets.newHashSet(range1);
+        Range range2 = makeTestRange("20190315_51", "datatype1\u0000a.b.c");
+        Set<Range> expectedRanges = Sets.newHashSet(range1, range2);
         
         RangeStream rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
         rangeStream.setLimitScanners(true);

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTest.java
@@ -1162,7 +1162,7 @@ public class RangeStreamTest {
         rangeStream.streamPlans(script);
         // streamPlans(script) to populate the StreamContext.
         assertFalse(rangeStream.iterator().hasNext());
-        assertEquals(IndexStream.StreamContext.DELAYED_FIELD, rangeStream.context());
+        assertEquals(IndexStream.StreamContext.ABSENT, rangeStream.context());
         // a non-existent field in a top level union means we cannot run this query. Logic changes if this union is nested within an intersection
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
@@ -3134,6 +3134,8 @@ public class RangeStreamTestX {
         rangeStream = new RangeStream(config, new ScannerFactory(config.getConnector(), 1), helper);
         rangeStream.setLimitScanners(false);
         runTest(rangeStream, script, expectedRanges, expectedQueries);
+        
+        rangeStream.close();
     }
     
     private void runTest(RangeStream rangeStream, ASTJexlScript script, List<Range> expectedRanges, List<String> expectedQueries) throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
@@ -3203,6 +3203,25 @@ public class RangeStreamTestX {
     }
     
     @Test
+    public void testIntersectionOfNestedUnionsOnHasDelayedTerm_flipped() throws Exception {
+        String query = "(F3 == '3' || ((_Delayed_ = true) && (F4 == '4'))) && (F1 == '1' || F2 == '2')";
+        
+        List<Range> expectedRanges = new ArrayList<>();
+        expectedRanges.add(makeTestRange("20200101_10", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200101_11", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200101_12", "datatype1\0a.b.c"));
+        expectedRanges.add(makeTestRange("20200101_13", "datatype1\0a.b.c"));
+        
+        List<String> expectedQueries = new ArrayList<>();
+        expectedQueries.add("(F1 == '1' || F2 == '2') && (F3 == '3' || ((_Delayed_ = true) && (F4 == '4')))");
+        expectedQueries.add("F1 == '1' && (F3 == '3' || ((_Delayed_ = true) && (F4 == '4')))"); // F2 skips shard_11
+        expectedQueries.add("(F1 == '1' || F2 == '2') && ((_Delayed_ = true) && (F4 == '4'))"); // F3 skips shard _12
+        expectedQueries.add("(F1 == '1' || F2 == '2') && (F3 == '3' || ((_Delayed_ = true) && (F4 == '4')))");
+        
+        runTest(query, expectedRanges, expectedQueries);
+    }
+    
+    @Test
     public void testOrAndOr() throws Exception {
         String query = "F2 == '2' || (F1 == '1' && (F3 == '3' || F4 == '4'))";
         

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/UnionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/UnionTest.java
@@ -457,6 +457,6 @@ public class UnionTest {
             elements.add(new Tuple2<>(shard, info));
         }
         
-        return ScannerStream.variable(elements.iterator(), node);
+        return ScannerStream.withData(elements.iterator(), node);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NationalSecurityAgency/datawave/issues/1643

- queries should no longer duplicate subtrees when delayed terms exist
- document range query plans now have delayed terms propagated correctly
- fix rare case that would skip shards for queries like `A && (B or delayed(C))` by adding an `IndexStreamComparator` to ensure that VARIABLE children are advanced *after* a context has been found
- RangeStream correctly handles a top level union with a VARIALBE context
- Intersection and Union report more accurate stream contexts
- IndexStreams support nexting with context
- ConcurrentScannerInitializer builds index streams with correct context