### PR TITLE
Fixed NPE in FullSSDeepDiscoveryChainStrategy when the initial query returned no results

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
@@ -41,6 +41,11 @@ public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSS
 
         String queryString = captureScoredMatchesAndBuildQuery(initialQueryResults, scoredMatches);
 
+        if (scoredMatches.isEmpty()) {
+            log.info("Did not receive scored matches from initial query, returning null latter query");
+            return null;
+        }
+
         Query q = new QueryImpl(); // TODO, need to use a factory? don't hardcode this.
         q.setQuery(queryString);
         q.setId(UUID.randomUUID());

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepRuntimeQueryException.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepRuntimeQueryException.java
@@ -1,0 +1,7 @@
+package datawave.query.tables.ssdeep;
+
+public class SSDeepRuntimeQueryException extends RuntimeException {
+    public SSDeepRuntimeQueryException(String message) {
+        super(message);
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
@@ -125,6 +125,12 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
 
         final int indexBuckets = config.getIndexBuckets();
 
+        if (queryMap.isEmpty()) {
+            String message = "Unable to generate SSDeepHash ngrams for query: " + settings.getQuery() + ", possibly due to invalid SSDeep hash(es)?";
+            log.error(message);
+            throw new SSDeepRuntimeQueryException(message);
+        }
+
         // TODO: stream?
         for (NGramTuple ct : queryMap.keys()) {
             final String sizeAndChunk = chunkSizeEncoder.encode(ct.getChunkSize()) + ct.getChunk();

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIndexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIndexQueryTest.java
@@ -162,6 +162,28 @@ public class SSDeepIndexQueryTest {
         runSingleQuery(true);
     }
 
+    @Test(expected = SSDeepRuntimeQueryException.class)
+    public void testSingleQueryWithNoValidNgrams() throws Exception {
+        String query = "CHECKSUM_SSDEEP:12288:zzzzzzzzzzzz:zzzzzz";
+
+        final int minScoreThreshold = 0;
+
+        EventQueryResponseBase response = runSSDeepQuery(query, minScoreThreshold);
+        List<EventBase> events = response.getEvents();
+        Assert.assertNull(events);
+    }
+
+    @Test
+    public void testSingleQueryWithNoResults() throws Exception {
+        String query = "CHECKSUM_SSDEEP:12288:aabbccddeeff:abcdef";
+
+        final int minScoreThreshold = 0;
+
+        EventQueryResponseBase response = runSSDeepQuery(query, minScoreThreshold);
+        List<EventBase> events = response.getEvents();
+        Assert.assertNull(events);
+    }
+
     private static void logSSDeepTestData(String tableName) throws TableNotFoundException {
         Scanner scanner = accumuloClient.createScanner(tableName, auths);
         Iterator<Map.Entry<Key,Value>> iterator = scanner.iterator();

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
@@ -156,7 +156,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
     @Test
     public void testSSDeepDiscovery() throws Exception {
-        log.info("------ testDiscovery ------");
+        log.info("------ testSSDeepDiscovery ------");
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
         String query = "CHECKSUM_SSDEEP:\"" + testSSDeep + "\"";
         EventQueryResponseBase response = runSSDeepQuery(query, discoveryQueryLogic, 0);
@@ -182,7 +182,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
     @Test
     public void testChainedSSDeepDiscovery() throws Exception {
-        log.info("------ testSSDeepDiscovery ------");
+        log.info("------ testChainedSSDeepDiscovery ------");
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504---";
         String targetSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
         String query = "CHECKSUM_SSDEEP:" + testSSDeep;
@@ -211,6 +211,24 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
         Assert.assertTrue("Results had unexpected fields: " + resultFields, resultFields.isEmpty());
 
+    }
+
+    @Test
+    public void testChainedSSDeepDiscoveryNoResults() throws Exception {
+        log.info("------ testChainedSSDeepDiscoveryNoResults ------");
+        String testSSDeep = "384:aabbccddeeff:abcdef";
+        String query = "CHECKSUM_SSDEEP:" + testSSDeep;
+
+        EventQueryResponseBase response = runSSDeepQuery(query, similarityDiscoveryQueryLogic, 0);
+    }
+
+    @Test(expected = SSDeepRuntimeQueryException.class)
+    public void testChainedSSDeepDiscoveryNoValidQuery() throws Exception {
+        log.info("------ testChainedSSDeepDiscoveryNoValidQuery ------");
+        String testSSDeep = "384:zzzzzzzzzzzz:zzzzzz";
+        String query = "CHECKSUM_SSDEEP:" + testSSDeep;
+
+        EventQueryResponseBase response = runSSDeepQuery(query, similarityDiscoveryQueryLogic, 0);
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
When running the SSDeepSimilarityDiscovery query, where we first run a query to find similar ssdeep hashes and then run a discovery query on the similar ssdeep hashes that were found - it was discovered that if the first query returns no similar ssdeep hashes, the second query will still attempt to run, but ends up throwing an NPE.

This fix will avoid attempting to run the second query when no similar ssdeep hashes are returned from the first query. The query will return zero results instead.

Added unit tests for this case. While writing these tests also discovered an issue where it is possible that a user can enter a valid ssdeep hash for which we will generate no ngrams (due repeating letters in the hash). Added a fix and tests for this pathalogical case as well.