### PR TITLE
backport #2051 to 5.8

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetFunction.java
@@ -45,7 +45,7 @@ public class TermOffsetFunction implements com.google.common.base.Function<Tuple
 
         logStart();
         Map<String,Object> map = new HashMap<>(tfPopulator.getContextMap(from.first(), docKeys, fields));
-        logStop(docKeys.iterator().next());
+        logStop(docKeys);
 
         Document merged = from.second();
         merged.putAll(tfPopulator.document(), false);
@@ -96,14 +96,19 @@ public class TermOffsetFunction implements com.google.common.base.Function<Tuple
         aggregationStart = System.currentTimeMillis();
     }
 
-    private void logStop(Key k) {
+    private void logStop(Set<Key> keys) {
         if (aggregationThreshold == -1) {
             return;
         }
 
         long elapsed = System.currentTimeMillis() - aggregationStart;
         if (elapsed > aggregationThreshold) {
-            log.warn("time to aggregate offsets " + k.getRow() + " " + k.getColumnFamily().toString().replace("\0", "0x00") + " was " + elapsed);
+            if (keys == null || keys.isEmpty()) {
+                log.warn("time to aggregate offsets was " + elapsed);
+            } else {
+                Key k = keys.iterator().next();
+                log.warn("time to aggregate offsets " + k.getRow() + " " + k.getColumnFamily().toString().replace("\0", "0x00") + " was " + elapsed);
+            }
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/TermOffsetFunctionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/postprocessing/tf/TermOffsetFunctionTest.java
@@ -1,0 +1,58 @@
+package datawave.query.postprocessing.tf;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import datawave.query.attributes.Document;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.util.Tuple2;
+import datawave.query.util.Tuple3;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TermOffsetFunctionTest {
+
+    @Test
+    public void testApplyWithLogLogAggregationPruneToZero() throws Exception {
+        TermFrequencyConfig config = new TermFrequencyConfig();
+        config.setScript(JexlASTHelper.parseAndFlattenJexlQuery("content:phrase(FOO, termOffsetMap, 'bar', 'baz')"));
+        DocumentKeysFunction docKeyFunction = new DocumentKeysFunction(config);
+
+        MyTermOffsetPopulator termOffsetPopulator = new MyTermOffsetPopulator(null, config);
+
+        TermOffsetFunction termOffsetFunction = new TermOffsetFunction(termOffsetPopulator, Collections.emptySet(), docKeyFunction);
+        Tuple3<Key,Document,Map<String,Object>> tuple = termOffsetFunction.apply(new Tuple2<>(new Key(), new Document()));
+        assertEquals(new Key(), tuple.first());
+        assertEquals(new Document(), tuple.second());
+        assertEquals(new HashMap<String,Object>(), tuple.third());
+    }
+
+    // no-op
+    private static class MyTermOffsetPopulator extends TermOffsetPopulator {
+
+        public MyTermOffsetPopulator(Multimap<String,String> termFrequencyFieldValues, TermFrequencyConfig config) {
+            super(termFrequencyFieldValues, config);
+        }
+
+        public Multimap<String,String> getTermFrequencyFieldValues() {
+            return HashMultimap.create();
+        }
+
+        public Map<String,Object> getContextMap(Key docKey, Set<Key> keys, Set<String> fields) {
+            return new HashMap<>();
+        }
+
+        public Document document() {
+            return new Document();
+        }
+    }
+
+}


### PR DESCRIPTION
Backport of #2051 to release/version5.8

Note that 2051 used jupiter api which is not available in 5.8, those imports were switched to junit. 