### PR TITLE
in openjdk 11.0.17, there is a bug described here:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1738,6 +1738,14 @@
                                     <additionalJOption>-J-Xmx768m</additionalJOption>
                                     <tags>
                                         <tag>
+                                            <name>XmlSchema</name>
+                                            <placement>X</placement>
+                                        </tag>
+                                        <tag>
+                                            <name>XmlNs</name>
+                                            <placement>X</placement>
+                                        </tag>
+                                        <tag>
                                             <name>HTTP</name>
                                             <placement>m</placement>
                                             <head>HTTP Return Codes</head>


### PR DESCRIPTION
https://stackoverflow.com/questions/55906161/weird-javadoc-error-with-jdk12-for-osgi-version-annotation Some non-javadoc annotations are causing the javadoc generation to fail. This patch makes the javadoc-plugin ignore the annotations, as it should.