### PR TITLE
Avoid downloading wildfly each time datawaveBuildDeploy is run

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
@@ -360,7 +360,7 @@ function datawaveUninstall() {
    datawaveIngestUninstall
    datawaveWebUninstall
 
-   [[ "${1}" == "${DW_UNINSTALL_RM_BINARIES_FLAG_LONG}" || "${1}" == "${DW_UNINSTALL_RM_BINARIES_FLAG_SHORT}" ]] && rm -f "${DW_DATAWAVE_SERVICE_DIR}"/*.tar.gz
+   [[ "${1}" == "${DW_UNINSTALL_RM_BINARIES_FLAG_LONG}" || "${1}" == "${DW_UNINSTALL_RM_BINARIES_FLAG_SHORT}" ]] && rm -f "${DW_DATAWAVE_SERVICE_DIR}"/datawave*.tar.gz
 }
 
 function datawaveInstall() {


### PR DESCRIPTION
Instead of removing all tar.gz files in the quickstart service directory for datawave, just remove those that start with the name datawave. This will allow us to avoid downloading wildfly each time datawaveBuildDeploy is run because datawaveUninstall will no longer remove it.