### PR TITLE
2535 disable maven build cache

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -23,7 +23,7 @@
      -->
 
     <configuration>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <hashAlgorithm>SHA-256</hashAlgorithm>
         <validateXml>true</validateXml>
         <local>

--- a/contrib/datawave-quickstart/docker/pom.xml
+++ b/contrib/datawave-quickstart/docker/pom.xml
@@ -17,6 +17,7 @@
         <dist.maven>apache-maven-3.8.8-bin.tar.gz</dist.maven>
         <dist.wildfly>wildfly-17.0.1.Final.tar.gz</dist.wildfly>
         <dist.zookeeper>apache-zookeeper-3.7.2-bin.tar.gz</dist.zookeeper>
+        <docker.image.prefix />
         <skipIngest>false</skipIngest>
         <url.accumulo>https://dlcdn.apache.org/accumulo/2.1.3/${dist.accumulo}</url.accumulo>
         <url.hadoop>https://dlcdn.apache.org/hadoop/common/hadoop-3.3.6/${dist.hadoop}</url.hadoop>

--- a/contrib/datawave-quickstart/docker/pom.xml
+++ b/contrib/datawave-quickstart/docker/pom.xml
@@ -17,7 +17,6 @@
         <dist.maven>apache-maven-3.8.8-bin.tar.gz</dist.maven>
         <dist.wildfly>wildfly-17.0.1.Final.tar.gz</dist.wildfly>
         <dist.zookeeper>apache-zookeeper-3.7.2-bin.tar.gz</dist.zookeeper>
-        <docker.image.prefix />
         <skipIngest>false</skipIngest>
         <url.accumulo>https://dlcdn.apache.org/accumulo/2.1.3/${dist.accumulo}</url.accumulo>
         <url.hadoop>https://dlcdn.apache.org/hadoop/common/hadoop-3.3.6/${dist.hadoop}</url.hadoop>


### PR DESCRIPTION
Disables build cache by default. Maven build cache causes problems for quickstart docker images.