### PR TITLE
remove instances of junit.framework

### DIFF
--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/facet/ApproximateAlgorithmsTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/facet/ApproximateAlgorithmsTest.java
@@ -6,7 +6,7 @@ import com.clearspring.analytics.stream.frequency.CountMinSketch;
 import org.apache.log4j.Logger;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ApproximateAlgorithmsTest {
     

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
@@ -29,10 +29,10 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class JexlASTHelperTest {
     
@@ -44,7 +44,7 @@ public class JexlASTHelperTest {
         List<ASTEQNode> eqNodes = JexlASTHelper.getEQNodes(query);
         
         for (JexlNode eqNode : eqNodes) {
-            Assert.assertFalse(JexlASTHelper.isWithinOr(eqNode));
+            assertFalse(JexlASTHelper.isWithinOr(eqNode));
         }
     }
     
@@ -61,9 +61,9 @@ public class JexlASTHelperTest {
         
         for (JexlNode eqNode : eqNodes) {
             String value = JexlASTHelper.getLiteralValue(eqNode).toString();
-            Assert.assertTrue(expectations.containsKey(value));
+            assertTrue(expectations.containsKey(value));
             
-            Assert.assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
+            assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
         }
     }
     
@@ -80,9 +80,9 @@ public class JexlASTHelperTest {
         
         for (JexlNode eqNode : eqNodes) {
             String value = JexlASTHelper.getLiteralValue(eqNode).toString();
-            Assert.assertTrue(expectations.containsKey(value));
+            assertTrue(expectations.containsKey(value));
             
-            Assert.assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
+            assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
         }
     }
     
@@ -96,9 +96,9 @@ public class JexlASTHelperTest {
         
         for (JexlNode eqNode : eqNodes) {
             String value = JexlASTHelper.getLiteralValue(eqNode).toString();
-            Assert.assertTrue(expectations.containsKey(value));
+            assertTrue(expectations.containsKey(value));
             
-            Assert.assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
+            assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
         }
     }
     
@@ -114,9 +114,9 @@ public class JexlASTHelperTest {
         
         for (JexlNode eqNode : eqNodes) {
             String value = JexlASTHelper.getLiteralValue(eqNode).toString();
-            Assert.assertTrue(expectations.containsKey(value));
+            assertTrue(expectations.containsKey(value));
             
-            Assert.assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
+            assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(eqNode));
         }
         
         List<ASTERNode> erNodes = JexlASTHelper.getERNodes(query);
@@ -127,9 +127,8 @@ public class JexlASTHelperTest {
         
         for (JexlNode erNode : erNodes) {
             String value = JexlASTHelper.getLiteralValue(erNode).toString();
-            Assert.assertTrue(expectations.containsKey(value));
-            
-            Assert.assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(erNode));
+            assertTrue(expectations.containsKey(value));
+            assertEquals(expectations.get(value), JexlASTHelper.isWithinOr(erNode));
         }
     }
     
@@ -149,7 +148,7 @@ public class JexlASTHelperTest {
     public void sameJexlNodeEquality() throws Exception {
         ASTJexlScript query = JexlASTHelper.parseJexlQuery("FOO == '1'");
         
-        Assert.assertTrue(JexlASTHelper.equals(query, query));
+        assertTrue(JexlASTHelper.equals(query, query));
     }
     
     @Test
@@ -157,7 +156,7 @@ public class JexlASTHelperTest {
         ASTJexlScript one = JexlASTHelper.parseJexlQuery("FOO == '1'");
         ASTJexlScript two = JexlASTHelper.parseJexlQuery("FOO == '1'");
         
-        Assert.assertTrue(JexlASTHelper.equals(one, two));
+        assertTrue(JexlASTHelper.equals(one, two));
     }
     
     @Test
@@ -165,7 +164,7 @@ public class JexlASTHelperTest {
         ASTJexlScript one = JexlASTHelper.parseJexlQuery("FOO == '1'");
         ASTJexlScript two = JexlASTHelper.parseJexlQuery("'1' == '1'");
         
-        Assert.assertFalse(JexlASTHelper.equals(one, two));
+        assertFalse(JexlASTHelper.equals(one, two));
     }
     
     @Test
@@ -173,9 +172,9 @@ public class JexlASTHelperTest {
         ASTJexlScript one = JexlASTHelper.parseJexlQuery("FOO == '1'");
         ASTJexlScript two = null;
         
-        Assert.assertFalse(JexlASTHelper.equals(one, two));
+        assertFalse(JexlASTHelper.equals(one, two));
         
-        Assert.assertFalse(JexlASTHelper.equals(two, one));
+        assertFalse(JexlASTHelper.equals(two, one));
     }
     
     @Test
@@ -183,7 +182,7 @@ public class JexlASTHelperTest {
         ASTJexlScript one = JexlASTHelper.parseJexlQuery("FOO == '1'");
         ASTJexlScript two = JexlASTHelper.parseJexlQuery("'1' == FOO");
         
-        Assert.assertFalse(JexlASTHelper.equals(one, two));
+        assertFalse(JexlASTHelper.equals(one, two));
     }
     
     @Test
@@ -191,7 +190,7 @@ public class JexlASTHelperTest {
         ASTJexlScript one = JexlASTHelper.parseJexlQuery("FOO == '1' && (BAR == 'bar' || BAR == 'baz')");
         ASTJexlScript two = JexlASTHelper.parseJexlQuery("FOO == '1' && (BAR == 'bar' || BAR == 'baz')");
         
-        Assert.assertTrue(JexlASTHelper.equals(one, two));
+        assertTrue(JexlASTHelper.equals(one, two));
     }
     
     @Test
@@ -199,11 +198,11 @@ public class JexlASTHelperTest {
         ASTJexlScript one = JexlASTHelper.parseJexlQuery("FOO == '1' && (BAR == 'bar' || BAR == 'baz')");
         ASTJexlScript two = JexlASTHelper.parseJexlQuery("FOO == '1' && (BAR == 'baz' || BAR == 'bar')");
         
-        Assert.assertFalse(JexlASTHelper.equals(one, two));
+        assertFalse(JexlASTHelper.equals(one, two));
         
         ASTJexlScript three = JexlASTHelper.parseJexlQuery("(BAR == 'bar' || BAR == 'baz') && FOO == '1'");
         
-        Assert.assertFalse(JexlASTHelper.equals(two, three));
+        assertFalse(JexlASTHelper.equals(two, three));
     }
     
     @Test
@@ -216,7 +215,7 @@ public class JexlASTHelperTest {
         
         ASTJexlScript two = JexlNodeFactory.createScript(and);
         
-        Assert.assertTrue(JexlASTHelper.equals(one, two));
+        assertTrue(JexlASTHelper.equals(one, two));
     }
     
     @Test
@@ -226,7 +225,7 @@ public class JexlASTHelperTest {
         JexlNode child = script.jjtGetChild(0);
         
         JexlNode test = JexlASTHelper.dereference(child);
-        Assert.assertEquals("FOO == 'a' && FOO == 'b'", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
+        assertEquals("FOO == 'a' && FOO == 'b'", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
     }
     
     @Test
@@ -236,7 +235,7 @@ public class JexlASTHelperTest {
         JexlNode child = script.jjtGetChild(0);
         
         JexlNode test = JexlASTHelper.dereference(child);
-        Assert.assertEquals("FOO == 'a' || FOO == 'b'", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
+        assertEquals("FOO == 'a' || FOO == 'b'", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
     }
     
     @Test
@@ -246,7 +245,7 @@ public class JexlASTHelperTest {
         JexlNode child = script.jjtGetChild(0);
         
         JexlNode test = JexlASTHelper.dereference(child);
-        Assert.assertEquals("(_Value_ = true) && (FOO =~ 'a.*')", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
+        assertEquals("(_Value_ = true) && (FOO =~ 'a.*')", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
         // Note: this is bad. In a larger intersection with other terms, we have now effectively lost which term is marked
         // Example: (_Value_ = true) && (FOO =~ 'a.*') && FOO2 == 'bar' && FOO3 == 'baz'
     }
@@ -259,7 +258,7 @@ public class JexlASTHelperTest {
         JexlNode child = script.jjtGetChild(0);
         
         JexlNode test = JexlASTHelper.dereferenceSafely(child);
-        Assert.assertEquals("((_Value_ = true) && (FOO =~ 'a.*'))", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
+        assertEquals("((_Value_ = true) && (FOO =~ 'a.*'))", JexlStringBuildingVisitor.buildQueryWithoutParse(test));
     }
     
     @Test
@@ -271,7 +270,7 @@ public class JexlASTHelperTest {
         }
         JexlNode literal = script.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0);
         ASTReference ref = JexlASTHelper.normalizeLiteral(literal, normalizer);
-        Assert.assertEquals("astring", ref.jjtGetChild(0).image);
+        assertEquals("astring", ref.jjtGetChild(0).image);
     }
     
     @Test
@@ -281,7 +280,7 @@ public class JexlASTHelperTest {
             PrintingVisitor.printQuery(script);
         }
         JexlNode literal = JexlASTHelper.findLiteral(script);
-        Assert.assertTrue(literal instanceof ASTNumberLiteral);
+        assertTrue(literal instanceof ASTNumberLiteral);
     }
     
     @Test
@@ -315,13 +314,13 @@ public class JexlASTHelperTest {
         
         LiteralRange range = JexlASTHelper.findRange().getRange(script.jjtGetChild(0));
         
-        Assert.assertNull(range);
+        assertNull(range);
         
         script = JexlASTHelper.parseJexlQuery("(A < 5 && A > 1)");
         
         range = JexlASTHelper.findRange().getRange(script.jjtGetChild(0));
         
-        Assert.assertNull(range);
+        assertNull(range);
         
         script = JexlASTHelper.parseJexlQuery("((_Bounded_ = true) && (A < 5 && A > 1))");
         
@@ -330,10 +329,10 @@ public class JexlASTHelperTest {
         Assert.assertNotNull(range);
         Assert.assertNotNull(range.getLowerNode());
         Assert.assertNotNull(range.getUpperNode());
-        Assert.assertEquals(1, range.getLower());
-        Assert.assertEquals(5, range.getUpper());
-        Assert.assertFalse(range.isLowerInclusive());
-        Assert.assertFalse(range.isUpperInclusive());
+        assertEquals(1, range.getLower());
+        assertEquals(5, range.getUpper());
+        assertFalse(range.isLowerInclusive());
+        assertFalse(range.isUpperInclusive());
         
         script = JexlASTHelper.parseJexlQuery("((_Bounded_ = true) && (A <= 5 && A >= 1))");
         
@@ -342,10 +341,10 @@ public class JexlASTHelperTest {
         Assert.assertNotNull(range);
         Assert.assertNotNull(range.getLowerNode());
         Assert.assertNotNull(range.getUpperNode());
-        Assert.assertEquals(1, range.getLower());
-        Assert.assertEquals(5, range.getUpper());
-        Assert.assertTrue(range.isLowerInclusive());
-        Assert.assertTrue(range.isUpperInclusive());
+        assertEquals(1, range.getLower());
+        assertEquals(5, range.getUpper());
+        assertTrue(range.isLowerInclusive());
+        assertTrue(range.isUpperInclusive());
     }
     
     @Test
@@ -354,7 +353,7 @@ public class JexlASTHelperTest {
         
         LiteralRange range = JexlASTHelper.findRange().getRange(script.jjtGetChild(0));
         
-        Assert.assertNull(range);
+        assertNull(range);
         
         script = JexlASTHelper.parseJexlQuery("((_Delayed_ = true) && ((_Bounded_ = true) && (A < 'b' && A > 'a')))");
         
@@ -363,10 +362,10 @@ public class JexlASTHelperTest {
         Assert.assertNotNull(range);
         Assert.assertNotNull(range.getLowerNode());
         Assert.assertNotNull(range.getUpperNode());
-        Assert.assertEquals("a", range.getLower());
-        Assert.assertEquals("b", range.getUpper());
-        Assert.assertFalse(range.isLowerInclusive());
-        Assert.assertFalse(range.isUpperInclusive());
+        assertEquals("a", range.getLower());
+        assertEquals("b", range.getUpper());
+        assertFalse(range.isLowerInclusive());
+        assertFalse(range.isUpperInclusive());
     }
     
     @Test
@@ -375,7 +374,7 @@ public class JexlASTHelperTest {
         
         LiteralRange range = JexlASTHelper.findRange().notDelayed().getRange(script.jjtGetChild(0));
         
-        Assert.assertNull(range);
+        assertNull(range);
         
         script = JexlASTHelper.parseJexlQuery("((_Bounded_ = true) && (A < 5 && A > 1))");
         
@@ -384,10 +383,10 @@ public class JexlASTHelperTest {
         Assert.assertNotNull(range);
         Assert.assertNotNull(range.getLowerNode());
         Assert.assertNotNull(range.getUpperNode());
-        Assert.assertEquals(1, range.getLower());
-        Assert.assertEquals(5, range.getUpper());
-        Assert.assertFalse(range.isLowerInclusive());
-        Assert.assertFalse(range.isUpperInclusive());
+        assertEquals(1, range.getLower());
+        assertEquals(5, range.getUpper());
+        assertFalse(range.isLowerInclusive());
+        assertFalse(range.isUpperInclusive());
     }
     
     @Test
@@ -402,16 +401,16 @@ public class JexlASTHelperTest {
         Assert.assertNotNull(range);
         Assert.assertNotNull(range.getLowerNode());
         Assert.assertNotNull(range.getUpperNode());
-        Assert.assertEquals("a", range.getLower());
-        Assert.assertEquals("b", range.getUpper());
-        Assert.assertFalse(range.isLowerInclusive());
-        Assert.assertFalse(range.isUpperInclusive());
+        assertEquals("a", range.getLower());
+        assertEquals("b", range.getUpper());
+        assertFalse(range.isLowerInclusive());
+        assertFalse(range.isUpperInclusive());
         
         script = JexlASTHelper.parseJexlQuery("B < 5 && B > 1");
         
         range = JexlASTHelper.findRange().indexedOnly(null, helper).getRange(script.jjtGetChild(0));
         
-        Assert.assertNull(range);
+        assertNull(range);
     }
     
     @Test
@@ -419,7 +418,7 @@ public class JexlASTHelperTest {
         String query = "CITY == 'city\\\\'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -427,7 +426,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'city\\\\'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -435,7 +434,7 @@ public class JexlASTHelperTest {
         String query = "CITY == 'city\\\\\\\\'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -443,7 +442,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'city\\\\\\\\'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -451,7 +450,7 @@ public class JexlASTHelperTest {
         String query = "CITY == 'city\\\\\\\\\\\\'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -459,7 +458,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'city\\\\\\\\\\\\'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -467,7 +466,7 @@ public class JexlASTHelperTest {
         String query = "CITY == '\\\\city'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -475,7 +474,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ '\\\\city'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -483,7 +482,7 @@ public class JexlASTHelperTest {
         String query = "CITY == '\\\\\\\\city'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -491,7 +490,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ '\\\\\\\\city'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -499,7 +498,7 @@ public class JexlASTHelperTest {
         String query = "CITY == '\\\\\\\\\\\\city'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -507,7 +506,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ '\\\\\\\\\\\\city'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -515,7 +514,7 @@ public class JexlASTHelperTest {
         String query = "CITY == 'ci\\\\ty'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -523,7 +522,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'ci\\\\ty'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -531,7 +530,7 @@ public class JexlASTHelperTest {
         String query = "CITY == 'ci\\\\\\\\ty'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -539,7 +538,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'ci\\\\\\\\ty'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -547,7 +546,7 @@ public class JexlASTHelperTest {
         String query = "CITY == 'ci\\\\\\\\\\\\ty'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     @Test
@@ -555,7 +554,7 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'ci\\\\\\\\\\\\ty'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals(query, interpretedQuery);
     }
     
     // This test is here to ensure that we can freely convert between a jexl tree and
@@ -569,10 +568,10 @@ public class JexlASTHelperTest {
         String interpretedQuery = JexlStringBuildingVisitor.buildQuery(node);
         JexlNode newNode = JexlASTHelper.parseJexlQuery(interpretedQuery);
         String reinterpretedQuery = JexlStringBuildingVisitor.buildQuery(newNode);
-        Assert.assertEquals("CITY =~ 'ci\\\\\\\\\\\\ty\\.blah'", interpretedQuery);
-        Assert.assertEquals(reinterpretedQuery, interpretedQuery);
-        Assert.assertEquals("ci\\\\\\\\\\\\ty\\.blah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image, newNode.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals("CITY =~ 'ci\\\\\\\\\\\\ty\\.blah'", interpretedQuery);
+        assertEquals(reinterpretedQuery, interpretedQuery);
+        assertEquals("ci\\\\\\\\\\\\ty\\.blah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image, newNode.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
     }
     
     // This test is here to ensure that we can freely convert between a jexl tree and
@@ -588,10 +587,10 @@ public class JexlASTHelperTest {
         JexlNode newNode = JexlASTHelper.parseJexlQuery(interpretedQuery);
         String reinterpretedQuery = JexlStringBuildingVisitor.buildQuery(newNode);
         // note: while this is different from the original query, it produces the same string literal
-        Assert.assertEquals("CITY == 'ci\\\\\\\\\\\\ty\\\\.blah'", interpretedQuery);
-        Assert.assertEquals(reinterpretedQuery, interpretedQuery);
-        Assert.assertEquals("ci\\\\\\ty\\.blah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image, newNode.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals("CITY == 'ci\\\\\\\\\\\\ty\\\\.blah'", interpretedQuery);
+        assertEquals(reinterpretedQuery, interpretedQuery);
+        assertEquals("ci\\\\\\ty\\.blah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image, newNode.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
     }
     
     // This is similar to the last test, but shows the usage of an explicit, escaped backslash before '.blah'
@@ -605,10 +604,10 @@ public class JexlASTHelperTest {
         JexlNode newNode = JexlASTHelper.parseJexlQuery(interpretedQuery);
         String reinterpretedQuery = JexlStringBuildingVisitor.buildQuery(newNode);
         // note: while this is different from the original query, it produces the same string literal
-        Assert.assertEquals("CITY == 'ci\\\\\\\\\\\\ty\\\\.blah'", interpretedQuery);
-        Assert.assertEquals(reinterpretedQuery, interpretedQuery);
-        Assert.assertEquals("ci\\\\\\ty\\.blah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image, newNode.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals("CITY == 'ci\\\\\\\\\\\\ty\\\\.blah'", interpretedQuery);
+        assertEquals(reinterpretedQuery, interpretedQuery);
+        assertEquals("ci\\\\\\ty\\.blah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image, newNode.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
     }
     
     // This test ensures that the literal value of a regex node preserves the full number of backslashes as present in the query.
@@ -620,8 +619,8 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'ci\\\\\\\\\\\\ty\\\\.bl\\'ah'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(node);
-        Assert.assertEquals("ci\\\\\\\\\\\\ty\\\\.bl'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals("ci\\\\\\\\\\\\ty\\\\.bl'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(query, interpretedQuery);
     }
     
     // This test is is similar to the previous one, but with multiple backslashes before the embedded single quote.
@@ -632,8 +631,8 @@ public class JexlASTHelperTest {
         String query = "CITY =~ 'ci\\\\\\\\\\\\ty\\\\.bl\\\\\\'ah'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(node);
-        Assert.assertEquals("ci\\\\\\\\\\\\ty\\\\.bl\\\\'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals("ci\\\\\\\\\\\\ty\\\\.bl\\\\'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(query, interpretedQuery);
     }
     
     // This test ensures that the literal value of an equals node has had the escape characters removed for each backslash.
@@ -645,8 +644,8 @@ public class JexlASTHelperTest {
         String query = "CITY == 'ci\\\\\\\\\\\\ty\\\\.bl\\'ah'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(node);
-        Assert.assertEquals("ci\\\\\\ty\\.bl'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals("ci\\\\\\ty\\.bl'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(query, interpretedQuery);
     }
     
     // This test is is similar to the previous one, but with multiple backslashes before the embedded single quote.
@@ -657,8 +656,8 @@ public class JexlASTHelperTest {
         String query = "CITY == 'ci\\\\\\\\\\\\ty\\\\.bl\\\\\\'ah'";
         JexlNode node = JexlASTHelper.parseJexlQuery(query);
         String interpretedQuery = JexlStringBuildingVisitor.buildQueryWithoutParse(node);
-        Assert.assertEquals("ci\\\\\\ty\\.bl\\'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
-        Assert.assertEquals(query, interpretedQuery);
+        assertEquals("ci\\\\\\ty\\.bl\\'ah", node.jjtGetChild(0).jjtGetChild(1).jjtGetChild(0).image);
+        assertEquals(query, interpretedQuery);
     }
     
     // Verify that true is returned for a query with valid junctions.

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/NodeTypeCountTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/NodeTypeCountTest.java
@@ -10,9 +10,9 @@ import org.junit.Test;
 
 import java.util.Set;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class NodeTypeCountTest {
     


### PR DESCRIPTION
- remove instances of junit.framework
- prefer static access instead of qualified asserts in changed tests 

integration tested by default, as only test classes changed