### PR TITLE
Add Field and Term counts to serialized iterator options

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -461,6 +461,15 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private boolean pruneQueryOptions = false;
 
     /**
+     * Flag to control gathering field counts from the global index and persisting those to the query iterator. Negated terms and branches are not considered.
+     */
+    private boolean useFieldCounts = false;
+    /**
+     * Flag to control gathering term counts from the global index and persisting those to the query iterator. Negated terms and branches are not considered.
+     */
+    private boolean useTermCounts = false;
+
+    /**
      * Default constructor
      */
     public ShardQueryConfiguration() {
@@ -675,6 +684,8 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setTfAggregationThresholdMs(other.getTfAggregationThresholdMs());
         this.setGroupFields(GroupFields.copyOf(other.getGroupFields()));
         this.setPruneQueryOptions(other.getPruneQueryOptions());
+        this.setUseFieldCounts(other.getUseFieldCounts());
+        this.setUseTermCounts(other.getUseTermCounts());
     }
 
     /**
@@ -2609,5 +2620,21 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setReduceIngestTypesPerShard(boolean reduceIngestTypesPerShard) {
         this.reduceIngestTypesPerShard = reduceIngestTypesPerShard;
+    }
+
+    public boolean getUseTermCounts() {
+        return useTermCounts;
+    }
+
+    public void setUseTermCounts(boolean useTermCounts) {
+        this.useTermCounts = useTermCounts;
+    }
+
+    public boolean getUseFieldCounts() {
+        return useFieldCounts;
+    }
+
+    public void setUseFieldCounts(boolean useFieldCounts) {
+        this.useFieldCounts = useFieldCounts;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/edge/DefaultExtendedEdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/edge/DefaultExtendedEdgeQueryLogic.java
@@ -184,16 +184,14 @@ public class DefaultExtendedEdgeQueryLogic extends EdgeQueryLogic {
         }
 
         this.scanner = scanner;
-        iterator = scanner.iterator();
+        this.iterator = scanner.iterator();
     }
 
     @Override
     protected QueryData configureRanges(String queryString) throws ParseException {
-        QueryData qData = new QueryData();
         if (this.summaryInputType) {
             Set<Range> ranges = computeRanges((EdgeExtendedSummaryConfiguration) this.config);
-            qData.setRanges(ranges);
-            return qData;
+            return new QueryData().withRanges(ranges);
         } else {
             return super.configureRanges(queryString);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
@@ -3,6 +3,7 @@ package datawave.query.index.lookup;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -69,12 +70,20 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
 
     public static final String COLLAPSE_UIDS = "index.lookup.collapse";
     public static final String PARSE_TLD_UIDS = "index.lookup.parse.tld.uids";
+    public static final String FIELD_COUNTS = "field.counts";
+    public static final String TERM_COUNTS = "term.counts";
 
     protected boolean collapseUids = false;
     protected boolean parseTldUids = false;
+    protected boolean fieldCounts = false;
+    protected boolean termCounts = false;
+
     protected SortedKeyValueIterator<Key,Value> src;
     protected Key tk;
     protected IndexInfo tv;
+
+    private String field;
+    private String value;
 
     @Override
     public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
@@ -91,6 +100,14 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
             final String parseTldUidsOption = options.get(PARSE_TLD_UIDS);
             if (null != parseTldUidsOption) {
                 parseTldUids = Boolean.parseBoolean(parseTldUidsOption);
+            }
+            final String fieldCountOpt = options.get(FIELD_COUNTS);
+            if (null != fieldCountOpt) {
+                fieldCounts = Boolean.parseBoolean(fieldCountOpt);
+            }
+            final String termCountsOpt = options.get(TERM_COUNTS);
+            if (null != termCountsOpt) {
+                termCounts = Boolean.parseBoolean(termCountsOpt);
             }
         }
     }
@@ -137,6 +154,14 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
             }
             tk = reference;
         }
+
+        if (fieldCounts && tv != null) {
+            tv.setFieldCounts(createFieldCounts(field, tv.count()));
+        }
+
+        if (termCounts && tv != null) {
+            tv.setTermCounts(createTermCounts(field, value, tv.count()));
+        }
     }
 
     /**
@@ -150,9 +175,35 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
             seekRange = skipKey(range);
         }
 
+        fieldFromRange(seekRange);
+        valueFromRange(seekRange);
+
         src.seek(seekRange, columnFamilies, inclusive);
 
         next();
+    }
+
+    /**
+     * Attempt to extract a field from the seek range.
+     *
+     * @param range
+     *            the range
+     */
+    private void fieldFromRange(Range range) {
+        if (range.getStartKey() != null) {
+            this.field = range.getStartKey().getColumnFamily().toString();
+        } else {
+            this.field = "NO_FIELD";
+        }
+    }
+
+    private void valueFromRange(Range range) {
+        if (range.getStartKey() != null) {
+            this.value = range.getStartKey().getRow().toString();
+        } else {
+            this.value = "NO_VALUE";
+        }
+
     }
 
     /**
@@ -240,6 +291,18 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
         final ByteSequence row = k.getRowData(), cf = k.getColumnFamilyData(), cv = k.getColumnVisibilityData();
         return new Key(row.getBackingArray(), row.offset(), row.length(), cf.getBackingArray(), cf.offset(), cf.length(), strippedCq.getBackingArray(),
                         strippedCq.offset(), strippedCq.length(), cv.getBackingArray(), cv.offset(), cv.length(), k.getTimestamp());
+    }
+
+    private Map<String,Long> createFieldCounts(String field, Long count) {
+        Map<String,Long> counts = new HashMap<>();
+        counts.put(field, count);
+        return counts;
+    }
+
+    private Map<String,Long> createTermCounts(String field, String value, Long count) {
+        Map<String,Long> counts = new HashMap<>();
+        counts.put(field + " == '" + value + "'", count);
+        return counts;
     }
 
     /*

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
@@ -10,12 +10,16 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.jexl3.parser.ASTOrNode;
 import org.apache.commons.jexl3.parser.ASTReferenceExpression;
 import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.hadoop.io.MapWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.VIntWritable;
 import org.apache.hadoop.io.VLongWritable;
 import org.apache.hadoop.io.Writable;
@@ -52,6 +56,9 @@ public class IndexInfo implements Writable, UidIntersector {
     // a set of document uids. In some cases this list is pruned when a threshold is exceeded
     // In the pruned case, the count will exceed the size of the uid set
     protected ImmutableSortedSet<IndexMatch> uids;
+
+    protected Map<String,Long> fieldCounts = new HashMap<>();
+    protected Map<String,Long> termCounts = new HashMap<>();
 
     public IndexInfo() {
         this.count = 0;
@@ -91,8 +98,20 @@ public class IndexInfo implements Writable, UidIntersector {
     public void write(DataOutput out) throws IOException {
         new VLongWritable(count).write(out);
         new VIntWritable(uids.size()).write(out);
-        for (IndexMatch uid : uids)
+        for (IndexMatch uid : uids) {
             uid.write(out);
+        }
+        MapWritable fieldMapWritable = new MapWritable();
+        for (Map.Entry<String,Long> entry : fieldCounts.entrySet()) {
+            fieldMapWritable.put(new Text(entry.getKey()), new VLongWritable(entry.getValue()));
+        }
+        fieldMapWritable.write(out);
+
+        MapWritable termMapWritable = new MapWritable();
+        for (Map.Entry<String,Long> entry : termCounts.entrySet()) {
+            termMapWritable.put(new Text(entry.getKey()), new VLongWritable(entry.getValue()));
+        }
+        termMapWritable.write(out);
     }
 
     public void applyNode(JexlNode node) {
@@ -126,6 +145,20 @@ public class IndexInfo implements Writable, UidIntersector {
             setBuilder.add(index);
         }
         this.uids = setBuilder.build();
+
+        MapWritable fieldMapWritable = new MapWritable();
+        fieldMapWritable.readFields(in);
+        this.fieldCounts = new HashMap<>();
+        for (Writable key : fieldMapWritable.keySet()) {
+            fieldCounts.put(key.toString(), Long.valueOf(fieldMapWritable.get(key).toString()));
+        }
+
+        MapWritable termMapWritable = new MapWritable();
+        termMapWritable.readFields(in);
+        this.termCounts = new HashMap<>();
+        for (Writable key : termMapWritable.keySet()) {
+            termCounts.put(key.toString(), Long.valueOf(termMapWritable.get(key).toString()));
+        }
     }
 
     public IndexInfo union(IndexInfo o) {
@@ -185,6 +218,12 @@ public class IndexInfo implements Writable, UidIntersector {
         } else {
             merged.myNode = JexlNodeFactory.createOrNode(nodeSet.getNodes());
         }
+
+        merged.setFieldCounts(first.getFieldCounts());
+        merged.mergeFieldCounts(o.getFieldCounts());
+
+        merged.setTermCounts(first.getTermCounts());
+        merged.mergeTermCounts(o.getTermCounts());
 
         return merged;
     }
@@ -288,6 +327,12 @@ public class IndexInfo implements Writable, UidIntersector {
             merged.uids = ImmutableSortedSet.copyOf(matches);
             merged.count = merged.uids.size();
         }
+
+        merged.setFieldCounts(this.getFieldCounts());
+        merged.mergeFieldCounts(o.getFieldCounts());
+
+        merged.setTermCounts(this.getTermCounts());
+        merged.mergeTermCounts(o.getTermCounts());
 
         /*
          * If there are multiple levels within a union we could have an ASTOrNode. We cannot prune OrNodes as we would with an intersection, so propagate the
@@ -398,6 +443,12 @@ public class IndexInfo implements Writable, UidIntersector {
             merged.uids = ImmutableSortedSet.of();
         }
 
+        merged.setFieldCounts(this.getFieldCounts());
+        merged.mergeFieldCounts(o.getFieldCounts());
+
+        merged.setTermCounts(this.getTermCounts());
+        merged.mergeTermCounts(o.getTermCounts());
+
         // now handle updating the top level node
         JexlNodeSet nodes = new JexlNodeSet();
         if (this.getNode() != null) {
@@ -488,5 +539,55 @@ public class IndexInfo implements Writable, UidIntersector {
         for (IndexMatch uid : uids) {
             uid.set(myNode);
         }
+    }
+
+    public void setFieldCounts(Map<String,Long> fieldCounts) {
+        this.fieldCounts.putAll(fieldCounts);
+    }
+
+    public void setTermCounts(Map<String,Long> termCounts) {
+        this.termCounts.putAll(termCounts);
+    }
+
+    public void mergeFieldCounts(Map<String,Long> otherCounts) {
+        if (fieldCounts == null || fieldCounts.isEmpty()) {
+            fieldCounts = otherCounts;
+            return;
+        }
+
+        for (String field : otherCounts.keySet()) {
+            if (fieldCounts.containsKey(field)) {
+                Long existingCount = fieldCounts.get(field);
+                Long otherCount = otherCounts.get(field);
+                fieldCounts.put(field, existingCount + otherCount);
+            } else {
+                fieldCounts.put(field, otherCounts.get(field));
+            }
+        }
+    }
+
+    public void mergeTermCounts(Map<String,Long> otherCounts) {
+        if (termCounts == null || termCounts.isEmpty()) {
+            termCounts = otherCounts;
+            return;
+        }
+
+        for (String field : otherCounts.keySet()) {
+            if (termCounts.containsKey(field)) {
+                Long existingCount = termCounts.get(field);
+                Long otherCount = otherCounts.get(field);
+                termCounts.put(field, existingCount + otherCount);
+            } else {
+                termCounts.put(field, otherCounts.get(field));
+            }
+        }
+    }
+
+    public Map<String,Long> getFieldCounts() {
+        return fieldCounts;
+    }
+
+    public Map<String,Long> getTermCounts() {
+        return termCounts;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -60,7 +60,6 @@ import org.apache.commons.jexl3.parser.JexlNodes;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -139,6 +138,8 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
     protected ExecutorService streamExecutor;
 
     protected boolean collapseUids = false;
+    protected boolean fieldCounts = false;
+    protected boolean termCounts = false;
 
     protected Set<String> indexOnlyFields = Sets.newHashSet();
 
@@ -153,6 +154,8 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         streamExecutor = new ThreadPoolExecutor(executeLookupMin, maxLookup, 100, TimeUnit.MILLISECONDS, runnables);
         fieldDataTypes = config.getQueryFieldsDatatypes();
         collapseUids = config.getCollapseUids();
+        fieldCounts = config.getUseFieldCounts();
+        termCounts = config.getUseTermCounts();
         try {
             Set<String> ioFields = metadataHelper.getIndexOnlyFields(null);
             if (null != ioFields) {
@@ -327,34 +330,6 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
             }
 
             return true;
-        }
-    }
-
-    public static class MinimizeRanges implements Function<QueryPlan,QueryPlan> {
-
-        StreamContext myContext;
-
-        public MinimizeRanges(StreamContext myContext) {
-            this.myContext = myContext;
-        }
-
-        public QueryPlan apply(QueryPlan plan) {
-
-            if (StreamContext.EXCEEDED_TERM_THRESHOLD == myContext || StreamContext.EXCEEDED_VALUE_THRESHOLD == myContext) {
-
-                Set<Range> newRanges = Sets.newHashSet();
-
-                for (Range range : plan.getRanges()) {
-                    if (isEventSpecific(range)) {
-                        Key topKey = range.getStartKey();
-                        newRanges.add(new Range(topKey.getRow().toString(), true, topKey.getRow() + Constants.NULL_BYTE_STRING, false));
-                    } else {
-                        newRanges.add(range);
-                    }
-                }
-                plan.setRanges(newRanges);
-            }
-            return plan;
         }
     }
 
@@ -563,8 +538,10 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                                 config.getShardsPerDayThreshold());
 
                 uidSetting = new IteratorSetting(stackStart++, createUidsIteratorClass);
-                uidSetting.addOption(CreateUidsIterator.COLLAPSE_UIDS, Boolean.valueOf(collapseUids).toString());
-                uidSetting.addOption(CreateUidsIterator.PARSE_TLD_UIDS, Boolean.valueOf(config.getParseTldUids()).toString());
+                uidSetting.addOption(CreateUidsIterator.COLLAPSE_UIDS, Boolean.toString(collapseUids));
+                uidSetting.addOption(CreateUidsIterator.PARSE_TLD_UIDS, Boolean.toString(config.getParseTldUids()));
+                uidSetting.addOption(CreateUidsIterator.FIELD_COUNTS, Boolean.toString(fieldCounts));
+                uidSetting.addOption(CreateUidsIterator.TERM_COUNTS, Boolean.toString(termCounts));
 
             } else {
                 // Setup so this is a pass-through
@@ -572,8 +549,10 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                                 config.getShardsPerDayThreshold());
 
                 uidSetting = new IteratorSetting(stackStart++, createUidsIteratorClass);
-                uidSetting.addOption(CreateUidsIterator.COLLAPSE_UIDS, Boolean.valueOf(false).toString());
-                uidSetting.addOption(CreateUidsIterator.PARSE_TLD_UIDS, Boolean.valueOf(false).toString());
+                uidSetting.addOption(CreateUidsIterator.COLLAPSE_UIDS, Boolean.toString(false));
+                uidSetting.addOption(CreateUidsIterator.PARSE_TLD_UIDS, Boolean.toString(false));
+                uidSetting.addOption(CreateUidsIterator.FIELD_COUNTS, Boolean.toString(false));
+                uidSetting.addOption(CreateUidsIterator.TERM_COUNTS, Boolean.toString(false));
             }
 
             /*

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
@@ -122,8 +122,9 @@ public class ShardRangeStream extends RangeStream {
         }
 
         public QueryPlan apply(Entry<Key,Value> entry) {
-            Key start = new Key(entry.getKey().getRow(), entry.getKey().getColumnFamily());
-            Key end = entry.getKey().followingKey(PartialKey.ROW_COLFAM);
+            Key key = entry.getKey();
+            Key start = new Key(key.getRow(), key.getColumnFamily());
+            Key end = start.followingKey(PartialKey.ROW_COLFAM);
             Range range = new Range(start, true, end, false);
             //  @formatter:off
             return new QueryPlan()

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -269,6 +270,9 @@ public class QueryOptions implements OptionDescriber {
 
     public static final String TERM_FREQUENCY_AGGREGATION_THRESHOLD_MS = "tf.agg.threshold";
 
+    public static final String FIELD_COUNTS = "field.counts";
+    public static final String TERM_COUNTS = "term.counts";
+
     protected Map<String,String> options;
 
     protected String scanId;
@@ -431,6 +435,9 @@ public class QueryOptions implements OptionDescriber {
     private int docAggregationThresholdMs = -1;
     private int tfAggregationThresholdMs = -1;
 
+    private Map<String,Long> fieldCounts;
+    private Map<String,Long> termCounts;
+
     public void deepCopy(QueryOptions other) {
         this.options = other.options;
         this.query = other.query;
@@ -539,6 +546,9 @@ public class QueryOptions implements OptionDescriber {
 
         this.docAggregationThresholdMs = other.docAggregationThresholdMs;
         this.tfAggregationThresholdMs = other.tfAggregationThresholdMs;
+
+        this.fieldCounts = other.fieldCounts;
+        this.termCounts = other.termCounts;
     }
 
     public String getQuery() {
@@ -1253,6 +1263,8 @@ public class QueryOptions implements OptionDescriber {
         options.put(TF_NEXT_SEEK, "The number of next calls made by a Term Frequency data filter or aggregator before a seek is issued");
         options.put(DOC_AGGREGATION_THRESHOLD_MS, "Document aggregations that exceed this threshold are logged as a warning");
         options.put(TERM_FREQUENCY_AGGREGATION_THRESHOLD_MS, "TermFrequency aggregations that exceed this threshold are logged as a warning");
+        options.put(FIELD_COUNTS, "Map of field counts from the global index");
+        options.put(TERM_COUNTS, "Map of term counts from the global index");
         return new IteratorOptions(getClass().getSimpleName(), "Runs a query against the DATAWAVE tables", options, null);
     }
 
@@ -1376,6 +1388,16 @@ public class QueryOptions implements OptionDescriber {
                 this.disallowListedFields = new HashSet<>();
                 Collections.addAll(this.disallowListedFields, StringUtils.split(fieldList, Constants.PARAM_VALUE_SEP));
             }
+        }
+
+        if (options.containsKey(FIELD_COUNTS)) {
+            String serializedMap = options.get(FIELD_COUNTS);
+            this.fieldCounts = mapFromString(serializedMap);
+        }
+
+        if (options.containsKey(TERM_COUNTS)) {
+            String serializedMap = options.get(TERM_COUNTS);
+            this.termCounts = mapFromString(serializedMap);
         }
 
         this.evaluationFilter = null;
@@ -1973,6 +1995,31 @@ public class QueryOptions implements OptionDescriber {
         }
 
         return sb.toString();
+    }
+
+    public static String mapToString(Map<String,Long> map) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<String> keys = new TreeSet<>(map.keySet()).iterator();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            sb.append(key).append(Constants.COMMA).append(map.get(key));
+            if (keys.hasNext()) {
+                sb.append(";");
+            }
+        }
+        return sb.toString();
+    }
+
+    public static Map<String,Long> mapFromString(String serialized) {
+        Map<String,Long> counts = new HashMap<>();
+        String[] parts = serialized.split(";");
+        for (String part : parts) {
+            int index = part.indexOf(Constants.COMMA);
+            String key = part.substring(0, index);
+            Long value = Long.valueOf(part.substring(index + 1));
+            counts.put(key, value);
+        }
+        return counts;
     }
 
     public static Set<String> buildIgnoredColumnFamilies(String colFams) {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/BooleanChunkingQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/BooleanChunkingQueryPlanner.java
@@ -36,8 +36,8 @@ public class BooleanChunkingQueryPlanner extends DefaultQueryPlanner {
 
     @Override
     protected ASTJexlScript updateQueryTree(ScannerFactory scannerFactory, MetadataHelper metadataHelper, DateIndexHelper dateIndexHelper,
-                    ShardQueryConfiguration config, String query, QueryData queryData, Query settings) throws DatawaveQueryException {
-        ASTJexlScript queryTree = super.updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, queryData, settings);
+                    ShardQueryConfiguration config, String query, Query settings) throws DatawaveQueryException {
+        ASTJexlScript queryTree = super.updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, settings);
 
         if (queryTree == null) {
             return null;
@@ -91,10 +91,7 @@ public class BooleanChunkingQueryPlanner extends DefaultQueryPlanner {
     @Override
     protected CloseableIterable<QueryData> process(ScannerFactory scannerFactory, MetadataHelper metadataHelper, DateIndexHelper dateIndexHelper,
                     ShardQueryConfiguration config, String query, Query settings) throws DatawaveQueryException {
-        final QueryData queryData = new QueryData();
-        final ArrayList<QueryData> data = Lists.newArrayList();
-
-        ASTJexlScript queryTree = updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, queryData, settings);
+        ASTJexlScript queryTree = updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, settings);
         if (queryTree == null) {
             return DefaultQueryPlanner.emptyCloseableIterator();
         }
@@ -108,17 +105,18 @@ public class BooleanChunkingQueryPlanner extends DefaultQueryPlanner {
             log.debug(newQueryString);
         }
 
-        queryData.setQuery(newQueryString);
+        final ArrayList<QueryData> data = Lists.newArrayList();
+        final QueryData queryData = new QueryData().withQuery(newQueryString);
         data.add(queryData);
 
-        return new CloseableIterable<QueryData>() {
+        return new CloseableIterable<>() {
             @Override
             public Iterator<QueryData> iterator() {
                 return data.iterator();
             }
 
             @Override
-            public void close() throws IOException {}
+            public void close() {}
         };
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/planner/FacetedQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/FacetedQueryPlanner.java
@@ -94,13 +94,13 @@ public class FacetedQueryPlanner extends IndexQueryPlanner {
 
     @Override
     protected ASTJexlScript updateQueryTree(ScannerFactory scannerFactory, MetadataHelper metadataHelper, DateIndexHelper dateIndexHelper,
-                    ShardQueryConfiguration config, String query, QueryData queryData, Query settings) throws DatawaveQueryException {
+                    ShardQueryConfiguration config, String query, Query settings) throws DatawaveQueryException {
         // we want all terms expanded (except when max terms is reached)
         config.setExpandAllTerms(true);
 
         // update the query tree
 
-        return super.updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, queryData, settings);
+        return super.updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, settings);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/planner/IndexQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/IndexQueryPlanner.java
@@ -56,12 +56,12 @@ public class IndexQueryPlanner extends DefaultQueryPlanner {
 
     @Override
     protected ASTJexlScript updateQueryTree(ScannerFactory scannerFactory, MetadataHelper metadataHelper, DateIndexHelper dateIndexHelper,
-                    ShardQueryConfiguration config, String query, QueryData queryData, Query settings) throws DatawaveQueryException {
+                    ShardQueryConfiguration config, String query, Query settings) throws DatawaveQueryException {
         // we want all terms expanded (except when max terms is reached)
         config.setExpandAllTerms(true);
 
         // update the query tree
-        ASTJexlScript script = super.updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, queryData, settings);
+        ASTJexlScript script = super.updateQueryTree(scannerFactory, metadataHelper, dateIndexHelper, config, query, settings);
 
         return limitQueryTree(script, config);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundlerIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundlerIterator.java
@@ -24,6 +24,8 @@ import com.google.common.collect.Lists;
 import datawave.common.util.MultiComparator;
 import datawave.common.util.concurrent.BoundedBlockingQueue;
 import datawave.query.CloseableIterable;
+import datawave.query.iterator.QueryIterator;
+import datawave.query.iterator.QueryOptions;
 import datawave.query.tld.TLDQueryIterator;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.Query;
@@ -145,7 +147,8 @@ public class ThreadedRangeBundlerIterator implements Iterator<QueryData>, Closea
 
                     // if the generated query is larger, use the original
                     if (null != queryTree && (plan.getQueryString().length() > original.getQuery().length())) {
-                        plan.setQuery(original.getQuery(), queryTree);
+                        plan.setQueryTree(queryTree);
+                        plan.withQueryString(original.getQuery());
                     }
                     if (log.isTraceEnabled())
                         log.trace("size of ranges is " + plan.getRanges());
@@ -275,6 +278,15 @@ public class ThreadedRangeBundlerIterator implements Iterator<QueryData>, Closea
 
             IteratorSetting newSetting = new IteratorSetting(setting.getPriority(), setting.getName(), iterClazz);
             newSetting.addOptions(setting.getOptions());
+
+            if (plan.getFieldCounts() != null && !plan.getTermCounts().isEmpty()) {
+                newSetting.addOption(QueryOptions.FIELD_COUNTS, QueryOptions.mapToString(plan.getFieldCounts()));
+            }
+
+            if (plan.getTermCounts() != null && !plan.getTermCounts().isEmpty()) {
+                newSetting.addOption(QueryOptions.TERM_COUNTS, QueryOptions.mapToString(plan.getTermCounts()));
+            }
+
             settings.add(newSetting);
         }
 

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/SequentialScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/SequentialScheduler.java
@@ -126,8 +126,9 @@ public class SequentialScheduler extends Scheduler {
                 if (this.queries.hasNext()) {
                     // Keep track of how many QueryData's we make
                     QueryData qd = this.queries.next();
-                    if (null != qd.getRanges())
+                    if (null != qd.getRanges()) {
                         rangesSeen += qd.getRanges().size();
+                    }
                     count.incrementAndGet();
                     if (null == newQueryData)
                         newQueryData = new QueryData(qd);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -2750,4 +2750,20 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     public void setPruneQueryOptions(boolean pruneQueryOptions) {
         getConfig().setPruneQueryOptions(pruneQueryOptions);
     }
+
+    public boolean getUseFieldCounts() {
+        return getConfig().getUseFieldCounts();
+    }
+
+    public void setUseFieldCounts(boolean useFieldCounts) {
+        getConfig().setUseFieldCounts(useFieldCounts);
+    }
+
+    public boolean getUseTermCounts() {
+        return getConfig().getUseTermCounts();
+    }
+
+    public void setUseTermCounts(boolean useTermCounts) {
+        getConfig().setUseTermCounts(useTermCounts);
+    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
@@ -346,7 +346,6 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
      */
     protected QueryData configureRanges(String queryString) throws ParseException {
         queryString = EdgeQueryLogic.fixQueryString(queryString);
-        QueryData qData = new QueryData();
         Parser parser = new Parser(new StringProvider(";"));
         ASTJexlScript script;
         try {
@@ -362,8 +361,7 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         visitationContext = (VisitationContext) script.jjtAccept(visitor, null);
 
         Set<Range> ranges = visitationContext.getRanges();
-        qData.setRanges(ranges);
-        return qData;
+        return new QueryData().withRanges(ranges);
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetQueryPlanVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetQueryPlanVisitor.java
@@ -2,10 +2,10 @@ package datawave.query.tables.facets;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -63,7 +63,7 @@ public class FacetQueryPlanVisitor extends BaseVisitor implements CloseableItera
         Key startKey = new Key(literal + "\u0000");
         Key endKey = new Key(literal + "\uFFFF");
 
-        Collection<String> fieldPairs = new ArrayList<>();
+        List<String> fieldPairs = new ArrayList<>();
         for (String facet : facetedFields) {
             StringBuilder facetBuilder = new StringBuilder(fieldName);
             facetBuilder.append("\u0000").append(facet);

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -549,6 +549,11 @@ public class ShardQueryConfigurationTest {
 
         defaultValues.put("groupFields", new GroupFields());
         updatedValues.put("groupFields", GroupFields.from("GROUP(FIELD_G,FIELD_H)"));
+
+        defaultValues.put("useFieldCounts", false);
+        updatedValues.put("useFieldCounts", true);
+        defaultValues.put("useTermCounts", false);
+        updatedValues.put("useTermCounts", true);
     }
 
     private Query createQuery(String query) {

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/CreateUidsIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/CreateUidsIteratorTest.java
@@ -313,6 +313,52 @@ public class CreateUidsIteratorTest {
         assertFalse(iterator.hasTop());
     }
 
+    @Test
+    public void testTermCounts() throws IOException {
+        List<String> uids = List.of("parent.doc.id", "parent.doc.id.child01", "parent.doc.id.child02");
+        Value value = valueForUids(uids);
+
+        TreeMap<Key,Value> data = new TreeMap<>();
+        data.put(keyForTerm("FIELD", "value"), value);
+
+        Map<String,String> options = new HashMap<>();
+        options.put(CreateUidsIterator.FIELD_COUNTS, "true");
+
+        CreateUidsIterator iterator = iteratorFromOptions(options, data);
+        assertTrue(iterator.hasTop());
+
+        IndexInfo info = infoFromValue(iterator.getTopValue());
+
+        Map<String,Long> expected = new HashMap<>();
+        expected.put("NO_FIELD", 3L); // NO_FIELD because the test framework didn't pass in a real seek range
+        assertEquals(expected, info.getFieldCounts());
+    }
+
+    private Value valueForUids(Collection<String> uids) {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.addAllUID(uids);
+        builder.setCOUNT(uids.size());
+        builder.setIGNORE(false);
+        return new Value(builder.build().toByteArray());
+    }
+
+    private Key keyForTerm(String field, String value) {
+        return new Key(value, field, "20190314_1\u0000datatypeA");
+    }
+
+    private IndexInfo infoFromValue(Value value) throws IOException {
+        IndexInfo indexInfo = new IndexInfo();
+        indexInfo.readFields(new DataInputStream(new ByteArrayInputStream(value.get())));
+        return indexInfo;
+    }
+
+    private CreateUidsIterator iteratorFromOptions(Map<String,String> options, TreeMap<Key,Value> data) throws IOException {
+        CreateUidsIterator iterator = new CreateUidsIterator();
+        iterator.init(new SortedMapIterator(data), options, null);
+        iterator.seek(new Range(), Collections.emptySet(), false);
+        return iterator;
+    }
+
     static void addToExpectedDocs(String dataType, Iterable<String> docIds, Collection<IndexMatch> expected, JexlNode node) {
         for (String id : docIds)
             expected.add(new IndexMatch(dataType + '\u0000' + id, node));

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
@@ -215,6 +215,19 @@ public class QueryOptionsTest {
     }
 
     @Test
+    public void testMapSerialization() {
+        Map<String,Long> map = new HashMap<>();
+        map.put("FIELD_A", 23L);
+        map.put("FIELD_B", 146L);
+
+        String serialized = QueryOptions.mapToString(map);
+        assertEquals("FIELD_A,23;FIELD_B,146", serialized);
+
+        Map<String,Long> deserialized = QueryOptions.mapFromString(serialized);
+        assertEquals(map, deserialized);
+    }
+
+    @Test
     public void testNoDataTypeFilter() {
         Map<String,String> noOpts = Collections.emptyMap();
         QueryOptions opts = new QueryOptions();

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -259,6 +259,9 @@
         <property name="reduceTypeMetadataPerShard" value="false" />
         <!--    should the query prune fields by ingest type    -->
         <property name="pruneQueryByIngestTypes" value="false" />
+        <!--   should the range stream also generate field and term counts    -->
+        <property name="useFieldCounts" value="true" />
+        <property name="useTermCounts" value="true" />
     </bean>
 
     <bean id="TLDEventQuery" scope="prototype" parent="BaseEventQuery" class="datawave.query.tables.TLDQueryLogic">

--- a/web-services/query/src/main/java/datawave/webservice/query/configuration/QueryData.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/configuration/QueryData.java
@@ -18,6 +18,7 @@ public class QueryData {
     private Collection<Range> ranges = new HashSet<>();
     private Collection<String> columnFamilies = new HashSet<>();
     private List<IteratorSetting> settings = new ArrayList<>();
+    private boolean rebuildHashCode = true;
     private int hashCode = -1;
 
     public QueryData() {
@@ -55,26 +56,7 @@ public class QueryData {
         this.columnFamilies = new HashSet<>(other.columnFamilies);
         this.settings = new ArrayList<>(other.settings);
         this.hashCode = other.hashCode;
-    }
-
-    public QueryData withQuery(String query) {
-        setQuery(query);
-        return this;
-    }
-
-    public QueryData withRanges(Collection<Range> ranges) {
-        setRanges(ranges);
-        return this;
-    }
-
-    public QueryData withColumnFamilies(Collection<String> columnFamilies) {
-        setColumnFamilies(columnFamilies);
-        return this;
-    }
-
-    public QueryData withSettings(List<IteratorSetting> settings) {
-        setSettings(settings);
-        return this;
+        this.rebuildHashCode = other.rebuildHashCode;
     }
 
     @Deprecated(since = "6.5.0", forRemoval = true)
@@ -106,8 +88,30 @@ public class QueryData {
         this.columnFamilies.addAll(columnFamilies);
     }
 
-    public List<IteratorSetting> getSettings() {
-        return settings;
+    // builder style methods
+
+    public QueryData withQuery(String query) {
+        this.query = query;
+        resetHashCode();
+        return this;
+    }
+
+    public QueryData withRanges(Collection<Range> ranges) {
+        this.ranges = ranges;
+        resetHashCode();
+        return this;
+    }
+
+    public QueryData withColumnFamilies(Collection<String> columnFamilies) {
+        this.columnFamilies = columnFamilies;
+        resetHashCode();
+        return this;
+    }
+
+    public QueryData withSettings(List<IteratorSetting> settings) {
+        this.settings = settings;
+        resetHashCode();
+        return this;
     }
 
     public void setSettings(List<IteratorSetting> settings) {
@@ -115,13 +119,17 @@ public class QueryData {
         resetHashCode();
     }
 
-    public String getQuery() {
-        return query;
+    public List<IteratorSetting> getSettings() {
+        return settings;
     }
 
     public void setQuery(String query) {
         this.query = query;
         resetHashCode();
+    }
+
+    public String getQuery() {
+        return query;
     }
 
     public Collection<Range> getRanges() {
@@ -175,7 +183,7 @@ public class QueryData {
 
     @Override
     public int hashCode() {
-        if (hashCode == -1) {
+        if (rebuildHashCode) {
             //  @formatter:off
             hashCode = new HashCodeBuilder()
                             .append(query)
@@ -183,6 +191,7 @@ public class QueryData {
                             .append(columnFamilies)
                             .append(settings)
                             .hashCode();
+            rebuildHashCode = false;
             //  @formatter:on
         }
         return hashCode;
@@ -192,6 +201,6 @@ public class QueryData {
      * Method to reset the hashcode when an internal variable is updated
      */
     private void resetHashCode() {
-        hashCode = -1;
+        rebuildHashCode = true;
     }
 }

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/QueryDataTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/QueryDataTest.java
@@ -12,8 +12,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.junit.Test;
 
-import com.google.common.collect.Lists;
-
 public class QueryDataTest {
 
     @Test


### PR DESCRIPTION
Optionally persist field or term counts from the shard index through to the query iterator. Refactored QueryPlan and QueryData to support.