### PR TITLE
TLD TermFrequency enhancement

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/ContentFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/ContentFunction.java
@@ -1,0 +1,28 @@
+package datawave.query.postprocessing.tf;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ContentFunction {
+    
+    private final String field;
+    private final Set<String> values;
+    
+    public ContentFunction(String field, Collection<String> values) {
+        this.field = field;
+        this.values = new HashSet<>(values);
+    }
+    
+    public String getField() {
+        return this.field;
+    }
+    
+    public boolean containsValue(String value) {
+        return this.values.contains(value);
+    }
+    
+    public Set<String> getValues() {
+        return this.values;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/DocumentKeysFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/DocumentKeysFunction.java
@@ -1,0 +1,291 @@
+package datawave.query.postprocessing.tf;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.Attributes;
+import datawave.query.attributes.Document;
+import datawave.query.attributes.PreNormalizedAttribute;
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.accumulo.core.data.Key;
+import org.apache.commons.jexl2.parser.ASTIdentifier;
+import org.apache.commons.jexl2.parser.ASTNumberLiteral;
+import org.apache.commons.jexl2.parser.ASTOrNode;
+import org.apache.commons.jexl2.parser.ASTUnaryMinusNode;
+import org.apache.commons.jexl2.parser.JexlNode;
+import org.apache.log4j.Logger;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static datawave.query.jexl.functions.ContentFunctions.CONTENT_ADJACENT_FUNCTION_NAME;
+import static datawave.query.jexl.functions.ContentFunctions.CONTENT_PHRASE_FUNCTION_NAME;
+import static datawave.query.jexl.functions.ContentFunctions.CONTENT_SCORED_PHRASE_FUNCTION_NAME;
+import static datawave.query.jexl.functions.ContentFunctions.CONTENT_WITHIN_FUNCTION_NAME;
+import static datawave.query.jexl.functions.ContentFunctions.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME;
+
+/**
+ * A function that intersects document keys prior to fetching term offsets.
+ * <p>
+ * This only works on positive phrase queries -- that is, no guarantee is made for negated phrases
+ */
+public class DocumentKeysFunction {
+    
+    private static final Logger log = Logger.getLogger(DocumentKeysFunction.class);
+    
+    private final Multimap<String,ContentFunction> contentFunctions = LinkedListMultimap.create();
+    
+    /**
+     * @param config
+     *            a {@link TermFrequencyConfig}
+     */
+    public DocumentKeysFunction(TermFrequencyConfig config) {
+        populateContentFunctions(config.getScript());
+    }
+    
+    protected void populateContentFunctions(JexlNode node) {
+        
+        Multimap<String,Function> functions = TermOffsetPopulator.getContentFunctions(node);
+        for (String key : functions.keySet()) {
+            Collection<Function> coll = functions.get(key);
+            for (Function f : coll) {
+                ContentFunction contentFunction = transformFunction(f);
+                contentFunctions.put(contentFunction.getField(), contentFunction);
+            }
+        }
+    }
+    
+    private ContentFunction transformFunction(Function function) {
+        
+        boolean specialCase = false;
+        int index = findValueStartIndex(function);
+        
+        // Parse the values first. Might have to lookup fields by value.
+        TreeSet<String> values = getValuesFromArgs(function.args(), index);
+        
+        TreeSet<String> fields;
+        if (specialCase) {
+            // field(s) were not present in the function, and cannot lookup fields by value.
+            throw new IllegalStateException("cannot lookup fields by value");
+        } else {
+            // function's first arg is the field, or fields in the form (FIELD_A || FIELD_B)
+            fields = parseField(function.args().get(0));
+        }
+        
+        return new ContentFunction(fields.first(), values);
+    }
+    
+    // functions may take different forms..
+    // within = {field, number, termOffsetMap, terms...}
+    // within = {number, termOffsetMap, terms...}
+    // adjacent = {field, termOffsetMap, terms...}
+    // adjacent = {termOffsetMap, terms...}
+    // phrase = {field, termOffsetMap, terms...}
+    // phrase = {termOffsetMap, terms...}
+    // scoredPhrase = {-1.5, termOffsetMap,'boy','car'}
+    private int findValueStartIndex(Function function) {
+        int index;
+        switch (function.name()) {
+            case CONTENT_WITHIN_FUNCTION_NAME:
+                index = 3;
+                break;
+            case CONTENT_ADJACENT_FUNCTION_NAME:
+            case CONTENT_PHRASE_FUNCTION_NAME:
+            case CONTENT_SCORED_PHRASE_FUNCTION_NAME:
+                index = 2;
+                break;
+            default:
+                throw new IllegalStateException("unexpected function name: " + function.name());
+        }
+        
+        // if the first node is a number of a 'termOffsetMap'
+        if (isFirstNodeSpecial(function.args().get(0))) {
+            index++;
+        }
+        return index;
+    }
+    
+    // A node is special if it is not the fields being searched. That is, the first node is a number or a variable 'termOffsetMap'
+    private boolean isFirstNodeSpecial(JexlNode node) {
+        node = JexlASTHelper.dereference(node);
+        if (node instanceof ASTNumberLiteral || node instanceof ASTUnaryMinusNode) {
+            return true;
+        } else if (node instanceof ASTIdentifier || node instanceof ASTOrNode) {
+            List<ASTIdentifier> ids = JexlASTHelper.getIdentifiers(node);
+            return ids.size() == 1 && ids.get(0).image.equals(TERM_OFFSET_MAP_JEXL_VARIABLE_NAME);
+        }
+        return false;
+    }
+    
+    /**
+     * Extract fields from a JexlNode. Node may be an OR node like (FIELD_A || FIELD_B).
+     *
+     * @param node
+     *            a jexl node
+     * @return a sorted set of fields
+     */
+    private TreeSet<String> parseField(JexlNode node) {
+        TreeSet<String> fields = new TreeSet<>();
+        List<ASTIdentifier> identifiers = JexlASTHelper.getIdentifiers(node);
+        for (ASTIdentifier identifier : identifiers) {
+            fields.add(JexlASTHelper.deconstructIdentifier(identifier));
+        }
+        return fields;
+    }
+    
+    /**
+     * Parse the values out of a content functions arguments
+     *
+     * @param args
+     *            content function arguments as a list of Jexl nodes
+     * @param start
+     *            the start index for the values
+     * @return a list of normalized string values
+     */
+    private TreeSet<String> getValuesFromArgs(List<JexlNode> args, int start) {
+        TreeSet<String> values = new TreeSet<>();
+        for (int i = start; i < args.size(); i++) {
+            List<String> parsed = parseArg(args.get(i));
+            values.addAll(parsed);
+        }
+        return values;
+    }
+    
+    private List<String> parseArg(JexlNode node) {
+        List<String> parsed = new LinkedList<>();
+        List<Object> values = JexlASTHelper.getLiteralValues(node);
+        for (Object value : values) {
+            if (value instanceof String) {
+                parsed.add((String) value);
+            } else {
+                throw new IllegalStateException("Expected literal value to be String cast-able");
+            }
+        }
+        return parsed;
+    }
+    
+    /**
+     * Reduces the search space to the union of the document keys associated with each content function
+     *
+     * @param d
+     *            the document
+     * @param docKeys
+     *            the set of keys associated with the {@link Document#DOCKEY_FIELD_NAME} field
+     * @return a filtered set of document keys
+     */
+    protected Set<Key> getDocKeys(Document d, Set<Key> docKeys) {
+        Multimap<String,Key> valueToKeys = buildValueToKeys(d);
+        
+        // this is the union of each content function's intersection
+        Set<Key> filterKeys = buildFilterKeys(valueToKeys);
+        
+        int origSize = docKeys.size();
+        docKeys.retainAll(filterKeys);
+        int nextSize = docKeys.size();
+        if (origSize != nextSize) {
+            log.info("reduced document keys from " + origSize + " to " + nextSize + " (-" + (origSize - nextSize) + ")");
+        }
+        
+        return docKeys;
+    }
+    
+    /**
+     * Constructs the multimap of value to document keys
+     *
+     * @param d
+     *            a document
+     * @return a multimap of value to document keys
+     */
+    private Multimap<String,Key> buildValueToKeys(Document d) {
+        Multimap<String,Key> valueToKeys = HashMultimap.create();
+        for (String key : contentFunctions.keySet()) {
+            Attribute<?> attr = d.get(key);
+            if (attr != null) {
+                Collection<String> values = getValuesForKey(key, contentFunctions);
+                putValueKey(attr, valueToKeys, values);
+            }
+        }
+        return valueToKeys;
+    }
+    
+    /**
+     * Gets the sum of all content function values
+     *
+     * @param key
+     *            the field
+     * @param functions
+     *            the multimap of field to content functions
+     * @return a union of all values
+     */
+    private Set<String> getValuesForKey(String key, Multimap<String,ContentFunction> functions) {
+        Set<String> values = new HashSet<>();
+        for (ContentFunction f : functions.get(key)) {
+            values.addAll(f.getValues());
+        }
+        return values;
+    }
+    
+    /**
+     * Extract value or values from the provided Attribute, only adding to the multimap if the values match the filter
+     *
+     * @param attr
+     *            an {@link Attribute}
+     * @param valueToKeys
+     *            a multimap of value to document keys
+     * @param values
+     *            a set of values used as a filter
+     */
+    private void putValueKey(Attribute<?> attr, Multimap<String,Key> valueToKeys, Collection<String> values) {
+        if (attr instanceof Attributes) {
+            Attributes attrs = (Attributes) attr;
+            for (Attribute<?> att : attrs.getAttributes()) {
+                if (att instanceof PreNormalizedAttribute) {
+                    PreNormalizedAttribute pre = (PreNormalizedAttribute) att;
+                    if (values.contains(pre.getValue())) {
+                        valueToKeys.put(pre.getValue(), pre.getMetadata());
+                    }
+                } else {
+                    if (values.contains(att.getData())) {
+                        valueToKeys.put((String) att.getData(), att.getMetadata());
+                    }
+                }
+            }
+        } else if (values.contains(attr.getData())) {
+            valueToKeys.put((String) attr.getData(), attr.getMetadata());
+        }
+    }
+    
+    /**
+     * Builds the filter keys from the content functions and value-to-keys multimap
+     *
+     * @param valueToKeys
+     *            a multimap of value to document keys
+     * @return a set of filter keys
+     */
+    private Set<Key> buildFilterKeys(Multimap<String,Key> valueToKeys) {
+        Set<Key> filterKeys = new HashSet<>();
+        for (ContentFunction function : contentFunctions.values()) {
+            Set<Key> keys = null;
+            for (String value : function.getValues()) {
+                if (keys == null) {
+                    keys = new HashSet<>(valueToKeys.get(value));
+                } else {
+                    keys.retainAll(valueToKeys.get(value));
+                }
+                
+                if (keys.isEmpty())
+                    break;
+            }
+            
+            if (keys != null) {
+                filterKeys.addAll(keys);
+            }
+        }
+        return filterKeys;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TFFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TFFactory.java
@@ -61,9 +61,15 @@ public class TFFactory {
         if (termFrequencyFieldValues.isEmpty()) {
             return new EmptyTermFrequencyFunction();
         } else {
-            TermOffsetPopulator offsetPopulator = new TermOffsetPopulator(termFrequencyFieldValues, config.getContentExpansionFields(),
-                            config.getEvaluationFilter(), config.getSource());
-            return new TermOffsetFunction(offsetPopulator, config.getTfFields());
+            
+            DocumentKeysFunction docKeyFunction = null;
+            
+            if (config.isTld()) {
+                docKeyFunction = new DocumentKeysFunction(config);
+            }
+            
+            TermOffsetPopulator offsetPopulator = new TermOffsetPopulator(termFrequencyFieldValues, config);
+            return new TermOffsetFunction(offsetPopulator, config.getTfFields(), docKeyFunction);
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetFunction.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import com.google.common.collect.Multimap;
 import datawave.query.attributes.Attribute;
@@ -15,6 +16,7 @@ import datawave.query.util.Tuple3;
 import datawave.query.util.Tuples;
 
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
 
 public class TermOffsetFunction implements com.google.common.base.Function<Tuple2<Key,Document>,Tuple3<Key,Document,Map<String,Object>>> {
     
@@ -47,7 +49,7 @@ public class TermOffsetFunction implements com.google.common.base.Function<Tuple
     
     private Set<Key> getDocumentKeys(Tuple2<Key,Document> from) {
         Attribute<?> docKeyAttr = from.second().get(Document.DOCKEY_FIELD_NAME);
-        Set<Key> docKeys = new HashSet<>();
+        Set<Key> docKeys = new TreeSet<>((left, right) -> left.compareTo(right, PartialKey.ROW_COLFAM));
         if (docKeyAttr == null) {
             docKeys.add(from.first());
         } else if (docKeyAttr instanceof DocumentKey) {

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
@@ -48,7 +48,7 @@ import static datawave.query.Constants.TERM_FREQUENCY_COLUMN_FAMILY;
 public class TermOffsetPopulator {
     private static final Logger log = Logger.getLogger(TermOffsetPopulator.class);
     
-    static final Set<String> phraseFunctions;
+    private static final Set<String> phraseFunctions;
     
     static {
         Set<String> _phraseFunctions = Sets.newHashSet();
@@ -65,14 +65,14 @@ public class TermOffsetPopulator {
     private Document document;
     private Set<String> contentExpansionFields;
     
-    private TermFrequencyConfig config;
+    private final TermFrequencyConfig config;
     
     public TermOffsetPopulator(Multimap<String,String> termFrequencyFieldValues, TermFrequencyConfig config) {
         this.termFrequencyFieldValues = termFrequencyFieldValues;
-        this.contentExpansionFields = config.getContentExpansionFields();
-        this.source = config.getSource();
-        this.evaluationFilter = config.getEvaluationFilter();
         this.config = config;
+        this.contentExpansionFields = this.config.getContentExpansionFields();
+        this.source = this.config.getSource();
+        this.evaluationFilter = this.config.getEvaluationFilter();
     }
     
     public Document document() {

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetPopulator.java
@@ -1,30 +1,24 @@
 package datawave.query.postprocessing.tf;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.SortedSet;
-
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.google.common.collect.TreeMultimap;
+import com.google.protobuf.InvalidProtocolBufferException;
 import datawave.core.iterators.TermFrequencyIterator;
 import datawave.data.type.NoOpType;
 import datawave.data.type.Type;
 import datawave.ingest.protobuf.TermWeight;
 import datawave.ingest.protobuf.TermWeightPosition;
-import datawave.query.jexl.functions.TermFrequencyList;
-import datawave.query.predicate.EventDataQueryFilter;
 import datawave.query.Constants;
 import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
 import datawave.query.jexl.functions.ContentFunctions;
+import datawave.query.jexl.functions.TermFrequencyList;
 import datawave.query.jexl.visitors.LiteralNodeSubsetVisitor;
-
+import datawave.query.predicate.EventDataQueryFilter;
 import datawave.util.StringUtils;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -37,20 +31,24 @@ import org.apache.commons.jexl2.parser.ParseException;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.Sets;
-import com.google.common.collect.TreeMultimap;
-import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedSet;
 
 import static datawave.query.Constants.TERM_FREQUENCY_COLUMN_FAMILY;
 
 public class TermOffsetPopulator {
     private static final Logger log = Logger.getLogger(TermOffsetPopulator.class);
     
-    private static final Set<String> phraseFunctions;
+    static final Set<String> phraseFunctions;
     
     static {
         Set<String> _phraseFunctions = Sets.newHashSet();
@@ -67,12 +65,14 @@ public class TermOffsetPopulator {
     private Document document;
     private Set<String> contentExpansionFields;
     
-    public TermOffsetPopulator(Multimap<String,String> termFrequencyFieldValues, Set<String> contentExpansionFields, EventDataQueryFilter evaluationFilter,
-                    SortedKeyValueIterator<Key,Value> source) {
+    private TermFrequencyConfig config;
+    
+    public TermOffsetPopulator(Multimap<String,String> termFrequencyFieldValues, TermFrequencyConfig config) {
         this.termFrequencyFieldValues = termFrequencyFieldValues;
-        this.contentExpansionFields = contentExpansionFields;
-        this.source = source;
-        this.evaluationFilter = evaluationFilter;
+        this.contentExpansionFields = config.getContentExpansionFields();
+        this.source = config.getSource();
+        this.evaluationFilter = config.getEvaluationFilter();
+        this.config = config;
     }
     
     public Document document() {
@@ -132,10 +132,14 @@ public class TermOffsetPopulator {
             }
         }
         
+        if (keys.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        
         Range range = getRange(keys);
         try {
             tfSource.init(source, null, null);
-            tfSource.seek(getRange(keys), null, false);
+            tfSource.seek(range, null, false);
         } catch (IOException e) {
             log.error("Seek to the range failed: " + range, e);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/DocumentKeysFunctionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/DocumentKeysFunctionTest.java
@@ -52,14 +52,14 @@ public class DocumentKeysFunctionTest {
         // biz+biz is all odd children
         // combined search space should be tld + all children
         String query = "(content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz') &&"
-                        + "(content:phrase(FOO, termOffsetMap, 'biz', 'biz') && FOO == 'biz' && FOO == 'biz') ";
+                        + "!(content:phrase(FOO, termOffsetMap, 'biz', 'biz') && FOO == 'biz' && FOO == 'biz') ";
         Set<Key> expected = Sets.newHashSet(docKey, docKey1, docKey2, docKey3, docKey4, docKey5);
         test(query, expected);
     }
     
     @Test
     public void testOnlyNegatedPhrase() throws Exception {
-        String query = "content:phrase(FOO, termOffsetMap, 'baz', 'baz') && FOO == 'baz'";
+        String query = "!(content:phrase(FOO, termOffsetMap, 'baz', 'baz') && FOO == 'baz')";
         Set<Key> expected = Sets.newHashSet(docKey, docKey2, docKey4);
         test(query, expected);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/DocumentKeysFunctionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/DocumentKeysFunctionTest.java
@@ -1,0 +1,86 @@
+package datawave.query.postprocessing.tf;
+
+import com.google.common.collect.Sets;
+import datawave.query.attributes.Document;
+import datawave.query.attributes.PreNormalizedAttribute;
+import datawave.query.jexl.JexlASTHelper;
+import org.apache.accumulo.core.data.Key;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class DocumentKeysFunctionTest {
+    
+    private final Key docKey = new Key("row", "datatype\0uid");
+    private final Key docKey1 = new Key("row", "datatype\0uid.1");
+    private final Key docKey2 = new Key("row", "datatype\0uid.2");
+    private final Key docKey3 = new Key("row", "datatype\0uid.3");
+    private final Key docKey4 = new Key("row", "datatype\0uid.4");
+    private final Key docKey5 = new Key("row", "datatype\0uid.5");
+    private final Set<Key> docKeys = Sets.newHashSet(docKey, docKey1, docKey2, docKey3, docKey4, docKey5);
+    
+    @Test
+    public void testTldAndEvenChildren() throws Exception {
+        // top level document + all event children
+        String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz'";
+        Set<Key> expected = Sets.newHashSet(docKey, docKey2, docKey4);
+        test(query, expected);
+    }
+    
+    @Test
+    public void testTldAndOddChildren() throws Exception {
+        // top level document + all odd children
+        String query = "content:phrase(FOO, termOffsetMap, 'bar', 'biz') && FOO == 'bar' && FOO == 'biz'";
+        Set<Key> expected = Sets.newHashSet(docKey, docKey1, docKey3, docKey5);
+        test(query, expected);
+    }
+    
+    // current implementation just make sure keys exist
+    @Test
+    public void testTldAndNonIntersectingChildren() throws Exception {
+        // top level document. even and odd children do not intersect
+        String query = "content:phrase(FOO, termOffsetMap, 'baz', 'biz') && FOO == 'baz' && FOO == 'biz'";
+        test(query, Collections.singleton(docKey));
+    }
+    
+    private void test(String query, Set<Key> expectedDocKeys) throws Exception {
+        TermFrequencyConfig config = new TermFrequencyConfig();
+        config.setScript(JexlASTHelper.parseAndFlattenJexlQuery(query));
+        
+        DocumentKeysFunction function = new DocumentKeysFunction(config);
+        
+        Set<Key> filteredKeys = function.getDocKeys(createDocument(), docKeys);
+        assertEquals(expectedDocKeys, filteredKeys);
+    }
+    
+    private Document createDocument() {
+        Document d = new Document();
+        
+        // FOO == 'bar' hits in TLD and all five children
+        d.put("FOO", new PreNormalizedAttribute("bar", new Key("row", "datatype\0uid"), true));
+        d.put("FOO", new PreNormalizedAttribute("bar", new Key("row", "datatype\0uid.1"), true));
+        d.put("FOO", new PreNormalizedAttribute("bar", new Key("row", "datatype\0uid.2"), true));
+        d.put("FOO", new PreNormalizedAttribute("bar", new Key("row", "datatype\0uid.3"), true));
+        d.put("FOO", new PreNormalizedAttribute("bar", new Key("row", "datatype\0uid.4"), true));
+        d.put("FOO", new PreNormalizedAttribute("bar", new Key("row", "datatype\0uid.5"), true));
+        
+        // FOO == 'baz' hits in TLD an all EVEN children
+        d.put("FOO", new PreNormalizedAttribute("baz", new Key("row", "datatype\0uid"), true));
+        d.put("FOO", new PreNormalizedAttribute("baz", new Key("row", "datatype\0uid.2"), true));
+        d.put("FOO", new PreNormalizedAttribute("baz", new Key("row", "datatype\0uid.4"), true));
+        
+        // FOO == 'biz' hits in TLD and all ODD children
+        d.put("FOO", new PreNormalizedAttribute("biz", new Key("row", "datatype\0uid"), true));
+        d.put("FOO", new PreNormalizedAttribute("biz", new Key("row", "datatype\0uid.1"), true));
+        d.put("FOO", new PreNormalizedAttribute("biz", new Key("row", "datatype\0uid.3"), true));
+        d.put("FOO", new PreNormalizedAttribute("biz", new Key("row", "datatype\0uid.5"), true));
+        
+        // TODO -- different column visibilities
+        
+        return d;
+    }
+    
+}

--- a/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/DocumentKeysFunctionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/DocumentKeysFunctionTest.java
@@ -24,7 +24,7 @@ public class DocumentKeysFunctionTest {
     
     @Test
     public void testTldAndEvenChildren() throws Exception {
-        // top level document + all event children
+        // top level document + all even children
         String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz'";
         Set<Key> expected = Sets.newHashSet(docKey, docKey2, docKey4);
         test(query, expected);
@@ -44,6 +44,24 @@ public class DocumentKeysFunctionTest {
         // top level document. even and odd children do not intersect
         String query = "content:phrase(FOO, termOffsetMap, 'baz', 'biz') && FOO == 'baz' && FOO == 'biz'";
         test(query, Collections.singleton(docKey));
+    }
+    
+    @Test
+    public void testTldWithNegatedPhrase() throws Exception {
+        // bar+baz is all even children
+        // biz+biz is all odd children
+        // combined search space should be tld + all children
+        String query = "(content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz') &&"
+                        + "(content:phrase(FOO, termOffsetMap, 'biz', 'biz') && FOO == 'biz' && FOO == 'biz') ";
+        Set<Key> expected = Sets.newHashSet(docKey, docKey1, docKey2, docKey3, docKey4, docKey5);
+        test(query, expected);
+    }
+    
+    @Test
+    public void testOnlyNegatedPhrase() throws Exception {
+        String query = "content:phrase(FOO, termOffsetMap, 'baz', 'baz') && FOO == 'baz'";
+        Set<Key> expected = Sets.newHashSet(docKey, docKey2, docKey4);
+        test(query, expected);
     }
     
     private void test(String query, Set<Key> expectedDocKeys) throws Exception {


### PR DESCRIPTION
Key Points
- function intersects docs keys prior to fetching offsets (only for TLD queries)
- document key set only considers the ROW_COLFAM (ignores keys with different column visibilities)
- greater integration of TermFrequencyConfig