### PR TITLE
Refactor QueryPlan

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -322,7 +322,8 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                 }
 
                 // update the query tree with the (potentially) pruned
-                plan.setQuery(JexlStringBuildingVisitor.buildQueryWithoutParse(result), result);
+                plan.setQueryTree(result);
+                plan.setQueryTreeString(JexlStringBuildingVisitor.buildQueryWithoutParse(result));
             }
 
             return true;

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
@@ -1,5 +1,6 @@
 package datawave.query.index.lookup;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -122,8 +123,14 @@ public class ShardRangeStream extends RangeStream {
         }
 
         public QueryPlan apply(Entry<Key,Value> entry) {
-            return new QueryPlan(node, new Range(new Key(entry.getKey().getRow(), entry.getKey().getColumnFamily()), true,
-                            entry.getKey().followingKey(PartialKey.ROW_COLFAM), false));
+            Key start = new Key(entry.getKey().getRow(), entry.getKey().getColumnFamily());
+            Key end = entry.getKey().followingKey(PartialKey.ROW_COLFAM);
+            Range range = new Range(start, true, end, false);
+            //  @formatter:off
+            return new QueryPlan()
+                            .withQueryTree(node)
+                            .withRanges(Collections.singleton(range));
+            //  @formatter:on
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
@@ -1,6 +1,5 @@
 package datawave.query.index.lookup;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/TupleToRange.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/TupleToRange.java
@@ -1,6 +1,5 @@
 package datawave.query.index.lookup;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/TupleToRange.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/TupleToRange.java
@@ -1,5 +1,6 @@
 package datawave.query.index.lookup;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -116,8 +117,9 @@ public class TupleToRange implements Function<Tuple2<String,IndexInfo>,Iterator<
                 range = RangeFactory.createDocumentSpecificRange(shard, docId);
             }
 
-            if (log.isTraceEnabled())
+            if (log.isTraceEnabled()) {
                 log.trace(queryNode + " " + indexMatch.getNode());
+            }
 
             // don't really want log statement if uid.getNode is null
 
@@ -129,7 +131,8 @@ public class TupleToRange implements Function<Tuple2<String,IndexInfo>,Iterator<
                                 + JexlStringBuildingVisitor.buildQuery(indexMatch.getNode()));
             }
 
-            ranges.add(new QueryPlan(indexMatch.getNode(), range));
+            QueryPlan queryPlan = new QueryPlan().withQueryTree(indexMatch.getNode()).withRanges(Collections.singleton(range));
+            ranges.add(queryPlan);
         }
         return ranges.iterator();
     }
@@ -146,7 +149,8 @@ public class TupleToRange implements Function<Tuple2<String,IndexInfo>,Iterator<
             log.trace("Building shard " + range + " From " + JexlStringBuildingVisitor.buildQuery(myNode));
         }
 
-        return Collections.singleton(new QueryPlan(myNode, range)).iterator();
+        QueryPlan queryPlan = new QueryPlan().withQueryTree(myNode).withRanges(Collections.singleton(range));
+        return Collections.singleton(queryPlan).iterator();
     }
 
     public static Iterator<QueryPlan> createDayRange(JexlNode queryNode, String shard, IndexInfo indexInfo) {
@@ -156,8 +160,11 @@ public class TupleToRange implements Function<Tuple2<String,IndexInfo>,Iterator<
         }
 
         Range range = RangeFactory.createDayRange(shard);
-        if (log.isTraceEnabled())
+        if (log.isTraceEnabled()) {
             log.trace("Building day" + range + " from " + (null == myNode ? "NoQueryNode" : JexlStringBuildingVisitor.buildQuery(myNode)));
-        return Collections.singleton(new QueryPlan(myNode, range)).iterator();
+        }
+
+        QueryPlan queryPlan = new QueryPlan().withQueryTree(myNode).withRanges(Collections.singleton(range));
+        return Collections.singleton(queryPlan).iterator();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2580,7 +2580,13 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             log.trace("Produced range is " + r);
         }
 
-        return new CloseableListIterable<>(Collections.singletonList(new QueryPlan(queryTree, r)));
+        //  @formatter:off
+        QueryPlan queryPlan = new QueryPlan()
+                        .withQueryTree(queryTree)
+                        .withRanges(Collections.singleton(r));
+        //  @formatter:on
+
+        return new CloseableListIterable<>(Collections.singletonList(queryPlan));
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlan.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlan.java
@@ -1,5 +1,9 @@
 package datawave.query.planner;
 
+import static datawave.query.iterator.QueryOptions.QUERY;
+import static datawave.query.iterator.QueryOptions.RANGES;
+
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,16 +15,13 @@ import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.ParseException;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.log4j.Logger;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
-import datawave.query.iterator.QueryIterator;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
-import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.configuration.QueryData;
 
 /**
@@ -28,100 +29,214 @@ import datawave.webservice.query.configuration.QueryData;
  */
 public class QueryPlan {
 
-    private static final Logger log = ThreadConfigurableLogger.getLogger(QueryPlan.class);
-
     protected JexlNode queryTree = null;
     protected String queryTreeString = null;
-    protected List<Range> ranges = null;
-    protected int hashCode;
-    protected List<String> columnFamilies = Lists.newArrayList();
+    protected Collection<Range> ranges = null;
+    protected Collection<String> columnFamilies = Lists.newArrayList();
     protected List<IteratorSetting> settings = Lists.newArrayList();
+    protected int hashCode;
 
+    public QueryPlan() {
+        // empty constructor for when using a builder-like pattern
+    }
+
+    /**
+     * Preferred full constructor
+     *
+     * @param queryTree
+     *            the query tree
+     * @param ranges
+     *            a collection of ranges
+     * @param columnFamilies
+     *            a collection of column families
+     * @param settings
+     *            a list of IteratorSetting
+     */
+    public QueryPlan(JexlNode queryTree, Collection<Range> ranges, Collection<String> columnFamilies, List<IteratorSetting> settings) {
+        this.queryTree = queryTree;
+        this.queryTreeString = JexlStringBuildingVisitor.buildQueryWithoutParse(queryTree);
+        this.ranges = ranges;
+        this.columnFamilies = columnFamilies;
+        this.settings = settings;
+        resetHashCode();
+    }
+
+    /**
+     * Alternate full constructor, accepts a query string instead of a JexlNode
+     *
+     * @param queryString
+     *            the query string
+     * @param ranges
+     *            a collection of ranges
+     * @param columnFamilies
+     *            a collection of column families
+     * @param settings
+     *            a list of IteratorSetting
+     */
+    public QueryPlan(String queryString, Collection<Range> ranges, Collection<String> columnFamilies, List<IteratorSetting> settings) {
+        this.queryTree = null;
+        this.queryTreeString = queryString;
+        this.ranges = ranges;
+        this.columnFamilies = columnFamilies;
+        this.settings = settings;
+        resetHashCode();
+    }
+
+    /**
+     * Copy constructor
+     *
+     * @param other
+     *            a different QueryPlan
+     */
+    public QueryPlan(QueryPlan other) {
+        this.queryTree = other.queryTree;
+        this.queryTreeString = other.queryTreeString;
+        this.ranges = new ArrayList<>(other.ranges);
+        this.columnFamilies = new ArrayList<>(other.columnFamilies);
+        this.settings = new ArrayList<>(other.settings);
+        resetHashCode();
+    }
+
+    /**
+     * Builder style method for setting the query tree
+     *
+     * @param node
+     *            the root node of a query tree
+     * @return this QueryPlan
+     */
+    public QueryPlan withQueryTree(JexlNode node) {
+        this.queryTree = node;
+        resetHashCode();
+        return this;
+    }
+
+    /**
+     * Builder style method for setting the query tree string
+     *
+     * @param queryString
+     *            the query string
+     * @return this QueryPlan
+     */
+    public QueryPlan withQueryString(String queryString) {
+        this.queryTreeString = queryString;
+        resetHashCode();
+        return this;
+    }
+
+    /**
+     * Builder style method for setting the ranges
+     *
+     * @param ranges
+     *            a collection of ranges
+     * @return this QueryPlan
+     */
+    public QueryPlan withRanges(Collection<Range> ranges) {
+        this.ranges = ranges;
+        resetHashCode();
+        return this;
+    }
+
+    /**
+     * Builder style method for setting the column families
+     *
+     * @param columnFamilies
+     *            a collection of column families
+     * @return this QueryPlan
+     */
+    public QueryPlan withColumnFamilies(Collection<String> columnFamilies) {
+        this.columnFamilies = columnFamilies;
+        resetHashCode();
+        return this;
+    }
+
+    /**
+     * Builder style method for setting the IteratorSetting
+     *
+     * @param settings
+     *            a collection of IteratorSetting
+     * @return this QueryPlan
+     */
+    public QueryPlan withSettings(List<IteratorSetting> settings) {
+        this.settings = settings;
+        resetHashCode();
+        return this;
+    }
+
+    /**
+     * Partial constructor, missing IteratorSetting
+     *
+     * @param queryTreeString
+     *            the query string
+     * @param queryTree
+     *            the query tree
+     * @param ranges
+     *            the ranges
+     * @deprecated
+     */
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(String queryTreeString, JexlNode queryTree, Iterable<Range> ranges) {
         this(queryTreeString, queryTree, ranges, null);
     }
 
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(String queryTreeString, JexlNode queryTree, Iterable<Range> ranges, List<IteratorSetting> settings) {
         Preconditions.checkNotNull(queryTree);
         this.queryTree = queryTree;
         this.queryTreeString = queryTreeString;
         this.ranges = Lists.newArrayList(ranges);
-        if (null != settings)
+        if (null != settings) {
             this.settings = settings;
-        buildHashCode();
+        }
+        resetHashCode();
     }
 
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Iterable<Range> ranges, Collection<String> columnFamilies) {
         Preconditions.checkNotNull(queryTree);
         this.queryTree = queryTree;
         this.ranges = Lists.newArrayList(ranges);
         this.columnFamilies = Lists.newArrayList(columnFamilies);
-        buildHashCode();
+        resetHashCode();
     }
 
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Range range) {
         Preconditions.checkNotNull(queryTree);
         this.queryTree = queryTree;
         this.ranges = Lists.newArrayList(range);
-        buildHashCode();
+        resetHashCode();
     }
 
-    public void setQuery(String queryString, JexlNode queryTree) {
-        this.queryTree = queryTree;
-        this.queryTreeString = queryString;
-        buildHashCode();
-    }
-
-    private void buildHashCode() {
-
-        HashCodeBuilder builder = new HashCodeBuilder();
-
-        if (null != queryTree) {
-            builder = builder.append(queryTree);
-        } else if (null != queryTreeString) {
-            builder = builder.append(queryTreeString);
-        }
-
-        for (Range range : ranges) {
-            builder = builder.append(range);
-        }
-
-        for (String cf : columnFamilies) {
-            builder = builder.append(cf);
-        }
-
-        builder.append(settings);
-
-        hashCode = builder.toHashCode();
-
-    }
-
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(QueryData currentQueryData) throws ParseException {
         this.queryTreeString = currentQueryData.getQuery();
         this.ranges = Lists.newArrayList(currentQueryData.getRanges());
         this.settings.addAll(currentQueryData.getSettings());
         this.columnFamilies.addAll(currentQueryData.getColumnFamilies());
-        buildHashCode();
+        resetHashCode();
     }
 
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Iterable<Range> rangeIter, List<IteratorSetting> settings, Collection<String> columnFamilies) {
         this.queryTree = queryTree;
         this.ranges = Lists.newArrayList(rangeIter);
         for (IteratorSetting setting : settings) {
             IteratorSetting newSetting = new IteratorSetting(setting.getPriority(), setting.getName(), setting.getIteratorClass());
             newSetting.addOptions(setting.getOptions());
-            if (newSetting.getOptions().containsKey(QueryIterator.QUERY)) {
-                newSetting.addOption(QueryIterator.QUERY, JexlStringBuildingVisitor.buildQuery(queryTree));
-                newSetting.addOption(QueryIterator.RANGES, this.ranges.stream().map(Range::toString).collect(Collectors.joining(",", "[", "]")));
+            if (newSetting.getOptions().containsKey(QUERY)) {
+                newSetting.addOption(QUERY, JexlStringBuildingVisitor.buildQuery(queryTree));
+                newSetting.addOption(RANGES, this.ranges.stream().map(Range::toString).collect(Collectors.joining(",", "[", "]")));
             }
             this.settings.add(newSetting);
 
         }
-        if (null != columnFamilies)
+        if (null != columnFamilies) {
             this.columnFamilies.addAll(columnFamilies);
-        buildHashCode();
+        }
+        resetHashCode();
     }
 
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Iterable<Range> rangeIter, List<IteratorSetting> settings) {
         this(queryTree, rangeIter, settings, null);
     }
@@ -129,55 +244,78 @@ public class QueryPlan {
     public JexlNode getQueryTree() {
         if (null == queryTree) {
             Preconditions.checkNotNull(queryTreeString);
-
             try {
                 queryTree = JexlASTHelper.parseAndFlattenJexlQuery(queryTreeString);
+                resetHashCode();
             } catch (ParseException e) {
                 throw new RuntimeException(e);
             }
-
         }
         return queryTree;
+    }
+
+    public void setQueryTree(JexlNode queryTree) {
+        this.queryTree = queryTree;
+        resetHashCode();
+    }
+
+    public void setQueryTreeString(String queryString) {
+        this.queryTreeString = queryString;
+        resetHashCode();
+    }
+
+    @Deprecated(since = "6.5.0", forRemoval = true)
+    public void setQuery(String queryString, JexlNode queryTree) {
+        this.queryTree = queryTree;
+        this.queryTreeString = queryString;
+        resetHashCode();
+    }
+
+    @Deprecated(since = "6.5.0", forRemoval = true)
+    public void setQuery(String queryString, ASTJexlScript queryTree) {
+        this.queryTree = queryTree;
+        this.queryTreeString = queryString;
+        resetHashCode();
     }
 
     public String getQueryString() {
         if (null == queryTreeString) {
             Preconditions.checkNotNull(queryTree);
             queryTreeString = JexlStringBuildingVisitor.buildQuery(queryTree);
+            resetHashCode();
         }
         return queryTreeString;
     }
 
-    public void addColumnFamily(String cf) {
-        columnFamilies.add(cf);
+    public Iterable<Range> getRanges() {
+        return ranges;
+    }
+
+    public void setRanges(Collection<Range> ranges) {
+        this.ranges.clear();
+        this.ranges.addAll(ranges);
+        resetHashCode();
+    }
+
+    public void addRanges(Collection<Range> ranges) {
+        this.ranges.addAll(ranges);
+    }
+
+    public void addRange(Range range) {
+        ranges.add(range);
+    }
+
+    public void addRanges(Iterable<Range> ranges) {
+        Iterables.addAll(this.ranges, ranges);
     }
 
     public Collection<String> getColumnFamilies() {
         return columnFamilies;
     }
 
-    public void addRange(Range range) {
-        ranges.add(range);
-        buildHashCode();
-    }
-
-    public void addRanges(Collection<Range> ranges) {
-        this.ranges.addAll(ranges);
-        buildHashCode();
-    }
-
-    public void addRanges(Iterable<Range> ranges) {
-        Iterables.addAll(this.ranges, ranges);
-        buildHashCode();
-    }
-
-    public void setRanges(Collection<Range> ranges) {
-        this.ranges.clear();
-        addRanges(ranges);
-    }
-
-    public Iterable<Range> getRanges() {
-        return ranges;
+    public void addColumnFamily(String cf) {
+        columnFamilies.add(cf);
+        resetHashCode();
     }
 
     public List<IteratorSetting> getSettings() {
@@ -187,29 +325,45 @@ public class QueryPlan {
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof QueryPlan) {
-            EqualsBuilder equalsBuilder = new EqualsBuilder();
-            equalsBuilder.append(columnFamilies, ((QueryPlan) obj).columnFamilies);
-            return hashCode == ((QueryPlan) obj).hashCode && equalsBuilder.append(ranges, ((QueryPlan) obj).ranges).isEquals();
-
-        } else
-            return false;
+            QueryPlan other = (QueryPlan) obj;
+            //  @formatter:off
+            return new EqualsBuilder()
+                            .append(queryTree, other.queryTree)
+                            .append(queryTreeString, other.queryTreeString)
+                            .append(ranges, other.ranges)
+                            .append(columnFamilies, other.columnFamilies)
+                            .append(settings, other.settings)
+                            .isEquals();
+            //  @formatter:on
+        }
+        return false;
     }
 
     @Override
     public int hashCode() {
+        if (hashCode == -1) {
+            //  @formatter:off
+            hashCode = new HashCodeBuilder()
+                            .append(queryTree)
+                            .append(queryTreeString)
+                            .append(ranges)
+                            .append(columnFamilies)
+                            .append(settings)
+                            .hashCode();
+            //  @formatter:on
+        }
         return hashCode;
+    }
+
+    /**
+     * Resets the hashcode. This method is called when an update is made.
+     */
+    private void resetHashCode() {
+        hashCode = -1;
     }
 
     @Override
     public String toString() {
-        return new StringBuilder().append(ranges).append(getQueryString()).append(columnFamilies).toString().intern();
+        return (ranges + getQueryString() + columnFamilies).intern();
     }
-
-    public void setQuery(String queryString, ASTJexlScript queryTree) {
-        this.queryTree = queryTree;
-        this.queryTreeString = queryString;
-        buildHashCode();
-
-    }
-
 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlan.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlan.java
@@ -34,6 +34,7 @@ public class QueryPlan {
     protected Collection<Range> ranges = null;
     protected Collection<String> columnFamilies = Lists.newArrayList();
     protected List<IteratorSetting> settings = Lists.newArrayList();
+    protected boolean rebuildHashCode = true;
     protected int hashCode;
 
     public QueryPlan() {
@@ -173,12 +174,12 @@ public class QueryPlan {
      *            the ranges
      * @deprecated
      */
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(String queryTreeString, JexlNode queryTree, Iterable<Range> ranges) {
         this(queryTreeString, queryTree, ranges, null);
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(String queryTreeString, JexlNode queryTree, Iterable<Range> ranges, List<IteratorSetting> settings) {
         Preconditions.checkNotNull(queryTree);
         this.queryTree = queryTree;
@@ -190,7 +191,7 @@ public class QueryPlan {
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Iterable<Range> ranges, Collection<String> columnFamilies) {
         Preconditions.checkNotNull(queryTree);
         this.queryTree = queryTree;
@@ -199,7 +200,7 @@ public class QueryPlan {
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Range range) {
         Preconditions.checkNotNull(queryTree);
         this.queryTree = queryTree;
@@ -207,7 +208,7 @@ public class QueryPlan {
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(QueryData currentQueryData) throws ParseException {
         this.queryTreeString = currentQueryData.getQuery();
         this.ranges = Lists.newArrayList(currentQueryData.getRanges());
@@ -216,7 +217,7 @@ public class QueryPlan {
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Iterable<Range> rangeIter, List<IteratorSetting> settings, Collection<String> columnFamilies) {
         this.queryTree = queryTree;
         this.ranges = Lists.newArrayList(rangeIter);
@@ -236,7 +237,7 @@ public class QueryPlan {
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public QueryPlan(JexlNode queryTree, Iterable<Range> rangeIter, List<IteratorSetting> settings) {
         this(queryTree, rangeIter, settings, null);
     }
@@ -264,14 +265,14 @@ public class QueryPlan {
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public void setQuery(String queryString, JexlNode queryTree) {
         this.queryTree = queryTree;
         this.queryTreeString = queryString;
         resetHashCode();
     }
 
-    @Deprecated(since = "6.5.0", forRemoval = true)
+    @Deprecated(since = "6.9.0", forRemoval = true)
     public void setQuery(String queryString, ASTJexlScript queryTree) {
         this.queryTree = queryTree;
         this.queryTreeString = queryString;
@@ -341,7 +342,7 @@ public class QueryPlan {
 
     @Override
     public int hashCode() {
-        if (hashCode == -1) {
+        if (rebuildHashCode) {
             //  @formatter:off
             hashCode = new HashCodeBuilder()
                             .append(queryTree)
@@ -351,6 +352,7 @@ public class QueryPlan {
                             .append(settings)
                             .hashCode();
             //  @formatter:on
+            rebuildHashCode = false;
         }
         return hashCode;
     }
@@ -359,7 +361,7 @@ public class QueryPlan {
      * Resets the hashcode. This method is called when an update is made.
      */
     private void resetHashCode() {
-        hashCode = -1;
+        rebuildHashCode = true;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetQueryPlanVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/facets/FacetQueryPlanVisitor.java
@@ -70,8 +70,13 @@ public class FacetQueryPlanVisitor extends BaseVisitor implements CloseableItera
             fieldPairs.add(facetBuilder.toString());
         }
 
-        QueryPlan plan = new QueryPlan(node, Collections.singleton(new Range(startKey, true, endKey, false)), fieldPairs);
-        // toString of String returns the String
+        //  @formatter:off
+        QueryPlan plan = new QueryPlan()
+                        .withQueryTree(node)
+                        .withRanges(Collections.singleton(new Range(startKey, true, endKey, false)))
+                        .withColumnFamilies(fieldPairs);
+        //  @formatter:on
+
         queryPlans.add(plan);
         return plan;
 


### PR DESCRIPTION
Refactor QueryPlan to be more decoupled, deprecate multiple constructors in favor of builder style methods.
- QueryPlan hashcode is built on demand and invalidated when any setter method is called
- updated existing code to use non-deprecated constructors