### PR TITLE
Encapsulate Document Serialization in the QueryIterator

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -59,7 +59,6 @@ import datawave.data.type.util.NumericalEncoder;
 import datawave.ingest.data.config.ingest.CompositeIngest;
 import datawave.marking.MarkingFunctionsFactory;
 import datawave.query.Constants;
-import datawave.query.DocumentSerialization.ReturnType;
 import datawave.query.attributes.AttributeKeepFilter;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.ExcerptFields;
@@ -81,10 +80,6 @@ import datawave.query.function.MaskedValueFilterFactory;
 import datawave.query.function.MaskedValueFilterInterface;
 import datawave.query.function.RangeProvider;
 import datawave.query.function.RemoveGroupingContext;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
-import datawave.query.function.serializer.KryoDocumentSerializer;
-import datawave.query.function.serializer.ToStringDocumentSerializer;
-import datawave.query.function.serializer.WritableDocumentSerializer;
 import datawave.query.iterator.aggregation.DocumentData;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.iterator.pipeline.PipelineFactory;
@@ -172,7 +167,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
     protected SortedKeyValueIterator<Key,Value> sourceForDeepCopies;
     protected Map<String,String> documentOptions;
     protected NestedIterator<Key> initKeySource, seekKeySource;
-    protected Iterator<Entry<Key,Value>> serializedDocuments;
+    protected Iterator<Entry<Key,Document>> documentIterator;
     protected boolean fieldIndexSatisfiesQuery = false;
 
     protected Range range;
@@ -385,7 +380,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
                 // see if we can fail fast. If we were rebuilt with the FinalDocument key, then we are already completely done
                 if (collectTimingDetails && FinalDocumentTrackingIterator.isFinalDocumentKey(range.getStartKey())) {
                     this.seekKeySource = new EmptyTreeIterable();
-                    this.serializedDocuments = EmptyIterator.emptyIterator();
+                    this.documentIterator = EmptyIterator.emptyIterator();
                     prepareKeyValue();
                     return;
                 }
@@ -493,47 +488,26 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
                 return true;
             });
 
-            if (this.getReturnType() == ReturnType.kryo) {
-                // Serialize the Document using Kryo
-                this.serializedDocuments = Iterators.transform(pipelineDocuments, new KryoDocumentSerializer(isReducedResponse(), isCompressResults()));
-            } else if (this.getReturnType() == ReturnType.writable) {
-                // Use the Writable interface to serialize the Document
-                this.serializedDocuments = Iterators.transform(pipelineDocuments, new WritableDocumentSerializer(isReducedResponse()));
-            } else if (this.getReturnType() == ReturnType.tostring) {
-                // Just return a toString() representation of the document
-                this.serializedDocuments = Iterators.transform(pipelineDocuments, new ToStringDocumentSerializer(isReducedResponse()));
-            } else {
-                throw new IllegalArgumentException("Unknown return type of: " + this.getReturnType());
-            }
-
-            if (log.isTraceEnabled()) {
-                KryoDocumentDeserializer dser = new KryoDocumentDeserializer();
-                this.serializedDocuments = Iterators.filter(this.serializedDocuments, keyValueEntry -> {
-                    log.trace("after serializing, keyValueEntry:" + dser.apply(keyValueEntry));
-                    return true;
-                });
-            }
+            this.documentIterator = pipelineDocuments;
 
             // now add the result count to the keys (required when not sorting UIDs)
             // Cannot do this on document specific ranges as the count would place the keys outside the initial range
             if (!sortedUIDs && documentRange == null) {
-                this.serializedDocuments = new ResultCountingIterator(serializedDocuments, resultCount, yield);
+                this.documentIterator = new ResultCountingIterator(documentIterator, resultCount, yield);
             } else if (this.sortedUIDs) {
                 // we have sorted UIDs, so we can mask out the cq
-                this.serializedDocuments = new KeyAdjudicator<>(serializedDocuments, yield);
+                this.documentIterator = new KeyAdjudicator<>(documentIterator, yield);
             }
 
             // only add the final document tracking iterator which sends stats back to the client if collectTimingDetails is true
             if (collectTimingDetails) {
                 // if there is no document to return, then add an empty document
                 // to store the timing metadata
-                this.serializedDocuments = new FinalDocumentTrackingIterator(querySpanCollector, trackingSpan, originalRange, this.serializedDocuments,
-                                this.getReturnType(), this.isReducedResponse(), this.isCompressResults(), this.yield);
+                this.documentIterator = new FinalDocumentTrackingIterator(querySpanCollector, trackingSpan, originalRange, documentIterator, yield);
             }
             if (log.isTraceEnabled()) {
-                KryoDocumentDeserializer dser = new KryoDocumentDeserializer();
-                this.serializedDocuments = Iterators.filter(this.serializedDocuments, keyValueEntry -> {
-                    log.debug("finally, considering:" + dser.apply(keyValueEntry));
+                this.documentIterator = Iterators.filter(this.documentIterator, keyValueEntry -> {
+                    log.debug("finally, considering:" + keyValueEntry);
                     return true;
                 });
             }
@@ -1234,12 +1208,18 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
         }
     }
 
-    private void prepareKeyValue() {
-        if (this.serializedDocuments.hasNext()) {
-            Entry<Key,Value> entry = this.serializedDocuments.next();
+    /**
+     * Gets the next document and serializes it for return
+     */
+    protected void prepareKeyValue() {
+        if (documentIterator.hasNext()) {
+
+            // just in time serialization
+            Entry<Key,Document> docEntry = documentIterator.next();
+            Entry<Key,Value> entry = getDocumentSerializer().apply(docEntry);
 
             if (log.isTraceEnabled()) {
-                log.trace("next() returned " + entry);
+                log.trace("next() returned " + entry.getKey());
             }
 
             this.key = entry.getKey();

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ResultCountingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ResultCountingIterator.java
@@ -5,31 +5,31 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.YieldCallback;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.collect.Maps;
 
 import datawave.data.type.util.NumericalEncoder;
+import datawave.query.attributes.Document;
 
 /**
  * Created on 9/6/16.
  */
-public class ResultCountingIterator implements Iterator<Entry<Key,Value>> {
-    private AtomicLong resultCount = new AtomicLong(0);
-    private Iterator<Entry<Key,Value>> serializedDocuments = null;
-    private YieldCallback<Key> yield;
+public class ResultCountingIterator implements Iterator<Entry<Key,Document>> {
+    private final AtomicLong resultCount = new AtomicLong(0);
+    private final Iterator<Entry<Key,Document>> documentIterator;
+    private final YieldCallback<Key> yield;
 
-    public ResultCountingIterator(Iterator<Entry<Key,Value>> serializedDocuments, long resultCount, YieldCallback<Key> yieldCallback) {
-        this.serializedDocuments = serializedDocuments;
+    public ResultCountingIterator(Iterator<Entry<Key,Document>> documentIterator, long resultCount, YieldCallback<Key> yieldCallback) {
+        this.documentIterator = documentIterator;
         this.resultCount.set(resultCount);
         this.yield = yieldCallback;
     }
 
     @Override
     public boolean hasNext() {
-        boolean hasNext = serializedDocuments.hasNext();
+        boolean hasNext = documentIterator.hasNext();
         if (yield != null && yield.hasYielded()) {
             yield.yield(addKeyCount(yield.getPositionAndReset()));
         }
@@ -37,8 +37,8 @@ public class ResultCountingIterator implements Iterator<Entry<Key,Value>> {
     }
 
     @Override
-    public Entry<Key,Value> next() {
-        Entry<Key,Value> next = serializedDocuments.next();
+    public Entry<Key,Document> next() {
+        Entry<Key,Document> next = documentIterator.next();
         if (next != null) {
             next = Maps.immutableEntry(addKeyCount(next.getKey()), next.getValue());
         }
@@ -53,6 +53,6 @@ public class ResultCountingIterator implements Iterator<Entry<Key,Value>> {
 
     @Override
     public void remove() {
-        serializedDocuments.remove();
+        documentIterator.remove();
     }
 }


### PR DESCRIPTION
Standardized and encapsulated document serialization, eliminated need for a serialized iterator