### PR TITLE
Pass query parameters to remoteQueryService.planQuery call

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEventQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEventQueryLogic.java
@@ -103,7 +103,7 @@ public class RemoteEventQueryLogic extends BaseQueryLogic<EventBase> implements 
     
     @Override
     public String getPlan(Connector connection, Query settings, Set<Authorizations> auths, boolean expandFields, boolean expandValues) throws Exception {
-        GenericResponse<String> planResponse = remoteQueryService.planQuery(getRemoteQueryLogic(), getCallerObject());
+        GenericResponse<String> planResponse = remoteQueryService.planQuery(getRemoteQueryLogic(), settings.toMap(), getCallerObject());
         return planResponse.getResult();
     }
     


### PR DESCRIPTION
* Previously, no parameters were passed as a part of the remote call to the `/plan` endpoint. This meant the receiver did not get any information about the query to plan, resulting in an odd `415 Unsupported Media Type` error due to the empty POST body.