### PR TITLE
Make the configcheck module optional as it is a separate utility not

### DIFF
--- a/microservices/configcheck/pom.xml
+++ b/microservices/configcheck/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>gov.nsa.datawave.microservice</groupId>
     <artifactId>datawave-microservice-configcheck</artifactId>
-    <version>6.7.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <distributionManagement>
         <repository>

--- a/microservices/pom.xml
+++ b/microservices/pom.xml
@@ -11,7 +11,6 @@
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     <modules>
-        <module>configcheck</module>
         <module>services</module>
         <module>starters</module>
     </modules>
@@ -36,6 +35,17 @@
             </activation>
             <modules>
                 <module>microservice-service-parent</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>configcheck</id>
+            <activation>
+                <property>
+                    <name>configcheck</name>
+                </property>
+            </activation>
+            <modules>
+                <module>configcheck</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
required in the main datawave builds