### PR TITLE
More ways to configure seeking in the QueryIterator

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -395,12 +395,13 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     // The class for the excerpt iterator
     private Class<? extends SortedKeyValueIterator<Key,Value>> excerptIterator = TermFrequencyExcerptIterator.class;
     
-    private int fiFieldSeek;
-    private int fiNextSeek;
-    private int eventFieldSeek;
-    private int eventNextSeek;
-    private int tfFieldSeek;
-    private int tfNextSeek;
+    // controls when to issue a seek. disabled by default.
+    private int fiFieldSeek = -1;
+    private int fiNextSeek = -1;
+    private int eventFieldSeek = -1;
+    private int eventNextSeek = -1;
+    private int tfFieldSeek = -1;
+    private int tfNextSeek = -1;
     
     /**
      * The maximum weight for entries in the visitor function cache. The weight is calculated as the total number of characters for each key and value in the

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -395,6 +395,13 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     // The class for the excerpt iterator
     private Class<? extends SortedKeyValueIterator<Key,Value>> excerptIterator = TermFrequencyExcerptIterator.class;
     
+    private int fiFieldSeek;
+    private int fiNextSeek;
+    private int eventFieldSeek;
+    private int eventNextSeek;
+    private int tfFieldSeek;
+    private int tfNextSeek;
+    
     /**
      * The maximum weight for entries in the visitor function cache. The weight is calculated as the total number of characters for each key and value in the
      * cache. Default is 5m characters, which is roughly 10MB
@@ -593,6 +600,12 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setNoExpansionFields(other.getNoExpansionFields());
         this.setExcerptFields(ExcerptFields.copyOf(other.getExcerptFields()));
         this.setExcerptIterator(other.getExcerptIterator());
+        this.setFiFieldSeek(other.getFiFieldSeek());
+        this.setFiNextSeek(other.getFiNextSeek());
+        this.setEventFieldSeek(other.getEventFieldSeek());
+        this.setEventNextSeek(other.getEventNextSeek());
+        this.setTfFieldSeek(other.getTfFieldSeek());
+        this.setTfNextSeek(other.getTfNextSeek());
         this.setVisitorFunctionMaxWeight(other.getVisitorFunctionMaxWeight());
         this.setQueryExecutionForPageTimeout(other.getQueryExecutionForPageTimeout());
         this.setLazySetMechanismEnabled(other.isLazySetMechanismEnabled());
@@ -2293,6 +2306,54 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     
     public void setExcerptIterator(Class<? extends SortedKeyValueIterator<Key,Value>> excerptIterator) {
         this.excerptIterator = excerptIterator;
+    }
+    
+    public int getFiFieldSeek() {
+        return fiFieldSeek;
+    }
+    
+    public void setFiFieldSeek(int fiFieldSeek) {
+        this.fiFieldSeek = fiFieldSeek;
+    }
+    
+    public int getFiNextSeek() {
+        return fiNextSeek;
+    }
+    
+    public void setFiNextSeek(int fiNextSeek) {
+        this.fiNextSeek = fiNextSeek;
+    }
+    
+    public int getEventFieldSeek() {
+        return eventFieldSeek;
+    }
+    
+    public void setEventFieldSeek(int eventFieldSeek) {
+        this.eventFieldSeek = eventFieldSeek;
+    }
+    
+    public int getEventNextSeek() {
+        return eventNextSeek;
+    }
+    
+    public void setEventNextSeek(int eventNextSeek) {
+        this.eventNextSeek = eventNextSeek;
+    }
+    
+    public int getTfFieldSeek() {
+        return tfFieldSeek;
+    }
+    
+    public void setTfFieldSeek(int tfFieldSeek) {
+        this.tfFieldSeek = tfFieldSeek;
+    }
+    
+    public int getTfNextSeek() {
+        return tfNextSeek;
+    }
+    
+    public void setTfNextSeek(int tfNextSeek) {
+        this.tfNextSeek = tfNextSeek;
     }
     
     public long getVisitorFunctionMaxWeight() {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -257,6 +257,14 @@ public class QueryOptions implements OptionDescriber {
     
     public static final String EXCERPT_ITERATOR = "excerpt.iterator.class";
     
+    // field and next thresholds before a seek is issued
+    public static final String FI_FIELD_SEEK = "fi.field.seek";
+    public static final String FI_NEXT_SEEK = "fi.next.seek";
+    public static final String EVENT_FIELD_SEEK = "event.field.seek";
+    public static final String EVENT_NEXT_SEEK = "event.next.seek";
+    public static final String TF_FIELD_SEEK = "tf.field.seek";
+    public static final String TF_NEXT_SEEK = "tf.next.seek";
+    
     protected Map<String,String> options;
     
     protected String scanId;
@@ -406,6 +414,13 @@ public class QueryOptions implements OptionDescriber {
     
     protected Class<? extends SortedKeyValueIterator<Key,Value>> excerptIterator = TermFrequencyExcerptIterator.class;
     
+    private int fiFieldSeek;
+    private int fiNextSeek;
+    private int eventFieldSeek;
+    private int eventNextSeek;
+    private int tfFieldSeek;
+    private int tfNextSeek;
+    
     public void deepCopy(QueryOptions other) {
         this.options = other.options;
         this.query = other.query;
@@ -506,6 +521,12 @@ public class QueryOptions implements OptionDescriber {
         this.excerptFields = other.excerptFields;
         this.excerptIterator = other.excerptIterator;
         
+        this.fiFieldSeek = other.fiFieldSeek;
+        this.fiNextSeek = other.fiNextSeek;
+        this.eventFieldSeek = other.eventFieldSeek;
+        this.eventNextSeek = other.eventNextSeek;
+        this.tfFieldSeek = other.tfFieldSeek;
+        this.tfNextSeek = other.tfNextSeek;
     }
     
     public String getQuery() {
@@ -1144,6 +1165,12 @@ public class QueryOptions implements OptionDescriber {
                                         + "', will use the default shared Active Query Log instance. If provided otherwise, uses a separate distinct Active Query Log that will include the unique name in log messages.");
         options.put(EXCERPT_FIELDS, "excerpt fields");
         options.put(EXCERPT_ITERATOR, "excerpt iterator class (default datawave.query.iterator.logic.TermFrequencyExcerptIterator");
+        options.put(FI_FIELD_SEEK, "The number of fields traversed by a Field Index data filter or aggregator before a seek is issued");
+        options.put(FI_NEXT_SEEK, "The number of next calls made by a Field Index data filter or aggregator before a seek is issued");
+        options.put(EVENT_FIELD_SEEK, "The number of fields traversed by an Event data filter or aggregator before a seek is issued");
+        options.put(EVENT_NEXT_SEEK, "The number of next calls made by an Event data filter or aggregator before a seek is issued");
+        options.put(TF_FIELD_SEEK, "The number of fields traversed by a Term Frequency data filter or aggregator before a seek is issued");
+        options.put(TF_NEXT_SEEK, "The number of next calls made by a Term Frequency data filter or aggregator before a seek is issued");
         return new IteratorOptions(getClass().getSimpleName(), "Runs a query against the DATAWAVE tables", options, null);
     }
     
@@ -1273,8 +1300,6 @@ public class QueryOptions implements OptionDescriber {
             }
         }
         
-        // log.info("Performing regular query : queryId=" + this.queryId);
-        
         this.equality = new PrefixEquality(PartialKey.ROW_COLFAM);
         this.evaluationFilter = null;
         this.getDocumentKey = GetStartKey.instance();
@@ -1309,6 +1334,31 @@ public class QueryOptions implements OptionDescriber {
         
         if (options.containsKey(INCLUDE_HIERARCHY_FIELDS)) {
             this.includeHierarchyFields = Boolean.parseBoolean(options.get(INCLUDE_HIERARCHY_FIELDS));
+        }
+        
+        // parse seek thresholds before building filters/aggregators
+        if (options.containsKey(FI_FIELD_SEEK)) {
+            this.fiFieldSeek = Integer.parseInt(options.get(FI_FIELD_SEEK));
+        }
+        
+        if (options.containsKey(FI_NEXT_SEEK)) {
+            this.fiNextSeek = Integer.parseInt(options.get(FI_NEXT_SEEK));
+        }
+        
+        if (options.containsKey(EVENT_FIELD_SEEK)) {
+            this.eventFieldSeek = Integer.parseInt(options.get(EVENT_FIELD_SEEK));
+        }
+        
+        if (options.containsKey(EVENT_NEXT_SEEK)) {
+            this.eventNextSeek = Integer.parseInt(options.get(EVENT_NEXT_SEEK));
+        }
+        
+        if (options.containsKey(TF_FIELD_SEEK)) {
+            this.tfFieldSeek = Integer.parseInt(options.get(TF_FIELD_SEEK));
+        }
+        
+        if (options.containsKey(TF_NEXT_SEEK)) {
+            this.tfNextSeek = Integer.parseInt(options.get(TF_NEXT_SEEK));
         }
         
         if (options.containsKey(DATATYPE_FILTER)) {
@@ -2022,4 +2072,51 @@ public class QueryOptions implements OptionDescriber {
         this.yieldThresholdMs = yieldThresholdMs;
     }
     
+    public int getFiFieldSeek() {
+        return fiFieldSeek;
+    }
+    
+    public void setFiFieldSeek(int fiFieldSeek) {
+        this.fiFieldSeek = fiFieldSeek;
+    }
+    
+    public int getFiNextSeek() {
+        return fiNextSeek;
+    }
+    
+    public void setFiNextSeek(int fiNextSeek) {
+        this.fiNextSeek = fiNextSeek;
+    }
+    
+    public int getEventFieldSeek() {
+        return eventFieldSeek;
+    }
+    
+    public void setEventFieldSeek(int eventFieldSeek) {
+        this.eventFieldSeek = eventFieldSeek;
+    }
+    
+    public int getEventNextSeek() {
+        return eventNextSeek;
+    }
+    
+    public void setEventNextSeek(int eventNextSeek) {
+        this.eventNextSeek = eventNextSeek;
+    }
+    
+    public int getTfFieldSeek() {
+        return tfFieldSeek;
+    }
+    
+    public void setTfFieldSeek(int tfFieldSeek) {
+        this.tfFieldSeek = tfFieldSeek;
+    }
+    
+    public int getTfNextSeek() {
+        return tfNextSeek;
+    }
+    
+    public void setTfNextSeek(int tfNextSeek) {
+        this.tfNextSeek = tfNextSeek;
+    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -414,12 +414,13 @@ public class QueryOptions implements OptionDescriber {
     
     protected Class<? extends SortedKeyValueIterator<Key,Value>> excerptIterator = TermFrequencyExcerptIterator.class;
     
-    private int fiFieldSeek;
-    private int fiNextSeek;
-    private int eventFieldSeek;
-    private int eventNextSeek;
-    private int tfFieldSeek;
-    private int tfNextSeek;
+    // off by default, controls when to issue a seek
+    private int fiFieldSeek = -1;
+    private int fiNextSeek = -1;
+    private int eventFieldSeek = -1;
+    private int eventNextSeek = -1;
+    private int tfFieldSeek = -1;
+    private int tfNextSeek = -1;
     
     public void deepCopy(QueryOptions other) {
         this.options = other.options;

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2058,6 +2058,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
                         configureAdditionalOptions(config, cfg);
                         
                         loadFields(cfg, config, isPreload);
+                        configureSeekingOptions(cfg, config);
                         
                         try {
                             CompositeMetadata compositeMetadata = metadataHelper.getCompositeMetadata().filter(config.getQueryFieldsDatatypes().keySet());
@@ -2131,6 +2132,35 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         } catch (TableNotFoundException e) {
             QueryException qe = new QueryException(DatawaveErrorCode.INDEX_ONLY_FIELDS_RETRIEVAL_ERROR, e);
             throw new DatawaveQueryException(qe);
+        }
+    }
+    
+    /**
+     * Configure options related to seek thresholds
+     *
+     * @param cfg
+     *            iterator setting
+     * @param config
+     *            shard query config
+     */
+    protected void configureSeekingOptions(IteratorSetting cfg, ShardQueryConfiguration config) {
+        if (config.getFiFieldSeek() > 0) {
+            addOption(cfg, QueryOptions.FI_FIELD_SEEK, String.valueOf(config.getFiFieldSeek()), false);
+        }
+        if (config.getFiNextSeek() > 0) {
+            addOption(cfg, QueryOptions.FI_NEXT_SEEK, String.valueOf(config.getFiNextSeek()), false);
+        }
+        if (config.getEventFieldSeek() > 0) {
+            addOption(cfg, QueryOptions.EVENT_FIELD_SEEK, String.valueOf(config.getEventFieldSeek()), false);
+        }
+        if (config.getEventNextSeek() > 0) {
+            addOption(cfg, QueryOptions.EVENT_NEXT_SEEK, String.valueOf(config.getEventNextSeek()), false);
+        }
+        if (config.getTfFieldSeek() > 0) {
+            addOption(cfg, QueryOptions.TF_FIELD_SEEK, String.valueOf(config.getTfFieldSeek()), false);
+        }
+        if (config.getTfNextSeek() > 0) {
+            addOption(cfg, QueryOptions.TF_NEXT_SEEK, String.valueOf(config.getTfNextSeek()), false);
         }
     }
     

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -1318,6 +1318,54 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         }
     }
     
+    public int getFiFieldSeek() {
+        return getConfig().getFiFieldSeek();
+    }
+    
+    public void setFiFieldSeek(int fiFieldSeek) {
+        getConfig().setFiFieldSeek(fiFieldSeek);
+    }
+    
+    public int getFiNextSeek() {
+        return getConfig().getFiNextSeek();
+    }
+    
+    public void setFiNextSeek(int fiNextSeek) {
+        getConfig().setFiNextSeek(fiNextSeek);
+    }
+    
+    public int getEventFieldSeek() {
+        return getConfig().getEventFieldSeek();
+    }
+    
+    public void setEventFieldSeek(int eventFieldSeek) {
+        getConfig().setEventFieldSeek(eventFieldSeek);
+    }
+    
+    public int getEventNextSeek() {
+        return getConfig().getEventNextSeek();
+    }
+    
+    public void setEventNextSeek(int eventNextSeek) {
+        getConfig().setEventNextSeek(eventNextSeek);
+    }
+    
+    public int getTfFieldSeek() {
+        return getConfig().getTfFieldSeek();
+    }
+    
+    public void setTfFieldSeek(int tfFieldSeek) {
+        getConfig().setTfFieldSeek(tfFieldSeek);
+    }
+    
+    public int getTfNextSeek() {
+        return getConfig().getTfNextSeek();
+    }
+    
+    public void setTfNextSeek(int tfNextSeek) {
+        getConfig().setTfNextSeek(tfNextSeek);
+    }
+    
     public String getBlacklistedFieldsString() {
         return getConfig().getBlacklistedFieldsAsString();
     }

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -206,6 +206,14 @@ public class ShardQueryConfigurationTest {
         Assert.assertEquals(Collections.emptySet(), config.getNoExpansionFields());
         Assert.assertEquals(Sets.newHashSet(".*", ".*?"), config.getDisallowedRegexPatterns());
         Assert.assertEquals(5000000L, config.getVisitorFunctionMaxWeight());
+        
+        // seeks
+        Assert.assertEquals(0, config.getFiFieldSeek());
+        Assert.assertEquals(0, config.getFiNextSeek());
+        Assert.assertEquals(0, config.getEventFieldSeek());
+        Assert.assertEquals(0, config.getEventNextSeek());
+        Assert.assertEquals(0, config.getTfFieldSeek());
+        Assert.assertEquals(0, config.getTfNextSeek());
     }
     
     /**
@@ -297,6 +305,13 @@ public class ShardQueryConfigurationTest {
         other.setVisitorFunctionMaxWeight(visitorFunctionMaxWeight);
         other.setAccumuloPassword("ChangeIt");
         other.setReduceQueryFields(true);
+        // seeks
+        other.setFiFieldSeek(12);
+        other.setFiNextSeek(13);
+        other.setEventFieldSeek(14);
+        other.setEventNextSeek(15);
+        other.setTfFieldSeek(16);
+        other.setTfNextSeek(17);
         
         // Copy 'other' ShardQueryConfiguration into a new config
         ShardQueryConfiguration config = ShardQueryConfiguration.create(other);
@@ -393,6 +408,14 @@ public class ShardQueryConfigurationTest {
         Assert.assertEquals(expectedUniqueFields, config.getUniqueFields());
         Assert.assertEquals(Lists.newArrayList("fieldA"), config.getContentFieldNames());
         Assert.assertEquals(Sets.newHashSet("NoExpansionFieldA"), config.getNoExpansionFields());
+        
+        // assert seeks
+        Assert.assertEquals(12, other.getFiFieldSeek());
+        Assert.assertEquals(13, other.getFiNextSeek());
+        Assert.assertEquals(14, other.getEventFieldSeek());
+        Assert.assertEquals(15, other.getEventNextSeek());
+        Assert.assertEquals(16, other.getTfFieldSeek());
+        Assert.assertEquals(17, other.getTfNextSeek());
     }
     
     @Test
@@ -483,7 +506,7 @@ public class ShardQueryConfigurationTest {
      */
     @Test
     public void testCheckForNewAdditions() throws IOException {
-        int expectedObjectCount = 191;
+        int expectedObjectCount = 197;
         ShardQueryConfiguration config = ShardQueryConfiguration.create();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(mapper.writeValueAsString(config));

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -208,12 +208,12 @@ public class ShardQueryConfigurationTest {
         Assert.assertEquals(5000000L, config.getVisitorFunctionMaxWeight());
         
         // seeks
-        Assert.assertEquals(0, config.getFiFieldSeek());
-        Assert.assertEquals(0, config.getFiNextSeek());
-        Assert.assertEquals(0, config.getEventFieldSeek());
-        Assert.assertEquals(0, config.getEventNextSeek());
-        Assert.assertEquals(0, config.getTfFieldSeek());
-        Assert.assertEquals(0, config.getTfNextSeek());
+        Assert.assertEquals(-1, config.getFiFieldSeek());
+        Assert.assertEquals(-1, config.getFiNextSeek());
+        Assert.assertEquals(-1, config.getEventFieldSeek());
+        Assert.assertEquals(-1, config.getEventNextSeek());
+        Assert.assertEquals(-1, config.getTfFieldSeek());
+        Assert.assertEquals(-1, config.getTfNextSeek());
     }
     
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
@@ -115,12 +115,12 @@ public class QueryOptionsTest {
         QueryOptions options = new QueryOptions();
         
         // initial state
-        assertEquals(0, options.getFiFieldSeek());
-        assertEquals(0, options.getFiNextSeek());
-        assertEquals(0, options.getEventFieldSeek());
-        assertEquals(0, options.getEventNextSeek());
-        assertEquals(0, options.getTfFieldSeek());
-        assertEquals(0, options.getTfNextSeek());
+        assertEquals(-1, options.getFiFieldSeek());
+        assertEquals(-1, options.getFiNextSeek());
+        assertEquals(-1, options.getEventFieldSeek());
+        assertEquals(-1, options.getEventNextSeek());
+        assertEquals(-1, options.getTfFieldSeek());
+        assertEquals(-1, options.getTfNextSeek());
         
         options.validateOptions(optionsMap);
         

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
@@ -10,6 +10,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static datawave.query.iterator.QueryOptions.EVENT_FIELD_SEEK;
+import static datawave.query.iterator.QueryOptions.EVENT_NEXT_SEEK;
+import static datawave.query.iterator.QueryOptions.FI_FIELD_SEEK;
+import static datawave.query.iterator.QueryOptions.FI_NEXT_SEEK;
+import static datawave.query.iterator.QueryOptions.QUERY;
+import static datawave.query.iterator.QueryOptions.TF_FIELD_SEEK;
+import static datawave.query.iterator.QueryOptions.TF_NEXT_SEEK;
 import static org.junit.Assert.assertEquals;
 
 public class QueryOptionsTest {
@@ -92,5 +99,37 @@ public class QueryOptionsTest {
         Set<String> expectedDataTypeKeys = Sets.newHashSet();
         Set<String> dataTypeKeys = QueryOptions.fetchDataTypeKeys(data);
         assertEquals("Failed to parse null option string", expectedDataTypeKeys, dataTypeKeys);
+    }
+    
+    @Test
+    public void testSeekingConfiguration() {
+        Map<String,String> optionsMap = new HashMap<>();
+        optionsMap.put(QUERY, "set to avoid early return");
+        optionsMap.put(FI_FIELD_SEEK, "10");
+        optionsMap.put(FI_NEXT_SEEK, "11");
+        optionsMap.put(EVENT_FIELD_SEEK, "12");
+        optionsMap.put(EVENT_NEXT_SEEK, "13");
+        optionsMap.put(TF_FIELD_SEEK, "14");
+        optionsMap.put(TF_NEXT_SEEK, "15");
+        
+        QueryOptions options = new QueryOptions();
+        
+        // initial state
+        assertEquals(0, options.getFiFieldSeek());
+        assertEquals(0, options.getFiNextSeek());
+        assertEquals(0, options.getEventFieldSeek());
+        assertEquals(0, options.getEventNextSeek());
+        assertEquals(0, options.getTfFieldSeek());
+        assertEquals(0, options.getTfNextSeek());
+        
+        options.validateOptions(optionsMap);
+        
+        // expected state
+        assertEquals(10, options.getFiFieldSeek());
+        assertEquals(11, options.getFiNextSeek());
+        assertEquals(12, options.getEventFieldSeek());
+        assertEquals(13, options.getEventNextSeek());
+        assertEquals(14, options.getTfFieldSeek());
+        assertEquals(15, options.getTfNextSeek());
     }
 }

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -231,6 +231,13 @@
         <property name="rangeBufferTimeoutMillis" value="15000" />
         <property name="rangeBufferPollMillis" value="100" />
         <property name="evaluationOnlyFields" value="_ANYFIELD_" />
+        <!--   variables that control when a seek is issued     -->
+        <property name="fiFieldSeek" value="-1" />
+        <property name="fiNextSeek" value="-1" />
+        <property name="eventFieldSeek" value="-1" />
+        <property name="eventNextSeek" value="-1" />
+        <property name="tfFieldSeek" value="-1" />
+        <property name="tfNextSeek" value="-1" />
     </bean>
 
     <bean id="TLDEventQuery" scope="prototype" parent="BaseEventQuery" class="datawave.query.tables.TLDQueryLogic">


### PR DESCRIPTION
Add more fine-grained options for configuring seeking in the query iterator. Intended for future use in the aggregators and data filters.