### PR TITLE
Draft: Stop tying ConfigurableAgeOffIterators refresh thread to table id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <version.hadoop-shaded>1.1.1</version.hadoop-shaded>
         <version.httpcomponents-httpclient>4.5.13</version.httpcomponents-httpclient>
         <version.httpcomponents-httpcore>4.4.8</version.httpcomponents-httpcore>
-        <version.in-memory-accumulo>2.1.0</version.in-memory-accumulo>
+        <version.in-memory-accumulo>2.1.1</version.in-memory-accumulo>
         <version.infinispan>9.4.21.Final</version.infinispan>
         <version.jackson>2.10.0.pr1</version.jackson>
         <version.javassist>3.24.0-GA</version.javassist>

--- a/warehouse/core/src/main/java/datawave/iterators/filter/ConfigurableAgeOffFilter.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/ConfigurableAgeOffFilter.java
@@ -134,7 +134,7 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
 
     protected static FileSystem fs = null;
 
-    private IteratorEnvironment myEnv;
+    protected IteratorEnvironment myEnv;
 
     private PluginEnvironment pluginEnv;
 
@@ -200,7 +200,7 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
     public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
 
         myEnv = env;
-        pluginEnv = env.getPluginEnv();
+        pluginEnv = env == null ? null : env.getPluginEnv();
         return ((ConfigurableAgeOffFilter) super.deepCopy(env)).initialize(this);
     }
 
@@ -314,7 +314,7 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
         super.init(source, options, env);
 
         myEnv = env;
-        pluginEnv = env.getPluginEnv();
+        pluginEnv = env == null ? null : env.getPluginEnv();
 
         // disabled if this is a system initialized major compaction and we are configured to disable as such
         String disableOnNonFullMajcStr = options.get(AgeOffConfigParams.DISABLE_ON_NON_FULL_MAJC);

--- a/warehouse/core/src/main/java/datawave/iterators/filter/ConfigurableAgeOffFilter.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/ConfigurableAgeOffFilter.java
@@ -8,13 +8,12 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.conf.AccumuloConfiguration;
+import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.Filter;
@@ -135,7 +134,9 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
 
     protected static FileSystem fs = null;
 
-    protected IteratorEnvironment myEnv;
+    private IteratorEnvironment myEnv;
+
+    private PluginEnvironment pluginEnv;
 
     // Adding the ability to disable the filter checks in the case of a system-initialized major compaction for example.
     // The thought is that we force compactions where we want the data to aged off.
@@ -199,6 +200,7 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
     public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
 
         myEnv = env;
+        pluginEnv = env.getPluginEnv();
         return ((ConfigurableAgeOffFilter) super.deepCopy(env)).initialize(this);
     }
 
@@ -312,6 +314,7 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
         super.init(source, options, env);
 
         myEnv = env;
+        pluginEnv = env.getPluginEnv();
 
         // disabled if this is a system initialized major compaction and we are configured to disable as such
         String disableOnNonFullMajcStr = options.get(AgeOffConfigParams.DISABLE_ON_NON_FULL_MAJC);
@@ -394,12 +397,10 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
     }
 
     private long getLongProperty(final String prop, final long defaultValue) {
-        if (this.myEnv != null && this.myEnv.getConfig() != null) {
-            AccumuloConfiguration conf = this.myEnv.getConfig();
-            Map<String,String> properties = new TreeMap<>();
-            conf.getProperties(properties, p -> Objects.equals(prop, p));
-            if (properties.containsKey(prop)) {
-                return Long.parseLong(properties.get(prop));
+        if (pluginEnv != null && pluginEnv.getConfiguration() != null) {
+            String propValue = pluginEnv.getConfiguration().get(prop);
+            if (propValue != null) {
+                return Long.parseLong(propValue);
             }
         }
         return defaultValue;

--- a/warehouse/core/src/test/java/datawave/iterators/filter/ConfigurableAgeOffFilterTest.java
+++ b/warehouse/core/src/test/java/datawave/iterators/filter/ConfigurableAgeOffFilterTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.DefaultConfiguration;
 import org.apache.accumulo.core.data.Key;
@@ -22,6 +23,7 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.util.ConfigurationImpl;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
@@ -42,17 +44,24 @@ public class ConfigurableAgeOffFilterTest extends EasyMockSupport {
     @Mock
     private IteratorEnvironment env;
     @Mock
+    private PluginEnvironment pluginEnv;
+    @Mock
     private SortedKeyValueIterator<Key,Value> source;
 
     private AccumuloConfiguration conf = DefaultConfiguration.getInstance();
 
     @Before
     public void setUp() throws Exception {
+        expect(pluginEnv.getConfiguration()).andReturn(new ConfigurationImpl(conf)).anyTimes();
+
         expect(env.getConfig()).andReturn(conf).anyTimes();
+        expect(env.getPluginEnv()).andReturn(pluginEnv).anyTimes();
+
         // These two are only for the disabled test
         expect(env.getIteratorScope()).andReturn(IteratorUtil.IteratorScope.majc).anyTimes();
         expect(env.isFullMajorCompaction()).andReturn(false).anyTimes();
-        replay(env);
+
+        replay(env, pluginEnv);
     }
 
     @Test


### PR DESCRIPTION
The ConfigurableAgeOffIterator's refresh thread is using the `getLongProperty()` method on each refresh cycle which ends up using `myEnv`. The `myEnv` was the IteratorEnvironment of the first invocation of the iterator stack on each tserver - tying it to a particular tableId internally (IteratorEnvironment -> ZooBasedConfiguration -> TablePropKey).

We need the refresh thread to NOT be tied to a particular table as tables can be deleted. The PluginEnvironment is not tied to a particular tableid.