### PR TITLE
Limit Query Logging in RangeStream

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -549,6 +549,12 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private DocumentScannerConfig documentScannerConfig;
 
     /**
+     * The maximum number of lines to print when streaming the query from the global index. Useful for limiting the logging footprint of large queries when
+     * debug logging is enabled.
+     */
+    private int maxLinesToPrint = -1;
+
+    /**
      * Default constructor
      */
     public ShardQueryConfiguration() {
@@ -800,6 +806,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                         other.getNoExpansionIfCurrentDateTypes() == null ? null : Sets.newHashSet(other.getNoExpansionIfCurrentDateTypes()));
         this.setUseDocumentScheduler(other.isUseDocumentScheduler());
         this.setDocumentScannerConfig(other.getDocumentScannerConfig());
+        this.setMaxLinesToPrint(other.getMaxLinesToPrint());
     }
 
     /**
@@ -3384,5 +3391,13 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setUseDocumentScheduler(boolean useDocumentScheduler) {
         this.useDocumentScheduler = useDocumentScheduler;
+    }
+
+    public int getMaxLinesToPrint() {
+        return maxLinesToPrint;
+    }
+
+    public void setMaxLinesToPrint(int maxLinesToPrint) {
+        this.maxLinesToPrint = maxLinesToPrint;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -155,6 +155,9 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
 
     protected NumShardFinder numShardFinder;
 
+    private int maxLinesToPrint = -1;
+    private int linesPrinted = 0;
+
     public RangeStream(ShardQueryConfiguration config, ScannerFactory scanners, MetadataHelper metadataHelper) {
         this.config = config;
         this.scanners = scanners;
@@ -220,8 +223,12 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         if (log.isDebugEnabled()) {
             log.debug("Query returned a stream with a context of " + this.context);
             if (queryStream != null) {
+                int count = 0;
                 for (String line : StringUtils.split(queryStream.getContextDebug(), '\n')) {
                     log.debug(line);
+                    if (maxLinesToPrint > 0 && ++count > maxLinesToPrint) {
+                        break;
+                    }
                 }
             }
         }
@@ -288,8 +295,12 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
 
                 if (log.isDebugEnabled()) {
                     log.debug("Query returned a stream with a context of " + this.context);
+                    int count = 0;
                     for (String line : StringUtils.split(queryStream.getContextDebug(), '\n')) {
                         log.debug(line);
+                        if (maxLinesToPrint > 0 && ++count > maxLinesToPrint) {
+                            break;
+                        }
                     }
                 }
 
@@ -317,6 +328,26 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         }
 
         return new EmptyPlanPruner();
+    }
+
+    /**
+     * Get the maximum number of lines to print. Useful when debug logging is enabled for very large queries. This property is disabled when set to -1 or 0.
+     *
+     * @return the maximum number of lines to print
+     */
+    public int getMaxLinesToPrint() {
+        return maxLinesToPrint;
+    }
+
+    /**
+     * Set the maximum number of lines to print. Number must be a positive integer to have an effect.
+     *
+     * @param maxLinesToPrint
+     *            the maximum number of lines to print
+     */
+    public RangeStream setMaxLinesToPrint(int maxLinesToPrint) {
+        this.maxLinesToPrint = maxLinesToPrint;
+        return this;
     }
 
     /**
@@ -572,22 +603,31 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         if (!isIndexed(fieldName, config.getIndexedFields())) {
             try {
                 if (this.getAllFieldsFromHelper().contains(fieldName)) {
-                    log.debug("{\"" + fieldName + "\": \"" + literal + "\"} is not indexed.");
+                    if (maxLinesToPrint > 0 && linesPrinted < maxLinesToPrint) {
+                        linesPrinted++;
+                        log.debug("{\"" + fieldName + "\": \"" + literal + "\"} is not indexed.");
+                    }
                     return ScannerStream.delayed(node);
                 }
             } catch (TableNotFoundException e) {
                 log.error(e);
                 throw new RuntimeException(e);
             }
-            log.debug("{\"" + fieldName + "\": \"" + literal + "\"} is not an observed field.");
-
+            if (maxLinesToPrint > 0 && ++linesPrinted < maxLinesToPrint) {
+                linesPrinted++;
+                log.debug("{\"" + fieldName + "\": \"" + literal + "\"} is not an observed field.");
+            }
             // even though the field is not indexed it may still be valuable when evaluating an event. mark this scanner stream as delayed, so it is correctly
             // propagated
             return ScannerStream.delayed(node);
         }
 
         // Final case, field is indexed
-        log.debug("\"" + fieldName + "\" is indexed. for " + literal);
+        if (maxLinesToPrint > 0 && linesPrinted < maxLinesToPrint) {
+            linesPrinted++;
+            log.debug("\"" + fieldName + "\" is indexed. for " + literal);
+        }
+
         try {
 
             int stackStart = config.getBaseIteratorPriority();

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -3112,7 +3112,12 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             RangeStream stream = rstream.getConstructor(ShardQueryConfiguration.class, ScannerFactory.class, MetadataHelper.class).newInstance(config,
                             scannerFactory, metadataHelper);
 
-            return stream.setUidIntersector(uidIntersector).setLimitScanners(limitScanners).setCreateUidsIteratorClass(createUidsIteratorClass);
+            //  @formatter:off
+            return stream.setUidIntersector(uidIntersector)
+                            .setLimitScanners(limitScanners)
+                            .setCreateUidsIteratorClass(createUidsIteratorClass)
+                            .setMaxLinesToPrint(config.getMaxLinesToPrint());
+            //  @formatter:on
 
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
                         | NoSuchMethodException | SecurityException e) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -3477,4 +3477,12 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
     public void setDateIndexIterator(boolean dateIndexIterator) {
         getConfig().setDateIndexIterator(dateIndexIterator);
     }
+
+    public int getMaxLinesToPrint() {
+        return getConfig().getMaxLinesToPrint();
+    }
+
+    public void setMaxLinesToPrint(int maxLinesToPrint) {
+        getConfig().setMaxLinesToPrint(maxLinesToPrint);
+    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -625,6 +625,9 @@ public class ShardQueryConfigurationTest {
         DocumentScannerConfig documentScannerConfig = new DocumentScannerConfig();
         defaultValues.put("documentScannerConfig", null);
         updatedValues.put("documentScannerConfig", documentScannerConfig);
+
+        defaultValues.put("maxLinesToPrint", -1);
+        updatedValues.put("maxLinesToPrint", 150);
     }
 
     private Query createQuery(String query) {

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -127,6 +127,7 @@
             </map>
         </property>
         <property name="queryPlanner" ref="DefaultQueryPlanner" />
+        <property name="maxLinesToPrint" value="100"/>
         <!--<property name="queryMacroFunction" ref="queryMacroFunction" />-->
         <property name="markingFunctions" ref="markingFunctions" />
         <!--   reduce type metadata     -->

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -365,6 +365,7 @@
         <property name="numRangesToBuffer" value="15" />
         <property name="rangeBufferTimeoutMillis" value="15000" />
         <property name="rangeBufferPollMillis" value="100" />
+        <property name="maxLinesToPrint" value="-1"/>
         <property name="evaluationOnlyFields" value="_ANYFIELD_" />
         <!--   variables that control when a seek is issued     -->
         <property name="fiFieldSeek" value="-1" />


### PR DESCRIPTION
Optionally limit the number of lines printed when streaming queries from the global index