### PR TITLE
Response object factory creation and use

### DIFF
--- a/properties/default.properties
+++ b/properties/default.properties
@@ -645,3 +645,11 @@ basemaps= {\
                   accessToken: 'your.mapbox.access.token' \
               }) \
           }
+
+##########################
+#
+# The response object factory class
+#
+##########################
+response.object.factory.class=datawave.webservice.query.result.event.DefaultResponseObjectFactory
+

--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryTransformer.java
@@ -1,31 +1,28 @@
 package datawave.query.discovery;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import java.util.HashMap;
+import com.google.common.base.Preconditions;
 import datawave.marking.MarkingFunctions;
 import datawave.marking.MarkingFunctions.Exception;
 import datawave.query.model.QueryModel;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.cachedresults.CacheableLogic;
 import datawave.webservice.query.cachedresults.CacheableQueryRow;
-import datawave.webservice.query.cachedresults.CacheableQueryRowImpl;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.FieldBase;
-import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.result.event.Metadata;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.BaseQueryResponse;
 import datawave.webservice.result.EventQueryResponseBase;
-
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Writable;
 
-import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class DiscoveryTransformer extends BaseQueryLogicTransformer<DiscoveredThing,EventBase> implements CacheableLogic {
     private List<String> variableFieldList = null;
@@ -121,7 +118,7 @@ public class DiscoveryTransformer extends BaseQueryLogicTransformer<DiscoveredTh
         List<CacheableQueryRow> cqoList = new ArrayList<>();
         EventBase event = (EventBase) o;
         
-        CacheableQueryRow cqo = new CacheableQueryRowImpl();
+        CacheableQueryRow cqo = responseObjectFactory.getCacheableQueryRow();
         Metadata metadata = event.getMetadata();
         cqo.setColFam(metadata.getDataType() + ":" + cqo.getEventId());
         cqo.setDataType(metadata.getDataType());

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEventQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEventQueryLogic.java
@@ -13,7 +13,6 @@ import datawave.webservice.query.exception.EmptyObjectException;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.QueryLogicTransformer;
-import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.EventQueryResponseBase;
@@ -209,7 +208,7 @@ public class RemoteEventQueryLogic extends BaseQueryLogic<EventBase> implements 
                     if (response != null) {
                         if (response.getReturnedEvents() == 0) {
                             if (response.isPartialResults()) {
-                                DefaultEvent e = new DefaultEvent();
+                                EventBase e = responseObjectFactory.getEvent();
                                 e.setIntermediateResult(true);
                                 data.add(e);
                             } else {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/content/ContentQueryTable.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/content/ContentQueryTable.java
@@ -231,7 +231,7 @@ public class ContentQueryTable extends BaseQueryLogic<Entry<Key,Value>> {
     
     @Override
     public QueryLogicTransformer getTransformer(Query settings) {
-        return new ContentQueryTransformer(settings, this.markingFunctions);
+        return new ContentQueryTransformer(settings, this.markingFunctions, this.responseObjectFactory);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/term/TermFrequencyQueryTable.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/term/TermFrequencyQueryTable.java
@@ -78,7 +78,7 @@ public class TermFrequencyQueryTable extends BaseQueryLogic<Entry<Key,Value>> {
     
     @Override
     public QueryLogicTransformer getTransformer(Query settings) {
-        return new TermFrequencyQueryTransformer(settings, markingFunctions);
+        return new TermFrequencyQueryTransformer(settings, markingFunctions, responseObjectFactory);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ContentQueryTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ContentQueryTransformer.java
@@ -1,39 +1,40 @@
 package datawave.query.transformer;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map.Entry;
-
 import datawave.marking.MarkingFunctions;
 import datawave.marking.MarkingFunctions.Exception;
 import datawave.query.table.parser.ContentKeyValueFactory;
 import datawave.query.table.parser.ContentKeyValueFactory.ContentKeyValue;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
-import datawave.webservice.query.result.event.DefaultEvent;
-import datawave.webservice.query.result.event.DefaultField;
 import datawave.webservice.query.result.event.EventBase;
+import datawave.webservice.query.result.event.FieldBase;
 import datawave.webservice.query.result.event.Metadata;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.BaseQueryResponse;
-import datawave.webservice.result.DefaultEventQueryResponse;
-
+import datawave.webservice.result.EventQueryResponseBase;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
 
-public class ContentQueryTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,DefaultEvent> {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+
+public class ContentQueryTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,EventBase> {
     
-    private Authorizations auths = null;
     private Logger log = Logger.getLogger(ContentQueryTransformer.class);
+    protected final Authorizations auths;
+    protected final ResponseObjectFactory responseObjectFactory;
     
-    public ContentQueryTransformer(Query query, MarkingFunctions markingFunctions) {
+    public ContentQueryTransformer(Query query, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory) {
         super(markingFunctions);
         this.auths = new Authorizations(query.getQueryAuthorizations().split(","));
+        this.responseObjectFactory = responseObjectFactory;
     }
     
     @Override
-    public DefaultEvent transform(Entry<Key,Value> entry) {
+    public EventBase transform(Entry<Key,Value> entry) {
         
         if (entry.getKey() == null && entry.getValue() == null)
             return null;
@@ -49,8 +50,8 @@ public class ContentQueryTransformer extends BaseQueryLogicTransformer<Entry<Key
             throw new IllegalArgumentException("Unable to parse visibility", e1);
         }
         
-        DefaultEvent e = new DefaultEvent();
-        DefaultField field = new DefaultField();
+        EventBase e = responseObjectFactory.getEvent();
+        FieldBase field = responseObjectFactory.getField();
         
         e.setMarkings(ckv.getMarkings());
         
@@ -65,21 +66,19 @@ public class ContentQueryTransformer extends BaseQueryLogicTransformer<Entry<Key
         field.setTimestamp(entry.getKey().getTimestamp());
         field.setValue(ckv.getContents());
         
-        List<DefaultField> fields = new ArrayList<>();
+        List<FieldBase> fields = new ArrayList<>();
         fields.add(field);
         e.setFields(fields);
         
         return e;
-        
     }
     
     @Override
     public BaseQueryResponse createResponse(List<Object> resultList) {
-        
-        DefaultEventQueryResponse response = new DefaultEventQueryResponse();
+        EventQueryResponseBase response = responseObjectFactory.getEventQueryResponse();
         List<EventBase> eventList = new ArrayList<>();
         for (Object o : resultList) {
-            DefaultEvent result = (DefaultEvent) o;
+            EventBase result = (EventBase) o;
             eventList.add(result);
         }
         response.setEvents(eventList);

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/DocumentTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/DocumentTransformer.java
@@ -10,7 +10,6 @@ import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.Flushable;
 import datawave.webservice.query.logic.WritesQueryMetrics;
 import datawave.webservice.query.logic.WritesResultCardinalities;
-import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.FieldBase;
 import datawave.webservice.query.result.event.Metadata;
@@ -108,7 +107,7 @@ public class DocumentTransformer extends DocumentTransformerSupport<Entry<Key,Va
         }
         
         if (documentEntry.getValue().isIntermediateResult()) {
-            DefaultEvent output = new DefaultEvent();
+            EventBase output = responseObjectFactory.getEvent();
             output.setIntermediateResult(true);
             return output;
         }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/EdgeQueryTransformerSupport.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/EdgeQueryTransformerSupport.java
@@ -8,7 +8,6 @@ import datawave.marking.MarkingFunctions;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.cachedresults.CacheableLogic;
 import datawave.webservice.query.cachedresults.CacheableQueryRow;
-import datawave.webservice.query.cachedresults.CacheableQueryRowImpl;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
 import datawave.webservice.query.result.EdgeQueryResponseBase;
@@ -20,7 +19,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -117,7 +115,7 @@ public abstract class EdgeQueryTransformerSupport<I,O> extends BaseQueryLogicTra
         List<CacheableQueryRow> cqoList = new ArrayList<>();
         EdgeBase edge = (EdgeBase) o;
         
-        CacheableQueryRow cqo = new CacheableQueryRowImpl();
+        CacheableQueryRow cqo = responseObjectFactory.getCacheableQueryRow();
         cqo.setColFam("");
         cqo.setDataType("");
         cqo.setEventId(generateEventId(edge));

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/EventQueryDataDecorator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/EventQueryDataDecorator.java
@@ -1,19 +1,14 @@
 package datawave.query.transformer;
 
+import com.google.common.collect.Multimap;
+import datawave.webservice.query.result.event.FieldBase;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
+import org.apache.log4j.Logger;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import javax.inject.Inject;
-
-import datawave.configuration.spring.SpringBean;
-import datawave.webservice.query.result.event.ResponseObjectFactory;
-import datawave.webservice.query.result.event.FieldBase;
-
-import org.apache.log4j.Logger;
-
-import com.google.common.collect.Multimap;
 
 public class EventQueryDataDecorator {
     private String fieldName = null;

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/EventQueryDataDecorator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/EventQueryDataDecorator.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import datawave.configuration.spring.SpringBean;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.result.event.FieldBase;
 
@@ -18,7 +19,6 @@ public class EventQueryDataDecorator {
     private String fieldName = null;
     private Map<String,String> patternMap = new LinkedHashMap<>();
     private Logger log = Logger.getLogger(EventQueryDataDecorator.class);
-    @Inject
     private ResponseObjectFactory responseObjectFactory;
     
     private EventQueryDataDecorator() {}

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ShardIndexQueryTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ShardIndexQueryTransformer.java
@@ -1,11 +1,6 @@
 package datawave.query.transformer;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.UUID;
-
+import com.google.protobuf.InvalidProtocolBufferException;
 import datawave.ingest.protobuf.Uid;
 import datawave.marking.MarkingFunctions;
 import datawave.marking.MarkingFunctions.Exception;
@@ -13,16 +8,14 @@ import datawave.query.model.QueryModel;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.cachedresults.CacheableLogic;
 import datawave.webservice.query.cachedresults.CacheableQueryRow;
-import datawave.webservice.query.cachedresults.CacheableQueryRowImpl;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.FieldBase;
-import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.result.event.Metadata;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.BaseQueryResponse;
-
 import datawave.webservice.result.EventQueryResponseBase;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -30,7 +23,11 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.log4j.Logger;
 
-import com.google.protobuf.InvalidProtocolBufferException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
 
 public class ShardIndexQueryTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,EventBase> implements CacheableLogic {
     
@@ -145,7 +142,7 @@ public class ShardIndexQueryTransformer extends BaseQueryLogicTransformer<Entry<
         List<CacheableQueryRow> cqoList = new ArrayList<>();
         EventBase event = (EventBase) o;
         
-        CacheableQueryRowImpl cqo = new CacheableQueryRowImpl();
+        CacheableQueryRow cqo = responseObjectFactory.getCacheableQueryRow();
         Metadata metadata = event.getMetadata();
         cqo.setColFam(metadata.getDataType() + ":" + cqo.getEventId());
         cqo.setDataType(metadata.getDataType());

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ShardQueryCountTableTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ShardQueryCountTableTransformer.java
@@ -1,29 +1,27 @@
 package datawave.query.transformer;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import datawave.marking.MarkingFunctions;
 import datawave.marking.MarkingFunctions.Exception;
 import datawave.query.Constants;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.cachedresults.CacheableLogic;
 import datawave.webservice.query.cachedresults.CacheableQueryRow;
-import datawave.webservice.query.cachedresults.CacheableQueryRowImpl;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.FieldBase;
-import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.result.event.Metadata;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.BaseQueryResponse;
-
 import datawave.webservice.result.EventQueryResponseBase;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class ShardQueryCountTableTransformer extends BaseQueryLogicTransformer<Entry<Long,ColumnVisibility>,EventBase> implements CacheableLogic {
     public static final String COUNT_CELL = "count";
@@ -103,7 +101,7 @@ public class ShardQueryCountTableTransformer extends BaseQueryLogicTransformer<E
         List<CacheableQueryRow> cqoList = new ArrayList<>();
         EventBase event = (EventBase) o;
         
-        CacheableQueryRowImpl cqo = new CacheableQueryRowImpl();
+        CacheableQueryRow cqo = responseObjectFactory.getCacheableQueryRow();
         Metadata metadata = event.getMetadata();
         cqo.setColFam(metadata.getDataType() + ":" + cqo.getEventId());
         cqo.setDataType(metadata.getDataType());

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TermFrequencyQueryTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TermFrequencyQueryTransformer.java
@@ -5,11 +5,11 @@ import java.util.List;
 import java.util.Map.Entry;
 
 import datawave.query.table.parser.TermFrequencyKeyValueFactory;
-import datawave.webservice.query.result.event.DefaultEvent;
-import datawave.webservice.query.result.event.DefaultField;
 import datawave.webservice.query.result.event.EventBase;
+import datawave.webservice.query.result.event.FieldBase;
 import datawave.webservice.query.result.event.Metadata;
-import datawave.webservice.result.DefaultEventQueryResponse;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
+import datawave.webservice.result.EventQueryResponseBase;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
@@ -23,32 +23,35 @@ import datawave.webservice.query.exception.EmptyObjectException;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
 import datawave.webservice.result.BaseQueryResponse;
 
-public class TermFrequencyQueryTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,DefaultEvent> {
+@SuppressWarnings("rawtypes")
+public class TermFrequencyQueryTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,EventBase> {
     
-    private Query query = null;
-    private Authorizations auths = null;
+    private final Query query;
+    private final Authorizations auths;
+    private final ResponseObjectFactory responseObjectFactory;
     
-    public TermFrequencyQueryTransformer(Query query, MarkingFunctions markingFunctions) {
+    public TermFrequencyQueryTransformer(Query query, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory) {
         super(markingFunctions);
         this.query = query;
+        this.responseObjectFactory = responseObjectFactory;
         this.auths = new Authorizations(StringUtils.split(this.query.getQueryAuthorizations(), ','));
     }
     
     @Override
     public BaseQueryResponse createResponse(List<Object> resultList) {
-        DefaultEventQueryResponse response = new DefaultEventQueryResponse();
+        EventQueryResponseBase response = responseObjectFactory.getEventQueryResponse();
         List<EventBase> eventList = new ArrayList<>();
         for (Object o : resultList) {
             EventBase result = (EventBase) o;
             eventList.add(result);
         }
         response.setEvents(eventList);
-        response.setReturnedEvents(new Long(eventList.size()));
+        response.setReturnedEvents((long) eventList.size());
         return response;
     }
     
     @Override
-    public DefaultEvent transform(Entry<Key,Value> entry) throws EmptyObjectException {
+    public EventBase transform(Entry<Key,Value> entry) throws EmptyObjectException {
         if (entry.getKey() == null && entry.getValue() == null) {
             return null;
         }
@@ -63,7 +66,7 @@ public class TermFrequencyQueryTransformer extends BaseQueryLogicTransformer<Ent
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to parse visibility", e);
         }
-        DefaultEvent e = new DefaultEvent();
+        EventBase e = responseObjectFactory.getEvent();
         
         e.setMarkings(tfkv.getMarkings());
         
@@ -73,7 +76,7 @@ public class TermFrequencyQueryTransformer extends BaseQueryLogicTransformer<Ent
         m.setInternalId(tfkv.getUid());
         e.setMetadata(m);
         
-        List<DefaultField> fields = ImmutableList.of(createField(tfkv, entry, "FIELD_NAME", tfkv.getFieldName()),
+        List<FieldBase> fields = ImmutableList.of(createField(tfkv, entry, "FIELD_NAME", tfkv.getFieldName()),
                         createField(tfkv, entry, "FIELD_VALUE", tfkv.getFieldValue()),
                         createField(tfkv, entry, "OFFSET_COUNT", String.valueOf(tfkv.getCount())),
                         createField(tfkv, entry, "OFFSETS", tfkv.getOffsets().toString()));
@@ -82,8 +85,8 @@ public class TermFrequencyQueryTransformer extends BaseQueryLogicTransformer<Ent
         return e;
     }
     
-    protected DefaultField createField(TermFrequencyKeyValue tfkv, Entry<Key,Value> e, String name, String value) {
-        DefaultField field = new DefaultField();
+    protected FieldBase createField(TermFrequencyKeyValue tfkv, Entry<Key,Value> e, String name, String value) {
+        FieldBase field = responseObjectFactory.getField();
         field.setMarkings(tfkv.getMarkings());
         field.setName(name);
         field.setValue(value);

--- a/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
@@ -930,6 +930,8 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
                 }
                 
                 e = eResponse.getEvents().get(0);
+            } else {
+                log.error("Received a " + response.getClass().getSimpleName() + " but expected a subclass of EventQueryResponseBase");
             }
         } catch (Exception ex) {
             log.error(ex);

--- a/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
@@ -22,11 +22,10 @@ import datawave.webservice.modification.ModificationRequestBase.MODE;
 import datawave.webservice.modification.configuration.ModificationServiceConfiguration;
 import datawave.webservice.query.QueryParametersImpl;
 import datawave.webservice.query.QueryPersistence;
-import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.runner.QueryExecutorBean;
 import datawave.webservice.result.BaseQueryResponse;
-import datawave.webservice.result.DefaultEventQueryResponse;
+import datawave.webservice.result.EventQueryResponseBase;
 import datawave.webservice.result.GenericResponse;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
@@ -901,7 +900,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
         
         String logicName = "LuceneUUIDEventQuery";
         
-        DefaultEvent e = null;
+        EventBase e = null;
         QueryExecutorBean queryService = this.getQueryService();
         
         String id = null;
@@ -921,8 +920,8 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
             
             id = createResponse.getResult();
             BaseQueryResponse response = queryService.next(id);
-            if (response instanceof DefaultEventQueryResponse) {
-                DefaultEventQueryResponse eResponse = (DefaultEventQueryResponse) response;
+            if (response instanceof EventQueryResponseBase) {
+                EventQueryResponseBase eResponse = (EventQueryResponseBase) response;
                 if (eResponse.getEvents().size() > 1) {
                     throw new IllegalStateException("More than one event matched " + uuid + " (" + eResponse.getEvents().size() + " matched)");
                 }
@@ -930,7 +929,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
                     throw new IllegalStateException("No event matched " + uuid);
                 }
                 
-                e = (DefaultEvent) eResponse.getEvents().get(0);
+                e = eResponse.getEvents().get(0);
             }
         } catch (Exception ex) {
             log.error(ex);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -21,10 +21,12 @@ import datawave.query.jexl.nodes.ExceededOrThresholdMarkerJexlNode;
 import datawave.query.jexl.nodes.ExceededValueThresholdMarkerJexlNode;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.ShardQueryLogic;
+import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.MockMetadataHelper;
 import datawave.query.util.WiseGuysIngest;
 import datawave.util.TableName;
+import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import org.apache.accumulo.core.client.Connector;
@@ -134,14 +136,16 @@ public abstract class ExecutableExpansionVisitorTest {
     
     @Deployment
     public static JavaArchive createDeployment() throws Exception {
+        System.setProperty("cdi.bean.context", "queryBeanRefContext.xml");
         
         return ShrinkWrap
                         .create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "nsa.datawave.query", "org.jboss.logging",
+                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
                                         "datawave.webservice.query.result.event")
+                        .deleteClass(DefaultEdgeEventQueryLogic.class)
+                        .deleteClass(RemoteEdgeDictionary.class)
                         .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
                         .deleteClass(datawave.query.metrics.ShardTableQueryMetricHandler.class)
-                        .deleteClass(datawave.query.tables.edge.DefaultEdgeEventQueryLogic.class)
                         .addAsManifestResource(
                                         new StringAsset("<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>"
                                                         + "</alternatives>"), "beans.xml");

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -139,7 +139,8 @@ public abstract class ExecutableExpansionVisitorTest {
         // basically this is avoiding WELD exceptions for beans that cannot be created because of various injection points
         // that would be null in this environment. For example the QueryMetricQueryLogic would fail to be created because
         // we do not have a caller principal, and the io.astefunutti.metrics.cdi classes are not available to this test case.
-        // Also we are adding the MockAlternative annotation which somehow (not sure why) enables looking at alternative beans.
+        // Also we are adding the beans.xml to enable resolving some beans. The MockAlternative is a placeholder for any
+        // mock bean alternatives we may use if annotated as such.
         return ShrinkWrap
                         .create(JavaArchive.class)
                         .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -136,8 +136,10 @@ public abstract class ExecutableExpansionVisitorTest {
     
     @Deployment
     public static JavaArchive createDeployment() throws Exception {
-        System.setProperty("cdi.bean.context", "queryBeanRefContext.xml");
-        
+        // basically this is avoiding WELD exceptions for beans that cannot be created because of various injection points
+        // that would be null in this environment. For example the QueryMetricQueryLogic would fail to be created because
+        // we do not have a caller principal, and the io.astefunutti.metrics.cdi classes are not available to this test case.
+        // Also we are adding the MockAlternative annotation which somehow (not sure why) enables looking at alternative beans.
         return ShrinkWrap
                         .create(JavaArchive.class)
                         .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicHttpTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicHttpTest.java
@@ -13,6 +13,7 @@ import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.remote.RemoteQueryServiceImpl;
 import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.DefaultField;
+import datawave.webservice.query.result.event.DefaultResponseObjectFactory;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.result.DefaultEventQueryResponse;
 import datawave.webservice.result.GenericResponse;
@@ -206,6 +207,7 @@ public class RemoteEventQueryLogicHttpTest {
         remote.setQueryServicePort(server.getAddress().getPort());
         remote.setExecutorService(null);
         remote.setObjectMapperDecorator(new DefaultMapperDecorator());
+        remote.setResponseObjectFactory(new DefaultResponseObjectFactory());
         remote.setJsseSecurityDomain(new JSSESecurityDomain() {
             @Override
             public KeyStore getKeyStore() throws SecurityException {

--- a/warehouse/query-core/src/test/resources/beanRefContext.xml
+++ b/warehouse/query-core/src/test/resources/beanRefContext.xml
@@ -9,9 +9,8 @@
         <constructor-arg>
             <list>
                 <value>classpath*:CDIProcessor.xml</value>
-                <value>classpath*:datawave/query/QueryLogicFactory.xml</value>
+                <value>classpath*:/datawave/query/QueryLogicFactory.xml</value>
                 <value>classpath*:/MarkingFunctionsContext.xml</value>
-                <value>classpath*:/ResponseObjectFactoryContext.xml</value>
                 <value>classpath*:/MetadataHelperContext.xml</value>
                 <value>classpath*:/JexlFunctionNamespaceRegistryContext.xml</value>
                 <value>classpath*:/CacheContext.xml</value>

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -13,6 +13,8 @@
         isn't defined in Accumulo for whatever reason...
     -->
 
+    <bean id="ResponseObjectFactory" class="datawave.webservice.query.result.event.DefaultResponseObjectFactory"/>
+
     <!-- A list of lucene to jexl query functions -->
     <util:list id="allowedQueryFunctions" value-type="datawave.query.language.functions.jexl.JexlQueryFunction">
         <bean class="datawave.query.language.functions.jexl.IsNull"/>
@@ -46,7 +48,8 @@
     
     <bean id="baseQueryLogic" class="datawave.webservice.query.logic.BaseQueryLogic" abstract="true" >
         <property name="roleManager" ref="easyRoleManager" />
-        <property name="markingFunctions" ref="markingFunctions" />
+	<property name="markingFunctions" ref="markingFunctions" />
+        <property name="responseObjectFactory" ref="ResponseObjectFactory" />
     </bean>
     
     <bean id="BaseEventQuery" parent="baseQueryLogic" scope="prototype" class="datawave.query.tables.ShardQueryLogic" abstract="true">

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -6,6 +6,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd 
                             http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd">
 
+    <bean id="ResponseObjectFactory" class="datawave.webservice.query.result.event.DefaultResponseObjectFactory"/>
 
     <!-- A list of lucene to jexl query functions -->
     <util:list id="allowedQueryFunctions" value-type="datawave.query.language.functions.jexl.JexlQueryFunction">
@@ -111,7 +112,8 @@
     
     <bean id="baseQueryLogic" class="datawave.webservice.query.logic.BaseQueryLogic" abstract="true" >
         <property name="roleManager" ref="easyRoleManager" />
-        <property name="markingFunctions" ref="markingFunctions" />
+	<property name="markingFunctions" ref="markingFunctions" />
+	<property name="responseObjectFactory" ref="ResponseObjectFactory" />
     </bean>
     
     <bean id="BaseEventQuery" parent="baseQueryLogic" scope="prototype" class="datawave.query.tables.ShardQueryLogic" abstract="true">

--- a/warehouse/query-core/src/test/resources/queryBeanRefContext.xml
+++ b/warehouse/query-core/src/test/resources/queryBeanRefContext.xml
@@ -11,7 +11,6 @@
                 <value>classpath*:CDIProcessor.xml</value>
                 <value>classpath*:/datawave/query/EventQueryLogicFactory.xml</value>
                 <value>classpath*:/MarkingFunctionsContext.xml</value>
-                <value>classpath*:/ResponseObjectFactoryContext.xml</value>
                 <value>classpath*:/MetadataHelperContext.xml</value>
                 <value>classpath*:/JexlFunctionNamespaceRegistryContext.xml</value>
                 <value>classpath*:/CacheContext.xml</value>

--- a/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedResultsBean.java
+++ b/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedResultsBean.java
@@ -203,6 +203,7 @@ public class CachedResultsBean {
     protected static final String BASE_COLUMNS = StringUtils.join(CacheableQueryRow.getFixedColumnSet(), ",");
     
     @Inject
+    @SpringBean(name = "ResponseObjectFactory")
     private ResponseObjectFactory responseObjectFactory;
     
     // reference "datawave/query/CachedResults.xml"

--- a/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedRunningQuery.java
+++ b/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedRunningQuery.java
@@ -813,7 +813,7 @@ public class CachedRunningQuery extends AbstractRunningQuery {
             cachedRowSet.beforeFirst();
             long resultBytes = 0;
             while (cachedRowSet.next() && !hitPageByteTrigger) {
-                CacheableQueryRow row = CacheableQueryRowReader.createRow(cachedRowSet, this.fixedFieldsInEvent);
+                CacheableQueryRow row = CacheableQueryRowReader.createRow(cachedRowSet, this.fixedFieldsInEvent, this.responseObjectFactory);
                 cacheableQueryRowList.add(row);
                 if (pageByteTrigger != 0) {
                     resultBytes += ObjectSizeOf.Sizer.getObjectSize(row);
@@ -842,7 +842,7 @@ public class CachedRunningQuery extends AbstractRunningQuery {
             while (cachedRowSet.next() && cachedRowSet.getRow() <= rowEnd && !hitPageByteTrigger) {
                 if (log.isTraceEnabled())
                     log.trace("CRS.position: " + cachedRowSet.getRow() + ", size: " + cachedRowSet.size());
-                CacheableQueryRow row = CacheableQueryRowReader.createRow(cachedRowSet, this.fixedFieldsInEvent);
+                CacheableQueryRow row = CacheableQueryRowReader.createRow(cachedRowSet, this.fixedFieldsInEvent, this.queryLogic.getResponseObjectFactory());
                 cacheableQueryRowList.add(row);
                 if (pageByteTrigger != 0) {
                     resultBytes += ObjectSizeOf.Sizer.getObjectSize(row);

--- a/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedRunningQuery.java
+++ b/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedRunningQuery.java
@@ -842,7 +842,7 @@ public class CachedRunningQuery extends AbstractRunningQuery {
             while (cachedRowSet.next() && cachedRowSet.getRow() <= rowEnd && !hitPageByteTrigger) {
                 if (log.isTraceEnabled())
                     log.trace("CRS.position: " + cachedRowSet.getRow() + ", size: " + cachedRowSet.size());
-                CacheableQueryRow row = CacheableQueryRowReader.createRow(cachedRowSet, this.fixedFieldsInEvent, this.queryLogic.getResponseObjectFactory());
+                CacheableQueryRow row = CacheableQueryRowReader.createRow(cachedRowSet, this.fixedFieldsInEvent, this.responseObjectFactory);
                 cacheableQueryRowList.add(row);
                 if (pageByteTrigger != 0) {
                     resultBytes += ObjectSizeOf.Sizer.getObjectSize(row);

--- a/web-services/client/src/main/java/datawave/webservice/query/cachedresults/CacheableQueryRow.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/cachedresults/CacheableQueryRow.java
@@ -1,13 +1,14 @@
 package datawave.webservice.query.cachedresults;
 
+import datawave.webservice.query.result.event.HasMarkings;
+import datawave.webservice.query.util.TypedValue;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import datawave.webservice.query.result.event.HasMarkings;
-import datawave.webservice.query.util.TypedValue;
 
 public abstract class CacheableQueryRow implements HasMarkings {
     
@@ -86,4 +87,17 @@ public abstract class CacheableQueryRow implements HasMarkings {
         return sb.toString();
     }
     
+    public abstract void setSizeInStoredCharacters(long characters);
+    
+    public abstract void setVariableColumnNames(Collection<String> variableColumnNames);
+    
+    public abstract void setColumnValues(Map<String,Set<String>> columnValues);
+    
+    public abstract void setUser(String user_);
+    
+    public abstract void setColumnMarkingsMap(Map<String,Map<String,String>> columnMarkingsMap);
+    
+    public abstract void setColumnColumnVisibilityMap(Map<String,String> columnVisibilityMap);
+    
+    public abstract void setColumnTimestampMap(Map<String,Long> parseColumnTimestamps);
 }

--- a/web-services/client/src/main/java/datawave/webservice/result/QueryWizardResultResponse.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/QueryWizardResultResponse.java
@@ -101,7 +101,7 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
         builder.append("<div id=\"myTable_wrapper\" class=\"dataTables_wrapper no-footer\">\n");
         builder.append("<table id=\"myTable\" class=\"dataTable no-footer\" role=\"grid\" aria-describedby=\"myTable_info\">\n");
         
-        if (response instanceof EdgeQueryResponseBase) {
+        if (response instanceof EventQueryResponseBase) {
             EventQueryResponseBase tempResponse = (EventQueryResponseBase) response;
             
             HashSet<String> fieldnameSet = buildTableColumnHeadings(builder, tempResponse);
@@ -170,6 +170,8 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
                 putTableCell(builder, String.valueOf(stat.selectivity));
                 putTableCell(builder, String.valueOf(stat.unique));
             }
+        } else {
+            throw new RuntimeException("Cannot handle a " + response.getClass().getSimpleName() + " response type");
         }
         
         builder.append("</tbody>");

--- a/web-services/client/src/main/java/datawave/webservice/result/QueryWizardResultResponse.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/QueryWizardResultResponse.java
@@ -1,23 +1,24 @@
 package datawave.webservice.result;
 
+import datawave.webservice.HtmlProvider;
+import datawave.webservice.query.result.EdgeQueryResponseBase;
+import datawave.webservice.query.result.edge.EdgeBase;
+import datawave.webservice.query.result.event.EventBase;
+import datawave.webservice.query.result.event.FieldBase;
+import datawave.webservice.query.result.istat.FieldStat;
+import datawave.webservice.query.result.istat.IndexStatsResponse;
+import datawave.webservice.query.result.metadata.MetadataFieldBase;
+
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorOrder;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import datawave.webservice.HtmlProvider;
-import datawave.webservice.query.result.edge.EdgeBase;
-import datawave.webservice.query.result.event.DefaultField;
-import datawave.webservice.query.result.event.EventBase;
-import datawave.webservice.query.result.istat.FieldStat;
-import datawave.webservice.query.result.istat.IndexStatsResponse;
-import datawave.webservice.query.result.metadata.MetadataFieldBase;
-
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 
 @XmlRootElement(name = "QueryWizardNextResult")
 @XmlAccessorType(XmlAccessType.NONE)
@@ -100,8 +101,8 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
         builder.append("<div id=\"myTable_wrapper\" class=\"dataTables_wrapper no-footer\">\n");
         builder.append("<table id=\"myTable\" class=\"dataTable no-footer\" role=\"grid\" aria-describedby=\"myTable_info\">\n");
         
-        if (response instanceof DefaultEventQueryResponse) {
-            DefaultEventQueryResponse tempResponse = (DefaultEventQueryResponse) response;
+        if (response instanceof EdgeQueryResponseBase) {
+            EventQueryResponseBase tempResponse = (EventQueryResponseBase) response;
             
             HashSet<String> fieldnameSet = buildTableColumnHeadings(builder, tempResponse);
             HashMap<String,String> fieldNameToValueMap = new HashMap<>();
@@ -114,8 +115,8 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
                 builder.append("<tr>");
                 putTableCell(builder, dataType);
                 for (Object field : event.getFields()) {
-                    if (field instanceof DefaultField) {
-                        DefaultField defaultField = (DefaultField) field;
+                    if (field instanceof FieldBase) {
+                        FieldBase defaultField = (FieldBase) field;
                         fieldNameToValueMap.put(defaultField.getName(), defaultField.getValueString());
                     }
                 }
@@ -132,8 +133,8 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
                 fieldNameToValueMap.clear();
                 builder.append("</tr>");
             }
-        } else if (response instanceof DefaultEdgeQueryResponse) {
-            DefaultEdgeQueryResponse tempResponse = (DefaultEdgeQueryResponse) response;
+        } else if (response instanceof EdgeQueryResponseBase) {
+            EdgeQueryResponseBase tempResponse = (EdgeQueryResponseBase) response;
             builder.append("<thead><tr><th>Source</th><th>Sink</th><th>Edge Type</th><th>Activity Date</th><th>Edge Relationship</th></tr></thead>");
             builder.append("<tbody>");
             for (EdgeBase edge : tempResponse.getEdges()) {
@@ -145,11 +146,11 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
                 putTableCell(builder, edge.getEdgeRelationship());
                 builder.append("</tr>");
             }
-        } else if (response instanceof DefaultMetadataQueryResponse) {
-            DefaultMetadataQueryResponse tempResponse = (DefaultMetadataQueryResponse) response;
+        } else if (response instanceof MetadataQueryResponseBase) {
+            MetadataQueryResponseBase tempResponse = (MetadataQueryResponseBase) response;
             builder.append("<thead><tr><th>Field Name</th><th>Internal Field Name</th><th>Data Type</th><th>Last Updated</th><th>Index only</th></tr></thead>");
             builder.append("<tbody>");
-            for (MetadataFieldBase field : tempResponse.getFields()) {
+            for (MetadataFieldBase field : ((List<MetadataFieldBase>) (tempResponse.getFields()))) {
                 builder.append("<tr>");
                 putTableCell(builder, field.getFieldName());
                 putTableCell(builder, field.getInternalFieldName());
@@ -187,14 +188,14 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
         return builder.toString();
     }
     
-    private HashSet<String> buildTableColumnHeadings(StringBuilder builder, DefaultEventQueryResponse tempResponse) {
+    private HashSet<String> buildTableColumnHeadings(StringBuilder builder, EventQueryResponseBase tempResponse) {
         
         HashSet<String> fieldnameSet = new HashSet<>();
         builder.append("<thead><tr><th>DataType</th>");
         for (EventBase event : tempResponse.getEvents()) {
             for (Object field : event.getFields()) {
-                if (field instanceof DefaultField) {
-                    fieldnameSet.add(((DefaultField) field).getName());
+                if (field instanceof FieldBase) {
+                    fieldnameSet.add(((FieldBase) field).getName());
                 }
             }
         }

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -10,7 +10,9 @@
     http://www.springframework.org/schema/context/spring-context-4.0.xsd
     http://www.springframework.org/schema/util
     http://www.springframework.org/schema/util/spring-util-4.0.xsd">
-    
+
+    <bean id="ResponseObjectFactory" class="datawave.webservice.query.result.event.DefaultResponseObjectFactory"/>
+
     <!--  part of what enforces any Required properties to be set on loading of the context -->
     <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />
 
@@ -127,6 +129,7 @@
     <bean id="baseQueryLogic" class="datawave.webservice.query.logic.BaseQueryLogic" abstract="true" >
         <property name="roleManager" ref="easyRoleManager" />
         <property name="markingFunctions" ref="markingFunctions" />
+        <property name="responseObjectFactory" ref="ResponseObjectFactory" />
     </bean>
 
     <!-- Here is an example of configuring a remote query service and a remote event query -->
@@ -134,7 +137,8 @@
         <property name="queryServiceScheme" value="https" />
         <property name="queryServiceHost" value="localhost" />
         <property name="queryServicePort" value="9443" />
-	<property name="queryServiceURI" value="/DataWave/Query/" />
+        <property name="queryServiceURI" value="/DataWave/Query/" />
+        <property name="responseObjectFactory" ref="ResponseObjectFactory" />
     </bean>
 
     <bean id="RemoteEventQuery" parent="baseQueryLogic" class="datawave.query.tables.RemoteEventQueryLogic">

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -11,7 +11,7 @@
     http://www.springframework.org/schema/util
     http://www.springframework.org/schema/util/spring-util-4.0.xsd">
 
-    <bean id="ResponseObjectFactory" class="datawave.webservice.query.result.event.DefaultResponseObjectFactory"/>
+    <bean id="ResponseObjectFactory" class="${response.object.factory.class}"/>
 
     <!--  part of what enforces any Required properties to be set on loading of the context -->
     <bean class="org.springframework.beans.factory.annotation.RequiredAnnotationBeanPostProcessor" />

--- a/web-services/query/src/main/java/datawave/webservice/query/cachedresults/CacheableQueryRowReader.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/cachedresults/CacheableQueryRowReader.java
@@ -1,5 +1,10 @@
 package datawave.webservice.query.cachedresults;
 
+import datawave.marking.MarkingFunctions;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
+import org.apache.log4j.Logger;
+
+import javax.sql.rowset.CachedRowSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -8,19 +13,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import javax.sql.rowset.CachedRowSet;
-
-import datawave.marking.MarkingFunctions;
-
-import org.apache.log4j.Logger;
-
 public class CacheableQueryRowReader {
     
     private static Logger log = Logger.getLogger(CacheableQueryRowReader.class);
     
-    public static CacheableQueryRow createRow(CachedRowSet cachedRowSet, Set<String> fixedFieldsInEvent) {
+    public static CacheableQueryRow createRow(CachedRowSet cachedRowSet, Set<String> fixedFieldsInEvent, ResponseObjectFactory responseObjectFactory) {
         
-        CacheableQueryRowImpl cqfc = new CacheableQueryRowImpl();
+        CacheableQueryRow cqfc = responseObjectFactory.getCacheableQueryRow();
         
         ResultSetMetaData metadata;
         try {
@@ -30,7 +29,7 @@ public class CacheableQueryRowReader {
             Map<String,Integer> columnToIndexMap = new HashMap<>();
             Map<String,Set<String>> columnValues = new HashMap<>();
             Set<String> variableColumnNames = new TreeSet<>();
-            Set<String> fixedColumnNames = CacheableQueryRowImpl.getFixedColumnSet();
+            Set<String> fixedColumnNames = CacheableQueryRow.getFixedColumnSet();
             // lets do a quick size estimate
             long characters = 0;
             for (int x = 1; x <= numColumns; x++) {

--- a/web-services/query/src/main/java/datawave/webservice/query/factory/Persister.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/factory/Persister.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.protobuf.InvalidProtocolBufferException;
 import datawave.configuration.DatawaveEmbeddedProjectStageHolder;
+import datawave.configuration.spring.SpringBean;
 import datawave.marking.SecurityMarking;
 import datawave.query.iterator.QueriesTableAgeOffIterator;
 import datawave.security.authorization.DatawavePrincipal;
@@ -100,6 +101,7 @@ public class Persister {
     protected EJBContext ctx;
     
     @Inject
+    @SpringBean(name = "ResponseObjectFactory")
     private ResponseObjectFactory responseObjectFactory;
     
     public Query create(String userDN, List<String> dnList, SecurityMarking marking, String queryLogicName, QueryParameters qp,

--- a/web-services/query/src/main/java/datawave/webservice/query/iterator/DatawaveTransformIterator.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/iterator/DatawaveTransformIterator.java
@@ -2,7 +2,6 @@ package datawave.webservice.query.iterator;
 
 import datawave.webservice.query.exception.EmptyObjectException;
 import datawave.webservice.query.logic.Flushable;
-import datawave.webservice.query.result.event.DefaultEvent;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.log4j.Logger;

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -14,7 +14,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.springframework.beans.factory.annotation.Required;
 
-import javax.inject.Inject;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.Iterator;
@@ -41,7 +40,6 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     protected Principal principal;
     protected RoleManager roleManager;
     protected MarkingFunctions markingFunctions;
-    @Inject
     protected ResponseObjectFactory responseObjectFactory;
     protected SelectorExtractor selectorExtractor;
     protected ResponseEnricherBuilder responseEnricherBuilder = null;

--- a/web-services/query/src/main/java/datawave/webservice/query/remote/RemoteQueryServiceImpl.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/remote/RemoteQueryServiceImpl.java
@@ -2,6 +2,7 @@ package datawave.webservice.query.remote;
 
 import com.codahale.metrics.Counter;
 import com.fasterxml.jackson.databind.ObjectReader;
+import datawave.configuration.spring.SpringBean;
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.webservice.common.remote.RemoteHttpService;
 import datawave.webservice.common.remote.RemoteHttpServiceConfiguration;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import org.xbill.DNS.TextParseException;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
@@ -58,7 +60,7 @@ public class RemoteQueryServiceImpl extends RemoteHttpService implements RemoteQ
     
     private ObjectReader eventQueryResponseReader;
     
-    private ResponseObjectFactory responseObjectFactory = new DefaultResponseObjectFactory();
+    private ResponseObjectFactory responseObjectFactory;
     
     private RemoteHttpServiceConfiguration config = new RemoteHttpServiceConfiguration();
     

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/BasicQueryBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/BasicQueryBean.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.annotation.Timed;
 import datawave.annotation.GenerateQuerySessionId;
 import datawave.annotation.Required;
 import datawave.configuration.DatawaveEmbeddedProjectStageHolder;
+import datawave.configuration.spring.SpringBean;
 import datawave.interceptor.RequiredInterceptor;
 import datawave.interceptor.ResponseInterceptor;
 import datawave.resteasy.interceptor.CreateQuerySessionIDFilter;
@@ -14,6 +15,7 @@ import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.QueryLogic;
 import datawave.webservice.query.logic.QueryLogicFactory;
+import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.result.logic.QueryLogicDescription;
 import datawave.webservice.result.BaseQueryResponse;
 import datawave.webservice.result.GenericResponse;
@@ -100,6 +102,10 @@ public class BasicQueryBean {
     @Resource
     private SessionContext sessionContext;
     
+    @Inject
+    @SpringBean(name = "ResponseObjectFactory")
+    private ResponseObjectFactory responseObjectFactory;
+    
     @PostConstruct
     public void init() {
         
@@ -130,7 +136,7 @@ public class BasicQueryBean {
         List<QueryLogicDescription> logicConfigurationList = new ArrayList<>();
         
         // reference query necessary to avoid NPEs in getting the Transformer and BaseResponse
-        Query q = new QueryImpl();
+        Query q = responseObjectFactory.getQueryImpl();
         Date now = new Date();
         q.setExpirationDate(now);
         q.setQuery("test");
@@ -218,7 +224,7 @@ public class BasicQueryBean {
         List<QueryLogic<?>> logicList = queryLogicFactory.getQueryLogicList();
         
         // reference query necessary to avoid NPEs in getting the Transformer and BaseResponse
-        Query q = new QueryImpl();
+        Query q = responseObjectFactory.getQueryImpl();
         Date now = new Date();
         q.setExpirationDate(now);
         q.setQuery("test");

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -233,6 +233,7 @@ public class QueryExecutorBean implements QueryExecutor {
     private SecurityMarking marking;
     
     @Inject
+    @SpringBean(name = "ResponseObjectFactory")
     private ResponseObjectFactory responseObjectFactory;
     
     private LookupUUIDUtil lookupUUIDUtil;
@@ -316,7 +317,7 @@ public class QueryExecutorBean implements QueryExecutor {
         List<QueryLogicDescription> logicConfigurationList = new ArrayList<>();
         
         // reference query necessary to avoid NPEs in getting the Transformer and BaseResponse
-        Query q = new QueryImpl();
+        Query q = responseObjectFactory.getQueryImpl();
         Date now = new Date();
         q.setExpirationDate(now);
         q.setQuery("test");
@@ -3260,7 +3261,7 @@ public class QueryExecutorBean implements QueryExecutor {
         }
         
         // reference query necessary to avoid NPEs in getting the Transformer and BaseResponse
-        Query q = new QueryImpl();
+        Query q = responseObjectFactory.getQueryImpl();
         Date now = new Date();
         q.setBeginDate(now);
         q.setEndDate(now);

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
@@ -19,7 +19,7 @@ import datawave.webservice.query.logic.QueryLogic;
 import datawave.webservice.query.logic.WritesQueryMetrics;
 import datawave.webservice.query.logic.WritesResultCardinalities;
 import datawave.webservice.query.metric.QueryMetricsBean;
-import datawave.webservice.query.result.event.DefaultEvent;
+import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
@@ -458,7 +458,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
                     hasNext.decrementAndGet();
                     gotNext.decrementAndGet();
                     
-                    if (o instanceof DefaultEvent && ((DefaultEvent) o).isIntermediateResult()) {
+                    if (o instanceof EventBase && ((EventBase) o).isIntermediateResult()) {
                         log.info("Received an intermediate result");
                         // in this case we have timed out up stream somewhere, so lets return what we have
                         hitIntermediateResult = true;

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -50,6 +50,7 @@ import datawave.webservice.query.logic.QueryLogicFactoryImpl;
 import datawave.webservice.query.logic.QueryLogicTransformer;
 import datawave.webservice.query.logic.RoleManager;
 import datawave.webservice.query.metric.QueryMetricsBean;
+import datawave.webservice.query.result.event.DefaultResponseObjectFactory;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.util.GetUUIDCriteria;
 import datawave.webservice.query.util.LookupUUIDUtil;
@@ -2576,6 +2577,7 @@ public class ExtendedQueryExecutorBeanTest {
         RoleManager roleManager2 = new DatawaveRoleManager(Arrays.asList("ROLE_1", "ROLE_2"));
         expect(this.queryLogic2.getRoleManager()).andReturn(roleManager2).times(2);
         expect(this.queryLogic2.getResponseClass(EasyMock.anyObject(Query.class))).andReturn(this.baseResponse.getClass().getCanonicalName());
+        expect(this.responseObjectFactory.getQueryImpl()).andReturn(new QueryImpl());
         Map<String,String> parsers = new HashMap<>();
         parsers.put("PARSER1", null);
         expect(this.queryLogic2.getQuerySyntaxParsers()).andReturn((Map) parsers);
@@ -2586,6 +2588,7 @@ public class ExtendedQueryExecutorBeanTest {
         setInternalState(subject, QueryLogicFactory.class, queryLogicFactory);
         setInternalState(subject, QueryExpirationConfiguration.class, queryExpirationConf);
         setInternalState(subject, QueryMetricFactory.class, new QueryMetricFactoryImpl());
+        setInternalState(subject, ResponseObjectFactory.class, responseObjectFactory);
         QueryLogicResponse result1 = subject.listQueryLogic();
         subject.close();
         PowerMock.verifyAll();
@@ -3308,6 +3311,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(subject.createQuery(queryLogicName, params, httpHeaders)).andReturn(createResponse);
         expect(this.cache.get(eq(queryId.toString()))).andReturn(this.runningQuery);
         expect(this.runningQuery.getMetric()).andReturn(this.queryMetric);
+        expect(this.responseObjectFactory.getQueryImpl()).andReturn(new QueryImpl());
         this.queryMetric.setCreateCallTime(EasyMock.geq(0L));
         // return streaming response
         

--- a/web-services/security/src/main/java/datawave/security/user/UserOperationsBean.java
+++ b/web-services/security/src/main/java/datawave/security/user/UserOperationsBean.java
@@ -17,6 +17,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import datawave.configuration.DatawaveEmbeddedProjectStageHolder;
+import datawave.configuration.spring.SpringBean;
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.security.authorization.DatawaveUser;
 import datawave.security.cache.CredentialsCacheBean;
@@ -45,6 +46,7 @@ public class UserOperationsBean {
     private CredentialsCacheBean credentialsCache;
     
     @Inject
+    @SpringBean(name = "ResponseObjectFactory")
     private ResponseObjectFactory responseObjectFactory;
     
     /**


### PR DESCRIPTION
* Updated to set the response object factory via spring for non-CDI instantiated object (i.e. query logics)
* Updated to fix responseObjectFactory usage various classes