### PR TITLE
Cleanup IndexIterator

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIterator.java
@@ -110,6 +110,8 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
     protected final String field;
     protected final String value;
     
+    protected Key limitKey;
+    
     protected PreNormalizedAttributeFactory attributeFactory;
     protected Document document;
     protected boolean buildDocument = false;
@@ -321,7 +323,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
             }
             
             // restrict the aggregation to the current target value within the document
-            limitedSource.setLimit(new Key(top.getRow(), columnFamily, new Text(valueMinPrefix + Constants.MAX_UNICODE_STRING)));
+            limitedSource.setLimit(getLimitKey(top.getRow()));
             
             // Aggregate the document. NOTE: This will advance the source iterator
             if (buildDocument) {
@@ -454,6 +456,22 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
         }
         
         return key;
+    }
+    
+    /**
+     * Get a key to limit the scan range of this iterator.
+     * <p>
+     * Practically the row will not change, so this 'get or build' pattern is safe.
+     *
+     * @param row
+     *            the row a shard index key (the partition in YYYYmmdd_n format)
+     * @return the limit key
+     */
+    public Key getLimitKey(Text row) {
+        if (limitKey == null) {
+            limitKey = new Key(row, columnFamily, new Text(valueMinPrefix + Constants.MAX_UNICODE_STRING));
+        }
+        return limitKey;
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/IndexIterator.java
@@ -2,7 +2,6 @@ package datawave.query.iterator.logic;
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Lists;
 import datawave.query.Constants;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.PreNormalizedAttributeFactory;
@@ -27,6 +26,7 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -100,7 +100,6 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
     protected final Text valueMinPrefix;
     protected final Text columnFamily;
     protected final Collection<ByteSequence> seekColumnFamilies;
-    protected final boolean includeColumnFamilies;
     
     // used for managing parent calls to seek
     protected Range scanRange;
@@ -154,8 +153,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
         
         // Make sure we properly set the ColumnFamilies when calling seek() to avoid
         // opening readers to locality groups we don't care about
-        this.seekColumnFamilies = Lists.newArrayList((ByteSequence) new ArrayByteSequence(columnFamilyBytes));
-        this.includeColumnFamilies = true;
+        this.seekColumnFamilies = Collections.singleton(new ArrayByteSequence(columnFamilyBytes));
         
         this.field = field.toString();
         this.value = value.toString();
@@ -191,7 +189,10 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
         
         tk = null;
         // reusable buffers
-        Text row = new Text(), cf = new Text(), cq = new Text();
+        Text row = new Text();
+        Text cf = new Text();
+        Text cq = new Text();
+        
         while (source.hasTop() && tk == null) {
             Key top = source.getTopKey();
             
@@ -215,7 +216,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
                     log.trace("cfDiff > 0, seeking to range: " + newRange);
                 }
                 
-                source.seek(newRange, seekColumnFamilies, includeColumnFamilies);
+                source.seek(newRange, seekColumnFamilies, true);
                 continue;
             } else if (cfDiff < 0) {
                 // need to move to the next row and try again
@@ -237,7 +238,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
                     log.trace("cfDiff < 0, seeking to range: " + newRange);
                 }
                 
-                source.seek(newRange, seekColumnFamilies, includeColumnFamilies);
+                source.seek(newRange, seekColumnFamilies, true);
                 continue;
             }
             
@@ -251,7 +252,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
                     log.trace("cqDiff > 0, seeking to range: " + newRange);
                 }
                 
-                source.seek(newRange, seekColumnFamilies, includeColumnFamilies);
+                source.seek(newRange, seekColumnFamilies, true);
                 continue;
             } else if (cqDiff < 0) {
                 // need to move to the next row and try again
@@ -273,7 +274,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
                     log.trace("cqDiff < 0, seeking to range: " + newRange);
                 }
                 
-                source.seek(newRange, seekColumnFamilies, includeColumnFamilies);
+                source.seek(newRange, seekColumnFamilies, true);
                 continue;
             }
             
@@ -298,7 +299,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
                 Range newRange;
                 if (timeSeekingFilter != null
                                 && (newRange = timeSeekingFilter.getSeekRange(top, this.scanRange.getEndKey(), this.scanRange.isEndKeyInclusive())) != null) {
-                    source.seek(newRange, seekColumnFamilies, includeColumnFamilies);
+                    source.seek(newRange, seekColumnFamilies, true);
                 } else {
                     source.next();
                 }
@@ -312,7 +313,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
                 Range newRange;
                 if (dataTypeSeekingFilter != null
                                 && (newRange = dataTypeSeekingFilter.getSeekRange(top, this.scanRange.getEndKey(), this.scanRange.isEndKeyInclusive())) != null) {
-                    source.seek(newRange, seekColumnFamilies, includeColumnFamilies);
+                    source.seek(newRange, seekColumnFamilies, true);
                 } else {
                     source.next();
                 }
@@ -321,9 +322,14 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
             
             // restrict the aggregation to the current target value within the document
             limitedSource.setLimit(new Key(top.getRow(), columnFamily, new Text(valueMinPrefix + Constants.MAX_UNICODE_STRING)));
+            
             // Aggregate the document. NOTE: This will advance the source iterator
-            tk = buildDocument ? aggregation.apply(limitedSource, document, attributeFactory) : aggregation.apply(limitedSource, scanRange, seekColumnFamilies,
-                            includeColumnFamilies);
+            if (buildDocument) {
+                tk = aggregation.apply(limitedSource, document, attributeFactory);
+            } else {
+                tk = aggregation.apply(limitedSource, scanRange, seekColumnFamilies, true);
+            }
+            
             if (log.isTraceEnabled()) {
                 log.trace("Doc size: " + this.document.size());
                 log.trace("Returning pointer " + tk.toStringNoTime());
@@ -359,7 +365,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
             log.trace(this + " seek'ing to: " + this.scanRange + " from " + range);
         }
         
-        source.seek(this.scanRange, this.seekColumnFamilies, this.includeColumnFamilies);
+        source.seek(this.scanRange, this.seekColumnFamilies, true);
         next();
     }
     
@@ -393,7 +399,7 @@ public class IndexIterator implements SortedKeyValueIterator<Key,Value>, Documen
             log.trace(this + " moving to: " + r);
         }
         
-        source.seek(r, seekColumnFamilies, includeColumnFamilies);
+        source.seek(r, seekColumnFamilies, true);
         
         if (log.isTraceEnabled()) {
             log.trace(this + " finished move. Now at " + (source.hasTop() ? source.getTopKey() : "null") + ", calling next()");

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -136,7 +136,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
     protected Map<Entry<String,String>,Entry<Key,Value>> limitedMap = null;
     protected Collection<String> includeReferences = UniversalSet.instance();
     protected Collection<String> excludeReferences = Collections.emptyList();
-    protected Predicate<Key> datatypeFilter = Predicates.<Key> alwaysTrue();
+    protected Predicate<Key> datatypeFilter;
     protected TimeFilter timeFilter;
     
     protected FileSystemCache hdfsFileSystem;
@@ -164,7 +164,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
     protected Set<String> termFrequencyFields = Collections.emptySet();
     protected boolean allowTermFrequencyLookup = true;
     protected Set<String> indexOnlyFields = Collections.emptySet();
-    protected FieldIndexAggregator fiAggregator = new IdentityAggregator(null);
+    protected FieldIndexAggregator fiAggregator;
     
     protected CompositeMetadata compositeMetadata;
     protected int compositeSeekThreshold = 10;
@@ -445,7 +445,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             builder.setFieldsToAggregate(fieldsToAggregate);
             builder.setTimeFilter(timeFilter);
             builder.setAttrFilter(attrFilter);
-            builder.setDatatypeFilter(datatypeFilter);
+            builder.setDatatypeFilter(getDatatypeFilter());
             builder.setEnv(env);
             builder.setTermFrequencyAggregator(getTermFrequencyAggregator(identifier, sourceNode, attrFilter, tfNextSeek));
             builder.setNode(rootNode);
@@ -589,8 +589,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setTypeMetadata(typeMetadata);
         builder.setFieldsToAggregate(fieldsToAggregate);
         builder.setTimeFilter(timeFilter);
-        builder.setDatatypeFilter(datatypeFilter);
-        builder.setKeyTransform(fiAggregator);
+        builder.setDatatypeFilter(getDatatypeFilter());
+        builder.setKeyTransform(getFiAggregator());
         builder.setEnv(env);
         builder.setNode(node);
         node.childrenAccept(this, builder);
@@ -668,8 +668,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setTimeFilter(getTimeFilter(node));
         builder.setTypeMetadata(typeMetadata);
         builder.setFieldsToAggregate(fieldsToAggregate);
-        builder.setDatatypeFilter(datatypeFilter);
-        builder.setKeyTransform(fiAggregator);
+        builder.setDatatypeFilter(getDatatypeFilter());
+        builder.setKeyTransform(getFiAggregator());
         builder.setEnv(env);
         builder.forceDocumentBuild(!limitLookup && this.isQueryFullySatisfied);
         builder.setNode(node);
@@ -921,8 +921,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setTimeFilter(TimeFilter.alwaysTrue());
         builder.setTypeMetadata(typeMetadata);
         builder.setFieldsToAggregate(fieldsToAggregate);
-        builder.setDatatypeFilter(datatypeFilter);
-        builder.setKeyTransform(fiAggregator);
+        builder.setDatatypeFilter(getDatatypeFilter());
+        builder.setKeyTransform(getFiAggregator());
         builder.setEnv(env);
         builder.setNode(rootNode);
         
@@ -956,8 +956,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setTimeFilter(getTimeFilter(node));
         builder.setTypeMetadata(typeMetadata);
         builder.setFieldsToAggregate(fieldsToAggregate);
-        builder.setDatatypeFilter(datatypeFilter);
-        builder.setKeyTransform(fiAggregator);
+        builder.setDatatypeFilter(getDatatypeFilter());
+        builder.setKeyTransform(getFiAggregator());
         builder.setEnv(env);
         
         node.childrenAccept(this, builder);
@@ -1413,8 +1413,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setCompositeMetadata(compositeMetadata);
         builder.setCompositeSeekThreshold(compositeSeekThreshold);
         builder.setFieldsToAggregate(fieldsToAggregate);
-        builder.setDatatypeFilter(datatypeFilter);
-        builder.setKeyTransform(fiAggregator);
+        builder.setDatatypeFilter(getDatatypeFilter());
+        builder.setKeyTransform(getFiAggregator());
         builder.setIvaratorCacheDirs(getIvaratorCacheDirs());
         builder.setHdfsFileCompressionCodec(hdfsFileCompressionCodec);
         builder.setQueryLock(queryLock);
@@ -1457,6 +1457,30 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                 }
             }
         }
+    }
+
+    /**
+     * Get the DatatypeFilter
+     *
+     * @return a DatatypeFilter
+     */
+    public Predicate<Key> getDatatypeFilter() {
+        if (datatypeFilter == null) {
+            datatypeFilter = Predicates.alwaysTrue();
+        }
+        return datatypeFilter;
+    }
+    
+    /**
+     * Get the FieldIndexAggregator
+     *
+     * @return a FieldIndexAggregator
+     */
+    public FieldIndexAggregator getFiAggregator() {
+        if (fiAggregator == null) {
+            fiAggregator = new IdentityAggregator(null);
+        }
+        return fiAggregator;
     }
     
     public IteratorBuildingVisitor setRange(Range documentRange) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -1458,7 +1458,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             }
         }
     }
-
+    
     /**
      * Get the DatatypeFilter
      *

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexBuildingVisitor.java
@@ -44,9 +44,9 @@ public class TLDIndexBuildingVisitor extends IteratorBuildingVisitor {
         TLDIndexIteratorBuilder builder = new TLDIndexIteratorBuilder();
         builder.setSource(source.deepCopy(env));
         builder.setTypeMetadata(typeMetadata);
-        builder.setDatatypeFilter(datatypeFilter);
+        builder.setDatatypeFilter(getDatatypeFilter());
         builder.setFieldsToAggregate(fieldsToAggregate);
-        builder.setKeyTransform(fiAggregator);
+        builder.setKeyTransform(getFiAggregator());
         builder.setTimeFilter(timeFilter);
         builder.setNode(node);
         node.childrenAccept(this, builder);
@@ -133,9 +133,9 @@ public class TLDIndexBuildingVisitor extends IteratorBuildingVisitor {
         builder.setSource(getSourceIterator(node, isNegation));
         builder.setTimeFilter(getTimeFilter(node));
         builder.setTypeMetadata(typeMetadata);
-        builder.setDatatypeFilter(datatypeFilter);
+        builder.setDatatypeFilter(getDatatypeFilter());
         builder.setFieldsToAggregate(fieldsToAggregate);
-        builder.setKeyTransform(fiAggregator);
+        builder.setKeyTransform(getFiAggregator());
         builder.forceDocumentBuild(!limitLookup && this.isQueryFullySatisfied);
         builder.setNode(node);
         node.childrenAccept(this, builder);


### PR DESCRIPTION
- encapsulate the field index aggregator and datatype filter
- build the limit key once
- remove useless boolean