### PR TITLE
Set data.name for JobSetupHandlers

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
@@ -4,6 +4,7 @@ import datawave.ingest.config.TableConfigCache;
 import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.ConfigurationHelper;
+import datawave.ingest.data.config.DataTypeHelper;
 import datawave.ingest.data.config.ingest.AccumuloHelper;
 import datawave.ingest.input.reader.event.EventSequenceFileInputFormat;
 import datawave.ingest.mapreduce.EventMapper;
@@ -545,6 +546,7 @@ public class IngestJob implements Tool {
                         Object o = Class.forName(handler).newInstance();
                         if (o instanceof JobSetupHandler) {
                             JobSetupHandler setupHandler = (JobSetupHandler) o;
+                            conf.set(DataTypeHelper.Properties.DATA_NAME, t.typeName());
                             setupHandler.setup(conf);
                         }
                     } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {


### PR DESCRIPTION
Some handlers expect the data.name to be set to their data type for looking up things like `<datatype>.some.config`. We were not setting the data.name when invoking `handler.setup()` for the new `JobSetupHandler`s. This led to configurations that were valid but failed ingest jobs. The data.name in IngestJob is set to whatever config xml was loaded last.