### PR TITLE
Replace nonpublic Accumulo ColumnSet

### DIFF
--- a/warehouse/core/src/main/java/datawave/util/ColumnSetUtil.java
+++ b/warehouse/core/src/main/java/datawave/util/ColumnSetUtil.java
@@ -1,6 +1,7 @@
 package datawave.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.apache.accumulo.core.util.Pair;
 import org.apache.hadoop.io.Text;
 
@@ -34,11 +35,9 @@ public class ColumnSetUtil {
         }
     }
 
-
     public static boolean isValidEncoding(String enc) {
         for (char c : enc.toCharArray()) {
-            boolean validChar = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
-                    || c == '_' || c == '-' || c == ':' || c == '%';
+            boolean validChar = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' || c == ':' || c == '%';
             if (!validChar) {
                 return false;
             }
@@ -52,8 +51,7 @@ public class ColumnSetUtil {
             int b = (0xff & t.getBytes()[i]);
 
             // very inefficient code
-            if ((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
-                    || b == '-') {
+            if ((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '-') {
                 sb.append((char) b);
             } else {
                 sb.append('%');
@@ -78,8 +76,7 @@ public class ColumnSetUtil {
                     int b = Integer.parseInt(hs, 16);
                     t.append(new byte[] {(byte) b}, 0, 1);
                 } else {
-                    throw new IllegalArgumentException("Invalid characters in encoded string (" + s + ")."
-                            + " Expected two characters after '%'");
+                    throw new IllegalArgumentException("Invalid characters in encoded string (" + s + ")." + " Expected two characters after '%'");
                 }
             } else {
                 t.append(new byte[] {sb[i]}, 0, 1);

--- a/warehouse/core/src/main/java/datawave/util/ColumnSetUtil.java
+++ b/warehouse/core/src/main/java/datawave/util/ColumnSetUtil.java
@@ -1,3 +1,8 @@
+/**
+ * Taken from org.apache.accumulo.core.iteratorsImpl.conf.ColumnSet.
+ * ColumnSet was not part of Accumulo's public API, so the parts that were needed were copied here.
+ */
+
 package datawave.util;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/warehouse/core/src/main/java/datawave/util/ColumnSetUtil.java
+++ b/warehouse/core/src/main/java/datawave/util/ColumnSetUtil.java
@@ -1,0 +1,91 @@
+package datawave.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.accumulo.core.util.Pair;
+import org.apache.hadoop.io.Text;
+
+public class ColumnSetUtil {
+
+    public static String encodeColumns(Text columnFamily, Text columnQualifier) {
+        StringBuilder sb = new StringBuilder();
+
+        encode(sb, columnFamily);
+        if (columnQualifier != null) {
+            sb.append(':');
+            encode(sb, columnQualifier);
+        }
+
+        return sb.toString();
+    }
+
+    public static Pair<Text,Text> decodeColumns(String columns) {
+        if (!isValidEncoding(columns)) {
+            throw new IllegalArgumentException("Invalid encoding " + columns);
+        }
+
+        String[] cols = columns.split(":");
+
+        if (cols.length == 1) {
+            return new Pair<>(decode(cols[0]), null);
+        } else if (cols.length == 2) {
+            return new Pair<>(decode(cols[0]), decode(cols[1]));
+        } else {
+            throw new IllegalArgumentException(columns);
+        }
+    }
+
+
+    public static boolean isValidEncoding(String enc) {
+        for (char c : enc.toCharArray()) {
+            boolean validChar = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                    || c == '_' || c == '-' || c == ':' || c == '%';
+            if (!validChar) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static void encode(StringBuilder sb, Text t) {
+        for (int i = 0; i < t.getLength(); i++) {
+            int b = (0xff & t.getBytes()[i]);
+
+            // very inefficient code
+            if ((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+                    || b == '-') {
+                sb.append((char) b);
+            } else {
+                sb.append('%');
+                sb.append(String.format("%02x", b));
+            }
+        }
+    }
+
+    static Text decode(String s) {
+        Text t = new Text();
+
+        byte[] sb = s.getBytes(UTF_8);
+
+        // very inefficient code
+        for (int i = 0; i < sb.length; i++) {
+            if (sb[i] == '%') {
+                int x = ++i;
+                int y = ++i;
+                if (y < sb.length) {
+                    byte[] hex = {sb[x], sb[y]};
+                    String hs = new String(hex, UTF_8);
+                    int b = Integer.parseInt(hs, 16);
+                    t.append(new byte[] {(byte) b}, 0, 1);
+                } else {
+                    throw new IllegalArgumentException("Invalid characters in encoded string (" + s + ")."
+                            + " Expected two characters after '%'");
+                }
+            } else {
+                t.append(new byte[] {sb[i]}, 0, 1);
+            }
+        }
+
+        return t;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.regex.Pattern;
 
-import datawave.util.ColumnSetUtil;
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -39,6 +38,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 import datawave.ingest.mapreduce.job.TableConfigurationUtil;
+import datawave.util.ColumnSetUtil;
 
 @SuppressWarnings("deprecation")
 public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,OV> {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.regex.Pattern;
 
+import datawave.util.ColumnSetUtil;
 import org.apache.accumulo.core.client.SampleNotPresentException;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.conf.AccumuloConfiguration;
@@ -22,7 +23,6 @@ import org.apache.accumulo.core.iterators.Combiner;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.IteratorUtil;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.iteratorsImpl.conf.ColumnSet;
 import org.apache.accumulo.core.iteratorsImpl.conf.ColumnToClassMapping;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.util.Pair;
@@ -176,7 +176,7 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                             Map<String,Entry<Map<String,String>,String>> columnMap = Maps.newHashMap();
 
                             for (String column : columns) {
-                                columnMap.put(ColumnSet.encodeColumns(new Text(column), null), Maps.immutableEntry(options, clazz));
+                                columnMap.put(ColumnSetUtil.encodeColumns(new Text(column), null), Maps.immutableEntry(options, clazz));
                             }
 
                             mapping = new CustomColumnToClassMapping(columnMap, priority);
@@ -386,7 +386,7 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                 if (ALL_CF_STR.equals(column)) {
                     pcic = new Pair<>(ALL_CF_KEY.getColumnFamily(), null);
                 } else {
-                    pcic = ColumnSet.decodeColumns(column);
+                    pcic = ColumnSetUtil.decodeColumns(column);
                 }
 
                 Combiner agg = null;
@@ -426,7 +426,7 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                 if (ALL_CF_STR.equals(column)) {
                     pcic = new Pair<>(ALL_CF_KEY.getColumnFamily(), null);
                 } else {
-                    pcic = ColumnSet.decodeColumns(column);
+                    pcic = ColumnSetUtil.decodeColumns(column);
                 }
 
                 Combiner agg = null;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Sets;
 import datawave.ingest.mapreduce.job.TableConfigurationUtil;
 import datawave.util.ColumnSetUtil;
 
-@SuppressWarnings("deprecation")
 public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,OV> {
 
     public static final String INGEST_VALUE_DEDUP_BY_TIMESTAMP_KEY = "ingest.value.dedup.by.timestamp";
@@ -287,7 +286,6 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
      * @throws InterruptedException
      *             if the thread is interrupted
      */
-    @SuppressWarnings("unchecked")
     public void doReduce(IK key, Iterable<IV> values, TaskInputOutputContext<?,?,OK,OV> context) throws IOException, InterruptedException {
         for (IV value : values) {
             context.write((OK) key, (OV) value);


### PR DESCRIPTION
ColumnSet is not part of Accumulo's public API. encode/decodeColumns are the only part of the class used in Datawave.

Replace the references of to Accumulo's ColumnSet with code that functions the same without the reference.

part of https://github.com/NationalSecurityAgency/datawave/issues/2443