### PR TITLE
Standardize Handling of FieldSets

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -101,8 +101,16 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private boolean enforceUniqueTermsWithinExpressions = false;
     // should this query reduce the set of fields prior to serialization
     private boolean reduceQueryFields = false;
+    // should the query planner intersect field sets with query fields
+    private boolean reduceFieldSets = false;
+    // should the VisitorFunction reduce field sets
+    private boolean reduceFieldSetsPerShard = false;
+    // should the query planner compress the serialized field sets
+    private boolean compressFieldSets = false;
+
     private boolean reduceTypeMetadata = false;
     private boolean reduceTypeMetadataPerShard = false;
+
     private boolean sequentialScheduler = false;
     private boolean collectTimingDetails = false;
     private boolean logTimingDetails = false;
@@ -473,6 +481,9 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setCollapseUidsThreshold(other.getCollapseUidsThreshold());
         this.setEnforceUniqueTermsWithinExpressions(other.getEnforceUniqueTermsWithinExpressions());
         this.setReduceQueryFields(other.getReduceQueryFields());
+        this.setReduceFieldSets(other.getReduceFieldSets());
+        this.setReduceFieldSetsPerShard(other.getReduceFieldSetsPerShard());
+        this.setCompressFieldSets(other.getCompressFieldSets());
         this.setReduceTypeMetadata(other.getReduceTypeMetadata());
         this.setReduceTypeMetadataPerShard(other.getReduceTypeMetadataPerShard());
         this.setParseTldUids(other.getParseTldUids());
@@ -2035,12 +2046,49 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.enforceUniqueTermsWithinExpressions = enforceUniqueTermsWithinExpressions;
     }
 
+    /**
+     * Deprecated in favor of {@link #getReduceFieldSets()}
+     *
+     * @return a boolean
+     */
+    @Deprecated
     public boolean getReduceQueryFields() {
         return reduceQueryFields;
     }
 
+    /**
+     * Deprecated in favor of {@link #setReduceFieldSets(boolean)}
+     *
+     * @param reduceQueryFields
+     *            boolean
+     */
+    @Deprecated
     public void setReduceQueryFields(boolean reduceQueryFields) {
         this.reduceQueryFields = reduceQueryFields;
+    }
+
+    public boolean getReduceFieldSets() {
+        return reduceFieldSets;
+    }
+
+    public void setReduceFieldSets(boolean reduceFieldSets) {
+        this.reduceFieldSets = reduceFieldSets;
+    }
+
+    public boolean getReduceFieldSetsPerShard() {
+        return reduceFieldSetsPerShard;
+    }
+
+    public void setReduceFieldSetsPerShard(boolean reduceFieldSetsPerShard) {
+        this.reduceFieldSetsPerShard = reduceFieldSetsPerShard;
+    }
+
+    public boolean getCompressFieldSets() {
+        return compressFieldSets;
+    }
+
+    public void setCompressFieldSets(boolean compressFieldSets) {
+        this.compressFieldSets = compressFieldSets;
     }
 
     public boolean getReduceTypeMetadata() {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/FieldIndexOnlyQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/FieldIndexOnlyQueryIterator.java
@@ -49,6 +49,7 @@ import datawave.query.jexl.functions.IdentityAggregator;
 import datawave.query.jexl.visitors.IteratorBuildingVisitor;
 import datawave.query.jexl.visitors.SatisfactionVisitor;
 import datawave.query.predicate.TimeFilter;
+import datawave.query.tables.async.event.FieldSets;
 import datawave.util.StringUtils;
 
 /**
@@ -114,6 +115,10 @@ public class FieldIndexOnlyQueryIterator extends QueryIterator {
 
         if (options.containsKey(QUERY_MAPPING_COMPRESS)) {
             compressedMappings = Boolean.valueOf(options.get(QUERY_MAPPING_COMPRESS));
+        }
+
+        if (options.containsKey(COMPRESS_FIELD_SETS)) {
+            setCompressFieldSets(true); // presence of key is enough
         }
 
         this.validateTypeMetadata(options);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -2199,6 +2199,30 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         this.getConfig().setReduceQueryFields(reduceQueryFields);
     }
 
+    public boolean getReduceFieldSets() {
+        return getConfig().getReduceFieldSets();
+    }
+
+    public void setReduceFieldSets(boolean reduceFieldSets) {
+        getConfig().setReduceFieldSets(reduceFieldSets);
+    }
+
+    public boolean getReduceFieldSetsPerShard() {
+        return getConfig().getReduceFieldSetsPerShard();
+    }
+
+    public void setReduceFieldSetsPerShard(boolean reduceFieldSetsPerShard) {
+        getConfig().setReduceFieldSetsPerShard(reduceFieldSetsPerShard);
+    }
+
+    public boolean getCompressFieldSets() {
+        return getConfig().getCompressFieldSets();
+    }
+
+    public void setCompressFieldSets(boolean compressFieldSets) {
+        getConfig().setCompressFieldSets(compressFieldSets);
+    }
+
     public boolean getReduceTypeMetadata() {
         return getConfig().getReduceTypeMetadata();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/async/event/FieldSets.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/async/event/FieldSets.java
@@ -1,0 +1,83 @@
+package datawave.query.tables.async.event;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Utility for reducing, serializing, and compressing field sets
+ */
+public class FieldSets {
+
+    private FieldSets() {
+        // static utility
+    }
+
+    public static String serializeFieldSet(Set<String> fieldSet) {
+        return Joiner.on(',').join(fieldSet);
+    }
+
+    public static Set<String> deserializeFieldSet(String fieldSetString) {
+        if (fieldSetString == null) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(StringUtils.split(fieldSetString, ',')).collect(Collectors.toSet());
+    }
+
+    public static String compressFieldSet(String serializedFieldSet) throws IOException {
+        return compressFieldSet(serializedFieldSet, StandardCharsets.UTF_8);
+    }
+
+    public static String compressFieldSet(final String serializedFieldSet, final Charset characterSet) throws IOException {
+        final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        final GZIPOutputStream gzipStream = new GZIPOutputStream(byteStream);
+        final DataOutputStream dataOut = new DataOutputStream(gzipStream);
+
+        byte[] arr = serializedFieldSet.getBytes(characterSet);
+        final int length = arr.length;
+
+        dataOut.writeInt(length);
+        dataOut.write(arr);
+
+        dataOut.close();
+        byteStream.close();
+
+        return new String(Base64.encodeBase64(byteStream.toByteArray()));
+    }
+
+    public static String decompressFieldSet(String serializedFieldSet) throws IOException {
+        return decompressFieldSet(serializedFieldSet, StandardCharsets.UTF_8);
+    }
+
+    public static String decompressFieldSet(final String serializedFieldSet, final Charset characterSet) throws IOException {
+        final byte[] inBase64 = Base64.decodeBase64(serializedFieldSet.getBytes());
+
+        final ByteArrayInputStream byteInputStream = new ByteArrayInputStream(inBase64);
+        final GZIPInputStream gzipInputStream = new GZIPInputStream(byteInputStream);
+        final DataInputStream dataInputStream = new DataInputStream(gzipInputStream);
+
+        final int length = dataInputStream.readInt();
+        final byte[] dataBytes = new byte[length];
+        dataInputStream.readFully(dataBytes, 0, length);
+
+        dataInputStream.close();
+        gzipInputStream.close();
+
+        return new String(dataBytes, characterSet);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -66,6 +66,9 @@ public class ShardQueryConfigurationTest {
         Assert.assertFalse(config.getCollapseUids());
         Assert.assertFalse(config.getParseTldUids());
         Assert.assertFalse(config.getReduceQueryFields());
+        Assert.assertFalse(config.getReduceFieldSets());
+        Assert.assertFalse(config.getReduceFieldSetsPerShard());
+        Assert.assertFalse(config.getCompressFieldSets());
         Assert.assertFalse(config.getReduceTypeMetadata());
         Assert.assertFalse(config.getReduceTypeMetadataPerShard());
         Assert.assertFalse(config.getSequentialScheduler());
@@ -311,6 +314,9 @@ public class ShardQueryConfigurationTest {
         other.setVisitorFunctionMaxWeight(visitorFunctionMaxWeight);
         other.setAccumuloPassword("ChangeIt");
         other.setReduceQueryFields(true);
+        other.setReduceFieldSets(true);
+        other.setReduceFieldSetsPerShard(true);
+        other.setCompressFieldSets(true);
         other.setReduceTypeMetadata(true);
         other.setReduceTypeMetadataPerShard(true);
         other.setDocAggregationThresholdMs(15000);
@@ -409,9 +415,11 @@ public class ShardQueryConfigurationTest {
         Assert.assertEquals(visitorFunctionMaxWeight, config.getVisitorFunctionMaxWeight());
         Assert.assertEquals("ChangeIt", config.getAccumuloPassword());
         Assert.assertTrue(config.getReduceQueryFields());
+        Assert.assertTrue(config.getReduceFieldSets());
+        Assert.assertTrue(config.getReduceFieldSetsPerShard());
+        Assert.assertTrue(config.getCompressFieldSets());
         Assert.assertTrue(config.getReduceTypeMetadata());
         Assert.assertTrue(config.getReduceTypeMetadataPerShard());
-
         // Account for QueryImpl.duplicate() generating a random UUID on the duplicate
         QueryImpl expectedQuery = new QueryImpl();
         expectedQuery.setId(config.getQuery().getId());
@@ -543,7 +551,7 @@ public class ShardQueryConfigurationTest {
      */
     @Test
     public void testCheckForNewAdditions() throws IOException {
-        int expectedObjectCount = 206;
+        int expectedObjectCount = 209;
         ShardQueryConfiguration config = ShardQueryConfiguration.create();
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(mapper.writeValueAsString(config));

--- a/warehouse/query-core/src/test/java/datawave/query/tables/async/event/FieldSetsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/async/event/FieldSetsTest.java
@@ -1,0 +1,93 @@
+package datawave.query.tables.async.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Sets;
+
+class FieldSetsTest {
+
+    final Set<String> fieldSet = Sets.newHashSet("F1", "F2", "F3", "F4");
+    final String serializedFieldSet = "F1,F2,F3,F4";
+
+    @Test
+    void testFieldSetSerDe() {
+        String serialized = FieldSets.serializeFieldSet(fieldSet);
+        assertEquals(serializedFieldSet, serialized);
+
+        Set<String> deserialized = FieldSets.deserializeFieldSet(serialized);
+        assertEquals(fieldSet, deserialized);
+    }
+
+    @Test
+    void testFieldSetSerDeWithEmptySet() {
+        String serialized = FieldSets.serializeFieldSet(Collections.emptySet());
+        assertEquals("", serialized);
+        assertEquals(Collections.emptySet(), FieldSets.deserializeFieldSet(""));
+    }
+
+    @Test
+    void testFieldSetSerDeWithCompression() throws IOException {
+        String serialized = FieldSets.serializeFieldSet(fieldSet);
+        assertEquals(serializedFieldSet, serialized);
+
+        // now compress
+        String expectedCompressed = "H4sIAAAAAAAAAGNgYOB2M9RxM9JxM9ZxMwEAvA/FWA8AAAA=";
+        String compressed = FieldSets.compressFieldSet(serialized);
+        assertEquals(expectedCompressed, compressed);
+
+        // deser
+        assertEquals(serializedFieldSet, FieldSets.decompressFieldSet(compressed));
+    }
+
+    @Test
+    void testFieldSetSerDeWithCompressionWithEmptySet() throws IOException {
+        String serialized = FieldSets.serializeFieldSet(Collections.emptySet());
+        assertEquals("", serialized);
+
+        String expectedCompressed = "H4sIAAAAAAAAAGNgYGAAABzfRCEEAAAA";
+        String compressed = FieldSets.compressFieldSet("");
+        assertEquals(expectedCompressed, compressed);
+
+        String deserialized = FieldSets.decompressFieldSet(compressed);
+        assertEquals("", deserialized);
+    }
+
+    @Test
+    void testFieldSetSerDeWithCompressionWithAlternateCharset() throws IOException {
+        String expectedUTF16 = "H4sIAAAAAAAAAGNgYJD495/BjcGQQQdIGoFJYzBpAgDrbj06HAAAAA==";
+        String compressedWithUTF16 = FieldSets.compressFieldSet(serializedFieldSet, StandardCharsets.UTF_16);
+        assertEquals(expectedUTF16, compressedWithUTF16);
+
+        String decompressedUTF16 = FieldSets.decompressFieldSet(compressedWithUTF16, StandardCharsets.UTF_16);
+        assertEquals(serializedFieldSet, decompressedUTF16);
+    }
+
+    @Test
+    void testCompressionWithMisMatchedCharsets() throws IOException {
+        String expectedUTF8 = "H4sIAAAAAAAAAGNgYOB2M9RxM9JxM9ZxMwEAvA/FWA8AAAA=";
+        String expectedUTF16 = "H4sIAAAAAAAAAGNgYJD495/BjcGQQQdIGoFJYzBpAgDrbj06HAAAAA==";
+
+        String compressedWithUTF8 = FieldSets.compressFieldSet(serializedFieldSet, StandardCharsets.UTF_8);
+        assertEquals(expectedUTF8, compressedWithUTF8);
+
+        String compressedWithUTF16 = FieldSets.compressFieldSet(serializedFieldSet, StandardCharsets.UTF_16);
+        assertEquals(expectedUTF16, compressedWithUTF16);
+
+        // different charsets should produce different strings
+        assertNotEquals(compressedWithUTF8, compressedWithUTF16);
+
+        String decompressedUTF8WithUTF16 = FieldSets.decompressFieldSet(compressedWithUTF8, StandardCharsets.UTF_16);
+        String decompressedUTF16WithUTF8 = FieldSets.decompressFieldSet(compressedWithUTF16, StandardCharsets.UTF_8);
+
+        assertNotEquals(serializedFieldSet, decompressedUTF8WithUTF16);
+        assertNotEquals(serializedFieldSet, decompressedUTF16WithUTF8);
+    }
+}

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -243,7 +243,12 @@
         <property name="tfAggregationThresholdMs" value="-1" />
         <!--   enable per-tablet pruning of certain query options     -->
         <property name="pruneQueryOptions" value="false" />
+        <!--   properties that control field set reduction and optionally compression    -->
         <property name="reduceQueryFields" value="false" />
+        <property name="reduceFieldSets" value="false" />
+        <property name="reduceFieldSetsPerShard" value="false" />
+        <property name="compressFieldSets" value="false" />
+        <!--   should type metadata be reduced to just the fields in the query     -->
         <property name="reduceTypeMetadata" value="false" />
         <property name="reduceTypeMetadataPerShard" value="false" />
     </bean>


### PR DESCRIPTION
Change Set
- fieldset serialization is now standardized
- fieldset reduction is now standardized and options exist for one reduction at the end of query planning or reduction applied on a per-shard basis (for use cases where range stream reduction is applied)
- fieldset compression inspired by https://github.com/NationalSecurityAgency/datawave/pull/1975 was added and is compatible with either mode of fieldset reduction. Note: compression only applied to indexed fields, index-only fields, and composite fields.