### PR TITLE
Replace deprecated OptionBuilder with Option.builder()

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/AccumuloCliOptions.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/AccumuloCliOptions.java
@@ -2,7 +2,7 @@ package datawave.ingest.util;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
@@ -21,11 +21,10 @@ public class AccumuloCliOptions {
 
     @SuppressWarnings("static-access")
     public AccumuloCliOptions() {
-
-        options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Accumulo username").create("u"));
-        options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Accumulo password").create("p"));
-        options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Accumulo instance name").create("i"));
-        options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Comma separated list of ZooKeeper servers").create("zk"));
+        options.addOption(Option.builder("u").argName("Username").hasArg().required().desc("Accumulo username").build());
+        options.addOption(Option.builder("p").argName("Password").hasArg().required().desc("Accumulo password").build());
+        options.addOption(Option.builder("i").argName("Instance Name").hasArg().required().desc("Accumulo instance name").build());
+        options.addOption(Option.builder("zk").argName("ZooKeeper Servers").hasArg().required().desc("Comma separated list of ZooKeeper servers").build());
     }
 
     /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
@@ -22,7 +22,7 @@ public class GenerateMultipleNumShardsCacheFile {
 
     public static final String MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE = "ns";
     public static final String CONFIG_DIRECTORY_LOCATION_OVERRIDE = "cd";
-    public static final String CONFIG_SUFFIEX_OVERRIDE = "cs";
+    public static final String CONFIG_SUFFIX_OVERRIDE = "cs";
 
     @SuppressWarnings("static-access")
     public static void main(String[] args) throws ParseException, AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException {
@@ -31,7 +31,7 @@ public class GenerateMultipleNumShardsCacheFile {
         // options.addOption(Option.builder("u").argName("Username").hasArg().required().desc("Accumulo username").build());
         options.addOption(Option.builder(CONFIG_DIRECTORY_LOCATION_OVERRIDE).argName("Config Directory Path").hasArg().required().desc("Config directory path")
                         .build());
-        options.addOption(Option.builder(CONFIG_SUFFIEX_OVERRIDE).argName("Config Suffix").hasArg().required().desc("Config file suffix").build());
+        options.addOption(Option.builder(CONFIG_SUFFIX_OVERRIDE).argName("Config Suffix").hasArg().required().desc("Config file suffix").build());
         options.addOption(Option.builder(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE).argName("Multiple NumShards Cache File Path").hasArg()
                         .desc("Multiple numShards cache file path").build());
         Configuration conf = accumuloOptions.getConf(args, true);
@@ -50,8 +50,8 @@ public class GenerateMultipleNumShardsCacheFile {
             if (cl.hasOption(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE)) {
                 conf.set(NumShards.MULTIPLE_NUMSHARDS_CACHE_PATH, cl.getOptionValue(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE));
             }
-            if (cl.hasOption(CONFIG_SUFFIEX_OVERRIDE)) {
-                configSuffix = cl.getOptionValue(CONFIG_SUFFIEX_OVERRIDE);
+            if (cl.hasOption(CONFIG_SUFFIX_OVERRIDE)) {
+                configSuffix = cl.getOptionValue(CONFIG_SUFFIX_OVERRIDE);
             } else {
                 configSuffix = "config.xml";
             }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
@@ -28,8 +28,9 @@ public class GenerateMultipleNumShardsCacheFile {
     public static void main(String[] args) throws ParseException, AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException {
         AccumuloCliOptions accumuloOptions = new AccumuloCliOptions();
         Options options = accumuloOptions.getOptions();
-        //options.addOption(Option.builder("u").argName("Username").hasArg().required().desc("Accumulo username").build());
-        options.addOption(Option.builder(CONFIG_DIRECTORY_LOCATION_OVERRIDE).argName("Config Directory Path").hasArg().required().desc("Config directory path").build());
+        // options.addOption(Option.builder("u").argName("Username").hasArg().required().desc("Accumulo username").build());
+        options.addOption(Option.builder(CONFIG_DIRECTORY_LOCATION_OVERRIDE).argName("Config Directory Path").hasArg().required().desc("Config directory path")
+                        .build());
         options.addOption(Option.builder(CONFIG_SUFFIEX_OVERRIDE).argName("Config Suffix").hasArg().required().desc("Config file suffix").build());
         options.addOption(Option.builder(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE).argName("Multiple NumShards Cache File Path").hasArg()
                         .desc("Multiple numShards cache file path").build());

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
@@ -8,6 +8,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -27,10 +28,11 @@ public class GenerateMultipleNumShardsCacheFile {
     public static void main(String[] args) throws ParseException, AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException {
         AccumuloCliOptions accumuloOptions = new AccumuloCliOptions();
         Options options = accumuloOptions.getOptions();
-        options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Config directory path").create(CONFIG_DIRECTORY_LOCATION_OVERRIDE));
-        options.addOption(OptionBuilder.isRequired(false).hasArg().withDescription("Config file suffix").create(CONFIG_SUFFIEX_OVERRIDE));
-        options.addOption(OptionBuilder.isRequired(false).hasArg().withDescription("Multiple numShards cache file path")
-                        .create(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE));
+        //options.addOption(Option.builder("u").argName("Username").hasArg().required().desc("Accumulo username").build());
+        options.addOption(Option.builder(CONFIG_DIRECTORY_LOCATION_OVERRIDE).argName("Config Directory Path").hasArg().required().desc("Config directory path").build());
+        options.addOption(Option.builder(CONFIG_SUFFIEX_OVERRIDE).argName("Config Suffix").hasArg().required().desc("Config file suffix").build());
+        options.addOption(Option.builder(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE).argName("Multiple NumShards Cache File Path").hasArg()
+                        .desc("Multiple numShards cache file path").build());
         Configuration conf = accumuloOptions.getConf(args, true);
         CommandLine cl;
         String configDirectory = null;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
@@ -28,10 +28,9 @@ public class GenerateMultipleNumShardsCacheFile {
     public static void main(String[] args) throws ParseException, AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException {
         AccumuloCliOptions accumuloOptions = new AccumuloCliOptions();
         Options options = accumuloOptions.getOptions();
-        // options.addOption(Option.builder("u").argName("Username").hasArg().required().desc("Accumulo username").build());
         options.addOption(Option.builder(CONFIG_DIRECTORY_LOCATION_OVERRIDE).argName("Config Directory Path").hasArg().required().desc("Config directory path")
                         .build());
-        options.addOption(Option.builder(CONFIG_SUFFIX_OVERRIDE).argName("Config Suffix").hasArg().required().desc("Config file suffix").build());
+        options.addOption(Option.builder(CONFIG_SUFFIX_OVERRIDE).argName("Config Suffix").hasArg().desc("Config file suffix").build());
         options.addOption(Option.builder(MULTIPLE_NUMSHARD_CACHE_FILE_LOCATION_OVERRIDE).argName("Multiple NumShards Cache File Path").hasArg()
                         .desc("Multiple numShards cache file path").build());
         Configuration conf = accumuloOptions.getConf(args, true);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateMultipleNumShardsCacheFile.java
@@ -9,7 +9,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateSplitsFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateSplitsFile.java
@@ -3,6 +3,7 @@ package datawave.ingest.util;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -22,9 +23,11 @@ public class GenerateSplitsFile {
     public static void main(String[] args) {
         AccumuloCliOptions accumuloOptions = new AccumuloCliOptions();
         Options options = accumuloOptions.getOptions();
-        options.addOption(OptionBuilder.isRequired(true).hasArg().withDescription("Config directory path").create("cd"));
-        options.addOption(OptionBuilder.isRequired(false).hasArg().withDescription("Config file suffix").create("cs"));
-        options.addOption(OptionBuilder.isRequired(false).hasArg().withDescription("Splits file path").create("sp"));
+
+        options.addOption(Option.builder("cd").argName("Config Directory Path").hasArg().required().desc("Config directory path").build());
+        options.addOption(Option.builder("cs").argName("Config Suffix").hasArg().desc("Config file suffix").build());
+        options.addOption(Option.builder("sp").argName("Splits File Path").hasArg().desc("Splits file path").build());
+
         Configuration conf = accumuloOptions.getConf(args, true);
         CommandLine cl;
         String configDirectory = null;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateSplitsFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateSplitsFile.java
@@ -4,7 +4,6 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/config/MetricsOptions.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/config/MetricsOptions.java
@@ -1,5 +1,6 @@
 package datawave.metrics.config;
 
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 
@@ -15,35 +16,20 @@ public class MetricsOptions extends Options {
     @SuppressWarnings("static-access")
     public MetricsOptions() {
         super();
-        super.addOption(OptionBuilder.withArgName("servers").hasArg().withDescription("Comma separated list of ZooKeeper servers").create("zookeepers"));
 
-        super.addOption(OptionBuilder.withArgName("user").hasArg().withDescription("Accumulo user name").create("user"));
-
-        super.addOption(OptionBuilder.withArgName("password").hasArg().withDescription("Accumulo user password").create("password"));
-
-        super.addOption(OptionBuilder.withArgName("defaultvis").hasArg().withDescription("Default visibility for certain Accumulo keys").create("defaultvis"));
-
-        super.addOption(OptionBuilder.withArgName("instance").hasArg().withDescription("Accumulo user password").create("instance"));
-
-        super.addOption(OptionBuilder.withArgName("\"ingest\"|\"loader\"").hasArg().withDescription("Type of metrics being ingested").create("type"));
-
-        super.addOption(OptionBuilder.withArgName("HDFS directory").hasArg().withDescription("Source of input files to MR job").create("input"));
-
-        super.addOption(OptionBuilder.withArgName("Path to metrics.xml").hasArg().withDescription("Path to the metrics.xml configuration file.")
-                        .create("conf"));
-
-        super.addOption(OptionBuilder.withArgName("Path to hdfs-site.xml").hasArg().withDescription("Path to the HDFS Configuration file").create("hdfsConf"));
-
-        super.addOption(OptionBuilder.withArgName("Path to webapp war file.").hasArg().withDescription("Path to the metrics web app war file.").create("war"));
-
-        super.addOption(OptionBuilder.withArgName("Start date to begin processing metrics.").hasArg()
-                        .withDescription("Start date to begin processing metrics, as yyyyMMddHHmm or yyyyMMdd.").create("start"));
-
-        super.addOption(OptionBuilder.withArgName("Stop date for processing metrics.").hasArg()
-                        .withDescription("Stop date for processing metrics, as yyyyMMddHHmm or yyyyMMdd.").create("end"));
-
-        super.addOption(OptionBuilder.withArgName("Ignore flag maker metrics for correlation").hasArg()
-                        .withDescription("Ignore flag maker metrics for correlation").create("ignoreFlagMakerMetrics"));
+        this.addOption(Option.builder("zookeepers").argName("servers").hasArg().desc("Comma separated list of ZooKeeper servers").build());
+        this.addOption(Option.builder("user").argName("user").hasArg().desc("Accumulo user name").build());
+        this.addOption(Option.builder("password").argName("password").hasArg().desc("Accumulo user password").build());
+        this.addOption(Option.builder("defaultvis").argName("defaultvis").hasArg().desc("Default visibility for certain Accumulo keys").build());
+        this.addOption(Option.builder("instance").argName("instance").hasArg().desc("Accumulo user password").build());
+        this.addOption(Option.builder("type").argName("\"ingest\"|\"loader\"").hasArg().desc("Type of metrics being ingested").build());
+        this.addOption(Option.builder("input").argName("HDFS directory").hasArg().desc("Source of input files to MR job").build());
+        this.addOption(Option.builder("conf").argName("Path to metrics.xml").hasArg().desc("Path to the metrics.xml configuration file.").build());
+        this.addOption(Option.builder("hdfsConf").argName("Path to hdfs-site.xml").hasArg().desc("Path to the HDFS Configuration file").build());
+        this.addOption(Option.builder("war").argName("Path to webapp war file.").hasArg().desc("Path to the metrics web app war file.").build());
+        this.addOption(Option.builder("start").argName("Start date to begin processing metrics.").hasArg().desc("Start date to begin processing metrics, as yyyyMMddHHmm or yyyyMMdd.").build());
+        this.addOption(Option.builder("end").argName("Stop date for processing metrics.").hasArg().desc("Stop date for processing metrics, as yyyyMMddHHmm or yyyyMMdd.").build());
+        this.addOption(Option.builder("ignoreFlagMakerMetrics").argName("Ignore flag maker metrics for correlation").hasArg().desc("Ignore flag maker metrics for correlation").build());
     }
 
 }

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/config/MetricsOptions.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/config/MetricsOptions.java
@@ -27,9 +27,12 @@ public class MetricsOptions extends Options {
         this.addOption(Option.builder("conf").argName("Path to metrics.xml").hasArg().desc("Path to the metrics.xml configuration file.").build());
         this.addOption(Option.builder("hdfsConf").argName("Path to hdfs-site.xml").hasArg().desc("Path to the HDFS Configuration file").build());
         this.addOption(Option.builder("war").argName("Path to webapp war file.").hasArg().desc("Path to the metrics web app war file.").build());
-        this.addOption(Option.builder("start").argName("Start date to begin processing metrics.").hasArg().desc("Start date to begin processing metrics, as yyyyMMddHHmm or yyyyMMdd.").build());
-        this.addOption(Option.builder("end").argName("Stop date for processing metrics.").hasArg().desc("Stop date for processing metrics, as yyyyMMddHHmm or yyyyMMdd.").build());
-        this.addOption(Option.builder("ignoreFlagMakerMetrics").argName("Ignore flag maker metrics for correlation").hasArg().desc("Ignore flag maker metrics for correlation").build());
+        this.addOption(Option.builder("start").argName("Start date to begin processing metrics.").hasArg()
+                        .desc("Start date to begin processing metrics, as yyyyMMddHHmm or yyyyMMdd.").build());
+        this.addOption(Option.builder("end").argName("Stop date for processing metrics.").hasArg()
+                        .desc("Stop date for processing metrics, as yyyyMMddHHmm or yyyyMMdd.").build());
+        this.addOption(Option.builder("ignoreFlagMakerMetrics").argName("Ignore flag maker metrics for correlation").hasArg()
+                        .desc("Ignore flag maker metrics for correlation").build());
     }
 
 }

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/config/MetricsOptions.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/config/MetricsOptions.java
@@ -1,7 +1,6 @@
 package datawave.metrics.config;
 
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 
 /**


### PR DESCRIPTION
The following classes have been updated to use Option.builder() instead of the deprecated class OptionBuilder:
1. datawave.ingest.util.AccumuloCliOptions
2. datawave.ingest.util.GenerateMultipleNumShardCacheFile
3. datawave.ingest.util.GenerateSplitFile
4. datawave.metrics.config.MetricOptions

part of #2443 