### PR TITLE
2013 - jexl uuid query parser research/changes

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlUUIDQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/jexl/LuceneToJexlUUIDQueryParser.java
@@ -12,7 +12,6 @@ import datawave.query.search.FieldedTerm;
 import datawave.query.search.RangeFieldedTerm;
 import datawave.query.search.WildcardFieldedTerm;
 
-@Deprecated
 public class LuceneToJexlUUIDQueryParser extends LuceneToJexlQueryParser {
     private List<UUIDType> uuidTypes = new ArrayList<>();
     private LuceneQueryParser luceneParser = new LuceneQueryParser();

--- a/warehouse/query-core/src/main/java/datawave/query/language/parser/lucene/LuceneQueryParser.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/parser/lucene/LuceneQueryParser.java
@@ -30,7 +30,6 @@ import datawave.query.search.FieldedTerm;
 import datawave.query.search.RangeFieldedTerm;
 import datawave.query.search.Term;
 
-@Deprecated
 public class LuceneQueryParser implements QueryParser {
     private static Logger log = Logger.getLogger(LuceneQueryParser.class.getName());
     private Map<String,String> filters = new HashMap<>();


### PR DESCRIPTION
```
In [20806624] LuceneToJexlUUIDQueryParser.java#L15, the LuceneToJexlUUIDQueryParser was marked deprecated, but no suggested replacement is indicated. It is used in the current QueryLogicFactory.xml#L295 . 
If this class isn't really needed anymore, we should update QueryLogicFactory.xml with an alternate configuration that replaces it.  If the class is still needed, we should remove the @Deprecated tag.

```
In testing the other classes that implement the QueryParser, I determined that no existing ones can replace the "Deprecared" LuceneQueryParser. Removed the @Deprecated tags.