### PR TITLE
Improvements to SSDeepSimilarityDiscoveryQuery

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepDiscoveryQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepDiscoveryQueryLogic.java
@@ -7,15 +7,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.iterators.TransformIterator;
 
 import datawave.audit.SelectorExtractor;
 import datawave.marking.MarkingFunctions;
-import datawave.query.discovery.DiscoveredThing;
 import datawave.query.discovery.DiscoveryLogic;
 import datawave.query.discovery.DiscoveryTransformer;
 import datawave.query.model.QueryModel;
@@ -76,14 +75,21 @@ public class SSDeepDiscoveryQueryLogic extends BaseQueryLogic<DiscoveredSSDeep> 
                 ResponseObjectFactory responseObjectFactory = discoveryDelegate.getResponseObjectFactory();
                 ScoredSSDeepPair scoredSSDeepPair = discoveredSSDeep.getScoredSSDeepPair();
                 if (scoredSSDeepPair != null) {
-                    List<FieldBase<?>> fields = eventBase.getFields();
-                    Optional<FieldBase<?>> valueFieldOptional = fields.stream().filter(field -> "VALUE".equals(field.getName())).findFirst();
+                    List<FieldBase<?>> originalFields = eventBase.getFields();
+                    Optional<FieldBase<?>> valueFieldOptional = originalFields.stream().filter(field -> "VALUE".equals(field.getName())).findFirst();
 
                     if (valueFieldOptional.isEmpty()) {
                         throw new IllegalStateException("Could not find value field in event");
                     }
 
                     FieldBase<?> valueField = valueFieldOptional.get();
+
+                    // Handles the case where the DiscoveryQuery returns a down-cased ssdeep. To do this, we remove the
+                    // original VALUE field from the discovery result and create a new one from the scoredSSDeepPair
+                    // which was returned from the original similarity query. This also updates the list stored in the
+                    // event with the filtered version.
+                    final List<FieldBase<?>> newFields = originalFields.stream().filter(field -> !"VALUE".equals(field.getName())).collect(Collectors.toList());
+                    eventBase.setFields(newFields);
 
                     {
                         FieldBase<?> field = responseObjectFactory.getField();
@@ -92,7 +98,18 @@ public class SSDeepDiscoveryQueryLogic extends BaseQueryLogic<DiscoveredSSDeep> 
                         field.setColumnVisibility(valueField.getColumnVisibility());
                         field.setTimestamp(valueField.getTimestamp());
                         field.setValue(scoredSSDeepPair.getQueryHash().toString());
-                        fields.add(field);
+                        newFields.add(field);
+                    }
+
+                    {
+                        // add a new value field that preserves the case of the original matched ssdeep.
+                        FieldBase<?> field = responseObjectFactory.getField();
+                        field.setName("VALUE");
+                        field.setMarkings(valueField.getMarkings());
+                        field.setColumnVisibility(valueField.getColumnVisibility());
+                        field.setTimestamp(valueField.getTimestamp());
+                        field.setValue(scoredSSDeepPair.getMatchingHash().toString());
+                        newFields.add(field);
                     }
 
                     {
@@ -102,11 +119,29 @@ public class SSDeepDiscoveryQueryLogic extends BaseQueryLogic<DiscoveredSSDeep> 
                         field.setColumnVisibility(valueField.getColumnVisibility());
                         field.setTimestamp(valueField.getTimestamp());
                         field.setValue(scoredSSDeepPair.getWeightedScore());
-                        fields.add(field);
+                        newFields.add(field);
                     }
 
-                }
+                    {
+                        FieldBase<?> field = responseObjectFactory.getField();
+                        field.setName("OVERLAP_SCORE");
+                        field.setMarkings(valueField.getMarkings());
+                        field.setColumnVisibility(valueField.getColumnVisibility());
+                        field.setTimestamp(valueField.getTimestamp());
+                        field.setValue(scoredSSDeepPair.getOverlapScore());
+                        newFields.add(field);
+                    }
 
+                    {
+                        FieldBase field = responseObjectFactory.getField();
+                        field.setName("OVERLAP_SSDEEP_NGRAMS");
+                        field.setMarkings(valueField.getMarkings());
+                        field.setColumnVisibility(valueField.getColumnVisibility());
+                        field.setTimestamp(valueField.getTimestamp());
+                        field.setValue(scoredSSDeepPair.getOverlapsAsString());
+                        newFields.add(field);
+                    }
+                }
                 return eventBase;
             }
         };

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -2,6 +2,7 @@ package datawave.query.tables.ssdeep;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -56,9 +57,9 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
     /** We'll toss out any matches that have scores less than this value. If set to 0 or less we'll keep all hashes */
     private final int minScoreThreshold;
 
-    private final SSDeepHashScorer editDistanceScorer;
+    private final SSDeepHashScorer<Integer> editDistanceScorer;
 
-    private final SSDeepHashScorer ngramOverlapScorer;
+    private final SSDeepHashScorer<Set<NGramTuple>> ngramOverlapScorer;
 
     public SSDeepScoringFunction(SSDeepSimilarityQueryConfiguration config) {
         this.queryMap = config.getQueryMap();
@@ -141,10 +142,10 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
         // score the match between each query ssdeep and matching hash, keep those that exceed the match
         // threshold.
         return queryHashes.stream().flatMap(queryHash -> {
-            int overlapScore = ngramOverlapScorer.apply(queryHash, matchingHash);
+            Set<NGramTuple> overlappingNGrams = ngramOverlapScorer.apply(queryHash, matchingHash);
             int weightedScore = editDistanceScorer.apply(queryHash, matchingHash);
             if (minScoreThreshold <= 0 || weightedScore > minScoreThreshold) {
-                return Stream.of(new ScoredSSDeepPair(queryHash, matchingHash, overlapScore, weightedScore));
+                return Stream.of(new ScoredSSDeepPair(queryHash, matchingHash, overlappingNGrams, weightedScore));
             } else {
                 return Stream.empty();
             }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTransformer.java
@@ -54,15 +54,22 @@ public class SSDeepSimilarityQueryTransformer extends BaseQueryLogicTransformer<
 
         {
             FieldBase field = responseObjectFactory.getField();
-            field.setName("MATCH_SCORE");
+            field.setName("WEIGHTED_SCORE");
+            field.setValue(String.valueOf(pair.getWeightedScore()));
+            fields.add(field);
+        }
+
+        {
+            FieldBase field = responseObjectFactory.getField();
+            field.setName("OVERLAP_SCORE");
             field.setValue(String.valueOf(pair.getOverlapScore()));
             fields.add(field);
         }
 
         {
             FieldBase field = responseObjectFactory.getField();
-            field.setName("WEIGHTED_SCORE");
-            field.setValue(String.valueOf(pair.getWeightedScore()));
+            field.setName("OVERLAP_SSDEEP_NGRAMS");
+            field.setValue(pair.getOverlapsAsString());
             fields.add(field);
         }
 

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/ScoredSSDeepPair.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/ScoredSSDeepPair.java
@@ -1,11 +1,15 @@
 package datawave.query.tables.ssdeep;
 
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
+import datawave.util.ssdeep.NGramTuple;
 import datawave.util.ssdeep.SSDeepHash;
 
 /**
- * Captures a scored pair of query hash and matching hash.
+ * Captures a scored pair of query hash and matching hash and a record of which ngrams appear in each.
  */
 public class ScoredSSDeepPair implements Comparable<ScoredSSDeepPair> {
 
@@ -14,13 +18,13 @@ public class ScoredSSDeepPair implements Comparable<ScoredSSDeepPair> {
     private final SSDeepHash queryHash;
     private final SSDeepHash matchingHash;
 
-    int overlapScore;
+    Set<NGramTuple> overlappingNgrams;
     int weightedScore;
 
-    public ScoredSSDeepPair(SSDeepHash queryHash, SSDeepHash matchingHash, int overlapScore, int weightedScore) {
+    public ScoredSSDeepPair(SSDeepHash queryHash, SSDeepHash matchingHash, Set<NGramTuple> overlappingNgrams, int weightedScore) {
         this.queryHash = queryHash;
         this.matchingHash = matchingHash;
-        this.overlapScore = overlapScore;
+        this.overlappingNgrams = overlappingNgrams;
         this.weightedScore = weightedScore;
     }
 
@@ -37,7 +41,16 @@ public class ScoredSSDeepPair implements Comparable<ScoredSSDeepPair> {
     }
 
     public int getOverlapScore() {
-        return overlapScore;
+        return overlappingNgrams.size();
+    }
+
+    public Set<NGramTuple> getOverlappingNgrams() {
+        return overlappingNgrams;
+    }
+
+    /** Return a String representing the sorted list of ngrams that are shared by both the query and the matching ssdeep */
+    public String getOverlapsAsString() {
+        return String.join(", ", getOverlappingNgrams().stream().map(NGramTuple::toString).collect(Collectors.toCollection(TreeSet::new)));
     }
 
     @Override
@@ -49,7 +62,7 @@ public class ScoredSSDeepPair implements Comparable<ScoredSSDeepPair> {
 
         ScoredSSDeepPair that = (ScoredSSDeepPair) o;
 
-        if (overlapScore != that.overlapScore)
+        if (!Objects.equals(overlappingNgrams, that.overlappingNgrams))
             return false;
         if (weightedScore != that.weightedScore)
             return false;
@@ -60,7 +73,7 @@ public class ScoredSSDeepPair implements Comparable<ScoredSSDeepPair> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(queryHash, matchingHash, weightedScore, overlapScore);
+        return Objects.hash(queryHash, matchingHash, weightedScore, overlappingNgrams);
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIndexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIndexQueryTest.java
@@ -1,5 +1,9 @@
 package datawave.query.tables.ssdeep;
 
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_2_OVERLAPS;
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_3_OVERLAPS;
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_4_OVERLAPS;
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.TEST_SSDEEPS;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
@@ -36,6 +40,7 @@ import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.ingest.mapreduce.handler.ssdeep.SSDeepIndexHandler;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.querymetric.QueryMetricFactoryImpl;
+import datawave.query.tables.ssdeep.util.SSDeepTestUtil;
 import datawave.query.testframework.AbstractDataTypeConfig;
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.security.authorization.DatawaveUser;
@@ -54,14 +59,6 @@ import datawave.webservice.result.EventQueryResponseBase;
 
 /** Simple unit test against the SSDeepIndex / SSDeepSimilarityLogic code */
 public class SSDeepIndexQueryTest {
-
-    public static String[] TEST_SSDEEPS = {"12288:002r/VG4GjeZHkwuPikQ7lKH5p5H9x1beZHkwulizQ1lK55pGxlXTd8zbW:002LVG4GjeZEXi37l6Br1beZEdic1lmu",
-            "6144:02C3nq73v1kHGhs6y7ppFj93NRW6/ftZTgC6e8o4toHZmk6ZxoXb0ns:02C4cGCLjj9Swfj9koHEk6/Fns",
-            "3072:02irbxzGAFYDMxud7fKg3dXVmbOn5u46Kjnz/G8VYrs123D6pIJLIOSP:02MKlWQ7Sg3d4bO968rm7JO",
-            "3072:03jscyaGAFYDMxud7fKg3dXVmbOn5u46Kjnz/G8VYrs123D6pIJLIOSP:03NLmXR7Sg3d4bO968rm7JO",
-            "3072:03jscyaZZZZZYYYYXXXWWdXVmbOn5u46KjnzWWWXXXXYYYYYYZZZZZZZ:03NLmXR7ZZZYYXW9WXYYZZZ",
-            "48:1aBhsiUw69/UXX0x0qzNkVkydf2klA8a7Z35:155w69MXAlNkmkWTF5", "196608:wEEE+EEEEE0LEEEEEEEEEEREEEEhEEETEEEEEWUEEEJEEEEcEEEEEEEE3EEEEEEN:",
-            "1536:0YgNvw/OmgPgiQeI+25Nh6+RS5Qa8LmbyfAiIRgizy1cBx76UKYbD+iD/RYgNvw6:", "12288:222222222222222222222222222222222:"};
 
     private static final Logger log = Logger.getLogger(SSDeepIndexQueryTest.class);
 
@@ -154,13 +151,13 @@ public class SSDeepIndexQueryTest {
     }
 
     @Test
-    /** Test that a single query ssdeep with no match score threshold returns the expected results */
+    /* Test that a single query ssdeep with no match score threshold returns the expected results */
     public void testSingleQueryNoMinScore() throws Exception {
         runSingleQuery(false);
     }
 
     @Test
-    /** Test that a single query ssdeep with a min score threshold returns the expected results */
+    /* Test that a single query ssdeep with a min score threshold returns the expected results */
     public void testSingleQueryMinScore() throws Exception {
         runSingleQuery(true);
     }
@@ -190,15 +187,15 @@ public class SSDeepIndexQueryTest {
         Assert.assertEquals(expectedEventCount, eventCount);
 
         // find the fields for the self match example.
-        assertMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[2], "65", "1", "100", observedEvents);
+        SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[2], "65", EXPECTED_2_2_OVERLAPS, "100", observedEvents);
 
         // find and validate the fields for the partial match example.
-        assertMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[3], "51", "2", "96", observedEvents);
+        SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[3], "51", EXPECTED_2_3_OVERLAPS, "96", observedEvents);
 
         if (applyMinScoreThreshold)
             assertNoMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[3], observedEvents);
         else
-            assertMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[4], "9", "3", "63", observedEvents);
+            SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[4], "9", EXPECTED_2_4_OVERLAPS, "63", observedEvents);
     }
 
     public EventQueryResponseBase runSSDeepQuery(String query, int minScoreThreshold) throws Exception {
@@ -248,34 +245,6 @@ public class SSDeepIndexQueryTest {
             }
         }
         return observedEvents;
-    }
-
-    /**
-     * assert that a match exists between the specified query and matching ssdeep and that the match has the expected properties
-     *
-     * @param querySsdeep
-     *            the query ssdeep we expect to find in the match results
-     * @param matchingSsdeep
-     *            the matching ssdeep we expect to find in the match results.
-     * @param matchScore
-     *            the base match score
-     * @param matchRank
-     *            the match rank
-     * @param weightedScore
-     *            the weighted match score.
-     * @param observedEvents
-     *            the map of observed events, created by extractObservedEvents on the event list obtained from query execution.
-     */
-    public static void assertMatch(String querySsdeep, String matchingSsdeep, String matchScore, String matchRank, String weightedScore,
-                    Map<String,Map<String,String>> observedEvents) {
-        final Map<String,String> observedFields = observedEvents.get(querySsdeep + "#" + matchingSsdeep);
-        Assert.assertNotNull("Observed fields was null", observedFields);
-        Assert.assertFalse("Observed fields was unexpectedly empty", observedFields.isEmpty());
-        Assert.assertEquals(matchScore, observedFields.remove("MATCH_SCORE"));
-        Assert.assertEquals(weightedScore, observedFields.remove("WEIGHTED_SCORE"));
-        Assert.assertEquals(querySsdeep, observedFields.remove("QUERY_SSDEEP"));
-        Assert.assertEquals(matchingSsdeep, observedFields.remove("MATCHING_SSDEEP"));
-        Assert.assertTrue("Observed unexpected field(s) in full match: " + observedFields, observedFields.isEmpty());
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
@@ -143,13 +143,14 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
         @SuppressWarnings("SpellCheckingInspection")
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
         String query = "CHECKSUM_SSDEEP:" + testSSDeep;
+        String expectedOverlaps = "384:+u5QT4Z, 384:/fP9FmW, 384:2aTgSO+, 384:4ZE1PIV, 384:5QT4ZE1, 384:9FmWVMd, 384:Fj2aTgS, 384:FmWVMdR, 384:MdRFj2a, 384:O+u5QT4, 384:P9FmWVM, 384:QT4ZE1P, 384:RFj2aTg, 384:SO+u5QT, 384:T4ZE1PI, 384:TgSO+u5, 384:VMdRFj2, 384:WVMdRFj, 384:aTgSO+u, 384:dRFj2aT, 384:fP9FmWV, 384:gSO+u5Q, 384:j2aTgSO, 384:mWVMdRF, 384:nv/fP9F, 384:u5QT4ZE, 384:v/fP9Fm, 768:DmWOdRF, 768:FNTTs50, 768:NTTs504, 768:OdRFNTT, 768:RFNTTs5, 768:TTs504c, 768:Ts504cQ, 768:WOdRFNT, 768:dRFNTTs, 768:mWOdRFN, 768:nDmWOdR";
         EventQueryResponseBase response = runSSDeepQuery(query, similarityQueryLogic, 0);
 
         List<EventBase> events = response.getEvents();
         Assert.assertEquals(1, events.size());
         Map<String,Map<String,String>> observedEvents = extractObservedEvents(events);
 
-        SSDeepTestUtil.assertSSDeepSimilarityMatch(testSSDeep, testSSDeep, "38", "100", observedEvents);
+        SSDeepTestUtil.assertSSDeepSimilarityMatch(testSSDeep, testSSDeep, "38", expectedOverlaps, "100", observedEvents);
     }
 
     @Test
@@ -165,15 +166,17 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
         Map.Entry<String,Map<String,String>> result = observedEvents.entrySet().iterator().next();
         Map<String,String> resultFields = result.getValue();
-        Assert.assertEquals(testSSDeep, resultFields.get("VALUE"));
-        Assert.assertEquals("CHECKSUM_SSDEEP", resultFields.get("FIELD"));
-        Assert.assertEquals("20201031", resultFields.get("DATE"));
-        Assert.assertEquals("ssdeep", resultFields.get("DATA TYPE"));
-        Assert.assertEquals("4", resultFields.get("RECORD COUNT"));
+        Assert.assertEquals(testSSDeep, resultFields.remove("VALUE"));
+        Assert.assertEquals("CHECKSUM_SSDEEP", resultFields.remove("FIELD"));
+        Assert.assertEquals("20201031", resultFields.remove("DATE"));
+        Assert.assertEquals("ssdeep", resultFields.remove("DATA TYPE"));
+        Assert.assertEquals("4", resultFields.remove("RECORD COUNT"));
 
         // At this point, the results have not been enriched with these fields, so they should not exist.
-        Assert.assertNull(null, resultFields.get("QUERY"));
-        Assert.assertNull(null, resultFields.get("WEIGHTED_SCORE"));
+        Assert.assertNull(null, resultFields.remove("QUERY"));
+        Assert.assertNull(null, resultFields.remove("WEIGHTED_SCORE"));
+
+        Assert.assertTrue("Results had unexpected fields: " + resultFields, resultFields.isEmpty());
     }
 
     @Test
@@ -182,6 +185,8 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504---";
         String targetSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
         String query = "CHECKSUM_SSDEEP:" + testSSDeep;
+        String expectedOverlaps = "384:+u5QT4Z, 384:/fP9FmW, 384:2aTgSO+, 384:4ZE1PIV, 384:5QT4ZE1, 384:9FmWVMd, 384:Fj2aTgS, 384:FmWVMdR, 384:MdRFj2a, 384:O+u5QT4, 384:P9FmWVM, 384:QT4ZE1P, 384:RFj2aTg, 384:SO+u5QT, 384:T4ZE1PI, 384:TgSO+u5, 384:VMdRFj2, 384:WVMdRFj, 384:aTgSO+u, 384:dRFj2aT, 384:fP9FmWV, 384:gSO+u5Q, 384:j2aTgSO, 384:mWVMdRF, 384:nv/fP9F, 384:u5QT4ZE, 384:v/fP9Fm, 768:DmWOdRF, 768:FNTTs50, 768:NTTs504, 768:OdRFNTT, 768:RFNTTs5, 768:WOdRFNT, 768:dRFNTTs, 768:mWOdRFN, 768:nDmWOdR";
+
         EventQueryResponseBase response = runSSDeepQuery(query, similarityDiscoveryQueryLogic, 0);
 
         List<EventBase> events = response.getEvents();
@@ -190,16 +195,21 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
         Map.Entry<String,Map<String,String>> result = observedEvents.entrySet().iterator().next();
         Map<String,String> resultFields = result.getValue();
-        Assert.assertEquals(targetSSDeep, resultFields.get("VALUE"));
+        Assert.assertEquals(targetSSDeep, resultFields.remove("VALUE"));
 
-        Assert.assertEquals("CHECKSUM_SSDEEP", resultFields.get("FIELD"));
-        Assert.assertEquals("20201031", resultFields.get("DATE"));
-        Assert.assertEquals("ssdeep", resultFields.get("DATA TYPE"));
-        Assert.assertEquals("4", resultFields.get("RECORD COUNT"));
+        Assert.assertEquals("CHECKSUM_SSDEEP", resultFields.remove("FIELD"));
+        Assert.assertEquals("20201031", resultFields.remove("DATE"));
+        Assert.assertEquals("ssdeep", resultFields.remove("DATA TYPE"));
+        Assert.assertEquals("4", resultFields.remove("RECORD COUNT"));
 
         // The results have been enriched with these fields at this point.
-        Assert.assertEquals(testSSDeep, resultFields.get("QUERY"));
-        Assert.assertEquals("100", resultFields.get("WEIGHTED_SCORE"));
+        Assert.assertEquals(testSSDeep, resultFields.remove("QUERY"));
+        Assert.assertEquals("100", resultFields.remove("WEIGHTED_SCORE"));
+        Assert.assertEquals("36", resultFields.remove("OVERLAP_SCORE"));
+        Assert.assertEquals(expectedOverlaps, resultFields.remove("OVERLAP_SSDEEP_NGRAMS"));
+
+        Assert.assertTrue("Results had unexpected fields: " + resultFields, resultFields.isEmpty());
+
     }
 
     @SuppressWarnings("rawtypes")

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
@@ -3,6 +3,9 @@ package datawave.query.tables.ssdeep;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.BUCKET_COUNT;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.BUCKET_ENCODING_BASE;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.BUCKET_ENCODING_LENGTH;
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_2_OVERLAPS;
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_3_OVERLAPS;
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_4_OVERLAPS;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.TEST_SSDEEPS;
 
 import java.util.Collections;
@@ -129,15 +132,15 @@ public class SSDeepSimilarityQueryTest {
         Assert.assertEquals(expectedEventCount, eventCount);
 
         // find the fields for the self match example.
-        SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[2], "65", "100", observedEvents);
+        SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[2], "65", EXPECTED_2_2_OVERLAPS, "100", observedEvents);
 
         // find and validate the fields for the partial match example.
-        SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[3], "51", "96", observedEvents);
+        SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[3], "51", EXPECTED_2_3_OVERLAPS, "96", observedEvents);
 
         if (applyMinScoreThreshold)
             SSDeepTestUtil.assertNoMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[3], observedEvents);
         else
-            SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[4], "9", "63", observedEvents);
+            SSDeepTestUtil.assertSSDeepSimilarityMatch(TEST_SSDEEPS[2], TEST_SSDEEPS[4], "9", EXPECTED_2_4_OVERLAPS, "63", observedEvents);
     }
 
     @SuppressWarnings("rawtypes")

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTransformerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTransformerTest.java
@@ -1,5 +1,6 @@
 package datawave.query.tables.ssdeep;
 
+import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_3_OVERLAPS;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.TEST_SSDEEPS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,7 +22,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import datawave.marking.MarkingFunctions;
 import datawave.query.config.SSDeepSimilarityQueryConfiguration;
+import datawave.util.ssdeep.NGramGenerator;
+import datawave.util.ssdeep.NGramTuple;
 import datawave.util.ssdeep.SSDeepHash;
+import datawave.util.ssdeep.SSDeepHashEditDistanceScorer;
+import datawave.util.ssdeep.SSDeepHashScorer;
+import datawave.util.ssdeep.SSDeepNGramOverlapScorer;
 import datawave.webservice.query.Query;
 import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.DefaultField;
@@ -52,20 +58,27 @@ public class SSDeepSimilarityQueryTransformerTest {
         EasyMock.expect(mockQuery.getQueryAuthorizations()).andReturn("A,B,C");
         EasyMock.expect(mockResponseFactory.getEventQueryResponse()).andAnswer(DefaultEventQueryResponse::new);
         EasyMock.expect(mockResponseFactory.getEvent()).andAnswer(DefaultEvent::new).times(1);
-        EasyMock.expect(mockResponseFactory.getField()).andAnswer(DefaultField::new).times(4);
+        EasyMock.expect(mockResponseFactory.getField()).andAnswer(DefaultField::new).times(5);
 
         expectedFields.add("MATCHING_SSDEEP");
         expectedFields.add("QUERY_SSDEEP");
-        expectedFields.add("MATCH_SCORE");
         expectedFields.add("WEIGHTED_SCORE");
+        expectedFields.add("OVERLAP_SCORE");
+        expectedFields.add("OVERLAP_SSDEEP_NGRAMS");
     }
 
     @Test
     public void transformTest() {
 
+        final SSDeepHashScorer<Set<NGramTuple>> ngramOverlapScorer = new SSDeepNGramOverlapScorer(NGramGenerator.DEFAULT_NGRAM_SIZE,
+                        SSDeepHash.DEFAULT_MAX_REPEATED_CHARACTERS, NGramGenerator.DEFAULT_MIN_HASH_SIZE);
+        final SSDeepHashScorer<Integer> editDistanceScorer = new SSDeepHashEditDistanceScorer(SSDeepHash.DEFAULT_MAX_REPEATED_CHARACTERS);
+
         final SSDeepHash query = SSDeepHash.parse(TEST_SSDEEPS[2]);
         final SSDeepHash match = SSDeepHash.parse(TEST_SSDEEPS[3]);
-        final ScoredSSDeepPair scoredSSDeepPair = new ScoredSSDeepPair(query, match, 51, 96);
+        final Set<NGramTuple> overlappingNGrams = ngramOverlapScorer.apply(query, match);
+        final Integer editDistance = editDistanceScorer.apply(query, match);
+        final ScoredSSDeepPair scoredSSDeepPair = new ScoredSSDeepPair(query, match, overlappingNGrams, editDistance);
 
         basicExpects();
 
@@ -91,7 +104,6 @@ public class SSDeepSimilarityQueryTransformerTest {
         DefaultEvent defaultEvent = (DefaultEvent) eventBase;
 
         List<DefaultField> fields = defaultEvent.getFields();
-        assertEquals(4, fields.size());
         for (DefaultField field : fields) {
             assertTrue("Unexpected field: " + field.getName(), expectedFields.remove(field.getName()));
             switch (field.getName()) {
@@ -101,17 +113,21 @@ public class SSDeepSimilarityQueryTransformerTest {
                 case "QUERY_SSDEEP":
                     assertEquals(TEST_SSDEEPS[2], field.getValueString());
                     break;
-                case "MATCH_SCORE":
-                    assertEquals("51", field.getValueString());
-                    break;
                 case "WEIGHTED_SCORE":
                     assertEquals("96", field.getValueString());
+                    break;
+                case "OVERLAP_SCORE":
+                    assertEquals("51", field.getValueString());
+                    break;
+                case "OVERLAP_SSDEEP_NGRAMS":
+                    assertEquals(EXPECTED_2_3_OVERLAPS, field.getValueString());
                     break;
                 default:
                     fail("Unexpected field: " + field.getName());
             }
 
         }
+        assertEquals(5, fields.size());
         assertTrue("Did not observe all expected fields: " + expectedFields, expectedFields.isEmpty());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/util/SSDeepTestUtil.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/util/SSDeepTestUtil.java
@@ -45,6 +45,10 @@ public class SSDeepTestUtil {
     public static final int BUCKET_ENCODING_BASE = BucketAccumuloKeyGenerator.DEFAULT_BUCKET_ENCODING_BASE;
     public static final int BUCKET_ENCODING_LENGTH = BucketAccumuloKeyGenerator.DEFAULT_BUCKET_ENCODING_LENGTH;
 
+    public static final String EXPECTED_2_2_OVERLAPS = "3072:/G8VYrs, 3072:02irbxz, 3072:123D6pI, 3072:23D6pIJ, 3072:2irbxzG, 3072:3D6pIJL, 3072:3dXVmbO, 3072:46Kjnz/, 3072:5u46Kjn, 3072:6Kjnz/G, 3072:6pIJLIO, 3072:7fKg3dX, 3072:8VYrs12, 3072:AFYDMxu, 3072:D6pIJLI, 3072:DMxud7f, 3072:FYDMxud, 3072:G8VYrs1, 3072:GAFYDMx, 3072:Kg3dXVm, 3072:Kjnz/G8, 3072:Mxud7fK, 3072:On5u46K, 3072:VYrs123, 3072:VmbOn5u, 3072:XVmbOn5, 3072:YDMxud7, 3072:Yrs123D, 3072:bOn5u46, 3072:bxzGAFY, 3072:d7fKg3d, 3072:dXVmbOn, 3072:fKg3dXV, 3072:g3dXVmb, 3072:irbxzGA, 3072:jnz/G8V, 3072:mbOn5u4, 3072:n5u46Kj, 3072:nz/G8VY, 3072:pIJLIOS, 3072:rbxzGAF, 3072:rs123D6, 3072:s123D6p, 3072:u46Kjnz, 3072:ud7fKg3, 3072:xud7fKg, 3072:xzGAFYD, 3072:z/G8VYr, 3072:zGAFYDM, 6144:02MKlWQ, 6144:2MKlWQ7, 6144:3d4bO96, 6144:4bO968r, 6144:7Sg3d4b, 6144:968rm7J, 6144:KlWQ7Sg, 6144:MKlWQ7S, 6144:O968rm7, 6144:Q7Sg3d4, 6144:Sg3d4bO, 6144:WQ7Sg3d, 6144:bO968rm, 6144:d4bO968, 6144:g3d4bO9, 6144:lWQ7Sg3";
+    public static final String EXPECTED_2_3_OVERLAPS = "3072:/G8VYrs, 3072:123D6pI, 3072:23D6pIJ, 3072:3D6pIJL, 3072:3dXVmbO, 3072:46Kjnz/, 3072:5u46Kjn, 3072:6Kjnz/G, 3072:6pIJLIO, 3072:7fKg3dX, 3072:8VYrs12, 3072:AFYDMxu, 3072:D6pIJLI, 3072:DMxud7f, 3072:FYDMxud, 3072:G8VYrs1, 3072:GAFYDMx, 3072:Kg3dXVm, 3072:Kjnz/G8, 3072:Mxud7fK, 3072:On5u46K, 3072:VYrs123, 3072:VmbOn5u, 3072:XVmbOn5, 3072:YDMxud7, 3072:Yrs123D, 3072:bOn5u46, 3072:d7fKg3d, 3072:dXVmbOn, 3072:fKg3dXV, 3072:g3dXVmb, 3072:jnz/G8V, 3072:mbOn5u4, 3072:n5u46Kj, 3072:nz/G8VY, 3072:pIJLIOS, 3072:rs123D6, 3072:s123D6p, 3072:u46Kjnz, 3072:ud7fKg3, 3072:xud7fKg, 3072:z/G8VYr, 6144:3d4bO96, 6144:4bO968r, 6144:7Sg3d4b, 6144:968rm7J, 6144:O968rm7, 6144:Sg3d4bO, 6144:bO968rm, 6144:d4bO968, 6144:g3d4bO9";
+    public static final String EXPECTED_2_4_OVERLAPS = "3072:5u46Kjn, 3072:On5u46K, 3072:VmbOn5u, 3072:XVmbOn5, 3072:bOn5u46, 3072:dXVmbOn, 3072:mbOn5u4, 3072:n5u46Kj, 3072:u46Kjnz";
+
     public static void loadSSDeepIndexTextData(AccumuloClient accumuloClient) throws Exception {
         // configuration
         String ssdeepTableName = SSDeepIndexHandler.DEFAULT_SSDEEP_INDEX_TABLE_NAME;
@@ -92,19 +96,21 @@ public class SSDeepTestUtil {
      *            the query ssdeep we expect to find in the match results
      * @param matchingSsdeep
      *            the matching ssdeep we expect to find in the match results.
-     * @param matchScore
-     *            the base match score
+     * @param overlapScore
+     *            the base match score that counts the number of overlapping ngrams found between the two hashes.
      * @param weightedScore
-     *            the weighted match score.
+     *            the weighted match score which is a normalized edit distance that ranges from 0-100
      * @param observedEvents
      *            the map of observed events, created by extractObservedEvents on the event list obtained from query execution.
      */
-    public static void assertSSDeepSimilarityMatch(String querySsdeep, String matchingSsdeep, String matchScore, String weightedScore,
-                    Map<String,Map<String,String>> observedEvents) {
+    public static void assertSSDeepSimilarityMatch(String querySsdeep, String matchingSsdeep, String overlapScore, String overlapSsdeepNgrams,
+                    String weightedScore, Map<String,Map<String,String>> observedEvents) {
         final Map<String,String> observedFields = observedEvents.get(querySsdeep + "#" + matchingSsdeep);
         Assert.assertNotNull("Observed fields was null", observedFields);
         Assert.assertFalse("Observed fields was unexpectedly empty", observedFields.isEmpty());
-        Assert.assertEquals(matchScore, observedFields.remove("MATCH_SCORE"));
+        Assert.assertEquals(overlapScore, observedFields.remove("OVERLAP_SCORE"));
+        Assert.assertEquals(overlapSsdeepNgrams, observedFields.remove("OVERLAP_SSDEEP_NGRAMS"));
+
         Assert.assertEquals(weightedScore, observedFields.remove("WEIGHTED_SCORE"));
         Assert.assertEquals(querySsdeep, observedFields.remove("QUERY_SSDEEP"));
         Assert.assertEquals(matchingSsdeep, observedFields.remove("MATCHING_SSDEEP"));

--- a/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashEditDistanceScorer.java
+++ b/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashEditDistanceScorer.java
@@ -5,7 +5,7 @@ import org.apache.log4j.Logger;
 
 /**
  * Implements functions to calculate a similarity score for a pair of SSDeepHashes. This implementation will calculate an edit distance between two hashes and
- * the create a normalized score between 0-100, with 100 being a great match and 0 being a horrible match. This is designed to give relatively equal footing to
+ * then create a normalized score between 0-100, with 100 being a great match and 0 being a horrible match. This is designed to give relatively equal footing to
  * hash comparisons that have different lenghts.
  */
 public class SSDeepHashEditDistanceScorer implements SSDeepHashScorer<Integer> {

--- a/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashEditDistanceScorer.java
+++ b/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashEditDistanceScorer.java
@@ -3,8 +3,12 @@ package datawave.util.ssdeep;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.apache.log4j.Logger;
 
-/** Implements functions to calculate a similarity score for a pair of SSDeepHashes */
-public class SSDeepHashEditDistanceScorer implements SSDeepHashScorer {
+/**
+ * Implements functions to calculate a similarity score for a pair of SSDeepHashes. This implementation will calculate an edit distance between two hashes and
+ * the create a normalized score between 0-100, with 100 being a great match and 0 being a horrible match. This is designed to give relatively equal footing to
+ * hash comparisons that have different lenghts.
+ */
+public class SSDeepHashEditDistanceScorer implements SSDeepHashScorer<Integer> {
     private static final Logger log = Logger.getLogger(SSDeepHash.class);
 
     private final int maxRepeatedCharacters;
@@ -27,7 +31,7 @@ public class SSDeepHashEditDistanceScorer implements SSDeepHashScorer {
      *            the second object to be compared.
      * @return an integer between 0 and 100
      */
-    public int apply(SSDeepHash signature1, SSDeepHash signature2) {
+    public Integer apply(SSDeepHash signature1, SSDeepHash signature2) {
         if ((null == signature1) || (null == signature2)) {
             return -1;
         }

--- a/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashScorer.java
+++ b/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashScorer.java
@@ -1,5 +1,10 @@
 package datawave.util.ssdeep;
 
-public interface SSDeepHashScorer {
-    public int apply(SSDeepHash signature1, SSDeepHash signature2);
+/**
+ * An interface for things that take two hashes and compare the to produce some sort of result.
+ *
+ * @param <T>
+ */
+public interface SSDeepHashScorer<T> {
+    public T apply(SSDeepHash signature1, SSDeepHash signature2);
 }

--- a/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashScorer.java
+++ b/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepHashScorer.java
@@ -1,7 +1,7 @@
 package datawave.util.ssdeep;
 
 /**
- * An interface for things that take two hashes and compare the to produce some sort of result.
+ * An interface for things that take two hashes and compare them to produce some sort of result.
  *
  * @param <T>
  */

--- a/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepNGramOverlapScorer.java
+++ b/warehouse/ssdeep-common/src/main/java/datawave/util/ssdeep/SSDeepNGramOverlapScorer.java
@@ -2,7 +2,11 @@ package datawave.util.ssdeep;
 
 import java.util.Set;
 
-public class SSDeepNGramOverlapScorer implements SSDeepHashScorer {
+/**
+ * Implements scoring between a pair of hashes based on the number of ngrams they have in common. Returns a unique set of the overlapping ngrams as a result,
+ * the overlap score is calculated based on the size of this set.
+ */
+public class SSDeepNGramOverlapScorer implements SSDeepHashScorer<Set<NGramTuple>> {
 
     NGramGenerator generator;
 
@@ -10,11 +14,11 @@ public class SSDeepNGramOverlapScorer implements SSDeepHashScorer {
         generator = new NGramGenerator(ngramSize, maxRepeatedChars, minHashSize);
     }
 
-    public int apply(SSDeepHash signature1, SSDeepHash signature2) {
+    public Set<NGramTuple> apply(SSDeepHash signature1, SSDeepHash signature2) {
         Set<NGramTuple> ngrams1 = generator.generateNgrams(signature1);
         Set<NGramTuple> ngrams2 = generator.generateNgrams(signature2);
 
         ngrams1.retainAll(ngrams2);
-        return ngrams1.size();
+        return ngrams1;
     }
 }

--- a/warehouse/ssdeep-common/src/test/java/datawave/util/ssdeep/SSDeepHashEditDistanceScorerTest.java
+++ b/warehouse/ssdeep-common/src/test/java/datawave/util/ssdeep/SSDeepHashEditDistanceScorerTest.java
@@ -29,7 +29,7 @@ public class SSDeepHashEditDistanceScorerTest {
 
     @Test
     public void testCompare() {
-        SSDeepHashScorer scorer = new SSDeepHashEditDistanceScorer();
+        SSDeepHashScorer<Integer> scorer = new SSDeepHashEditDistanceScorer(SSDeepHash.DEFAULT_MAX_REPEATED_CHARACTERS);
         for (int i = 0; i < testData.length; i++) {
             SSDeepHash queryHash = SSDeepHash.parse(testData[i][0]);
             SSDeepHash targetHash = SSDeepHash.parse(testData[i][1]);

--- a/warehouse/ssdeep-common/src/test/java/datawave/util/ssdeep/SSDeepNGramOverlapScorerTest.java
+++ b/warehouse/ssdeep-common/src/test/java/datawave/util/ssdeep/SSDeepNGramOverlapScorerTest.java
@@ -1,5 +1,7 @@
 package datawave.util.ssdeep;
 
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,11 +30,12 @@ public class SSDeepNGramOverlapScorerTest {
 
     @Test
     public void testCompare() {
-        SSDeepHashScorer scorer = new SSDeepNGramOverlapScorer(7, 3, 6);
+        SSDeepHashScorer<Set<NGramTuple>> scorer = new SSDeepNGramOverlapScorer(7, 3, 6);
         for (int i = 0; i < testData.length; i++) {
             SSDeepHash queryHash = SSDeepHash.parse(testData[i][0]);
             SSDeepHash targetHash = SSDeepHash.parse(testData[i][1]);
-            int score = scorer.apply(queryHash, targetHash);
+            Set<NGramTuple> overlappingTuples = scorer.apply(queryHash, targetHash);
+            int score = overlappingTuples.size();
             Assert.assertEquals("Expected score of " + expectedScores[i] + " for query: " + queryHash + ", target: " + targetHash, expectedScores[i], score);
         }
     }


### PR DESCRIPTION
* When scoring a match based on ngram overlaps, collect the actual matching ngrams - not just the score.
* Use the matching ssdeep from the SSDeepSimilarityQuery in the SSDeepSimilarityDiscoveryQuery results, instead of the ssdeep returned from the Discovery query, because the field in the index may have been downcased, whereas the similarity query results retain the original case.
* Rename MATCH_SCORE to OVERLAP_SCORE to be clearer about what the score represents.
* Added return the list of overlapping ssdeep NGrams from the SSDeepSimilarityQueryLogic in the OVERLAP_SSDEEP_NGRAMS field.
* Added unit tests for overlapping ngrams