### PR TITLE
Fix remote service redirects so that they will work in docker-compose/consul or in kubernetes

### DIFF
--- a/properties/default.properties
+++ b/properties/default.properties
@@ -106,9 +106,11 @@ auditing.remoteauditservice.port=8443
 # The scheme to use when connecting to the remote dictionary service
 dictionary.remoteservice.scheme=https
 # The host to connect to (or do a SRV lookup on) for the remote dictionary service
-dictionary.remoteservice.host=dictionary
+dictionary.remoteservice.host=localhost
 # The port to connect to (unless a SRV lookup was performed) for the remote dictionary service
-dictionary.remoteservice.port=8443
+dictionary.remoteservice.port=8843
+# Use the configured scheme/host/port for redirect calls (instead of those from the request)
+dictionary.remoteservice.useConfiguredURIForRedirect=true
 
 ############################
 #
@@ -147,6 +149,8 @@ querymetric.remoteservice.host=localhost
 querymetric.remoteservice.port=9043
 # Is the remote service enabled
 querymetric.remoteservice.enabled=false
+# Use the configured scheme/host/port for redirect calls (instead of those from the request)
+querymetric.remoteservice.useConfiguredURIForRedirect=true
 
 ############################
 #

--- a/warehouse/data-dictionary-core/src/main/java/datawave/webservice/datadictionary/RemoteDataDictionary.java
+++ b/warehouse/data-dictionary-core/src/main/java/datawave/webservice/datadictionary/RemoteDataDictionary.java
@@ -1,11 +1,14 @@
 package datawave.webservice.datadictionary;
 
+import java.net.URI;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.apache.deltaspike.core.api.config.ConfigProperty;
+import org.apache.http.client.utils.URIBuilder;
+import org.xbill.DNS.TextParseException;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.annotation.Metric;
@@ -49,6 +52,10 @@ public class RemoteDataDictionary extends RemoteHttpService {
     @Inject
     @ConfigProperty(name = "dw.remoteDictionary.port", defaultValue = "8843")
     private int dictServicePort;
+
+    @Inject
+    @ConfigProperty(name = "dw.remoteDictionary.useConfiguredURIForRedirect", defaultValue = "false")
+    private boolean useConfiguredURIForRedirect;
 
     @Inject
     @ConfigProperty(name = "dw.remoteDictionary.data.uri", defaultValue = "/dictionary/data/v1/")
@@ -109,6 +116,10 @@ public class RemoteDataDictionary extends RemoteHttpService {
                 entity -> dataDictReader.readValue(entity.getContent()),
                 () -> "getDataDictionary [" + modelName + ", " + modelTableName + ", " + metadataTableName + ", " + auths + "]");
         // @formatter:on
+    }
+
+    public URIBuilder buildRedirectURI(String suffix, URI baseURI) throws TextParseException {
+        return buildRedirectURI(suffix, baseURI, useConfiguredURIForRedirect);
     }
 
     @Override
@@ -175,5 +186,4 @@ public class RemoteDataDictionary extends RemoteHttpService {
     protected Counter failureCounter() {
         return failureCounter;
     }
-
 }

--- a/warehouse/edge-dictionary-core/src/main/java/datawave/webservice/edgedictionary/RemoteEdgeDictionary.java
+++ b/warehouse/edge-dictionary-core/src/main/java/datawave/webservice/edgedictionary/RemoteEdgeDictionary.java
@@ -1,11 +1,14 @@
 package datawave.webservice.edgedictionary;
 
+import java.net.URI;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.apache.deltaspike.core.api.config.ConfigProperty;
+import org.apache.http.client.utils.URIBuilder;
+import org.xbill.DNS.TextParseException;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.annotation.Metric;
@@ -50,6 +53,10 @@ public class RemoteEdgeDictionary extends RemoteHttpService {
     @Inject
     @ConfigProperty(name = "dw.remoteDictionary.port", defaultValue = "8843")
     private int dictServicePort;
+
+    @Inject
+    @ConfigProperty(name = "dw.remoteDictionary.useConfiguredURIForRedirect", defaultValue = "false")
+    private boolean useConfiguredURIForRedirect;
 
     @Inject
     @ConfigProperty(name = "dw.remoteDictionary.edge.uri", defaultValue = "/dictionary/edge/v1/")
@@ -107,6 +114,10 @@ public class RemoteEdgeDictionary extends RemoteHttpService {
                 entity -> edgeDictReader.readValue(entity.getContent()),
                 () -> "getEdgeDictionary [" + metadataTableName + ", " + settings.getQueryAuthorizations() + "]");
         // @formatter:on
+    }
+
+    public URIBuilder buildRedirectURI(String suffix, URI baseURI) throws TextParseException {
+        return buildRedirectURI(suffix, baseURI, useConfiguredURIForRedirect);
     }
 
     @Override

--- a/web-services/common/src/main/java/datawave/metrics/remote/RemoteQueryMetricService.java
+++ b/web-services/common/src/main/java/datawave/metrics/remote/RemoteQueryMetricService.java
@@ -1,5 +1,6 @@
 package datawave.metrics.remote;
 
+import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
@@ -15,7 +16,9 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.deltaspike.core.api.config.ConfigProperty;
 import org.apache.http.HttpEntity;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
+import org.xbill.DNS.TextParseException;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.annotation.Metric;
@@ -77,6 +80,10 @@ public class RemoteQueryMetricService extends RemoteHttpService {
     @Inject
     @ConfigProperty(name = "dw.remoteQueryMetricService.port", defaultValue = "8443")
     private int servicePort;
+
+    @Inject
+    @ConfigProperty(name = "dw.remoteQueryMetricService.useConfiguredURIForRedirect", defaultValue = "false")
+    private boolean useConfiguredURIForRedirect;
 
     @Inject
     @ConfigProperty(name = "dw.remoteQueryMetricService.uri", defaultValue = "/querymetric/v1/")
@@ -222,6 +229,10 @@ public class RemoteQueryMetricService extends RemoteHttpService {
                 entity -> queryMetricsSummaryResponseReader.readValue(entity.getContent()),
                 () -> suffix);
         // @formatter:on
+    }
+
+    public URIBuilder buildRedirectURI(String suffix, URI baseURI) throws TextParseException {
+        return buildRedirectURI(suffix, baseURI, useConfiguredURIForRedirect);
     }
 
     protected String getBearer() {

--- a/web-services/common/src/main/java/datawave/webservice/common/remote/RemoteHttpService.java
+++ b/web-services/common/src/main/java/datawave/webservice/common/remote/RemoteHttpService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.ConnectException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.security.Key;
@@ -256,6 +257,17 @@ public abstract class RemoteHttpService {
         if (suffix == null)
             suffix = "";
         return buildURI().setPath(serviceURI() + suffix);
+    }
+
+    public URIBuilder buildRedirectURI(String suffix, URI baseURI, boolean useConfiguredBaseURI) throws TextParseException {
+        URIBuilder builder;
+        if (useConfiguredBaseURI) {
+            builder = buildURI();
+        } else {
+            builder = new URIBuilder(baseURI);
+        }
+        builder.setPath(serviceURI() + suffix);
+        return builder;
     }
 
     protected <T> T executeGetMethod(Consumer<URIBuilder> uriCustomizer, Consumer<HttpGet> requestCustomizer, IOFunction<T> resultConverter,

--- a/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
+++ b/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
@@ -131,6 +131,7 @@ module add --name=com.mysql.driver --dependencies=javax.api,javax.transaction.ap
 /system-property=dw.remoteDictionary.scheme:add(value=${dictionary.remoteservice.scheme})
 /system-property=dw.remoteDictionary.host:add(value=${dictionary.remoteservice.host})
 /system-property=dw.remoteDictionary.port:add(value=${dictionary.remoteservice.port})
+/system-property=dw.remoteDictionary.useConfiguredURIForRedirect:add(value=${dictionary.remoteservice.useConfiguredURIForRedirect})
 
 # Accumulo microservice config
 /system-property=dw.remoteAccumuloService.useSrvDnsLookup:add(value=${accumulo.remoteservice.srv.lookup.enabled})
@@ -147,6 +148,7 @@ module add --name=com.mysql.driver --dependencies=javax.api,javax.transaction.ap
 /system-property=dw.remoteQueryMetricService.scheme:add(value=${querymetric.remoteservice.scheme})
 /system-property=dw.remoteQueryMetricService.host:add(value=${querymetric.remoteservice.host})
 /system-property=dw.remoteQueryMetricService.port:add(value=${querymetric.remoteservice.port})
+/system-property=dw.remoteQueryMetricService.useConfiguredURIForRedirect:add(value=${querymetric.remoteservice.useConfiguredURIForRedirect})
 
 # Disable SASL client authentication in zookeeper
 /system-property=zookeeper.sasl.client:add(value=false)

--- a/web-services/dictionary/src/main/java/datawave/webservice/dictionary/DataDictionaryBean.java
+++ b/web-services/dictionary/src/main/java/datawave/webservice/dictionary/DataDictionaryBean.java
@@ -50,7 +50,7 @@ public class DataDictionaryBean {
     }
 
     private Response sendRedirect(String suffix, UriInfo uriInfo) throws TextParseException, URISyntaxException {
-        URIBuilder builder = remoteDataDictionary.buildURI(suffix);
+        URIBuilder builder = remoteDataDictionary.buildRedirectURI(suffix, uriInfo.getBaseUri());
         uriInfo.getQueryParameters().forEach((pname, valueList) -> valueList.forEach(pvalue -> builder.addParameter(pname, pvalue)));
         return Response.temporaryRedirect(builder.build()).build();
     }

--- a/web-services/dictionary/src/main/java/datawave/webservice/dictionary/EdgeDictionaryBean.java
+++ b/web-services/dictionary/src/main/java/datawave/webservice/dictionary/EdgeDictionaryBean.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.deltaspike.core.api.config.ConfigProperty;
 import org.apache.http.client.utils.URIBuilder;
 import org.xbill.DNS.TextParseException;
 
@@ -42,7 +43,7 @@ public class EdgeDictionaryBean {
     @GET
     @Path("/")
     public Response getEdgeDictionary(@Context UriInfo uriInfo) throws TextParseException, URISyntaxException {
-        URIBuilder builder = remoteEdgeDictionary.buildURI("");
+        URIBuilder builder = remoteEdgeDictionary.buildRedirectURI("", uriInfo.getBaseUri());
         uriInfo.getQueryParameters().forEach((pname, valueList) -> valueList.forEach(pvalue -> builder.addParameter(pname, pvalue)));
         return Response.temporaryRedirect(builder.build()).build();
     }

--- a/web-services/query/src/main/java/datawave/webservice/query/metric/QueryMetricsBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/metric/QueryMetricsBean.java
@@ -398,10 +398,8 @@ public class QueryMetricsBean {
     }
 
     private Response sendRedirect(String suffix, UriInfo uriInfo) throws TextParseException, URISyntaxException {
-        URIBuilder builder = remoteQueryMetricService.buildURI(suffix);
-        if (uriInfo != null) {
-            uriInfo.getQueryParameters().forEach((pname, valueList) -> valueList.forEach(pvalue -> builder.addParameter(pname, pvalue)));
-        }
+        URIBuilder builder = remoteQueryMetricService.buildRedirectURI(suffix, uriInfo.getBaseUri());
+        uriInfo.getQueryParameters().forEach((pname, valueList) -> valueList.forEach(pvalue -> builder.addParameter(pname, pvalue)));
         return Response.temporaryRedirect(builder.build()).build();
     }
 }


### PR DESCRIPTION
The default is to use the request scheme/host/port and to only change the path