### PR TITLE
Enforce term limits during EdgeQueries

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/EdgeQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/EdgeQueryConfiguration.java
@@ -65,6 +65,7 @@ public class EdgeQueryConfiguration extends GenericQueryConfiguration {
         setModelName(configuredLogic.getModelName());
         setModelTableName(configuredLogic.getModelTableName());
         setEdgeQueryModel(configuredLogic.getEdgeQueryModel());
+        setMaxQueryTerms(configuredLogic.getMaxQueryTerms());
     }
 
     public List<? extends Type<?>> getDataTypes() {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitor.java
@@ -168,11 +168,6 @@ public class EdgeTableRangeBuildingVisitor extends BaseVisitor implements EdgeMo
      */
     @Override
     public Object visit(ASTAndNode node, Object data) {
-        if (termCount > maxTerms) {
-            log.error("Query has too many terms");
-            throw new IllegalArgumentException("Too many search terms " + termCount);
-        }
-
         // run the visitor against all of the children
         List<List<? extends EdgeContext>> childContexts = new ArrayList<>(node.jjtGetNumChildren());
         for (int i = 0; i < node.jjtGetNumChildren(); i++) {
@@ -274,11 +269,6 @@ public class EdgeTableRangeBuildingVisitor extends BaseVisitor implements EdgeMo
      */
     @Override
     public Object visit(ASTOrNode node, Object data) {
-        if (termCount > maxTerms) {
-            log.error("Query has too many terms");
-            throw new IllegalArgumentException("Too many search terms " + termCount);
-        }
-
         // run the visitor against all of the children
         List<List<? extends EdgeContext>> childContexts = new ArrayList<>(node.jjtGetNumChildren());
         for (int i = 0; i < node.jjtGetNumChildren(); i++) {
@@ -410,8 +400,15 @@ public class EdgeTableRangeBuildingVisitor extends BaseVisitor implements EdgeMo
      */
     @Override
     public Object visit(ASTEQNode node, Object data) {
-        termCount++;
+        incrementTermCountAndCheck();
         return visitExpresionNode(node, EQUALS);
+    }
+
+    private void incrementTermCountAndCheck() {
+        if (++termCount > maxTerms) {
+            log.error("Query has too many terms");
+            throw new IllegalArgumentException("Too many search terms " + termCount);
+        }
     }
 
     /**
@@ -428,7 +425,7 @@ public class EdgeTableRangeBuildingVisitor extends BaseVisitor implements EdgeMo
      */
     @Override
     public Object visit(ASTERNode node, Object data) {
-        termCount++;
+        incrementTermCountAndCheck();
         List<IdentityContext> contexts = (List<IdentityContext>) visitExpresionNode(node, EQUALS_REGEX);
         if (contexts.get(0).getIdentity().equals(EDGE_SOURCE)) {
             sawEquivalenceRegexSource = true;
@@ -440,13 +437,13 @@ public class EdgeTableRangeBuildingVisitor extends BaseVisitor implements EdgeMo
 
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        termCount++;
+        incrementTermCountAndCheck();
         return visitExpresionNode(node, NOT_EQUALS_REGEX);
     }
 
     @Override
     public Object visit(ASTNENode node, Object data) {
-        termCount++;
+        incrementTermCountAndCheck();
         return visitExpresionNode(node, NOT_EQUALS);
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitor.java
@@ -406,8 +406,9 @@ public class EdgeTableRangeBuildingVisitor extends BaseVisitor implements EdgeMo
 
     private void incrementTermCountAndCheck() {
         if (++termCount > maxTerms) {
-            log.error("Query has too many terms");
-            throw new IllegalArgumentException("Too many search terms " + termCount);
+            String message = "Exceeded max term limit of " + maxTerms;
+            log.error(message);
+            throw new IllegalArgumentException(message);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitorTest.java
@@ -1,0 +1,38 @@
+package datawave.query.jexl.visitors;
+
+import datawave.query.tables.edge.EdgeQueryLogic;
+import org.apache.commons.jexl3.JexlFeatures;
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.Parser;
+import org.apache.commons.jexl3.parser.StringProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertThrows;
+
+public class EdgeTableRangeBuildingVisitorTest {
+
+    private int termLimit = 3;
+    private Parser parser;
+
+    private EdgeTableRangeBuildingVisitor visitor;
+
+    @Before
+    public void setup() {
+        parser = new Parser(new StringProvider(";"));
+
+        visitor = new EdgeTableRangeBuildingVisitor(false, emptyList(), termLimit, emptyList());
+    }
+
+    @Test
+    public void shouldEnforceTermLimit() {
+        ASTJexlScript parsedQuery = parseQuery("TYPE == 'like it' OR TYPE == 'love it' OR TYPE == 'gotta have it' OR TYPE == 'hand it over or else'");
+
+        assertThrows(IllegalArgumentException.class, () -> parsedQuery.jjtAccept(visitor, null));
+    }
+
+    private ASTJexlScript parseQuery(String query) {
+        return parser.parse(null, new JexlFeatures(), EdgeQueryLogic.fixQueryString(query), null);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/EdgeTableRangeBuildingVisitorTest.java
@@ -1,6 +1,9 @@
 package datawave.query.jexl.visitors;
 
-import datawave.query.tables.edge.EdgeQueryLogic;
+import static java.util.Collections.emptyList;
+
+import static org.junit.Assert.assertThrows;
+
 import org.apache.commons.jexl3.JexlFeatures;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.Parser;
@@ -8,8 +11,7 @@ import org.apache.commons.jexl3.parser.StringProvider;
 import org.junit.Before;
 import org.junit.Test;
 
-import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertThrows;
+import datawave.query.tables.edge.EdgeQueryLogic;
 
 public class EdgeTableRangeBuildingVisitorTest {
 


### PR DESCRIPTION
We currently do not limit terms correctly for EdgeQueries due to the condition being checked in the parent AND or OR node before we have visited the terms and incremented the termCount.

Updated to increment the term count and check as we go.