### PR TITLE
IngestTypePruningVisitor correctly handles null literals

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypePruningVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypePruningVisitor.java
@@ -374,6 +374,13 @@ public class IngestTypePruningVisitor extends BaseVisitor {
      * @return a set of ingestTypes
      */
     public Set<String> getIngestTypesForLeaf(JexlNode node) {
+        node = JexlASTHelper.dereference(node);
+        if (node instanceof ASTEQNode) {
+            Object literal = JexlASTHelper.getLiteralValue(node);
+            if (literal == null) {
+                return Collections.singleton(UNKNOWN_TYPE);
+            }
+        }
         return ingestTypeVisitor.getIngestTypes(node);
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypeVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypeVisitor.java
@@ -53,7 +53,7 @@ public class IngestTypeVisitor extends BaseVisitor {
 
     private static final Logger log = Logger.getLogger(IngestTypeVisitor.class);
 
-    private static final String UNKNOWN_TYPE = "UNKNOWN_TYPE";
+    protected static final String UNKNOWN_TYPE = "UNKNOWN_TYPE";
     // cache expensive calls to get ingest types per field
     private final TypeMetadata typeMetadata;
     private final Map<String,Set<String>> ingestTypeCache;
@@ -260,6 +260,14 @@ public class IngestTypeVisitor extends BaseVisitor {
      * @return a set of ingestTypes
      */
     public Set<String> getIngestTypesForLeaf(JexlNode node) {
+        node = JexlASTHelper.dereference(node);
+        if (node instanceof ASTEQNode) {
+            Object literal = JexlASTHelper.getLiteralValue(node);
+            if (literal == null) {
+                return Collections.singleton(UNKNOWN_TYPE);
+            }
+        }
+
         Set<String> ingestTypes = new HashSet<>();
         Set<String> fields = getFieldsForLeaf(node);
         for (String field : fields) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IngestTypeVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IngestTypeVisitorTest.java
@@ -143,6 +143,12 @@ class IngestTypeVisitorTest {
         assertSingleNode("D == '4' || E == '5'", Collections.emptySet());
     }
 
+    @Test
+    void testEqNull() {
+        assertSingleNode("A == null", Collections.emptySet());
+        assertSingleNode("!(A == null)", Collections.emptySet());
+    }
+
     private void assertSingleNode(String query, Set<String> expectedIngestTypes) {
         assertSingleNode(query, expectedIngestTypes, typeMetadata);
     }


### PR DESCRIPTION
The IngestTypePruningVisitor did not handle the following cases
- `FIELD == null`
- `!(FIELD == null)`