### PR TITLE
3.41 Backport for: Update query limits handling to allow rules based on systemFrom values

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -29,6 +29,7 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     private String logicDescription = "Not configured";
     private AuditType auditType = null;
     private Map<String,Long> dnResultLimits = null;
+    private Map<String,Long> systemFromResultLimits = null;
     protected long maxResults = -1L;
     protected ScannerBase scanner;
     @SuppressWarnings("unchecked")
@@ -371,6 +372,16 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
     @Override
     public Map<String,Long> getDnResultLimits() {
         return dnResultLimits;
+    }
+    
+    @Override
+    public void setSystemFromResultLimits(Map<String,Long> systemFromLimits) {
+        this.systemFromResultLimits = systemFromLimits;
+    }
+    
+    @Override
+    public Map<String,Long> getSystemFromResultLimits() {
+        return systemFromResultLimits;
     }
     
     @Override

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/DelegatingQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/DelegatingQueryLogic.java
@@ -327,8 +327,18 @@ public abstract class DelegatingQueryLogic implements QueryLogic<Object> {
     }
     
     @Override
-    public long getResultLimit(Collection<String> dns) {
-        return delegate.getResultLimit(dns);
+    public void setSystemFromResultLimits(Map<String,Long> systemFromResultLimits) {
+        delegate.setSystemFromResultLimits(systemFromResultLimits);
+    }
+    
+    @Override
+    public Map<String,Long> getSystemFromResultLimits() {
+        return delegate.getSystemFromResultLimits();
+    }
+    
+    @Override
+    public long getResultLimit(Query settings) {
+        return delegate.getResultLimit(settings);
     }
     
     @Override

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
@@ -7,6 +7,7 @@ import datawave.webservice.common.audit.Auditor.AuditType;
 import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.security.authorization.UserOperations;
 import datawave.webservice.query.Query;
+import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.cache.ResultsPage;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.exception.DatawaveErrorCode;
@@ -356,21 +357,49 @@ public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidato
     Map<String,Long> getDnResultLimits();
     
     /**
-     * Return the maximum number of results to include for the query for any DN present in the specified collection. If limits are found for multiple DNs in the
-     * collection, the smallest value will be returned. If the provided collection is null or empty, or if no limits are found for any DN, the value of
-     * {@link #getMaxResults()} will be returned.
+     * Set the map of DNs to query result limits. This should override the default limit returned by {@link #getMaxResults()} for any included DNs.
      *
-     * @param dns
-     *            the DNs to determine the maximum number of results to include for the query. It's expected that this list represents all the DNs in the DN
-     *            chain for an individual user.
+     * @param systemFromResultLimits
+     *            the map of system from values to query result limits
+     */
+    void setSystemFromResultLimits(Map<String,Long> systemFromResultLimits);
+    
+    /**
+     * Return a map of System From values to results limits.
+     *
+     * @return the map of system from values to query result limits.
+     */
+    Map<String,Long> getSystemFromResultLimits();
+    
+    /**
+     * Return the maximum number of results to include for the query based on criteria including the DN or systemFrom stored in the query setting object that is
+     * provided. If limits are found for multiple criteria in the collection, the smallest value will be returned. If no limits are found for any criteria, the
+     * value of {@link #getMaxResults()} will be returned. If both the DN and systemFrom rules match the request, the DN result will take precedence over the
+     * systemFrom rules.
+     *
+     * @param settings
+     *            the query settings used to determine the maximum number of results to include for the query. It's expected that this includes the list of all
+     *            DNs for a user and any systemFrom parameter values.
      * @return the maximum number of results to include
      */
-    default long getResultLimit(Collection<String> dns) {
-        Map<String,Long> dnResultLimits = getDnResultLimits();
-        if (dnResultLimits == null || dns == null) {
-            return getMaxResults();
+    default long getResultLimit(Query settings) {
+        long maxResults = getMaxResults();
+        
+        Map<String,Long> systemFromLimits = getSystemFromResultLimits();
+        QueryImpl.Parameter systemFromParam = settings.findParameter("systemFrom");
+        if (systemFromLimits != null && systemFromParam != null) {
+            // this findParameter implementation never returns null, it will return a parameter with an empty string
+            // as the value if the parameter is not present.
+            maxResults = systemFromLimits.getOrDefault(systemFromParam.getParameterValue(), maxResults);
         }
-        return dns.stream().filter(dnResultLimits::containsKey).map(dnResultLimits::get).min(Long::compareTo).orElseGet(this::getMaxResults);
+        
+        Map<String,Long> dnResultLimits = getDnResultLimits();
+        Collection<String> dns = settings.getDnList();
+        if (dnResultLimits != null && dns != null) {
+            maxResults = dns.stream().filter(dnResultLimits::containsKey).map(dnResultLimits::get).min(Long::compareTo).orElse(maxResults);
+        }
+        
+        return maxResults;
     }
     
     /**

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
@@ -10,6 +10,7 @@ import datawave.security.authorization.UserOperations;
 import datawave.security.util.AuthorizationsUtil;
 import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import datawave.webservice.query.Query;
+import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.cache.AbstractRunningQuery;
 import datawave.webservice.query.cache.ResultsPage;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
@@ -35,6 +36,7 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -146,7 +148,8 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
         if (null != connection) {
             setConnection(connection);
         }
-        this.maxResults = this.logic.getResultLimit(this.settings.getDnList());
+        
+        this.maxResults = this.logic.getResultLimit(this.settings);
         if (this.maxResults != this.logic.getMaxResults()) {
             log.info("Maximum results set to " + this.maxResults + " instead of default " + this.logic.getMaxResults() + ", user " + this.settings.getUserDN()
                             + " has a DN configured with a different limit");

--- a/web-services/query/src/test/java/datawave/webservice/query/cache/QueryCacheBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/cache/QueryCacheBeanTest.java
@@ -122,7 +122,7 @@ public class QueryCacheBeanTest {
         
         expect(logic.getCollectQueryMetrics()).andReturn(false);
         expect(logic.isLongRunningQuery()).andReturn(false);
-        expect(logic.getResultLimit(q.getDnList())).andReturn(-1L);
+        expect(logic.getResultLimit(q)).andReturn(-1L);
         expect(logic.getMaxResults()).andReturn(-1L);
         expect(logic.getUserOperations()).andReturn(null);
         

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import datawave.webservice.common.audit.Auditor;
 import datawave.webservice.common.connection.AccumuloConnectionFactory.Priority;
 import datawave.webservice.query.Query;
+import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.EasyRoleManager;
 import datawave.webservice.query.logic.QueryLogicTransformer;
@@ -17,8 +18,10 @@ import org.powermock.api.easymock.PowerMock;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -104,53 +107,216 @@ public class TestBaseQueryLogic {
         assertFalse(logic.containsDNWithAccess(Collections.emptySet()));
     }
     
+    /**
+     * Sets up expectations and asserts the results from 3 types of query dn list with an empty system from in each case
+     *
+     * @param dns
+     *            a list of dns to return from the first test permutation
+     * @param logic
+     *            the logic we will be testing
+     * @param limits
+     *            the expected limits to be returned in each case
+     */
+    public void assertGetResultsLimitsDn(List<String> dns, BaseQueryLogic<Object> logic, long... limits) {
+        PowerMock.resetAll();
+        expect(query.getDnList()).andReturn(dns);
+        expect(query.getDnList()).andReturn(null);
+        expect(query.getDnList()).andReturn(Collections.emptyList());
+        expect(query.findParameter("systemFrom")).andReturn(null).anyTimes();
+        PowerMock.replayAll();
+        for (long limit : limits) {
+            assertEquals(limit, logic.getResultLimit(query));
+        }
+        PowerMock.verifyAll();
+    }
+    
+    /**
+     * Sets up expectations and asserts the results from 3 types of query system from lists with an empty dn list in each case
+     *
+     * @param logic
+     *            the logic we will be testing
+     * @param limits
+     *            the expected limits to be returned in each case
+     */
+    public void assertGetResultsLimitsSystemFrom(BaseQueryLogic<Object> logic, long... limits) {
+        PowerMock.resetAll();
+        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", "hoplark"));
+        expect(query.findParameter("systemFrom")).andReturn(null);
+        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", ""));
+        expect(query.getDnList()).andReturn(null).anyTimes();
+        PowerMock.replayAll();
+        for (long limit : limits) {
+            assertEquals(limit, logic.getResultLimit(query));
+        }
+        PowerMock.verifyAll();
+    }
+    
+    /**
+     * Sets up expectations and asserts the results from 3 pairs of system from parameters and dn lists to ensure that the dn list always takes precedence when
+     * present.
+     *
+     * @param logic
+     *            the logic we will be testing
+     * @param limits
+     *            the expected limits to be returned in each case
+     */
+    public void assertGetResultsLimitsDnPrecedence(List<String> dns, BaseQueryLogic<Object> logic, long... limits) {
+        PowerMock.resetAll();
+        
+        // first call, populated dn list and populated system from
+        expect(query.getDnList()).andReturn(dns);
+        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", "hoplark"));
+        
+        // second call, populated dn list and empty system from
+        expect(query.getDnList()).andReturn(dns);
+        expect(query.findParameter("systemFrom")).andReturn(null);
+        
+        // third call, null dn list and populated system from
+        expect(query.getDnList()).andReturn(null);
+        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", "hoplark"));
+        
+        PowerMock.replayAll();
+        for (long limit : limits) {
+            assertEquals(limit, logic.getResultLimit(query));
+        }
+        PowerMock.verifyAll();
+    }
+    
     @Test
-    public void testGetResultLimit() {
-        Set<String> dns = Sets.newHashSet("dn=user", "dn=user chain 1", "dn=user chain 2");
+    public void testGetResultLimitDn() {
+        List<String> dns = Arrays.asList("dn=user", "dn=user chain 1", "dn=user chain 2");
         BaseQueryLogic<Object> logic = new TestQueryLogic<>();
         logic.setMaxResults(1000L);
         
         // Assert cases given dnResultLimits == null. The maxResults should be returned.
-        assertEquals(1000L, logic.getResultLimit(dns));
-        assertEquals(1000L, logic.getResultLimit(null));
-        assertEquals(1000L, logic.getResultLimit(Collections.emptySet()));
+        assertGetResultsLimitsDn(dns, logic, 1000L, 1000L, 1000L);
         
         // Assert cases given dnResultLimits == empty map. The maxResults should be returned.
         logic.setDnResultLimits(Collections.emptyMap());
-        assertEquals(1000L, logic.getResultLimit(dns));
-        assertEquals(1000L, logic.getResultLimit(null));
-        assertEquals(1000L, logic.getResultLimit(Collections.emptySet()));
+        assertGetResultsLimitsDn(dns, logic, 1000L, 1000L, 1000L);
         
         // Assert cases given dnResultLimits == non-empty map with no matches. The maxResults should be returned.
         Map<String,Long> dnResultLimits = new HashMap<>();
         dnResultLimits.put("dn=other user", 25L);
         logic.setDnResultLimits(dnResultLimits);
-        assertEquals(1000L, logic.getResultLimit(dns));
-        assertEquals(1000L, logic.getResultLimit(null));
-        assertEquals(1000L, logic.getResultLimit(Collections.emptySet()));
+        assertGetResultsLimitsDn(dns, logic, 1000L, 1000L, 1000L);
         
         // Assert cases given dnResultLimits == non-empty map with single match of a smaller limit. The matching limit should be returned when applicable.
         dnResultLimits.clear();
         dnResultLimits.put("dn=user", 25L);
-        assertEquals(25L, logic.getResultLimit(dns));
-        assertEquals(1000L, logic.getResultLimit(null));
-        assertEquals(1000L, logic.getResultLimit(Collections.emptySet()));
+        assertGetResultsLimitsDn(dns, logic, 25L, 1000L, 1000L);
         
         // Assert cases given dnResultLimits == non-empty map with single match of a larger limit. The matching limit should be returned when applicable.
         dnResultLimits.clear();
         dnResultLimits.put("dn=user", 5000L);
-        assertEquals(5000L, logic.getResultLimit(dns));
-        assertEquals(1000L, logic.getResultLimit(null));
-        assertEquals(1000L, logic.getResultLimit(Collections.emptySet()));
+        assertGetResultsLimitsDn(dns, logic, 5000L, 1000L, 1000L);
         
         // Assert cases given dnResultLimits == non-empty map with multiple matches. The smallest matching limit should be returned when applicable.
         dnResultLimits.clear();
         dnResultLimits.put("dn=user", 25L);
         dnResultLimits.put("dn=user chain 1", 50L);
         dnResultLimits.put("dn=user chain 2", 1L);
-        assertEquals(1L, logic.getResultLimit(dns));
-        assertEquals(1000L, logic.getResultLimit(null));
-        assertEquals(1000L, logic.getResultLimit(Collections.emptySet()));
+        assertGetResultsLimitsDn(dns, logic, 1L, 1000L, 1000L);
+    }
+    
+    @Test
+    public void testGetResultLimitSystemFrom() {
+        BaseQueryLogic<Object> logic = new TestQueryLogic<>();
+        logic.setMaxResults(1000L);
+        
+        // Assert cases given systemFromResultLimits == null. The maxResults should be returned.
+        assertGetResultsLimitsSystemFrom(logic, 1000L, 1000L, 1000L);
+        
+        // Assert cases given systemFromResultLimits == empty map. The maxResults should be returned.
+        logic.setSystemFromResultLimits(Collections.emptyMap());
+        assertGetResultsLimitsSystemFrom(logic, 1000L, 1000L, 1000L);
+        
+        // Assert cases given systemFromResultLimits == non-empty map with no matches. The maxResults should be returned.
+        Map<String,Long> systemFromResultLimits = new HashMap<>();
+        systemFromResultLimits.put("someOtherSystem", 25L);
+        logic.setSystemFromResultLimits(systemFromResultLimits);
+        assertGetResultsLimitsSystemFrom(logic, 1000L, 1000L, 1000L);
+        
+        // Assert cases given systemFromResultLimits == non-empty map with single match of a smaller limit. The matching limit should be returned when
+        // applicable.
+        systemFromResultLimits.clear();
+        systemFromResultLimits.put("hoplark", 25L);
+        assertGetResultsLimitsSystemFrom(logic, 25L, 1000L, 1000L);
+        
+        // Assert cases given systemFromResultLimits == non-empty map with single match of a larger limit. The matching limit should be returned when
+        // applicable.
+        systemFromResultLimits.clear();
+        systemFromResultLimits.put("hoplark", 5000L);
+        assertGetResultsLimitsSystemFrom(logic, 5000L, 1000L, 1000L);
+    }
+    
+    @Test
+    public void testGetResultLimitDnPrecedence() {
+        List<String> dns = Arrays.asList("dn=user", "dn=user chain 1", "dn=user chain 2");
+        BaseQueryLogic<Object> logic = new TestQueryLogic<>();
+        logic.setMaxResults(1000L);
+        
+        // Assert cases given dnResultLimits == null and systemFromResults = null The maxResults should be returned.
+        assertGetResultsLimitsDnPrecedence(dns, logic, 1000L, 1000L, 1000L);
+        
+        // Assert cases given dnResultLimits == empty map and systemFromResults == empty map. The maxResults should be returned.
+        logic.setDnResultLimits(Collections.emptyMap());
+        logic.setSystemFromResultLimits(Collections.emptyMap());
+        assertGetResultsLimitsDnPrecedence(dns, logic, 1000L, 1000L, 1000L);
+        
+        // Assert cases given dnResultLimits == non-empty map with no matches and a systemFromResults as a non empty map with no matches. The maxResults should
+        // be returned.
+        Map<String,Long> dnResultLimits = new HashMap<>();
+        Map<String,Long> systemFromResultLimits = new HashMap<>();
+        
+        dnResultLimits.put("dn=other user", 25L);
+        systemFromResultLimits.put("someOtherSystem", 50L);
+        
+        logic.setDnResultLimits(dnResultLimits);
+        logic.setSystemFromResultLimits(systemFromResultLimits);
+        
+        assertGetResultsLimitsDnPrecedence(dns, logic, 1000L, 1000L, 1000L);
+        
+        // Assert cases given dnResultLimits == non-empty map with single match of a smaller limit and a systemFromResults with a matching limit. The matching
+        // limit should be returned when applicable.
+        dnResultLimits.clear();
+        dnResultLimits.put("dn=user", 25L);
+        
+        systemFromResultLimits.clear();
+        systemFromResultLimits.put("hoplark", 50L);
+        
+        assertGetResultsLimitsDnPrecedence(dns, logic, 25L, 25L, 50L);
+        
+        // Assert cases given dnResultLimits == non-empty map with single match of a larger limit and a systemFromResults with a matching limit. The matching
+        // limit should be returned when applicable.
+        dnResultLimits.clear();
+        dnResultLimits.put("dn=user", 5000L);
+        
+        systemFromResultLimits.clear();
+        systemFromResultLimits.put("hoplark", 50L);
+        assertGetResultsLimitsDnPrecedence(dns, logic, 5000L, 5000L, 50L);
+        
+        // Assert cases given dnResultLimits == non-empty map with multiple matches and a systemFromResults with a matching limit. The smallest matching limit
+        // should be returned when applicable.
+        dnResultLimits.clear();
+        dnResultLimits.put("dn=user", 25L);
+        dnResultLimits.put("dn=user chain 1", 50L);
+        dnResultLimits.put("dn=user chain 2", 1L);
+        
+        systemFromResultLimits.clear();
+        systemFromResultLimits.put("hoplark", 75L);
+        
+        assertGetResultsLimitsDnPrecedence(dns, logic, 1L, 1L, 75L);
+        
+        // Assert cases given a dnResultsLimit == non-empty map with no matches and a systemFromResults with a matching limit. The systemFrom results limit
+        // should take effect.
+        dnResultLimits.clear();
+        dnResultLimits.put("dn=other user", 25L);
+        
+        systemFromResultLimits.clear();
+        systemFromResultLimits.put("hoplark", 75L);
+        
+        assertGetResultsLimitsDnPrecedence(dns, logic, 75L, 1000L, 75L);
     }
     
     private class TestQueryLogic<T> extends BaseQueryLogic<T> {

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -395,7 +395,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.queryLogic1.getConnectionPriority()).andReturn(Priority.NORMAL);
         expect(this.queryLogic1.getCollectQueryMetrics()).andReturn(false);
         expect(this.queryLogic1.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.getUserOperations()).andReturn(null);
         cache.put(eq(queryId.toString()), isA(RunningQuery.class));
@@ -801,7 +801,7 @@ public class ExtendedQueryExecutorBeanTest {
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.getUserOperations()).andReturn(null);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
@@ -977,7 +977,7 @@ public class ExtendedQueryExecutorBeanTest {
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.getUserOperations()).andReturn(null);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
@@ -1138,7 +1138,7 @@ public class ExtendedQueryExecutorBeanTest {
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic1.setupQuery(this.genericConfiguration);
@@ -1299,7 +1299,7 @@ public class ExtendedQueryExecutorBeanTest {
         PowerMock.expectLastCall().times(2);
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic1.setupQuery(this.genericConfiguration);
@@ -1486,7 +1486,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
         expect(this.queryLogic1.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.getUserOperations()).andReturn(null);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
@@ -1782,7 +1782,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
         expect(this.queryLogic1.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic1.setupQuery(this.genericConfiguration);
@@ -2835,7 +2835,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.query.getParameters()).andReturn((Set) Collections.emptySet()).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
         expect(this.queryLogic1.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.getUserOperations()).andReturn(null);
         this.cache.put(eq(queryId.toString()), isA(RunningQuery.class));
@@ -3340,7 +3340,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.query.getUserDN()).andReturn(userDN).anyTimes();
         expect(this.query.getDnList()).andReturn(dnList).anyTimes();
         expect(this.queryLogic1.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic1.getResultLimit(dnList)).andReturn(-1L);
+        expect(this.queryLogic1.getResultLimit(this.query)).andReturn(-1L);
         expect(this.queryLogic1.getMaxResults()).andReturn(-1L);
         expect(this.queryLogic1.getUserOperations()).andReturn(null);
         expect(this.query.toMap()).andReturn(map);

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -161,7 +161,6 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths).times(2);
         expect(this.query.getColumnVisibility()).andReturn(columnVisibility);
         expect(this.query.getUserDN()).andReturn(userDN).times(3);
-        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
@@ -178,7 +177,7 @@ public class ExtendedRunningQueryTest {
         expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
         expect(this.genericConfiguration.getQueryString()).andReturn(query).once();
         expect(this.queryLogic.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
+        expect(this.queryLogic.getResultLimit(eq(this.query))).andReturn(maxResults);
         expect(this.queryLogic.getUserOperations()).andReturn(null);
         this.queryLogic.setPageProcessingStartTime(anyLong());
         
@@ -248,12 +247,11 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths).times(2);
         expect(this.query.getUserDN()).andReturn(userDN).times(3);
         expect(this.query.getColumnVisibility()).andReturn(columnVisibility);
-        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
         expect(this.queryLogic.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
+        expect(this.queryLogic.getResultLimit(eq(this.query))).andReturn(maxResults);
         
         Iterator<Object> iterator = resultObjects.iterator();
         int count = 0;
@@ -320,7 +318,6 @@ public class ExtendedRunningQueryTest {
         expect(this.exceptionHandler.getThrowable()).andReturn(null).times(3);
         expect(this.query.getId()).andReturn(queryId).times(3);
         expect(this.query.getUserDN()).andReturn(userDN).times(3);
-        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.query.getOwner()).andReturn(userSid);
         expect(this.query.getQuery()).andReturn(query);
         expect(this.query.getQueryLogicName()).andReturn(queryLogicName);
@@ -338,7 +335,7 @@ public class ExtendedRunningQueryTest {
         expect(this.transformIterator.hasNext()).andReturn(true).times(0, 1);
         expect(this.genericConfiguration.getQueryString()).andReturn("query").once();
         expect(this.queryLogic.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
+        expect(this.queryLogic.getResultLimit(eq(this.query))).andReturn(maxResults);
         expect(this.queryLogic.getMaxResults()).andReturn(maxResults);
         expect(this.queryLogic.getUserOperations()).andReturn(null);
         this.queryLogic.setPageProcessingStartTime(anyLong());
@@ -380,7 +377,6 @@ public class ExtendedRunningQueryTest {
         expect(this.exceptionHandler.getThrowable()).andReturn(null);
         expect(this.query.getId()).andReturn(queryId).times(3);
         expect(this.query.getUserDN()).andReturn(userDN).times(3);
-        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.query.getOwner()).andReturn(null);
         expect(this.query.getQuery()).andReturn(null);
         expect(this.query.getQueryLogicName()).andReturn(null);
@@ -393,7 +389,7 @@ public class ExtendedRunningQueryTest {
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         expect(this.genericConfiguration.getQueryString()).andReturn("query").once();
         expect(this.queryLogic.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(maxResults);
+        expect(this.queryLogic.getResultLimit(eq(this.query))).andReturn(maxResults);
         expect(this.queryLogic.getMaxResults()).andReturn(maxResults);
         expect(this.queryLogic.getUserOperations()).andReturn(null);
         this.queryLogic.setupQuery(this.genericConfiguration);
@@ -459,12 +455,11 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths).times(2);
         expect(this.query.getUserDN()).andReturn(userDN).times(4);
         expect(this.query.getColumnVisibility()).andReturn(columnVisibility);
-        expect(this.query.getDnList()).andReturn(dnList);
         expect(this.queryLogic.initialize(eq(this.connector), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
         expect(this.queryLogic.isLongRunningQuery()).andReturn(false);
-        expect(this.queryLogic.getResultLimit(eq(dnList))).andReturn(dnResultLimit);
+        expect(this.queryLogic.getResultLimit(eq(this.query))).andReturn(dnResultLimit);
         
         Iterator<Object> iterator = resultObjects.iterator();
         int count = 0;

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -287,7 +287,7 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getCollectQueryMetrics()).andReturn(Boolean.FALSE);
         EasyMock.expect(logic.isLongRunningQuery()).andReturn(false);
-        EasyMock.expect(logic.getResultLimit(q.getDnList())).andReturn(-1L);
+        EasyMock.expect(logic.getResultLimit(q)).andReturn(-1L);
         EasyMock.expect(logic.getMaxResults()).andReturn(-1L);
         EasyMock.expect(logic.getUserOperations()).andReturn(null);
         PowerMock.replayAll();
@@ -693,7 +693,7 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(logic.getAuditType(q)).andReturn(AuditType.NONE);
         EasyMock.expect(logic.getConnPoolName()).andReturn("connPool1");
         EasyMock.expect(logic.isLongRunningQuery()).andReturn(false);
-        EasyMock.expect(logic.getResultLimit(eq(q.getDnList()))).andReturn(-1L).anyTimes();
+        EasyMock.expect(logic.getResultLimit(eq(q))).andReturn(-1L).anyTimes();
         EasyMock.expect(logic.getMaxResults()).andReturn(-1L).anyTimes();
         EasyMock.expect(logic.getUserOperations()).andReturn(null);
         

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/RunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/RunningQueryTest.java
@@ -112,7 +112,7 @@ public class RunningQueryTest {
         expect(logic.getCollectQueryMetrics()).andReturn(Boolean.FALSE);
         expect(logic.getTransformIterator(settings)).andReturn(iter);
         expect(logic.isLongRunningQuery()).andReturn(false);
-        expect(logic.getResultLimit(settings.getDnList())).andReturn(-1L);
+        expect(logic.getResultLimit(settings)).andReturn(-1L);
         expect(logic.getMaxResults()).andReturn(-1L);
         expect(logic.getUserOperations()).andReturn(null);
         replay(logic);
@@ -134,7 +134,7 @@ public class RunningQueryTest {
         
         expect(logic.getCollectQueryMetrics()).andReturn(false);
         expect(logic.isLongRunningQuery()).andReturn(false);
-        expect(logic.getResultLimit(settings.getDnList())).andReturn(-1L);
+        expect(logic.getResultLimit(settings)).andReturn(-1L);
         expect(logic.getMaxResults()).andReturn(-1L);
         expect(logic.getUserOperations()).andReturn(null);
         replay(logic);


### PR DESCRIPTION
Backport to version 3.41 original PR for `integration` was merged in https://github.com/NationalSecurityAgency/datawave/pull/1951