### PR TITLE
Add multi-fielded versions of the isNull and isNotNull functions to m…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -1,6 +1,7 @@
 package datawave.query.jexl.functions;
 
 import com.google.common.base.CharMatcher;
+import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.ValueTuple;
@@ -145,6 +146,29 @@ public class EvaluationPhaseFilterFunctions {
                 return FunctionalSet.singleton(getHitTerm(fieldValue));
             }
         }
+
+        return FunctionalSet.emptySet();
+    }
+
+    /**
+     * Returns a {@link FunctionalSet} of hit terms found for {@code fieldValue1}. If {@code fieldValue1} is a singular value tuple, a singleton
+     * {@link FunctionalSet} with the hit term from it will be returned. If {@code fieldValue1} and {@code fieldValue2} are non-empty collections of value tuples, a
+     * {@link FunctionalSet} containing the hit terms from each value in the {@code fieldValue1} collection will be returned. Otherwise, an empty {@link FunctionalSet} will be
+     * returned.
+     *
+     * @param fieldValue1
+     *            1st field value to evaluate.
+     * @param fieldValue2
+     *            2nd field value to evaluate.
+     * @return the {@link FunctionalSet} of hit terms found
+     */
+    public static FunctionalSet<ValueTuple> isNotNull(Object fieldValue1, Object fieldValue2){
+        FunctionalSet<ValueTuple> matches = isNotNull(fieldValue1);
+
+        if (matches != FunctionalSet.EMPTY_SET && !((FunctionalSet)isNotNull(fieldValue2)).isEmpty()) {
+            return matches;
+        }
+
         return FunctionalSet.emptySet();
     }
     
@@ -158,7 +182,26 @@ public class EvaluationPhaseFilterFunctions {
     public static boolean isNull(Object fieldValue) {
         return fieldValue instanceof Collection ? ((Collection<?>) fieldValue).isEmpty() : fieldValue == null;
     }
-    
+
+    /**
+     * Returns whether {@code fieldValue1} or {@code fieldValue2} is considered an equivalently null field value.
+     *
+     * @param fieldValue1
+     *            the 1st fieldValue
+     * @param fieldValue2
+     *            the 2nd fieldValue
+     * @return true if {@code fieldValue1} or {@code fieldValue2} is a null {@link Object} or an empty {@link Collection}, or false otherwise
+     */
+    public static boolean isNull(Object fieldValue1, Object fieldValue2) {
+        if (isNull(fieldValue1)){
+            return true;
+        } else if(isNull(fieldValue2)){
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * Return whether no match was found for the given regex against the value of the field value. If the regex string contains case-insensitive flags, e.g.
      * {@code (?i).*(?-i)}, a search for a match will also be done against the normalized value of the field value.

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -146,15 +146,15 @@ public class EvaluationPhaseFilterFunctions {
                 return FunctionalSet.singleton(getHitTerm(fieldValue));
             }
         }
-
+        
         return FunctionalSet.emptySet();
     }
-
+    
     /**
      * Returns a {@link FunctionalSet} of hit terms found for {@code fieldValue1}. If {@code fieldValue1} is a singular value tuple, a singleton
-     * {@link FunctionalSet} with the hit term from it will be returned. If {@code fieldValue1} and {@code fieldValue2} are non-empty collections of value tuples, a
-     * {@link FunctionalSet} containing the hit terms from each value in the {@code fieldValue1} collection will be returned. Otherwise, an empty {@link FunctionalSet} will be
-     * returned.
+     * {@link FunctionalSet} with the hit term from it will be returned. If {@code fieldValue1} and {@code fieldValue2} are non-empty collections of value
+     * tuples, a {@link FunctionalSet} containing the hit terms from each value in the {@code fieldValue1} collection will be returned. Otherwise, an empty
+     * {@link FunctionalSet} will be returned.
      *
      * @param fieldValue1
      *            1st field value to evaluate.
@@ -162,13 +162,13 @@ public class EvaluationPhaseFilterFunctions {
      *            2nd field value to evaluate.
      * @return the {@link FunctionalSet} of hit terms found
      */
-    public static FunctionalSet<ValueTuple> isNotNull(Object fieldValue1, Object fieldValue2){
+    public static FunctionalSet<ValueTuple> isNotNull(Object fieldValue1, Object fieldValue2) {
         FunctionalSet<ValueTuple> matches = isNotNull(fieldValue1);
-
-        if (matches != FunctionalSet.EMPTY_SET && !((FunctionalSet)isNotNull(fieldValue2)).isEmpty()) {
+        
+        if (matches != FunctionalSet.EMPTY_SET && !((FunctionalSet) isNotNull(fieldValue2)).isEmpty()) {
             return matches;
         }
-
+        
         return FunctionalSet.emptySet();
     }
     
@@ -182,7 +182,7 @@ public class EvaluationPhaseFilterFunctions {
     public static boolean isNull(Object fieldValue) {
         return fieldValue instanceof Collection ? ((Collection<?>) fieldValue).isEmpty() : fieldValue == null;
     }
-
+    
     /**
      * Returns whether {@code fieldValue1} or {@code fieldValue2} is considered an equivalently null field value.
      *
@@ -193,15 +193,15 @@ public class EvaluationPhaseFilterFunctions {
      * @return true if {@code fieldValue1} or {@code fieldValue2} is a null {@link Object} or an empty {@link Collection}, or false otherwise
      */
     public static boolean isNull(Object fieldValue1, Object fieldValue2) {
-        if (isNull(fieldValue1)){
+        if (isNull(fieldValue1)) {
             return true;
-        } else if(isNull(fieldValue2)){
+        } else if (isNull(fieldValue2)) {
             return true;
         }
-
+        
         return false;
     }
-
+    
     /**
      * Return whether no match was found for the given regex against the value of the field value. If the regex string contains case-insensitive flags, e.g.
      * {@code (?i).*(?-i)}, a search for a match will also be done against the normalized value of the field value.

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -1,7 +1,6 @@
 package datawave.query.jexl.functions;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Function;
 import com.google.common.collect.Sets;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.ValueTuple;
@@ -151,25 +150,26 @@ public class EvaluationPhaseFilterFunctions {
     }
     
     /**
-     * Returns a {@link FunctionalSet} of hit terms found for {@code fieldValue1}. If {@code fieldValue1} is a singular value tuple, a singleton
-     * {@link FunctionalSet} with the hit term from it will be returned. If {@code fieldValue1} and {@code fieldValue2} are non-empty collections of value
-     * tuples, a {@link FunctionalSet} containing the hit terms from each value in the {@code fieldValue1} collection will be returned. Otherwise, an empty
-     * {@link FunctionalSet} will be returned.
+     * Behaves similarly to isNotNull(Object) except with multiple parameters. When evaluating multiple parameters, every parameter must meet the criteria or an
+     * emptySet will be returned. Returns List of {@link FunctionalSet} hit terms found foreach object in {@code iterable} collection. If {@code iterable} is
+     * non-empty collection of value tuples, a List of {@link FunctionalSet} containing the hit terms from each value in {@code iterable} collection will be
+     * returned.
      *
-     * @param fieldValue1
-     *            1st field value to evaluate.
-     * @param fieldValue2
-     *            2nd field value to evaluate.
-     * @return the {@link FunctionalSet} of hit terms found
+     * @param iterable
+     *            Collection of objects to iterate and utilize to populate return list of FunctionalSet objects.
+     * @return List of {@link FunctionalSet} of hit terms found.
      */
-    public static FunctionalSet<ValueTuple> isNotNull(Object fieldValue1, Object fieldValue2) {
-        FunctionalSet<ValueTuple> matches = isNotNull(fieldValue1);
-        
-        if (matches != FunctionalSet.EMPTY_SET && !((FunctionalSet) isNotNull(fieldValue2)).isEmpty()) {
-            return matches;
+    public static List<FunctionalSet<ValueTuple>> isNotNull(Iterable<?> iterable) {
+        List<FunctionalSet<ValueTuple>> resultSet = new ArrayList<>();
+        if (iterable != null) {
+            for (Object o : iterable) {
+                resultSet.add(isNotNull(o));
+            }
+        } else {
+            resultSet.add(FunctionalSet.emptySet());
         }
         
-        return FunctionalSet.emptySet();
+        return resultSet;
     }
     
     /**
@@ -184,22 +184,27 @@ public class EvaluationPhaseFilterFunctions {
     }
     
     /**
-     * Returns whether {@code fieldValue1} or {@code fieldValue2} is considered an equivalently null field value.
+     * Returns whether {@code iterable} is considered an equivalently null field value.
      *
-     * @param fieldValue1
-     *            the 1st fieldValue
-     * @param fieldValue2
-     *            the 2nd fieldValue
-     * @return true if {@code fieldValue1} or {@code fieldValue2} is a null {@link Object} or an empty {@link Collection}, or false otherwise
+     * @param iterable
+     *            a iterable collection of objects.
+     * @return true if {@code iterable} contains a null {@link Object} or an empty {@link Collection}, or false otherwise.
      */
-    public static boolean isNull(Object fieldValue1, Object fieldValue2) {
-        if (isNull(fieldValue1)) {
-            return true;
-        } else if (isNull(fieldValue2)) {
-            return true;
+    public static boolean isNull(Iterable<?> iterable) {
+        boolean rslt = false;
+        
+        if (iterable == null) {
+            rslt = true;
+        } else {
+            for (Object o : iterable) {
+                rslt = isNull(o) || String.valueOf(o).isEmpty();
+                
+                if (rslt)
+                    break;
+            }
         }
         
-        return false;
+        return rslt;
     }
     
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/DatawaveInterpreterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/DatawaveInterpreterTest.java
@@ -5,6 +5,7 @@ import datawave.data.type.LcNoDiacriticsType;
 import datawave.query.attributes.TypeAttribute;
 import datawave.query.attributes.ValueTuple;
 import datawave.query.collections.FunctionalSet;
+import datawave.query.jexl.functions.EvaluationPhaseFilterFunctions;
 import org.apache.accumulo.core.data.Key;
 import org.apache.commons.jexl2.DatawaveJexlScript;
 import org.apache.commons.jexl2.ExpressionImpl;
@@ -14,7 +15,6 @@ import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.jexl2.Script;
 import org.apache.commons.jexl2.parser.ASTStringLiteral;
 import org.easymock.EasyMock;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -285,7 +285,6 @@ public class DatawaveInterpreterTest {
         test(query, buildBoundedRangeContext(), false);
     }
     
-    // test filter:isNull
     @Test
     public void testFilterFunctionIsNull() {
         // single field, present
@@ -297,32 +296,27 @@ public class DatawaveInterpreterTest {
         test(query, buildDefaultContext(), true);
     }
     
-    @Ignore
     @Test
     public void testFilterFunctionMultiFieldedIsNull() {
         // Once #1604 is complete these tests will evaluate correctly
         
         // multi field, all present
-        String query = "FOO == 'bar' && filter:isNull(FOO || FOO)";
+        String query = "FOO == 'bar' && (filter:isNull(FOO) || filter:isNull(FOO))";
         test(query, buildDefaultContext(), false);
         
         // multi field, (present || absent)
-        query = "FOO == 'bar' && filter:isNull(FOO || FOO)";
-        test(query, buildDefaultContext(), true);
-        
-        query = "FOO == 'bar' && filter:isNull(FOO || ABSENT)";
+        query = "FOO == 'bar' && (filter:isNull(FOO) || filter:isNull(ABSENT))";
         test(query, buildDefaultContext(), true);
         
         // multi field, (absent || present)
-        query = "FOO == 'bar' && filter:isNull(ABSENT || FOO)";
+        query = "FOO == 'bar' && (filter:isNull(ABSENT) || filter:isNull(FOO))";
         test(query, buildDefaultContext(), true);
         
         // multi field, all absent
-        query = "FOO == 'bar' && filter:isNull(ABSENT || ABSENT)";
+        query = "FOO == 'bar' && (filter:isNull(ABSENT) || filter:isNull(ABSENT))";
         test(query, buildDefaultContext(), true);
     }
     
-    // test filter:isNotNull and not(filter:isNull)
     @Test
     public void testFilterFunctionIsNotNull() {
         // single field, present
@@ -340,40 +334,39 @@ public class DatawaveInterpreterTest {
         test(query, buildDefaultContext(), false);
     }
     
-    @Ignore
     @Test
     public void testFilterFunctionsMultiFieldedIsNotNull() {
         // Once #1604 is complete these tests will evaluate correctly
         
         // multi field, all present
-        String query = "FOO == 'bar' && filter:isNotNull(FOO || FOO)";
+        String query = "FOO == 'bar' && (filter:isNotNull(FOO) || filter:isNotNull(FOO))";
         test(query, buildDefaultContext(), true);
         
-        query = "FOO == 'bar' && !(filter:isNull(FOO || FOO))";
+        query = "FOO == 'bar' && !(filter:isNull(FOO) || filter:isNull(FOO))";
         test(query, buildDefaultContext(), true);
         
         // multi field, (present || absent)
-        query = "FOO == 'bar' && filter:isNotNull(FOO || ABSENT)";
+        query = "FOO == 'bar' && (filter:isNotNull(FOO) || filter:IsNotNull(ABSENT))";
         test(query, buildDefaultContext(), true);
         
-        query = "FOO == 'bar' && !(filter:isNull(FOO || ABSENT))";
+        query = "FOO == 'bar' && (filter:isNull(FOO) || filter:isNull(ABSENT))";
         test(query, buildDefaultContext(), true);
         
         query = "FOO == 'bar' && ( !(filter:isNull(FOO)) || !(filter:isNull(ABSENT)) )";
         test(query, buildDefaultContext(), true);
         
         // multi field, (absent || present)
-        query = "FOO == 'bar' && filter:isNotNull(ABSENT || FOO)";
-        test(query, buildDefaultContext(), false); // this is wrong. isNotNull expands into an AND so both values must be null.
-        
-        query = "FOO == 'bar' && !(filter:isNull(ABSENT || FOO))";
-        test(query, buildDefaultContext(), false); // this is wrong. isNotNull expands into an AND so both values must be null.
-        
-        // multi field, all absent
-        query = "FOO == 'bar' && filter:isNotNull(ABSENT || ABSENT)";
+        query = "FOO == 'bar' && (filter:isNotNull(ABSENT) || filter:isNotNull(FOO))";
         test(query, buildDefaultContext(), false);
         
-        query = "FOO == 'bar' && !(filter:isNull(ABSENT || ABSENT))";
+        query = "FOO == 'bar' && !(filter:isNull(ABSENT) || filter:isNull(FOO))";
+        test(query, buildDefaultContext(), false);
+        
+        // multi field, all absent
+        query = "FOO == 'bar' && (filter:isNotNull(ABSENT) || filter:isNotNull(ABSENT))";
+        test(query, buildDefaultContext(), false);
+        
+        query = "FOO == 'bar' && !(filter:isNull(ABSENT) || filter:isNotNull(ABSENT))";
         test(query, buildDefaultContext(), false);
     }
     
@@ -439,6 +432,10 @@ public class DatawaveInterpreterTest {
      */
     protected JexlContext buildDefaultContext() {
         //  @formatter:off
+
+        //The following property must be reset for proper testing of EvaluationPhaseFilterFunctions.isNotNull() logic.
+        EvaluationPhaseFilterFunctions.setMultiSetIsNotNullEmptySetFound(false);
+
         DatawaveJexlContext context = new DatawaveJexlContext();
 
         //  standard field value pair

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsTest.java
@@ -476,29 +476,57 @@ public class EvaluationPhaseFilterFunctionsTest {
      * Tests for {@link EvaluationPhaseFilterFunctions#isNotNull(Object)}.
      */
     public static class IsNotNullTests {
-        
-        private Object fieldValue;
+        private Object fieldValue1;
+        private Object fieldValue2;
         
         // Verify that a null object returns an empty set.
         @Test
         public void testNullValue() {
-            givenFieldValue(null);
+            givenFieldValue1(null);
             assertThat(result()).isEmpty();
+        }
+
+        // Verify that a null object returns an empty set with multiple filter fields.
+        @Test
+        public void testNullValueWithMultipleFields(){
+            givenFieldValue1(null);
+            givenFieldValue2("FOO.1");
+
+            assertThat(resultForMultipleFieldValues()).isEmpty();
         }
         
         // Verify that a non-null value tuple returns a set with that value tuple.
         @Test
         public void testNonNullValue() {
             ValueTuple valueTuple = toValueTuple("FOO.1,BAR,bar");
-            givenFieldValue(valueTuple);
+            givenFieldValue1(valueTuple);
             assertThat(result()).containsExactly(valueTuple);
+        }
+
+        // Verify that a non-null value tuple returns a set with that value tuple with use of multiple filter fields.
+        @Test
+        public void testNonNullValuesWithMultipleFields(){
+            ValueTuple valueTuple = toValueTuple("F00.1,BAR,bar");
+            givenFieldValue1(valueTuple);
+            givenFieldValue2("F00.1");
+
+            assertThat(resultForMultipleFieldValues()).containsExactly(valueTuple);
         }
         
         // Verify that an empty collection returns an empty set.
         @Test
         public void testEmptyCollection() {
-            givenFieldValue(Collections.emptySet());
+            givenFieldValue1(Collections.emptySet());
             assertThat(result()).isEmpty();
+        }
+
+        // Verify that an empty collection returns an empty set with use of multiple filter fields.
+        @Test
+        public void testEmptyCollectionWithMultipleFields(){
+            givenFieldValue1("FOO.1");
+            givenFieldValue2(Collections.emptySet());
+
+            assertThat(resultForMultipleFieldValues()).isEmpty();
         }
         
         // Verify that a non-empty collection of value tuples returns a set with the tuples.
@@ -506,16 +534,39 @@ public class EvaluationPhaseFilterFunctionsTest {
         public void givenNonEmptyCollection() {
             ValueTuple valueTuple1 = toValueTuple("FOO.1,BAR,bar");
             ValueTuple valueTuple2 = toValueTuple("FOO.1,ZOOM,zoom");
-            givenFieldValue(Sets.newHashSet(valueTuple1, valueTuple2));
+            givenFieldValue1(Sets.newHashSet(valueTuple1, valueTuple2));
             assertThat(result()).containsExactlyInAnyOrder(valueTuple1, valueTuple2);
         }
-        
-        private void givenFieldValue(Object fieldValue) {
-            this.fieldValue = fieldValue;
+
+        // Verify that a non-empty collection of value tuples returns a set of the provided tuples,
+        //  while utilizing multiple filter fields.
+        @Test
+        public void givenNonEmptyCollectionWithMultipleFields(){
+            ValueTuple valueTuple1 = toValueTuple("FOO.1,BAR,bar");
+            ValueTuple valueTuple2 = toValueTuple("FOO.1,ZOOM,zoom");
+            givenFieldValue1(Sets.newHashSet(valueTuple1, valueTuple2));
+
+            ValueTuple valueTuple3 = toValueTuple("FOO.2,BAT,bat");
+            ValueTuple valueTuple4 = toValueTuple("FOO.2,ZAP,zap");
+            givenFieldValue2(Sets.newHashSet(valueTuple3, valueTuple4));
+
+            assertThat(resultForMultipleFieldValues()).containsExactlyInAnyOrder(valueTuple1, valueTuple2);
         }
-        
+
+        private void givenFieldValue1(Object fieldValue1) {
+            this.fieldValue1 = fieldValue1;
+        }
+
+        private void givenFieldValue2(Object fieldValue2) {
+            this.fieldValue2 = fieldValue2;
+        }
+
         public Collection<ValueTuple> result() {
-            return EvaluationPhaseFilterFunctions.isNotNull(fieldValue);
+            return EvaluationPhaseFilterFunctions.isNotNull(fieldValue1);
+        }
+
+        public Collection<ValueTuple> resultForMultipleFieldValues(){
+            return EvaluationPhaseFilterFunctions.isNotNull(fieldValue1, fieldValue2);
         }
     }
     
@@ -524,42 +575,85 @@ public class EvaluationPhaseFilterFunctionsTest {
      */
     public static class IsNullTests {
         
-        private Object fieldValue;
+        private Object fieldValue1;
+        private Object fieldValue2;
         
         // Verify that a null object is considered null.
         @Test
         public void testNullObject() {
-            givenFieldValue(null);
+            givenFieldValue1(null);
             assertTrue(result());
         }
-        
+
+        // Verify that a null object is considered null with multiple filter fields.
+        @Test
+        public void testNullWithMultipleFields(){
+            givenFieldValue1("FOO.1");
+            givenFieldValue2(null);
+
+            assertTrue(resultForMultipleFieldValues());
+        }
+
         // Verify that a non-null object that is not a collection is not considered null.
         @Test
         public void testNonNullNonCollection() {
-            givenFieldValue(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
+            givenFieldValue1(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
             assertFalse(result());
+        }
+
+        //Verify that a non-null object that is not a collection is not considered null with multiple filter fields.
+        @Test
+        public void testNonNullWithMultipleFields(){
+            givenFieldValue1("FOO.1");
+            givenFieldValue2("BAR");
+
+            assertFalse(resultForMultipleFieldValues());
         }
         
         // Verify that an empty collection is considered null.
         @Test
         public void testEmptyCollection() {
-            givenFieldValue(Collections.emptySet());
+            givenFieldValue1(Collections.emptySet());
             assertTrue(result());
+        }
+
+        // Verify that an empty collection is considered null with multiple filter fields.
+        @Test
+        public void testEmptyCollectionWithMultipleFields(){
+            givenFieldValue1("FOO.1");
+            givenFieldValue2(Collections.emptySet());
+
+            assertTrue(resultForMultipleFieldValues());
         }
         
         // Verify that non-empty collection is not considered null.
         @Test
         public void testNonEmptyCollection() {
-            givenFieldValue(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
+            givenFieldValue1(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
             assertFalse(result());
         }
-        
-        private void givenFieldValue(Object fieldValue) {
-            this.fieldValue = fieldValue;
+
+        // Verify that non-empty collection is not considered null with multiple filter fields.
+        @Test
+        public void testNonEmptyCollectionWithMultipleFields(){
+            givenFieldValue1("FOO.1");
+            givenFieldValue2(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
+
+            assertFalse(resultForMultipleFieldValues());
         }
         
+        private void givenFieldValue1(Object fieldValue1) {
+            this.fieldValue1 = fieldValue1;
+        }
+
+        private void givenFieldValue2(Object fieldValue2) {this.fieldValue2 = fieldValue2;}
+
         public boolean result() {
-            return EvaluationPhaseFilterFunctions.isNull(fieldValue);
+            return EvaluationPhaseFilterFunctions.isNull(fieldValue1);
+        }
+
+        public boolean resultForMultipleFieldValues(){
+            return EvaluationPhaseFilterFunctions.isNull(fieldValue1, fieldValue2);
         }
     }
     

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsTest.java
@@ -485,13 +485,13 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(null);
             assertThat(result()).isEmpty();
         }
-
+        
         // Verify that a null object returns an empty set with multiple filter fields.
         @Test
-        public void testNullValueWithMultipleFields(){
+        public void testNullValueWithMultipleFields() {
             givenFieldValue1(null);
             givenFieldValue2("FOO.1");
-
+            
             assertThat(resultForMultipleFieldValues()).isEmpty();
         }
         
@@ -502,14 +502,14 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(valueTuple);
             assertThat(result()).containsExactly(valueTuple);
         }
-
+        
         // Verify that a non-null value tuple returns a set with that value tuple with use of multiple filter fields.
         @Test
-        public void testNonNullValuesWithMultipleFields(){
+        public void testNonNullValuesWithMultipleFields() {
             ValueTuple valueTuple = toValueTuple("F00.1,BAR,bar");
             givenFieldValue1(valueTuple);
             givenFieldValue2("F00.1");
-
+            
             assertThat(resultForMultipleFieldValues()).containsExactly(valueTuple);
         }
         
@@ -519,13 +519,13 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(Collections.emptySet());
             assertThat(result()).isEmpty();
         }
-
+        
         // Verify that an empty collection returns an empty set with use of multiple filter fields.
         @Test
-        public void testEmptyCollectionWithMultipleFields(){
+        public void testEmptyCollectionWithMultipleFields() {
             givenFieldValue1("FOO.1");
             givenFieldValue2(Collections.emptySet());
-
+            
             assertThat(resultForMultipleFieldValues()).isEmpty();
         }
         
@@ -537,35 +537,35 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(Sets.newHashSet(valueTuple1, valueTuple2));
             assertThat(result()).containsExactlyInAnyOrder(valueTuple1, valueTuple2);
         }
-
+        
         // Verify that a non-empty collection of value tuples returns a set of the provided tuples,
-        //  while utilizing multiple filter fields.
+        // while utilizing multiple filter fields.
         @Test
-        public void givenNonEmptyCollectionWithMultipleFields(){
+        public void givenNonEmptyCollectionWithMultipleFields() {
             ValueTuple valueTuple1 = toValueTuple("FOO.1,BAR,bar");
             ValueTuple valueTuple2 = toValueTuple("FOO.1,ZOOM,zoom");
             givenFieldValue1(Sets.newHashSet(valueTuple1, valueTuple2));
-
+            
             ValueTuple valueTuple3 = toValueTuple("FOO.2,BAT,bat");
             ValueTuple valueTuple4 = toValueTuple("FOO.2,ZAP,zap");
             givenFieldValue2(Sets.newHashSet(valueTuple3, valueTuple4));
-
+            
             assertThat(resultForMultipleFieldValues()).containsExactlyInAnyOrder(valueTuple1, valueTuple2);
         }
-
+        
         private void givenFieldValue1(Object fieldValue1) {
             this.fieldValue1 = fieldValue1;
         }
-
+        
         private void givenFieldValue2(Object fieldValue2) {
             this.fieldValue2 = fieldValue2;
         }
-
+        
         public Collection<ValueTuple> result() {
             return EvaluationPhaseFilterFunctions.isNotNull(fieldValue1);
         }
-
-        public Collection<ValueTuple> resultForMultipleFieldValues(){
+        
+        public Collection<ValueTuple> resultForMultipleFieldValues() {
             return EvaluationPhaseFilterFunctions.isNotNull(fieldValue1, fieldValue2);
         }
     }
@@ -584,29 +584,29 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(null);
             assertTrue(result());
         }
-
+        
         // Verify that a null object is considered null with multiple filter fields.
         @Test
-        public void testNullWithMultipleFields(){
+        public void testNullWithMultipleFields() {
             givenFieldValue1("FOO.1");
             givenFieldValue2(null);
-
+            
             assertTrue(resultForMultipleFieldValues());
         }
-
+        
         // Verify that a non-null object that is not a collection is not considered null.
         @Test
         public void testNonNullNonCollection() {
             givenFieldValue1(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
             assertFalse(result());
         }
-
-        //Verify that a non-null object that is not a collection is not considered null with multiple filter fields.
+        
+        // Verify that a non-null object that is not a collection is not considered null with multiple filter fields.
         @Test
-        public void testNonNullWithMultipleFields(){
+        public void testNonNullWithMultipleFields() {
             givenFieldValue1("FOO.1");
             givenFieldValue2("BAR");
-
+            
             assertFalse(resultForMultipleFieldValues());
         }
         
@@ -616,13 +616,13 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(Collections.emptySet());
             assertTrue(result());
         }
-
+        
         // Verify that an empty collection is considered null with multiple filter fields.
         @Test
-        public void testEmptyCollectionWithMultipleFields(){
+        public void testEmptyCollectionWithMultipleFields() {
             givenFieldValue1("FOO.1");
             givenFieldValue2(Collections.emptySet());
-
+            
             assertTrue(resultForMultipleFieldValues());
         }
         
@@ -632,27 +632,29 @@ public class EvaluationPhaseFilterFunctionsTest {
             givenFieldValue1(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
             assertFalse(result());
         }
-
+        
         // Verify that non-empty collection is not considered null with multiple filter fields.
         @Test
-        public void testNonEmptyCollectionWithMultipleFields(){
+        public void testNonEmptyCollectionWithMultipleFields() {
             givenFieldValue1("FOO.1");
             givenFieldValue2(Sets.newHashSet(toValueTuple("FOO.1,BAR,bar")));
-
+            
             assertFalse(resultForMultipleFieldValues());
         }
         
         private void givenFieldValue1(Object fieldValue1) {
             this.fieldValue1 = fieldValue1;
         }
-
-        private void givenFieldValue2(Object fieldValue2) {this.fieldValue2 = fieldValue2;}
-
+        
+        private void givenFieldValue2(Object fieldValue2) {
+            this.fieldValue2 = fieldValue2;
+        }
+        
         public boolean result() {
             return EvaluationPhaseFilterFunctions.isNull(fieldValue1);
         }
-
-        public boolean resultForMultipleFieldValues(){
+        
+        public boolean resultForMultipleFieldValues() {
             return EvaluationPhaseFilterFunctions.isNull(fieldValue1, fieldValue2);
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctionsTest.java
@@ -475,7 +475,6 @@ public class EvaluationPhaseFilterFunctionsTest {
      */
     public static class IsNotNullTests {
         private Object fieldValue;
-        private List<Object> listOfValues;
         
         // Verify that a null object returns an empty set.
         @Test
@@ -484,20 +483,11 @@ public class EvaluationPhaseFilterFunctionsTest {
             assertThat(result()).isEmpty();
         }
         
-        // Verify that a null object returns an empty set with multiple filter fields.
+        // // Verify that a null object returns an empty set with multiple filter fields.
         @Test
-        public void testNullListOfFilterFields() {
-            givenListOfValues(null);
-            
-            boolean result = false;
-            for (FunctionalSet<ValueTuple> resultSet : resultForListOfFieldValues()) {
-                if (!resultSet.isEmpty()) {
-                    result = true;
-                    break;
-                }
-            }
-            
-            assertFalse(result);
+        public void testEmptyListOfFilterFields() {
+            givenFieldValue(Arrays.asList());
+            assertThat(result()).isEmpty();
         }
         
         // Verify that a non-null value tuple returns a set with that value tuple.
@@ -513,22 +503,6 @@ public class EvaluationPhaseFilterFunctionsTest {
         public void testEmptyCollection() {
             givenFieldValue(Collections.emptySet());
             assertThat(result()).isEmpty();
-        }
-        
-        // Verify that an empty collection returns an empty set with use of multiple filter fields.
-        @Test
-        public void testEmptyListOfFilterFields() {
-            givenListOfValues(Arrays.asList(Collections.emptySet()));
-            
-            boolean result = false;
-            for (FunctionalSet<ValueTuple> resultSet : resultForListOfFieldValues()) {
-                if (!resultSet.isEmpty()) {
-                    result = true;
-                    break;
-                }
-            }
-            
-            assertFalse(result);
         }
         
         // Verify that a non-empty collection of value tuples returns a set with the tuples.
@@ -548,33 +522,17 @@ public class EvaluationPhaseFilterFunctionsTest {
             ValueTuple valueTuple2 = toValueTuple("FOO.1,ZOOM,zoom");
             ValueTuple valueTuple3 = toValueTuple("FOO.2,BAT,bat");
             ValueTuple valueTuple4 = toValueTuple("FOO.2,ZAP,zap");
-            givenListOfValues(Arrays.asList(valueTuple1, valueTuple2, valueTuple3, valueTuple4));
+            givenFieldValue(Arrays.asList(valueTuple1, valueTuple2, valueTuple3, valueTuple4));
             
-            boolean valueTuple3Found = false;
-            for (FunctionalSet<ValueTuple> resultSet : resultForListOfFieldValues()) {
-                if (resultSet.contains(valueTuple3)) {
-                    valueTuple3Found = true;
-                    break;
-                }
-            }
-            
-            assertTrue(valueTuple3Found);
+            assertThat(result()).containsExactlyInAnyOrder(valueTuple1, valueTuple2, valueTuple3, valueTuple4);
         }
         
         private void givenFieldValue(Object fieldValue) {
             this.fieldValue = fieldValue;
         }
         
-        private void givenListOfValues(List<Object> listOfValues) {
-            this.listOfValues = listOfValues;
-        }
-        
         public Collection<ValueTuple> result() {
             return EvaluationPhaseFilterFunctions.isNotNull(fieldValue);
-        }
-        
-        public List<FunctionalSet<ValueTuple>> resultForListOfFieldValues() {
-            return EvaluationPhaseFilterFunctions.isNotNull(listOfValues);
         }
     }
     


### PR DESCRIPTION
Ticket Details:  "The EvaluationPhaseFilterFunctions class has methods for single fielded isNull and isNotNull functions. When a multi-fielded isNull or isNotNull is in a query it is evaluated using the single fielded method and produces an incorrect evaluation."

- Added method overloads for EvaluationPhaseFilterFunctions IsNull and isNotNull that will except an Iterable<?> parameter and performed original method logic for each object found in new parameter.
- Added unit tests to EvaluationPhaseFilterFunctionsTest IsNotNullTests class.
- Added unit tests to EvaluationPhaseFilterFunctionsTest IsNullTests class.