### PR TITLE
remove bad excerpt pruning logic

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -566,10 +566,8 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
      *            the IteratorSetting
      */
     private void configureExcerpts(ShardQueryConfiguration config, IteratorSetting cfg) {
-        if (config.isTermFrequenciesRequired()) {
-            addOption(cfg, QueryOptions.EXCERPT_FIELDS, config.getExcerptFields().toString(), true);
-            addOption(cfg, QueryOptions.EXCERPT_ITERATOR, config.getExcerptIterator().getName(), false);
-        }
+        addOption(cfg, QueryOptions.EXCERPT_FIELDS, config.getExcerptFields().toString(), true);
+        addOption(cfg, QueryOptions.EXCERPT_ITERATOR, config.getExcerptIterator().getName(), false);
     }
 
     /*

--- a/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
@@ -476,11 +476,7 @@ public class VisitorFunction implements Function<ScannerChunk,ScannerChunk> {
      *            the iterator settings
      */
     protected void pruneQueryOptions(ASTJexlScript script, IteratorSetting settings) {
-
-        if (config.isTermFrequenciesRequired() && TermOffsetPopulator.getContentFunctions(script).isEmpty()) {
-            settings.removeOption(QueryOptions.EXCERPT_FIELDS);
-            settings.removeOption(QueryOptions.EXCERPT_ITERATOR);
-        }
+        // stub for now
     }
 
     // push down large fielded lists. Assumes that the hdfs query cache uri and


### PR DESCRIPTION
I'm leaving the `pruneQueryOptions` method in the VisitorFunction because I would like to use that in the future. 

The reason this isn't a direct revert of the original merge request is due to non-trivial changes in the shard query config test and import sorting.