### PR TITLE
Do not reduce fields when preloading iterator options

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2105,7 +2105,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
 
             addOption(cfg, QueryOptions.SORTED_UIDS, Boolean.toString(config.isSortedUIDs()), false);
 
-            configureTypeMappings(config, cfg, metadataHelper, getCompressOptionMappings());
+            configureTypeMappings(config, cfg, metadataHelper, getCompressOptionMappings(), isPreload);
             configureAdditionalOptions(config, cfg);
 
             loadFields(cfg, config, isPreload);
@@ -2273,6 +2273,11 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
 
     public static void configureTypeMappings(ShardQueryConfiguration config, IteratorSetting cfg, MetadataHelper metadataHelper, boolean compressMappings)
                     throws DatawaveQueryException {
+        configureTypeMappings(config, cfg, metadataHelper, compressMappings, false);
+    }
+
+    public static void configureTypeMappings(ShardQueryConfiguration config, IteratorSetting cfg, MetadataHelper metadataHelper, boolean compressMappings,
+                    boolean isPreload) throws DatawaveQueryException {
         try {
             addOption(cfg, QueryOptions.QUERY_MAPPING_COMPRESS, Boolean.toString(compressMappings), false);
 
@@ -2286,7 +2291,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
 
             TypeMetadata typeMetadata = metadataHelper.getTypeMetadata(config.getDatatypeFilter());
 
-            if (config.getReduceTypeMetadata()) {
+            if (config.getReduceTypeMetadata() && !isPreload) {
                 Set<String> fieldsToRetain = ReduceFields.getQueryFields(config.getQueryTree());
                 typeMetadata = typeMetadata.reduce(fieldsToRetain);
             }


### PR DESCRIPTION
When preloading iterator options a race condition exists between the builder thread accessing the query tree and the query planner parsing the query string into a jexl tree. Avoid this situation by not applying type metadata reduction when preloading iterator options.