### PR TITLE
re #1887 RemoteHttpService parent class should not call init after @P…

### DIFF
--- a/web-services/common/src/main/java/datawave/webservice/common/remote/RemoteHttpService.java
+++ b/web-services/common/src/main/java/datawave/webservice/common/remote/RemoteHttpService.java
@@ -373,7 +373,6 @@ public abstract class RemoteHttpService {
     
     public <T> T executePostMethodWithRuntimeException(String uriSuffix, Consumer<URIBuilder> uriCustomizer, Consumer<HttpPost> requestCustomizer,
                     IOFunction<T> resultConverter, Supplier<String> errorSupplier) {
-        init();
         try {
             return executePostMethod(uriSuffix, uriCustomizer, requestCustomizer, resultConverter, errorSupplier);
         } catch (URISyntaxException e) {
@@ -398,7 +397,6 @@ public abstract class RemoteHttpService {
     
     public <T> T executeGetMethodWithRuntimeException(String uriSuffix, Consumer<URIBuilder> uriCustomizer, Consumer<HttpGet> requestCustomizer,
                     IOFunction<T> resultConverter, Supplier<String> errorSupplier) {
-        init();
         try {
             return executeGetMethod(uriSuffix, uriCustomizer, requestCustomizer, resultConverter, errorSupplier);
         } catch (URISyntaxException e) {

--- a/web-services/query/src/main/java/datawave/webservice/query/remote/RemoteQueryServiceImpl.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/remote/RemoteQueryServiceImpl.java
@@ -74,6 +74,7 @@ public class RemoteQueryServiceImpl extends RemoteHttpService implements RemoteQ
     }
     
     private GenericResponse<String> query(String endPoint, String queryLogicName, Map<String,List<String>> queryParameters, Object callerObject) {
+        init();
         final DatawavePrincipal principal = getDatawavePrincipal(callerObject);
         
         final List<NameValuePair> nameValuePairs = new ArrayList<>();
@@ -109,6 +110,7 @@ public class RemoteQueryServiceImpl extends RemoteHttpService implements RemoteQ
     
     @Override
     public BaseQueryResponse next(String id, Object callerObject) {
+        init();
         final DatawavePrincipal principal = getDatawavePrincipal(callerObject);
         
         final String suffix = String.format(NEXT, id);
@@ -123,6 +125,7 @@ public class RemoteQueryServiceImpl extends RemoteHttpService implements RemoteQ
     
     @Override
     public VoidResponse close(String id, Object callerObject) {
+        init();
         final DatawavePrincipal principal = getDatawavePrincipal(callerObject);
         
         final String suffix = String.format(CLOSE, id);
@@ -137,6 +140,7 @@ public class RemoteQueryServiceImpl extends RemoteHttpService implements RemoteQ
     
     @Override
     public GenericResponse<String> planQuery(String id, Object callerObject) {
+        init();
         final DatawavePrincipal principal = getDatawavePrincipal(callerObject);
         
         final String suffix = String.format(PLAN, id);


### PR DESCRIPTION
RemoteHttpService parent class should not call init after @PostConstruct #1887

While some new Spring-created subclasses call both their @OverRide int() method and the base class init() method while protecting against executing the logic twice, calling init() from RemoteHttpService is causing other non-Spring-created subclasses to be constantly re-initialized whenever executePostMethodWithRuntimeException or executeGetMethodWithRuntimeException are called.