### PR TITLE
1799 Create Code Style Document

### DIFF
--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,6 @@
+githooks enable a user to have things happen automatically based on the git action taken.  DataWave has the following hooks:
+
+pre-push
+Before pushing the code up to github, this script will 
+RUN:
+  ln -fns githooks/pre-push .git/hooks/pre-push 

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Format files
+mvn -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Pautoformat

--- a/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQueryLog.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tracking/ActiveQueryLog.java
@@ -77,7 +77,7 @@ public class ActiveQueryLog {
 
     /**
      * Return the {@link ActiveQueryLog} instance associated with the specified name. If one does not exist, it will be created.
-     *
+     * <p>
      * If the specified name is null or blank, the default instance with the name '{@value #DEFAULT_NAME}' will be returned. Additionally, the time the log was
      * last accessed will be updated to the current time in milliseconds, and if the log's timer was cancelled, it will be restarted.
      *


### PR DESCRIPTION
Changed gears. There are elements to the style that the autoformatter does that requires users to change other settings in their IDE (which could be different if they used IntelliJ or Eclipse or something else).

INSTEAD -- I have added a `pre-push` git hook (see the githooks) directory. Users can (optionally) create a symlink from <project dir>/.git/hooks/pre-push to this new `pre-push` script, which will run the autoformatter on their code before pushing the changes up.  This would ensure that the code meets the style. 

Added a README to the githooks directory.

OLD below, for posterity...
Brought in the  google java intellij code style xml to project.
Ran it on 3 files as examples of formatted code.

When I was working my first ticket, I found that the default setting for IntelliJ will change the imports to look like: `import xyz.abc.util.*`. I'm not sure what other settings I could be missing.  I'm proposing that we start with the Google Java settings as a base (used it for my last project and it seemed pretty good overall), and then build on top of that.  I'm not sure of any sticking points for people (outside the star imports), so I modified a few files as examples.

If we do end up using this configuration, when someone works a file, they can run the formatter to clean it up.  From experience, it's way too much to try to change all the files in one fell swoop.
I'd also go and edit the confluence/github documentation to add in steps to include the properly configured formatter, to ensure consistent code across developers.