### PR TITLE
re #2008: Make the default normalization expansions as they were before

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <version.microservice.base-rest-responses>2.1.0</version.microservice.base-rest-responses>
         <version.microservice.common-utils>1.1</version.microservice.common-utils>
         <version.microservice.dictionary-api>2.1.0</version.microservice.dictionary-api>
-        <version.microservice.metadata-utils>2.1.1.2</version.microservice.metadata-utils>
+        <version.microservice.metadata-utils>2.1.1.3</version.microservice.metadata-utils>
         <version.microservice.metrics-reporter>1.3</version.microservice.metrics-reporter>
         <version.microservice.query-metric-api>1.5.7</version.microservice.query-metric-api>
         <version.microservice.type-utils>1.14</version.microservice.type-utils>

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryModelVisitor.java
@@ -2,14 +2,12 @@ package datawave.query.jexl.visitors;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
 import datawave.query.Constants;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
-import datawave.query.jexl.JexlNodeFactory.ContainerType;
 import datawave.query.jexl.LiteralRange;
 import datawave.query.jexl.nodes.BoundedRange;
 import datawave.query.model.QueryModel;
@@ -36,6 +34,7 @@ import org.apache.commons.jexl2.parser.ASTReferenceExpression;
 import org.apache.commons.jexl2.parser.ASTSizeMethod;
 import org.apache.commons.jexl2.parser.JexlNode;
 import org.apache.commons.jexl2.parser.JexlNodes;
+import org.apache.commons.jexl2.parser.LenientExpression;
 import org.apache.commons.jexl2.parser.Node;
 import org.apache.commons.jexl2.parser.ParserTreeConstants;
 import org.apache.commons.jexl2.parser.StrictExpression;
@@ -317,6 +316,15 @@ public class QueryModelVisitor extends RebuildingVisitor {
             List<JexlNode> expressions = new ArrayList<>();
             for (List<String> fieldPair : fieldPairs) {
                 boolean strict = isStrict(fieldPair.get(0)) || isStrict(fieldPair.get(1));
+                boolean lenient = isLenient(fieldPair.get(0)) || isLenient(fieldPair.get(1));
+
+                // if somehow this expression is marked as lenient and strict, then default to old behaviour
+                if (strict && lenient) {
+                    log.warn("Field pair " + fieldPair + " is marked as both strict and lenient.  Applying neither.");
+                    strict = false;
+                    lenient = false;
+                }
+
                 Set<JexlNode> leftSet = left.get(fieldPair.get(0));
                 Set<JexlNode> rightSet = right.get(fieldPair.get(1));
                 product.addAll(Sets.cartesianProduct(leftSet, rightSet));
@@ -340,6 +348,8 @@ public class QueryModelVisitor extends RebuildingVisitor {
                     }
                     if (strict) {
                         expanded = StrictExpression.create(expanded);
+                    } else if (lenient) {
+                        expanded = LenientExpression.create(expanded);
                     }
 
                 }
@@ -489,11 +499,11 @@ public class QueryModelVisitor extends RebuildingVisitor {
     }
 
     /**
-     * Model mappings are lenient by default
+     * Determine if field marked as lenient
      *
      * @param field
      *            The field to test
-     * @return true if not explicitly marked as being strict.
+     * @return true if explicitly marked as lenient
      */
     public boolean isLenient(String field) {
         // user specifications will override the model settings
@@ -503,7 +513,6 @@ public class QueryModelVisitor extends RebuildingVisitor {
             if (userLenient && userStrict) {
                 throw new IllegalArgumentException("Cannot specify the same field as being strict and lenient");
             }
-            return !userStrict;
         }
 
         // determine what the model is treating this as
@@ -513,22 +522,40 @@ public class QueryModelVisitor extends RebuildingVisitor {
             if (modelLenient && modelStrict) {
                 throw new IllegalStateException("The model cannot have both a strict and lenient marker for the same field");
             }
-            return !modelStrict;
         }
 
-        // lenient by default
-        return true;
+        // lenient if explicitly marked as lenient
+        return userLenient || (modelLenient && !userStrict);
     }
 
     /**
-     * Strict if not lenient
+     * Determine if field marked as strict
      *
      * @param field
      *            The field to test
-     * @return true if not lenient
+     * @return true if explicitly marked as strict
      */
     public boolean isStrict(String field) {
-        return !isLenient(field);
+        // user specifications will override the model settings
+        boolean userLenient = lenientFields.contains(field);
+        boolean userStrict = strictFields.contains(field);
+        if (userLenient || userStrict) {
+            if (userLenient && userStrict) {
+                throw new IllegalArgumentException("Cannot specify the same field as being strict and lenient");
+            }
+        }
+
+        // determine what the model is treating this as
+        boolean modelLenient = queryModel.getModelFieldAttributes(field).contains(QueryModel.LENIENT);
+        boolean modelStrict = queryModel.getModelFieldAttributes(field).contains(QueryModel.STRICT);
+        if (modelLenient || modelStrict) {
+            if (modelLenient && modelStrict) {
+                throw new IllegalStateException("The model cannot have both a strict and lenient marker for the same field");
+            }
+        }
+
+        // strict if explicitly marked as strict
+        return userStrict || (modelStrict && !userLenient);
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/LenientFieldsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LenientFieldsTest.java
@@ -246,6 +246,7 @@ public abstract class LenientFieldsTest {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
+        extraParameters.put("lenient.fields", "ETA,AGE,MAGIC,NOME,NAME,NAM,AG");
 
         if (log.isDebugEnabled()) {
             log.debug("testLenientFields");

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -3,15 +3,14 @@ package datawave.query.jexl.visitors;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import datawave.data.type.DateType;
 import datawave.data.type.IpAddressType;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.LcType;
 import datawave.data.type.NoOpType;
 import datawave.data.type.NumberType;
+import datawave.data.type.PointType;
 import datawave.data.type.StringType;
 import datawave.data.type.TrimLeadingZerosType;
-import datawave.data.type.PointType;
 import datawave.data.type.Type;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.jexl.JexlASTHelper;
@@ -31,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -606,6 +606,7 @@ public class ExpandMultiNormalizedTermsTest {
         helper.addTermFrequencyFields(dataTypes.keySet());
 
         config.setQueryFieldsDatatypes(dataTypes);
+        config.setLenientFields(Collections.singleton("FOO"));
 
         // this tests for the successful normalization as a simple number can be normalized as a regex
         String original = "(FOO == 'ab32')";
@@ -639,6 +640,28 @@ public class ExpandMultiNormalizedTermsTest {
         helper.addTermFrequencyFields(dataTypes.keySet());
 
         config.setQueryFieldsDatatypes(dataTypes);
+
+        // this tests for the successful normalization as a simple number can be normalized as a regex
+        String original = "FOO =~ '32' && FOO !~ '42'";
+        String expected = "(FOO =~ '32' || FOO =~ '\\Q+bE3.2\\E') && (FOO !~ '\\Q+bE4.2\\E' && FOO !~ '42')";
+        expandTerms(original, expected);
+
+        // in this case the numeric normalization fails but others succeed (e.g. lcnodiacritics)
+        original = "FOO =~ '3.*2' && FOO !~ '3.*22'";
+        expected = "((_Eval_ = true) && (FOO =~ '3.*2')) && ((_Eval_ = true) && (FOO !~ '3.*22'))";
+        expandTerms(original, expected);
+    }
+
+    @Test
+    public void testLenientFailedRegexNormalizersAndNRNodes() throws ParseException {
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType(), new LcType(), new NumberType()));
+
+        helper.setIndexedFields(dataTypes.keySet());
+        helper.addTermFrequencyFields(dataTypes.keySet());
+
+        config.setQueryFieldsDatatypes(dataTypes);
+        config.setLenientFields(Collections.singleton("FOO"));
 
         // this tests for the successful normalization as a simple number can be normalized as a regex
         String original = "FOO =~ '32' && FOO !~ '42'";

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryModelVisitorTest.java
@@ -353,14 +353,14 @@ public class QueryModelVisitorTest {
     @Test
     public void testLenientQuery() throws ParseException {
         String original = "AG == '123'";
-        String expected = "(AGE == '123') || (ETA == '123')";
+        String expected = "((_Lenient_ = true) && (AGE == '123' || ETA == '123'))";
         assertResult(original, expected);
     }
 
     @Test
     public void testLenientRegexQuery() throws ParseException {
         String original = "AG =~ '123'";
-        String expected = "(AGE =~ '123') || (ETA =~ '123')";
+        String expected = "((_Lenient_ = true) && (AGE =~ '123' || ETA =~ '123'))";
         assertResult(original, expected);
     }
 
@@ -374,7 +374,7 @@ public class QueryModelVisitorTest {
     @Test
     public void testLenientOptionRegexQuery() throws ParseException {
         String original = "FOO =~ '123' && f:lenient(FOO)";
-        String expected = "(BAR1 =~ '123') || (BAR2 =~ '123')";
+        String expected = "((_Lenient_ = true) && (BAR1 =~ '123' || BAR2 =~ '123'))";
         testWithOptionFunction(original, expected, model, Collections.emptySet(), Sets.newHashSet("FOO"), Collections.emptySet());
     }
 


### PR DESCRIPTION
* This will make any lenient/script code updates only applicable if a model field is explicitly marked as such
* The default normalization strategy remains as it was before.