### PR TITLE
ShardTableConfigHelper supports setting maxUids on index and reverse index tables

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 public class GlobalIndexUidAggregator extends PropogatingCombiner {
     private static final Logger log = LoggerFactory.getLogger(GlobalIndexUidAggregator.class);
     private static final String TIMESTAMPS_IGNORED = "timestampsIgnored";
+    public static final String MAX_UIDS = "maxUids";
     
     /**
      * Using a set instead of a list so that duplicate UIDs are filtered out of the list. This might happen in the case of rows with masked fields that share a
@@ -329,6 +330,9 @@ public class GlobalIndexUidAggregator extends PropogatingCombiner {
         if (valid) {
             if (options.containsKey(TIMESTAMPS_IGNORED)) {
                 timestampsIgnored = Boolean.parseBoolean(options.get(TIMESTAMPS_IGNORED));
+            }
+            if (options.containsKey(MAX_UIDS)) {
+                maxUids = Integer.parseInt(options.get(MAX_UIDS));
             }
         }
         return valid;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/config/ShardTableConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/config/ShardTableConfigHelper.java
@@ -14,6 +14,7 @@ import datawave.ingest.table.balancer.ShardedTableTabletBalancer;
 import datawave.ingest.table.bloomfilter.ShardKeyFunctor;
 import datawave.ingest.table.bloomfilter.ShardIndexKeyFunctor;
 
+import datawave.iterators.PropogatingIterator;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -32,6 +33,7 @@ public class ShardTableConfigHelper extends AbstractTableConfigHelper {
     protected static final String SHARDED_TABLET_BALANCER_CLASS = ShardedTableTabletBalancer.class.getName();
     
     public static final String KEEP_COUNT_ONLY_INDEX_ENTRIES = "index.tables.keep.count.only.entries";
+    public static final String MAX_INDEX_UIDS = "index.tables.max.uids";
     
     public static final String SHARD_TABLE_BALANCER_CONFIG = "shard.table.balancer.class";
     protected String shardTableBalancerClass = SHARDED_TABLET_BALANCER_CLASS;
@@ -203,6 +205,16 @@ public class ShardTableConfigHelper extends AbstractTableConfigHelper {
                 aggClass = KeepCountOnlyUidAggregator.class.getName();
             }
             
+            if (conf.get(MAX_INDEX_UIDS) != null) {
+                String maxUids = conf.get(MAX_INDEX_UIDS);
+                String maxUidProperty = stem + PropogatingIterator.getOptString("*", GlobalIndexUidAggregator.MAX_UIDS);
+                setPropertyIfNecessary(tableName, maxUidProperty, maxUids, tops, log);
+                
+                // anytime a property is set also must set this property for Combiner properties
+                String combinerProperty = stem + PropogatingIterator.getOptString("*", "all");
+                setPropertyIfNecessary(tableName, combinerProperty, "true", tops, log);
+            }
+            
             setPropertyIfNecessary(tableName, stem + "*", aggClass, tops, log);
             
             if (markingsSetupIteratorEnabled) {
@@ -230,6 +242,16 @@ public class ShardTableConfigHelper extends AbstractTableConfigHelper {
             String aggClass = GlobalIndexUidAggregator.class.getName();
             if (conf.getBoolean(KEEP_COUNT_ONLY_INDEX_ENTRIES, false)) {
                 aggClass = KeepCountOnlyUidAggregator.class.getName();
+            }
+            
+            if (conf.get(MAX_INDEX_UIDS) != null) {
+                String maxUids = conf.get(MAX_INDEX_UIDS);
+                String maxUidProperty = stem + PropogatingIterator.getOptString("*", GlobalIndexUidAggregator.MAX_UIDS);
+                setPropertyIfNecessary(tableName, maxUidProperty, maxUids, tops, log);
+                
+                // anytime a property is set also must set this property for Combiner properties
+                String combinerProperty = stem + PropogatingIterator.getOptString("*", "all");
+                setPropertyIfNecessary(tableName, combinerProperty, "true", tops, log);
             }
             
             setPropertyIfNecessary(tableName, stem + "*", aggClass, tops, log);

--- a/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
@@ -20,6 +20,7 @@ import org.apache.commons.collections.map.HashedMap;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -96,6 +97,10 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
     protected Map<String,String> options = Maps.newHashMap();
     
     private static final Logger log = Logger.getLogger(PropogatingIterator.class);
+    
+    public static String getOptString(String cf, String aggOpt) {
+        return cf + AGGREGATOR_OPTS + aggOpt;
+    }
     
     /**
      * Deep copy implementation
@@ -309,7 +314,8 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
     @Override
     public IteratorOptions describeOptions() {
         
-        return new IteratorOptions(ATTRIBUTE_NAME, ATTRIBUTE_DESCRIPTION, defaultMapOptions, Collections.singletonList("<ColumnFamily> <Combiner>"));
+        return new IteratorOptions(ATTRIBUTE_NAME, ATTRIBUTE_DESCRIPTION, defaultMapOptions, Arrays.asList("<ColumnFamily> <Combiner>", "<ColumnFamily>"
+                        + AGGREGATOR_OPTS + "<CombinerOptionName> <CombinerOptionValue>"));
     }
     
     @Override

--- a/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/iterators/PropogatingIteratorTest.java
@@ -225,12 +225,12 @@ public class PropogatingIteratorTest {
     public void testAggregateWithMaxUids() throws IOException {
         TreeMultimap<Key,Value> map = TreeMultimap.create();
         
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.1").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.2").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.3").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.4").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.1").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.2").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.3").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.4").build().toByteArray()));
         
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), new Value(createValueWithUid("abc.3").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), new Value(createValueWithUid("xyz.3").build().toByteArray()));
         
         SortedMultiMapIterator data = new SortedMultiMapIterator(map);
         
@@ -240,9 +240,9 @@ public class PropogatingIteratorTest {
         options.put(PropogatingIterator.AGGREGATOR_DEFAULT, GlobalIndexUidAggregator.class.getCanonicalName());
         
         // reduce the max uids down to 0
-        options.put(PropogatingIterator.AGGREGATOR_DEFAULT + PropogatingIterator.AGGREGATOR_OPTS + MAX_UIDS, "0");
+        options.put(PropogatingIterator.getOptString(PropogatingIterator.AGGREGATOR_DEFAULT, MAX_UIDS), "0");
         // although it is never used by GlobalIndexUidAggregator this must be set to have valid options
-        options.put(PropogatingIterator.AGGREGATOR_DEFAULT + PropogatingIterator.AGGREGATOR_OPTS + "all", "true");
+        options.put(PropogatingIterator.getOptString(PropogatingIterator.AGGREGATOR_DEFAULT, "all"), "true");
         
         IteratorEnvironment env = new MockIteratorEnvironment(false);
         
@@ -266,15 +266,15 @@ public class PropogatingIteratorTest {
     public void testAggregateWithMaxOneUid() throws IOException {
         TreeMultimap<Key,Value> map = TreeMultimap.create();
         
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.1").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.2").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.3").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("abc.4").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.1").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.2").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.3").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abc"), new Value(createValueWithUid("xyz.4").build().toByteArray()));
         
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), new Value(createValueWithUid("abc.3").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), new Value(createValueWithUid("xyz.3").build().toByteArray()));
         
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abe"), new Value(createValueWithUid("abc.1").build().toByteArray()));
-        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abe"), new Value(createValueWithUid("abc.3").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abe"), new Value(createValueWithUid("xyz.1").build().toByteArray()));
+        map.put(newKey(SHARD, FIELD_TO_AGGREGATE, "abe"), new Value(createValueWithUid("xyz.3").build().toByteArray()));
         
         SortedMultiMapIterator data = new SortedMultiMapIterator(map);
         
@@ -283,10 +283,10 @@ public class PropogatingIteratorTest {
         
         options.put(PropogatingIterator.AGGREGATOR_DEFAULT, GlobalIndexUidAggregator.class.getCanonicalName());
         
-        // reduce the max uids down to 0
-        options.put(PropogatingIterator.AGGREGATOR_DEFAULT + PropogatingIterator.AGGREGATOR_OPTS + MAX_UIDS, "1");
+        // reduce the max uids down to 1
+        options.put(PropogatingIterator.getOptString(PropogatingIterator.AGGREGATOR_DEFAULT, MAX_UIDS), "1");
         // although it is never used by GlobalIndexUidAggregator this must be set to have valid options
-        options.put(PropogatingIterator.AGGREGATOR_DEFAULT + PropogatingIterator.AGGREGATOR_OPTS + "all", "true");
+        options.put(PropogatingIterator.getOptString(PropogatingIterator.AGGREGATOR_DEFAULT, "all"), "true");
         
         IteratorEnvironment env = new MockIteratorEnvironment(false);
         
@@ -303,7 +303,7 @@ public class PropogatingIteratorTest {
         iter.next();
         topKey = iter.getTopKey();
         Assert.assertEquals(newKey(SHARD, FIELD_TO_AGGREGATE, "abd"), topKey);
-        validateUids(iter.getTopValue(), "abc.3");
+        validateUids(iter.getTopValue(), "xyz.3");
         iter.next();
         topKey = iter.getTopKey();
         Assert.assertEquals(newKey(SHARD, FIELD_TO_AGGREGATE, "abe"), topKey);


### PR DESCRIPTION
See #1891 dependent on #1889. Should be a single commit after merge.