### PR TITLE
fixes #2175: composite query logic error handling

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeLogicException.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeLogicException.java
@@ -1,11 +1,44 @@
 package datawave.webservice.query.logic.composite;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
+import datawave.webservice.query.exception.QueryException;
+
 public class CompositeLogicException extends RuntimeException {
+    public CompositeLogicException(String message, String logicName, Exception exception) {
+        super(getMessage(message, Collections.singletonMap(logicName, exception)), exception);
+    }
+
     public CompositeLogicException(String message, Map<String,Exception> exceptions) {
-        super(getMessage(message, exceptions));
-        exceptions.values().stream().forEach(e -> addSuppressed(e));
+        super(getMessage(message, exceptions), getQueryException(exceptions.values()));
+        if (exceptions.size() > 1) {
+            exceptions.values().stream().forEach(e -> addSuppressed(e));
+        }
+    }
+
+    // looking for an exception that has a nested QueryException such that we may return an error code
+    private static Exception getQueryException(Collection<Exception> exceptions) {
+        if (exceptions.size() == 1) {
+            return exceptions.iterator().next();
+        }
+        Exception e = null;
+        for (Exception test : exceptions) {
+            if (e == null) {
+                e = test;
+            } else if (isQueryException(test)) {
+                e = test;
+            }
+            if (isQueryException(e)) {
+                break;
+            }
+        }
+        return e;
+    }
+
+    private static boolean isQueryException(Exception e) {
+        return new QueryException(e).getQueryExceptionsInStack().size() > 1;
     }
 
     private static String getMessage(String message, Map<String,Exception> exceptions) {

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogic.java
@@ -3,7 +3,6 @@ package datawave.webservice.query.logic.composite;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -133,7 +132,8 @@ public class CompositeQueryLogic extends BaseQueryLogic<Object> {
                 Object last = new Object();
                 if (this.getMaxResults() <= 0)
                     this.setMaxResults(Long.MAX_VALUE);
-                while ((null != last) && !interrupted && transformIterator.hasNext() && (resultCount < this.getMaxResults())) {
+                // allow us to get 1 more than maxResults so that the RunningQuery can detect the MAX_RESULTS condition.
+                while ((null != last) && !interrupted && transformIterator.hasNext() && (resultCount <= this.getMaxResults())) {
                     try {
                         last = transformIterator.next();
                         if (null != last) {
@@ -170,7 +170,7 @@ public class CompositeQueryLogic extends BaseQueryLogic<Object> {
                 }
                 success = true;
             } catch (Exception e) {
-                throw new CompositeLogicException("Failed to retrieve results", Collections.singletonMap(getLogicName(), e));
+                throw new CompositeLogicException("Failed to retrieve results", getLogicName(), e);
             } finally {
                 if (success) {
                     completionLatch.countDown();

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogicResultsIterator.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogicResultsIterator.java
@@ -36,6 +36,9 @@ public class CompositeQueryLogicResultsIterator implements Iterator<Object>, Thr
             }
             while (nextEntry == null) {
                 try {
+                    if (failure != null) {
+                        Throwables.propagate(failure);
+                    }
                     while (nextEntry == null && failure == null && (!results.isEmpty() || logic.getCompletionLatch().getCount() > 0)) {
                         nextEntry = results.poll(1, TimeUnit.SECONDS);
                     }
@@ -62,6 +65,9 @@ public class CompositeQueryLogicResultsIterator implements Iterator<Object>, Thr
                         }
                     }
                 } catch (InterruptedException e) {
+                    if (failure != null) {
+                        Throwables.propagate(failure);
+                    }
                     throw new RuntimeException(e);
                 }
             }
@@ -84,6 +90,9 @@ public class CompositeQueryLogicResultsIterator implements Iterator<Object>, Thr
             if (hasNext()) {
                 current = nextEntry;
                 nextEntry = null;
+            }
+            if (failure != null) {
+                Throwables.propagate(failure);
             }
         }
         return current;

--- a/web-services/query/src/test/java/datawave/webservice/query/logic/composite/CompositeQueryLogicTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/logic/composite/CompositeQueryLogicTest.java
@@ -44,6 +44,7 @@ import datawave.webservice.query.cache.ResultsPage;
 import datawave.webservice.query.cache.ResultsPage.Status;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
 import datawave.webservice.query.exception.EmptyObjectException;
+import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.logic.BaseQueryLogic;
 import datawave.webservice.query.logic.BaseQueryLogicTransformer;
 import datawave.webservice.query.logic.DatawaveRoleManager;
@@ -695,6 +696,47 @@ public class CompositeQueryLogicTest {
         c.getTransformer(settings);
     }
 
+    @Test
+    public void testInitializeAllFailQueryExceptionCause() throws Exception {
+
+        Map<String,QueryLogic<?>> logics = new HashMap<>();
+        logics.put("TestQueryLogic", new TestQueryLogic() {
+            @Override
+            public GenericQueryConfiguration initialize(AccumuloClient connection, Query settings, Set<Authorizations> runtimeQueryAuthorizations)
+                            throws Exception {
+                throw new Exception("initialize failed");
+            }
+        });
+
+        logics.put("TestQueryLogic2", new TestQueryLogic2() {
+            @Override
+            public GenericQueryConfiguration initialize(AccumuloClient connection, Query settings, Set<Authorizations> runtimeQueryAuthorizations)
+                            throws Exception {
+                throw new RuntimeException(new QueryException("query initialize failed"));
+            }
+        });
+
+        QueryImpl settings = new QueryImpl();
+        settings.setPagesize(100);
+        settings.setQueryAuthorizations(auths.toString());
+        settings.setQuery("FOO == 'BAR'");
+        settings.setParameters(new HashSet<>());
+        settings.setId(UUID.randomUUID());
+
+        CompositeQueryLogic c = new CompositeQueryLogic();
+        c.setAllMustInitialize(true);
+        c.setQueryLogics(logics);
+
+        c.setPrincipal(principal);
+        try {
+            c.initialize(null, settings, Collections.singleton(auths));
+
+            c.getTransformer(settings);
+        } catch (CompositeLogicException e) {
+            Assert.assertEquals("query initialize failed", e.getCause().getCause().getMessage());
+        }
+    }
+
     @Test(expected = RuntimeException.class)
     public void testInitializeWithDifferentResponseTypes() throws Exception {
 
@@ -1150,8 +1192,8 @@ public class CompositeQueryLogicTest {
 
         CompositeQueryLogic c = new CompositeQueryLogic();
         // max.results.override is set to -1 when it is not passed in as it is an optional parameter
-        logic1.setMaxResults(1);
-        logic2.setMaxResults(4);
+        logic1.setMaxResults(2); // it can return 4, so this will cap it at 3 (1 more than max)
+        logic2.setMaxResults(1); // it cat return 4, so this will cap it at 2 (1 more than max)
         /**
          * RunningQuery.setupConnection()
          */


### PR DESCRIPTION
* Allow the underlying logics to return 1 more than the max results
  * This allows the RunningQuery to detect the MAX_RESULTS case
* Ensure that any QueryException (which contains the error code) is selected as the cause when passing the exception up