### PR TITLE
Update query and executor services to be able to use a separate hazelcast cache for storing query status

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,10 @@ jobs:
         run: |
           BUILD="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -DskipServices -Ddeploy -Ddist -T1C -pl "-:config-service" clean install -DskipTests"
           $BUILD
+      - name: Run a script
+        run: |
+          echo "This step will fail"
+          exit 1
       - name: Run Microservice Unit Tests
         env:
           USER_NAME: ${{ secrets.USER_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,12 @@ name: Tests
 
 on:
   push:
-    paths-ignore: [ '*.md', 'CODEOWNERS', 'LICENSE' ]
+    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
     branches:
-      - 'integration'
-      - 'release/version*'
-      - 'task/GITHUB-2414'
+    - 'integration'
+    - 'release/version*'
   pull_request:
-    paths-ignore: [ '*.md', 'CODEOWNERS', 'LICENSE' ]
+    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
   workflow_dispatch:
 
 env:
@@ -23,56 +22,56 @@ jobs:
   check-code-formatting:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK ${{env.JAVA_VERSION}}
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{env.JAVA_DISTRIBUTION}}
-          java-version: ${{env.JAVA_VERSION}}
-          maven-version: 3.9.5
-          cache: 'maven'
-      - name: Format code
-        env:
-          USER_NAME: ${{ secrets.USER_NAME }}
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: |
-          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat
-          git status
-          git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
-      - name: Commit Changes
-        run: |
-          if [ "$diffs_found" = true ]; then
-            git config --global user.name "GitHub Actions"
-            git config --global user.email "datawave@github.com"
-            git commit -am "Formatting job fix"
-            git push
-          else
-            echo "Nothing to do"
-          fi
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set up JDK ${{env.JAVA_VERSION}}
+      uses: actions/setup-java@v3
+      with:
+        distribution: ${{env.JAVA_DISTRIBUTION}}
+        java-version: ${{env.JAVA_VERSION}}
+        maven-version: 3.9.5
+        cache: 'maven'
+    - name: Format code
+      env:
+        USER_NAME: ${{ secrets.USER_NAME }}
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      run: |
+        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat
+        git status
+        git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
+    - name: Commit Changes
+      run: |
+        if [ "$diffs_found" = true ]; then
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "datawave@github.com"
+          git commit -am "Formatting job fix"
+          git push
+        else
+          echo "Nothing to do"
+        fi
 
   # Build the code and run the unit/integration tests.
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK ${{env.JAVA_VERSION}}
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{env.JAVA_DISTRIBUTION}}
-          java-version: ${{env.JAVA_VERSION}}
-          maven-version: 3.9.5
-          cache: 'maven'
-      - name: Build and Run Unit Tests
-        env:
-          USER_NAME: ${{ secrets.USER_NAME }}
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: |
-          RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean verify"
-          $RUN_TESTS \
-            || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
-            || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set up JDK ${{env.JAVA_VERSION}}
+      uses: actions/setup-java@v3
+      with:
+        distribution: ${{env.JAVA_DISTRIBUTION}}
+        java-version: ${{env.JAVA_VERSION}}
+        maven-version: 3.9.5
+        cache: 'maven'
+    - name: Build and Run Unit Tests
+      env:
+        USER_NAME: ${{ secrets.USER_NAME }}
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      run: |
+        RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean verify"
+        $RUN_TESTS \
+          || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
+          || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
 
   # This step can be uncommented to support feature development.  When developing a
   # feature which spans multiple repos, you can update the poms to use the latest
@@ -126,35 +125,35 @@ jobs:
   quickstart-build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-      - name: Set up JDK ${{env.JAVA_VERSION}}
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{env.JAVA_DISTRIBUTION}}
-          java-version: ${{env.JAVA_VERSION}}
-          maven-version: 3.9.5
-          cache: 'maven'
-      # Allow us to use the "--squash" option below
-      - name: Turn on Docker experimental features and move Docker data root
-        run: |
-          if [[ -f /etc/docker/daemon.json ]]; then
-            sudo sed -ri 's|\s*}\s*$|, "experimental": true, "data-root": "/mnt/docker" }|' /etc/docker/daemon.json
-          else
-            echo $'{\n    "experimental": true, "data-root": "/mnt/docker"\n}' | sudo tee /etc/docker/daemon.json
-          fi
-          sudo systemctl restart docker
-          echo Docker Experimental Features: $(docker version -f '{{.Server.Experimental}}')
-      # Builds the quickstart docker image and run the query tests
-      - name: Quickstart Query Tests
-        env:
-          DW_DATAWAVE_BUILD_COMMAND: "mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -B -V -e -ntp -Dstyle.color=always -Dmaven.build.cache.enabled=false -Pdev -Ddeploy -Dtar -DskipTests clean package"
-          DOCKER_BUILD_OPTS: "--squash --force-rm"
-          USER_NAME: ${{ secrets.USER_NAME }}
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: |
-          TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
-          contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set up JDK ${{env.JAVA_VERSION}}
+      uses: actions/setup-java@v3
+      with:
+        distribution: ${{env.JAVA_DISTRIBUTION}}
+        java-version: ${{env.JAVA_VERSION}}
+        maven-version: 3.9.5
+        cache: 'maven'
+    # Allow us to use the "--squash" option below
+    - name: Turn on Docker experimental features and move Docker data root
+      run: |
+        if [[ -f /etc/docker/daemon.json ]]; then
+          sudo sed -ri 's|\s*}\s*$|, "experimental": true, "data-root": "/mnt/docker" }|' /etc/docker/daemon.json
+        else
+          echo $'{\n    "experimental": true, "data-root": "/mnt/docker"\n}' | sudo tee /etc/docker/daemon.json
+        fi
+        sudo systemctl restart docker
+        echo Docker Experimental Features: $(docker version -f '{{.Server.Experimental}}')
+    # Builds the quickstart docker image and run the query tests
+    - name: Quickstart Query Tests
+      env:
+        DW_DATAWAVE_BUILD_COMMAND: "mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -B -V -e -ntp -Dstyle.color=always -Dmaven.build.cache.enabled=false -Pdev -Ddeploy -Dtar -DskipTests clean package"
+        DOCKER_BUILD_OPTS: "--squash --force-rm"
+        USER_NAME: ${{ secrets.USER_NAME }}
+        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      run: |
+        TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
+        contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
 
   compose-build-and-test-latest-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,10 @@ jobs:
           java-version: ${{env.JAVA_VERSION}}
           maven-version: 3.9.5
           cache: 'maven'
+      - name: Run a script
+        run: |
+          echo "This step will fail"
+          exit 1
       - name: Build and Run Unit Tests
         env:
           USER_NAME: ${{ secrets.USER_NAME }}
@@ -107,10 +111,6 @@ jobs:
         run: |
           BUILD="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -DskipServices -Ddeploy -Ddist -T1C -pl "-:config-service" clean install -DskipTests"
           $BUILD
-      - name: Run a script
-        run: |
-          echo "This step will fail"
-          exit 1
       - name: Run Microservice Unit Tests
         env:
           USER_NAME: ${{ secrets.USER_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,10 +100,6 @@ jobs:
             ${{ runner.os }}-maven-build-
             ${{ runner.os }}-maven-format-
             ${{ runner.os }}-maven-
-      - name: Run a script
-        run: |
-          echo "This step will fail"
-          exit 1
       - name: Build Project
         env:
           USER_NAME: ${{ secrets.USER_NAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,10 @@ jobs:
             ${{ runner.os }}-maven-build-
             ${{ runner.os }}-maven-format-
             ${{ runner.os }}-maven-
+      - name: Run a script
+        run: |
+          echo "This step will fail"
+          exit 1
       - name: Build Project
         env:
           USER_NAME: ${{ secrets.USER_NAME }}
@@ -118,10 +122,6 @@ jobs:
           $RUN_TESTS \
             || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
             || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
-      - name: Run a script
-        run: |
-          echo "This step will fail"
-          exit 1
 
   quickstart-build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,14 +2,15 @@ name: Tests
 
 on:
   push:
-    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+    paths-ignore: [ '*.md', 'CODEOWNERS', 'LICENSE' ]
     branches:
-    - 'integration'
-    - 'release/version*'
+      - 'integration'
+      - 'release/version*'
+      - 'task/GITHUB-2414'
   pull_request:
-    paths-ignore: ['*.md', 'CODEOWNERS', 'LICENSE']
+    paths-ignore: [ '*.md', 'CODEOWNERS', 'LICENSE' ]
   workflow_dispatch:
-  
+
 env:
   JAVA_VERSION: '11'
   JAVA_DISTRIBUTION: 'zulu' #This is the default on v1 of the action for 1.8
@@ -22,133 +23,184 @@ jobs:
   check-code-formatting:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
-    - name: Set up JDK ${{env.JAVA_VERSION}}
-      uses: actions/setup-java@v3
-      with:
-        distribution: ${{env.JAVA_DISTRIBUTION}}
-        java-version: ${{env.JAVA_VERSION}}
-        maven-version: 3.9.5
-        cache: 'maven'
-    - name: Format code
-      env:
-        USER_NAME: ${{ secrets.USER_NAME }}
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      run: |
-        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat
-        git status
-        git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
-    - name: Commit Changes
-      run: |
-        if [ "$diffs_found" = true ]; then
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "datawave@github.com"
-          git commit -am "Formatting job fix"
-          git push
-        else
-          echo "Nothing to do"
-        fi
-        
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK ${{env.JAVA_VERSION}}
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          java-version: ${{env.JAVA_VERSION}}
+          maven-version: 3.9.5
+          cache: 'maven'
+      - name: Format code
+        env:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat
+          git status
+          git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
+      - name: Commit Changes
+        run: |
+          if [ "$diffs_found" = true ]; then
+            git config --global user.name "GitHub Actions"
+            git config --global user.email "datawave@github.com"
+            git commit -am "Formatting job fix"
+            git push
+          else
+            echo "Nothing to do"
+          fi
+
   # Build the code and run the unit/integration tests.
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
-    - name: Set up JDK ${{env.JAVA_VERSION}}
-      uses: actions/setup-java@v3
-      with:
-        distribution: ${{env.JAVA_DISTRIBUTION}}
-        java-version: ${{env.JAVA_VERSION}}
-        maven-version: 3.9.5
-        cache: 'maven'
-    - name: Build and Run Unit Tests
-      env:
-        USER_NAME: ${{ secrets.USER_NAME }}
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      run: |
-        RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean verify"
-        $RUN_TESTS \
-          || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
-          || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Set up JDK ${{env.JAVA_VERSION}}
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          java-version: ${{env.JAVA_VERSION}}
+          maven-version: 3.9.5
+          cache: 'maven'
+      - name: Build and Run Unit Tests
+        env:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean verify"
+          $RUN_TESTS \
+            || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
+            || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
+              # Starts up docker services and runs test queries
+      - name: Start up docker quickstart services and run test
+        env:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: docker-compose -f docker/docker-compose.yml up -d
+      - name: Run TestAll script
+        env:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          docker-compose -f docker/docker-compose.yml exec web docker/scripts/testall.sh || echo "Tests failed"
 
-  # This step can be uncommented to support feature development.  When developing a 
-  # feature which spans multiple repos, you can update the poms to use the latest 
-  # SNAPSHOT across the board, and run this action as a sanity check to ensure 
-  # everything is working in unison.
+    # This step can be uncommented to support feature development.  When developing a
+    # feature which spans multiple repos, you can update the poms to use the latest
+    # SNAPSHOT across the board, and run this action as a sanity check to ensure
+    # everything is working in unison.
 
-  # # Build the code and run the microservice unit/integration tests.
-  # build-and-test-microservices:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: 'recursive'
-  #     - name: Set up JDK ${{env.JAVA_VERSION}}
-  #       uses: actions/setup-java@v3
-  #       with:
-  #         distribution: ${{env.JAVA_DISTRIBUTION}}
-  #         java-version: ${{env.JAVA_VERSION}}
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: ~/.m2/repository
-  #         key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-maven-build-
-  #           ${{ runner.os }}-maven-format-
-  #           ${{ runner.os }}-maven-
-  #     - name: Build Project
-  #       env:
-  #         USER_NAME: ${{ secrets.USER_NAME }}
-  #         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-  #       run: |
-  #         BUILD="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -DskipServices -Ddeploy -Ddist -T1C -pl "-:config-service" clean install -DskipTests"
-  #         $BUILD
-  #     - name: Run Microservice Unit Tests
-  #       env:
-  #         USER_NAME: ${{ secrets.USER_NAME }}
-  #         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-  #       run: |
-  #         RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Dmaven.build.cache.enabled=false verify"
-  #         cd microservices
-  #         $RUN_TESTS \
-  #           || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
-  #           || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
+    # Build the code and run the microservice unit/integration tests.
+    build-and-test-microservices:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout Code
+          uses: actions/checkout@v3
+          with:
+            submodules: 'recursive'
+        - name: Set up JDK ${{env.JAVA_VERSION}}
+          uses: actions/setup-java@v3
+          with:
+            distribution: ${{env.JAVA_DISTRIBUTION}}
+            java-version: ${{env.JAVA_VERSION}}
+        - uses: actions/cache@v3
+          with:
+            path: ~/.m2/repository
+            key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
+            restore-keys: |
+              ${{ runner.os }}-maven-build-
+              ${{ runner.os }}-maven-format-
+              ${{ runner.os }}-maven-
+        - name: Build Project
+          env:
+            USER_NAME: ${{ secrets.USER_NAME }}
+            ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          run: |
+            BUILD="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -DskipServices -Ddeploy -Ddist -T1C -pl "-:config-service" clean install -DskipTests"
+            $BUILD
+        - name: Run Microservice Unit Tests
+          env:
+            USER_NAME: ${{ secrets.USER_NAME }}
+            ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          run: |
+            RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Dmaven.build.cache.enabled=false verify"
+            cd microservices
+            $RUN_TESTS \
+              || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
+              || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
 
-  quickstart-build-and-test:
+  compose-build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
-    - name: Set up JDK ${{env.JAVA_VERSION}}
-      uses: actions/setup-java@v3
-      with:
-        distribution: ${{env.JAVA_DISTRIBUTION}}
-        java-version: ${{env.JAVA_VERSION}}
-        maven-version: 3.9.5
-        cache: 'maven'
-    # Allow us to use the "--squash" option below
-    - name: Turn on Docker experimental features and move Docker data root
-      run: |
-        if [[ -f /etc/docker/daemon.json ]]; then
-          sudo sed -ri 's|\s*}\s*$|, "experimental": true, "data-root": "/mnt/docker" }|' /etc/docker/daemon.json
-        else
-          echo $'{\n    "experimental": true, "data-root": "/mnt/docker"\n}' | sudo tee /etc/docker/daemon.json
-        fi
-        sudo systemctl restart docker
-        echo Docker Experimental Features: $(docker version -f '{{.Server.Experimental}}')
-    # Builds the quickstart docker image and run the query tests
-    - name: Quickstart Query Tests
-      env:
-        DW_DATAWAVE_BUILD_COMMAND: "mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -B -V -e -ntp -Dstyle.color=always -Dmaven.build.cache.enabled=false -Pdev -Ddeploy -Dtar -DskipTests clean package"
-        DOCKER_BUILD_OPTS: "--squash --force-rm"
-        USER_NAME: ${{ secrets.USER_NAME }}
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      run: |
-        TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
-        contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
+      - name: Checkout Code
+        uses: action/checkout@v2
+      - name: Set up JDK ${{env.JAVA_VERSION}}
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          java-version: ${{env.JAVA_VERSION}}
+          maven-version: 3.9.5
+      # Starts up docker services and runs test queries
+      - name: Start up docker quickstart services and run test
+        uses: docker/login-action@v2
+        with:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      - name: Check and install Docker Compose
+        run: |
+          if ! [ -x "$(command -v docker-compose)" ]; then
+            sudo apt-get update
+            sudo apt-get install -y docker-compose
+          fi
+      - name: Build and run Docker Compose
+        run: |
+          docker-compose up -d
+      - name: Run TestAll script
+        id: test_all
+        run: |
+          docker-compose -f docker/docker-compose.yml exec web docker/scripts/testAll.sh || echo "Tests failed"
+      - name: Tear down Docker Compose
+        run: |
+          docker-compose down
+      - name: Create test badge
+        if: ${{ steps.test_all.outcome == 'failure' }}
+        run: |
+          echo "![Test Status](https://img.shields.io/badge/tests-failing-red)" > test-status-badge.md
+        continue-on-error: true
+
+#  quickstart-build-and-test:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout Code
+#        uses: actions/checkout@v3
+#      - name: Set up JDK ${{env.JAVA_VERSION}}
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: ${{env.JAVA_DISTRIBUTION}}
+#          java-version: ${{env.JAVA_VERSION}}
+#          maven-version: 3.9.5
+#          cache: 'maven'
+#      # Allow us to use the "--squash" option below
+#      - name: Turn on Docker experimental features and move Docker data root
+#        run: |
+#          if [[ -f /etc/docker/daemon.json ]]; then
+#            sudo sed -ri 's|\s*}\s*$|, "experimental": true, "data-root": "/mnt/docker" }|' /etc/docker/daemon.json
+#          else
+#            echo $'{\n    "experimental": true, "data-root": "/mnt/docker"\n}' | sudo tee /etc/docker/daemon.json
+#          fi
+#          sudo systemctl restart docker
+#          echo Docker Experimental Features: $(docker version -f '{{.Server.Experimental}}')
+#      # Builds the quickstart docker image and run the query tests
+#      - name: Quickstart Query Tests
+#        env:
+#          DW_DATAWAVE_BUILD_COMMAND: "mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -B -V -e -ntp -Dstyle.color=always -Dmaven.build.cache.enabled=false -Pdev -Ddeploy -Dtar -DskipTests clean package"
+#          DOCKER_BUILD_OPTS: "--squash --force-rm"
+#          USER_NAME: ${{ secrets.USER_NAME }}
+#          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+#        run: |
+#          TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
+#          contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
 
   compose-build-and-test-latest-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,134 +73,84 @@ jobs:
           $RUN_TESTS \
             || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
             || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
-              # Starts up docker services and runs test queries
-      - name: Start up docker quickstart services and run test
-        env:
-          USER_NAME: ${{ secrets.USER_NAME }}
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: docker-compose -f docker/docker-compose.yml up -d
-      - name: Run TestAll script
+
+  # This step can be uncommented to support feature development.  When developing a
+  # feature which spans multiple repos, you can update the poms to use the latest
+  # SNAPSHOT across the board, and run this action as a sanity check to ensure
+  # everything is working in unison.
+
+  # Build the code and run the microservice unit/integration tests.
+  build-and-test-microservices:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Set up JDK ${{env.JAVA_VERSION}}
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{env.JAVA_DISTRIBUTION}}
+          java-version: ${{env.JAVA_VERSION}}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-build-
+            ${{ runner.os }}-maven-format-
+            ${{ runner.os }}-maven-
+      - name: Build Project
         env:
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
-          docker-compose -f docker/docker-compose.yml exec web docker/scripts/testall.sh || echo "Tests failed"
+          BUILD="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -DskipServices -Ddeploy -Ddist -T1C -pl "-:config-service" clean install -DskipTests"
+          $BUILD
+      - name: Run Microservice Unit Tests
+        env:
+          USER_NAME: ${{ secrets.USER_NAME }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Dmaven.build.cache.enabled=false verify"
+          cd microservices
+          $RUN_TESTS \
+            || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
+            || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
+        continue-on-error: true
 
-    # This step can be uncommented to support feature development.  When developing a
-    # feature which spans multiple repos, you can update the poms to use the latest
-    # SNAPSHOT across the board, and run this action as a sanity check to ensure
-    # everything is working in unison.
-
-    # Build the code and run the microservice unit/integration tests.
-    build-and-test-microservices:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout Code
-          uses: actions/checkout@v3
-          with:
-            submodules: 'recursive'
-        - name: Set up JDK ${{env.JAVA_VERSION}}
-          uses: actions/setup-java@v3
-          with:
-            distribution: ${{env.JAVA_DISTRIBUTION}}
-            java-version: ${{env.JAVA_VERSION}}
-        - uses: actions/cache@v3
-          with:
-            path: ~/.m2/repository
-            key: ${{ runner.os }}-maven-build-${{ hashFiles('**/pom.xml') }}
-            restore-keys: |
-              ${{ runner.os }}-maven-build-
-              ${{ runner.os }}-maven-format-
-              ${{ runner.os }}-maven-
-        - name: Build Project
-          env:
-            USER_NAME: ${{ secrets.USER_NAME }}
-            ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          run: |
-            BUILD="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Pdev,examples,assemble,spotbugs -Dmaven.build.cache.enabled=false -DskipServices -Ddeploy -Ddist -T1C -pl "-:config-service" clean install -DskipTests"
-            $BUILD
-        - name: Run Microservice Unit Tests
-          env:
-            USER_NAME: ${{ secrets.USER_NAME }}
-            ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          run: |
-            RUN_TESTS="mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -Dmaven.build.cache.enabled=false verify"
-            cd microservices
-            $RUN_TESTS \
-              || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
-              || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
-
-  compose-build-and-test:
+  quickstart-build-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: action/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK ${{env.JAVA_VERSION}}
         uses: actions/setup-java@v3
         with:
           distribution: ${{env.JAVA_DISTRIBUTION}}
           java-version: ${{env.JAVA_VERSION}}
           maven-version: 3.9.5
-      # Starts up docker services and runs test queries
-      - name: Start up docker quickstart services and run test
-        uses: docker/login-action@v2
-        with:
+          cache: 'maven'
+      # Allow us to use the "--squash" option below
+      - name: Turn on Docker experimental features and move Docker data root
+        run: |
+          if [[ -f /etc/docker/daemon.json ]]; then
+            sudo sed -ri 's|\s*}\s*$|, "experimental": true, "data-root": "/mnt/docker" }|' /etc/docker/daemon.json
+          else
+            echo $'{\n    "experimental": true, "data-root": "/mnt/docker"\n}' | sudo tee /etc/docker/daemon.json
+          fi
+          sudo systemctl restart docker
+          echo Docker Experimental Features: $(docker version -f '{{.Server.Experimental}}')
+      # Builds the quickstart docker image and run the query tests
+      - name: Quickstart Query Tests
+        env:
+          DW_DATAWAVE_BUILD_COMMAND: "mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -B -V -e -ntp -Dstyle.color=always -Dmaven.build.cache.enabled=false -Pdev -Ddeploy -Dtar -DskipTests clean package"
+          DOCKER_BUILD_OPTS: "--squash --force-rm"
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      - name: Check and install Docker Compose
         run: |
-          if ! [ -x "$(command -v docker-compose)" ]; then
-            sudo apt-get update
-            sudo apt-get install -y docker-compose
-          fi
-      - name: Build and run Docker Compose
-        run: |
-          docker-compose up -d
-      - name: Run TestAll script
-        id: test_all
-        run: |
-          docker-compose -f docker/docker-compose.yml exec web docker/scripts/testAll.sh || echo "Tests failed"
-      - name: Tear down Docker Compose
-        run: |
-          docker-compose down
-      - name: Create test badge
-        if: ${{ steps.test_all.outcome == 'failure' }}
-        run: |
-          echo "![Test Status](https://img.shields.io/badge/tests-failing-red)" > test-status-badge.md
-        continue-on-error: true
-
-#  quickstart-build-and-test:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout Code
-#        uses: actions/checkout@v3
-#      - name: Set up JDK ${{env.JAVA_VERSION}}
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: ${{env.JAVA_DISTRIBUTION}}
-#          java-version: ${{env.JAVA_VERSION}}
-#          maven-version: 3.9.5
-#          cache: 'maven'
-#      # Allow us to use the "--squash" option below
-#      - name: Turn on Docker experimental features and move Docker data root
-#        run: |
-#          if [[ -f /etc/docker/daemon.json ]]; then
-#            sudo sed -ri 's|\s*}\s*$|, "experimental": true, "data-root": "/mnt/docker" }|' /etc/docker/daemon.json
-#          else
-#            echo $'{\n    "experimental": true, "data-root": "/mnt/docker"\n}' | sudo tee /etc/docker/daemon.json
-#          fi
-#          sudo systemctl restart docker
-#          echo Docker Experimental Features: $(docker version -f '{{.Server.Experimental}}')
-#      # Builds the quickstart docker image and run the query tests
-#      - name: Quickstart Query Tests
-#        env:
-#          DW_DATAWAVE_BUILD_COMMAND: "mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -B -V -e -ntp -Dstyle.color=always -Dmaven.build.cache.enabled=false -Pdev -Ddeploy -Dtar -DskipTests clean package"
-#          DOCKER_BUILD_OPTS: "--squash --force-rm"
-#          USER_NAME: ${{ secrets.USER_NAME }}
-#          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-#        run: |
-#          TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
-#          contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
+          TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
+          contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
 
   compose-build-and-test-latest-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,10 +64,6 @@ jobs:
           java-version: ${{env.JAVA_VERSION}}
           maven-version: 3.9.5
           cache: 'maven'
-      - name: Run a script
-        run: |
-          echo "This step will fail"
-          exit 1
       - name: Build and Run Unit Tests
         env:
           USER_NAME: ${{ secrets.USER_NAME }}
@@ -86,6 +82,7 @@ jobs:
   # Build the code and run the microservice unit/integration tests.
   build-and-test-microservices:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -121,7 +118,10 @@ jobs:
           $RUN_TESTS \
             || { echo "***** TESTS FAILED. Attempting retry."; $RUN_TESTS; } \
             || { echo "***** TESTS FAILED. Attempting final retry."; $RUN_TESTS; }
-        continue-on-error: true
+      - name: Run a script
+        run: |
+          echo "This step will fail"
+          exit 1
 
   quickstart-build-and-test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # My Project
 
 [![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg)
-![CI](https://img.shields.io/endpoint?url=https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?jobs=build-and-test-microservices)
+![CI](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?branch=task%2FGITHUB-2414&event=push)
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...
 
 * Data fusion across structured and unstructured datasets

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 # My Project
 
-![CI](https://github.com/username/repository/actions/workflows/ci.yml/badge.svg?jobs=build-and-test-microservices)
 [![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg)
-
+![CI](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?jobs=build-and-test-microservices)
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...
 
 * Data fusion across structured and unstructured datasets

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # My Project
 
 [![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg)
-![CI](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?branch=task%2FGITHUB-2414&event=push)
+![2414](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?branch=task%2FGITHUB-2414&event=push)
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...
 
 * Data fusion across structured and unstructured datasets

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # My Project
 
 [![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg)
-![CI](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?jobs=build-and-test-microservices)
+![CI](https://img.shields.io/endpoint?url=https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?jobs=build-and-test-microservices)
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...
 
 * Data fusion across structured and unstructured datasets

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # My Project
 
 [![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg)
-![2414](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?branch=task%2FGITHUB-2414&event=push)
+![2414](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg?job=build-and-test-microservices)
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...
 
 * Data fusion across structured and unstructured datasets

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
    <img src="datawave-readme.png" />
 </p>
 
+# My Project
+
+![CI](https://github.com/username/repository/actions/workflows/ci.yml/badge.svg?jobs=build-and-test-microservices)
 [![Apache License][li]][ll] ![Build Status](https://github.com/NationalSecurityAgency/datawave/actions/workflows/tests.yml/badge.svg)
 
 DataWave is a Java-based ingest and query framework that leverages [Apache Accumulo](http://accumulo.apache.org/) to provide fast, secure access to your data. DataWave supports a wide variety of use cases, including but not limited to...

--- a/contrib/datawave-quickstart/docker/pom.xml
+++ b/contrib/datawave-quickstart/docker/pom.xml
@@ -17,6 +17,7 @@
         <dist.maven>apache-maven-3.8.8-bin.tar.gz</dist.maven>
         <dist.wildfly>wildfly-17.0.1.Final.tar.gz</dist.wildfly>
         <dist.zookeeper>apache-zookeeper-3.7.2-bin.tar.gz</dist.zookeeper>
+        <docker.image.prefix>ghcr.io/nationalsecurityagency/</docker.image.prefix>
         <skipIngest>false</skipIngest>
         <url.accumulo>https://dlcdn.apache.org/accumulo/2.1.2/${dist.accumulo}</url.accumulo>
         <url.hadoop>https://dlcdn.apache.org/hadoop/common/hadoop-3.3.6/${dist.hadoop}</url.hadoop>

--- a/docker/config/application.yml
+++ b/docker/config/application.yml
@@ -75,7 +75,10 @@ spring:
 
 hazelcast:
   client:
-    clusterName: cache
+    cluster1:
+      clusterName: cache
+    cluster2:
+      clusterName: cache2
 
 # The default URI for remote authorization
 datawave:

--- a/docker/config/application.yml
+++ b/docker/config/application.yml
@@ -75,10 +75,7 @@ spring:
 
 hazelcast:
   client:
-    cluster1:
-      clusterName: cache
-    cluster2:
-      clusterName: cache2
+    clusterName: cache
 
 # The default URI for remote authorization
 datawave:

--- a/docker/config/executor.yml
+++ b/docker/config/executor.yml
@@ -65,3 +65,9 @@ datawave:
       logStatusPeriodMs: 600000
       logStatusWhenChangedMs: 300000
       queryMetricsUrlPrefix: https://localhost:8543/querymetric/v1/id/
+
+hazelcast:
+  clusterName: 'cache2'
+  client:
+    enabled: true
+    clusterName: 'cache2'

--- a/docker/config/query.yml
+++ b/docker/config/query.yml
@@ -54,7 +54,7 @@ datawave:
     accumulo:
       uri: 'https://localhost:9143/accumulo'
     cache:
-      uri: 'https://localhost:8844/cache'
+      uri: 'https://localhost:8843/cache'
     config:
       uri: 'https://localhost:8888/configserver'
     authorization:
@@ -72,3 +72,9 @@ audit-client:
   discovery:
     enabled: false
   uri: '${AUDIT_SERVER_URL:http://localhost:11111/audit}'
+
+hazelcast:
+  clusterName: 'cache2'
+  client:
+    enabled: true
+    clusterName: 'cache2'

--- a/docker/config/query.yml
+++ b/docker/config/query.yml
@@ -54,7 +54,7 @@ datawave:
     accumulo:
       uri: 'https://localhost:9143/accumulo'
     cache:
-      uri: 'https://localhost:8843/cache'
+      uri: 'https://localhost:8844/cache'
     config:
       uri: 'https://localhost:8888/configserver'
     authorization:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -193,7 +193,7 @@ services:
     networks:
       - demo
     healthcheck:
-      test: curl -f http://localhost:8080/cache/mgmt/health
+      test: curl -f http://localhost:8082/cache2/mgmt/health
       interval: 10s
       timeout: 1s
       start_period: 45s
@@ -201,7 +201,6 @@ services:
     depends_on:
       configuration:
         condition: service_started
-
 
   authorization:
     entrypoint: [ "java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008","-jar","app.jar" ]
@@ -606,9 +605,9 @@ services:
   #    - ns datawaveUsers
   #    - m.entries
   management-center:
-    profiles:
-      - management
-      - full
+#    profiles:
+#      - management
+#      - full
     image: docker.io/hazelcast/management-center:5.1.2
     environment:
       - |-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -173,6 +173,36 @@ services:
       configuration:
         condition: service_started
 
+  cache2:
+    image: datawave/hazelcast-service
+    scale: 1
+    command:
+      - --spring.application.name=cache2
+      - --hazelcast.client.cluster-members
+      - --spring.profiles.active=consul,compose,remoteauth
+      - --spring.output.ansi.enabled=ALWAYS
+      - --spring.cloud.consul.host=consul
+      - --spring.cloud.consul.discovery.instance-id=$${spring.application.name}:$${random.value}
+    ports:
+      - "5701-5703"
+      - "8082"
+      - "8844:8443"
+    volumes:
+      - ${PKI_DIR:-./pki}:/etc/pki:ro
+      - ./logs:/logs
+    networks:
+      - demo
+    healthcheck:
+      test: curl -f http://localhost:8080/cache/mgmt/health
+      interval: 10s
+      timeout: 1s
+      start_period: 45s
+      retries: 3
+    depends_on:
+      configuration:
+        condition: service_started
+
+
   authorization:
     entrypoint: [ "java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008","-jar","app.jar" ]
     image: datawave/authorization-service

--- a/properties/dev.properties
+++ b/properties/dev.properties
@@ -1,7 +1,7 @@
 CONFIGURATION=test
 RCPT_TO=hadoop@localhost
 
-docker.image.prefix=
+docker.image.prefix=ghcr.io/nationalsecurityagency/
 
 # ingest properties
 DATAWAVE_INGEST_HOME=/local/datawave-ingest


### PR DESCRIPTION
Configuration for creating an additional hazelcast cluster: Follow the example in the docker-compose.yml in this branch, where a new hazelcast cluster is created after the default one.
Make sure "- --spring.application.name=<new cluster name>" is added under the "command" header in the additional cluster's config.

Configuration for the service: Point a service to a specifec hazelcast cluster by adding 
hazelcast:
  clusterName: '<new cluster name>'
  client:
    enabled: true
    clusterName: '<new cluster name>'
(example of this can be seen in the query.yml and executor.yml files in this branch)