### PR TITLE
Add systemFrom as a first-class query setting/parameter

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/webservice/modification/MutableMetadataHandler.java
@@ -1016,7 +1016,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
         try {
             MultivaluedMap<String,String> paramsMap = new MultivaluedMapImpl<>();
             paramsMap.putAll(QueryParametersImpl.paramsToMap(logicName, query.toString(), "Query to find matching records for metadata modification",
-                            columnVisibility, new Date(0), new Date(), StringUtils.join(auths, ','), expiration, 2, -1, null, QueryPersistence.TRANSIENT,
+                            columnVisibility, new Date(0), new Date(), StringUtils.join(auths, ','), expiration, 2, -1, null, QueryPersistence.TRANSIENT, null,
                             queryOptions.toString(), false));
             GenericResponse<String> createResponse = queryService.createQuery(logicName, paramsMap);
             

--- a/web-services/client/src/main/java/datawave/webservice/query/Query.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/Query.java
@@ -73,6 +73,10 @@ public abstract class Query {
     
     public abstract void setEndDate(Date endDate);
     
+    public abstract String getSystemFrom();
+    
+    public abstract void setSystemFrom(String systemFrom);
+    
     public abstract Query duplicate(String newQueryName);
     
     public abstract Parameter findParameter(String parameter);

--- a/web-services/client/src/main/java/datawave/webservice/query/QueryImpl.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/QueryImpl.java
@@ -226,6 +226,9 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
     protected String owner;
     @XmlElement
     protected String columnVisibility;
+    @XmlElement
+    protected String systemFrom;
+    
     @XmlTransient
     protected Map<String,List<String>> optionalQueryParameters;
     
@@ -386,6 +389,16 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         this.endDate = endDate;
     }
     
+    @Override
+    public String getSystemFrom() {
+        return systemFrom;
+    }
+    
+    @Override
+    public void setSystemFrom(String systemFrom) {
+        this.systemFrom = systemFrom;
+    }
+    
     public Map<String,List<String>> getOptionalQueryParameters() {
         return optionalQueryParameters;
     }
@@ -413,6 +426,7 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         query.setColumnVisibility(this.getColumnVisibility());
         query.setBeginDate(this.getBeginDate());
         query.setEndDate(this.getEndDate());
+        query.setSystemFrom(this.getSystemFrom());
         if (CollectionUtils.isNotEmpty(this.parameters))
             query.setParameters(new HashSet<Parameter>(this.parameters));
         query.setDnList(this.dnList);
@@ -431,7 +445,7 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
                         .append(UUID.randomUUID()).append(this.getPagesize()).append(this.getPageTimeout())
                         .append(this.isMaxResultsOverridden() ? this.getMaxResultsOverride() : 0).append(this.getQuery()).append(this.getQueryAuthorizations())
                         .append(this.getUserDN()).append(this.getOwner()).append(this.getParameters()).append(this.getDnList())
-                        .append(this.getColumnVisibility()).append(this.getBeginDate()).append(this.getEndDate()).toHashCode();
+                        .append(this.getColumnVisibility()).append(this.getBeginDate()).append(this.getEndDate()).append(this.getSystemFrom()).toHashCode();
     }
     
     @Override
@@ -453,6 +467,8 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         tsb.append("columnVisibility", this.getColumnVisibility());
         tsb.append("beginDate", this.getBeginDate());
         tsb.append("endDate", this.getEndDate());
+        tsb.append("systemFrom", this.getSystemFrom());
+        
         return tsb.toString();
     }
     
@@ -483,6 +499,7 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         eb.append(this.getColumnVisibility(), other.getColumnVisibility());
         eb.append(this.getBeginDate(), other.getBeginDate());
         eb.append(this.getEndDate(), other.getEndDate());
+        eb.append(this.getSystemFrom(), other.getSystemFrom());
         eb.append(this.getDnList(), other.getDnList());
         eb.append(this.getParameters(), other.getParameters());
         return eb.isEquals();
@@ -579,6 +596,9 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
             if (message.pageTimeout == 0)
                 throw new UninitializedMessageException(message, SCHEMA);
             output.writeUInt32(15, message.pageTimeout, false);
+            
+            if (message.systemFrom != null)
+                output.writeString(16, message.systemFrom, false);
         }
         
         public void mergeFrom(Input input, QueryImpl message) throws IOException {
@@ -636,6 +656,8 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
                     case 15:
                         message.pageTimeout = input.readUInt32();
                         break;
+                    case 16:
+                        message.systemFrom = input.readString();
                     default:
                         input.handleUnknownField(number, this);
                         break;
@@ -675,6 +697,8 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
                     return "columnVisibility";
                 case 15:
                     return "pageTimeout";
+                case 16:
+                    return "systemFrom";
                 default:
                     return null;
             }
@@ -702,6 +726,7 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
             fieldMap.put("dnList", 13);
             fieldMap.put("columnVisibility", 14);
             fieldMap.put("pageTimeout", 15);
+            fieldMap.put("systemFrom", 16);
         }
     };
     
@@ -727,6 +752,7 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
         this.owner = getOwner(this.userDN);
         this.beginDate = qp.getBeginDate();
         this.endDate = qp.getEndDate();
+        this.systemFrom = qp.getSystemFrom();
         if (optionalQueryParameters != null) {
             for (Entry<String,List<String>> entry : optionalQueryParameters.entrySet()) {
                 if (entry.getValue().get(0) != null) {
@@ -827,6 +853,10 @@ public class QueryImpl extends Query implements Serializable, Message<QueryImpl>
             }
         }
         p.set(QueryParameters.QUERY_PAGETIMEOUT, Integer.toString(this.pageTimeout));
+        
+        if (this.systemFrom != null) {
+            p.set("systemFrom", this.systemFrom);
+        }
         
         if (this.parameters != null) {
             for (Parameter parameter : parameters) {

--- a/web-services/client/src/main/java/datawave/webservice/query/QueryParameters.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/QueryParameters.java
@@ -26,6 +26,7 @@ public interface QueryParameters extends ParameterValidator {
     String QUERY_PARAMS = "params";
     String QUERY_VISIBILITY = "columnVisibility";
     String QUERY_LOGIC_NAME = "logicName";
+    String QUERY_SYSTEM_FROM = "systemFrom";
     
     String getQuery();
     
@@ -80,6 +81,10 @@ public interface QueryParameters extends ParameterValidator {
     String getLogicName();
     
     void setLogicName(String logicName);
+    
+    String getSystemFrom();
+    
+    void setSystemFrom(String systemFrom);
     
     Map<String,List<String>> getRequestHeaders();
     

--- a/web-services/client/src/main/java/datawave/webservice/query/QueryParametersImpl.java
+++ b/web-services/client/src/main/java/datawave/webservice/query/QueryParametersImpl.java
@@ -18,9 +18,9 @@ import java.util.Map;
 
 public class QueryParametersImpl implements QueryParameters {
     
-    private static final List<String> KNOWN_PARAMS = Arrays
-                    .asList(QUERY_STRING, QUERY_NAME, QUERY_PERSISTENCE, QUERY_PAGESIZE, QUERY_PAGETIMEOUT, QUERY_AUTHORIZATIONS, QUERY_EXPIRATION,
-                                    QUERY_TRACE, QUERY_BEGIN, QUERY_END, QUERY_VISIBILITY, QUERY_LOGIC_NAME, QUERY_MAX_RESULTS_OVERRIDE);
+    private static final List<String> KNOWN_PARAMS = Arrays.asList(QUERY_STRING, QUERY_NAME, QUERY_PERSISTENCE, QUERY_PAGESIZE, QUERY_PAGETIMEOUT,
+                    QUERY_AUTHORIZATIONS, QUERY_EXPIRATION, QUERY_TRACE, QUERY_BEGIN, QUERY_END, QUERY_VISIBILITY, QUERY_LOGIC_NAME,
+                    QUERY_MAX_RESULTS_OVERRIDE, QUERY_SYSTEM_FROM);
     
     protected String query;
     protected String queryName;
@@ -36,6 +36,7 @@ public class QueryParametersImpl implements QueryParameters {
     protected Date endDate;
     protected String visibility;
     protected String logicName;
+    protected String systemFrom;
     protected Map<String,List<String>> requestHeaders;
     
     public QueryParametersImpl() {
@@ -117,6 +118,8 @@ public class QueryParametersImpl implements QueryParameters {
                 this.visibility = values.get(0);
             } else if (QUERY_LOGIC_NAME.equals(param)) {
                 this.logicName = values.get(0);
+            } else if (QUERY_SYSTEM_FROM.equals(param)) {
+                this.systemFrom = values.get(0);
             } else {
                 throw new IllegalArgumentException("Unknown condition.");
             }
@@ -175,6 +178,8 @@ public class QueryParametersImpl implements QueryParameters {
             return false;
         if (requestHeaders != null ? !requestHeaders.equals(that.requestHeaders) : that.requestHeaders != null)
             return false;
+        if (systemFrom != null ? !systemFrom.equals(that.systemFrom) : that.systemFrom != null)
+            return false;
         return true;
     }
     
@@ -196,6 +201,7 @@ public class QueryParametersImpl implements QueryParameters {
         result = 31 * result + (visibility != null ? visibility.hashCode() : 0);
         result = 31 * result + (logicName != null ? logicName.hashCode() : 0);
         result = 31 * result + (requestHeaders != null ? requestHeaders.hashCode() : 0);
+        result = 31 * result + (systemFrom != null ? systemFrom.hashCode() : 0);
         return result;
     }
     
@@ -264,7 +270,8 @@ public class QueryParametersImpl implements QueryParameters {
      * The 'parameters' argument will not be parsed, so its internal elements will not be placed into the map. If non-null, the 'parameters' value will be
      * mapped directly to the QUERY_PARAMS key.
      * 
-     * No attempt is made to determine whether or not the given arguments constitute a valid query. If validation is desired, see the {@link validate} method
+     * No attempt is made to determine whether or not the given arguments constitute a valid query. If validation is desired, see the {@link #validate(Map)}
+     * method
      *
      * @param queryLogicName
      *            - name of QueryLogic to use
@@ -298,7 +305,7 @@ public class QueryParametersImpl implements QueryParameters {
      */
     public static Map<String,List<String>> paramsToMap(String queryLogicName, String query, String queryName, String queryVisibility, Date beginDate,
                     Date endDate, String queryAuthorizations, Date expirationDate, Integer pagesize, Integer pageTimeout, Long maxResultsOverride,
-                    QueryPersistence persistenceMode, String parameters, Boolean trace) throws ParseException {
+                    QueryPersistence persistenceMode, String systemFrom, String parameters, Boolean trace) throws ParseException {
         
         MultiValueMap<String,String> p = new LinkedMultiValueMap<>();
         if (queryLogicName != null) {
@@ -341,6 +348,9 @@ public class QueryParametersImpl implements QueryParameters {
         }
         if (trace != null) {
             p.set(QueryParameters.QUERY_TRACE, trace.toString());
+        }
+        if (systemFrom != null) {
+            p.set(QueryParameters.QUERY_SYSTEM_FROM, systemFrom);
         }
         if (parameters != null) {
             p.set(QueryParameters.QUERY_PARAMS, parameters);
@@ -485,6 +495,16 @@ public class QueryParametersImpl implements QueryParameters {
     }
     
     @Override
+    public String getSystemFrom() {
+        return systemFrom;
+    }
+    
+    @Override
+    public void setSystemFrom(String systemFrom) {
+        this.systemFrom = systemFrom;
+    }
+    
+    @Override
     public Map<String,List<String>> getRequestHeaders() {
         return requestHeaders;
     }
@@ -521,5 +541,6 @@ public class QueryParametersImpl implements QueryParameters {
         this.visibility = null;
         this.logicName = null;
         this.requestHeaders = null;
+        this.systemFrom = null;
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/dashboard/DashboardQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/dashboard/DashboardQuery.java
@@ -23,6 +23,7 @@ public class DashboardQuery {
     private static final int pageSize = 10000;
     private static final int pageTimeout = -1;
     private static final Long maxResultsOverride = null;
+    private static final String systemFrom = "";
     
     private DashboardQuery() {}
     
@@ -32,7 +33,7 @@ public class DashboardQuery {
         
         MultivaluedMap<String,String> paramsMap = new MultivaluedMapImpl<>();
         paramsMap.putAll(QueryParametersImpl.paramsToMap(logicName, queryString, queryName, columnVisibility, beginDate, endDate, auths,
-                        DateUtils.addDays(now, 1), pageSize, pageTimeout, maxResultsOverride, persistence, parameters, trace));
+                        DateUtils.addDays(now, 1), pageSize, pageTimeout, maxResultsOverride, persistence, systemFrom, parameters, trace));
         return (ExtJsResponse) queryExecutor.createQueryAndNext(logicName, paramsMap);
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/QueryLogic.java
@@ -386,11 +386,11 @@ public interface QueryLogic<T> extends Iterable<T>, Cloneable, ParameterValidato
         long maxResults = getMaxResults();
         
         Map<String,Long> systemFromLimits = getSystemFromResultLimits();
-        QueryImpl.Parameter systemFromParam = settings.findParameter("systemFrom");
+        String systemFromParam = settings.getSystemFrom();
         if (systemFromLimits != null && systemFromParam != null) {
             // this findParameter implementation never returns null, it will return a parameter with an empty string
             // as the value if the parameter is not present.
-            maxResults = systemFromLimits.getOrDefault(systemFromParam.getParameterValue(), maxResults);
+            maxResults = systemFromLimits.getOrDefault(systemFromParam, maxResults);
         }
         
         Map<String,Long> dnResultLimits = getDnResultLimits();

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/TestBaseQueryLogic.java
@@ -122,7 +122,7 @@ public class TestBaseQueryLogic {
         expect(query.getDnList()).andReturn(dns);
         expect(query.getDnList()).andReturn(null);
         expect(query.getDnList()).andReturn(Collections.emptyList());
-        expect(query.findParameter("systemFrom")).andReturn(null).anyTimes();
+        expect(query.getSystemFrom()).andReturn(null).anyTimes();
         PowerMock.replayAll();
         for (long limit : limits) {
             assertEquals(limit, logic.getResultLimit(query));
@@ -140,9 +140,9 @@ public class TestBaseQueryLogic {
      */
     public void assertGetResultsLimitsSystemFrom(BaseQueryLogic<Object> logic, long... limits) {
         PowerMock.resetAll();
-        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", "hoplark"));
-        expect(query.findParameter("systemFrom")).andReturn(null);
-        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", ""));
+        expect(query.getSystemFrom()).andReturn("hoplark");
+        expect(query.getSystemFrom()).andReturn(null);
+        expect(query.getSystemFrom()).andReturn("");
         expect(query.getDnList()).andReturn(null).anyTimes();
         PowerMock.replayAll();
         for (long limit : limits) {
@@ -165,15 +165,15 @@ public class TestBaseQueryLogic {
         
         // first call, populated dn list and populated system from
         expect(query.getDnList()).andReturn(dns);
-        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", "hoplark"));
+        expect(query.getSystemFrom()).andReturn("hoplark");
         
         // second call, populated dn list and empty system from
         expect(query.getDnList()).andReturn(dns);
-        expect(query.findParameter("systemFrom")).andReturn(null);
+        expect(query.getSystemFrom()).andReturn(null);
         
         // third call, null dn list and populated system from
         expect(query.getDnList()).andReturn(null);
-        expect(query.findParameter("systemFrom")).andReturn(new QueryImpl.Parameter("systemFrom", "hoplark"));
+        expect(query.getSystemFrom()).andReturn("hoplark");
         
         PowerMock.replayAll();
         for (long limit : limits) {

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -1893,12 +1893,13 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         
         MultivaluedMap<String,String> p = new MultivaluedMapImpl<>();
         p.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations, expirationDate,
-                        pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                        pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
         
         // Run the test
         PowerMock.replayAll();
@@ -1936,12 +1937,13 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         
         MultivaluedMap<String,String> p = new MultivaluedMapImpl<>();
         p.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations, expirationDate,
-                        pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                        pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
         
         // Run the test
         PowerMock.replayAll();
@@ -1979,13 +1981,14 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         // Set expectations
         
         MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
         queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
         marking.validate(queryParameters);
@@ -2048,6 +2051,7 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         
@@ -2068,7 +2072,7 @@ public class ExtendedQueryExecutorBeanTest {
         try {
             MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
             queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
             
             subject.createQueryAndNext(queryLogicName, queryParameters);
             
@@ -2099,6 +2103,7 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         
@@ -2111,7 +2116,7 @@ public class ExtendedQueryExecutorBeanTest {
         try {
             MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
             queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
             
             subject.defineQuery(queryLogicName, queryParameters);
             
@@ -2141,6 +2146,7 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         
         boolean trace = false;
@@ -2154,7 +2160,7 @@ public class ExtendedQueryExecutorBeanTest {
         try {
             MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
             queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
             
             subject.defineQuery(queryLogicName, queryParameters);
         } catch (DatawaveWebApplicationException e) {
@@ -2194,7 +2200,7 @@ public class ExtendedQueryExecutorBeanTest {
         
         MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
         queryParameters.putAll(QueryParametersImpl.paramsToMap(null, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, null, trace));
+                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, null, null, trace));
         queryParameters.putSingle("valid", "param");
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
@@ -3762,7 +3768,7 @@ public class ExtendedQueryExecutorBeanTest {
         try {
             MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
             queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                            expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
             
             result1 = subject.execute(queryLogicName, queryParameters, httpHeaders);
             
@@ -4407,13 +4413,14 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         // Set expectations
         
         MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
         queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
         marking.validate(queryParameters);
@@ -4477,13 +4484,14 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         // Set expectations
         
         MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
         queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
         marking.validate(queryParameters);
@@ -4547,13 +4555,14 @@ public class ExtendedQueryExecutorBeanTest {
         int pageTimeout = -1;
         Long maxResultsOverride = null;
         QueryPersistence persistenceMode = QueryPersistence.PERSISTENT;
+        String systemFrom = null;
         String parameters = null;
         boolean trace = false;
         // Set expectations
         
         MultivaluedMap<String,String> queryParameters = new MultivaluedMapImpl<>();
         queryParameters.putAll(QueryParametersImpl.paramsToMap(queryLogicName, query, queryName, queryVisibility, beginDate, endDate, queryAuthorizations,
-                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, parameters, trace));
+                        expirationDate, pagesize, pageTimeout, maxResultsOverride, persistenceMode, systemFrom, parameters, trace));
         
         ColumnVisibilitySecurityMarking marking = new ColumnVisibilitySecurityMarking();
         marking.validate(queryParameters);


### PR DESCRIPTION
Previously we read systemFrom directly from the query parameters, which lead to some issues around persistence of this parameter. This PR updates the Query/QueryParameters code to implement systemFrom as a field that can be directly accessed and preserved as necessary.