### PR TITLE
re #1899 UserOperations.getRemoteUser() should be able to handle duplicate DNs in principal.getProxiedUsers()

### DIFF
--- a/web-services/common-util/src/main/java/datawave/security/authorization/UserOperations.java
+++ b/web-services/common-util/src/main/java/datawave/security/authorization/UserOperations.java
@@ -29,7 +29,7 @@ public interface UserOperations {
         // create a new set of proxied users
         List<DatawaveUser> mappedUsers = new ArrayList<>();
         Map<SubjectIssuerDNPair,DatawaveUser> localUsers = principal.getProxiedUsers().stream()
-                        .collect(Collectors.toMap(DatawaveUser::getDn, Function.identity()));
+                        .collect(Collectors.toMap(DatawaveUser::getDn, Function.identity(), (v1, v2) -> v2));
         
         // create a mapped user for the primary user with the auths returned by listEffectiveAuthorizations
         SubjectIssuerDNPair primaryDn = SubjectIssuerDNPair.of(auths.getUserDn(), auths.getIssuerDn());


### PR DESCRIPTION
For various reasons, it's possible to have duplicate DNs (DatawaveUsers) in principal.getProxiedUsers()

e.g. same DN passed as trustedHeader/certificate and also in proxiedUsers
e.g. duplicate entry in proxiedUsers

If this happens, when UserOperations.getRemoteUser() reaches
`Map<SubjectIssuerDNPair,DatawaveUser> localUsers = principal.getProxiedUsers().stream() .collect(Collectors.toMap(DatawaveUser::getDn);`
Collectors.toMap will throw an IllegalStateException complaining about the duplicate key
We can avoid the exception by supplying a function to handle duplicate keys
`Map<SubjectIssuerDNPair,DatawaveUser> localUsers = principal.getProxiedUsers().stream() .collect(Collectors.toMap(DatawaveUser::getDn, Function.identity(), (v1, v2) -> v2));`
Which would use the second value added to the map which is the same thing that would happen if we were doing this in a way that didn't include lambda expressions and Collectors.