### PR TITLE
Improve TLDEventDataFilter's query field parse

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -784,6 +784,8 @@ public class QueryOptions implements OptionDescriber {
         allFields.addAll(getContentExpansionFields());
         allFields.addAll(getIndexedFields());
         allFields.addAll(getTermFrequencyFields());
+        // also grab non-indexed fields
+        allFields.addAll(getNonIndexedDataTypeMap().keySet());
         return allFields;
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -764,6 +764,29 @@ public class QueryOptions implements OptionDescriber {
         return nonEventFields;
     }
     
+    /**
+     * Get the union of all fields set via the following QueryOptions
+     * <ul>
+     * <li>{@link #INDEXED_FIELDS}</li>
+     * <li>{@link #INDEX_ONLY_FIELDS}</li>
+     * <li>{@link #TERM_FREQUENCY_FIELDS}</li>
+     * <li>{@link #COMPOSITE_FIELDS}</li>
+     * <li>{@link #CONTENT_EXPANSION_FIELDS}</li>
+     * </ul>
+     *
+     * @return the union of all configured fields
+     */
+    public Set<String> getAllFields() {
+        Set<String> allFields = new HashSet<>();
+        // includes index only fields plus composite fields
+        allFields.addAll(getAllIndexOnlyFields());
+        // should be a subset of tf fields
+        allFields.addAll(getContentExpansionFields());
+        allFields.addAll(getIndexedFields());
+        allFields.addAll(getTermFrequencyFields());
+        return allFields;
+    }
+    
     public boolean isContainsIndexOnlyTerms() {
         return containsIndexOnlyTerms;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
@@ -2,11 +2,14 @@ package datawave.query.predicate;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import datawave.query.tld.TLD;
 import datawave.query.util.TypeMetadata;
 import org.apache.accumulo.core.data.ByteSequence;
@@ -63,9 +66,10 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
     
     private Set<String> nonEventFields;
     
-    public TLDEventDataFilter(ASTJexlScript script, TypeMetadata attributeFactory, Set<String> whitelist, Set<String> blacklist, long maxFieldsBeforeSeek,
-                    long maxKeysBeforeSeek) {
-        this(script, attributeFactory, whitelist, blacklist, maxFieldsBeforeSeek, maxKeysBeforeSeek, Collections.EMPTY_MAP, null, Collections.EMPTY_SET);
+    public TLDEventDataFilter(ASTJexlScript script, Set<String> queryFields, TypeMetadata attributeFactory, Set<String> whitelist, Set<String> blacklist,
+                    long maxFieldsBeforeSeek, long maxKeysBeforeSeek) {
+        this(script, queryFields, attributeFactory, whitelist, blacklist, maxFieldsBeforeSeek, maxKeysBeforeSeek, Collections.EMPTY_MAP, null,
+                        Collections.EMPTY_SET);
     }
     
     /**
@@ -78,8 +82,8 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
      * 
      * @param script
      */
-    public TLDEventDataFilter(ASTJexlScript script, TypeMetadata attributeFactory, Set<String> whitelist, Set<String> blacklist, long maxFieldsBeforeSeek,
-                    long maxKeysBeforeSeek, Map<String,Integer> limitFieldsMap, String limitFieldsField, Set<String> nonEventFields) {
+    public TLDEventDataFilter(ASTJexlScript script, Set<String> queryFields, TypeMetadata attributeFactory, Set<String> whitelist, Set<String> blacklist,
+                    long maxFieldsBeforeSeek, long maxKeysBeforeSeek, Map<String,Integer> limitFieldsMap, String limitFieldsField, Set<String> nonEventFields) {
         super(script, attributeFactory, nonEventFields);
         
         this.maxFieldsBeforeSeek = maxFieldsBeforeSeek;
@@ -91,7 +95,7 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
         // set the anyFieldLimit once if specified otherwise set to -1
         anyFieldLimit = limitFieldsMap.get(Constants.ANY_FIELD) != null ? limitFieldsMap.get(Constants.ANY_FIELD) : -1;
         
-        extractQueryFieldsFromScript(script);
+        setQueryFields(queryFields, script);
         updateLists(whitelist, blacklist);
         setSortedLists(whitelist, blacklist);
     }
@@ -601,38 +605,36 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
      * Extract the query fields from the script and sort them
      *
      * @param script
+     *            the query script
+     * @return a set of identifiers
      */
-    private void extractQueryFieldsFromScript(ASTJexlScript script) {
-        queryFields = new ArrayList<>();
+    private Set<String> extractIdentifiersFromScript(ASTJexlScript script) {
+        Set<String> ids = new HashSet<>();
         String field;
         List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(script);
         for (ASTIdentifier identifier : identifiers) {
             field = JexlASTHelper.deconstructIdentifier(identifier);
-            if (!queryFields.contains(field) && !containsLowers(field)) {
-                queryFields.add(field);
-            }
+            ids.add(field);
         }
-        
-        // sort the queryFields
-        Collections.sort(queryFields);
-        queryFields = Collections.unmodifiableList(queryFields);
+        return ids;
     }
     
     /**
-     * Fields are always uppercase
-     * 
-     * @param field
-     *            the field
-     * @return true if all characters are uppercase
+     * Intersect the fields serialized along with the query iterator with the identifiers in the query
+     *
+     * @param fields
+     *            the serialized fields
+     * @param script
+     *            the query script
      */
-    private boolean containsLowers(String field) {
-        for (char c : field.toCharArray()) {
-            // ascii 97 is 'a' and 122 is 'z'
-            if (c >= 97 && c < 122) {
-                return true;
-            }
-        }
-        return false;
+    private void setQueryFields(Set<String> fields, ASTJexlScript script) {
+        
+        Set<String> identifiers = extractIdentifiersFromScript(script);
+        fields = Sets.intersection(fields, identifiers);
+        
+        queryFields = Lists.newArrayList(fields);
+        Collections.sort(queryFields);
+        queryFields = Collections.unmodifiableList(queryFields);
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
@@ -608,7 +608,7 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
         List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(script);
         for (ASTIdentifier identifier : identifiers) {
             field = JexlASTHelper.deconstructIdentifier(identifier);
-            if (!queryFields.contains(field)) {
+            if (!queryFields.contains(field) && !containsLowers(field)) {
                 queryFields.add(field);
             }
         }
@@ -616,6 +616,23 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
         // sort the queryFields
         Collections.sort(queryFields);
         queryFields = Collections.unmodifiableList(queryFields);
+    }
+    
+    /**
+     * Fields are always uppercase
+     * 
+     * @param field
+     *            the field
+     * @return true if all characters are uppercase
+     */
+    private boolean containsLowers(String field) {
+        for (char c : field.toCharArray()) {
+            // ascii 97 is 'a' and 122 is 'z'
+            if (c >= 97 && c < 122) {
+                return true;
+            }
+        }
+        return false;
     }
     
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
@@ -11,6 +11,7 @@ import datawave.query.iterator.QueryIterator;
 import datawave.query.iterator.SourcedOptions;
 import datawave.query.iterator.logic.IndexIterator;
 import datawave.query.jexl.visitors.IteratorBuildingVisitor;
+import datawave.query.jexl.visitors.QueryFieldsVisitor;
 import datawave.query.planner.SeekingQueryPlanner;
 import datawave.query.postprocessing.tf.TFFactory;
 import datawave.query.postprocessing.tf.TermFrequencyConfig;
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This is a TLD (Top Level Document) QueryIterator implementation.
@@ -184,9 +186,9 @@ public class TLDQueryIterator extends QueryIterator {
     public EventDataQueryFilter getEvaluationFilter() {
         if (this.evaluationFilter == null && script != null) {
             // setup an evaluation filter to avoid loading every single child key into the event
-            this.evaluationFilter = new TLDEventDataFilter(script, typeMetadata, useWhiteListedFields ? whiteListedFields : null,
+            this.evaluationFilter = new TLDEventDataFilter(script, getAllFields(), typeMetadata, useWhiteListedFields ? whiteListedFields : null,
                             useBlackListedFields ? blackListedFields : null, maxFieldHitsBeforeSeek, maxKeysBeforeSeek,
-                            limitFieldsPreQueryEvaluation ? limitFieldsMap : Collections.EMPTY_MAP, limitFieldsField, getNonEventFields());
+                            limitFieldsPreQueryEvaluation ? limitFieldsMap : Collections.emptyMap(), limitFieldsField, getNonEventFields());
         }
         return this.evaluationFilter != null ? evaluationFilter.clone() : null;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
@@ -18,6 +18,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.commons.jexl2.parser.ASTJexlScript;
 import org.apache.commons.jexl2.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,6 +73,7 @@ public class TermFrequencyIndexIteratorTest {
         filter = new EventDataQueryExpressionFilter(
                         JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='buz' || FOO=='alf' || FOO=='arm'"), typeMetadata,
                         fieldsToKeep);
+        
         aggregator = new TermFrequencyAggregator(fieldsToKeep, filter);
     }
     
@@ -308,9 +310,13 @@ public class TermFrequencyIndexIteratorTest {
     
     @Test
     public void testScanFullRangeExclusiveTLD() throws IOException, ParseException {
+        String query = "FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'";
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        
         Range r = new Range(getFiKey("row", "type1", "123.345.456", "FOO", "alf"), false, getFiKey("row", "type1", "123.345.456.2", "FOO", "buz"), false);
-        filter = new TLDEventDataFilter(JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'"), typeMetadata, null, null, -1, -1,
-                        Collections.emptyMap(), null, fieldsToKeep);
+        
+        filter = new TLDEventDataFilter(script, Collections.singleton("FOO"), typeMetadata, null, null, -1, -1, Collections.emptyMap(), null, fieldsToKeep);
+        
         aggregator = new TLDTermFrequencyAggregator(fieldsToKeep, filter, -1);
         TermFrequencyIndexIterator iterator = new TermFrequencyIndexIterator(r, source, null, typeMetadata, true, null, aggregator);
         

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
@@ -708,6 +708,12 @@ public class JexlASTHelperTest {
         // original full query
         query = "(AGE > '+bE1' || ETA > '+bE1') && (AGE < '+cE1' || ETA < '+cE1') && ((_Eval_ = true) && ((AGE || ETA).getValuesForGroups(grouping:getGroupsForMatchesInGroup((NOME || NAME), 'MEADOW', (GENERE || GENDER), 'FEMALE')) == MAGIC))";
         testIdentifierParse(query, Sets.newHashSet("AGE", "ETA", "GENDER", "GENERE", "MAGIC", "NAME", "NOME"));
+        
+        query = "content:phrase(termOffsetMap, 'bar', 'baz')";
+        testIdentifierParse(query, Collections.singleton("termOffsetMap"));
+        
+        query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz')";
+        testIdentifierParse(query, Sets.newHashSet("FOO", "termOffsetMap"));
     }
     
     private void testIdentifierParse(String query, Set<String> expectedIdentifiers) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryFieldsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryFieldsVisitorTest.java
@@ -30,6 +30,14 @@ public class QueryFieldsVisitorTest {
     public void testEQ() throws ParseException {
         String query = "FOO == 'bar'";
         test(query, Collections.singleton("FOO"));
+        
+        // identifiers
+        query = "$12 == 'bar'";
+        test(query, Collections.singleton("12"));
+        
+        // grouping context
+        query = "FOO.12 == 'bar'";
+        test(query, Collections.singleton("FOO"));
     }
     
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
@@ -599,15 +599,17 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     
     @Test
     public void testBadIdentifier() throws ParseException {
-        String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz'";
+        String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz' && Foo2 == 'bad'";
         ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
         
         // silly mock stuff
         expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
         replayAll();
         
-        filter = new TLDEventDataFilter(script, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(script, Sets.newHashSet("FOO", "FOO2"), mockAttributeFactory, null, null, -1, -1);
         
+        // asserts that 'termOffsetMap' is not considered a query field
+        // asserts that malformed field 'Foo2' is not considered a query field
         assertEquals(Collections.singletonList("FOO"), filter.queryFields);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
@@ -1,5 +1,6 @@
 package datawave.query.predicate;
 
+import com.google.common.collect.Sets;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberType;
 import datawave.query.Constants;
@@ -68,7 +69,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "column", "FIELD" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
         assertEquals("FIELD", field);
@@ -85,7 +86,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "column", "FIELD.part_1.part_2.part_3" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
         assertEquals("FIELD", field);
@@ -102,7 +103,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "fi" + Constants.NULL + "FIELD", "value" + Constants.NULL + "datatype" + Constants.NULL + "123.345.456");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
         assertEquals("FIELD", field);
@@ -119,7 +120,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "fi" + Constants.NULL + "FIELD.name", "value" + Constants.NULL + "datatype" + Constants.NULL + "123.345.456");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
         assertEquals("FIELD", field);
@@ -136,7 +137,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "tf", "datatype" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "FIELD");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
         assertEquals("FIELD", field);
@@ -152,7 +153,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "tf", "datatype" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "FIELD.name");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
         assertEquals("FIELD", field);
@@ -171,7 +172,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD",
+                        Collections.emptySet());
         
         assertTrue(filter.keep(key));
         assertNull(filter.getSeekRange(key, key.followingKey(PartialKey.ROW), false));
@@ -193,7 +195,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "datatype" + Constants.NULL + "123.345.456", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
+        filter = new TLDEventDataFilter(query, Collections.singleton("FIELD2"), mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD",
+                        Collections.emptySet());
         
         assertTrue(filter.keep(key));
         // increments counts = 1
@@ -228,7 +231,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         Key key1 = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key2 = new Key("row", "column", "FIELD2" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD",
+                        Collections.emptySet());
         
         assertTrue(filter.keep(key1));
         // increments counts = 1
@@ -284,7 +288,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         Key key1 = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key2 = new Key("row", "column", "FIELD2" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 3, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, 3, -1, fieldLimits, "LIMIT_FIELD",
+                        Collections.emptySet());
         
         assertTrue(filter.keep(key1));
         // increments counts = 1
@@ -320,7 +325,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         // expected key structure
         Key key = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         
         TLDEventDataFilter.ParseInfo info = filter.getParseInfo(key);
         assertNotNull(info);
@@ -396,7 +401,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.1", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key3 = new Key("row", "datatype" + Constants.NULL + "123.234.34567", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
         
         filter.startNewDocument(key1);
         // set the lastParseInfo to this key
@@ -421,7 +426,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         replayAll();
         
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, 1);
+        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, 1);
         
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FOO" + Constants.NULL_BYTE_STRING + "baz");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.11", "FOO" + Constants.NULL_BYTE_STRING + "baz");
@@ -442,7 +447,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         replayAll();
         
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, 1);
+        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, 1);
         
         // process parent first to set up proper root calculations
         Key parent = new Key("row", "datatype" + Constants.NULL + "123.234.345", "BAR" + Constants.NULL_BYTE_STRING + "baz");
@@ -470,7 +475,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("FOO"));
         assertTrue(filter.queryFields.contains("BAR"));
@@ -489,7 +494,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("FOO"));
     }
@@ -507,7 +512,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("BAR"));
     }
@@ -525,7 +530,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("BAR"));
         assertTrue(filter.queryFields.contains("FOO"));
@@ -552,7 +557,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         Key rootKey = new Key("row", "datatype" + Constants.NULL + "123.345.456", "FIELD3" + Constants.NULL_BYTE_STRING + "value");
         // child key that would normally not be kept
         Key key = new Key("row", "datatype" + Constants.NULL + "123.345.456.1", "FIELD2" + Constants.NULL_BYTE_STRING + "bar");
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD", nonEventFields);
+        filter = new TLDEventDataFilter(query, Collections.singleton("FIELD2"), mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD",
+                        nonEventFields);
         
         // set the parse info correctly
         filter.startNewDocument(rootKey);
@@ -571,7 +577,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         replayAll();
         
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, -1);
         
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FOO" + Constants.NULL_BYTE_STRING + "baz");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.11", "FOO" + Constants.NULL_BYTE_STRING + "baz");
@@ -600,7 +606,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
         replayAll();
         
-        filter = new TLDEventDataFilter(script, mockAttributeFactory, null, null, -1, -1);
+        filter = new TLDEventDataFilter(script, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, -1);
         
         assertEquals(Collections.singletonList("FOO"), filter.queryFields);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
@@ -594,4 +594,18 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         assertFalse(result3);
         assertTrue(result4);
     }
+    
+    @Test
+    public void testBadIdentifier() throws ParseException {
+        String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz'";
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        
+        // silly mock stuff
+        expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
+        replayAll();
+        
+        filter = new TLDEventDataFilter(script, mockAttributeFactory, null, null, -1, -1);
+        
+        assertEquals(Collections.singletonList("FOO"), filter.queryFields);
+    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
@@ -3,7 +3,6 @@ package datawave.query.predicate;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberType;
 import datawave.query.Constants;
-import datawave.query.attributes.AttributeFactory;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
@@ -31,20 +30,19 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class TLDEventDataFilterTest extends EasyMockSupport {
     private TLDEventDataFilter filter;
     private ASTJexlScript mockScript;
     private TypeMetadata mockAttributeFactory;
     
-    private AttributeFactory attrFactory;
-    private MockMetadataHelper helper = new MockMetadataHelper();
-    private MockDateIndexHelper helper2 = new MockDateIndexHelper();
-    private ShardQueryConfiguration config = new ShardQueryConfiguration();
+    private final MockMetadataHelper helper = new MockMetadataHelper();
+    private final MockDateIndexHelper helper2 = new MockDateIndexHelper();
+    private final ShardQueryConfiguration config = new ShardQueryConfiguration();
     
     @Before
     public void setup() {
@@ -55,12 +53,10 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         String number = NumberType.class.getName();
         
         TypeMetadata md = new TypeMetadata();
-        md.put("FOO", "dataType", lcNoDiacritics);
-        md.put("BAZ", "dataType", number);
-        md.put("BAR", "dataType", lcNoDiacritics);
-        md.put("BAR", "dataType", number);
-        
-        attrFactory = new AttributeFactory(md);
+        md.put("FOO", "datatype", lcNoDiacritics);
+        md.put("BAZ", "datatype", number);
+        md.put("BAR", "datatype", lcNoDiacritics);
+        md.put("BAR", "datatype", number);
     }
     
     @Test
@@ -71,11 +67,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "column", "field" + Constants.NULL_BYTE_STRING + "value");
+        Key key = new Key("row", "column", "FIELD" + Constants.NULL_BYTE_STRING + "value");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
-        assertEquals("field", field);
+        assertEquals("FIELD", field);
         
         verifyAll();
     }
@@ -88,11 +84,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "column", "field.part_1.part_2.part_3" + Constants.NULL_BYTE_STRING + "value");
+        Key key = new Key("row", "column", "FIELD.part_1.part_2.part_3" + Constants.NULL_BYTE_STRING + "value");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
-        assertEquals("field", field);
+        assertEquals("FIELD", field);
         
         verifyAll();
     }
@@ -105,11 +101,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "fi" + Constants.NULL + "field", "value" + Constants.NULL + "dataType" + Constants.NULL + "123.345.456");
+        Key key = new Key("row", "fi" + Constants.NULL + "FIELD", "value" + Constants.NULL + "datatype" + Constants.NULL + "123.345.456");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
-        assertTrue(field.equals("field"));
+        assertEquals("FIELD", field);
         
         verifyAll();
     }
@@ -122,11 +118,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "fi" + Constants.NULL + "field.name", "value" + Constants.NULL + "dataType" + Constants.NULL + "123.345.456");
+        Key key = new Key("row", "fi" + Constants.NULL + "FIELD.name", "value" + Constants.NULL + "datatype" + Constants.NULL + "123.345.456");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
-        assertTrue(field.equals("field"));
+        assertEquals("FIELD", field);
         
         verifyAll();
     }
@@ -139,11 +135,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "tf", "dataType" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "field");
+        Key key = new Key("row", "tf", "datatype" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "FIELD");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
-        assertTrue(field.equals("field"));
+        assertEquals("FIELD", field);
         
         verifyAll();
     }
@@ -155,11 +151,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "tf", "dataType" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "field.name");
+        Key key = new Key("row", "tf", "datatype" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "FIELD.name");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         String field = filter.getCurrentField(key);
         
-        assertTrue(field.equals("field"));
+        assertEquals("FIELD", field);
         
         verifyAll();
     }
@@ -174,8 +170,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "column", "field1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.EMPTY_SET);
+        Key key = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
+        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
         
         assertTrue(filter.keep(key));
         assertNull(filter.getSeekRange(key, key.followingKey(PartialKey.ROW), false));
@@ -189,15 +185,15 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         fieldLimits.put(Constants.ANY_FIELD, 1);
         
         Set<String> blacklist = new HashSet<>();
-        blacklist.add("field3");
+        blacklist.add("FIELD3");
         
-        ASTJexlScript query = JexlASTHelper.parseJexlQuery("field2 == 'bar'");
+        ASTJexlScript query = JexlASTHelper.parseJexlQuery("FIELD2 == 'bar'");
         
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "dataType" + Constants.NULL + "123.345.456", "field1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.EMPTY_SET);
+        Key key = new Key("row", "datatype" + Constants.NULL + "123.345.456", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
+        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
         
         assertTrue(filter.keep(key));
         // increments counts = 1
@@ -205,14 +201,14 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         assertNull(filter.getSeekRange(key, key.followingKey(PartialKey.ROW), false));
         // does not increment counts so will still return true
         assertTrue(filter.keep(key));
-        // increments counts = 2 so rejects based on field filter
+        // increment counts = 2 so rejects based on field filter
         assertFalse(filter.apply(new AbstractMap.SimpleEntry<>(key, null)));
         Range seekRange = filter.getSeekRange(key, key.followingKey(PartialKey.ROW), false);
         assertNotNull(seekRange);
         assertEquals(seekRange.getStartKey().getRow(), key.getRow());
         assertEquals(seekRange.getStartKey().getColumnFamily(), key.getColumnFamily());
-        assertEquals(seekRange.getStartKey().getColumnQualifier().toString(), "field1" + "\u0001");
-        assertEquals(true, seekRange.isStartKeyInclusive());
+        assertEquals(seekRange.getStartKey().getColumnQualifier().toString(), "FIELD1" + "\u0001");
+        assertTrue(seekRange.isStartKeyInclusive());
         
         // now fails
         assertFalse(filter.keep(key));
@@ -223,16 +219,16 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     @Test
     public void keep_limitFieldTest() {
         Map<String,Integer> fieldLimits = new HashMap<>(1);
-        fieldLimits.put("field1", 1);
+        fieldLimits.put("FIELD1", 1);
         
         expect(mockScript.jjtGetNumChildren()).andReturn(0).anyTimes();
         expect(mockScript.jjtAccept(isA(EventDataQueryExpressionVisitor.class), eq(""))).andReturn(null);
         
         replayAll();
         
-        Key key1 = new Key("row", "column", "field1" + Constants.NULL_BYTE_STRING + "value");
-        Key key2 = new Key("row", "column", "field2" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.EMPTY_SET);
+        Key key1 = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
+        Key key2 = new Key("row", "column", "FIELD2" + Constants.NULL_BYTE_STRING + "value");
+        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
         
         assertTrue(filter.keep(key1));
         // increments counts = 1
@@ -247,8 +243,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         assertNotNull(seekRange);
         assertEquals(seekRange.getStartKey().getRow(), key1.getRow());
         assertEquals(seekRange.getStartKey().getColumnFamily(), key1.getColumnFamily());
-        assertEquals(seekRange.getStartKey().getColumnQualifier().toString(), "field1" + "\u0001");
-        assertEquals(true, seekRange.isStartKeyInclusive());
+        assertEquals(seekRange.getStartKey().getColumnQualifier().toString(), "FIELD1" + "\u0001");
+        assertTrue(seekRange.isStartKeyInclusive());
         // now fails
         assertFalse(filter.keep(key1));
         
@@ -256,7 +252,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         assertNotNull(limitKey);
         assertEquals(limitKey.getRow(), key1.getRow());
         assertEquals(limitKey.getColumnFamily(), key1.getColumnFamily());
-        assertEquals(limitKey.getColumnQualifier().toString(), "LIMIT_FIELD" + Constants.NULL + "field1");
+        assertEquals(limitKey.getColumnQualifier().toString(), "LIMIT_FIELD" + Constants.NULL + "FIELD1");
         
         // unlimited field
         assertTrue(filter.keep(key2));
@@ -279,16 +275,16 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     @Test
     public void getSeekRange_maxFieldSeekNotEqualToLimit() {
         Map<String,Integer> fieldLimits = new HashMap<>(1);
-        fieldLimits.put("field1", 1);
+        fieldLimits.put("FIELD1", 1);
         
         expect(mockScript.jjtGetNumChildren()).andReturn(0).anyTimes();
         expect(mockScript.jjtAccept(isA(EventDataQueryExpressionVisitor.class), eq(""))).andReturn(null);
         
         replayAll();
         
-        Key key1 = new Key("row", "column", "field1" + Constants.NULL_BYTE_STRING + "value");
-        Key key2 = new Key("row", "column", "field2" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 3, -1, fieldLimits, "LIMIT_FIELD", Collections.EMPTY_SET);
+        Key key1 = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
+        Key key2 = new Key("row", "column", "FIELD2" + Constants.NULL_BYTE_STRING + "value");
+        filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, 3, -1, fieldLimits, "LIMIT_FIELD", Collections.emptySet());
         
         assertTrue(filter.keep(key1));
         // increments counts = 1
@@ -296,7 +292,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         assertNull(filter.getSeekRange(key1, key1.followingKey(PartialKey.ROW), false));
         // does not increment counts so will still return true
         assertTrue(filter.keep(key1));
-        // increments counts = 2 rejected by field count
+        // increment counts = 2 rejected by field count
         assertFalse(filter.apply(new AbstractMap.SimpleEntry<>(key1, null)));
         assertNull(filter.getSeekRange(key1, key1.followingKey(PartialKey.ROW), false));
         
@@ -309,8 +305,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         assertNotNull(seekRange);
         assertEquals(seekRange.getStartKey().getRow(), key1.getRow());
         assertEquals(seekRange.getStartKey().getColumnFamily(), key1.getColumnFamily());
-        assertEquals(seekRange.getStartKey().getColumnQualifier().toString(), "field1" + "\u0001");
-        assertEquals(true, seekRange.isStartKeyInclusive());
+        assertEquals(seekRange.getStartKey().getColumnQualifier().toString(), "FIELD1" + "\u0001");
+        assertTrue(seekRange.isStartKeyInclusive());
         
         verifyAll();
     }
@@ -323,67 +319,67 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key = new Key("row", "dataype" + Constants.NULL + "123.234.345", "field1" + Constants.NULL_BYTE_STRING + "value");
+        Key key = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         
         TLDEventDataFilter.ParseInfo info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertTrue(info.isRoot());
         
         // first two calls are made without the internal update to the cached parseInfo so are calculated independently
         
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertTrue(info.isRoot());
         
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345.1", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345.1", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         // this was wrong assumption based when fixed length UID parse assumptions were being made in the TLDEventDataFilter
         assertTrue(info.isRoot());
         
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         // use the keep method to set the previous call state
         filter.keep(key);
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertTrue(info.isRoot());
         
         // now test the child and see that it is not root
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345.1", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345.1", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         filter.keep(key);
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertFalse(info.isRoot());
         
         // a second child
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345.2", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345.2", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         filter.keep(key);
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertFalse(info.isRoot());
         
         // a longer child
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345.23", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345.23", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         filter.keep(key);
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertFalse(info.isRoot());
         
         // jump back to the original
-        key = new Key("row", "dataype" + Constants.NULL + "123.234.345", "field1" + Constants.NULL_BYTE_STRING + "value");
+        key = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         filter.keep(key);
         info = filter.getParseInfo(key);
         assertNotNull(info);
-        assertEquals("field1", info.getField());
+        assertEquals("FIELD1", info.getField());
         assertTrue(info.isRoot());
         
         verifyAll();
@@ -397,9 +393,9 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         replayAll();
         
         // expected key structure
-        Key key1 = new Key("row", "dataype" + Constants.NULL + "123.234.345", "field1" + Constants.NULL_BYTE_STRING + "value");
-        Key key2 = new Key("row", "dataype" + Constants.NULL + "123.234.345.1", "field1" + Constants.NULL_BYTE_STRING + "value");
-        Key key3 = new Key("row", "dataype" + Constants.NULL + "123.234.34567", "field1" + Constants.NULL_BYTE_STRING + "value");
+        Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
+        Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.1", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
+        Key key3 = new Key("row", "datatype" + Constants.NULL + "123.234.34567", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         filter = new TLDEventDataFilter(mockScript, mockAttributeFactory, null, null, -1, -1);
         
         filter.startNewDocument(key1);
@@ -425,7 +421,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         replayAll();
         
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, 01);
+        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, 1);
         
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FOO" + Constants.NULL_BYTE_STRING + "baz");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.11", "FOO" + Constants.NULL_BYTE_STRING + "baz");
@@ -446,9 +442,9 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         
         replayAll();
         
-        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, 01);
+        filter = new TLDEventDataFilter(query, mockAttributeFactory, null, null, -1, 1);
         
-        // process parent first to setup proper root calculations
+        // process parent first to set up proper root calculations
         Key parent = new Key("row", "datatype" + Constants.NULL + "123.234.345", "BAR" + Constants.NULL_BYTE_STRING + "baz");
         filter.keep(parent);
         filter.apply(new AbstractMap.SimpleEntry<>(parent, null));
@@ -474,7 +470,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 01);
+        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("FOO"));
         assertTrue(filter.queryFields.contains("BAR"));
@@ -493,7 +489,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 01);
+        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("FOO"));
     }
@@ -511,7 +507,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 01);
+        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("BAR"));
     }
@@ -529,7 +525,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
         
-        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 01);
+        filter = new TLDEventDataFilter(newScript, mockAttributeFactory, null, null, -1, 1);
         
         assertTrue(filter.queryFields.contains("BAR"));
         assertTrue(filter.queryFields.contains("FOO"));
@@ -541,21 +537,21 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         fieldLimits.put(Constants.ANY_FIELD, 1);
         
         Set<String> blacklist = new HashSet<>();
-        blacklist.add("field3");
+        blacklist.add("FIELD3");
         
-        ASTJexlScript query = JexlASTHelper.parseJexlQuery("field2 == 'bar'");
+        ASTJexlScript query = JexlASTHelper.parseJexlQuery("FIELD2 == 'bar'");
         
         Set<String> nonEventFields = new HashSet<>();
-        nonEventFields.add("field2");
+        nonEventFields.add("FIELD2");
         
-        expect(mockAttributeFactory.getTypeMetadata("field2", "dataType")).andReturn(Collections.emptyList()).anyTimes();
+        expect(mockAttributeFactory.getTypeMetadata("FIELD2", "datatype")).andReturn(Collections.emptyList()).anyTimes();
         
         replayAll();
         
         // blacklisted tld key to initialize doc
-        Key rootKey = new Key("row", "dataType" + Constants.NULL + "123.345.456", "field3" + Constants.NULL_BYTE_STRING + "value");
+        Key rootKey = new Key("row", "datatype" + Constants.NULL + "123.345.456", "FIELD3" + Constants.NULL_BYTE_STRING + "value");
         // child key that would normally not be kept
-        Key key = new Key("row", "dataType" + Constants.NULL + "123.345.456.1", "field2" + Constants.NULL_BYTE_STRING + "bar");
+        Key key = new Key("row", "datatype" + Constants.NULL + "123.345.456.1", "FIELD2" + Constants.NULL_BYTE_STRING + "bar");
         filter = new TLDEventDataFilter(query, mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD", nonEventFields);
         
         // set the parse info correctly


### PR DESCRIPTION
This addresses a defect where the `termOffsetMap` portion of a content function was considered a query field
- 5a7b4f4351f5ed3d9fb3c07124426215c4429869 correct defect 
- d7f2479255797cd1eb5a57cedc19414ceeb024b5 update test to address sonar/intellij warnings