### PR TITLE
Attributes build correct metadata key

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -98,44 +98,46 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected void setMetadata(Key key) {
         if (key == null) {
             this.metadata = null;
-        } else {
-            // convert the key to the form shard type\0uid cv, ts. Possible inputs are an event key, a fi key, or a tf key
-            final ByteSequence row = key.getRowData(), cf = key.getColumnFamilyData(), cv = key.getColumnVisibilityData();
-            if (isFieldIndex(cf)) {
-                // find the first null byte in the cq and take everything after that (cq = Normalized Field Value\0Data Type\0UID)
-                final ByteSequence cq = key.getColumnQualifierData();
-                int nullOffset = 0;
-                for (int i = 0; i < cq.length(); i++) {
-                    if (cq.byteAt(i) == '\0') {
-                        nullOffset = i;
-                        break;
-                    }
+            return;
+        }
+
+        // convert the key to the form shard type\0uid cv, ts. Possible inputs are an event key, a fi key, or a tf key
+        final ByteSequence row = key.getRowData();
+        final ByteSequence cf = key.getColumnFamilyData();
+        final ByteSequence cv = key.getColumnVisibilityData();
+        if (isFieldIndex(cf)) {
+            // CQ is 'value\0datatype\0value
+            // iterate backwards to avoid problems from values with nulls in them
+            final ByteSequence cq = key.getColumnQualifierData();
+            int nullOffset = 0;
+            int count = 0;
+            for (int i = cq.length() - 1; i >= 0; i--) {
+                if (cq.byteAt(i) == '\0' && ++count == 2) {
+                    nullOffset = i;
+                    break;
                 }
-                this.metadata = new Key(row.getBackingArray(), row.offset(), row.length(), cq.getBackingArray(), nullOffset + 1, cq.length() - (nullOffset + 1),
-                                EMPTY_BYTE_SEQUENCE.getBackingArray(), EMPTY_BYTE_SEQUENCE.offset(), EMPTY_BYTE_SEQUENCE.length(), cv.getBackingArray(),
-                                cv.offset(), cv.length(), key.getTimestamp());
-            } else if (isTermFrequency(cf)) {
-                // find the second null byte in the cq and take everything before that (cq = DataType\0UID\0Normalized Field Value\0Field Name)
-                final ByteSequence cq = key.getColumnQualifierData();
-                int nullOffset = 0;
-                int count = 0;
-                for (int i = 0; i < cf.length(); i++) {
-                    if (cf.byteAt(i) == '\0') {
-                        count++;
-                        if (count == 2) {
-                            nullOffset = i;
-                            break;
-                        }
-                    }
-                }
-                this.metadata = new Key(row.getBackingArray(), row.offset(), row.length(), cq.getBackingArray(), cq.offset(), nullOffset,
-                                EMPTY_BYTE_SEQUENCE.getBackingArray(), EMPTY_BYTE_SEQUENCE.offset(), EMPTY_BYTE_SEQUENCE.length(), cv.getBackingArray(),
-                                cv.offset(), cv.length(), key.getTimestamp());
-            } else {
-                this.metadata = new Key(row.getBackingArray(), row.offset(), row.length(), cf.getBackingArray(), cf.offset(), cf.length(),
-                                EMPTY_BYTE_SEQUENCE.getBackingArray(), EMPTY_BYTE_SEQUENCE.offset(), EMPTY_BYTE_SEQUENCE.length(), cv.getBackingArray(),
-                                cv.offset(), cv.length(), key.getTimestamp());
             }
+            this.metadata = new Key(row.getBackingArray(), row.offset(), row.length(), cq.getBackingArray(), nullOffset + 1, cq.length() - (nullOffset + 1),
+                            EMPTY_BYTE_SEQUENCE.getBackingArray(), EMPTY_BYTE_SEQUENCE.offset(), EMPTY_BYTE_SEQUENCE.length(), cv.getBackingArray(),
+                            cv.offset(), cv.length(), key.getTimestamp());
+        } else if (isTermFrequency(cf)) {
+            // find the second null byte in the cq and take everything before that (cq = DataType\0UID\0Normalized Field Value\0Field Name)
+            final ByteSequence cq = key.getColumnQualifierData();
+            int nullOffset = 0;
+            int count = 0;
+            for (int i = 0; i < cq.length(); i++) {
+                if (cq.byteAt(i) == '\0' && ++count == 2) {
+                    nullOffset = i;
+                    break;
+                }
+            }
+            this.metadata = new Key(row.getBackingArray(), row.offset(), row.length(), cq.getBackingArray(), cq.offset(), nullOffset,
+                            EMPTY_BYTE_SEQUENCE.getBackingArray(), EMPTY_BYTE_SEQUENCE.offset(), EMPTY_BYTE_SEQUENCE.length(), cv.getBackingArray(),
+                            cv.offset(), cv.length(), key.getTimestamp());
+        } else {
+            this.metadata = new Key(row.getBackingArray(), row.offset(), row.length(), cf.getBackingArray(), cf.offset(), cf.length(),
+                            EMPTY_BYTE_SEQUENCE.getBackingArray(), EMPTY_BYTE_SEQUENCE.offset(), EMPTY_BYTE_SEQUENCE.length(), cv.getBackingArray(),
+                            cv.offset(), cv.length(), key.getTimestamp());
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -106,7 +106,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         final ByteSequence cf = key.getColumnFamilyData();
         final ByteSequence cv = key.getColumnVisibilityData();
         if (isFieldIndex(cf)) {
-            // CQ is 'value\0datatype\0value
+            // CQ is 'value\0datatype\0uid
             // iterate backwards to avoid problems from values with nulls in them
             final ByteSequence cq = key.getColumnQualifierData();
             int nullOffset = 0;

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/ContentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/ContentTest.java
@@ -1,9 +1,25 @@
 package datawave.query.attributes;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.accumulo.core.data.Key;
 import org.junit.Test;
 
 public class ContentTest extends AttributeTest {
+
+    private final Key expectedMetadata = new Key("row", "datatype\0uid");
+
+    @Test
+    public void testMetadataFromTermFrequencyKey() {
+        Key tfKey = new Key("row", "tf", "datatype\0uid\0value\0FIELD");
+        Content content = new Content("value", tfKey, true);
+        assertEquals(expectedMetadata, content.getMetadata());
+
+        // value contains nulls
+        tfKey = new Key("row", "tf", "datatype\0uid\0val\0ue\0FIELD");
+        content = new Content("value", tfKey, true);
+        assertEquals(expectedMetadata, content.getMetadata());
+    }
 
     @Test
     public void validateSerializationOfToKeepFlag() {

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/NumericTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/NumericTest.java
@@ -1,9 +1,49 @@
 package datawave.query.attributes;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.accumulo.core.data.Key;
 import org.junit.Test;
 
 public class NumericTest extends AttributeTest {
+
+    private final Key expectedMetadata = new Key("row", "datatype\0uid");
+
+    @Test
+    public void testMetadataFromFieldIndexKey() {
+        Key fiKey = new Key("row", "fi\0FIELD", "42\0datatype\0uid");
+        Numeric numeric = new Numeric("42", fiKey, true);
+        assertEquals(expectedMetadata, numeric.getMetadata());
+
+        // value contains null
+        fiKey = new Key("row", "fi\0FIELD", "4\u00002\0datatype\0uid");
+        numeric = new Numeric("42", fiKey, true);
+        assertEquals(expectedMetadata, numeric.getMetadata());
+    }
+
+    @Test
+    public void testMetadataFromEventKey() {
+        Key eventKey = new Key("row", "datatype\0uid", "FIELD\u000042");
+        Numeric numeric = new Numeric("42", eventKey, true);
+        assertEquals(expectedMetadata, numeric.getMetadata());
+
+        // value contains null
+        eventKey = new Key("row", "datatype\0uid", "FIELD\u00004\u00002");
+        numeric = new Numeric("42", eventKey, true);
+        assertEquals(expectedMetadata, numeric.getMetadata());
+    }
+
+    @Test
+    public void testMetadataFromTermFrequencyKey() {
+        Key tfKey = new Key("row", "tf", "datatype\0uid\u000042\0FIELD");
+        Numeric numeric = new Numeric("42", tfKey, true);
+        assertEquals(expectedMetadata, numeric.getMetadata());
+
+        // value contains null
+        tfKey = new Key("row", "tf", "datatype\0uid\u00004\u00002\0FIELD");
+        numeric = new Numeric("42", tfKey, true);
+        assertEquals(expectedMetadata, numeric.getMetadata());
+    }
 
     @Test
     public void validateSerializationOfToKeepFlag() {

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/PreNormalizedAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/PreNormalizedAttributeTest.java
@@ -1,9 +1,25 @@
 package datawave.query.attributes;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.accumulo.core.data.Key;
 import org.junit.Test;
 
 public class PreNormalizedAttributeTest extends AttributeTest {
+
+    @Test
+    public void testMetadataFromFieldIndexKey() {
+        Key fiKey = new Key("row", "fi\0FIELD", "value\0datatype\0uid");
+        PreNormalizedAttribute attribute = new PreNormalizedAttribute("value", fiKey, true);
+
+        Key expectedMetadata = new Key("row", "datatype\0uid");
+        assertEquals(expectedMetadata, attribute.getMetadata());
+
+        // also test a value with nulls in it
+        fiKey = new Key("row", "fi\0FIELD", "va\0lue\0datatype\0uid");
+        attribute = new PreNormalizedAttribute("value", fiKey, true);
+        assertEquals(expectedMetadata, attribute.getMetadata());
+    }
 
     @Test
     public void validateSerializationOfToKeepFlag() {

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/TermFrequencyIndexIteratorTest.java
@@ -4,6 +4,7 @@ import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.Expre
 import static datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.getExpressionFilters;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -188,8 +189,8 @@ public class TermFrequencyIndexIteratorTest {
         assertTrue(d.getDictionary().get("FOO").getData() != null);
         assertTrue(((Set) d.getDictionary().get("FOO").getData()).size() == 2);
         Iterator<PreNormalizedAttribute> i = ((Set) d.getDictionary().get("FOO").getData()).iterator();
-        assertTrue(i.next().getValue().equals("bar"));
         assertTrue(i.next().getValue().equals("baz"));
+        assertTrue(i.next().getValue().equals("bar"));
 
         iterator.next();
 
@@ -216,8 +217,8 @@ public class TermFrequencyIndexIteratorTest {
         assertTrue(d.getDictionary().get("FOO").getData() != null);
         assertTrue(((Set) d.getDictionary().get("FOO").getData()).size() == 2);
         i = ((Set) d.getDictionary().get("FOO").getData()).iterator();
-        assertTrue(i.next().getValue().equals("alf"));
         assertTrue(i.next().getValue().equals("arm"));
+        assertTrue(i.next().getValue().equals("alf"));
     }
 
     @Test
@@ -232,19 +233,19 @@ public class TermFrequencyIndexIteratorTest {
 
         assertTrue(iterator.hasTop());
         Document d = iterator.document();
-        assertTrue(d != null);
-        assertTrue(d.getDictionary().size() == 2);
-        assertTrue(d.getDictionary().get("FOO") != null);
-        assertTrue(d.getDictionary().get("RECORD_ID") != null);
-        assertTrue(d.getDictionary().get("FOO").getData() != null);
-        assertTrue(((Set) d.getDictionary().get("FOO").getData()).size() == 6);
+        assertNotNull(d);
+        assertEquals(2, d.getDictionary().size());
+        assertNotNull(d.getDictionary().get("FOO"));
+        assertNotNull(d.getDictionary().get("RECORD_ID"));
+        assertNotNull(d.getDictionary().get("FOO").getData());
+        assertEquals(6, ((Set) d.getDictionary().get("FOO").getData()).size());
         Iterator<PreNormalizedAttribute> i = ((Set) d.getDictionary().get("FOO").getData()).iterator();
-        assertTrue(i.next().getValue().equals("bar"));
-        assertTrue(i.next().getValue().equals("baz"));
-        assertTrue(i.next().getValue().equals("buf"));
-        assertTrue(i.next().getValue().equals("buz"));
-        assertTrue(i.next().getValue().equals("alf"));
-        assertTrue(i.next().getValue().equals("arm"));
+        assertEquals("baz", i.next().getValue());
+        assertEquals("bar", i.next().getValue());
+        assertEquals("buf", i.next().getValue());
+        assertEquals("buz", i.next().getValue());
+        assertEquals("alf", i.next().getValue());
+        assertEquals("arm", i.next().getValue());
 
         iterator.next();
         assertFalse(iterator.hasTop());
@@ -291,8 +292,8 @@ public class TermFrequencyIndexIteratorTest {
         assertTrue(d.getDictionary().get("RECORD_ID") != null);
         assertTrue(d.getDictionary().get("FOO").getData() != null);
         Iterator<PreNormalizedAttribute> i = ((Set) d.getDictionary().get("FOO").getData()).iterator();
-        assertTrue(i.next().getValue().equals("bar"));
         assertTrue(i.next().getValue().equals("baz"));
+        assertTrue(i.next().getValue().equals("bar"));
 
         iterator.next();
 
@@ -342,16 +343,16 @@ public class TermFrequencyIndexIteratorTest {
 
         assertTrue(iterator.hasTop());
         Document d = iterator.document();
-        assertTrue(d != null);
-        assertTrue(d.getDictionary().size() == 2);
-        assertTrue(d.getDictionary().get("FOO") != null);
-        assertTrue(d.getDictionary().get("RECORD_ID") != null);
-        assertTrue(d.getDictionary().get("FOO").getData() != null);
+        assertNotNull(d);
+        assertEquals(2, d.getDictionary().size());
+        assertNotNull(d.getDictionary().get("FOO"));
+        assertNotNull(d.getDictionary().get("RECORD_ID"));
+        assertNotNull(d.getDictionary().get("FOO").getData());
         Iterator<PreNormalizedAttribute> i = ((Set) d.getDictionary().get("FOO").getData()).iterator();
-        assertTrue(i.next().getValue().equals("bar"));
-        assertTrue(i.next().getValue().equals("baz"));
-        assertTrue(i.next().getValue().equals("buf"));
-        assertTrue(i.next().getValue().equals("arm"));
+        assertEquals("baz", i.next().getValue());
+        assertEquals("bar", i.next().getValue());
+        assertEquals("buf", i.next().getValue());
+        assertEquals("arm", i.next().getValue());
 
         iterator.next();
         assertFalse(iterator.hasTop());
@@ -374,18 +375,18 @@ public class TermFrequencyIndexIteratorTest {
 
         assertTrue(iterator.hasTop());
         Document d = iterator.document();
-        assertTrue(d != null);
-        assertTrue(d.getDictionary().size() == 2);
-        assertTrue(d.getDictionary().get("FOO") != null);
-        assertTrue(d.getDictionary().get("RECORD_ID") != null);
-        assertTrue(d.getDictionary().get("FOO").getData() != null);
+        assertNotNull(d);
+        assertEquals(2, d.getDictionary().size());
+        assertNotNull(d.getDictionary().get("FOO"));
+        assertNotNull(d.getDictionary().get("RECORD_ID"));
+        assertNotNull(d.getDictionary().get("FOO").getData());
         Iterator<PreNormalizedAttribute> i = ((Set) d.getDictionary().get("FOO").getData()).iterator();
-        assertTrue(i.next().getValue().equals("bar"));
-        assertTrue(i.next().getValue().equals("baz"));
-        assertTrue(i.next().getValue().equals("buf"));
-        assertTrue(i.next().getValue().equals("buz"));
-        assertTrue(i.next().getValue().equals("alf"));
-        assertTrue(i.next().getValue().equals("arm"));
+        assertEquals("baz", i.next().getValue());
+        assertEquals("bar", i.next().getValue());
+        assertEquals("buf", i.next().getValue());
+        assertEquals("buz", i.next().getValue());
+        assertEquals("alf", i.next().getValue());
+        assertEquals("arm", i.next().getValue());
 
         iterator.next();
         assertFalse(iterator.hasTop());


### PR DESCRIPTION
Corrected several issues with how Attributes built their metadata key
- term frequency keys now build the correct column family of datatype/uid, the setMetadata method was looking at a TF key's column family. It now examines the column qualifier.
- field index keys could build incorrect metadata keys if the field value contained a null. changed the algorithm to iterate backwards through a field index key's column qualifier to avoid this problem