### PR TITLE
Update for caching and additional profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <version.kryonet>2.20</version.kryonet>
         <version.log4j2>2.17.2</version.log4j2>
         <version.lucene>7.5.0</version.lucene>
+        <version.maven-install-plugin>2.5.2</version.maven-install-plugin>
         <version.metrics-cdi>1.6.0</version.metrics-cdi>
         <version.microservice.accumulo-api>3.0.0</version.microservice.accumulo-api>
         <version.microservice.accumulo-utils>3.0.0</version.microservice.accumulo-utils>
@@ -1494,6 +1495,11 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${version.maven-install-plugin}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
Update for maven 3.9 when using profiles that invoke source only packages.