### PR TITLE
Allow table cache to be bypassed by ModelBean (#2359)

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/ModelBean.test
+++ b/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/ModelBean.test
@@ -1,0 +1,102 @@
+modelName=Model1
+modelFile=${DW_DATAWAVE_SOURCE_DIR}/web-services/model/src/test/resources/ModelBeanTest_m1.xml
+
+################################################################
+# Test /Model/import endpoint
+#
+
+setCurlData @${modelFile}
+
+configureTest \
+        ImportQueryModel200 \
+        "Imports an example query model named '${modelName}'" \
+        "--header 'Content-Type: application/xml;charset=UTF-8' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Model/import" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest
+
+################################################################
+# Test GET /Model/admin/{name} endpoint (200 b/c cache bypassed)
+#
+
+configureTest \
+        AdminGetQueryModel200 \
+        "Retrieve the imported query model" \
+        "-X GET ${URI_ROOT}/Model/admin/${modelName}" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest
+
+################################################################
+# Retry /Model/import on the same file
+#
+
+setCurlData @${modelFile}
+
+configureTest \
+        ImportQueryModelAgain412 \
+        "Try to import the same query model, expecting 412 response b/c model exists" \
+        "--header 'Content-Type: application/xml;charset=UTF-8' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Model/import" \
+        "application/xml;charset=UTF-8" \
+        412
+
+runTest
+
+################################################################
+# Retry import on the same file, but this time using -X PUT
+# '/Model/import/{modelName}' to enable update/replace 
+#
+
+setCurlData @${modelFile}
+
+configureTest \
+        ImportQueryModelAgainWithPUT200 \
+        "Try to import the same query model, expecting 200 response b/c '/Model/import/{modelName}' was used" \
+        "--header 'Content-Type: application/xml;charset=UTF-8' ${DW_CURL_DATA} -X PUT ${URI_ROOT}/Model/import/${modelName}" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest
+
+################################################################
+# Attempt '/Model/import/WrongModelName' and get 412 error 
+#
+
+setCurlData @${modelFile}
+
+configureTest \
+        ImportQueryModelAgainWithPUT412 \
+        "Try to update/replace but pass incorrect model name, expecting 412" \
+        "--header 'Content-Type: application/xml;charset=UTF-8' ${DW_CURL_DATA} -X PUT ${URI_ROOT}/Model/import/WrongModelName" \
+        "application/xml;charset=UTF-8" \
+        412
+
+runTest
+
+################################################################
+# Test DELETE /Model/{name} endpoint
+#
+
+configureTest \
+        DeleteQueryModel200 \
+        "Delete the imported query model" \
+        "-X DELETE ${URI_ROOT}/Model/${modelName}" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest
+
+################################################################
+# Try to GET the deleted model with admin endpoint: 404 b/c cache is bypassed
+#
+
+configureTest \
+        GetDeletedQueryModelAndFail404 \
+        "Try and fail to retrieve the deleted query model, as appropriate" \
+        "-X GET ${URI_ROOT}/Model/admin/${modelName}" \
+        "application/xml;charset=UTF-8" \
+        404
+
+# This last test is executed by run.sh, as usual

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <version.maven-install-plugin>2.5.2</version.maven-install-plugin>
         <version.metrics-cdi>1.6.0</version.metrics-cdi>
         <version.microservice.accumulo-api>3.0.0</version.microservice.accumulo-api>
-        <version.microservice.accumulo-utils>3.0.2</version.microservice.accumulo-utils>
+        <version.microservice.accumulo-utils>3.0.3</version.microservice.accumulo-utils>
         <version.microservice.audit-api>3.0.0</version.microservice.audit-api>
         <version.microservice.authorization-api>3.0.0</version.microservice.authorization-api>
         <version.microservice.base-rest-responses>3.0.0</version.microservice.base-rest-responses>

--- a/web-services/model/src/test/java/datawave/webservice/query/model/ModelBeanTest.java
+++ b/web-services/model/src/test/java/datawave/webservice/query/model/ModelBeanTest.java
@@ -139,7 +139,7 @@ public class ModelBeanTest {
         EasyMock.expect(ctx.getCallerPrincipal()).andReturn(principal);
         PowerMock.replayAll();
 
-        bean.importModel(MODEL_ONE, (String) null);
+        bean.importModel(MODEL_ONE, (String) null, (String) null, false);
         PowerMock.verifyAll();
     }
 
@@ -160,7 +160,7 @@ public class ModelBeanTest {
         EasyMock.expect(cache.reloadCache(ModelBean.DEFAULT_MODEL_TABLE_NAME)).andReturn(null);
         PowerMock.replayAll();
 
-        bean.importModel(MODEL_ONE, (String) null);
+        bean.importModel(MODEL_ONE, (String) null, (String) null, false);
         PowerMock.verifyAll();
         PowerMock.resetAll();
 
@@ -178,7 +178,7 @@ public class ModelBeanTest {
         EasyMock.expect(cache.reloadCache(ModelBean.DEFAULT_MODEL_TABLE_NAME)).andReturn(null);
         PowerMock.replayAll();
 
-        bean.importModel(MODEL_TWO, (String) null);
+        bean.importModel(MODEL_TWO, (String) null, (String) null, false);
 
         PowerMock.verifyAll();
     }
@@ -247,7 +247,7 @@ public class ModelBeanTest {
         EasyMock.expect(System.currentTimeMillis()).andReturn(TIMESTAMP);
         PowerMock.replayAll();
 
-        bean.deleteModel(MODEL_TWO.getName(), (String) null);
+        bean.deleteModel(MODEL_TWO.getName(), (String) null, false);
         PowerMock.verifyAll();
         PowerMock.resetAll();
 
@@ -318,7 +318,7 @@ public class ModelBeanTest {
         EasyMock.expect(System.currentTimeMillis()).andReturn(TIMESTAMP);
         PowerMock.replayAll();
 
-        bean.cloneModel(MODEL_ONE.getName(), "MODEL2", (String) null);
+        bean.cloneModel(MODEL_ONE.getName(), "MODEL2", (String) null, false);
         PowerMock.verifyAll();
         PowerMock.resetAll();
         EasyMock.expect(ctx.getCallerPrincipal()).andReturn(principal);


### PR DESCRIPTION
Depends on https://github.com/NationalSecurityAgency/datawave-accumulo-utils/pull/14

The goal here is to allow certain ModelBean operations to be performed in a more timely manner. E.g., in order to replace a given query model, the current implementation requires that a user first perform a model DELETE operation and then wait for an asynchronous cache refresh, so that the subsequent model import can succeed. If the cache isn't fully refreshed, the import fails with an error, because the deleted model is still resident in the stale cache. That process can be drastically streamlined by simply allowing the table cache to be bypassed by an "admin" user

This PR also fixes a bug in the `listModelNames` method that misidentifies row: `edge_key` colf: `version` as a query model