### PR TITLE
issue-1275: Fix to handle sparse multivalued fields in GROUPBY. Fixed…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
@@ -182,8 +182,6 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
             countingMap.clear();
             return entry;
         }
-        
         return null;
     }
-    
 }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -107,7 +107,7 @@ public abstract class GroupingTest {
         protected BaseQueryResponse runTestQueryWithGrouping(Map<String,Integer> expected, String querystr, Date startDate, Date endDate,
                         Map<String,String> extraParms, RebuildingScannerTestHelper.TEARDOWN teardown, RebuildingScannerTestHelper.INTERRUPT interrupt)
                         throws Exception {
-            System.out.println("runTestQueryWithGrouping teardown/interrupt: " + teardown.name() + "/" + interrupt.name());
+            log.debug("runTestQueryWithGrouping teardown/interrupt: " + teardown.name() + "/" + interrupt.name());
             QueryTestTableHelper qtth = new QueryTestTableHelper(ShardRange.class.getName(), log, teardown, interrupt);
             AccumuloClient client = qtth.client;
             VisibilityWiseGuysIngest.writeItAll(client, VisibilityWiseGuysIngest.WhatKindaRange.SHARD);
@@ -543,7 +543,7 @@ public abstract class GroupingTest {
         // @formatter:on
         
         extraParameters.put("group.fields", "GENDER,DEPENDENTS");
-
+        
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
             for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
                 runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
@@ -562,7 +562,7 @@ public abstract class GroupingTest {
         String queryString = "UUID =~ '^[CS].*'";
         
         Map<String,Integer> expectedMap = ImmutableMap.of("FEAR", 2, "MONEY", 1);
-
+        
         extraParameters.put("group.fields", "MOTIVE");
         
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
@@ -583,7 +583,7 @@ public abstract class GroupingTest {
         String queryString = "UUID == 'CORLEONE'";
         
         Map<String,Integer> expectedMap = ImmutableMap.of("FEAR", 1, "MONEY", 1);
-
+        
         extraParameters.put("group.fields", "MOTIVE");
         
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -543,8 +543,7 @@ public abstract class GroupingTest {
         // @formatter:on
         
         extraParameters.put("group.fields", "GENDER,DEPENDENTS");
-        // extraParameters.put("group.fields.batch.size", "12");
-        
+
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
             for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
                 runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
@@ -563,8 +562,7 @@ public abstract class GroupingTest {
         String queryString = "UUID =~ '^[CS].*'";
         
         Map<String,Integer> expectedMap = ImmutableMap.of("FEAR", 2, "MONEY", 1);
-        // Map<String,Integer> expectedMap = ImmutableMap.of("WISEGUY", 3);
-        
+
         extraParameters.put("group.fields", "MOTIVE");
         
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
@@ -585,8 +583,7 @@ public abstract class GroupingTest {
         String queryString = "UUID == 'CORLEONE'";
         
         Map<String,Integer> expectedMap = ImmutableMap.of("FEAR", 1, "MONEY", 1);
-        // Map<String,Integer> expectedMap = ImmutableMap.of("WISEGUY", 3);
-        
+
         extraParameters.put("group.fields", "MOTIVE");
         
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -77,7 +77,6 @@ import static datawave.query.RebuildingScannerTestHelper.TEARDOWN.RANDOM_SANS_CO
 
 /**
  * Applies grouping to queries
- * 
  */
 public abstract class GroupingTest {
     
@@ -108,6 +107,7 @@ public abstract class GroupingTest {
         protected BaseQueryResponse runTestQueryWithGrouping(Map<String,Integer> expected, String querystr, Date startDate, Date endDate,
                         Map<String,String> extraParms, RebuildingScannerTestHelper.TEARDOWN teardown, RebuildingScannerTestHelper.INTERRUPT interrupt)
                         throws Exception {
+            System.out.println("runTestQueryWithGrouping teardown/interrupt: " + teardown.name() + "/" + interrupt.name());
             QueryTestTableHelper qtth = new QueryTestTableHelper(ShardRange.class.getName(), log, teardown, interrupt);
             AccumuloClient client = qtth.client;
             VisibilityWiseGuysIngest.writeItAll(client, VisibilityWiseGuysIngest.WhatKindaRange.SHARD);
@@ -233,11 +233,15 @@ public abstract class GroupingTest {
                     case "GENDER":
                     case "GEN":
                     case "BIRTHDAY":
+                    case "TYPE":
+                    case "MOTIVE":
+                    case "MEASURE_HEIGHT":
                         firstKey = fieldBase.getValueString();
                         break;
                     case "AGE":
                     case "AG":
                     case "RECORD":
+                    case "DEPENDENTS":
                         secondKey = fieldBase.getValueString();
                         break;
                 }
@@ -252,7 +256,7 @@ public abstract class GroupingTest {
             } else {
                 key = secondKey;
             }
-            Assert.assertEquals(expected.get(key), value);
+            Assert.assertEquals("key = " + key, expected.get(key), value);
         }
         return response;
     }
@@ -445,7 +449,7 @@ public abstract class GroupingTest {
     }
     
     @Test
-    public void testGroupingMixedEntriesWithAndWithNoContext() throws Exception {
+    public void testGroupingMixedWithAndWithNoContext() throws Exception {
         // Testing multivalued entries with no grouping context in combination with a grouping context entries
         Map<String,String> extraParameters = new HashMap<>();
         
@@ -465,6 +469,154 @@ public abstract class GroupingTest {
         
         extraParameters.put("group.fields", "GENDER,RECORD");
         // extraParameters.put("group.fields.batch.size", "12");
+        
+        for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
+            for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
+                runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
+            }
+        }
+    }
+    
+    @Test
+    public void testGroupingEntriesWithNoContextOneValue() throws Exception {
+        // Testing multivalued entries with no grouping context
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        Date startDate = format.parse("20091231");
+        Date endDate = format.parse("20150101");
+        
+        String queryString = "UUID =~ '^[CS].*'";
+        
+        Map<String,Integer> expectedMap = ImmutableMap.of("WISEGUY", 2, "REGGUY", 1);
+        
+        extraParameters.put("group.fields", "TYPE");
+        
+        for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
+            for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
+                runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
+            }
+        }
+    }
+    
+    @Test
+    public void testGroupingEntriesWithNoContextOneAndMultipleValue() throws Exception {
+        // Testing multivalued entries with no grouping context
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        Date startDate = format.parse("20091231");
+        Date endDate = format.parse("20150101");
+        
+        String queryString = "UUID =~ '^[CS].*'";
+        
+        Map<String,Integer> expectedMap = ImmutableMap.of("WISEGUY-1", 2, "REGGUY-1", 1);
+        
+        extraParameters.put("group.fields", "TYPE,RECORD");
+        
+        for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
+            for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
+                runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
+            }
+        }
+    }
+    
+    @Test
+    public void testGroupingWithFieldWithSparseGroupingEntries() throws Exception {
+        // Testing multivalued atoms where not all atoms have every field populated.
+        // This results in entries where the grouping context is sparse;
+        // that is, not all of the grouping contexts have data for a field.
+        // Look at VisibilityWiseGuysIngest and the DEPENDENTS fields in the data
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        Date startDate = format.parse("20091231");
+        Date endDate = format.parse("20150101");
+        
+        String queryString = "UUID =~ '^[CS].*'";
+        
+        // @formatter:off
+        // The expected counts correspond to the listed UIDs and contexts
+        Map<String,Integer> expectedMap = ImmutableMap.<String,Integer> builder()
+                .put("FEMALE-2", 1) // female w/2 dependents: sopranoUID 1
+                .put("MALE-2", 4) // male w/2 dependents: corleoneUID 1, 5, caponeUID 1, 3
+                .put("MALE-3", 2) // male w/3 dependents: corleoneUID 2, caponeUID 2
+                .put("MALE-4", 3) // male w/4 dependents: corleoneUID 4, sopranoUID 0, caponeUID 0
+                .build();
+        // @formatter:on
+        
+        extraParameters.put("group.fields", "GENDER,DEPENDENTS");
+        // extraParameters.put("group.fields.batch.size", "12");
+        
+        for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
+            for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
+                runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
+            }
+        }
+    }
+    
+    @Test
+    public void testGroupingEntriesWithSameContextSingle() throws Exception {
+        // Testing multivalued entries with no grouping context
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        Date startDate = format.parse("20091231");
+        Date endDate = format.parse("20150101");
+        
+        String queryString = "UUID =~ '^[CS].*'";
+        
+        Map<String,Integer> expectedMap = ImmutableMap.of("FEAR", 2, "MONEY", 1);
+        // Map<String,Integer> expectedMap = ImmutableMap.of("WISEGUY", 3);
+        
+        extraParameters.put("group.fields", "MOTIVE");
+        
+        for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
+            for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
+                runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
+            }
+        }
+    }
+    
+    @Test
+    public void testGroupingEntriesWithSameContextAll() throws Exception {
+        // Testing multivalued entries with no grouping context
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        Date startDate = format.parse("20091231");
+        Date endDate = format.parse("20150101");
+        
+        String queryString = "UUID == 'CORLEONE'";
+        
+        Map<String,Integer> expectedMap = ImmutableMap.of("FEAR", 1, "MONEY", 1);
+        // Map<String,Integer> expectedMap = ImmutableMap.of("WISEGUY", 3);
+        
+        extraParameters.put("group.fields", "MOTIVE");
+        
+        for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
+            for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
+                runTestQueryWithGrouping(expectedMap, queryString, startDate, endDate, extraParameters, teardown, interrupt);
+            }
+        }
+    }
+    
+    @Test
+    public void testGroupingEntriesWithFieldDesc() throws Exception {
+        // Testing multivalued entries with no grouping context
+        Map<String,String> extraParameters = new HashMap<>();
+        
+        Date startDate = format.parse("20091231");
+        Date endDate = format.parse("20150101");
+        
+        String queryString = "UUID =~ '^[CS].*'";
+        
+        // @formatter:off
+        Map<String,Integer> expectedMap = ImmutableMap.<String,Integer> builder()
+                .put("5-10", 4)
+                .put("5-9", 3)
+                .put("6-1", 2)
+                .put("5-3", 1)
+                .put("5-7", 1)
+                .build();
+        // @formatter:on
+        
+        extraParameters.put("group.fields", "MEASURE_HEIGHT");
         
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
             for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {

--- a/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysIngest.java
@@ -77,21 +77,43 @@ public class VisibilityWiseGuysIngest {
             mutation.put(datatype + "\u0000" + corleoneUID, "BIRTHDAY.3" + "\u0000" + "4", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + corleoneUID, "BIRTHDAY.4" + "\u0000" + "5", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + corleoneUID, "BIRTHDAY.5" + "\u0000" + "22", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "DEPENDENTS.1" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "DEPENDENTS.2" + "\u0000" + "3", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "DEPENDENTS.4" + "\u0000" + "4", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "DEPENDENTS.5" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + corleoneUID, "UUID.0" + "\u0000" + "CORLEONE", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + corleoneUID, "RECORD" + "\u0000" + "1", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + corleoneUID, "RECORD" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "TYPE" + "\u0000" + "WISEGUY", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MOTIVE.0" + "\u0000" + "FEAR", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MOTIVE.0" + "\u0000" + "MONEY", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.0" + "\u0000" + "5-10", columnVisibilityItalian, timeStamp,
+                            emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.1" + "\u0000" + "5-9", columnVisibilityItalian, timeStamp,
+                            emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.2" + "\u0000" + "5-9", columnVisibilityItalian, timeStamp,
+                            emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.3" + "\u0000" + "5-10", columnVisibilityItalian, timeStamp,
+                            emptyValue);
+            mutation.put(datatype + "\u0000" + corleoneUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.5" + "\u0000" + "6-1", columnVisibilityItalian, timeStamp,
+                            emptyValue);
             
             mutation.put(datatype + "\u0000" + sopranoUID, "NAME.0" + "\u0000" + "ANTHONY", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "NAME.1" + "\u0000" + "MEADOW", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "GENDER.0" + "\u0000" + "MALE", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "GENDER.1" + "\u0000" + "FEMALE", columnVisibilityEnglish, timeStamp, emptyValue);
-            // to test whether singleton values correctly get matched using the function set methods, only add AGE.1
-            // mutation.put(datatype + "\u0000" + sopranoUID, "AGE.0" + "\u0000" + "16", columnVisibility, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "AGE.0" + "\u0000" + "16", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "AGE.1" + "\u0000" + "18", columnVisibilityEnglish, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + sopranoUID, "DEPENDENTS.0" + "\u0000" + "4", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + sopranoUID, "DEPENDENTS.1" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "UUID.0" + "\u0000" + "SOPRANO", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "RECORD" + "\u0000" + "1", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "RECORD" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + sopranoUID, "TYPE" + "\u0000" + "REGGUY", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + sopranoUID, "MOTIVE.0" + "\u0000" + "FEAR", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + sopranoUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.0" + "\u0000" + "5-10", columnVisibilityItalian, timeStamp,
+                            emptyValue);
+            mutation.put(datatype + "\u0000" + sopranoUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.1" + "\u0000" + "5-3", columnVisibilityItalian, timeStamp, emptyValue);
             
             mutation.put(datatype + "\u0000" + caponeUID, "NAME.0" + "\u0000" + "ALPHONSE", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "NAME.1" + "\u0000" + "FRANK", columnVisibilityEnglish, timeStamp, emptyValue);
@@ -105,10 +127,19 @@ public class VisibilityWiseGuysIngest {
             mutation.put(datatype + "\u0000" + caponeUID, "AGE.1" + "\u0000" + "34", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "AGE.2" + "\u0000" + "20", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "AGE.3" + "\u0000" + "40", columnVisibilityEnglish, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "DEPENDENTS.0" + "\u0000" + "4", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "DEPENDENTS.1" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "DEPENDENTS.2" + "\u0000" + "3", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "DEPENDENTS.3" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "UUID.0" + "\u0000" + "CAPONE", columnVisibilityEnglish, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "RECORD" + "\u0000" + "1", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "RECORD" + "\u0000" + "2", columnVisibilityItalian, timeStamp, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "RECORD" + "\u0000" + "3", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "TYPE" + "\u0000" + "WISEGUY", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.0" + "\u0000" + "5-9", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.1" + "\u0000" + "5-10", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.2" + "\u0000" + "6-1", columnVisibilityItalian, timeStamp, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "MEASURE_HEIGHT.MEASURE.HEIGHT.3" + "\u0000" + "5-7", columnVisibilityItalian, timeStamp, emptyValue);
             
             bw.addMutation(mutation);
             


### PR DESCRIPTION
… multivalued fieldname with same context.

issue-1275: Fix to handle sparse multivalued fields in GROUPBY. Fixed multivalued fieldname with same context.

issue-1275: Fix to handle sparse multivalued fields in GROUPBY. Fixed multivalued fieldname with same context.