### PR TITLE
Refactor QueryData

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundlerIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundlerIterator.java
@@ -2,6 +2,7 @@ package datawave.query.planner;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -276,7 +277,14 @@ public class ThreadedRangeBundlerIterator implements Iterator<QueryData>, Closea
             newSetting.addOptions(setting.getOptions());
             settings.add(newSetting);
         }
-        return new QueryData(queryString, Lists.newArrayList(plan.getRanges()), settings, plan.getColumnFamilies());
+
+        //  @formatter:off
+        return new QueryData()
+                        .withQuery(queryString)
+                        .withRanges(Lists.newArrayList(plan.getRanges()))
+                        .withColumnFamilies(plan.getColumnFamilies())
+                        .withSettings(settings);
+        //  @formatter:on
     }
 
     /*

--- a/web-services/query/src/main/java/datawave/webservice/query/configuration/QueryData.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/configuration/QueryData.java
@@ -144,7 +144,7 @@ public class QueryData {
 
     public void addIterator(IteratorSetting cfg) {
         this.settings.add(cfg);
-        hashCode = -1;
+        resetHashCode();
     }
 
     @Override

--- a/web-services/query/src/main/java/datawave/webservice/query/configuration/QueryData.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/configuration/QueryData.java
@@ -2,43 +2,106 @@ package datawave.webservice.query.configuration;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Range;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Class to encapsulate all required information to run a query.
- *
  */
 public class QueryData {
-    List<IteratorSetting> settings = Lists.newArrayList();
-    String query;
-    Collection<Range> ranges = Sets.newHashSet();
-    Collection<String> columnFamilies = Sets.newHashSet();
+    private String query;
+    private Collection<Range> ranges = new HashSet<>();
+    private Collection<String> columnFamilies = new HashSet<>();
+    private List<IteratorSetting> settings = new ArrayList<>();
+    private int hashCode = -1;
 
-    public QueryData() {}
+    public QueryData() {
+        // empty constructor
+    }
 
+    /**
+     * Full constructor
+     *
+     * @param query
+     *            the query string
+     * @param ranges
+     *            a collection of ranges
+     * @param columnFamilies
+     *            a collection of column families
+     * @param settings
+     *            a list of IteratorSetting
+     */
+    public QueryData(String query, Collection<Range> ranges, Collection<String> columnFamilies, List<IteratorSetting> settings) {
+        this.query = query;
+        this.ranges = ranges;
+        this.columnFamilies = columnFamilies;
+        this.settings = settings;
+    }
+
+    /**
+     * Copy constructor
+     *
+     * @param other
+     *            another instance of QueryData
+     */
+    public QueryData(QueryData other) {
+        this.query = other.query;
+        this.ranges = new HashSet<>(other.ranges);
+        this.columnFamilies = new HashSet<>(other.columnFamilies);
+        this.settings = new ArrayList<>(other.settings);
+        this.hashCode = other.hashCode;
+    }
+
+    public QueryData withQuery(String query) {
+        setQuery(query);
+        return this;
+    }
+
+    public QueryData withRanges(Collection<Range> ranges) {
+        setRanges(ranges);
+        return this;
+    }
+
+    public QueryData withColumnFamilies(Collection<String> columnFamilies) {
+        setColumnFamilies(columnFamilies);
+        return this;
+    }
+
+    public QueryData withSettings(List<IteratorSetting> settings) {
+        setSettings(settings);
+        return this;
+    }
+
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryData(String query, Collection<Range> ranges, List<IteratorSetting> settings) {
         setQuery(query);
         setRanges(ranges);
         setSettings(settings);
     }
 
-    public QueryData(QueryData other) {
-        this(other.getQuery(), other.getRanges(), other.getSettings());
-    }
-
+    /**
+     * Weak copy constructor that updates the ranges
+     *
+     * @param other
+     *            another QueryData
+     * @param ranges
+     *            a collection of updated ranges
+     * @deprecated
+     */
+    @Deprecated(since = "6.5.0", forRemoval = true)
     public QueryData(QueryData other, Collection<Range> ranges) {
         setQuery(other.getQuery());
         setSettings(other.getSettings());
         setRanges(ranges);
     }
 
-    public QueryData(String queryString, ArrayList<Range> ranges, List<IteratorSetting> settings, Collection<String> columnFamilies) {
+    @Deprecated(since = "6.5.0", forRemoval = true)
+    public QueryData(String queryString, List<Range> ranges, List<IteratorSetting> settings, Collection<String> columnFamilies) {
         this(queryString, ranges, settings);
         this.columnFamilies.addAll(columnFamilies);
     }
@@ -48,7 +111,8 @@ public class QueryData {
     }
 
     public void setSettings(List<IteratorSetting> settings) {
-        this.settings = Lists.newArrayList(settings);
+        this.settings = new ArrayList<>(settings);
+        resetHashCode();
     }
 
     public String getQuery() {
@@ -57,6 +121,7 @@ public class QueryData {
 
     public void setQuery(String query) {
         this.query = query;
+        resetHashCode();
     }
 
     public Collection<Range> getRanges() {
@@ -67,19 +132,66 @@ public class QueryData {
         return columnFamilies;
     }
 
+    public void setColumnFamilies(Collection<String> columnFamilies) {
+        this.columnFamilies = columnFamilies;
+        resetHashCode();
+    }
+
     public void setRanges(Collection<Range> ranges) {
-        if (null != ranges)
-            this.ranges.addAll(ranges);
+        this.ranges = ranges;
+        resetHashCode();
     }
 
     public void addIterator(IteratorSetting cfg) {
         this.settings.add(cfg);
+        hashCode = -1;
     }
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(256);
-        sb.append("Query: '").append(this.query).append("', Ranges: ").append(this.ranges).append(", Settings: ").append(this.settings);
-        return sb.toString();
+        //  @formatter:off
+        return new StringBuilder()
+                        .append("Query: '").append(this.query)
+                        .append("', Ranges: ").append(this.ranges)
+                        .append(", Settings: ").append(this.settings)
+                        .toString();
+        //  @formatter:on
+    }
+
+    public boolean equals(Object o) {
+        if (o instanceof QueryData) {
+            QueryData other = (QueryData) o;
+            //  @formatter:off
+            return new EqualsBuilder()
+                            .append(query, other.query)
+                            .append(ranges, other.ranges)
+                            .append(columnFamilies, other.columnFamilies)
+                            .append(settings, other.settings)
+                            .isEquals();
+            //  @formatter:on
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == -1) {
+            //  @formatter:off
+            hashCode = new HashCodeBuilder()
+                            .append(query)
+                            .append(ranges)
+                            .append(columnFamilies)
+                            .append(settings)
+                            .hashCode();
+            //  @formatter:on
+        }
+        return hashCode;
+    }
+
+    /**
+     * Method to reset the hashcode when an internal variable is updated
+     */
+    private void resetHashCode() {
+        hashCode = -1;
     }
 }

--- a/web-services/query/src/test/java/datawave/webservice/query/configuration/QueryDataTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/configuration/QueryDataTest.java
@@ -1,167 +1,102 @@
 package datawave.webservice.query.configuration;
 
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
-import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.api.easymock.annotation.Mock;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.Lists;
 
-/**
- *
- */
-@RunWith(PowerMockRunner.class)
 public class QueryDataTest {
-    @Mock
-    QueryData copy;
-
-    @Mock
-    IteratorSetting setting;
-
-    @Mock
-    Range range;
 
     @Test
     public void testCopyConstructor() {
-        // Set expectations
-        expect(this.copy.getQuery()).andReturn("TEST");
-        expect(this.copy.getRanges()).andReturn(Arrays.asList(this.range));
-        expect(this.copy.getSettings()).andReturn(Arrays.asList(this.setting));
+        String query = "FOO == 'bar'";
+        Collection<Range> ranges = Collections.singleton(new Range(new Key("row"), true, new Key("row\0"), false));
+        Collection<String> columnFamilies = Collections.singleton("FOO");
+        List<IteratorSetting> settings = new ArrayList<>();
+        settings.add(new IteratorSetting(20, "iterator", "QueryIterator.class"));
 
-        // Run the test
-        PowerMock.replayAll();
-        QueryData subject = new QueryData(this.copy);
-        String result1 = subject.getQuery();
-        Collection<Range> result2 = subject.getRanges();
-        subject.addIterator(this.setting);
-        Collection<IteratorSetting> result3 = subject.getSettings();
-        String result4 = subject.toString();
-        PowerMock.verifyAll();
+        QueryData original = new QueryData(query, ranges, columnFamilies, settings);
+        QueryData copy = new QueryData(original);
 
-        // Verify results
-        assertNotNull("Query should not be null", result1);
-        assertNotNull("Ranges should not be null", result2);
-        assertTrue("Ranges should not be empty", !result2.isEmpty());
-        assertNotNull("Settings should not be null", result3);
-        assertTrue("Settings should not be empty", !result3.isEmpty());
-        assertEquals("Settings should have a size of 2", 2, result3.size());
-        assertNotNull("toString should not be null", result4);
+        assertEquals(original.getQuery(), copy.getQuery());
+        assertEquals(original.getRanges(), copy.getRanges());
+        assertEquals(original.getColumnFamilies(), copy.getColumnFamilies());
+        assertEquals(original.getSettings(), copy.getSettings());
     }
 
     @Test
     public void testCorrectReuse() {
-        List<QueryData> queries = Lists.newArrayList();
+        String query = "FOO == 'bar'";
+        List<IteratorSetting> settings = new ArrayList<>();
+        settings.add(new IteratorSetting(20, "iter1", "iter1.class"));
 
-        QueryData query1 = new QueryData();
-        query1.setQuery("FOO == 'bar'");
-        query1.setSettings(Lists.newArrayList(new IteratorSetting(20, "iter1", "iter1.class")));
-        query1.setRanges(Collections.singleton(Range.prefix("1")));
+        QueryData original = new QueryData();
+        original.setQuery(query);
+        original.setSettings(settings);
+        original.setColumnFamilies(Collections.emptySet());
+        original.setRanges(Collections.singleton(Range.prefix("1")));
 
-        queries.add(query1);
-        queries.add(new QueryData(query1, Collections.singleton(Range.prefix("2"))));
-        queries.add(new QueryData(query1, Collections.singleton(Range.prefix("3"))));
+        List<QueryData> queries = new ArrayList<>();
+        queries.add(original);
+        queries.add(new QueryData(original).withRanges(Collections.singleton(Range.prefix("2"))));
+        queries.add(new QueryData(original).withRanges(Collections.singleton(Range.prefix("3"))));
 
-        Integer count = 1;
-        List<IteratorSetting> prevSettings = null;
-        String prevQuery = null;
+        int count = 1;
         for (QueryData qd : queries) {
-            if (null == prevSettings) {
-                prevSettings = qd.getSettings();
-            } else {
-                Assert.assertEquals(prevSettings, qd.getSettings());
-            }
-
-            if (null == prevQuery) {
-                prevQuery = qd.getQuery();
-            } else {
-                Assert.assertEquals(prevQuery, qd.getQuery());
-            }
-
-            Assert.assertEquals(1, qd.getRanges().size());
-
-            Range r = qd.getRanges().iterator().next();
-
-            Assert.assertEquals(count.toString(), r.getStartKey().getRow().toString());
-
+            assertEquals(query, qd.getQuery());
+            assertRange(Integer.toString(count), qd.getRanges());
+            assertEquals(0, qd.getColumnFamilies().size());
+            assertEquals(settings, qd.getSettings());
             count++;
         }
     }
 
     @Test
     public void testCorrectDownstreamReuse() {
-        List<QueryData> queries = Lists.newArrayList();
+        String query = "FOO == 'bar'";
+        List<IteratorSetting> settings = new ArrayList<>();
+        settings.add(new IteratorSetting(20, "iter1", "iter1.class"));
 
-        QueryData query1 = new QueryData();
-        query1.setQuery("FOO == 'bar'");
-        query1.setSettings(Lists.newArrayList(new IteratorSetting(20, "iter1", "iter1.class")));
-        query1.setRanges(Collections.singleton(Range.prefix("1")));
+        QueryData original = new QueryData();
+        original.setQuery(query);
+        original.setSettings(settings);
+        original.setRanges(Collections.singleton(Range.prefix("1")));
 
-        queries.add(query1);
-        queries.add(new QueryData(query1, Collections.singleton(Range.prefix("2"))));
-        queries.add(new QueryData(query1, Collections.singleton(Range.prefix("3"))));
+        List<QueryData> queries = new ArrayList<>();
+        queries.add(original);
+        queries.add(new QueryData(original).withRanges(Collections.singleton(Range.prefix("2"))));
+        queries.add(new QueryData(original).withRanges(Collections.singleton(Range.prefix("3"))));
 
         for (QueryData qd : queries) {
             qd.getSettings().add(new IteratorSetting(21, "iter2", "iter2.class"));
         }
 
-        Integer count = 1;
-        List<IteratorSetting> prevSettings = null;
-        String prevQuery = null;
+        List<IteratorSetting> expectedSettings = new ArrayList<>();
+        expectedSettings.add(new IteratorSetting(20, "iter1", "iter1.class"));
+        expectedSettings.add(new IteratorSetting(21, "iter2", "iter2.class"));
+
+        int count = 1;
         for (QueryData qd : queries) {
-            if (null == prevSettings) {
-                prevSettings = qd.getSettings();
-            } else {
-                Assert.assertTrue(equals(prevSettings, qd.getSettings()));
-            }
-
-            if (null == prevQuery) {
-                prevQuery = qd.getQuery();
-            } else {
-                Assert.assertEquals(prevQuery, qd.getQuery());
-            }
-
-            Assert.assertEquals(1, qd.getRanges().size());
-
-            Range r = qd.getRanges().iterator().next();
-
-            Assert.assertEquals(count.toString(), r.getStartKey().getRow().toString());
-
+            assertEquals(query, qd.getQuery());
+            assertRange(Integer.toString(count), qd.getRanges());
+            assertEquals(0, qd.getColumnFamilies().size());
+            assertEquals(expectedSettings, qd.getSettings());
             count++;
         }
     }
 
-    protected boolean equals(List<IteratorSetting> settings1, List<IteratorSetting> settings2) {
-        if ((null == settings1 && null != settings2) || (null != settings1 && null == settings2)) {
-            return false;
-        }
-
-        if (settings1.size() != settings2.size()) {
-            return false;
-        }
-
-        for (int i = 0; i < settings1.size(); i++) {
-            IteratorSetting s1 = settings1.get(i), s2 = settings2.get(i);
-            if (!(s1.getIteratorClass().equals(s2.getIteratorClass()) && s1.getName().equals(s2.getName()) && s1.getPriority() == s2.getPriority()
-                            && s1.getOptions().equals(s2.getOptions()))) {
-                return false;
-            }
-        }
-
-        return true;
+    private void assertRange(String expectedRow, Collection<Range> ranges) {
+        assertEquals(1, ranges.size());
+        Range range = ranges.iterator().next();
+        assertEquals(expectedRow, range.getStartKey().getRow().toString());
     }
-
 }


### PR DESCRIPTION
Refactor QueryData to support optional builder like methods
- QueryData test no longer relies on mock objects
- QueryData now implements equals and hashcode methods
- QueryData hashcode is built on demand and invalidated when any setter method is called
- copy constructor now copies all fields