### PR TITLE
Better exception handling for the IngestTypePruningVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypePruningVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypePruningVisitor.java
@@ -381,7 +381,13 @@ public class IngestTypePruningVisitor extends BaseVisitor {
     public Set<String> getFieldsForLeaf(JexlNode node) {
         JexlNode deref = JexlASTHelper.dereference(node);
         if (deref instanceof ASTFunctionNode) {
-            return getFieldsForFunctionNode((ASTFunctionNode) deref);
+            try {
+                return getFieldsForFunctionNode((ASTFunctionNode) deref);
+            } catch (Exception e) {
+                // if a FunctionsDescriptor throws an exception for any reason then return an empty collection
+                // so the node gets treated as an unknown type
+                return Collections.emptySet();
+            }
         }
 
         //  @formatter:off


### PR DESCRIPTION
Handles case when a FunctionsDescriptor is extended and throws an exception