### PR TITLE
Adjust datawave/bootstrap.sh to call `mvn package` where `mvn install` is  failing, likely due to Maven 3.9.0

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
@@ -31,7 +31,7 @@ DW_DATAWAVE_BUILD_PROFILE=${DW_DATAWAVE_BUILD_PROFILE:-dev}
 
 # Maven command
 
-DW_DATAWAVE_BUILD_COMMAND="${DW_DATAWAVE_BUILD_COMMAND:-mvn -P${DW_DATAWAVE_BUILD_PROFILE} -Ddeploy -Dtar -Ddist -Dservices -DskipTests clean install --builder smart -T1.0C}"
+DW_DATAWAVE_BUILD_COMMAND="${DW_DATAWAVE_BUILD_COMMAND:-mvn -P${DW_DATAWAVE_BUILD_PROFILE} -Ddeploy -Dtar -Ddist -Dservices -DskipTests clean package --builder smart -T1.0C}"
 
 # Home of any temp data and *.properties file overrides for this instance of DataWave
 


### PR DESCRIPTION
Continuation of  0637fbf, to allow `env.sh` to run correctly.