### PR TITLE
improve ShardIdpartitioner, add CachingShardIdPartitioner

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
@@ -252,6 +252,7 @@ public class IngestJob implements Tool {
 
     @Override
     public int run(String[] args) throws Exception {
+        long setupStart = System.currentTimeMillis();
 
         Logger.getLogger(TypeRegistry.class).setLevel(Level.ALL);
 
@@ -324,7 +325,6 @@ public class IngestJob implements Tool {
         conf = job.getConfiguration();
 
         setupHandlers(conf);
-
         if (!useMapOnly || !outputMutations) {
             // Calculate the sampled splits, splits file, and set up the partitioner, but not if only doing only a map phase and outputting mutations
             // if not outputting mutations and only doing a map phase, we still need to go through this logic as the MultiRFileOutputFormatter
@@ -368,6 +368,8 @@ public class IngestJob implements Tool {
 
         startDaemonProcesses(conf);
         long start = System.currentTimeMillis();
+        log.info("JOB SETUP TIME: " + (start - setupStart));
+
         job.submit();
         JobID jobID = job.getJobID();
         log.info("JOB ID: " + jobID);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/partition/CachingShardIdPartitioner.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/partition/CachingShardIdPartitioner.java
@@ -1,0 +1,36 @@
+package datawave.ingest.mapreduce.partition;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.log4j.Logger;
+
+import datawave.ingest.mapreduce.job.BulkIngestKey;
+
+/**
+ * The CachingShardIdPartitioner will generate partitions using ShardIdPartitioner's algorithm and cache the result
+ */
+public class CachingShardIdPartitioner extends ShardIdPartitioner implements Configurable, DelegatePartitioner {
+    private static final Logger log = Logger.getLogger(CachingShardIdPartitioner.class);
+    private Map<String,Integer> shardPartitions = new HashMap<>();
+
+    @Override
+    public synchronized int getPartition(BulkIngestKey key, Value value, int numReduceTasks) {
+        String shardId = key.getKey().getRow().toString();
+
+        try {
+            if (null != shardPartitions.get(shardId)) {
+                return shardPartitions.get(shardId);
+            }
+            long shardIndex = generateNumberForShardId(shardId, getBaseTime());
+            int partition = (int) (shardIndex % numReduceTasks);
+            shardPartitions.put(shardId, partition);
+            return partition;
+
+        } catch (Exception e) {
+            return (shardId.hashCode() & Integer.MAX_VALUE) % numReduceTasks;
+        }
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/ShardIdPartitionerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/ShardIdPartitionerTest.java
@@ -79,4 +79,47 @@ public class ShardIdPartitionerTest {
         }
     }
 
+    @Test
+    public void testCachingShardIdScheme() throws ParseException {
+        partitioner = new CachingShardIdPartitioner();
+        partitioner.setConf(conf);
+
+        Map<String,Path> shardedTableMapFiles = new HashMap<>();
+        shardedTableMapFiles.put("shard", new Path("/path/that/is/fake/to/make/the/test/pass"));
+
+        // now generate keys and ensure we have even distribution of the partitions
+        int shardCount = 0;
+        int[] partitions = new int[58];
+        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
+        Date date = format.parse("20100101");
+        Calendar c = Calendar.getInstance();
+        c.setTime(date);
+        for (int dateCnt = 0; dateCnt < 348; dateCnt++) {
+            for (int shard = 0; shard < 31; shard++) {
+                shardCount++;
+                StringBuilder shardId = new StringBuilder();
+                shardId.append(format.format(c.getTime()));
+                shardId.append('_').append(shard);
+                Key key = new Key(shardId.toString());
+                Value value = new Value();
+                int partition = partitioner.getPartition(new BulkIngestKey(new Text("shard"), key), value, 58);
+                partitions[partition]++;
+            }
+            c.add(Calendar.DATE, 1);
+        }
+        int expected = shardCount / 58;
+        boolean errored = false;
+        for (int i = 0; i < 58; i++) {
+            try {
+                Assert.assertEquals("Unexpected distribution for partition " + i + ": ", expected, partitions[i]);
+            } catch (Throwable e) {
+                System.err.println(e.getMessage());
+                errored = true;
+            }
+        }
+        if (errored) {
+            Assert.fail("Failed to get expected distribution.  See console for unexpected entries");
+        }
+    }
+
 }


### PR DESCRIPTION
- changed substring to StringUtils.split in ShardIdPartitioner -> 6% performance improvement
- added CachingShardIdPartitioner -> 20 - 93% improvement depending on number of shards and data distribution