### PR TITLE
Add auto commit of formatting diffs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,8 @@ env:
 
 jobs:
   # Runs the pom sorter and code formatter to ensure that the code
-  # is formatted and poms are sorted according to project rules. This
-  # will fail if the formatter makes any changes.
+  # is formatted and poms are sorted according to project rules. If changes are found,
+  # they are committed back to the branch
   check-code-formatting:
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +35,20 @@ jobs:
       run: |
         mvn -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Pautoformat
         git status
-        git diff-index --quiet HEAD || (echo "Error! There are modified files after formatting." && false)
+        git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
+    - name: Commit Changes
+      run: |
+        if [ "$diffs_found" = true ]; then
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "datawave@github.com"
+          git commit -am "Formatting job fix"
+          git push
+        else
+          echo "Nothing to do"
+        fi
+        
+      
+        
 
   # Build the code and run the unit/integration tests.
   build-and-test:


### PR DESCRIPTION
This PR changes the formatting job behavior to auto commit.

This has been tested to work both for the positive (changes found) and negative (changes not found) cases.

The new commit generated on the branch with the formatting changes will not create a new workflow as we are using the implicit github token to push, which is prevented from starting new workflows.