### PR TITLE
CompositeQueryLogic persists the max results calculated by getResultLimit()

### DIFF
--- a/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/BaseQueryLogic.java
@@ -79,6 +79,8 @@ public abstract class BaseQueryLogic<T> implements QueryLogic<T> {
         setRoleManager(other.getRoleManager());
         setSelectorExtractor(other.getSelectorExtractor());
         setResponseEnricherBuilder(other.getResponseEnricherBuilder());
+        this.dnResultLimits = other.dnResultLimits;
+        this.systemFromResultLimits = other.systemFromResultLimits;
     }
 
     public GenericQueryConfiguration getConfig() {

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogic.java
@@ -98,6 +98,9 @@ public class CompositeQueryLogic extends BaseQueryLogic<Object> {
 
         public void setMaxResults(long maxResults) {
             this.maxResults = maxResults;
+            if (maxResults > logic.getMaxResults() && logic.getMaxResults() != -1) {
+                logic.setMaxResults(maxResults);
+            }
         }
 
         public long getMaxResults() {
@@ -684,5 +687,16 @@ public class CompositeQueryLogic extends BaseQueryLogic<Object> {
 
     public CountDownLatch getCompletionLatch() {
         return completionLatch;
+    }
+
+    @Override
+    public void setMaxResults(long maxResults) {
+        this.maxResults = maxResults;
+        super.setMaxResults(maxResults);
+        if (queryLogics != null) {
+            for (QueryLogic<?> queryLogic : queryLogics.values()) {
+                queryLogic.setMaxResults(maxResults);
+            }
+        }
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogic.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/logic/composite/CompositeQueryLogic.java
@@ -693,10 +693,8 @@ public class CompositeQueryLogic extends BaseQueryLogic<Object> {
     public void setMaxResults(long maxResults) {
         this.maxResults = maxResults;
         super.setMaxResults(maxResults);
-        if (queryLogics != null) {
-            for (QueryLogic<?> queryLogic : queryLogics.values()) {
-                queryLogic.setMaxResults(maxResults);
-            }
+        for (QueryLogic<?> queryLogic : getQueryLogics().values()) {
+            queryLogic.setMaxResults(maxResults);
         }
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
@@ -156,6 +156,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
         if (this.maxResults != this.logic.getMaxResults()) {
             log.info("Maximum results set to " + this.maxResults + " instead of default " + this.logic.getMaxResults() + ", user " + this.settings.getUserDN()
                             + " has a DN configured with a different limit");
+            this.logic.setMaxResults(maxResults);
         }
     }
 

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -462,6 +462,7 @@ public class ExtendedRunningQueryTest {
         expect(this.query.getQueryAuthorizations()).andReturn(methodAuths).times(2);
         expect(this.query.getUserDN()).andReturn(userDN).times(4);
         expect(this.query.getColumnVisibility()).andReturn(columnVisibility);
+        expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
         expect(this.queryLogic.initialize(eq(this.client), eq(this.query), isA(Set.class))).andReturn(this.genericConfiguration);
         this.queryLogic.setupQuery(this.genericConfiguration);
         expect(this.queryLogic.getTransformIterator(this.query)).andReturn(this.transformIterator);
@@ -485,11 +486,11 @@ public class ExtendedRunningQueryTest {
         expect(this.queryLogic.getMaxPageSize()).andReturn(maxPageSize).anyTimes();
         expect(this.queryLogic.getPageByteTrigger()).andReturn(pageByteTrigger).anyTimes();
         expect(this.queryLogic.getMaxWork()).andReturn(maxWork).anyTimes();
-        expect(this.queryLogic.getMaxResults()).andReturn(maxResults).anyTimes();
         this.queryLogic.preInitialize(this.query, WSAuthorizationsUtil.buildAuthorizations(Collections.singleton(Collections.singleton("AUTH_1"))));
         expect(this.queryLogic.getUserOperations()).andReturn(null);
         expect(this.genericConfiguration.getQueryString()).andReturn(query).once();
         this.queryLogic.setPageProcessingStartTime(anyLong());
+        this.queryLogic.setMaxResults(anyLong());
 
         // Run the test
         PowerMock.replayAll();


### PR DESCRIPTION
CompositeQueryLogic now respects the max results calculated by getResultLimit(). This allows overriding the max results by user dn and system from.