### PR TITLE
Remove parse from JexlStringBuildingVisitor, deprecate old methods

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -1467,7 +1467,7 @@ public class JexlASTHelper {
      * @return a key for the node.
      */
     public static String nodeToKey(JexlNode node) {
-        return JexlStringBuildingVisitor.buildQueryWithoutParse(node, true);
+        return JexlStringBuildingVisitor.buildQuery(node, true);
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -131,7 +131,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
      * @return the original Jexl node if keepOriginalNode is false, otherwise the expanded Jexl node
      */
     protected JexlNode buildIndexLookup(JexlNode node, boolean ignoreComposites, boolean keepOriginalNode, Supplier<IndexLookup> indexLookupSupplier) {
-        String nodeString = JexlStringBuildingVisitor.buildQueryWithoutParse(TreeFlatteningRebuildingVisitor.flatten(node), true);
+        String nodeString = JexlStringBuildingVisitor.buildQuery(TreeFlatteningRebuildingVisitor.flatten(node), true);
 
         IndexLookup lookup = lookupMap.computeIfAbsent(nodeString, k -> indexLookupSupplier.get());
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/JexlStringBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/JexlStringBuildingVisitor.java
@@ -91,24 +91,11 @@ public class JexlStringBuildingVisitor extends BaseVisitor {
             StringBuilder sb = (StringBuilder) script.jjtAccept(visitor, new StringBuilder());
 
             s = sb.toString();
-
-            try {
-                JexlASTHelper.parseJexlQuery(s);
-            } catch (ParseException e) {
-                log.error("Could not parse JEXL AST after performing transformations to run the query", e);
-
-                for (String line : PrintingVisitor.formattedQueryStringList(script)) {
-                    log.error(line);
-                }
-                log.error("");
-
-                QueryException qe = new QueryException(DatawaveErrorCode.QUERY_EXECUTION_ERROR, e);
-                throw new DatawaveFatalQueryException(qe);
-            }
         } catch (StackOverflowError e) {
 
             throw e;
         }
+
         return s;
     }
 
@@ -124,7 +111,9 @@ public class JexlStringBuildingVisitor extends BaseVisitor {
     }
 
     /**
-     * Build a String that is the equivalent JEXL query.
+     * Build a String that is the equivalent JEXL query. <br/>
+     * <br/>
+     * Depreciated, use {@link #buildQuery(JexlNode, boolean)}
      *
      * @param script
      *            An ASTJexlScript
@@ -133,30 +122,23 @@ public class JexlStringBuildingVisitor extends BaseVisitor {
      *            beforehand for maximum 'dedupeage'.
      * @return a query string
      */
+    @Deprecated
     public static String buildQueryWithoutParse(JexlNode script, boolean sortDedupeChildren) {
-        JexlStringBuildingVisitor visitor = new JexlStringBuildingVisitor(sortDedupeChildren);
-
-        String s = null;
-        try {
-            StringBuilder sb = (StringBuilder) script.jjtAccept(visitor, new StringBuilder());
-
-            s = sb.toString();
-        } catch (StackOverflowError e) {
-
-            throw e;
-        }
-        return s;
+        return buildQuery(script, sortDedupeChildren);
     }
 
     /**
-     * Build a String that is the equivalent JEXL query.
+     * Build a String that is the equivalent JEXL query. <br/>
+     * <br/>
+     * Depreciated, use {@link #buildQuery(JexlNode)}
      *
      * @param script
      *            An ASTJexlScript
      * @return a query string
      */
+    @Deprecated
     public static String buildQueryWithoutParse(JexlNode script) {
-        return buildQueryWithoutParse(script, false);
+        return buildQuery(script);
     }
 
     public Object visit(ASTOrNode node, Object data) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UniqueExpressionTermsVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UniqueExpressionTermsVisitor.java
@@ -99,7 +99,7 @@ public class UniqueExpressionTermsVisitor extends RebuildingVisitor {
         Set<String> childKeys = new HashSet<>();
         List<JexlNode> unique = new ArrayList<>();
         for (JexlNode node : nodes) {
-            String childKey = JexlStringBuildingVisitor.buildQueryWithoutParse(TreeFlatteningRebuildingVisitor.flatten(node), true);
+            String childKey = JexlStringBuildingVisitor.buildQuery(TreeFlatteningRebuildingVisitor.flatten(node), true);
             if (childKeys.add(childKey)) {
                 unique.add(node);
             } else {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/SortedDedupedJexlStringBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/SortedDedupedJexlStringBuildingVisitorTest.java
@@ -122,7 +122,7 @@ public class SortedDedupedJexlStringBuildingVisitorTest {
     }
 
     private static String nodeToKey(JexlNode node) {
-        return JexlStringBuildingVisitor.buildQueryWithoutParse(TreeFlatteningRebuildingVisitor.flatten(node), true);
+        return JexlStringBuildingVisitor.buildQuery(TreeFlatteningRebuildingVisitor.flatten(node), true);
     }
 
 }


### PR DESCRIPTION
Deprecated buildQueryWithoutParse() methods and removed parse from buildQuery(). We can remove buildQueryWithoutParse() in a future release.