### PR TITLE
QueryPlannerOptions

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -140,18 +140,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
      */
     private boolean sortGeoWaveQueryRanges = false;
     /**
-     * Used to determine how many ranges the ThreadedRangeBundler should buffer before returning a range to the caller
-     */
-    private int numRangesToBuffer = 0;
-    /**
-     * Used to determine how long to allow the ThreadedRangeBundler to buffer ranges before returning a range to the caller
-     */
-    private long rangeBufferTimeoutMillis = 0;
-    /**
-     * Used to determine the poll interval when buffering ranges in ThreadedRangeBundler
-     */
-    private long rangeBufferPollMillis = 100;
-    /**
      * Used to determine the maximum number of query ranges to generate per tier when performing a geowave query against a GeometryType field.
      */
     private int geometryMaxExpansion = 8;
@@ -498,9 +486,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setSerializeQueryIterator(other.getSerializeQueryIterator());
         this.setDebugMultithreadedSources(other.isDebugMultithreadedSources());
         this.setSortGeoWaveQueryRanges(other.isSortGeoWaveQueryRanges());
-        this.setNumRangesToBuffer(other.getNumRangesToBuffer());
-        this.setRangeBufferTimeoutMillis(other.getRangeBufferTimeoutMillis());
-        this.setRangeBufferPollMillis(other.getRangeBufferPollMillis());
         this.setGeometryMaxExpansion(other.getGeometryMaxExpansion());
         this.setPointMaxExpansion(other.getPointMaxExpansion());
         this.setGeoMaxExpansion(other.getGeoMaxExpansion());
@@ -954,30 +939,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setSortGeoWaveQueryRanges(boolean sortGeoWaveQueryRanges) {
         this.sortGeoWaveQueryRanges = sortGeoWaveQueryRanges;
-    }
-
-    public int getNumRangesToBuffer() {
-        return numRangesToBuffer;
-    }
-
-    public void setNumRangesToBuffer(int numRangesToBuffer) {
-        this.numRangesToBuffer = numRangesToBuffer;
-    }
-
-    public long getRangeBufferTimeoutMillis() {
-        return rangeBufferTimeoutMillis;
-    }
-
-    public void setRangeBufferTimeoutMillis(long rangeBufferTimeoutMillis) {
-        this.rangeBufferTimeoutMillis = rangeBufferTimeoutMillis;
-    }
-
-    public long getRangeBufferPollMillis() {
-        return rangeBufferPollMillis;
-    }
-
-    public void setRangeBufferPollMillis(long rangeBufferPollMillis) {
-        this.rangeBufferPollMillis = rangeBufferPollMillis;
     }
 
     public int getGeometryMaxExpansion() {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlanner.java
@@ -17,6 +17,8 @@ import datawave.webservice.query.configuration.QueryData;
 
 public abstract class QueryPlanner implements PushDownPlanner {
 
+    protected QueryPlannerOptions options;
+
     protected Class<? extends SortedKeyValueIterator<Key,Value>> createUidsIteratorClass = CreateUidsIterator.class;
 
     protected UidIntersector uidIntersector = new IndexInfo();
@@ -38,8 +40,6 @@ public abstract class QueryPlanner implements PushDownPlanner {
      */
     public abstract CloseableIterable<QueryData> process(GenericQueryConfiguration config, String query, Query settings, ScannerFactory scannerFactory)
                     throws DatawaveQueryException;
-
-    public abstract long maxRangesPerQueryPiece();
 
     public abstract void close(GenericQueryConfiguration config, Query settings);
 
@@ -65,6 +65,14 @@ public abstract class QueryPlanner implements PushDownPlanner {
 
     public void setUidIntersector(UidIntersector uidIntersector) {
         this.uidIntersector = uidIntersector;
+    }
+
+    public QueryPlannerOptions getOptions() {
+        return options;
+    }
+
+    public void setOptions(QueryPlannerOptions options) {
+        this.options = options;
     }
 
 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlannerOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlannerOptions.java
@@ -2,10 +2,15 @@ package datawave.query.planner;
 
 /**
  * Options that control how a query is planned.
+ * <p>
+ * The QueryPlannerOptions exist as an internal, injectable variable in the {@link DefaultQueryPlanner}.
+ * <p>
+ * Any QueryLogic that extends {@link datawave.query.tables.ShardQueryLogic} may reference its own QueryPlannerOptions that gets set on the QueryPlanner. In
+ * this way multiple distinct query logics may reference distinct "planning profiles".
  */
 public class QueryPlannerOptions {
 
-    private boolean limitScanners;
+    private boolean limitScanners = true;
     private boolean disableBoundedLookup;
     private boolean disableAnyFieldLookup;
     private boolean disableCompositeFields;
@@ -16,6 +21,13 @@ public class QueryPlannerOptions {
     // threaded range bundler options here
     private long maxRangesPerQueryPiece;
     private long maxRangeWaitMillis = 125L;
+    // how many ranges should the threaded range bundler buffer before the first range is returned to the caller
+    private int numRangesToBuffer = 0;
+    // how long ranges are allowed to buffer before the first range is returned to the caller
+    private long rangeBufferTimeoutMillis = 0L;
+    // determines the poll interval when buffering ranges in the threaded range bundler
+    private long rangeBufferPollMillis = 100L;
+
     // misc options
     private boolean cacheDataTypes;
     private boolean compressMappings;
@@ -50,6 +62,9 @@ public class QueryPlannerOptions {
         // range bundler options
         this.maxRangesPerQueryPiece = other.maxRangesPerQueryPiece;
         this.maxRangeWaitMillis = other.maxRangeWaitMillis;
+        this.numRangesToBuffer = other.numRangesToBuffer;
+        this.rangeBufferTimeoutMillis = other.rangeBufferTimeoutMillis;
+        this.rangeBufferPollMillis = other.rangeBufferPollMillis;
         // misc options
         this.cacheDataTypes = other.cacheDataTypes;
         this.compressMappings = other.compressMappings;
@@ -195,5 +210,29 @@ public class QueryPlannerOptions {
 
     public void setShowReducedQueryPrune(boolean showReducedQueryPrune) {
         this.showReducedQueryPrune = showReducedQueryPrune;
+    }
+
+    public int getNumRangesToBuffer() {
+        return numRangesToBuffer;
+    }
+
+    public void setNumRangesToBuffer(int numRangesToBuffer) {
+        this.numRangesToBuffer = numRangesToBuffer;
+    }
+
+    public long getRangeBufferTimeoutMillis() {
+        return rangeBufferTimeoutMillis;
+    }
+
+    public void setRangeBufferTimeoutMillis(long rangeBufferTimeoutMillis) {
+        this.rangeBufferTimeoutMillis = rangeBufferTimeoutMillis;
+    }
+
+    public long getRangeBufferPollMillis() {
+        return rangeBufferPollMillis;
+    }
+
+    public void setRangeBufferPollMillis(long rangeBufferPollMillis) {
+        this.rangeBufferPollMillis = rangeBufferPollMillis;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlannerOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlannerOptions.java
@@ -1,0 +1,199 @@
+package datawave.query.planner;
+
+/**
+ * Options that control how a query is planned.
+ */
+public class QueryPlannerOptions {
+
+    private boolean limitScanners;
+    private boolean disableBoundedLookup;
+    private boolean disableAnyFieldLookup;
+    private boolean disableCompositeFields;
+    private boolean disableTestNonExistentFields;
+    private boolean disableWhindexFieldMappings;
+    private boolean disableExpandIndexFunctions;
+
+    // threaded range bundler options here
+    private long maxRangesPerQueryPiece;
+    private long maxRangeWaitMillis = 125L;
+    // misc options
+    private boolean cacheDataTypes;
+    private boolean compressMappings;
+    private boolean preloadOptions;
+    // if the number of query terms exceeds this threshold then all document ranges are pushed into shard ranges
+    private long pushdownThreshold = 500L;
+    private long sourceLimit;
+    private boolean executableExpansion = true;
+    // automated logical reduction of the query
+    private boolean reduceQuery = true;
+    // print the pruned query with assignment nodes. could be costly from a performance perspective.
+    private boolean showReducedQueryPrune = true;
+
+    public QueryPlannerOptions() {
+        // empty constructor
+    }
+
+    /**
+     * Copy constructor
+     *
+     * @param other
+     *            another instance of QueryPlannerOptions
+     */
+    public QueryPlannerOptions(QueryPlannerOptions other) {
+        this.limitScanners = other.limitScanners;
+        this.disableBoundedLookup = other.disableBoundedLookup;
+        this.disableAnyFieldLookup = other.disableAnyFieldLookup;
+        this.disableCompositeFields = other.disableCompositeFields;
+        this.disableTestNonExistentFields = other.disableTestNonExistentFields;
+        this.disableWhindexFieldMappings = other.disableWhindexFieldMappings;
+        this.disableExpandIndexFunctions = other.disableExpandIndexFunctions;
+        // range bundler options
+        this.maxRangesPerQueryPiece = other.maxRangesPerQueryPiece;
+        this.maxRangeWaitMillis = other.maxRangeWaitMillis;
+        // misc options
+        this.cacheDataTypes = other.cacheDataTypes;
+        this.compressMappings = other.compressMappings;
+        this.preloadOptions = other.preloadOptions;
+        this.pushdownThreshold = other.pushdownThreshold;
+        this.sourceLimit = other.sourceLimit;
+        this.executableExpansion = other.executableExpansion;
+        this.reduceQuery = other.reduceQuery;
+        this.showReducedQueryPrune = other.showReducedQueryPrune;
+    }
+
+    public boolean isLimitScanners() {
+        return limitScanners;
+    }
+
+    public void setLimitScanners(boolean limitScanners) {
+        this.limitScanners = limitScanners;
+    }
+
+    public boolean isDisableBoundedLookup() {
+        return disableBoundedLookup;
+    }
+
+    public void setDisableBoundedLookup(boolean disableBoundedLookup) {
+        this.disableBoundedLookup = disableBoundedLookup;
+    }
+
+    public boolean isDisableAnyFieldLookup() {
+        return disableAnyFieldLookup;
+    }
+
+    public void setDisableAnyFieldLookup(boolean disableAnyFieldLookup) {
+        this.disableAnyFieldLookup = disableAnyFieldLookup;
+    }
+
+    public boolean isDisableCompositeFields() {
+        return disableCompositeFields;
+    }
+
+    public void setDisableCompositeFields(boolean disableCompositeFields) {
+        this.disableCompositeFields = disableCompositeFields;
+    }
+
+    public boolean isDisableTestNonExistentFields() {
+        return disableTestNonExistentFields;
+    }
+
+    public void setDisableTestNonExistentFields(boolean disableTestNonExistentFields) {
+        this.disableTestNonExistentFields = disableTestNonExistentFields;
+    }
+
+    public boolean isDisableWhindexFieldMappings() {
+        return disableWhindexFieldMappings;
+    }
+
+    public void setDisableWhindexFieldMappings(boolean disableWhindexFieldMappings) {
+        this.disableWhindexFieldMappings = disableWhindexFieldMappings;
+    }
+
+    public boolean isDisableExpandIndexFunctions() {
+        return disableExpandIndexFunctions;
+    }
+
+    public void setDisableExpandIndexFunctions(boolean disableExpandIndexFunctions) {
+        this.disableExpandIndexFunctions = disableExpandIndexFunctions;
+    }
+
+    public boolean isCacheDataTypes() {
+        return cacheDataTypes;
+    }
+
+    public void setCacheDataTypes(boolean cacheDataTypes) {
+        this.cacheDataTypes = cacheDataTypes;
+    }
+
+    public long getMaxRangesPerQueryPiece() {
+        return maxRangesPerQueryPiece;
+    }
+
+    public void setMaxRangesPerQueryPiece(long maxRangesPerQueryPiece) {
+        this.maxRangesPerQueryPiece = maxRangesPerQueryPiece;
+    }
+
+    public boolean isCompressMappings() {
+        return compressMappings;
+    }
+
+    public void setCompressMappings(boolean compressMappings) {
+        this.compressMappings = compressMappings;
+    }
+
+    public boolean isPreloadOptions() {
+        return preloadOptions;
+    }
+
+    public void setPreloadOptions(boolean preloadOptions) {
+        this.preloadOptions = preloadOptions;
+    }
+
+    public long getMaxRangeWaitMillis() {
+        return maxRangeWaitMillis;
+    }
+
+    public void setMaxRangeWaitMillis(long maxRangeWaitMillis) {
+        this.maxRangeWaitMillis = maxRangeWaitMillis;
+    }
+
+    public long getPushdownThreshold() {
+        return pushdownThreshold;
+    }
+
+    public void setPushdownThreshold(long pushdownThreshold) {
+        this.pushdownThreshold = pushdownThreshold;
+    }
+
+    public long getSourceLimit() {
+        return sourceLimit;
+    }
+
+    public void setSourceLimit(long sourceLimit) {
+        this.sourceLimit = sourceLimit;
+    }
+
+    public boolean isExecutableExpansion() {
+        return executableExpansion;
+    }
+
+    public void setExecutableExpansion(boolean executableExpansion) {
+        this.executableExpansion = executableExpansion;
+    }
+
+    public boolean isReduceQuery() {
+        return reduceQuery;
+    }
+
+    public void setReduceQuery(boolean reduceQuery) {
+        this.reduceQuery = reduceQuery;
+    }
+
+    public boolean isShowReducedQueryPrune() {
+        return showReducedQueryPrune;
+    }
+
+    public void setShowReducedQueryPrune(boolean showReducedQueryPrune) {
+        this.showReducedQueryPrune = showReducedQueryPrune;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundler.java
@@ -142,8 +142,6 @@ public class ThreadedRangeBundler implements CloseableIterable<QueryData> {
         private long maxRanges;
         private Query settings;
         private ASTJexlScript queryTree;
-        private boolean docSpecificLimitOverride;
-        private int docsToCombine = -1;
         private long maxRangeWaitMillis = 50L;
         private Collection<Comparator<QueryPlan>> queryPlanComparators;
         private int numRangesToBuffer;

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -68,6 +68,7 @@ import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.planner.MetadataHelperQueryModelProvider;
 import datawave.query.planner.QueryModelProvider;
 import datawave.query.planner.QueryPlanner;
+import datawave.query.planner.QueryPlannerOptions;
 import datawave.query.scheduler.PushdownScheduler;
 import datawave.query.scheduler.Scheduler;
 import datawave.query.scheduler.SequentialScheduler;
@@ -186,6 +187,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     private Map<String,QueryParser> querySyntaxParsers = new HashMap<>();
     private Set<String> mandatoryQuerySyntax = null;
     private QueryPlanner planner = null;
+    private QueryPlannerOptions queryPlannerOptions = null;
     private QueryParser parser = null;
     private QueryLogicTransformer transformerInstance = null;
 
@@ -217,6 +219,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         this.setQuerySyntaxParsers(other.getQuerySyntaxParsers());
         this.setMandatoryQuerySyntax(other.getMandatoryQuerySyntax());
         this.setQueryPlanner(other.getQueryPlanner().clone());
+        this.setQueryPlannerOptions(other.getQueryPlannerOptions());
         this.setCreateUidsIteratorClass(other.getCreateUidsIteratorClass());
         this.setUidIntersector(other.getUidIntersector());
 
@@ -407,6 +410,10 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
 
             currentQueryPlanner.setMetadataHelper(metadataHelper);
             currentQueryPlanner.setDateIndexHelper(dateIndexHelper);
+
+            if (getQueryPlannerOptions() != null) {
+                currentQueryPlanner.setOptions(getQueryPlannerOptions());
+            }
 
             QueryModelProvider queryModelProvider = currentQueryPlanner.getQueryModelProviderFactory().createQueryModelProvider();
             if (queryModelProvider instanceof MetadataHelperQueryModelProvider) {
@@ -2005,6 +2012,14 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         this.planner = planner;
     }
 
+    public QueryPlannerOptions getQueryPlannerOptions() {
+        return queryPlannerOptions;
+    }
+
+    public void setQueryPlannerOptions(QueryPlannerOptions plannerOptions) {
+        this.queryPlannerOptions = plannerOptions;
+    }
+
     public Class<? extends SortedKeyValueIterator<Key,Value>> getCreateUidsIteratorClass() {
         return createUidsIteratorClass;
     }
@@ -2455,27 +2470,27 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     }
 
     public int getNumRangesToBuffer() {
-        return getConfig().getNumRangesToBuffer();
+        return getQueryPlannerOptions().getNumRangesToBuffer();
     }
 
     public void setNumRangesToBuffer(int numRangesToBuffer) {
-        getConfig().setNumRangesToBuffer(numRangesToBuffer);
+        getQueryPlannerOptions().setNumRangesToBuffer(numRangesToBuffer);
     }
 
     public long getRangeBufferTimeoutMillis() {
-        return getConfig().getRangeBufferTimeoutMillis();
+        return getQueryPlannerOptions().getRangeBufferTimeoutMillis();
     }
 
     public void setRangeBufferTimeoutMillis(long rangeBufferTimeoutMillis) {
-        getConfig().setRangeBufferTimeoutMillis(rangeBufferTimeoutMillis);
+        getQueryPlannerOptions().setRangeBufferTimeoutMillis(rangeBufferTimeoutMillis);
     }
 
     public long getRangeBufferPollMillis() {
-        return getConfig().getRangeBufferPollMillis();
+        return getQueryPlannerOptions().getRangeBufferPollMillis();
     }
 
     public void setRangeBufferPollMillis(long rangeBufferPollMillis) {
-        getConfig().setRangeBufferPollMillis(rangeBufferPollMillis);
+        getQueryPlannerOptions().setRangeBufferPollMillis(rangeBufferPollMillis);
     }
 
     public int getGeometryMaxExpansion() {

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -167,12 +167,6 @@ public class ShardQueryConfigurationTest {
         updatedValues.put("debugMultithreadedSources", true);
         defaultValues.put("sortGeoWaveQueryRanges", false);
         updatedValues.put("sortGeoWaveQueryRanges", true);
-        defaultValues.put("numRangesToBuffer", 0);
-        updatedValues.put("numRangesToBuffer", 4);
-        defaultValues.put("rangeBufferTimeoutMillis", 0L);
-        updatedValues.put("rangeBufferTimeoutMillis", 1000L);
-        defaultValues.put("rangeBufferPollMillis", 100L);
-        updatedValues.put("rangeBufferPollMillis", 140L);
         defaultValues.put("geometryMaxExpansion", 8);
         updatedValues.put("geometryMaxExpansion", 4);
         defaultValues.put("pointMaxExpansion", 32);

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -167,8 +167,33 @@
         </bean>
     </util:list>
 
-    <bean id="DefaultQueryPlanner" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner" >
-        <property name="transformRules" ref="transformRuleList" />
+    <bean id="DefaultQueryPlanner" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner">
+        <property name="transformRules" ref="transformRuleList"/>
+        <property name="options" ref="DefaultQueryPlannerOptions"/>
+    </bean>
+
+    <bean id="DefaultQueryPlannerOptions" scope="prototype" class="datawave.query.planner.QueryPlannerOptions">
+        <property name="limitScanners" value="false"/>
+        <property name="disableBoundedLookup" value="false"/>
+        <property name="disableAnyFieldLookup" value="false"/>
+        <property name="disableCompositeFields" value="false"/>
+        <property name="disableTestNonExistentFields" value="false"/>
+        <property name="disableWhindexFieldMappings" value="false"/>
+        <property name="disableExpandIndexFunctions" value="false"/>
+        <!--   range bundler options     -->
+        <property name="docsToCombineForEvaluation" value="-1"/>
+        <property name="docSpecificOverride" value="false"/>
+        <property name="maxRangesPerQueryPiece" value="10"/>
+        <property name="maxRangeWaitMillis" value="125"/>
+        <!--   misc. options     -->
+        <property name="cacheDataTypes" value="false"/>
+        <property name="compressMappings" value="false"/>
+        <property name="preloadOptions" value="false"/>
+        <property name="pushdownThreshold" value="500"/>
+        <property name="sourceLimit" value="-1"/>
+        <property name="executableExpansion" value="true"/>
+        <property name="reduceQuery" value="true"/>
+        <property name="showReducedQueryPrune" value="true"/>
     </bean>
 
     <bean id="datawaveRoleManager" class="datawave.webservice.query.logic.DatawaveRoleManager" />

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -128,6 +128,7 @@
             </map>
         </property>
         <property name="queryPlanner" ref="DefaultQueryPlanner" />
+        <property name="queryPlannerOptions" ref="DefaultQueryPlannerOptions"/>
         <!--<property name="queryMacroFunction" ref="queryMacroFunction" />-->
         <property name="markingFunctions" ref="markingFunctions" />
     </bean>
@@ -181,10 +182,11 @@
         <property name="disableWhindexFieldMappings" value="false"/>
         <property name="disableExpandIndexFunctions" value="false"/>
         <!--   range bundler options     -->
-        <property name="docsToCombineForEvaluation" value="-1"/>
-        <property name="docSpecificOverride" value="false"/>
         <property name="maxRangesPerQueryPiece" value="10"/>
         <property name="maxRangeWaitMillis" value="125"/>
+        <property name="numRangesToBuffer" value="15"/>
+        <property name="rangeBufferTimeoutMillis" value="15000"/>
+        <property name="rangeBufferPollMillis" value="100"/>
         <!--   misc. options     -->
         <property name="cacheDataTypes" value="false"/>
         <property name="compressMappings" value="false"/>

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -323,9 +323,34 @@
         </bean>
     </util:list>
 
-    <bean id="DefaultQueryPlanner" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner" >
-        <property name="transformRules" ref="transformRuleList" />
+    <bean id="DefaultQueryPlanner" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner">
+        <property name="transformRules" ref="transformRuleList"/>
         <property name="visitorManager" ref="TimedVisitorManager"/>
+        <property name="options" ref="DefaultQueryPlannerOptions"/>
+    </bean>
+
+    <bean id="DefaultQueryPlannerOptions" scope="prototype" class="datawave.query.planner.QueryPlannerOptions">
+        <property name="limitScanners" value="true"/>
+        <property name="disableBoundedLookup" value="false"/>
+        <property name="disableAnyFieldLookup" value="false"/>
+        <property name="disableCompositeFields" value="false"/>
+        <property name="disableTestNonExistentFields" value="false"/>
+        <property name="disableWhindexFieldMappings" value="false"/>
+        <property name="disableExpandIndexFunctions" value="false"/>
+        <!--   range bundler options     -->
+        <property name="docsToCombineForEvaluation" value="-1"/>
+        <property name="docSpecificOverride" value="false"/>
+        <property name="maxRangesPerQueryPiece" value="10"/>
+        <property name="maxRangeWaitMillis" value="125"/>
+        <!--   misc. options     -->
+        <property name="cacheDataTypes" value="false"/>
+        <property name="compressMappings" value="false"/>
+        <property name="preloadOptions" value="false"/>
+        <property name="pushdownThreshold" value="500"/>
+        <property name="sourceLimit" value="-1"/>
+        <property name="executableExpansion" value="true"/>
+        <property name="reduceQuery" value="true"/>
+        <property name="showReducedQueryPrune" value="true"/>
     </bean>
 
     <bean id="TimedVisitorManager" scope="prototype" class="datawave.query.planner.TimedVisitorManager">

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -229,12 +229,10 @@
             </map>
         </property>
         <property name="queryPlanner" ref="DefaultQueryPlanner" />
+        <property name="queryPlannerOptions" ref="DefaultQueryPlannerOptions" />
         <!--<property name="queryMacroFunction" ref="queryMacroFunction" />-->
         <property name="markingFunctions" ref="markingFunctions" />
         <property name="sortGeoWaveQueryRanges" value="true" />
-        <property name="numRangesToBuffer" value="15" />
-        <property name="rangeBufferTimeoutMillis" value="15000" />
-        <property name="rangeBufferPollMillis" value="100" />
         <property name="evaluationOnlyFields" value="_ANYFIELD_" />
         <!--   variables that control when a seek is issued     -->
         <property name="fiFieldSeek" value="-1" />
@@ -326,7 +324,6 @@
     <bean id="DefaultQueryPlanner" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner">
         <property name="transformRules" ref="transformRuleList"/>
         <property name="visitorManager" ref="TimedVisitorManager"/>
-        <property name="options" ref="DefaultQueryPlannerOptions"/>
     </bean>
 
     <bean id="DefaultQueryPlannerOptions" scope="prototype" class="datawave.query.planner.QueryPlannerOptions">
@@ -338,10 +335,11 @@
         <property name="disableWhindexFieldMappings" value="false"/>
         <property name="disableExpandIndexFunctions" value="false"/>
         <!--   range bundler options     -->
-        <property name="docsToCombineForEvaluation" value="-1"/>
-        <property name="docSpecificOverride" value="false"/>
         <property name="maxRangesPerQueryPiece" value="10"/>
         <property name="maxRangeWaitMillis" value="125"/>
+        <property name="numRangesToBuffer" value="15"/>
+        <property name="rangeBufferTimeoutMillis" value="15000"/>
+        <property name="rangeBufferPollMillis" value="100"/>
         <!--   misc. options     -->
         <property name="cacheDataTypes" value="false"/>
         <property name="compressMappings" value="false"/>

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -110,6 +110,14 @@
             <value>true</value>
         </constructor-arg>
         <!--<lookup-method name="getQueryModelProvider" bean="metadataHelperQueryModelProvider" />-->
+        <property name="options" ref="DefaultQueryPlannerOptions" />
+    </bean>
+
+    <bean id="DefaultQueryPlannerOptions" scope="prototype" class="datawave.query.planner.QueryPlannerOptions" >
+        <property name="limitScanners" value="false" />
+        <property name="disableBoundedLookup" value="false" />
+        <property name="disableAnyFieldLookup" value="false" />
+        <property name="disableCompositeFields" value="false" />
     </bean>
 
     <bean id="queryModelProviderFactory" class="datawave.query.planner.QueryModelProvider.Factory" >


### PR DESCRIPTION
This is an initial cut at making the DefaultQueryPlanner more modular and flexible. The goal is to eventually extract all options that control query planning from the shard query config into a query planner config object and define multiple planning profiles.

Open questions for this initial draft
- should the planner options exist in the query logic or the query logic config?
- what should the default values be for a non-configured query planning options be?

Summary of changes
- extracted default query planner variables to QueryPlannerOptions
- extracted variables from shard query config to QueryPlannerOptions
- documented loose flow of query planning