### PR TITLE
Enforce term threshold prior to range stream lookups

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -318,6 +318,8 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private int eventPerDayThreshold = 10000;
     private int shardsPerDayThreshold = 10;
     private int initialMaxTermThreshold = 2500;
+    // the intermediate term threshold is used to enforce a term limit prior to the range stream
+    private int intermediateMaxTermThreshold = 2500;
     private int finalMaxTermThreshold = 2500;
     private int maxDepthThreshold = 2500;
     private boolean expandFields = true;
@@ -585,6 +587,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setEventPerDayThreshold(other.getEventPerDayThreshold());
         this.setShardsPerDayThreshold(other.getShardsPerDayThreshold());
         this.setInitialMaxTermThreshold(other.getInitialMaxTermThreshold());
+        this.setIntermediateMaxTermThreshold(other.getIntermediateMaxTermThreshold());
         this.setFinalMaxTermThreshold(other.getFinalMaxTermThreshold());
         this.setMaxDepthThreshold(other.getMaxDepthThreshold());
         this.setMaxUnfieldedExpansionThreshold(other.getMaxUnfieldedExpansionThreshold());
@@ -1199,6 +1202,14 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setInitialMaxTermThreshold(int initialMaxTermThreshold) {
         this.initialMaxTermThreshold = initialMaxTermThreshold;
+    }
+
+    public int getIntermediateMaxTermThreshold() {
+        return intermediateMaxTermThreshold;
+    }
+
+    public void setIntermediateMaxTermThreshold(int intermediateMaxTermThreshold) {
+        this.intermediateMaxTermThreshold = intermediateMaxTermThreshold;
     }
 
     public int getFinalMaxTermThreshold() {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2558,6 +2558,12 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
 
             // count the terms
             int termCount = TermCountingVisitor.countTerms(queryTree);
+
+            if (config.getIntermediateMaxTermThreshold() > 0 && termCount > config.getIntermediateMaxTermThreshold()) {
+                throw new DatawaveFatalQueryException(
+                                "Query with " + termCount + " exceeds the initial max term threshold of " + config.getIntermediateMaxTermThreshold());
+            }
+
             if (termCount >= pushdownThreshold) {
                 if (log.isTraceEnabled()) {
                     log.trace("pushing down query because it has " + termCount + " when our max is " + pushdownThreshold);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -1532,6 +1532,14 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
         getConfig().setInitialMaxTermThreshold(initialMaxTermThreshold);
     }
 
+    public int getIntermediateMaxTermThreshold() {
+        return getConfig().getIntermediateMaxTermThreshold();
+    }
+
+    public void setIntermediateMaxTermThreshold(int intermediateMaxTermThreshold) {
+        getConfig().setIntermediateMaxTermThreshold(intermediateMaxTermThreshold);
+    }
+
     public int getFinalMaxTermThreshold() {
         return getConfig().getFinalMaxTermThreshold();
     }

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -319,6 +319,8 @@ public class ShardQueryConfigurationTest {
         updatedValues.put("shardsPerDayThreshold", 18);
         defaultValues.put("initialMaxTermThreshold", 2500);
         updatedValues.put("initialMaxTermThreshold", 2540);
+        defaultValues.put("intermediateMaxTermThreshold", 2500);
+        updatedValues.put("intermediateMaxTermThreshold", 5500);
         defaultValues.put("finalMaxTermThreshold", 2500);
         updatedValues.put("finalMaxTermThreshold", 2501);
         defaultValues.put("maxDepthThreshold", 2500);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -286,6 +286,7 @@ public abstract class ExecutableExpansionVisitorTest {
 
         logic.setMaxDepthThreshold(30);
         logic.setInitialMaxTermThreshold(10000);
+        logic.setIntermediateMaxTermThreshold(10000);
         logic.setFinalMaxTermThreshold(10000);
 
         //  @formatter:off
@@ -445,6 +446,8 @@ public abstract class ExecutableExpansionVisitorTest {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
+
+        logic.setIntermediateMaxTermThreshold(15);
 
         if (log.isDebugEnabled()) {
             log.debug("testMatchesAtLeastCountOf");

--- a/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
@@ -348,10 +348,12 @@ public class CompositeIndexTest {
                 "((_Bounded_ = true) && (" + WKT_BYTE_LENGTH_FIELD + " >= 0" + JEXL_AND_OP + WKT_BYTE_LENGTH_FIELD + " < 80))";
         // @formatter:on
 
-        List<QueryData> queries = getQueryRanges(query, false);
+        ShardQueryLogic logic = getShardQueryLogic(false);
+        logic.setIntermediateMaxTermThreshold(50);
+        List<QueryData> queries = getQueryRanges(logic, query, false);
         Assert.assertEquals(12, queries.size());
 
-        List<DefaultEvent> events = getQueryResults(query, false);
+        List<DefaultEvent> events = getQueryResults(logic, query, false);
         Assert.assertEquals(9, events.size());
 
         List<String> wktList = new ArrayList<>();
@@ -482,7 +484,10 @@ public class CompositeIndexTest {
 
     private List<QueryData> getQueryRanges(String queryString, boolean useIvarator) throws Exception {
         ShardQueryLogic logic = getShardQueryLogic(useIvarator);
+        return getQueryRanges(logic, queryString, useIvarator);
+    }
 
+    private List<QueryData> getQueryRanges(ShardQueryLogic logic, String queryString, boolean useIvarator) throws Exception {
         Iterator iter = getQueryRangesIterator(queryString, logic);
         List<QueryData> queryData = new ArrayList<>();
         while (iter.hasNext())
@@ -492,7 +497,10 @@ public class CompositeIndexTest {
 
     private List<DefaultEvent> getQueryResults(String queryString, boolean useIvarator) throws Exception {
         ShardQueryLogic logic = getShardQueryLogic(useIvarator);
+        return getQueryResults(logic, queryString, useIvarator);
+    }
 
+    private List<DefaultEvent> getQueryResults(ShardQueryLogic logic, String queryString, boolean useIvarator) throws Exception {
         Iterator iter = getResultsIterator(queryString, logic);
         List<DefaultEvent> events = new ArrayList<>();
         while (iter.hasNext())
@@ -564,6 +572,7 @@ public class CompositeIndexTest {
         // increase the depth threshold
         logic.setMaxDepthThreshold(20);
         logic.setInitialMaxTermThreshold(15);
+        logic.setIntermediateMaxTermThreshold(15);
         logic.setFinalMaxTermThreshold(15);
 
         // set the pushdown threshold really high to avoid collapsing uids into shards (overrides setCollapseUids if #terms is greater than this threshold)

--- a/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
@@ -8,6 +8,7 @@ import static datawave.webservice.query.QueryParameters.QUERY_LOGIC_NAME;
 import static datawave.webservice.query.QueryParameters.QUERY_NAME;
 import static datawave.webservice.query.QueryParameters.QUERY_PERSISTENCE;
 import static datawave.webservice.query.QueryParameters.QUERY_STRING;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
@@ -65,6 +66,7 @@ import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
 import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.GeoWaveQueryInfoVisitor;
 import datawave.query.tables.ShardQueryLogic;
@@ -274,6 +276,8 @@ public class GeoSortedQueryDataTest {
         // increase the depth threshold
         logic.setMaxDepthThreshold(10);
 
+        logic.setIntermediateMaxTermThreshold(50);
+
         // set the pushdown threshold really high to avoid collapsing uids into shards (overrides setCollapseUids if #terms is greater than this threshold)
         ((DefaultQueryPlanner) (logic.getQueryPlanner())).setPushdownThreshold(1000000);
     }
@@ -295,6 +299,14 @@ public class GeoSortedQueryDataTest {
                 assertTrue(prevQueryInfo.compareTo(queryInfo) <= 0);
             prevQueryInfo = queryInfo;
         }
+    }
+
+    @Test
+    public void testIntermediateMaxTermCountEnforcement() {
+        logic.setSortGeoWaveQueryRanges(true);
+        logic.setIntermediateMaxTermThreshold(10);
+
+        assertThrows(DatawaveFatalQueryException.class, this::initializeGeoQuery);
     }
 
     @Test

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -97,6 +97,7 @@
         <property name="shardsPerDayThreshold" value="4" />	<!-- ${beq.shardsPerDayThreshold} -->
         <!-- The max number of terms BEFORE all expansions -->
         <property name="initialMaxTermThreshold" value="10" />	<!-- was ${beq.initialMaxTermThreshold} -->
+        <property name="intermediateMaxTermThreshold" value="10" />
         <!-- The max number of terms AFTER all expansions -->
         <property name="finalMaxTermThreshold" value="10" />	<!-- was ${beq.finalMaxTermThreshold} -->
         <!-- The max query depth -->

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -198,6 +198,7 @@
         <property name="shardsPerDayThreshold" value="4" />	<!-- ${beq.shardsPerDayThreshold} -->
         <!-- The max number of terms BEFORE all expansions -->
         <property name="initialMaxTermThreshold" value="10" />	<!-- was ${beq.initialMaxTermThreshold} -->
+        <property name="intermediateMaxTermThreshold" value="10" />
         <!-- The max number of terms AFTER all expansions -->
         <property name="finalMaxTermThreshold" value="10" />	<!-- was ${beq.finalMaxTermThreshold} -->
         <!-- The max query depth -->


### PR DESCRIPTION
In addition to checking term thresholds at the beginning and very end of query planning, also check just prior to the range stream