### PR TITLE
fixes #1705: LimitFields performance

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -982,6 +982,8 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
         }
         
         if (!this.limitFieldsMap.isEmpty()) {
+            // note that we have already reduced the document to those attributes to keep. This will reduce the attributes further
+            // base on those fields we are limiting.
             if (gatherTimingDetails()) {
                 documents = Iterators.transform(documents,
                                 new EvaluationTrackingFunction<>(QuerySpan.Stage.LimitFields, trackingSpan, new LimitFields(this.getLimitFieldsMap())));

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -286,4 +286,36 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
     
+    @Test
+    public void testLimiting() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "false");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "CANINE=1,BIRD=1");
+        extraParameters.put("return.fields", "CANINE,BIRD");
+        
+        String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
+        
+        // CANINE is the hit, so that stays in. Only 1 bird is returned.
+        Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "CANINE:beagle");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+    @Test
+    public void testLimitingToZero() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "false");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "CANINE=0,BIRD=0");
+        extraParameters.put("return.fields", "CANINE,BIRD");
+        
+        String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
+        
+        // CANINE is the hit, so that stays in. Only 1 bird is returned.
+        Set<String> goodResults = Sets.newHashSet("CANINE:beagle");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
 }

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -281,7 +281,8 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "BIRD:canary", "CANINE:beagle");
+        Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "BIRD:canary", "CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd",
+                        "CANINE:bernese");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
@@ -292,12 +293,15 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         extraParameters.put("include.grouping.context", "false");
         extraParameters.put("hit.list", "true");
         extraParameters.put("limit.fields", "CANINE=1,BIRD=1");
-        extraParameters.put("return.fields", "CANINE,BIRD");
+        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        // CANINE is the hit, so that stays in. Only 1 bird is returned.
-        Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "CANINE:beagle");
+        // Only CANINE hits, 1 bird, and all fish and cats
+        Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd", "CANINE:bernese",
+                        "FISH:tuna", "CAT:tabby", "CAT:tom", "FISH:swordtail", "FISH:angelfish", "CAT:siamese", "FISH:goldfish", "CAT:himalayan",
+                        "CAT:leopard", "CAT:cougar", "CAT:calico", "CAT:tiger", "FISH:tetra", "FISH:mackerel", "FISH:shark", "CAT:puma", "CAT:ragdoll",
+                        "FISH:beta", "FISH:guppy", "FISH:salmon");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
@@ -308,14 +312,58 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         extraParameters.put("include.grouping.context", "false");
         extraParameters.put("hit.list", "true");
         extraParameters.put("limit.fields", "CANINE=0,BIRD=0");
-        extraParameters.put("return.fields", "CANINE,BIRD");
+        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        // CANINE is the hit, so that stays in. Only 1 bird is returned.
-        Set<String> goodResults = Sets.newHashSet("CANINE:beagle");
+        // Only CANINE hits, 0 birds, and all fish and cats
+        Set<String> goodResults = Sets.newHashSet("CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd", "CANINE:bernese", "FISH:tuna",
+                        "CAT:tabby", "CAT:tom", "FISH:swordtail", "FISH:angelfish", "CAT:siamese", "FISH:goldfish", "CAT:himalayan", "CAT:leopard",
+                        "CAT:cougar", "CAT:calico", "CAT:tiger", "FISH:tetra", "FISH:mackerel", "FISH:shark", "CAT:puma", "CAT:ragdoll", "FISH:beta",
+                        "FISH:guppy", "FISH:salmon");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
     
+    @Test
+    public void testLimitingWithGrouping() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "CANINE=1,BIRD=1");
+        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
+        
+        String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
+        
+        // CANINE hits along with the associated birds, all fish and cats
+        Set<String> goodResults = Sets.newHashSet("CANINE.PET.0:beagle", "BIRD.PET.0:parakeet", "CANINE.PET.1:basset", "BIRD.PET.1:canary",
+                        "CANINE.PET.12:bernese", "BIRD.PET.12:cockatiel", "CANINE.PET.13:shepherd", "BIRD.PET.13:lovebird", "CANINE.WILD.1:coyote",
+                        "BIRD.WILD.1:hawk", "FISH.PET.12:swordtail", "CAT.PET.13:ragdoll", "FISH.WILD.0:shark", "CAT.PET.1:calico", "FISH.PET.0:beta",
+                        "CAT.WILD.1:tiger", "FISH.PET.2:angelfish", "CAT.PET.0:tabby", "FISH.WILD.2:mackerel", "FISH.PET.13:tetra", "FISH.PET.1:goldfish",
+                        "FISH.PET.3:guppy", "CAT.PET.12:himalayan", "FISH.WILD.1:tuna", "FISH.WILD.3:salmon", "CAT.WILD.3:puma", "CAT.WILD.2:leopard",
+                        "CAT.PET.3:siamese", "CAT.WILD.0:cougar", "CAT.PET.2:tom");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
+    
+    @Test
+    public void testLimitingToZeroWithGrouping() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        extraParameters.put("limit.fields", "CANINE=0,BIRD=0");
+        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
+        
+        String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
+        
+        // CANINE hits along with the associated birds, all fish and cats
+        Set<String> goodResults = Sets.newHashSet("CANINE.PET.0:beagle", "BIRD.PET.0:parakeet", "CANINE.PET.1:basset", "BIRD.PET.1:canary",
+                        "CANINE.PET.12:bernese", "BIRD.PET.12:cockatiel", "CANINE.PET.13:shepherd", "BIRD.PET.13:lovebird", "CANINE.WILD.1:coyote",
+                        "BIRD.WILD.1:hawk", "FISH.PET.12:swordtail", "CAT.PET.13:ragdoll", "FISH.WILD.0:shark", "CAT.PET.1:calico", "FISH.PET.0:beta",
+                        "CAT.WILD.1:tiger", "FISH.PET.2:angelfish", "CAT.PET.0:tabby", "FISH.WILD.2:mackerel", "FISH.PET.13:tetra", "FISH.PET.1:goldfish",
+                        "FISH.PET.3:guppy", "CAT.PET.12:himalayan", "FISH.WILD.1:tuna", "FISH.WILD.3:salmon", "CAT.WILD.3:puma", "CAT.WILD.2:leopard",
+                        "CAT.PET.3:siamese", "CAT.WILD.0:cougar", "CAT.PET.2:tom");
+        
+        runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
+    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -298,7 +298,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        // Only CANINE hits, 1 bird, and all fish and cats
+        // Only CANINE hits, 1 bird, and all fish, cats, dog, and reptile
         Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd", "CANINE:bernese",
                         "FISH:tuna", "CAT:tabby", "CAT:tom", "FISH:swordtail", "FISH:angelfish", "CAT:siamese", "FISH:goldfish", "CAT:himalayan",
                         "CAT:leopard", "CAT:cougar", "CAT:calico", "CAT:tiger", "FISH:tetra", "FISH:mackerel", "FISH:shark", "CAT:puma", "CAT:ragdoll",
@@ -316,7 +316,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        // Only CANINE hits, 0 birds, and all fish and cats
+        // Only CANINE hits, 0 birds, and all fish and cats and reptile. The dog was not a hit.
         Set<String> goodResults = Sets.newHashSet("CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd", "CANINE:bernese", "FISH:tuna",
                         "CAT:tabby", "CAT:tom", "FISH:swordtail", "FISH:angelfish", "CAT:siamese", "FISH:goldfish", "CAT:himalayan", "CAT:leopard",
                         "CAT:cougar", "CAT:calico", "CAT:tiger", "FISH:tetra", "FISH:mackerel", "FISH:shark", "CAT:puma", "CAT:ragdoll", "FISH:beta",
@@ -334,7 +334,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        // CANINE hits along with the associated birds, all fish and cats
+        // CANINE hits along with the associated birds, all fish and cats and related dog and reptile
         Set<String> goodResults = Sets.newHashSet("CANINE.PET.0:beagle", "BIRD.PET.0:parakeet", "CANINE.PET.1:basset", "BIRD.PET.1:canary",
                         "CANINE.PET.12:bernese", "BIRD.PET.12:cockatiel", "CANINE.PET.13:shepherd", "BIRD.PET.13:lovebird", "CANINE.WILD.1:coyote",
                         "BIRD.WILD.1:hawk", "FISH.PET.12:swordtail", "CAT.PET.13:ragdoll", "FISH.WILD.0:shark", "CAT.PET.1:calico", "FISH.PET.0:beta",
@@ -354,7 +354,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
-        // CANINE hits along with the associated birds, all fish and cats
+        // CANINE hits along with the associated birds, all fish and cats and related dog and reptile
         Set<String> goodResults = Sets.newHashSet("CANINE.PET.0:beagle", "BIRD.PET.0:parakeet", "CANINE.PET.1:basset", "BIRD.PET.1:canary",
                         "CANINE.PET.12:bernese", "BIRD.PET.12:cockatiel", "CANINE.PET.13:shepherd", "BIRD.PET.13:lovebird", "CANINE.WILD.1:coyote",
                         "BIRD.WILD.1:hawk", "FISH.PET.12:swordtail", "CAT.PET.13:ragdoll", "FISH.WILD.0:shark", "CAT.PET.1:calico", "FISH.PET.0:beta",

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -228,7 +228,8 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         String queryString = "CANINE == 'shepherd'";
         
         // definitely should NOT include group 3
-        Set<String> goodResults = Sets.newHashSet("CANINE.PET.13:shepherd", "CAT.PET.13:ragdoll", "FISH.PET.13:tetra", "BIRD.PET.13:lovebird");
+        Set<String> goodResults = Sets.newHashSet("CANINE.PET.13:shepherd", "CAT.PET.13:ragdoll", "FISH.PET.13:tetra", "BIRD.PET.13:lovebird",
+                        "REPTILE.PET.1:snake", "DOG.WILD.1:coyote");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
@@ -248,7 +249,8 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
                 "CANINE.PET.1:basset", "CAT.PET.1:calico", "BIRD.PET.1:canary", "FISH.PET.1:goldfish",
                 "CANINE.PET.12:bernese", "CAT.PET.12:himalayan", "BIRD.PET.12:cockatiel", "FISH.PET.12:swordtail",
                 "CANINE.PET.13:shepherd", "CAT.PET.13:ragdoll", "BIRD.PET.13:lovebird", "FISH.PET.13:tetra",
-                "CANINE.WILD.1:coyote", "CAT.WILD.1:tiger", "BIRD.WILD.1:hawk", "FISH.WILD.1:tuna");
+                "CANINE.WILD.1:coyote", "CAT.WILD.1:tiger", "BIRD.WILD.1:hawk", "FISH.WILD.1:tuna",
+                "REPTILE.PET.1:snake", "DOG.WILD.1:coyote");
 
         //@formatter:on
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
@@ -292,8 +294,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "false");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "CANINE=1,BIRD=1");
-        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
+        extraParameters.put("limit.fields", "CANINE=1,BIRD=1,DOG=1");
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
@@ -301,7 +302,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Set<String> goodResults = Sets.newHashSet("BIRD:parakeet", "CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd", "CANINE:bernese",
                         "FISH:tuna", "CAT:tabby", "CAT:tom", "FISH:swordtail", "FISH:angelfish", "CAT:siamese", "FISH:goldfish", "CAT:himalayan",
                         "CAT:leopard", "CAT:cougar", "CAT:calico", "CAT:tiger", "FISH:tetra", "FISH:mackerel", "FISH:shark", "CAT:puma", "CAT:ragdoll",
-                        "FISH:beta", "FISH:guppy", "FISH:salmon");
+                        "FISH:beta", "FISH:guppy", "FISH:salmon", "REPTILE:snake", "DOG:coyote");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
@@ -311,8 +312,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "false");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "CANINE=0,BIRD=0");
-        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
+        extraParameters.put("limit.fields", "CANINE=0,BIRD=0,DOG=0");
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
@@ -320,7 +320,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Set<String> goodResults = Sets.newHashSet("CANINE:beagle", "CANINE:coyote", "CANINE:basset", "CANINE:shepherd", "CANINE:bernese", "FISH:tuna",
                         "CAT:tabby", "CAT:tom", "FISH:swordtail", "FISH:angelfish", "CAT:siamese", "FISH:goldfish", "CAT:himalayan", "CAT:leopard",
                         "CAT:cougar", "CAT:calico", "CAT:tiger", "FISH:tetra", "FISH:mackerel", "FISH:shark", "CAT:puma", "CAT:ragdoll", "FISH:beta",
-                        "FISH:guppy", "FISH:salmon");
+                        "FISH:guppy", "FISH:salmon", "REPTILE:snake");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
@@ -330,8 +330,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "CANINE=1,BIRD=1");
-        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
+        extraParameters.put("limit.fields", "CANINE=1,BIRD=1,DOG=1");
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
@@ -341,7 +340,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
                         "BIRD.WILD.1:hawk", "FISH.PET.12:swordtail", "CAT.PET.13:ragdoll", "FISH.WILD.0:shark", "CAT.PET.1:calico", "FISH.PET.0:beta",
                         "CAT.WILD.1:tiger", "FISH.PET.2:angelfish", "CAT.PET.0:tabby", "FISH.WILD.2:mackerel", "FISH.PET.13:tetra", "FISH.PET.1:goldfish",
                         "FISH.PET.3:guppy", "CAT.PET.12:himalayan", "FISH.WILD.1:tuna", "FISH.WILD.3:salmon", "CAT.WILD.3:puma", "CAT.WILD.2:leopard",
-                        "CAT.PET.3:siamese", "CAT.WILD.0:cougar", "CAT.PET.2:tom");
+                        "CAT.PET.3:siamese", "CAT.WILD.0:cougar", "CAT.PET.2:tom", "REPTILE.PET.1:snake", "DOG.WILD.1:coyote");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }
@@ -351,8 +350,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
-        extraParameters.put("limit.fields", "CANINE=0,BIRD=0");
-        extraParameters.put("return.fields", "CANINE,BIRD,FISH,CAT");
+        extraParameters.put("limit.fields", "CANINE=0,BIRD=0,DOG=0");
         
         String queryString = "filter:getAllMatches(CANINE,'.*e.*')";
         
@@ -362,7 +360,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
                         "BIRD.WILD.1:hawk", "FISH.PET.12:swordtail", "CAT.PET.13:ragdoll", "FISH.WILD.0:shark", "CAT.PET.1:calico", "FISH.PET.0:beta",
                         "CAT.WILD.1:tiger", "FISH.PET.2:angelfish", "CAT.PET.0:tabby", "FISH.WILD.2:mackerel", "FISH.PET.13:tetra", "FISH.PET.1:goldfish",
                         "FISH.PET.3:guppy", "CAT.PET.12:himalayan", "FISH.WILD.1:tuna", "FISH.WILD.3:salmon", "CAT.WILD.3:puma", "CAT.WILD.2:leopard",
-                        "CAT.PET.3:siamese", "CAT.WILD.0:cougar", "CAT.PET.2:tom");
+                        "CAT.PET.3:siamese", "CAT.WILD.0:cougar", "CAT.PET.2:tom", "REPTILE.PET.1:snake", "DOG.WILD.1:coyote");
         
         runTestQuery(queryString, format.parse("20091231"), format.parse("20150101"), extraParameters, goodResults);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/util/CommonalityTokenTestDataIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/CommonalityTokenTestDataIngest.java
@@ -105,6 +105,10 @@ public class CommonalityTokenTestDataIngest {
             mutation.put(datatype + "\u0000" + myUID, "FISH.WILD.3" + "\u0000" + "salmon", columnVisibility, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + myUID, "BIRD.WILD.3" + "\u0000" + "buzzard", columnVisibility, timeStamp, emptyValue);
             
+            // need some single attribute instances as well
+            mutation.put(datatype + "\u0000" + myUID, "DOG.WILD.1" + "\u0000" + "coyote", columnVisibility, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + myUID, "REPTILE.PET.1" + "\u0000" + "snake", columnVisibility, timeStamp, emptyValue);
+            
             bw.addMutation(mutation);
             
         } finally {


### PR DESCRIPTION
* Updated to avoid collecting all misses for any limited field
* Updated to use the toKeep mechanism instead of a collection of removals