### PR TITLE
Inject updated iterator environment into ConfigurableAgeOffFilter Rules

### DIFF
--- a/warehouse/core/src/main/java/datawave/iterators/filter/ConfigurableAgeOffFilter.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/ConfigurableAgeOffFilter.java
@@ -418,7 +418,7 @@ public class ConfigurableAgeOffFilter extends Filter implements OptionDescriber 
                 for (FilterRule rule : rules) {
                     // NOTE: this propagates the anchor time (scanStart) to all of the applied rules
                     // This is used to calculate the AgeOffPeriod for all of the rules
-                    filterList.add((AppliedRule) rule.deepCopy(this.scanStart));
+                    filterList.add((AppliedRule) rule.deepCopy(this.scanStart, myEnv));
                 }
             }
 

--- a/warehouse/core/src/main/java/datawave/iterators/filter/ageoff/AppliedRule.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/ageoff/AppliedRule.java
@@ -97,7 +97,7 @@ public abstract class AppliedRule implements FilterRule {
      * @see datawave.iterators.filter.ageoff.FilterRule#deepCopy(datawave.iterators.filter.ageoff.AgeOffPeriod)
      */
     @Override
-    public FilterRule deepCopy(AgeOffPeriod period) {
+    public FilterRule deepCopy(AgeOffPeriod period, IteratorEnvironment iterEnv) {
         AppliedRule newFilter;
         try {
             newFilter = (AppliedRule) super.getClass().getDeclaredConstructor().newInstance();
@@ -113,15 +113,11 @@ public abstract class AppliedRule implements FilterRule {
         return null;
     }
 
-    public FilterRule decorate(Object decorator) {
-        return this;
-    }
-
     /**
      * @param scanStart
      * @return
      */
-    public FilterRule deepCopy(long scanStart) {
+    public FilterRule deepCopy(long scanStart, IteratorEnvironment iterEnv) {
         AppliedRule newFilter;
         try {
             newFilter = (AppliedRule) super.getClass().newInstance();

--- a/warehouse/core/src/main/java/datawave/iterators/filter/ageoff/FilterRule.java
+++ b/warehouse/core/src/main/java/datawave/iterators/filter/ageoff/FilterRule.java
@@ -33,14 +33,12 @@ public interface FilterRule {
      */
     boolean accept(SortedKeyValueIterator<Key,Value> iter);
 
-    FilterRule decorate(Object decoratedObject);
-
-    FilterRule deepCopy(AgeOffPeriod period);
+    FilterRule deepCopy(AgeOffPeriod period, IteratorEnvironment iterEnv);
 
     /**
      * @param scanStart
      * @return
      */
-    FilterRule deepCopy(long scanStart);
+    FilterRule deepCopy(long scanStart, IteratorEnvironment iterEnv);
 
 }

--- a/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/TestFilter.java
+++ b/warehouse/core/src/test/java/datawave/ingest/util/cache/watch/TestFilter.java
@@ -40,17 +40,12 @@ public class TestFilter extends AppliedRule {
     }
 
     @Override
-    public FilterRule decorate(Object decoratedObject) {
+    public FilterRule deepCopy(AgeOffPeriod period, IteratorEnvironment iterEnv) {
         return null;
     }
 
     @Override
-    public FilterRule deepCopy(AgeOffPeriod period) {
-        return null;
-    }
-
-    @Override
-    public FilterRule deepCopy(long scanStart) {
+    public FilterRule deepCopy(long scanStart, IteratorEnvironment iterEnv) {
         return this;
     }
 }

--- a/warehouse/core/src/test/java/datawave/iterators/filter/ConfigurableAgeOffFilterTest.java
+++ b/warehouse/core/src/test/java/datawave/iterators/filter/ConfigurableAgeOffFilterTest.java
@@ -239,7 +239,7 @@ public class ConfigurableAgeOffFilterTest extends EasyMockSupport {
         inner.init(filterOpts);
         Collection<AppliedRule> list = new ArrayList<>();
         // need to do this because otherwise will use 0 as the anchor time
-        AppliedRule copyWithCorrectTimestamp = (AppliedRule) inner.deepCopy(System.currentTimeMillis());
+        AppliedRule copyWithCorrectTimestamp = (AppliedRule) inner.deepCopy(System.currentTimeMillis(), env);
         list.add(copyWithCorrectTimestamp);
         return list;
     }

--- a/warehouse/core/src/test/java/datawave/iterators/filter/ageoff/FieldAgeOffFilterTest.java
+++ b/warehouse/core/src/test/java/datawave/iterators/filter/ageoff/FieldAgeOffFilterTest.java
@@ -181,7 +181,7 @@ public class FieldAgeOffFilterTest {
         ageOffFilter.init(filterOptions, iterEnv);
         Assert.assertNotNull("IteratorEnvironment should not be null after init!", ageOffFilter.iterEnv);
         // originally this would cause the iterEnv to be lost and test would fail
-        ageOffFilter = (FieldAgeOffFilter) ageOffFilter.deepCopy(tenSecondsAgo);
+        ageOffFilter = (FieldAgeOffFilter) ageOffFilter.deepCopy(tenSecondsAgo, iterEnv);
 
         Assert.assertNotNull("IteratorEnvironment should not be null after deep copy!", ageOffFilter.iterEnv);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlRule.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Maps;
 import datawave.iterators.filter.ageoff.AgeOffPeriod;
 import datawave.iterators.filter.ageoff.AppliedRule;
 import datawave.iterators.filter.ageoff.FilterOptions;
-import datawave.iterators.filter.ageoff.FilterRule;
 import datawave.query.Constants;
 import datawave.query.iterator.QueryIterator;
 import datawave.query.iterator.QueryOptions;
@@ -36,8 +35,6 @@ public class JexlRule extends AppliedRule {
     protected boolean isApplied;
 
     private HashMap<String,String> iterOptions;
-
-    protected IteratorEnvironment environment;
 
     private static final Logger log = Logger.getLogger(JexlRule.class);
 
@@ -70,15 +67,6 @@ public class JexlRule extends AppliedRule {
         iterOptions.put(QueryOptions.CONTAINS_INDEX_ONLY_TERMS, "false");
     }
 
-    @Override
-    public FilterRule decorate(Object decorate) {
-        if (decorate instanceof IteratorEnvironment) {
-            this.environment = (IteratorEnvironment) decorate;
-        }
-
-        return this;
-    }
-
     /*
      * (non-Javadoc)
      *
@@ -101,7 +89,7 @@ public class JexlRule extends AppliedRule {
             if (queryIter == null) {
                 queryIter = new QueryIterator();
                 try {
-                    queryIter.init(iter.deepCopy(environment), iterOptions, environment);
+                    queryIter.init(iter.deepCopy(iterEnv), iterOptions, iterEnv);
                 } catch (IOException e) {
                     log.debug("Failed to initialize queryIter with provided query", e);
                     return false;


### PR DESCRIPTION
We are storing the ConfigurableAgeOffFilter's Rule objects statically in the JVM. They will have lingering references to whatever iteratorEnvironment was active when we initialized the Rules (whichever scan/compaction ran first). When a new compaction/scan uses the Rules, it will pull them from the cache and invoke the .deepCopy() method to make a fresh copy of each Rule it is using. Previously, the iterator environment was still pointing to the first operation done with the Rule (first compaction/scan). In this PR, I added the updated iterator environment to the deepCopy() invocations so that the clones of the Rule will now have the appropriate iterator environment instead of the stale/cached one.