### PR TITLE
Fixes Metadata created by TermFrequencyQueryTransformer

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TermFrequencyQueryTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TermFrequencyQueryTransformer.java
@@ -69,7 +69,7 @@ public class TermFrequencyQueryTransformer extends BaseQueryLogicTransformer<Ent
         
         Metadata m = new Metadata();
         m.setRow(tfkv.getShardId());
-        m.setDataType(tfkv.getShardId());
+        m.setDataType(tfkv.getDatatype());
         m.setInternalId(tfkv.getUid());
         e.setMetadata(m);
         


### PR DESCRIPTION
The current implementation of `TermFrequencyQueryTransformer` populates `Event` `Metadata` objects incorrectly. It stores the shard id in the `Metadata` data type field. This fixes that. 

It has been tested with the quickstart via API calls as no good unit test exists for this code at this point. 