### PR TITLE
Add ability to not summarize a stop watch that is a total of other stop watches

### DIFF
--- a/warehouse/query-core/pom.xml
+++ b/warehouse/query-core/pom.xml
@@ -169,6 +169,10 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
         </dependency>
         <dependency>

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -909,7 +909,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         }
         
         if (!disableBoundedLookup) {
-            stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Expand bounded query ranges (total)");
+            stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Expand bounded query ranges (total)", true);
             
             // Expand any bounded ranges into a conjunction of discrete terms
             try {

--- a/warehouse/query-core/src/main/java/datawave/query/util/QueryStopwatch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/QueryStopwatch.java
@@ -42,8 +42,6 @@ public class QueryStopwatch {
 
         TraceStopwatch sw = new TraceStopwatch(header);
 
-        System.out.println("ohhh");
-
         return sw;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/util/QueryStopwatch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/QueryStopwatch.java
@@ -61,7 +61,7 @@ public class QueryStopwatch {
 
     /**
      * Creates a new stopwatch that will be printed at summarization iff nonSummarized is false
-     * @param header header header string to print during summarization
+     * @param header stopwatch header to print during summarization
      * @param nonSummarized boolean to determine if this stopwatch's time is tabulated during summarization
      * @return newly created instance
      */

--- a/warehouse/query-core/src/main/java/datawave/query/util/QueryStopwatch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/QueryStopwatch.java
@@ -24,104 +24,139 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 
 /**
- * 
+ *
  */
 public class QueryStopwatch {
     public static final String NEWLINE = "\n", INDENT = "    ";
     protected ArrayDeque<Entry<String,TraceStopwatch>> watches = Queues.newArrayDeque();
-    
+
     /**
      * Creates a new Stopwatch for use but does not start it
-     * 
+     *
      * @param header
      *            the string header
      * @return new Stopwatch
      */
-    private TraceStopwatch newStopwatch(String header) {
+    TraceStopwatch newStopwatch(String header) {
         checkNotNull(header);
-        
+
         TraceStopwatch sw = new TraceStopwatch(header);
-        
+
+        System.out.println("ohhh");
+
+        return sw;
+    }
+
+    /**
+     * Creates a new Stopwatch whose time will not be tabulated into the total during summarization
+     *
+     * @return the newly created instance
+     */
+    TraceStopwatch newNonSummarizedStopwatch(String header) {
+        checkNotNull(header);
+
+        TraceStopwatch sw = new NonSummarizedStopWatch(header);
+
+        return sw;
+    }
+
+
+    /**
+     * Creates a new stopwatch that will be printed at summarization iff nonSummarized is false
+     * @param header header header string to print during summarization
+     * @param nonSummarized boolean to determine if this stopwatch's time is tabulated during summarization
+     * @return newly created instance
+     */
+    public TraceStopwatch newStartedStopwatch(String header, boolean nonSummarized) {
+        TraceStopwatch sw = nonSummarized ? newNonSummarizedStopwatch(header) : newStopwatch(header);
         watches.add(Maps.immutableEntry(header, sw));
-        
-        return sw;
-    }
-    
-    public TraceStopwatch newStartedStopwatch(String header) {
-        TraceStopwatch sw = newStopwatch(header);
         sw.start();
-        
         return sw;
     }
-    
+
+    /**
+     * Creates a new stopwatch that will tabulated into the total time during summarization
+     * @param header
+     * @return
+     */
+    public TraceStopwatch newStartedStopwatch(String header) {
+        return newStartedStopwatch(header,false);
+    }
+
     public TraceStopwatch peek() {
         Entry<String,TraceStopwatch> entry = watches.peekLast();
         if (null == entry) {
             NotFoundQueryException qe = new NotFoundQueryException(DatawaveErrorCode.STOPWATCH_MISSING);
             throw (NoSuchElementException) (new NoSuchElementException().initCause(qe));
         }
-        
+
         return entry.getValue();
     }
-    
+
     public String summarize() {
         List<String> logLines = summarizeAsList();
-        
+
         return Joiner.on('\n').join(logLines);
     }
-    
+
     public List<String> summarizeAsList() {
         if (this.watches.isEmpty()) {
             return Collections.emptyList();
         }
-        
+
+        if ( watches.stream().filter(sw -> !(sw.getValue() instanceof NonSummarizedStopWatch)).count() == 0){
+            throw new IllegalStateException("All stop watches are NonSummarized which is not a valid state");
+        }
+
+
         final List<String> lines = Lists.newArrayListWithCapacity(10);
         final StringBuilder sb = new StringBuilder(256);
-        
+
         int count = 1;
         long totalDurationMillis = 0l;
         for (Entry<String,TraceStopwatch> entry : watches) {
             String description = entry.getKey();
             TraceStopwatch sw = entry.getValue();
-            
+
             Preconditions.checkArgument(!sw.isRunning(), "Encountered a non-stopped stopwatch with description " + description);
-            
+
             final String countStr = Integer.toString(count);
-            
+
             final int length = Integer.toString(watches.size()).length();
-            
+
             final String paddedCount = new StringBuilder(INDENT).append(StringUtils.leftPad(countStr, length, "0")).append(") ").toString();
-            
+
             // Stopwatch.toString() will give us appropriate units for the timing
             sb.append(paddedCount).append(description).append(": ").append(sw);
             lines.add(sb.toString());
-            
-            totalDurationMillis += sw.elapsed(TimeUnit.MILLISECONDS);
+            if (! (sw instanceof NonSummarizedStopWatch)) {
+                totalDurationMillis += sw.elapsed(TimeUnit.MILLISECONDS);
+            }
             count++;
             sb.setLength(0);
         }
-        
+
         sb.append(INDENT).append("Total elapsed: ").append(formatMillis(totalDurationMillis));
         lines.add(sb.toString());
-        
+
         return lines;
     }
-    
+
     protected String formatMillis(long elapsedMillis) {
         TimeUnit unit = chooseUnit(elapsedMillis);
         double value = (double) elapsedMillis / MILLISECONDS.convert(1, unit);
-        
+
         // Too bad this functionality is not exposed as a regular method call
         return String.format("%.4g %s", value, abbreviate(unit));
     }
-    
+
     protected TimeUnit chooseUnit(long millis) {
         if (SECONDS.convert(millis, MILLISECONDS) > 0) {
             return SECONDS;
         }
         return MILLISECONDS;
     }
-    
+
     protected String abbreviate(TimeUnit unit) {
         switch (unit) {
             case MILLISECONDS:
@@ -130,6 +165,16 @@ public class QueryStopwatch {
                 return "s";
             default:
                 throw new AssertionError();
+        }
+    }
+
+    /**
+     * Purpose: Produces a stop watch instance that is not summarized by the query framework
+     */
+    static class NonSummarizedStopWatch extends TraceStopwatch {
+
+        public NonSummarizedStopWatch(final String description) {
+            super(description);
         }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/QueryStopwatchTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/QueryStopwatchTest.java
@@ -1,0 +1,174 @@
+package datawave.query.util;
+
+import datawave.query.util.QueryStopwatch.NonSummarizedStopWatch;
+import datawave.util.time.TraceStopwatch;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
+@RunWith(PowerMockRunner.class)
+public class QueryStopwatchTest  {
+
+    @Test
+    public void testNoTimer() throws Exception {
+        final QueryStopwatch sw = new QueryStopwatch();
+        QueryStopwatch stopwatch = PowerMockito.spy(  sw);
+
+        List<String> summaries = new ArrayList<>();
+
+        Assert.assertEquals(summaries,stopwatch.summarizeAsList());
+    }
+
+    @Test
+    public void testSingletimer() throws Exception {
+        final QueryStopwatch sw = new QueryStopwatch();
+        QueryStopwatch stopwatch = PowerMockito.spy(  sw);
+        //EasyMock.expect()
+
+        List<String> summaries = new ArrayList<>();
+        summaries.add("    1) test: 1.000 s");
+        summaries.add("    Total elapsed: 1.000 s");
+        NoTimeTraceStopWatch traceStopWatch = new NoTimeTraceStopWatch("test","1.000 s",1000);
+        PowerMockito.doReturn(traceStopWatch).when(stopwatch).newStopwatch(anyString());
+        stopwatch.newStartedStopwatch("test");
+
+        Assert.assertEquals(summaries,stopwatch.summarizeAsList());
+    }
+
+    @Test
+    public void testSummarization() throws Exception {
+        final QueryStopwatch sw = new QueryStopwatch();
+        QueryStopwatch stopwatch = PowerMockito.spy(  sw);
+        //EasyMock.expect()
+
+        List<String> summaries = new ArrayList<>();
+        summaries.add("    1) test (total): 2.000 s");
+        summaries.add("    2) test part: 1.000 s");
+        summaries.add("    Total elapsed: 2.000 s");
+        NoTimeTraceStopWatch traceStopWatch = new NoTimeTraceStopWatch("test (total)","2.000 s",2000);
+        NoTimeTraceStopWatchNonSummarized nonSummarizedStopWatch = new NoTimeTraceStopWatchNonSummarized("test part","1.000 s",1000);
+        PowerMockito.doReturn(traceStopWatch).when(stopwatch).newStopwatch("test (total)");
+        PowerMockito.doReturn(nonSummarizedStopWatch).when(stopwatch).newStopwatch("test part");
+        /***
+         * When we have summarized times
+         */
+        stopwatch.newStartedStopwatch("test (total)");
+        stopwatch.newStartedStopwatch("test part");
+
+        Assert.assertEquals(summaries,stopwatch.summarizeAsList());
+    }
+
+    @Test(expected =  IllegalStateException.class)
+    public void testAllSummarization() throws Exception {
+        final QueryStopwatch sw = new QueryStopwatch();
+        QueryStopwatch stopwatch = PowerMockito.spy(  sw);
+
+        List<String> summaries = new ArrayList<>();
+        summaries.add("    1) test (total): 2.000 s");
+        summaries.add("    2) test part: 1.000 s");
+        summaries.add("    Total elapsed: 2.000 s");
+        NoTimeTraceStopWatchNonSummarized traceStopWatch = new NoTimeTraceStopWatchNonSummarized("test (total)","2.000 s",2000);
+        NoTimeTraceStopWatchNonSummarized nonSummarizedStopWatch = new NoTimeTraceStopWatchNonSummarized("test part","1.000 s",1000);
+        PowerMockito.doReturn(traceStopWatch).when(stopwatch).newStopwatch("test (total)");
+        PowerMockito.doReturn(nonSummarizedStopWatch).when(stopwatch).newStopwatch("test part");
+        /***
+         * When we have summarized times
+         */
+        stopwatch.newStartedStopwatch("test (total)");
+        stopwatch.newStartedStopwatch("test part");
+
+        Assert.assertEquals(summaries,stopwatch.summarizeAsList());
+    }
+
+
+    private class NoTimeTraceStopWatch extends TraceStopwatch{
+
+        private final long time;
+        private final String verificationString;
+
+        public NoTimeTraceStopWatch(String description, String verificationString, long time) {
+            super(description);
+            this.time=time;
+            this.verificationString=verificationString;
+        }
+
+        @Override
+        public void start() {
+            // do nothing.
+        }
+        @Override
+        public void stop() {
+            // do nothing.
+        }
+
+        @Override
+        public long elapsed(TimeUnit desiredUnit) {
+            switch (desiredUnit){
+                case SECONDS:
+                    return time / 1000;
+                case MILLISECONDS:
+                    return time;
+                case MINUTES:
+                    return time / 60000;
+                case NANOSECONDS:
+                    return time * 1000000;
+            }
+            return 1000;
+        }
+
+        @Override
+        public String toString() {
+            return verificationString;
+        }
+    }
+
+    private class NoTimeTraceStopWatchNonSummarized extends NonSummarizedStopWatch {
+
+        private final long time;
+        private final String verificationString;
+
+        public NoTimeTraceStopWatchNonSummarized(String description, String verificationString, long time) {
+            super(description);
+            this.time=time;
+            this.verificationString=verificationString;
+        }
+
+        @Override
+        public void start() {
+            // do nothing.
+        }
+        @Override
+        public void stop() {
+            // do nothing.
+        }
+
+        @Override
+        public long elapsed(TimeUnit desiredUnit) {
+            switch (desiredUnit){
+                case SECONDS:
+                    return time / 1000;
+                case MILLISECONDS:
+                    return time;
+                case MINUTES:
+                    return time / 60000;
+                case NANOSECONDS:
+                    return time * 1000000;
+            }
+            return 1000;
+        }
+
+        @Override
+        public String toString() {
+            return verificationString;
+        }
+    }
+
+}


### PR DESCRIPTION
Solves #1982  and allows the bounded total to not be summarized. It will still be printed in logs but not tabulated in the total.