### PR TITLE
TLDEquality refactored to perform an in-line byte comparison

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/function/TLDEquality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/TLDEquality.java
@@ -35,6 +35,6 @@ public class TLDEquality implements Equality {
                 return true;
             }
         }
-        return true;
+        return len != 0;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/function/TLDEquality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/TLDEquality.java
@@ -3,11 +3,9 @@ package datawave.query.function;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 
-import datawave.query.tld.TLD;
-
 /**
  * A key equality implementation that compares to the root pointers of two doc Ids together.
- *
+ * <p>
  * For example, two IDs `h1.h2.h3.a.b.c.d` and `h1.h2.h3.e.f` would be considered equal by this check.
  */
 public class TLDEquality implements Equality {
@@ -23,8 +21,20 @@ public class TLDEquality implements Equality {
      */
     @Override
     public boolean partOf(Key key, Key other) {
-        ByteSequence docCF = TLD.estimateRootPointerFromId(key.getColumnFamilyData());
-        ByteSequence otherCF = TLD.estimateRootPointerFromId(other.getColumnFamilyData());
-        return otherCF.equals(docCF);
+        ByteSequence keyCf = key.getColumnFamilyData();
+        ByteSequence otherCf = other.getColumnFamilyData();
+
+        int dotCount = 0;
+        int len = Math.min(keyCf.length(), otherCf.length());
+        for (int i = 0; i < len; i++) {
+            byte a = keyCf.byteAt(i);
+            byte b = otherCf.byteAt(i);
+            if (a != b) {
+                return false;
+            } else if (a == '.' && ++dotCount == 3) {
+                return true;
+            }
+        }
+        return true;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/function/TLDEqualityTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/TLDEqualityTest.java
@@ -1,68 +1,64 @@
 package datawave.query.function;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.accumulo.core.data.Key;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TLDEqualityTest {
+class TLDEqualityTest {
+    private final Key key = new Key("row", "datatype\0-7m7uk9.oz9qpy.-nfahrv");
+    private final Key keyChildOne = new Key("row", "datatype\0-7m7uk9.oz9qpy.-nfahrv.123.987");
+    private final Key keyChildTwo = new Key("row", "datatype\0-7m7uk9.oz9qpy.-nfahrv.123.777");
+    private final Key otherKey = new Key("row", "datatype\0-7m7uk9.oz9qpy.-aaazzz");
+    private final Key otherKeyChildOne = new Key("row", "datatype\0-7m7uk9.oz9qpy.-aaazzz.123.987");
 
-    private TLDEquality equality = new TLDEquality();
+    private final TLDEquality equality = new TLDEquality();
 
     @Test
-    public void testSameParent() {
-        Key docKey = new Key("row", "parent.document.id");
-        Key otherKey = new Key("row", "parent.document.id");
-        assertTrue(equality.partOf(docKey, otherKey));
-        assertTrue(equality.partOf(otherKey, docKey));
+    void testSameParent() {
+        assertTrue(equality.partOf(key, key));
+        assertTrue(equality.partOf(otherKey, otherKey));
     }
 
     @Test
-    public void testDifferentParents() {
-        Key docKey = new Key("row", "parent.document.id");
-        Key otherKey = new Key("row", "parent.document.id2");
-        assertFalse(equality.partOf(docKey, otherKey));
-        assertFalse(equality.partOf(otherKey, docKey));
+    void testDifferentParents() {
+        assertFalse(equality.partOf(key, otherKey));
+        assertFalse(equality.partOf(otherKey, key));
     }
 
     @Test
-    public void testKeysOfDifferentDepths() {
-        Key docKey = new Key("row", "parent.document.id");
-        Key otherKey = new Key("row", "parent.document.id.child");
-        assertFalse(equality.partOf(docKey, otherKey));
-        assertFalse(equality.partOf(otherKey, docKey));
+    void testKeysOfDifferentDepths() {
+        assertTrue(equality.partOf(key, keyChildOne));
+        assertTrue(equality.partOf(keyChildOne, key));
+
+        assertTrue(equality.partOf(otherKey, otherKeyChildOne));
+        assertTrue(equality.partOf(otherKeyChildOne, otherKey));
     }
 
     @Test
-    public void testSameParentSameChildren() {
-        Key docKey = new Key("row", "parent.document.id.child");
-        Key otherKey = new Key("row", "parent.document.id.child");
-        assertTrue(equality.partOf(docKey, otherKey));
-        assertTrue(equality.partOf(otherKey, docKey));
+    void testSameParentSameChildren() {
+        assertTrue(equality.partOf(keyChildOne, keyChildOne));
+        assertTrue(equality.partOf(keyChildTwo, keyChildTwo));
+
+        assertTrue(equality.partOf(otherKeyChildOne, otherKeyChildOne));
     }
 
     @Test
-    public void testSameParentDifferentChildren() {
-        Key docKey = new Key("row", "parent.document.id.child");
-        Key otherKey = new Key("row", "parent.document.id.child2");
-        assertFalse(equality.partOf(docKey, otherKey));
-        assertFalse(equality.partOf(otherKey, docKey));
+    void testSameParentDifferentChildren() {
+        assertTrue(equality.partOf(keyChildOne, keyChildTwo));
+        assertTrue(equality.partOf(keyChildTwo, keyChildOne));
     }
 
     @Test
-    public void testDifferentParentSameChildren() {
-        Key docKey = new Key("row", "parent.document.id.child");
-        Key otherKey = new Key("row", "parent.document.id2.child");
-        assertFalse(equality.partOf(docKey, otherKey));
-        assertFalse(equality.partOf(otherKey, docKey));
+    void testDifferentParentSameChildren() {
+        assertFalse(equality.partOf(keyChildOne, otherKeyChildOne));
+        assertFalse(equality.partOf(otherKeyChildOne, keyChildOne));
     }
 
     @Test
-    public void testDifferentParentDifferentChildren() {
-        Key docKey = new Key("row", "parent.document.id.child");
-        Key otherKey = new Key("row", "parent.document.id2.child2");
-        assertFalse(equality.partOf(docKey, otherKey));
-        assertFalse(equality.partOf(otherKey, docKey));
+    void testDifferentParentDifferentChildren() {
+        assertFalse(equality.partOf(keyChildTwo, otherKeyChildOne));
+        assertFalse(equality.partOf(otherKeyChildOne, keyChildTwo));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/function/TLDEqualityTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/TLDEqualityTest.java
@@ -61,4 +61,15 @@ class TLDEqualityTest {
         assertFalse(equality.partOf(keyChildTwo, otherKeyChildOne));
         assertFalse(equality.partOf(otherKeyChildOne, keyChildTwo));
     }
+
+    @Test
+    void testEdgeCases() {
+        assertFalse(equality.partOf(key, new Key("", "")));
+        assertFalse(equality.partOf(new Key("", ""), key));
+
+        // in practice this should never happen
+        Key malformedUid = new Key("row", "datatype\0-7m7uk9.oz9qpy.-");
+        assertTrue(equality.partOf(key, malformedUid));
+        assertTrue(equality.partOf(malformedUid, key));
+    }
 }


### PR DESCRIPTION
TLDEquality refactored to perform an in-line byte comparison instead of delegating to expensive TLD utility methods