### PR TITLE
Updated to close the query automatically on

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -33,6 +33,9 @@ import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.webservice.common.exception.BadRequestException;
 import datawave.webservice.common.exception.DatawaveWebApplicationException;
 import datawave.webservice.common.exception.NoResultsException;
+import datawave.webservice.common.exception.NotFoundException;
+import datawave.webservice.common.exception.PreConditionFailedException;
+import datawave.webservice.common.exception.QueryCanceledException;
 import datawave.webservice.common.exception.UnauthorizedException;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.QueryImpl;
@@ -96,6 +99,7 @@ import org.apache.deltaspike.core.api.exclude.Exclude;
 import org.apache.log4j.Logger;
 import org.jboss.resteasy.annotations.GZIP;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
+import org.omg.CosNaming.NamingContextPackage.NotFound;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
@@ -2016,6 +2020,7 @@ public class QueryExecutorBean implements QueryExecutor {
             closedQueryCache.add(id); // remember that we auto-closed this query
             throw e;
         } catch (DatawaveWebApplicationException e) {
+            log.error("Failed Query", e);
             if (query != null) {
                 query.setActiveCall(false);
                 if (query.getLogic().getCollectQueryMetrics()) {
@@ -2032,7 +2037,9 @@ public class QueryExecutorBean implements QueryExecutor {
             } catch (Exception ex) {
                 log.error("Error marking transaction for roll back", ex);
             }
-            if (e.getCause() instanceof NoResultsException) {
+            // close out the query if at least it was a valid request
+            if (!((e instanceof BadRequestException) || (e instanceof NotFoundException) || (e instanceof QueryCanceledException)
+                            || (e instanceof UnauthorizedException) || (e instanceof PreConditionFailedException))) {
                 close(id);
                 closedQueryCache.add(id); // remember that we auto-closed this query
             }
@@ -2064,6 +2071,7 @@ public class QueryExecutorBean implements QueryExecutor {
             } else {
                 try {
                     close(id);
+                    closedQueryCache.add(id); // remember that we auto-closed this query
                 } catch (Exception ce) {
                     log.error(qe, ce);
                 }

--- a/web-services/query/src/main/java/datawave/webservice/query/util/LookupUUIDUtil.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/util/LookupUUIDUtil.java
@@ -28,6 +28,8 @@ import datawave.webservice.query.QueryParameters;
 import datawave.webservice.query.QueryParametersImpl;
 import datawave.webservice.query.QueryPersistence;
 import datawave.webservice.query.configuration.LookupUUIDConfiguration;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.FieldBase;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
@@ -611,7 +613,8 @@ public class LookupUUIDUtil {
                         if (!(contentQueryResponse instanceof EventQueryResponseBase)) {
                             EventQueryResponseBase er = responseObjectFactory.getEventQueryResponse();
                             er.addMessage("Unhandled response type " + contentQueryResponse + " from ContentQuery");
-                            throw new PreConditionFailedException(null, er);
+                            throw new DatawaveWebApplicationException(new QueryException(DatawaveErrorCode.BAD_RESPONSE_CLASS,
+                                            "Expected EventQueryResponseBase but got " + contentQueryResponse.getClass()), er);
                         }
                         
                         // Prevent NPE due to attempted merge when total events is null
@@ -864,7 +867,8 @@ public class LookupUUIDUtil {
         } else {
             final EventQueryResponseBase er = responseObjectFactory.getEventQueryResponse();
             er.addMessage("Unhandled response type from Query/createQueryAndNext");
-            throw new PreConditionFailedException(null, er);
+            throw new DatawaveWebApplicationException(new QueryException(DatawaveErrorCode.BAD_RESPONSE_CLASS, "Expected EventQueryResponseBase but got "
+                            + response.getClass()), er);
         }
         
         return pagedResponse;


### PR DESCRIPTION
Updated to close the query automatically on DatawaveWebApplicationExceptions that are NOT due to preconditions failing such as BaseRequest, PreConditionFailed, Unauthorized, QueryCancelled, NotFound