### PR TITLE
Improve TLDQueryIterator's EventDataQueryFilter

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/key/util/FiKeyUtil.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/key/util/FiKeyUtil.java
@@ -1,0 +1,111 @@
+package datawave.core.iterators.key.util;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+
+/**
+ * A utility for determining key type and accessing the field, value, datatype and uid components
+ * <p>
+ * Note: each method call will return a new object, values are not cached, state is not saved
+ * <p>
+ * A FieldIndex key structure is row:fi\0FIELD:value\0datatype\0uid
+ */
+public class FiKeyUtil {
+    
+    private FiKeyUtil() {
+        // static utility
+    }
+    
+    /**
+     * Determines if the provided key is an instance of a FieldIndex key
+     * 
+     * @param k
+     *            the key
+     * @return true if this a FieldIndex key
+     */
+    public static boolean instanceOf(Key k) {
+        ByteSequence bytes = k.getColumnFamilyData();
+        return bytes != null && bytes.length() > 3 && bytes.byteAt(2) == '\u0000' && bytes.byteAt(1) == 'i' && bytes.byteAt(0) == 'f';
+    }
+    
+    /**
+     * Parses the field as a String
+     * 
+     * @param k
+     *            the key
+     * @return the field
+     */
+    public static String getFieldString(Key k) {
+        ByteSequence bytes = k.getColumnFamilyData();
+        return bytes.subSequence(3, bytes.length()).toString();
+    }
+    
+    /**
+     * Parses the value as a String
+     * 
+     * @param k
+     *            the key
+     * @return the value
+     */
+    public static String getValueString(Key k) {
+        ByteSequence bytes = k.getColumnQualifierData();
+        int nullCount = 0;
+        for (int i = bytes.length() - 1; i >= 0; i--) {
+            if (bytes.byteAt(i) == 0x00 && ++nullCount == 2) {
+                return bytes.subSequence(0, i).toString();
+            }
+        }
+        return throwParseException(k);
+    }
+    
+    /**
+     * Parses the datatype as a String
+     * 
+     * @param k
+     *            the key
+     * @return the datatype
+     */
+    public static String getDatatypeString(Key k) {
+        ByteSequence bytes = k.getColumnQualifierData();
+        int stop = -1;
+        for (int i = bytes.length() - 1; i >= 0; i--) {
+            if (bytes.byteAt(i) == 0x00) {
+                if (stop == -1) {
+                    stop = i;
+                } else {
+                    return bytes.subSequence(i + 1, stop).toString();
+                }
+                
+            }
+        }
+        return throwParseException(k);
+    }
+    
+    /**
+     * Parses the uid as a String
+     * 
+     * @param k
+     *            the key
+     * @return the uid
+     */
+    public static String getUidString(Key k) {
+        ByteSequence bytes = k.getColumnQualifierData();
+        for (int i = bytes.length() - 1; i >= 0; i--) {
+            if (bytes.byteAt(i) == 0x00) {
+                return bytes.subSequence(i + 1, bytes.length()).toString();
+            }
+        }
+        return throwParseException(k);
+    }
+    
+    /**
+     * Utility method for throwing an illegal argument exception
+     * 
+     * @param k
+     *            the key
+     * @return nothing
+     */
+    private static String throwParseException(Key k) {
+        throw new IllegalArgumentException("Invalid number of null bytes in field index key column qualifier: " + k.getColumnQualifier().toString());
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
@@ -4,7 +4,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import datawave.query.attributes.Document;
-import datawave.query.data.parsers.DatawaveKey;
+import datawave.core.iterators.key.util.FiKeyUtil;
 import datawave.query.function.TLDEquality;
 import datawave.query.iterator.NestedIterator;
 import datawave.query.iterator.QueryIterator;
@@ -100,7 +100,7 @@ public class TLDQueryIterator extends QueryIterator {
     /**
      * Distinct from getEvaluation filter as the FI filter is used to prevent FI hits on nonEventFields that are not indexOnly fields
      * 
-     * @return
+     * @return an {@link EventDataQueryFilter}
      */
     protected EventDataQueryFilter getFIEvaluationFilter() {
         ChainableEventDataQueryFilter chainableEventDataQueryFilter = new ChainableEventDataQueryFilter();
@@ -128,13 +128,16 @@ public class TLDQueryIterator extends QueryIterator {
              * Keep any FI that is index only and part of the TLD or is not part of the TLD
              * 
              * @param k
-             * @return
+             *            a field index key
+             * @return true if the key should be kept for evaluation
              */
             @Override
             public boolean keep(Key k) {
                 boolean root = TLDEventDataFilter.isRootPointer(k);
-                DatawaveKey datawaveKey = new DatawaveKey(k);
-                return (root && getIndexOnlyFields().contains(datawaveKey.getFieldName())) || !root;
+                if (root) {
+                    return getIndexOnlyFields().contains(FiKeyUtil.getFieldString(k));
+                }
+                return true;
             }
             
             @Override

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/key/util/FiKeyUtilTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/key/util/FiKeyUtilTest.java
@@ -51,10 +51,12 @@ public class FiKeyUtilTest {
         assertEquals("datatype", FiKeyUtil.getDatatypeString(key));
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    // getUidString simply returns everything after the last null byte. If the column qualifier is wrong
+    // then the method will return the wrong value
+    @Test
     public void testParseNoUid() {
         Key key = new Key("row", "fi\0FIELD", "value\0datatype");
-        assertEquals("uid", FiKeyUtil.getDatatypeString(key));
+        assertEquals("datatype", FiKeyUtil.getUidString(key));
     }
     
 }

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/key/util/FiKeyUtilTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/key/util/FiKeyUtilTest.java
@@ -1,0 +1,60 @@
+package datawave.core.iterators.key.util;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FiKeyUtilTest {
+    
+    private final Key fikey = new Key("row", "fi\0FIELD", "value\0datatype\0uid");
+    private final Key fikeyWithNulls = new Key("row", "fi\0FIELD", "v\0a\0l\0u\0e\0datatype\0uid");
+    private final Key fikeyWithChildUid = new Key("row", "fi\0FIELD", "value\0datatype\0uid.12.37");
+    
+    @Test
+    public void testSimpleParse() {
+        assertTrue(FiKeyUtil.instanceOf(fikey));
+        assertEquals("FIELD", FiKeyUtil.getFieldString(fikey));
+        assertEquals("value", FiKeyUtil.getValueString(fikey));
+        assertEquals("datatype", FiKeyUtil.getDatatypeString(fikey));
+        assertEquals("uid", FiKeyUtil.getUidString(fikey));
+    }
+    
+    @Test
+    public void testParsingValueWithNulls() {
+        assertTrue(FiKeyUtil.instanceOf(fikey));
+        assertEquals("FIELD", FiKeyUtil.getFieldString(fikeyWithNulls));
+        assertEquals("v\0a\0l\0u\0e", FiKeyUtil.getValueString(fikeyWithNulls));
+        assertEquals("datatype", FiKeyUtil.getDatatypeString(fikeyWithNulls));
+        assertEquals("uid", FiKeyUtil.getUidString(fikeyWithNulls));
+    }
+    
+    @Test
+    public void testParseChildUid() {
+        assertTrue(FiKeyUtil.instanceOf(fikey));
+        assertEquals("FIELD", FiKeyUtil.getFieldString(fikeyWithChildUid));
+        assertEquals("value", FiKeyUtil.getValueString(fikeyWithChildUid));
+        assertEquals("datatype", FiKeyUtil.getDatatypeString(fikeyWithChildUid));
+        assertEquals("uid.12.37", FiKeyUtil.getUidString(fikeyWithChildUid));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseNoValue() {
+        Key key = new Key("row", "fi\0FIELD", "datatype\0uid");
+        assertEquals("value", FiKeyUtil.getValueString(key));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseNoDatatype() {
+        Key key = new Key("row", "fi\0FIELD", "value\0uid");
+        assertEquals("datatype", FiKeyUtil.getDatatypeString(key));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseNoUid() {
+        Key key = new Key("row", "fi\0FIELD", "value\0datatype");
+        assertEquals("uid", FiKeyUtil.getDatatypeString(key));
+    }
+    
+}


### PR DESCRIPTION
- refactored logic to only parse keys that are part of the root document
- removed DatawaveKey as parse mechanism
- added FiKeyUtil and test for parsing logical components from field index keys