### PR TITLE
re #1895 Refactor QueryMetricsWriter to improve reliability, failure …

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/metric/QueryMetricsWriter.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/metric/QueryMetricsWriter.java
@@ -3,29 +3,32 @@ package datawave.webservice.query.metric;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
-import javax.annotation.security.DeclareRoles;
-import javax.annotation.security.RolesAllowed;
 import javax.annotation.security.RunAs;
 import javax.ejb.LocalBean;
 import javax.ejb.Lock;
 import javax.ejb.LockType;
-import javax.ejb.Schedule;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
+import javax.enterprise.concurrent.ManagedThreadFactory;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 import javax.jms.Message;
@@ -34,7 +37,6 @@ import javax.jms.Queue;
 
 import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.deltaspike.core.api.exclude.Exclude;
 import org.apache.log4j.Logger;
 
@@ -45,14 +47,11 @@ import datawave.metrics.remote.RemoteQueryMetricService;
 import datawave.microservice.querymetric.BaseQueryMetric;
 import datawave.microservice.querymetric.BaseQueryMetric.Lifecycle;
 import datawave.microservice.querymetric.BaseQueryMetric.PageMetric;
-import datawave.security.authorization.DatawavePrincipal;
 import datawave.util.timely.UdpClient;
 import datawave.webservice.query.exception.QueryExceptionType;
 import datawave.webservice.result.VoidResponse;
 
 @RunAs("InternalUser")
-@RolesAllowed({"AuthorizedUser", "AuthorizedQueryServer", "InternalUser", "Administrator"})
-@DeclareRoles({"AuthorizedUser", "AuthorizedQueryServer", "InternalUser", "Administrator"})
 @Startup
 @Singleton
 @LocalBean
@@ -60,10 +59,13 @@ import datawave.webservice.result.VoidResponse;
 @Exclude(ifProjectStage = DatawaveEmbeddedProjectStageHolder.DatawaveEmbedded.class)
 public class QueryMetricsWriter {
 
-    private Logger log = Logger.getLogger(this.getClass());
+    private Logger log = Logger.getLogger(QueryMetricsWriter.class);
 
-    @Inject
-    private JMSContext jmsContext;
+    @Resource(mappedName = "java:jboss/ee/concurrency/factory/default")
+    private ManagedThreadFactory managedThreadFactory;
+
+    @Resource(mappedName = "java:jboss/DefaultJMSConnectionFactory")
+    private ConnectionFactory connectionFactory;
 
     @Resource(mappedName = "java:/queue/QueryMetrics")
     private Queue dest;
@@ -72,22 +74,39 @@ public class QueryMetricsWriter {
     private QueryMetricHandler<? extends BaseQueryMetric> queryMetricHandler;
 
     @Inject
+    private RemoteQueryMetricService remoteQueryMetricService;
+
+    @Inject
     @SpringBean(name = "QueryMetricsWriterConfiguration", refreshable = true)
     private QueryMetricsWriterConfiguration queryMetricsWriterConfiguration;
 
     private UdpClient timelyClient = null;
     private Map<String,Long> lastPageMetricMap;
 
-    private Map<String,Long> lastPageMap;
-    private List<QueryMetricHolder> metricQueue;
     private DecimalFormat df = new DecimalFormat("0.00");
+    private Future future = null;
+    private volatile boolean shuttingDown = false;
+    private List<FailureRecord> failedMetrics = new ArrayList<>();
 
-    @Inject
-    private RemoteQueryMetricService remoteQueryMetricService;
+    @PostConstruct
+    private void init() {
+        // noinspection unchecked
+        lastPageMetricMap = new LRUMap(1000);
+        timelyClient = createUdpClient();
+        ExecutorService executorService = Executors.newSingleThreadExecutor(managedThreadFactory);
+        this.future = executorService.submit(new MetricProcessor());
+    }
 
-    private List<FailureRecord> failedMetricList = new ArrayList<>();
+    @PreDestroy
+    public void shutdown() {
+        // try to ensure that the task running on the managed thread exits before shutdown
+        this.shuttingDown = true;
+        try {
+            this.future.get(5000, TimeUnit.SECONDS);
+        } catch (Exception e) {
 
-    private static volatile AtomicBoolean receivingMetrics = new AtomicBoolean(false);
+        }
+    }
 
     private UdpClient createUdpClient() {
         if (queryMetricsWriterConfiguration != null && StringUtils.isNotBlank(queryMetricsWriterConfiguration.getTimelyHost())) {
@@ -104,16 +123,7 @@ public class QueryMetricsWriter {
         }
     }
 
-    @PostConstruct
-    private void init() {
-        // noinspection unchecked
-        lastPageMap = new LRUMap(1000);
-        lastPageMetricMap = new LRUMap(1000);
-        metricQueue = new ArrayList<>();
-        timelyClient = createUdpClient();
-    }
-
-    private List<QueryMetricHolder> getMetricsFromQueue() {
+    private List<QueryMetricHolder> getMetricsFromQueue(JMSContext jmsContext) {
         List metricHolderList = new ArrayList<>();
         long start = System.currentTimeMillis();
         try (JMSConsumer consumer = jmsContext.createConsumer(dest)) {
@@ -142,8 +152,8 @@ public class QueryMetricsWriter {
                         continue;
                     }
                 }
-                // break out of loop every minute to ensure flush and acknowledge messages
-                if (metricHolderList.size() >= 1000 || (System.currentTimeMillis() - start) > 60000) {
+                // break out of loop when batchSize is met or at least every minute
+                if (metricHolderList.size() >= queryMetricsWriterConfiguration.getBatchSize() || (System.currentTimeMillis() - start) > 60000) {
                     break;
                 }
             } while (message != null);
@@ -154,19 +164,27 @@ public class QueryMetricsWriter {
     }
 
     private static class FailureRecord {
-        private BaseQueryMetric metric;
+        private QueryMetricHolder queryMetricHolder;
         private long created = System.currentTimeMillis();
-        private int totalFailures;
-        private int failuresWhenOthersSucceeded;
+        private long totalFailures;
+        private long failuresWhenOthersSucceeded;
 
         public FailureRecord(BaseQueryMetric metric, boolean anySuccess) {
-            this.metric = metric;
+            this(new QueryMetricHolder(null, metric), anySuccess);
+        }
+
+        public FailureRecord(QueryMetricHolder queryMetricHolder, boolean anySuccess) {
+            this.queryMetricHolder = queryMetricHolder;
             this.totalFailures = 1;
             this.failuresWhenOthersSucceeded = anySuccess ? 1 : 0;
         }
 
         public BaseQueryMetric getMetric() {
-            return metric;
+            return queryMetricHolder.getQueryMetric();
+        }
+
+        public QueryMetricHolder getQueryMetricHolder() {
+            return queryMetricHolder;
         }
 
         public void incrementFailures(boolean anySuccess) {
@@ -176,11 +194,11 @@ public class QueryMetricsWriter {
             }
         }
 
-        public int getTotalFailures() {
+        public long getTotalFailures() {
             return totalFailures;
         }
 
-        public int getFailuresWhenOthersSucceeded() {
+        public long getFailuresWhenOthersSucceeded() {
             return failuresWhenOthersSucceeded;
         }
 
@@ -189,158 +207,145 @@ public class QueryMetricsWriter {
         }
     }
 
-    @Schedule(hour = "*", minute = "*", second = "*/10", persistent = false)
-    public void processQueryMetrics() {
-        if (queryMetricsWriterConfiguration.getUseRemoteService()) {
-            useRemoteService();
-        } else {
-            useQueryMetricHandler();
-        }
-    }
-
-    private void useRemoteService() {
-        if (receivingMetrics.compareAndSet(false, true)) {
-            try {
-                List<BaseQueryMetric> metricQueue = getMetricsFromQueue().stream().map(h -> h.getQueryMetric()).collect(Collectors.toList());
-                if (!metricQueue.isEmpty()) {
-                    try {
-                        log.debug("writing " + metricQueue.size() + " query metric updates to the RemoteQueryMetricService");
-                        writeMetricsToRemoteService(metricQueue);
-                        log.debug("wrote " + metricQueue.size() + " query metric updates to the RemoteQueryMetricService");
-                    } catch (Exception e) {
-                        log.error(metricQueue.size() + " metrics failed write to remote service as a batch, will retry individually - " + e.getMessage(), e);
-                        List<BaseQueryMetric> failedMetrics = writeMetricsToRemoteServiceIndividually(metricQueue);
-                        boolean anySuccess = failedMetrics.size() < metricQueue.size();
-                        failedMetrics.forEach(m -> {
-                            failedMetricList.add(new FailureRecord(m, anySuccess));
-                        });
-                    }
-                    retryFailures();
-                }
-            } finally {
-                receivingMetrics.set(false);
-            }
-        }
-    }
-
-    private void useQueryMetricHandler() {
-        if (receivingMetrics.compareAndSet(false, true)) {
-            long start = System.currentTimeMillis();
-            List<QueryMetricHolder> failedMetrics = new ArrayList<>();
-            try {
-                if (!metricQueue.isEmpty()) {
-                    try {
-                        // write previously failed metrics
-                        failedMetrics = writeMetricsToHandler(queryMetricHandler, metricQueue);
-                        int successful = metricQueue.size() - failedMetrics.size();
-                        if (successful > 0) {
-                            // logged at ERROR to record successful write of previously failed writes
-                            log.error("Wrote " + successful + " previously failed query metric updates");
-                        }
-                        if (!failedMetrics.isEmpty()) {
-                            throw new IllegalStateException(failedMetrics.size() + " metrics failed write");
-                        }
-                    } catch (Throwable t) {
-                        log.error(failedMetrics.size() + " metric updates failed a second time, removing");
-                        for (QueryMetricHolder h : failedMetrics) {
-                            log.error("Failed write : " + h.getQueryMetric());
-                        }
-                    } finally {
-                        metricQueue.clear();
-                    }
-                }
-
-                try (JMSConsumer consumer = jmsContext.createConsumer(dest)) {
-                    Message message;
-                    do {
-                        message = consumer.receive(500);
-                        if (message != null) {
-                            try {
-                                if (message instanceof ObjectMessage) {
-                                    ObjectMessage objectMessage = (ObjectMessage) message;
-                                    Object o = objectMessage.getObject();
-                                    QueryMetricHolder queryMetricHolder = null;
-                                    if (o instanceof QueryMetricHolder) {
-                                        queryMetricHolder = (QueryMetricHolder) o;
-                                    } else if (o instanceof QueryMetricMessage) {
-                                        queryMetricHolder = ((QueryMetricMessage) o).getMetricHolder();
-                                    }
-                                    if (queryMetricHolder != null) {
-                                        metricQueue.add(queryMetricHolder);
-                                    }
-                                }
-                            } catch (Exception e) {
-                                log.error(e.getMessage() + " messageID:" + message.getJMSMessageID());
-                                continue;
+    private class MetricProcessor implements Runnable {
+        @Override
+        public void run() {
+            // create JMSContext inside the ManagedThread so that the
+            // session is active when we use it to create a consumer
+            JMSContext jmsContext = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE);
+            boolean useRemoteService = queryMetricsWriterConfiguration.getUseRemoteService();
+            while (!shuttingDown) {
+                try {
+                    // only process metrics if they are being successfully written
+                    if (failedMetrics.isEmpty()) {
+                        List<QueryMetricHolder> metricQueue = getMetricsFromQueue(jmsContext);
+                        if (metricQueue.isEmpty()) {
+                            Thread.sleep(5000);
+                        } else {
+                            if (useRemoteService) {
+                                processQueryMetricsWithRemoteService(metricQueue);
+                            } else {
+                                processQueryMetricsWithHandler(metricQueue);
                             }
                         }
-                        // break out of loop every minute to ensure flush and acknowledge messages
-                        if (metricQueue.size() >= 1000 || (System.currentTimeMillis() - start) > 60000) {
-                            break;
+                    } else {
+                        boolean success = writeFailedMetrics();
+                        if (!success) {
+                            // prevent a tight loop where we keep failing to write failedMetrics
+                            Thread.sleep(60000);
                         }
-                    } while (message != null);
-                }
-
-                failedMetrics = writeMetricsToHandler(queryMetricHandler, metricQueue);
-                if (log.isTraceEnabled() && (metricQueue.size() - failedMetrics.size()) > 0) {
-                    log.trace("Wrote " + (metricQueue.size() - failedMetrics.size()) + " query metric updates");
-                }
-                metricQueue.clear();
-                if (!failedMetrics.isEmpty()) {
-                    metricQueue.addAll(failedMetrics);
-                    throw new IllegalStateException(metricQueue.size() + " metrics failed write");
-                }
-            } catch (Throwable t) {
-                log.error(t.getMessage(), t);
-                log.error("Error writing " + metricQueue.size() + " query metric updates.  Creating new queryMetricHandler.");
-                // error during write or flush, create a new handler so that we can re-try next time
-                queryMetricHandler.reload();
-            } finally {
-                try {
-                    queryMetricHandler.flush();
-                } catch (Throwable t) {
-                    log.error(t.getMessage(), t);
-                } finally {
-                    receivingMetrics.set(false);
+                    }
+                } catch (Exception e) {
+                    log.error(e.getMessage(), e);
                 }
             }
         }
     }
 
-    private void retryFailures() {
-        Iterator<FailureRecord> itr = failedMetricList.iterator();
-        boolean anySuccess = false;
+    private void processQueryMetricsWithRemoteService(List<QueryMetricHolder> metricHolderQueue) {
+        List<BaseQueryMetric> metricQueue = metricHolderQueue.stream().map(QueryMetricHolder::getQueryMetric).collect(Collectors.toList());
+        if (!metricQueue.isEmpty()) {
+            try {
+                writeMetricsToRemoteService(metricQueue);
+                log.debug("wrote " + metricQueue.size() + " query metric updates to the RemoteQueryMetricService");
+            } catch (Exception e) {
+                log.error(metricQueue.size() + " metrics failed write to RemoteQueryMetricService as a batch, will retry individually - " + e.getMessage(), e);
+                metricQueue.forEach(m -> {
+                    failedMetrics.add(new FailureRecord(m, false));
+                });
+            }
+        }
+    }
+
+    private void processQueryMetricsWithHandler(List<QueryMetricHolder> metricQueue) {
+        List<QueryMetricHolder> currentFailures = new ArrayList<>();
+        AtomicBoolean anySuccess = new AtomicBoolean(false);
+        try {
+            if (!metricQueue.isEmpty()) {
+                currentFailures.addAll(writeMetricsToHandler(queryMetricHandler, metricQueue));
+                log.debug("wrote " + (metricQueue.size() - currentFailures.size()) + " query metric updates to queryMetricHandler");
+                anySuccess.set(currentFailures.size() < metricQueue.size());
+            }
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            currentFailures.addAll(metricQueue);
+        } finally {
+            if (!metricQueue.isEmpty()) {
+                if (!currentFailures.isEmpty()) {
+                    log.error(currentFailures.size() + " metrics failed write to queryMetricHandler, will retry individually");
+                    currentFailures.stream().forEach(queryMetricHolder -> {
+                        this.failedMetrics.add(new FailureRecord(queryMetricHolder, anySuccess.get()));
+                    });
+                }
+                if (!anySuccess.get()) {
+                    // error during write or flush, create a new handler so that we can re-try next time
+                    log.error("error writing " + metricQueue.size() + " query metric updates - creating new queryMetricHandler");
+                    queryMetricHandler.reload();
+                }
+            }
+        }
+    }
+
+    private boolean writeFailedMetrics() {
+        Iterator<FailureRecord> itr = failedMetrics.iterator();
+        int successful = 0;
         while (itr.hasNext()) {
             FailureRecord f = itr.next();
-            if (f.getFailuresWhenOthersSucceeded() > 2) {
-                log.error("discarding metric: " + f.getMetric());
-                itr.remove();
-            } else {
+            if (queryMetricsWriterConfiguration.getUseRemoteService()) {
                 try {
                     writeMetricsToRemoteService(Collections.singletonList(f.getMetric()));
                     itr.remove();
-                    anySuccess = true;
-                } catch (Exception e1) {
-                    log.error("metric failed write to remote service, will retry - " + e1.getMessage());
+                    successful++;
+                } catch (Exception e) {
+                    // failures will remain in failedMetrics and be processed in processFailedMetricList
+                }
+            } else {
+                // On failure, writeMetricsToHandler returns a list of failed metrics. If empty, then success
+                if (writeMetricsToHandler(queryMetricHandler, Collections.singletonList(f.getQueryMetricHolder())).isEmpty()) {
+                    itr.remove();
+                    successful++;
                 }
             }
         }
-        for (FailureRecord f : failedMetricList) {
-            f.incrementFailures(anySuccess);
-        }
+        log.debug("writeFailedMetrics: success:" + successful + " failures:" + failedMetrics.size());
+        boolean anySuccessful = successful > 0;
+        processFailedMetricList(anySuccessful);
+        return failedMetrics.isEmpty() || anySuccessful;
     }
 
-    private List<BaseQueryMetric> writeMetricsToRemoteServiceIndividually(List<BaseQueryMetric> metricQueue) {
-        List<BaseQueryMetric> failedMetrics = new ArrayList<>();
-        metricQueue.forEach(m -> {
-            try {
-                writeMetricsToRemoteService(Collections.singletonList(m));
-            } catch (Exception e1) {
-                log.error("metric failed write to remote service, will retry - " + e1.getMessage());
-                failedMetrics.add(m);
+    private void processFailedMetricList(boolean anySuccessful) {
+        long discardForFailureCount = 0;
+        Set<String> discardForFailureMetrics = new TreeSet<>();
+        long discardForTimeCount = 0;
+        Set<String> discardForTimeMetrics = new TreeSet<>();
+        Iterator<FailureRecord> itr = failedMetrics.iterator();
+        while (itr.hasNext()) {
+            FailureRecord f = itr.next();
+            f.incrementFailures(anySuccessful);
+            String queryId = f.getMetric().getQueryId();
+            long iFailures = f.getFailuresWhenOthersSucceeded();
+            long tFailures = f.getTotalFailures();
+            if (iFailures >= 2) {
+                // If a metric update fails to write twice when others succeeded, then discard the update
+                itr.remove();
+                discardForFailureMetrics.add(queryId);
+                discardForFailureCount++;
+            } else if (f.getAge() > TimeUnit.MINUTES.toMillis(60)) {
+                // Don't allow failed metrics to stop metric writing forever. Either there is a system problem or
+                // all updates in failedMetrics are coincidentally failing for some metric-specific reason
+                itr.remove();
+                discardForTimeMetrics.add(queryId);
+                discardForTimeCount++;
+            } else {
+                log.trace("failures individual/total:" + iFailures + "/" + tFailures + " for metric update " + queryId);
             }
-        });
-        return failedMetrics;
+        }
+        if (discardForFailureCount > 0) {
+            log.error("Discarding " + discardForFailureCount + " updates from queries " + discardForFailureMetrics + " for repeated failures");
+        }
+        if (discardForTimeCount > 0) {
+            log.error("Discarding " + discardForTimeCount + " updates from queries " + discardForTimeMetrics + " for exceeding max time in failure queue");
+        }
     }
 
     private void writeMetricsToRemoteService(List<BaseQueryMetric> updatedMetrics) throws Exception {
@@ -353,30 +358,22 @@ public class QueryMetricsWriter {
         }
     }
 
-    private List<QueryMetricHolder> writeMetricsToHandler(QueryMetricHandler queryMetricHandler, List<QueryMetricHolder> metricQueue) throws Exception {
-
+    private List<QueryMetricHolder> writeMetricsToHandler(QueryMetricHandler queryMetricHandler, List<QueryMetricHolder> metricQueue) {
         List<QueryMetricHolder> failedMetrics = new ArrayList<>();
-
         if (!metricQueue.isEmpty()) {
-            log.debug("writing " + metricQueue.size() + " query metric updates to queryMetricHandler");
-            for (QueryMetricHolder queryMetricHolder : metricQueue) {
+            for (QueryMetricHolder metricHolder : metricQueue) {
                 try {
-                    BaseQueryMetric queryMetric = queryMetricHolder.getQueryMetric();
-                    handleLegacyEvents(queryMetric);
-                    DatawavePrincipal datawavePrincipal = queryMetricHolder.getPrincipal();
-                    queryMetricHandler.updateMetric(queryMetric, datawavePrincipal);
-                    sendMetricsToTimely(queryMetric);
-                } catch (Throwable t) {
-                    log.error("query metric updates failed: " + t.getMessage(), t);
-                    failedMetrics.add(queryMetricHolder);
+                    queryMetricHandler.updateMetric(metricHolder.getQueryMetric(), metricHolder.getPrincipal());
+                    try {
+                        sendMetricsToTimely(metricHolder.getQueryMetric());
+                    } catch (Exception e) {
+                        log.error(e.getMessage(), e);
+                    }
+                } catch (Exception e) {
+                    log.error("query metric update failed: " + e.getMessage());
+                    failedMetrics.add(metricHolder);
                 }
             }
-            try {
-                queryMetricHandler.flush();
-            } catch (Throwable t) {
-                failedMetrics.addAll(metricQueue);
-            }
-            log.debug("wrote " + (metricQueue.size() - failedMetrics.size()) + " query metric updates to queryMetricHandler");
         }
         return failedMetrics;
     }
@@ -458,50 +455,6 @@ public class QueryMetricsWriter {
 
             } catch (Exception e) {
                 log.error(e.getMessage(), e);
-            }
-        }
-    }
-
-    private void handleLegacyEvents(BaseQueryMetric queryMetric) {
-        long lastUpdated;
-        List<PageMetric> pages = queryMetric.getPageTimes();
-        if (pages != null && !pages.isEmpty()) {
-            // only old events should lack page numbers
-            if (pages.get(0).getPageNumber() == -1) {
-
-                Comparator<PageMetric> c = (m1, m2) -> {
-                    CompareToBuilder builder = new CompareToBuilder();
-                    builder.append(m1.getPageRequested(), m2.getPageRequested());
-                    builder.append(m1.getPageReturned(), m2.getPageReturned());
-                    return builder.toComparison();
-                };
-
-                // Sort by pageRequested and pageReturned
-                Collections.sort(pages, c);
-
-                // lastUpdated used to be set in the ShardTableQueryMetricHandler
-                // Now it is done in the QueryMetricsBean.
-                // If this message was stuck on the queue, then lastUpdated will not have been set yet.
-                lastUpdated = pages.get(pages.size() - 1).getPageReturned();
-
-                // if an older message is pulled off of the queue that does not have page numbers assigned,
-                // then sort by pageRequested time and assign page numbers
-                long x = 0;
-                Long lastPage = lastPageMap.get(queryMetric.getQueryId());
-                Iterator<PageMetric> itr = pages.iterator();
-                while (itr.hasNext()) {
-                    x++;
-                    PageMetric p = itr.next();
-                    // if we have a record of the last page recorded, then remove that page and all
-                    // pages before it to limit the time necessary in updating
-                    if (lastPage != null && x <= lastPage) {
-                        itr.remove();
-                    } else {
-                        p.setPageNumber(x);
-                    }
-                }
-                lastPageMap.put(queryMetric.getQueryId(), x);
-                queryMetric.setLastUpdated(new Date(lastUpdated));
             }
         }
     }

--- a/web-services/query/src/main/java/datawave/webservice/query/metric/QueryMetricsWriterConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/metric/QueryMetricsWriterConfiguration.java
@@ -7,6 +7,7 @@ public class QueryMetricsWriterConfiguration {
 
     private String timelyHost = null;
     private int timelyPort = 0;
+    private int batchSize = 100;
     private Set<String> timelyMetricTags = new HashSet<>();
     private boolean useRemoteService = false;
 
@@ -24,6 +25,14 @@ public class QueryMetricsWriterConfiguration {
 
     public void setTimelyPort(int timelyPort) {
         this.timelyPort = timelyPort;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
     }
 
     public Set<String> getTimelyMetricTags() {


### PR DESCRIPTION
Make number of updates that are pulled off of the queue at a time configurable. This impacts the RemoteQueryMetricService path more than the ShardTableQueryMetricHandler path because we send the updates as one POST request to the remote service while the updates one at a time to the ShardTableQueryMetricHandler

Get rid of code duplication and use common methods for 1) fetching the updates from the queue 2) handling of failed writing of updates

Improve logging of failure handling

Use an EJB managed thread and a Runnable to continuously process metric updates instead of relying on a @Scheduled method where the executions overlap and produce log messages warning about this.

Improve ShardTableQueryMetricHandler throughput by relying on the BatchWriter's latency and maxmemory settings instead of calling flush()

Delete @RolesAllowed and @DeclareRoles lines as users don't interact with QueryMetricsWriter