### PR TITLE
Refactor data query expression filter constructors

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorQueryIterator.java
@@ -1,5 +1,7 @@
 package datawave.query.ancestor;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.getExpressionFilters;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
@@ -28,6 +30,7 @@ import com.google.common.base.Predicates;
 
 import datawave.query.Constants;
 import datawave.query.attributes.Attribute;
+import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.ValueTuple;
 import datawave.query.function.AncestorEquality;
@@ -41,6 +44,7 @@ import datawave.query.iterator.SourcedOptions;
 import datawave.query.iterator.logic.IndexIterator;
 import datawave.query.jexl.DatawaveJexlContext;
 import datawave.query.jexl.HitListArithmetic;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.jexl.visitors.IteratorBuildingVisitor;
 import datawave.query.predicate.AncestorEventDataFilter;
 import datawave.query.predicate.ConfiguredPredicate;
@@ -124,9 +128,13 @@ public class AncestorQueryIterator extends QueryIterator {
     @Override
     public EventDataQueryFilter getEvaluationFilter() {
         if (evaluationFilter == null && script != null) {
-            evaluationFilter = new AncestorEventDataFilter(script, typeMetadata, getNonEventFields());
+
+            AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+            Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
+            evaluationFilter = new AncestorEventDataFilter(expressionFilters);
         }
-        // return a new script each time as this is not thread safe (maintains state)
+        // return a new filter each time as this is not thread safe (maintains state)
         return evaluationFilter != null ? evaluationFilter.clone() : null;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ParentQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ParentQueryIterator.java
@@ -1,5 +1,7 @@
 package datawave.query.iterator;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.getExpressionFilters;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
@@ -17,11 +19,13 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterators;
 
 import datawave.query.attributes.Attribute;
+import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
 import datawave.query.composite.CompositeMetadata;
 import datawave.query.function.Aggregation;
 import datawave.query.function.KeyToDocumentData;
 import datawave.query.function.RangeProvider;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.predicate.EventDataQueryFilter;
 import datawave.query.predicate.ParentEventDataFilter;
 import datawave.query.predicate.ParentRangeProvider;
@@ -56,7 +60,11 @@ public class ParentQueryIterator extends QueryIterator {
     @Override
     public EventDataQueryFilter getEvaluationFilter() {
         if (evaluationFilter == null && script != null) {
-            this.evaluationFilter = new ParentEventDataFilter(script, typeMetadata, getNonEventFields());
+
+            AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+            Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
+            this.evaluationFilter = new ParentEventDataFilter(expressionFilters);
         }
         return evaluationFilter != null ? evaluationFilter.clone() : null;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -108,6 +107,7 @@ import datawave.query.jexl.functions.TermFrequencyAggregator;
 import datawave.query.jexl.nodes.ExceededOrThresholdMarkerJexlNode;
 import datawave.query.jexl.nodes.ExceededValueThresholdMarkerJexlNode;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.parser.JavaRegexAnalyzer;
 import datawave.query.parser.JavaRegexAnalyzer.JavaRegexParseException;
 import datawave.query.predicate.ChainableEventDataQueryFilter;
@@ -1329,8 +1329,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         }
 
         AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
-        Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node,
-                        attributeFactory);
+        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node, attributeFactory);
 
         chainableFilter.addFilter(new TermFrequencyDataFilter(expressionFilters));
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -1306,22 +1306,6 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         return new TermFrequencyAggregator(toAggregate, filter, maxNextCount);
     }
 
-    /**
-     * Wrap an existing {@link EventDataQueryFilter} with a {@link TermFrequencyDataFilter}
-     *
-     * @param identifier
-     *            the field
-     * @param node
-     *            a node in the query
-     * @param existing
-     *            an existing EventDataQueryFilter
-     * @return a ChainableEventDataQueryFilter
-     */
-    @Deprecated
-    protected ChainableEventDataQueryFilter createWrappedTermFrequencyFilter(String identifier, JexlNode node, EventDataQueryFilter existing) {
-        return createWrappedTermFrequencyFilter(node, existing);
-    }
-
     protected ChainableEventDataQueryFilter createWrappedTermFrequencyFilter(JexlNode node, EventDataQueryFilter existing) {
         ChainableEventDataQueryFilter chainableFilter = new ChainableEventDataQueryFilter();
         if (existing != null) {

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/AncestorEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/AncestorEventDataFilter.java
@@ -4,33 +4,16 @@ import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.Expre
 
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
-import org.apache.commons.jexl2.parser.ASTJexlScript;
 
 import datawave.query.Constants;
-import datawave.query.util.TypeMetadata;
 
 /**
  * This filter will filter event data keys by only those fields that are required in the specified query except for the base document in which case all fields
  * are returned.
  */
 public class AncestorEventDataFilter extends EventDataQueryExpressionFilter {
-    /**
-     * Initialize the query field filter with all of the fields required to evaluation this query
-     *
-     * @param script
-     *            a script
-     * @param nonEventFields
-     *            set of non event fields
-     * @param metadata
-     *            type metadata
-     */
-    @Deprecated
-    public AncestorEventDataFilter(ASTJexlScript script, TypeMetadata metadata, Set<String> nonEventFields) {
-        super(script, metadata, nonEventFields);
-    }
 
     /**
      * Preferred constructor

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/AncestorEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/AncestorEventDataFilter.java
@@ -1,5 +1,8 @@
 package datawave.query.predicate;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
+
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -7,7 +10,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.commons.jexl2.parser.ASTJexlScript;
 
 import datawave.query.Constants;
-import datawave.query.tld.TLD;
 import datawave.query.util.TypeMetadata;
 
 /**
@@ -25,8 +27,19 @@ public class AncestorEventDataFilter extends EventDataQueryExpressionFilter {
      * @param metadata
      *            type metadata
      */
+    @Deprecated
     public AncestorEventDataFilter(ASTJexlScript script, TypeMetadata metadata, Set<String> nonEventFields) {
         super(script, metadata, nonEventFields);
+    }
+
+    /**
+     * Preferred constructor
+     *
+     * @param filters
+     *            a map of expression filters
+     */
+    public AncestorEventDataFilter(Map<String,ExpressionFilter> filters) {
+        super(filters);
     }
 
     public AncestorEventDataFilter(AncestorEventDataFilter other) {

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryExpressionFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryExpressionFilter.java
@@ -37,16 +37,14 @@ public class EventDataQueryExpressionFilter implements EventDataQueryFilter {
     @Deprecated
     public EventDataQueryExpressionFilter(ASTJexlScript script, TypeMetadata metadata, Set<String> nonEventFields) {
         AttributeFactory attributeFactory = new AttributeFactory(metadata);
-        Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(script,
-                        attributeFactory);
+        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(script, attributeFactory);
         setFilters(expressionFilters);
     }
 
     @Deprecated
     public EventDataQueryExpressionFilter(JexlNode node, TypeMetadata metadata, Set<String> nonEventFields) {
         AttributeFactory attributeFactory = new AttributeFactory(metadata);
-        Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node,
-                        attributeFactory);
+        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node, attributeFactory);
         setFilters(expressionFilters);
     }
 
@@ -56,12 +54,12 @@ public class EventDataQueryExpressionFilter implements EventDataQueryFilter {
      * @param filters
      *            a prebuilt map of expression filters
      */
-    public EventDataQueryExpressionFilter(Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> filters) {
+    public EventDataQueryExpressionFilter(Map<String,ExpressionFilter> filters) {
         setFilters(filters);
     }
 
     public EventDataQueryExpressionFilter(EventDataQueryExpressionFilter other) {
-        setFilters(EventDataQueryExpressionVisitor.ExpressionFilter.clone(other.getFilters()));
+        setFilters(ExpressionFilter.clone(other.getFilters()));
         if (other.document != null) {
             document = new Key(other.document);
         }
@@ -71,7 +69,7 @@ public class EventDataQueryExpressionFilter implements EventDataQueryFilter {
     public void startNewDocument(Key document) {
         this.document = document;
         // since we are starting a new document, reset the filters
-        EventDataQueryExpressionVisitor.ExpressionFilter.reset(filters);
+        ExpressionFilter.reset(filters);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryExpressionFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryExpressionFilter.java
@@ -2,21 +2,15 @@ package datawave.query.predicate;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
-import org.apache.commons.jexl2.parser.ASTJexlScript;
-import org.apache.commons.jexl2.parser.JexlNode;
 
 import com.google.common.collect.Maps;
 
-import datawave.query.attributes.AttributeFactory;
 import datawave.query.data.parsers.DatawaveKey;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
-import datawave.query.util.TypeMetadata;
 
 /**
  * This class is used to filter out fields that are required for evaluation by apply the query expressions to the field values on the fly. This filter will
@@ -28,25 +22,6 @@ public class EventDataQueryExpressionFilter implements EventDataQueryFilter {
     private boolean initialized = false;
 
     protected Key document = null;
-
-    @Deprecated
-    public EventDataQueryExpressionFilter() {
-        super();
-    }
-
-    @Deprecated
-    public EventDataQueryExpressionFilter(ASTJexlScript script, TypeMetadata metadata, Set<String> nonEventFields) {
-        AttributeFactory attributeFactory = new AttributeFactory(metadata);
-        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(script, attributeFactory);
-        setFilters(expressionFilters);
-    }
-
-    @Deprecated
-    public EventDataQueryExpressionFilter(JexlNode node, TypeMetadata metadata, Set<String> nonEventFields) {
-        AttributeFactory attributeFactory = new AttributeFactory(metadata);
-        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node, attributeFactory);
-        setFilters(expressionFilters);
-    }
 
     /**
      * Preferred constructor

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/ParentEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/ParentEventDataFilter.java
@@ -1,5 +1,8 @@
 package datawave.query.predicate;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
+
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
@@ -22,8 +25,19 @@ public class ParentEventDataFilter extends EventDataQueryExpressionFilter {
      * @param nonEventFields
      *            set of non event fields
      */
+    @Deprecated
     public ParentEventDataFilter(ASTJexlScript script, TypeMetadata metadata, Set<String> nonEventFields) {
         super(script, metadata, nonEventFields);
+    }
+
+    /**
+     * Preferred constructor
+     *
+     * @param filters
+     *            a map of expression filters
+     */
+    public ParentEventDataFilter(Map<String,ExpressionFilter> filters) {
+        super(filters);
     }
 
     public ParentEventDataFilter(ParentEventDataFilter other) {

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/ParentEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/ParentEventDataFilter.java
@@ -3,32 +3,13 @@ package datawave.query.predicate;
 import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
-import org.apache.commons.jexl2.parser.ASTJexlScript;
-
-import datawave.query.util.TypeMetadata;
 
 /**
  * This filter will filter event data keys by only those fields that are required in the specified query.
  */
 public class ParentEventDataFilter extends EventDataQueryExpressionFilter {
-
-    /**
-     * Initialize the query field filter with all of the fields required to evaluation this query
-     *
-     * @param script
-     *            the script
-     * @param metadata
-     *            type metadata
-     * @param nonEventFields
-     *            set of non event fields
-     */
-    @Deprecated
-    public ParentEventDataFilter(ASTJexlScript script, TypeMetadata metadata, Set<String> nonEventFields) {
-        super(script, metadata, nonEventFields);
-    }
 
     /**
      * Preferred constructor

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
@@ -24,7 +24,6 @@ import datawave.query.Constants;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.tld.TLD;
-import datawave.query.util.TypeMetadata;
 
 /**
  * This filter will filter event data keys by only those fields that are required in the specified query except for the root document in which case all fields
@@ -68,13 +67,6 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
 
     private Set<String> nonEventFields;
 
-    @Deprecated
-    public TLDEventDataFilter(ASTJexlScript script, Set<String> queryFields, TypeMetadata attributeFactory, Set<String> whitelist, Set<String> blacklist,
-                    long maxFieldsBeforeSeek, long maxKeysBeforeSeek) {
-        this(script, queryFields, attributeFactory, whitelist, blacklist, maxFieldsBeforeSeek, maxKeysBeforeSeek, Collections.EMPTY_MAP, null,
-                        Collections.EMPTY_SET);
-    }
-
     public TLDEventDataFilter(ASTJexlScript script, Set<String> queryFields, Map<String,ExpressionFilter> expressionFilters, Set<String> includedFields,
                     Set<String> excludedFields, long maxFieldsBeforeSeek, long maxKeysBeforeSeek) {
         this(script, queryFields, expressionFilters, includedFields, excludedFields, maxFieldsBeforeSeek, maxKeysBeforeSeek, Collections.emptyMap(), null,
@@ -85,49 +77,6 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
      * Field which should be used when transform() is called on a rejected Key that is field limited to store the field
      */
     private String limitFieldsField = null;
-
-    /**
-     * Initialize the query field filter with all of the fields required to evaluation this query
-     *
-     * @param script
-     *            - script
-     * @param typeMetadata
-     *            - TypeMetadata
-     * @param blacklist
-     *            - blacklist
-     * @param limitFieldsField
-     *            - limitFieldsField
-     * @param limitFieldsMap
-     *            - limitFieldsMap
-     * @param maxFieldsBeforeSeek
-     *            - maxFieldsBeforeSeek
-     * @param maxKeysBeforeSeek
-     *            - maxFieldsBeforeSeek
-     * @param nonEventFields
-     *            - nonEventFields
-     * @param queryFields
-     *            - queryFields
-     * @param whitelist
-     *            - whitelist
-     */
-    @Deprecated
-    public TLDEventDataFilter(ASTJexlScript script, Set<String> queryFields, TypeMetadata typeMetadata, Set<String> whitelist, Set<String> blacklist,
-                    long maxFieldsBeforeSeek, long maxKeysBeforeSeek, Map<String,Integer> limitFieldsMap, String limitFieldsField, Set<String> nonEventFields) {
-        super(script, typeMetadata, nonEventFields);
-
-        this.maxFieldsBeforeSeek = maxFieldsBeforeSeek;
-        this.maxKeysBeforeSeek = maxKeysBeforeSeek;
-        this.limitFieldsMap = Collections.unmodifiableMap(limitFieldsMap);
-        this.limitFieldsField = limitFieldsField;
-        this.nonEventFields = nonEventFields;
-
-        // set the anyFieldLimit once if specified otherwise set to -1
-        anyFieldLimit = limitFieldsMap.get(Constants.ANY_FIELD) != null ? limitFieldsMap.get(Constants.ANY_FIELD) : -1;
-
-        setQueryFields(queryFields, script);
-        updateLists(whitelist, blacklist);
-        setSortedLists(whitelist, blacklist);
-    }
 
     /**
      * Preferred constructor that accepts prebuilt expression filters

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TermFrequencyDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TermFrequencyDataFilter.java
@@ -1,10 +1,12 @@
 package datawave.query.predicate;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.commons.jexl2.parser.JexlNode;
 
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
 import datawave.query.util.TypeMetadata;
 
 /**
@@ -22,8 +24,19 @@ public class TermFrequencyDataFilter extends EventDataQueryExpressionFilter {
      * @param nonEventFields
      *            a set of non-event fields
      */
+    @Deprecated
     public TermFrequencyDataFilter(JexlNode node, TypeMetadata typeMetadata, Set<String> nonEventFields) {
         super(node, typeMetadata, nonEventFields);
+    }
+
+    /**
+     * Constructor matching {@link EventDataQueryExpressionVisitor}
+     *
+     * @param filters
+     *            a map of expression filters
+     */
+    public TermFrequencyDataFilter(Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> filters) {
+        super(filters);
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TermFrequencyDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TermFrequencyDataFilter.java
@@ -1,34 +1,16 @@
 package datawave.query.predicate;
 
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
-import org.apache.commons.jexl2.parser.JexlNode;
 
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
-import datawave.query.util.TypeMetadata;
 
 /**
  * A data filter that operates on TermFrequency keys
  */
 public class TermFrequencyDataFilter extends EventDataQueryExpressionFilter {
-
-    /**
-     * Constructor matching {@link EventDataQueryExpressionFilter}
-     *
-     * @param node
-     *            a node in the query tree
-     * @param typeMetadata
-     *            an instance of {@link TypeMetadata}
-     * @param nonEventFields
-     *            a set of non-event fields
-     */
-    @Deprecated
-    public TermFrequencyDataFilter(JexlNode node, TypeMetadata typeMetadata, Set<String> nonEventFields) {
-        super(node, typeMetadata, nonEventFields);
-    }
 
     /**
      * Constructor matching {@link EventDataQueryExpressionVisitor}

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TermFrequencyDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TermFrequencyDataFilter.java
@@ -7,6 +7,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.commons.jexl2.parser.JexlNode;
 
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.util.TypeMetadata;
 
 /**
@@ -35,7 +36,7 @@ public class TermFrequencyDataFilter extends EventDataQueryExpressionFilter {
      * @param filters
      *            a map of expression filters
      */
-    public TermFrequencyDataFilter(Map<String,EventDataQueryExpressionVisitor.ExpressionFilter> filters) {
+    public TermFrequencyDataFilter(Map<String,ExpressionFilter> filters) {
         super(filters);
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
@@ -1,5 +1,7 @@
 package datawave.query.tld;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.getExpressionFilters;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Collection;
@@ -21,6 +23,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
+import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
 import datawave.query.function.Equality;
 import datawave.query.function.RangeProvider;
@@ -31,6 +34,7 @@ import datawave.query.iterator.QueryIterator;
 import datawave.query.iterator.SourcedOptions;
 import datawave.query.iterator.logic.IndexIterator;
 import datawave.query.jexl.functions.FieldIndexAggregator;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.jexl.visitors.IteratorBuildingVisitor;
 import datawave.query.postprocessing.tf.TFFactory;
 import datawave.query.postprocessing.tf.TermFrequencyConfig;
@@ -119,8 +123,12 @@ public class TLDQueryIterator extends QueryIterator {
     @Override
     public EventDataQueryFilter getEvaluationFilter() {
         if (this.evaluationFilter == null && script != null) {
+
+            AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+            Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
             // setup an evaluation filter to avoid loading every single child key into the event
-            this.evaluationFilter = new TLDEventDataFilter(script, getAllFields(), typeMetadata, useWhiteListedFields ? whiteListedFields : null,
+            this.evaluationFilter = new TLDEventDataFilter(script, getAllFields(), expressionFilters, useWhiteListedFields ? whiteListedFields : null,
                             useBlackListedFields ? blackListedFields : null, getEventFieldSeek(), getEventNextSeek(),
                             limitFieldsPreQueryEvaluation ? limitFieldsMap : Collections.emptyMap(), limitFieldsField, getNonEventFields());
         }

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
@@ -329,7 +329,10 @@ public class TermFrequencyIndexIteratorTest {
 
         Range r = new Range(getFiKey("row", "type1", "123.345.456", "FOO", "alf"), false, getFiKey("row", "type1", "123.345.456.2", "FOO", "buz"), false);
 
-        filter = new TLDEventDataFilter(script, Collections.singleton("FOO"), typeMetadata, null, null, -1, -1, Collections.emptyMap(), null, fieldsToKeep);
+        AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+        filter = new TLDEventDataFilter(script, Collections.singleton("FOO"), expressionFilters, null, null, -1, -1, Collections.emptyMap(), null,
+                        fieldsToKeep);
 
         aggregator = new TLDTermFrequencyAggregator(fieldsToKeep, filter, -1);
         TermFrequencyIndexIterator iterator = new TermFrequencyIndexIterator(r, source, null, typeMetadata, true, aggregator);

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.iterator.logic;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.getExpressionFilters;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +28,7 @@ import org.junit.Test;
 
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.query.Constants;
+import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.PreNormalizedAttribute;
 import datawave.query.iterator.SortedListKeyValueIterator;
@@ -71,9 +74,11 @@ public class TermFrequencyIndexIteratorTest {
         fieldsToKeep = new HashSet<>();
         fieldsToKeep.add("FOO");
 
-        filter = new EventDataQueryExpressionFilter(
-                        JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='buz' || FOO=='alf' || FOO=='arm'"), typeMetadata,
-                        fieldsToKeep);
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='buz' || FOO=='alf' || FOO=='arm'");
+        AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
+        filter = new EventDataQueryExpressionFilter(expressionFilters);
 
         aggregator = new TermFrequencyAggregator(fieldsToKeep, filter);
     }
@@ -249,8 +254,12 @@ public class TermFrequencyIndexIteratorTest {
     public void testEndingFieldMismatch() throws IOException, ParseException {
         Range r = new Range(getFiKey("row", "type1", "123.345.456.3", "FOO", "alf"), true,
                         getFiKey("row", "type1", "123.345.456.3", Constants.MAX_UNICODE_STRING, "buz"), false);
-        filter = new EventDataQueryExpressionFilter(JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'"), typeMetadata,
-                        fieldsToKeep);
+
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'");
+        AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
+        filter = new EventDataQueryExpressionFilter(expressionFilters);
         aggregator = new TermFrequencyAggregator(fieldsToKeep, filter);
         TermFrequencyIndexIterator iterator = new TermFrequencyIndexIterator(r, source, null, typeMetadata, true, aggregator);
 
@@ -262,8 +271,12 @@ public class TermFrequencyIndexIteratorTest {
     @Test
     public void testScanFullRangeExclusive() throws IOException, ParseException {
         Range r = new Range(getFiKey("row", "type1", "123.345.456", "FOO", "alf"), false, getFiKey("row", "type1", "123.345.456.2", "FOO", "buz"), false);
-        filter = new EventDataQueryExpressionFilter(JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'"), typeMetadata,
-                        fieldsToKeep);
+
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'");
+        AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
+        filter = new EventDataQueryExpressionFilter(expressionFilters);
         aggregator = new TermFrequencyAggregator(fieldsToKeep, filter);
         TermFrequencyIndexIterator iterator = new TermFrequencyIndexIterator(r, source, null, typeMetadata, true, aggregator);
 
@@ -344,8 +357,12 @@ public class TermFrequencyIndexIteratorTest {
     @Test
     public void testScanFullRangeExclusiveEventDataQueryExpressionFilter() throws IOException, ParseException {
         Range r = new Range(getFiKey("row", "type1", "123.345.456", "FOO", "alf"), false, getFiKey("row", "type1", "123.345.456.2", "FOO", "buz"), false);
-        filter = new EventDataQueryExpressionFilter(JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'"), typeMetadata,
-                        fieldsToKeep);
+
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery("FOO=='bar' || FOO=='baz' || FOO=='buf' || FOO=='arm'");
+        AttributeFactory attributeFactory = new AttributeFactory(typeMetadata);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, attributeFactory);
+
+        filter = new EventDataQueryExpressionFilter(expressionFilters);
         aggregator = new TLDTermFrequencyAggregator(fieldsToKeep, filter, -1);
         TermFrequencyIndexIterator iterator = new TermFrequencyIndexIterator(r, source, null, typeMetadata, true, aggregator);
 

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDEventDataFilterTest.java
@@ -1,5 +1,6 @@
 package datawave.query.predicate;
 
+import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.getExpressionFilters;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
@@ -30,9 +31,11 @@ import com.google.common.collect.Sets;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberType;
 import datawave.query.Constants;
+import datawave.query.attributes.AttributeFactory;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.jexl.visitors.FunctionIndexQueryExpansionVisitor;
 import datawave.query.util.MockDateIndexHelper;
 import datawave.query.util.MockMetadataHelper;
@@ -41,7 +44,7 @@ import datawave.query.util.TypeMetadata;
 public class TLDEventDataFilterTest extends EasyMockSupport {
     private TLDEventDataFilter filter;
     private ASTJexlScript mockScript;
-    private TypeMetadata mockAttributeFactory;
+    private TypeMetadata mockTypeMetadata;
 
     private final MockMetadataHelper helper = new MockMetadataHelper();
     private final MockDateIndexHelper helper2 = new MockDateIndexHelper();
@@ -50,7 +53,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     @Before
     public void setup() {
         mockScript = createMock(ASTJexlScript.class);
-        mockAttributeFactory = createMock(TypeMetadata.class);
+        mockTypeMetadata = createMock(TypeMetadata.class);
 
         String lcNoDiacritics = LcNoDiacriticsType.class.getName();
         String number = NumberType.class.getName();
@@ -73,7 +76,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "column", "FIELD" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
         String field = filter.getCurrentField(key);
 
         assertEquals("FIELD", field);
@@ -90,7 +94,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "column", "FIELD.part_1.part_2.part_3" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
         String field = filter.getCurrentField(key);
 
         assertEquals("FIELD", field);
@@ -107,7 +112,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "fi" + Constants.NULL + "FIELD", "value" + Constants.NULL + "datatype" + Constants.NULL + "123.345.456");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
         String field = filter.getCurrentField(key);
 
         assertEquals("FIELD", field);
@@ -124,7 +130,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "fi" + Constants.NULL + "FIELD.name", "value" + Constants.NULL + "datatype" + Constants.NULL + "123.345.456");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
         String field = filter.getCurrentField(key);
 
         assertEquals("FIELD", field);
@@ -141,7 +148,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "tf", "datatype" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "FIELD");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
         String field = filter.getCurrentField(key);
 
         assertEquals("FIELD", field);
@@ -157,7 +165,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "tf", "datatype" + Constants.NULL + "123.234.345" + Constants.NULL + "value" + Constants.NULL + "FIELD.name");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
         String field = filter.getCurrentField(key);
 
         assertEquals("FIELD", field);
@@ -176,7 +185,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD",
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, 1, -1, fieldLimits, "LIMIT_FIELD",
                         Collections.emptySet());
 
         assertTrue(filter.keep(key));
@@ -199,7 +209,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "datatype" + Constants.NULL + "123.345.456", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(query, Collections.singleton("FIELD2"), mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD",
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(query, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(query, Collections.singleton("FIELD2"), expressionFilters, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD",
                         Collections.emptySet());
 
         assertTrue(filter.keep(key));
@@ -235,7 +246,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         Key key1 = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key2 = new Key("row", "column", "FIELD2" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, 1, -1, fieldLimits, "LIMIT_FIELD",
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, 1, -1, fieldLimits, "LIMIT_FIELD",
                         Collections.emptySet());
 
         assertTrue(filter.keep(key1));
@@ -292,7 +304,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         Key key1 = new Key("row", "column", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key2 = new Key("row", "column", "FIELD2" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, 3, -1, fieldLimits, "LIMIT_FIELD",
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, 3, -1, fieldLimits, "LIMIT_FIELD",
                         Collections.emptySet());
 
         assertTrue(filter.keep(key1));
@@ -329,7 +342,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
 
         // expected key structure
         Key key = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
 
         TLDEventDataFilter.ParseInfo info = filter.getParseInfo(key);
         assertNotNull(info);
@@ -405,7 +419,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.1", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
         Key key3 = new Key("row", "datatype" + Constants.NULL + "123.234.34567", "FIELD1" + Constants.NULL_BYTE_STRING + "value");
-        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(mockScript, Collections.singleton("FIELD"), expressionFilters, null, null, -1, -1);
 
         filter.startNewDocument(key1);
         // set the lastParseInfo to this key
@@ -426,11 +441,12 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     public void apply_acceptSuperRejectTest() throws ParseException {
         ASTJexlScript query = JexlASTHelper.parseJexlQuery("FOO == 'bar'");
 
-        expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList());
+        expect(mockTypeMetadata.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList());
 
         replayAll();
 
-        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(query, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), expressionFilters, null, null, -1, 1);
 
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FOO" + Constants.NULL_BYTE_STRING + "baz");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.11", "FOO" + Constants.NULL_BYTE_STRING + "baz");
@@ -447,11 +463,12 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     public void apply_acceptSuperRejectChildTest() throws ParseException {
         ASTJexlScript query = JexlASTHelper.parseJexlQuery("FOO == 'bar'");
 
-        expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList());
+        expect(mockTypeMetadata.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList());
 
         replayAll();
 
-        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(query, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), expressionFilters, null, null, -1, 1);
 
         // process parent first to set up proper root calculations
         Key parent = new Key("row", "datatype" + Constants.NULL + "123.234.345", "BAR" + Constants.NULL_BYTE_STRING + "baz");
@@ -479,7 +496,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
 
-        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(newScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), expressionFilters, null, null, -1, 1);
 
         assertTrue(filter.queryFields.contains("FOO"));
         assertTrue(filter.queryFields.contains("BAR"));
@@ -498,7 +516,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
 
-        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(mockScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), expressionFilters, null, null, -1, 1);
 
         assertTrue(filter.queryFields.contains("FOO"));
     }
@@ -516,7 +535,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
 
-        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(newScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), expressionFilters, null, null, -1, 1);
 
         assertTrue(filter.queryFields.contains("BAR"));
     }
@@ -534,7 +554,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(originalQuery);
         ASTJexlScript newScript = FunctionIndexQueryExpansionVisitor.expandFunctions(config, helper, helper2, script);
 
-        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), mockAttributeFactory, null, null, -1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(newScript, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(newScript, Sets.newHashSet("FOO", "BAR"), expressionFilters, null, null, -1, 1);
 
         assertTrue(filter.queryFields.contains("BAR"));
         assertTrue(filter.queryFields.contains("FOO"));
@@ -553,7 +574,7 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         Set<String> nonEventFields = new HashSet<>();
         nonEventFields.add("FIELD2");
 
-        expect(mockAttributeFactory.getTypeMetadata("FIELD2", "datatype")).andReturn(Collections.emptyList()).anyTimes();
+        expect(mockTypeMetadata.getTypeMetadata("FIELD2", "datatype")).andReturn(Collections.emptyList()).anyTimes();
 
         replayAll();
 
@@ -561,7 +582,8 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         Key rootKey = new Key("row", "datatype" + Constants.NULL + "123.345.456", "FIELD3" + Constants.NULL_BYTE_STRING + "value");
         // child key that would normally not be kept
         Key key = new Key("row", "datatype" + Constants.NULL + "123.345.456.1", "FIELD2" + Constants.NULL_BYTE_STRING + "bar");
-        filter = new TLDEventDataFilter(query, Collections.singleton("FIELD2"), mockAttributeFactory, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD",
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(query, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(query, Collections.singleton("FIELD2"), expressionFilters, null, blacklist, 1, -1, fieldLimits, "LIMIT_FIELD",
                         nonEventFields);
 
         // set the parse info correctly
@@ -577,11 +599,12 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
     @Test
     public void apply_acceptGroupingFields() throws ParseException {
         ASTJexlScript query = JexlASTHelper.parseJexlQuery("grouping:matchesInGroup(FOO, 'bar')");
-        expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
+        expect(mockTypeMetadata.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
 
         replayAll();
 
-        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(query, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(query, Collections.singleton("FOO"), expressionFilters, null, null, -1, -1);
 
         Key key1 = new Key("row", "datatype" + Constants.NULL + "123.234.345", "FOO" + Constants.NULL_BYTE_STRING + "baz");
         Key key2 = new Key("row", "datatype" + Constants.NULL + "123.234.345.11", "FOO" + Constants.NULL_BYTE_STRING + "baz");
@@ -606,10 +629,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         String query = "content:phrase(FOO, termOffsetMap, 'bar', 'baz') && FOO == 'bar' && FOO == 'baz' && Foo2 == 'bad'";
         ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
 
-        expect(mockAttributeFactory.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
+        expect(mockTypeMetadata.getTypeMetadata("FOO", "datatype")).andReturn(Collections.emptyList()).anyTimes();
         replayAll();
 
-        filter = new TLDEventDataFilter(script, Sets.newHashSet("FOO", "FOO2"), mockAttributeFactory, null, null, -1, -1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(script, Sets.newHashSet("FOO", "FOO2"), expressionFilters, null, null, -1, -1);
 
         // asserts that 'termOffsetMap' is not considered a query field
         // asserts that malformed field 'Foo2' is not considered a query field
@@ -621,10 +645,11 @@ public class TLDEventDataFilterTest extends EasyMockSupport {
         String query = "FOO == 'bar' && FOO2 == 'value3'";
         ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
 
-        expect(mockAttributeFactory.getTypeMetadata("FOO2", "datatype")).andReturn(Collections.emptyList()).anyTimes();
+        expect(mockTypeMetadata.getTypeMetadata("FOO2", "datatype")).andReturn(Collections.emptyList()).anyTimes();
         replayAll();
 
-        filter = new TLDEventDataFilter(script, Sets.newHashSet("FOO", "FOO2"), mockAttributeFactory, null, null, 1, 1);
+        Map<String,ExpressionFilter> expressionFilters = getExpressionFilters(script, new AttributeFactory(mockTypeMetadata));
+        filter = new TLDEventDataFilter(script, Sets.newHashSet("FOO", "FOO2"), expressionFilters, null, null, 1, 1);
 
         Key k1 = new Key("row", "datatype\u0000d8zay2.-3pnndm.-anolok", "FOO\0bar");
         Key k2 = new Key("row", "datatype\u0000d8zay2.-3pnndm.-anolok.1", "FOO2\0value1");

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TermFrequencyDataFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TermFrequencyDataFilterTest.java
@@ -3,6 +3,7 @@ package datawave.query.predicate;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
@@ -13,7 +14,10 @@ import org.junit.Test;
 import com.google.common.collect.Sets;
 
 import datawave.data.type.LcNoDiacriticsType;
+import datawave.query.attributes.AttributeFactory;
 import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor;
+import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.query.util.TypeMetadata;
 
 public class TermFrequencyDataFilterTest {
@@ -48,7 +52,10 @@ public class TermFrequencyDataFilterTest {
     @Test
     public void testSingleFieldAndValue() {
         JexlNode node = JexlNodeFactory.buildEQNode("FIELD1", "value");
-        filter = new TermFrequencyDataFilter(node, metadata, nonEventFields);
+        AttributeFactory attributeFactory = new AttributeFactory(metadata);
+        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node, attributeFactory);
+
+        filter = new TermFrequencyDataFilter(expressionFilters);
 
         // first key matches 'FIELD1' and 'value'
         assertTrue(filter.keep(tfKey1));
@@ -64,8 +71,12 @@ public class TermFrequencyDataFilterTest {
     // same test as above, different field
     @Test
     public void testOtherFieldAndValue() {
+
         JexlNode node = JexlNodeFactory.buildEQNode("FIELD3", "value");
-        filter = new TermFrequencyDataFilter(node, metadata, nonEventFields);
+        AttributeFactory attributeFactory = new AttributeFactory(metadata);
+        Map<String,ExpressionFilter> expressionFilters = EventDataQueryExpressionVisitor.getExpressionFilters(node, attributeFactory);
+
+        filter = new TermFrequencyDataFilter(expressionFilters);
 
         // third key matches 'FIELD3' and 'value'
         assertFalse(filter.keep(tfKey1));


### PR DESCRIPTION
This merge request decouples the creation of expression filter maps from the `EventDataQueryExpressionFilter` constructors. The tight coupling limits options for optimizing expression filters.

Change summary
- added constructor to `EventDataQueryExpressionFilter` that accepts a prebuilt map of `ExpressionFilters`
- added matching constructors for filters that extend `EventDataQueryExpressionFilter`
- deprecated other constructors in `EventDataQueryExpressionFilter`
- deprecated other constructors for filters that extend `EventDataQueryExpressionFilter`
- migrated usages of deprecated `EventDataQueryExpressionFilter` constructors to new constructor
- IteratorBuildingVisitor had a method with an used parameter, `createWrappedTermFrequencyFilter(String identifier, JexlNode node, EventDataQueryFilter existing)`. Deprecated this and migrated usages to method that only accepts a jexl node and query filter.

If reviewers would prefer this broken up to reduce the size of the change set I am happy to accommodate. 