### PR TITLE
Move createBatchScanner method

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.mr.bulk.RfileResource;
 import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.tables.ShardQueryLogic;
 import datawave.webservice.common.connection.AccumuloConnectionFactory;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
@@ -189,7 +188,7 @@ public class PushdownScheduler extends Scheduler {
      */
     @Override
     public BatchScanner createBatchScanner(ShardQueryConfiguration config, ScannerFactory scannerFactory, QueryData qd) throws TableNotFoundException {
-        return config.createBatchScanner(scannerFactory, qd);
+        return scannerFactory.newScanner(config, qd);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
@@ -189,7 +189,7 @@ public class PushdownScheduler extends Scheduler {
      */
     @Override
     public BatchScanner createBatchScanner(ShardQueryConfiguration config, ScannerFactory scannerFactory, QueryData qd) throws TableNotFoundException {
-        return ShardQueryLogic.createBatchScanner(config, scannerFactory, qd);
+        return config.createBatchScanner(scannerFactory, qd);
     }
     
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/SequentialScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/SequentialScheduler.java
@@ -77,7 +77,7 @@ public class SequentialScheduler extends Scheduler {
      */
     @Override
     public BatchScanner createBatchScanner(ShardQueryConfiguration config, ScannerFactory scannerFactory, QueryData qd) throws TableNotFoundException {
-        return ShardQueryLogic.createBatchScanner(config, scannerFactory, qd);
+        return config.createBatchScanner(scannerFactory, qd);
     }
     
     public class SequentialSchedulerIterator implements Iterator<Entry<Key,Value>> {
@@ -142,7 +142,7 @@ public class SequentialScheduler extends Scheduler {
             if (null != newQueryData) {
                 
                 try {
-                    this.currentBS = createBatchScanner(this.config, this.scannerFactory, newQueryData);
+                    this.currentBS = this.config.createBatchScanner(this.scannerFactory, newQueryData);
                 } catch (TableNotFoundException e) {
                     throw new RuntimeException(e);
                 }

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/SequentialScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/SequentialScheduler.java
@@ -6,7 +6,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.tables.stats.ScanSessionStats;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
@@ -77,7 +76,7 @@ public class SequentialScheduler extends Scheduler {
      */
     @Override
     public BatchScanner createBatchScanner(ShardQueryConfiguration config, ScannerFactory scannerFactory, QueryData qd) throws TableNotFoundException {
-        return config.createBatchScanner(scannerFactory, qd);
+        return scannerFactory.newScanner(config, qd);
     }
     
     public class SequentialSchedulerIterator implements Iterator<Entry<Key,Value>> {
@@ -142,7 +141,7 @@ public class SequentialScheduler extends Scheduler {
             if (null != newQueryData) {
                 
                 try {
-                    this.currentBS = this.config.createBatchScanner(this.scannerFactory, newQueryData);
+                    this.currentBS = this.scannerFactory.newScanner(this.config, newQueryData);
                 } catch (TableNotFoundException e) {
                     throw new RuntimeException(e);
                 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ScannerFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ScannerFactory.java
@@ -18,8 +18,10 @@ import datawave.webservice.common.connection.WrappedConnector;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 
+import datawave.webservice.query.configuration.QueryData;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -305,4 +307,22 @@ public class ScannerFactory {
         
         return baseScanner;
     }
+
+    public BatchScanner newScanner(ShardQueryConfiguration config, QueryData qd) throws TableNotFoundException {
+        final BatchScanner bs = this.newScanner(config.getShardTableName(), config.getAuthorizations(), config.getNumQueryThreads(),
+                config.getQuery());
+
+        if (log.isTraceEnabled()) {
+            log.trace("Running with " + config.getAuthorizations() + " and " + config.getNumQueryThreads() + " threads: " + qd);
+        }
+
+        bs.setRanges(qd.getRanges());
+
+        for (IteratorSetting cfg : qd.getSettings()) {
+            bs.addScanIterator(cfg);
+        }
+
+        return bs;
+    }
+
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -236,9 +236,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
             this.setEventQueryDataDecoratorTransformer(new EventQueryDataDecoratorTransformer(other.getEventQueryDataDecoratorTransformer()));
         }
     }
-    
-//
-    
+
     @Override
     public GenericQueryConfiguration initialize(AccumuloClient client, Query settings, Set<Authorizations> auths) throws Exception {
         

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -237,22 +237,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         }
     }
     
-    public static BatchScanner createBatchScanner(ShardQueryConfiguration config, ScannerFactory scannerFactory, QueryData qd) throws TableNotFoundException {
-        final BatchScanner bs = scannerFactory.newScanner(config.getShardTableName(), config.getAuthorizations(), config.getNumQueryThreads(),
-                        config.getQuery());
-        
-        if (log.isTraceEnabled()) {
-            log.trace("Running with " + config.getAuthorizations() + " and " + config.getNumQueryThreads() + " threads: " + qd);
-        }
-        
-        bs.setRanges(qd.getRanges());
-        
-        for (IteratorSetting cfg : qd.getSettings()) {
-            bs.addScanIterator(cfg);
-        }
-        
-        return bs;
-    }
+//
     
     @Override
     public GenericQueryConfiguration initialize(AccumuloClient client, Query settings, Set<Authorizations> auths) throws Exception {


### PR DESCRIPTION
I have mixed feelings. On the one hand, the static createBatchScanner method in ShardQueryLogic feels out of place. Its 'config' parameter acts like a 'this' pointer pointing at a 'that'. Even though SQL has-a ShardQueryConfiguration, that is not the one used (and the method is static anyway).
The method seems to work fine as a non-static method in ShardQueryConfiguration, but that class might be a bad place to start dumping actual logic methods instead of just getter/setters.
Thoughts?

(edited)
Maybe the method would be happy in ScannerFactory instead. 
I moved it to ScannerFactory.