### PR TITLE
Ordering Visitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -468,6 +468,17 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
      * Flag to control gathering term counts from the global index and persisting those to the query iterator. Negated terms and branches are not considered.
      */
     private boolean useTermCounts = false;
+    /**
+     * Flag to control sorting a query by inferred default costs prior to the global index lookup. This step may reduce time performing a secondary sort as when
+     * {@link #sortQueryByCounts} is enabled.
+     */
+    private boolean sortQueryBeforeGlobalIndex = false;
+
+    /**
+     * Flag to control if a query is sorted by either field or term counts. Either {@link #useFieldCounts} or {@link #useTermCounts} must be set for this option
+     * to take effect.
+     */
+    private boolean sortQueryByCounts = false;
 
     /**
      * Default constructor
@@ -686,6 +697,8 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setPruneQueryOptions(other.getPruneQueryOptions());
         this.setUseFieldCounts(other.getUseFieldCounts());
         this.setUseTermCounts(other.getUseTermCounts());
+        this.setSortQueryBeforeGlobalIndex(other.isSortQueryBeforeGlobalIndex());
+        this.setSortQueryByCounts(other.isSortQueryByCounts());
     }
 
     /**
@@ -2636,5 +2649,21 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setUseFieldCounts(boolean useFieldCounts) {
         this.useFieldCounts = useFieldCounts;
+    }
+
+    public boolean isSortQueryBeforeGlobalIndex() {
+        return sortQueryBeforeGlobalIndex;
+    }
+
+    public void setSortQueryBeforeGlobalIndex(boolean sortQueryBeforeGlobalIndex) {
+        this.sortQueryBeforeGlobalIndex = sortQueryBeforeGlobalIndex;
+    }
+
+    public boolean isSortQueryByCounts() {
+        return sortQueryByCounts;
+    }
+
+    public void setSortQueryByCounts(boolean sortQueryByCounts) {
+        this.sortQueryByCounts = sortQueryByCounts;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
@@ -28,6 +28,7 @@ import datawave.ingest.protobuf.Uid;
 import datawave.query.tld.TLD;
 import datawave.query.util.Tuple3;
 import datawave.query.util.Tuples;
+import datawave.query.util.count.CountMap;
 
 /**
  * <pre>
@@ -293,14 +294,14 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
                         strippedCq.offset(), strippedCq.length(), cv.getBackingArray(), cv.offset(), cv.length(), k.getTimestamp());
     }
 
-    private Map<String,Long> createFieldCounts(String field, Long count) {
-        Map<String,Long> counts = new HashMap<>();
+    private CountMap createFieldCounts(String field, Long count) {
+        CountMap counts = new CountMap();
         counts.put(field, count);
         return counts;
     }
 
-    private Map<String,Long> createTermCounts(String field, String value, Long count) {
-        Map<String,Long> counts = new HashMap<>();
+    private CountMap createTermCounts(String field, String value, Long count) {
+        CountMap counts = new CountMap();
         counts.put(field + " == '" + value + "'", count);
         return counts;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
@@ -10,7 +10,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +36,7 @@ import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.jexl.visitors.RebuildingVisitor;
 import datawave.query.jexl.visitors.TreeFlatteningRebuildingVisitor;
 import datawave.query.language.parser.jexl.JexlNodeSet;
+import datawave.query.util.count.CountMap;
 
 /**
  * This class represents information about hits in the index.
@@ -57,8 +57,8 @@ public class IndexInfo implements Writable, UidIntersector {
     // In the pruned case, the count will exceed the size of the uid set
     protected ImmutableSortedSet<IndexMatch> uids;
 
-    protected Map<String,Long> fieldCounts = new HashMap<>();
-    protected Map<String,Long> termCounts = new HashMap<>();
+    protected CountMap fieldCounts = new CountMap();
+    protected CountMap termCounts = new CountMap();
 
     public IndexInfo() {
         this.count = 0;
@@ -148,14 +148,14 @@ public class IndexInfo implements Writable, UidIntersector {
 
         MapWritable fieldMapWritable = new MapWritable();
         fieldMapWritable.readFields(in);
-        this.fieldCounts = new HashMap<>();
+        this.fieldCounts = new CountMap();
         for (Writable key : fieldMapWritable.keySet()) {
             fieldCounts.put(key.toString(), Long.valueOf(fieldMapWritable.get(key).toString()));
         }
 
         MapWritable termMapWritable = new MapWritable();
         termMapWritable.readFields(in);
-        this.termCounts = new HashMap<>();
+        this.termCounts = new CountMap();
         for (Writable key : termMapWritable.keySet()) {
             termCounts.put(key.toString(), Long.valueOf(termMapWritable.get(key).toString()));
         }
@@ -541,15 +541,15 @@ public class IndexInfo implements Writable, UidIntersector {
         }
     }
 
-    public void setFieldCounts(Map<String,Long> fieldCounts) {
+    public void setFieldCounts(CountMap fieldCounts) {
         this.fieldCounts.putAll(fieldCounts);
     }
 
-    public void setTermCounts(Map<String,Long> termCounts) {
+    public void setTermCounts(CountMap termCounts) {
         this.termCounts.putAll(termCounts);
     }
 
-    public void mergeFieldCounts(Map<String,Long> otherCounts) {
+    public void mergeFieldCounts(CountMap otherCounts) {
         if (fieldCounts == null || fieldCounts.isEmpty()) {
             fieldCounts = otherCounts;
             return;
@@ -566,7 +566,7 @@ public class IndexInfo implements Writable, UidIntersector {
         }
     }
 
-    public void mergeTermCounts(Map<String,Long> otherCounts) {
+    public void mergeTermCounts(CountMap otherCounts) {
         if (termCounts == null || termCounts.isEmpty()) {
             termCounts = otherCounts;
             return;
@@ -583,11 +583,11 @@ public class IndexInfo implements Writable, UidIntersector {
         }
     }
 
-    public Map<String,Long> getFieldCounts() {
+    public CountMap getFieldCounts() {
         return fieldCounts;
     }
 
-    public Map<String,Long> getTermCounts() {
+    public CountMap getTermCounts() {
         return termCounts;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
@@ -60,6 +61,7 @@ import org.apache.commons.jexl3.parser.JexlNodes;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
+import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -84,6 +86,7 @@ import datawave.query.jexl.visitors.ExecutableDeterminationVisitor;
 import datawave.query.jexl.visitors.IngestTypePruningVisitor;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.jexl.visitors.TreeFlatteningRebuildingVisitor;
+import datawave.query.jexl.visitors.order.OrderByCostVisitor;
 import datawave.query.planner.QueryPlan;
 import datawave.query.tables.RangeStreamScanner;
 import datawave.query.tables.ScannerFactory;
@@ -259,6 +262,10 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                 }
 
                 this.itr = filter(concat(transform(queryStream, new TupleToRange(queryStream.currentNode(), config))), getEmptyPlanPruner());
+
+                if (config.isSortQueryByCounts() && (config.getUseFieldCounts() || config.getUseTermCounts())) {
+                    this.itr = transform(itr, new OrderingTransform(config.getUseFieldCounts(), config.getUseTermCounts()));
+                }
             }
         } finally {
             // shut down the executor as all threads have completed
@@ -330,6 +337,34 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
             }
 
             return true;
+        }
+    }
+
+    /**
+     * Transform that reorders a query tree according to field or term counts.
+     * <p>
+     * If both flags are set then the more precise term counts are used.
+     */
+    public static class OrderingTransform implements Function<QueryPlan,QueryPlan> {
+
+        private final boolean useFieldCounts;
+        private final boolean useTermCounts;
+
+        public OrderingTransform(boolean useFieldCounts, boolean useTermCounts) {
+            this.useFieldCounts = useFieldCounts;
+            this.useTermCounts = useTermCounts;
+        }
+
+        @Override
+        public QueryPlan apply(QueryPlan plan) {
+            if (useTermCounts) {
+                Map<String,Long> counts = plan.getTermCounts().getCounts();
+                OrderByCostVisitor.orderByTermCount(plan.getQueryTree(), counts);
+            } else if (useFieldCounts) {
+                Map<String,Long> counts = plan.getTermCounts().getCounts();
+                OrderByCostVisitor.orderByFieldCount(plan.getQueryTree(), counts);
+            }
+            return plan;
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -39,7 +39,12 @@ import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -93,6 +98,8 @@ import datawave.query.statsd.QueryStatsDClient;
 import datawave.query.tables.async.Scan;
 import datawave.query.tracking.ActiveQueryLog;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.count.CountMap;
+import datawave.query.util.count.CountMapSerDe;
 import datawave.query.util.sortedset.FileSortedSet;
 import datawave.util.StringUtils;
 import datawave.util.UniversalSet;
@@ -435,8 +442,9 @@ public class QueryOptions implements OptionDescriber {
     private int docAggregationThresholdMs = -1;
     private int tfAggregationThresholdMs = -1;
 
-    private Map<String,Long> fieldCounts;
-    private Map<String,Long> termCounts;
+    private CountMap fieldCounts;
+    private CountMap termCounts;
+    private CountMapSerDe mapSerDe;
 
     public void deepCopy(QueryOptions other) {
         this.options = other.options;
@@ -1392,12 +1400,12 @@ public class QueryOptions implements OptionDescriber {
 
         if (options.containsKey(FIELD_COUNTS)) {
             String serializedMap = options.get(FIELD_COUNTS);
-            this.fieldCounts = mapFromString(serializedMap);
+            this.fieldCounts = getMapSerDe().deserializeFromString(serializedMap);
         }
 
         if (options.containsKey(TERM_COUNTS)) {
             String serializedMap = options.get(TERM_COUNTS);
-            this.termCounts = mapFromString(serializedMap);
+            this.termCounts = getMapSerDe().deserializeFromString(serializedMap);
         }
 
         this.evaluationFilter = null;
@@ -1997,29 +2005,16 @@ public class QueryOptions implements OptionDescriber {
         return sb.toString();
     }
 
-    public static String mapToString(Map<String,Long> map) {
-        StringBuilder sb = new StringBuilder();
-        Iterator<String> keys = new TreeSet<>(map.keySet()).iterator();
-        while (keys.hasNext()) {
-            String key = keys.next();
-            sb.append(key).append(Constants.COMMA).append(map.get(key));
-            if (keys.hasNext()) {
-                sb.append(";");
-            }
+    /**
+     * Get a serialization and deserialization utility for {@link datawave.query.util.count.CountMap}
+     *
+     * @return count map utility
+     */
+    private CountMapSerDe getMapSerDe() {
+        if (mapSerDe == null) {
+            mapSerDe = new CountMapSerDe();
         }
-        return sb.toString();
-    }
-
-    public static Map<String,Long> mapFromString(String serialized) {
-        Map<String,Long> counts = new HashMap<>();
-        String[] parts = serialized.split(";");
-        for (String part : parts) {
-            int index = part.indexOf(Constants.COMMA);
-            String key = part.substring(0, index);
-            Long value = Long.valueOf(part.substring(index + 1));
-            counts.put(key, value);
-        }
-        return counts;
+        return mapSerDe;
     }
 
     public static Set<String> buildIgnoredColumnFamilies(String colFams) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/DefaultNodeCostComparator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/DefaultNodeCostComparator.java
@@ -1,0 +1,69 @@
+package datawave.query.jexl.nodes;
+
+import org.apache.commons.jexl3.parser.ASTAndNode;
+import org.apache.commons.jexl3.parser.ASTOrNode;
+import org.apache.commons.jexl3.parser.ASTReference;
+import org.apache.commons.jexl3.parser.ASTReferenceExpression;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.JexlNodes;
+import org.apache.commons.jexl3.parser.ParserTreeConstants;
+
+/**
+ * Provides default node cost calculations based on the Jexl node id
+ */
+public class DefaultNodeCostComparator extends NodeCostComparator {
+
+    /**
+     *
+     * @param node
+     *            an arbitrary JexlNode
+     * @return the node cost
+     */
+    @Override
+    protected int getCostIndex(JexlNode node) {
+        if (node.jjtGetNumChildren() == 1 && (node instanceof ASTReference || node instanceof ASTReferenceExpression)) {
+            QueryPropertyMarker.Instance instance = QueryPropertyMarker.findInstance(node);
+            if (instance.isAnyType()) {
+                return Integer.MAX_VALUE - 4;
+            }
+            return getCostIndex(node.jjtGetChild(0));
+        } else if (node instanceof ASTOrNode) {
+            int sum = 0;
+            for (int i = 0; i < node.jjtGetNumChildren(); i++) {
+                sum += getCostIndex(node.jjtGetChild(i));
+            }
+            return sum;
+        } else if (node instanceof ASTAndNode) {
+            int lowest = Integer.MAX_VALUE;
+            for (int i = 0; i < node.jjtGetNumChildren(); i++) {
+                int cost = getCostIndex(node.jjtGetChild(i));
+                if (cost < lowest)
+                    lowest = cost;
+            }
+            return lowest;
+        } else {
+            return getNodeScore(node);
+        }
+    }
+
+    /**
+     * Wrapper around {@link JexlNodes#id(JexlNode)} so that we can boost the score of negated terms
+     *
+     * @param node
+     *            any JexlNode
+     * @return a score for the node
+     */
+    private int getNodeScore(JexlNode node) {
+        int id = JexlNodes.id(node);
+        switch (id) {
+            case ParserTreeConstants.JJTNENODE:
+                return Integer.MAX_VALUE - 3;
+            case ParserTreeConstants.JJTNRNODE:
+                return Integer.MAX_VALUE - 2;
+            case ParserTreeConstants.JJTNOTNODE:
+                return Integer.MAX_VALUE - 1;
+            default:
+                return id;
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/FieldOrTermNodeCostComparator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/FieldOrTermNodeCostComparator.java
@@ -1,0 +1,113 @@
+package datawave.query.jexl.nodes;
+
+import java.util.Map;
+
+import org.apache.commons.jexl3.parser.ASTAndNode;
+import org.apache.commons.jexl3.parser.ASTFunctionNode;
+import org.apache.commons.jexl3.parser.ASTNENode;
+import org.apache.commons.jexl3.parser.ASTNRNode;
+import org.apache.commons.jexl3.parser.ASTNotNode;
+import org.apache.commons.jexl3.parser.ASTOrNode;
+import org.apache.commons.jexl3.parser.ASTReference;
+import org.apache.commons.jexl3.parser.ASTReferenceExpression;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.JexlNodes;
+import org.apache.commons.jexl3.parser.ParserTreeConstants;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+
+/**
+ * Orders nodes based on field or term counts
+ */
+public class FieldOrTermNodeCostComparator extends NodeCostComparator {
+
+    private final boolean isFieldCount;
+    private static final long NODE_ID_MULTIPLIER = 5000;
+    private final Map<String,Long> counts;
+
+    public FieldOrTermNodeCostComparator(Map<String,Long> counts, boolean isFieldCount) {
+        this.counts = counts;
+        this.isFieldCount = isFieldCount;
+    }
+
+    @Override
+    int getCostIndex(JexlNode node) {
+        if (node.jjtGetNumChildren() == 1 && (node instanceof ASTReference || node instanceof ASTReferenceExpression)) {
+            return getCostIndex(node.jjtGetChild(0));
+        } else if (node instanceof ASTOrNode) {
+            int sum = 0;
+            for (int i = 0; i < node.jjtGetNumChildren(); i++) {
+                sum += getCostIndex(node.jjtGetChild(i));
+            }
+            return sum;
+        } else if (node instanceof ASTAndNode) {
+            int lowest = Integer.MAX_VALUE;
+            for (int i = 0; i < node.jjtGetNumChildren(); i++) {
+                int cost = getCostIndex(node.jjtGetChild(i));
+                if (cost < lowest)
+                    lowest = cost;
+            }
+            return lowest;
+        } else {
+            return getCostForLeaf(node);
+        }
+    }
+
+    /**
+     * Get the cost for a leaf according to the count map.
+     * <p>
+     * The extra code to handle integer overflows is due to term counts in the global index being a Long but Java's {@link Comparable#compareTo(Object)} returns
+     * an integer.
+     *
+     * @param node
+     *            a JexlNode
+     * @return an integer used to compare nodes
+     */
+    private int getCostForLeaf(JexlNode node) {
+        String key = getNodeKey(node);
+        long value = counts.getOrDefault(key, getNodeScore(node));
+        if (value > Integer.MAX_VALUE) {
+            value = Integer.MAX_VALUE;
+        }
+        return (int) value;
+    }
+
+    /**
+     * Generate a key for the count map. It's either the field, or the whole node.
+     *
+     * @param node
+     *            a JexlNode
+     * @return a node key
+     */
+    private String getNodeKey(JexlNode node) {
+        if (node instanceof ASTNotNode || node instanceof ASTNENode || node instanceof ASTNRNode || node instanceof ASTFunctionNode) {
+            return "NO_KEY";
+        } else if (isFieldCount) {
+            return JexlASTHelper.getIdentifier(node);
+        } else {
+            return JexlStringBuildingVisitor.buildQueryWithoutParse(node);
+        }
+    }
+
+    /**
+     * Wrapper around {@link JexlNodes#id(JexlNode)} so that we can boost the score of negated terms
+     *
+     * @param node
+     *            any JexlNode
+     * @return a score for the node
+     */
+    private long getNodeScore(JexlNode node) {
+        int id = JexlNodes.id(node);
+        switch (id) {
+            case ParserTreeConstants.JJTNENODE:
+                return Integer.MAX_VALUE - 3L;
+            case ParserTreeConstants.JJTNRNODE:
+                return Integer.MAX_VALUE - 2L;
+            case ParserTreeConstants.JJTNOTNODE:
+                return Integer.MAX_VALUE - 1L;
+            default:
+                return id * NODE_ID_MULTIPLIER;
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/NodeCostComparator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/NodeCostComparator.java
@@ -1,0 +1,31 @@
+package datawave.query.jexl.nodes;
+
+import java.util.Comparator;
+
+import org.apache.commons.jexl3.parser.JexlNode;
+
+/**
+ * Compare nodes based on arbitrary cost.
+ * <p>
+ * EQ &lt; ER &lt; Functions
+ */
+public abstract class NodeCostComparator implements Comparator<JexlNode> {
+
+    @Override
+    public int compare(JexlNode left, JexlNode right) {
+        int leftCost = getCostIndex(left);
+        int rightCost = getCostIndex(right);
+        return Integer.compare(leftCost, rightCost);
+    }
+
+    // Evaluate OR nodes last, then And nodes, then nodes by node id
+
+    /**
+     * Calculates a cost for the provided node
+     *
+     * @param node
+     *            an arbitrary JexlNode
+     * @return the integer cost
+     */
+    abstract int getCostIndex(JexlNode node);
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/order/OrderByCostVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/order/OrderByCostVisitor.java
@@ -1,0 +1,204 @@
+package datawave.query.jexl.visitors.order;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.apache.commons.jexl3.parser.ASTAndNode;
+import org.apache.commons.jexl3.parser.ASTFunctionNode;
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ASTOrNode;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.JexlNodes;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.apache.log4j.Logger;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.nodes.DefaultNodeCostComparator;
+import datawave.query.jexl.nodes.FieldOrTermNodeCostComparator;
+import datawave.query.jexl.nodes.NodeCostComparator;
+import datawave.query.jexl.nodes.QueryPropertyMarker;
+import datawave.query.jexl.visitors.BaseVisitor;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+
+/**
+ * Orders query nodes by cost.
+ * <p>
+ * Cost is calculated based on field counts, term counts, or a default cost based on the node id {@link org.apache.commons.jexl3.parser.ParserTreeConstants}.
+ * <p>
+ * In general an EQ node is faster to resolve than an ER node.
+ * <p>
+ * In general an ER node is faster to resolve than a function node.
+ */
+public class OrderByCostVisitor extends BaseVisitor {
+
+    private static final Logger log = Logger.getLogger(OrderByCostVisitor.class);
+
+    private NodeCostComparator costComparator;
+    private final boolean isFieldMap;
+    private final Map<String,Long> countMap;
+
+    /**
+     * Wrapper method for {@link #order(ASTJexlScript)}.
+     *
+     * @param query
+     *            a string representation of a query
+     * @return a cost-ordered query
+     */
+    public static String order(String query) {
+        try {
+            ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+            script = order(script);
+            return JexlStringBuildingVisitor.buildQueryWithoutParse(script);
+        } catch (ParseException e) {
+            log.error("Could not order query by cost: " + query);
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * Orders the query tree by arbitrary cost
+     *
+     * @param script
+     *            the query tree
+     * @return a query tree ordered by arbitrary cost
+     */
+    public static ASTJexlScript order(ASTJexlScript script) {
+        return order(script, null, false);
+    }
+
+    /**
+     * Orders the query by field counts
+     *
+     * @param script
+     *            the query tree
+     * @param counts
+     *            a map of field counts
+     * @return a query tree ordered by field counts
+     */
+    public static ASTJexlScript orderByFieldCount(ASTJexlScript script, Map<String,Long> counts) {
+        return order(script, counts, true);
+    }
+
+    /**
+     * Orders the query by field counts
+     *
+     * @param node
+     *            an arbitrary JexlNode
+     * @param counts
+     *            a map of field counts
+     * @return a query tree ordered by field counts
+     */
+    public static ASTJexlScript orderByFieldCount(JexlNode node, Map<String,Long> counts) {
+        return order(node, counts, true);
+    }
+
+    /**
+     * Orders the query tree by term counts
+     *
+     * @param script
+     *            the query tree
+     * @param counts
+     *            a map of term counts
+     * @return a query tree ordered by term counts
+     */
+    public static ASTJexlScript orderByTermCount(ASTJexlScript script, Map<String,Long> counts) {
+        return order(script, counts, false);
+    }
+
+    /**
+     * Orders the query tree by term counts
+     *
+     * @param node
+     *            an arbitrary JexlNode
+     * @param counts
+     *            a map of term counts
+     * @return a query tree ordered by term counts
+     */
+    public static ASTJexlScript orderByTermCount(JexlNode node, Map<String,Long> counts) {
+        return order(node, counts, false);
+    }
+
+    /**
+     * Orders a query tree
+     *
+     * @param script
+     *            the query tree
+     * @param counts
+     *            a map of field or term counts
+     * @param isFieldMap
+     *            a flag that determines how the count map is interpreted
+     * @return an ordered query tree
+     */
+    private static ASTJexlScript order(ASTJexlScript script, Map<String,Long> counts, boolean isFieldMap) {
+        OrderByCostVisitor visitor = new OrderByCostVisitor(counts, isFieldMap);
+        return (ASTJexlScript) script.jjtAccept(visitor, null);
+    }
+
+    /**
+     * Orders a query tree
+     *
+     * @param node
+     *            the query tree
+     * @param counts
+     *            a map of field or term counts
+     * @param isFieldMap
+     *            a flag that determines how the count map is interpreted
+     * @return an ordered query tree
+     */
+    private static ASTJexlScript order(JexlNode node, Map<String,Long> counts, boolean isFieldMap) {
+        OrderByCostVisitor visitor = new OrderByCostVisitor(counts, isFieldMap);
+        return (ASTJexlScript) node.jjtAccept(visitor, null);
+    }
+
+    public OrderByCostVisitor(Map<String,Long> counts, boolean isFieldMap) {
+        this.countMap = counts;
+        this.isFieldMap = isFieldMap;
+    }
+
+    @Override
+    public Object visit(ASTJexlScript node, Object data) {
+        node.childrenAccept(this, data);
+        return node;
+    }
+
+    @Override
+    public Object visit(ASTOrNode node, Object data) {
+        return visitJunction(node, data);
+    }
+
+    @Override
+    public Object visit(ASTAndNode node, Object data) {
+        return visitJunction(node, data);
+    }
+
+    // Do not descend into functions
+    @Override
+    public Object visit(ASTFunctionNode node, Object data) {
+        return data;
+    }
+
+    private Object visitJunction(JexlNode node, Object data) {
+        QueryPropertyMarker.Instance instance = QueryPropertyMarker.findInstance(node);
+        if (!instance.isAnyType()) {
+            JexlNode[] children = JexlNodes.getChildren(node);
+            Arrays.sort(children, getCostComparator());
+            JexlNodes.setChildren(node, children);
+
+            node.childrenAccept(this, data);
+        }
+        return data;
+    }
+
+    private NodeCostComparator getCostComparator() {
+        if (costComparator == null) {
+            if (countMap != null) {
+                costComparator = new FieldOrTermNodeCostComparator(countMap, isFieldMap);
+            } else {
+                costComparator = new DefaultNodeCostComparator();
+            }
+        }
+        return costComparator;
+    }
+
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -148,6 +148,7 @@ import datawave.query.jexl.visitors.UnmarkedBoundedRangeDetectionVisitor;
 import datawave.query.jexl.visitors.ValidComparisonVisitor;
 import datawave.query.jexl.visitors.ValidPatternVisitor;
 import datawave.query.jexl.visitors.ValidateFilterFunctionVisitor;
+import datawave.query.jexl.visitors.order.OrderByCostVisitor;
 import datawave.query.jexl.visitors.whindex.WhindexVisitor;
 import datawave.query.model.QueryModel;
 import datawave.query.planner.comparator.DefaultQueryPlanComparator;
@@ -2671,6 +2672,10 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             } else {
                 throw new DatawaveFatalQueryException("Check query for mutually exclusive ingest types, query was non-executable after pruning by ingest type");
             }
+        }
+
+        if (config.isSortQueryBeforeGlobalIndex()) {
+            queryTree = OrderByCostVisitor.order((ASTJexlScript) queryTree);
         }
 
         // if a simple examination of the query has not forced a full table

--- a/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlan.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/QueryPlan.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.util.count.CountMap;
 import datawave.webservice.query.configuration.QueryData;
 
 /**
@@ -35,8 +36,8 @@ public class QueryPlan {
     protected Collection<Range> ranges = null;
     protected Collection<String> columnFamilies = new ArrayList<>();
     protected List<IteratorSetting> settings = new ArrayList<>();
-    protected Map<String,Long> termCounts;
-    protected Map<String,Long> fieldCounts;
+    protected CountMap termCounts;
+    protected CountMap fieldCounts;
 
     protected boolean rebuildHashCode = true;
     protected int hashCode;
@@ -259,13 +260,13 @@ public class QueryPlan {
         return this;
     }
 
-    public QueryPlan withFieldCounts(Map<String,Long> fieldCounts) {
+    public QueryPlan withFieldCounts(CountMap fieldCounts) {
         this.fieldCounts = fieldCounts;
         resetHashCode();
         return this;
     }
 
-    public QueryPlan withTermCounts(Map<String,Long> termCounts) {
+    public QueryPlan withTermCounts(CountMap termCounts) {
         this.termCounts = termCounts;
         resetHashCode();
         return this;
@@ -352,11 +353,11 @@ public class QueryPlan {
         return settings;
     }
 
-    public Map<String,Long> getFieldCounts() {
+    public CountMap getFieldCounts() {
         return this.fieldCounts;
     }
 
-    public Map<String,Long> getTermCounts() {
+    public CountMap getTermCounts() {
         return this.termCounts;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundlerIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/ThreadedRangeBundlerIterator.java
@@ -27,6 +27,7 @@ import datawave.query.CloseableIterable;
 import datawave.query.iterator.QueryIterator;
 import datawave.query.iterator.QueryOptions;
 import datawave.query.tld.TLDQueryIterator;
+import datawave.query.util.count.CountMapSerDe;
 import datawave.webservice.common.logging.ThreadConfigurableLogger;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.configuration.QueryData;
@@ -62,6 +63,8 @@ public class ThreadedRangeBundlerIterator implements Iterator<QueryData>, Closea
     protected long rangeBufferTimeoutMillis;
     protected long rangeBufferPollMillis;
     protected long startTimeMillis;
+
+    private CountMapSerDe mapSerDe;
 
     private ThreadedRangeBundlerIterator(Builder builder) {
 
@@ -280,11 +283,11 @@ public class ThreadedRangeBundlerIterator implements Iterator<QueryData>, Closea
             newSetting.addOptions(setting.getOptions());
 
             if (plan.getFieldCounts() != null && !plan.getTermCounts().isEmpty()) {
-                newSetting.addOption(QueryOptions.FIELD_COUNTS, QueryOptions.mapToString(plan.getFieldCounts()));
+                newSetting.addOption(QueryOptions.FIELD_COUNTS, getMapSerDe().serializeToString(plan.getFieldCounts()));
             }
 
             if (plan.getTermCounts() != null && !plan.getTermCounts().isEmpty()) {
-                newSetting.addOption(QueryOptions.TERM_COUNTS, QueryOptions.mapToString(plan.getTermCounts()));
+                newSetting.addOption(QueryOptions.TERM_COUNTS, getMapSerDe().serializeToString(plan.getTermCounts()));
             }
 
             settings.add(newSetting);
@@ -297,6 +300,13 @@ public class ThreadedRangeBundlerIterator implements Iterator<QueryData>, Closea
                         .withColumnFamilies(plan.getColumnFamilies())
                         .withSettings(settings);
         //  @formatter:on
+    }
+
+    private CountMapSerDe getMapSerDe() {
+        if (mapSerDe == null) {
+            mapSerDe = new CountMapSerDe();
+        }
+        return mapSerDe;
     }
 
     /*

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -2766,4 +2766,20 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> {
     public void setUseTermCounts(boolean useTermCounts) {
         getConfig().setUseTermCounts(useTermCounts);
     }
+
+    public boolean getSortQueryBeforeGlobalIndex() {
+        return getConfig().isSortQueryBeforeGlobalIndex();
+    }
+
+    public void setSortQueryBeforeGlobalIndex(boolean sortQueryBeforeGlobalIndex) {
+        getConfig().setSortQueryBeforeGlobalIndex(sortQueryBeforeGlobalIndex);
+    }
+
+    public boolean getSortQueryByCounts() {
+        return getConfig().isSortQueryByCounts();
+    }
+
+    public void setSortQueryByCounts(boolean sortQueryByCounts) {
+        getConfig().setSortQueryByCounts(sortQueryByCounts);
+    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/util/count/CountMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/count/CountMap.java
@@ -1,0 +1,90 @@
+package datawave.query.util.count;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Wrapper around a HashMap that supports Kryo serialization
+ */
+public class CountMap implements KryoSerializable {
+
+    private final Map<String,Long> counts;
+
+    public CountMap() {
+        counts = new HashMap<>();
+    }
+
+    public Long put(String key, Long value) {
+        return counts.put(key, value);
+    }
+
+    public void putAll(CountMap other) {
+        counts.putAll(other.counts);
+    }
+
+    public Set<String> keySet() {
+        return counts.keySet();
+    }
+
+    public Long get(String key) {
+        return counts.get(key);
+    }
+
+    public Set<Entry<String,Long>> entrySet() {
+        return counts.entrySet();
+    }
+
+    public boolean isEmpty() {
+        return counts.isEmpty();
+    }
+
+    public boolean containsKey(String key) {
+        return counts.containsKey(key);
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        counts.clear();
+        int size = input.readInt();
+        for (int i = 0; i < size; i++) {
+            String key = input.readString();
+            Long value = input.readLong();
+            put(key, value);
+        }
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeInt(keySet().size());
+        for (Entry<String,Long> entry : entrySet()) {
+            output.writeString(entry.getKey());
+            output.writeLong(entry.getValue());
+        }
+    }
+
+    public Map<String,Long> getCounts() {
+        return counts;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof CountMap) {
+            CountMap other = (CountMap) o;
+            return this.counts.equals(other.counts);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return counts.hashCode();
+    }
+
+}

--- a/warehouse/query-core/src/main/java/datawave/query/util/count/CountMapSerDe.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/count/CountMapSerDe.java
@@ -1,0 +1,50 @@
+package datawave.query.util.count;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Utility class for serializing and deserializing a {@link CountMap}
+ */
+public class CountMapSerDe {
+
+    private final Kryo kryo;
+    private final ByteArrayOutputStream baos;
+
+    public CountMapSerDe() {
+        kryo = new Kryo();
+        baos = new ByteArrayOutputStream(4096);
+    }
+
+    public String serializeToString(CountMap map) {
+        return new String(serialize(map), StandardCharsets.ISO_8859_1);
+    }
+
+    public byte[] serialize(CountMap map) {
+        baos.reset();
+        Output output = new Output(baos);
+        kryo.writeObject(output, map);
+        output.close();
+        return baos.toByteArray();
+    }
+
+    public CountMap deserializeFromString(String data) {
+        return deserialize(data.getBytes(StandardCharsets.ISO_8859_1));
+    }
+
+    public CountMap deserialize(byte[] data) {
+        Input input = new Input(data);
+        CountMap map = kryo.readObject(input, CountMap.class);
+        input.close();
+
+        if (map == null) {
+            throw new RuntimeException("Deserialized null CountMap");
+        }
+
+        return map;
+    }
+}

--- a/warehouse/query-core/src/main/java/org/apache/commons/jexl3/parser/JexlNodes.java
+++ b/warehouse/query-core/src/main/java/org/apache/commons/jexl3/parser/JexlNodes.java
@@ -77,6 +77,21 @@ public class JexlNodes {
     }
 
     /**
+     * Get the children of the provided node as an array. Children are NOT copied, direct references to the children are returned.
+     *
+     * @param node
+     *            a Jexl node
+     * @return an array of the node's children
+     */
+    public static JexlNode[] getChildren(JexlNode node) {
+        JexlNode[] children = new JexlNode[node.jjtGetNumChildren()];
+        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
+            children[i] = node.jjtGetChild(i);
+        }
+        return children;
+    }
+
+    /**
      * Sets the supplied child array as the children member of {node} and sets the parent reference of each element in {children} to {node}.
      *
      * @param node

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -554,6 +554,10 @@ public class ShardQueryConfigurationTest {
         updatedValues.put("useFieldCounts", true);
         defaultValues.put("useTermCounts", false);
         updatedValues.put("useTermCounts", true);
+        defaultValues.put("sortQueryBeforeGlobalIndex", false);
+        updatedValues.put("sortQueryBeforeGlobalIndex", true);
+        defaultValues.put("sortQueryByCounts", false);
+        updatedValues.put("sortQueryByCounts", true);
     }
 
     private Query createQuery(String query) {

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/CreateUidsIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/CreateUidsIteratorTest.java
@@ -331,7 +331,7 @@ public class CreateUidsIteratorTest {
 
         Map<String,Long> expected = new HashMap<>();
         expected.put("NO_FIELD", 3L); // NO_FIELD because the test framework didn't pass in a real seek range
-        assertEquals(expected, info.getFieldCounts());
+        assertEquals(expected, info.getFieldCounts().getCounts());
     }
 
     private Value valueForUids(Collection<String> uids) {

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/IndexInfoTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/IndexInfoTest.java
@@ -28,6 +28,7 @@ import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
+import datawave.query.util.count.CountMap;
 
 /**
  * Test basic functionality of the {@link IndexInfo} class.
@@ -353,7 +354,7 @@ public class IndexInfoTest {
     @Test
     public void testFieldCountSerialization() throws IOException {
 
-        Map<String,Long> counts = new HashMap<>();
+        CountMap counts = new CountMap();
         counts.put("FIELD_A", 23L);
         counts.put("FIELD_B", 2077L);
 
@@ -377,10 +378,10 @@ public class IndexInfoTest {
 
     @Test
     public void testMergeFieldCounts() {
-        Map<String,Long> firstCounts = new HashMap<>();
+        CountMap firstCounts = new CountMap();
         firstCounts.put("FOO", 17L);
 
-        Map<String,Long> secondCounts = new HashMap<>();
+        CountMap secondCounts = new CountMap();
         secondCounts.put("FOO", 23L);
 
         IndexInfo first = new IndexInfo();

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
@@ -12,7 +12,6 @@ import static datawave.query.iterator.QueryOptions.TF_NEXT_SEEK;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.lang.reflect.InaccessibleObjectException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -212,19 +211,6 @@ public class QueryOptionsTest {
         Map<String,Set<String>> actual = QueryOptions.buildFieldDataTypeMap(data);
 
         Assert.assertEquals(expected, actual);
-    }
-
-    @Test
-    public void testMapSerialization() {
-        Map<String,Long> map = new HashMap<>();
-        map.put("FIELD_A", 23L);
-        map.put("FIELD_B", 146L);
-
-        String serialized = QueryOptions.mapToString(map);
-        assertEquals("FIELD_A,23;FIELD_B,146", serialized);
-
-        Map<String,Long> deserialized = QueryOptions.mapFromString(serialized);
-        assertEquals(map, deserialized);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/nodes/DefaultNodeCostComparatorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/nodes/DefaultNodeCostComparatorTest.java
@@ -1,0 +1,80 @@
+package datawave.query.jexl.nodes;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.junit.Test;
+
+import datawave.query.jexl.JexlNodeFactory;
+
+public class DefaultNodeCostComparatorTest {
+
+    @Test
+    public void testCompareTwoEq() {
+        JexlNode left = JexlNodeFactory.buildEQNode("FOO", "bar");
+        JexlNode right = JexlNodeFactory.buildEQNode("FOO", "baz");
+
+        List<JexlNode> nodes = new LinkedList<>();
+        nodes.add(left);
+        nodes.add(right);
+
+        Iterator<JexlNode> iter = nodes.iterator();
+        assertEquals(left, iter.next());
+        assertEquals(right, iter.next());
+
+        nodes.sort(new DefaultNodeCostComparator());
+
+        // Order should not have changed
+        iter = nodes.iterator();
+        assertEquals(left, iter.next());
+        assertEquals(right, iter.next());
+    }
+
+    @Test
+    public void testCompareEqAndRe() {
+        JexlNode left = JexlNodeFactory.buildEQNode("FOO", "bar");
+        JexlNode right = JexlNodeFactory.buildERNode("FOO", "baz.*");
+
+        List<JexlNode> nodes = new LinkedList<>();
+        nodes.add(right);
+        nodes.add(left);
+
+        // Assert insert order
+        Iterator<JexlNode> iter = nodes.iterator();
+        assertEquals(right, iter.next());
+        assertEquals(left, iter.next());
+
+        nodes.sort(new DefaultNodeCostComparator());
+
+        // Assert proper sort order, EQ before ER
+        iter = nodes.iterator();
+        assertEquals(left, iter.next());
+        assertEquals(right, iter.next());
+    }
+
+    @Test
+    public void testCompareEqAndFunction() {
+        JexlNode left = JexlNodeFactory.buildEQNode("FOO", "bar");
+        JexlNode right = JexlNodeFactory.buildFunctionNode("content", "phrase", "FOO", "baz");
+
+        List<JexlNode> nodes = new LinkedList<>();
+        nodes.add(right);
+        nodes.add(left);
+
+        // Assert insert order
+        Iterator<JexlNode> iter = nodes.iterator();
+        assertEquals(right, iter.next());
+        assertEquals(left, iter.next());
+
+        nodes.sort(new DefaultNodeCostComparator());
+
+        // Assert proper sort order, EQ before ER
+        iter = nodes.iterator();
+        assertEquals(left, iter.next());
+        assertEquals(right, iter.next());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/order/OrderByCostVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/order/OrderByCostVisitorTest.java
@@ -1,0 +1,301 @@
+package datawave.query.jexl.visitors.order;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.jexl3.parser.ASTERNode;
+import org.apache.commons.jexl3.parser.ASTGENode;
+import org.apache.commons.jexl3.parser.ASTGTNode;
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ASTLENode;
+import org.apache.commons.jexl3.parser.ASTLTNode;
+import org.apache.commons.jexl3.parser.ASTNENode;
+import org.apache.commons.jexl3.parser.ASTNRNode;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.Test;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
+import datawave.query.jexl.visitors.TreeEqualityVisitor;
+
+public class OrderByCostVisitorTest {
+
+    private Map<String,Long> fieldCounts;
+    private Map<String,Long> termCounts;
+
+    @Test
+    public void testSimpleQuery() throws ParseException {
+        String query = "A == '1'";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, query);
+        testTermOrdering(query, query);
+    }
+
+    @Test
+    public void testUnionOfEqs_noChange() throws ParseException {
+        String query = "A == '1' || B == '2'";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "B == '2' || A == '1'");
+        testTermOrdering(query, "B == '2' || A == '1'");
+    }
+
+    @Test
+    public void testIntersectionOfEqs_noChange() throws ParseException {
+        String query = "A == '1' && B == '2'";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "B == '2' && A == '1'");
+        testTermOrdering(query, "B == '2' && A == '1'");
+    }
+
+    @Test
+    public void testNegativeCase() throws ParseException {
+        String query = "A == '1' && B != '2'";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, query);
+        testTermOrdering(query, query);
+
+        query = "B != '2' && A == '1'";
+        String expected = "A == '1' && B != '2'";
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, expected);
+        testTermOrdering(query, expected);
+    }
+
+    @Test
+    public void testAvoidFunctions() throws ParseException {
+        String query = "A == '1' && content:phrase((B || C), termOffsetMap, 'quick', 'brown', 'fox')";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, query);
+        testTermOrdering(query, query);
+    }
+
+    @Test
+    public void testNegatedFunctionFirst() throws ParseException {
+        // even though we do not descend into function nodes (yet), a negated union of functions should get pushed to the right
+        String query = "!(content:phrase(A, termOffsetMap, '1', '2') || content:phrase(B, termOffsetMap, '3', '4')) && C == '1'";
+        String expected = "C == '1' && !(content:phrase(A, termOffsetMap, '1', '2') || content:phrase(B, termOffsetMap, '3', '4'))";
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, expected);
+        testTermOrdering(query, expected);
+    }
+
+    @Test
+    public void testOrderingOfUnionSubtrees() throws ParseException {
+        // For unions with ordered subtrees, assert that the order of the unions changes
+        String query = "(A =~ '1' && B =~ '2') || (C == '3' && D == '4')";
+        String expected = "(C == '3' && D == '4') || (A =~ '1' && B =~ '2')";
+        // Regex node causes first union to move
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, "(D == '4' && C == '3') || (B =~ '2' && A =~ '1')");
+        testTermOrdering(query, "(D == '4' && C == '3') || (A =~ '1' && B =~ '2')");
+
+        // Now assert that given ordered unions, order of subtrees changes
+        query = "(A =~ '1' && B == '2') || (content:phrase(C, termOffsetMap, 'star', 'fox') && D == '4')";
+        expected = "(B == '2' && A =~ '1') || (D == '4' && content:phrase(C, termOffsetMap, 'star', 'fox'))";
+        // Regex in left intersection causes move, content function in right intersection causes move
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, "(D == '4' && content:phrase(C, termOffsetMap, 'star', 'fox')) || (B == '2' && A =~ '1')");
+        testTermOrdering(query, "(D == '4' && content:phrase(C, termOffsetMap, 'star', 'fox')) || (B == '2' && A =~ '1')");
+
+        // Assert that both order of unions and subtrees changes
+        query = "(A !~ '1' && B =~ '2') || (content:phrase(C, termOffsetMap, 'star', 'fox') && D == '4')";
+        expected = "(D == '4' && content:phrase(C, termOffsetMap, 'star', 'fox')) || (B =~ '2' && A !~ '1')";
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, expected);
+        testTermOrdering(query, expected);
+    }
+
+    @Test
+    public void testOrderingOfIntersectionSubtrees() throws ParseException {
+        // For intersections with ordered subtrees, assert that the order of the intersections changes
+        String query = "(A =~ '1' || B =~ '2') && (C == '3' || D == '4')";
+        String expected = "(C == '3' || D == '4') && (A =~ '1' || B =~ '2')";
+        // Regexes in left subtree causes move
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, "(D == '4' || C == '3') && (B =~ '2' || A =~ '1')"); // field counts in reverse order
+        testTermOrdering(query, "(D == '4' || C == '3') && (A =~ '1' || B =~ '2')");
+
+        // Now assert that given ordered intersections, order of subtrees changes
+        query = "(A != '1' || B == '2') && (C != '3' || D == '4')";
+        expected = "(B == '2' || A != '1') && (D == '4' || C != '3')";
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, "(D == '4' || C != '3') && (B == '2' || A != '1')");
+        testTermOrdering(query, "(D == '4' || C != '3') && (B == '2' || A != '1')");
+
+        // Assert that both order of intersections and subtrees changes
+        query = "(A !~ '1' || B =~ '2') && (C != '3' || D == '4')";
+        expected = "(D == '4' || C != '3') && (B =~ '2' || A !~ '1')";
+        // EQ before NE, ER before NR
+        testDefaultOrdering(query, expected);
+        testFieldOrdering(query, expected);
+        testTermOrdering(query, expected);
+    }
+
+    @Test
+    public void testOrderingOfNestedJunctions() throws ParseException {
+        // certain unions should sort before others given the sum of the field or term counts
+        String query = "(A == '1' || B == '2' || C == '3') && (A == '1' || B == '2' || D == '4') && (A == '1' || B == '2' || E == '5')";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "(E == '5' || B == '2' || A == '1') && (D == '4' || B == '2' || A == '1') && (C == '3' || B == '2' || A == '1')");
+        testTermOrdering(query, "(E == '5' || B == '2' || A == '1') && (D == '4' || B == '2' || A == '1') && (C == '3' || B == '2' || A == '1')");
+
+        // certain intersections should sort before others given the lowest field or term count
+        query = "(A == '1' && B == '2' && C == '3') || (A == '1' && B == '2' && D == '4') || (A == '1' && B == '2' && E == '5')";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "(E == '5' && B == '2' && A == '1') || (D == '4' && B == '2' && A == '1') || (C == '3' && B == '2' && A == '1')");
+        testTermOrdering(query, "(E == '5' && B == '2' && A == '1') || (D == '4' && B == '2' && A == '1') || (C == '3' && B == '2' && A == '1')");
+    }
+
+    @Test
+    public void testMarkerNodeSorts() throws ParseException {
+        // value
+        String query = "A == '1' && B == '2' && ((_Value_ = true) && (A =~ 'ba.*'))";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "B == '2' && A == '1' && ((_Value_ = true) && (A =~ 'ba.*'))");
+        testTermOrdering(query, "B == '2' && A == '1' && ((_Value_ = true) && (A =~ 'ba.*'))");
+
+        // list
+
+        // term
+        query = "A == '1' && B == '2' && ((_Term_ = true) && (_ANYFIELD_ =~ 'ba.*'))";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "B == '2' && A == '1' && ((_Term_ = true) && (_ANYFIELD_ =~ 'ba.*'))");
+        testTermOrdering(query, "B == '2' && A == '1' && ((_Term_ = true) && (_ANYFIELD_ =~ 'ba.*'))");
+
+        // bounded
+        query = "A == '1' && B == '2' && ((_Bounded_ = true) && (A > '1' && A < '3'))";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "B == '2' && A == '1' && ((_Bounded_ = true) && (A > '1' && A < '3'))");
+        testTermOrdering(query, "B == '2' && A == '1' && ((_Bounded_ = true) && (A > '1' && A < '3'))");
+
+        // evaluation
+        query = "A == '1' && B == '2' && ((_Eval_ = true) && (A == '1'))";
+        testDefaultOrdering(query, query);
+        testFieldOrdering(query, "B == '2' && A == '1' && ((_Eval_ = true) && (A == '1'))");
+        testTermOrdering(query, "B == '2' && A == '1' && ((_Eval_ = true) && (A == '1'))");
+    }
+
+    // Given a set of nodes added to a query in random order, assert proper order every time
+    @Test
+    public void randomOrderTest() throws ParseException {
+        List<JexlNode> nodes = new ArrayList<>();
+        nodes.add(JexlNodeFactory.buildEQNode("A", "1"));
+        nodes.add(JexlNodeFactory.buildNode((ASTNENode) null, "B", "2"));
+        nodes.add(JexlNodeFactory.buildNode((ASTERNode) null, "C", "3.*"));
+        nodes.add(JexlNodeFactory.buildNode((ASTNRNode) null, "D", "4.*"));
+        nodes.add(JexlNodeFactory.buildNode((ASTGENode) null, "E", "5"));
+        nodes.add(JexlNodeFactory.buildNode((ASTLENode) null, "F", "6"));
+        nodes.add(JexlNodeFactory.buildNode((ASTGTNode) null, "G", "7"));
+        nodes.add(JexlNodeFactory.buildNode((ASTLTNode) null, "H", "8"));
+        nodes.add(JexlNodeFactory.buildFunctionNode("content", "phrase", "Q", "termOffsetMap", "Bond", "James", "Bond"));
+
+        String expectedOr = "A == '1' || H < '8' || G > '7' || F <= '6' || E >= '5' || C =~ '3.*' || content:phrase(Q, 'termOffsetMap', 'Bond', 'James', 'Bond') || B != '2' || D !~ '4.*'";
+        String expectedAnd = "A == '1' && H < '8' && G > '7' && F <= '6' && E >= '5' && C =~ '3.*' && content:phrase(Q, 'termOffsetMap', 'Bond', 'James', 'Bond') && B != '2' && D !~ '4.*'";
+
+        String query;
+        int numPerturbs = 100;
+        for (int i = 0; i < numPerturbs; i++) {
+            query = buildRandomQuery(nodes, " || ");
+            testDefaultOrdering(query, expectedOr);
+            testFieldOrdering(query,
+                            "H < '8' || G > '7' || F <= '6' || E >= '5' || C =~ '3.*' || A == '1' || content:phrase(Q, 'termOffsetMap', 'Bond', 'James', 'Bond') || B != '2' || D !~ '4.*'");
+            testTermOrdering(query, expectedOr);
+
+            query = buildRandomQuery(nodes, " && ");
+            testDefaultOrdering(query, expectedAnd);
+            testFieldOrdering(query,
+                            "H < '8' && G > '7' && F <= '6' && E >= '5' && C =~ '3.*' && A == '1' && content:phrase(Q, 'termOffsetMap', 'Bond', 'James', 'Bond') && B != '2' && D !~ '4.*'");
+            testTermOrdering(query, expectedAnd);
+        }
+    }
+
+    private String buildRandomQuery(List<JexlNode> nodes, String joiner) {
+        Collections.shuffle(nodes);
+        StringBuilder sb = new StringBuilder();
+        Iterator<JexlNode> nodeIter = nodes.iterator();
+        while (nodeIter.hasNext()) {
+            sb.append(JexlStringBuildingVisitor.buildQueryWithoutParse(nodeIter.next()));
+            if (nodeIter.hasNext()) {
+                sb.append(joiner);
+            }
+        }
+        return sb.toString();
+    }
+
+    private void testDefaultOrdering(String query, String expected) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        ASTJexlScript ordered = OrderByCostVisitor.order(script);
+        // built queries should be functionally equivalent (no lost nodes)
+        assertTrue(TreeEqualityVisitor.isEqual(script, ordered));
+        // ordered query string should match expected query string
+        String orderedString = JexlStringBuildingVisitor.buildQueryWithoutParse(ordered);
+        assertEquals(expected, orderedString);
+    }
+
+    private void testFieldOrdering(String query, String expected) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        ASTJexlScript ordered = OrderByCostVisitor.orderByFieldCount(script, getFieldCounts());
+        // built queries should be functionally equivalent (no lost nodes)
+        assertTrue(TreeEqualityVisitor.isEqual(script, ordered));
+        // ordered query string should match expected query string
+        String orderedString = JexlStringBuildingVisitor.buildQueryWithoutParse(ordered);
+        assertEquals(expected, orderedString);
+    }
+
+    private void testTermOrdering(String query, String expected) throws ParseException {
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
+        ASTJexlScript ordered = OrderByCostVisitor.orderByTermCount(script, getTermCounts());
+        // built queries should be functionally equivalent (no lost nodes)
+        assertTrue(TreeEqualityVisitor.isEqual(script, ordered));
+        // ordered query string should match expected query string
+        String orderedString = JexlStringBuildingVisitor.buildQueryWithoutParse(ordered);
+        assertEquals(expected, orderedString);
+    }
+
+    private Map<String,Long> getFieldCounts() {
+        if (fieldCounts == null) {
+            fieldCounts = getFieldCountMap();
+        }
+        return fieldCounts;
+    }
+
+    private Map<String,Long> getFieldCountMap() {
+        Map<String,Long> counts = new HashMap<>();
+        counts.put("A", 9L);
+        counts.put("B", 8L);
+        counts.put("C", 7L);
+        counts.put("D", 6L);
+        counts.put("E", 5L);
+        counts.put("F", 4L); // same counts for E and F
+        counts.put("G", 3L);
+        counts.put("H", 2L);
+        return counts;
+    }
+
+    private Map<String,Long> getTermCounts() {
+        if (termCounts == null) {
+            termCounts = getTermCountMap();
+        }
+        return termCounts;
+    }
+
+    private Map<String,Long> getTermCountMap() {
+        Map<String,Long> counts = new HashMap<>();
+        counts.put("A == '1'", 9L);
+        counts.put("B == '2'", 8L);
+        counts.put("C == '3'", 7L);
+        counts.put("D == '4'", 6L);
+        counts.put("E == '5'", 5L);
+        counts.put("F == '6'", 5L); // same counts for E and F
+        return counts;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicTest.java
@@ -27,7 +27,6 @@ import datawave.webservice.common.remote.RemoteHttpService;
 import datawave.webservice.common.remote.RemoteQueryService;
 import datawave.webservice.query.QueryImpl;
 import datawave.webservice.query.configuration.GenericQueryConfiguration;
-import datawave.webservice.query.remote.RemoteQueryServiceImpl;
 import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.DefaultField;
 import datawave.webservice.query.result.event.EventBase;

--- a/warehouse/query-core/src/test/java/datawave/query/util/count/CountMapSerDeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/count/CountMapSerDeTest.java
@@ -1,0 +1,45 @@
+package datawave.query.util.count;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link CountMapSerDe}
+ */
+class CountMapSerDeTest {
+    private final CountMapSerDe serDe = new CountMapSerDe();
+
+    @Test
+    void testSerDeBytes() {
+        CountMap map = new CountMap();
+        map.put("FIELD_A", 12L);
+        map.put("FIELD_B", 23L);
+
+        byte[] data = serDe.serialize(map);
+        CountMap deserialized = serDe.deserialize(data);
+
+        assertMap(map, deserialized);
+    }
+
+    @Test
+    void testSerDeString() {
+        CountMap map = new CountMap();
+        map.put("FIELD_A", 12L);
+        map.put("FIELD_B", 23L);
+
+        String s = serDe.serializeToString(map);
+        CountMap deserialized = serDe.deserializeFromString(s);
+
+        assertMap(map, deserialized);
+    }
+
+    private void assertMap(CountMap expected, CountMap map) {
+        assertEquals(expected.keySet(), map.keySet());
+        for (String key : expected.keySet()) {
+            assertEquals(expected.get(key), map.get(key));
+        }
+        assertEquals(expected, map);
+    }
+
+}

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -262,6 +262,8 @@
         <!--   should the range stream also generate field and term counts    -->
         <property name="useFieldCounts" value="true" />
         <property name="useTermCounts" value="true" />
+        <property name="sortQueryBeforeGlobalIndex" value="true" />
+        <property name="sortQueryByCounts" value="true" />
     </bean>
 
     <bean id="TLDEventQuery" scope="prototype" parent="BaseEventQuery" class="datawave.query.tables.TLDQueryLogic">


### PR DESCRIPTION
Provide several options for ordering a query, building on the work done in https://github.com/NationalSecurityAgency/datawave/pull/2219.

Ordering can be based on
- node type
- field cardinality
- term cardinality