### PR TITLE
Enable Seeking Event Aggregation

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/ancestor/AncestorQueryIterator.java
@@ -40,6 +40,7 @@ import datawave.query.function.JexlEvaluation;
 import datawave.query.function.RangeProvider;
 import datawave.query.iterator.NestedQueryIterator;
 import datawave.query.iterator.QueryIterator;
+import datawave.query.iterator.QueryOptions;
 import datawave.query.iterator.SourcedOptions;
 import datawave.query.iterator.logic.IndexIterator;
 import datawave.query.jexl.DatawaveJexlContext;
@@ -136,6 +137,15 @@ public class AncestorQueryIterator extends QueryIterator {
         }
         // return a new filter each time as this is not thread safe (maintains state)
         return evaluationFilter != null ? evaluationFilter.clone() : null;
+    }
+
+    /**
+     * In the Ancestor case replace the {@link QueryOptions#eventFilter} with an evaluation filter
+     *
+     * @return an evaluation filter
+     */
+    public EventDataQueryFilter getEventFilter() {
+        return getEvaluationFilter();
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
@@ -46,6 +46,7 @@ public class LookupUUIDTune implements Profile {
     protected boolean reduceQuery = false;
     private boolean enforceUniqueTermsWithinExpressions = false;
     private boolean reduceQueryFields = false;
+    private boolean seekingEventAggregation;
     protected List<NodeTransformRule> transforms = null;
     protected Map<String,QueryParser> querySyntaxParsers = null;
 
@@ -64,6 +65,7 @@ public class LookupUUIDTune implements Profile {
             rsq.setFiNextSeek(getFiNextSeek());
             rsq.setEventFieldSeek(getEventFieldSeek());
             rsq.setEventNextSeek(getEventNextSeek());
+            rsq.setSeekingEventAggregation(isSeekingEventAggregation());
 
             if (querySyntaxParsers != null) {
                 rsq.setQuerySyntaxParsers(querySyntaxParsers);
@@ -136,6 +138,7 @@ public class LookupUUIDTune implements Profile {
             rsqc.setFiNextSeek(getFiNextSeek());
             rsqc.setEventFieldSeek(getEventFieldSeek());
             rsqc.setEventNextSeek(getEventNextSeek());
+            rsqc.setSeekingEventAggregation(isSeekingEventAggregation());
 
             // we need this since we've finished the deep copy already
             rsqc.setSpeculativeScanning(speculativeScanning);
@@ -353,5 +356,13 @@ public class LookupUUIDTune implements Profile {
 
     public void setQuerySyntaxParsers(Map<String,QueryParser> querySyntaxParsers) {
         this.querySyntaxParsers = querySyntaxParsers;
+    }
+
+    public boolean isSeekingEventAggregation() {
+        return seekingEventAggregation;
+    }
+
+    public void setSeekingEventAggregation(boolean seekingEventAggregation) {
+        this.seekingEventAggregation = seekingEventAggregation;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -448,6 +448,11 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private int tfNextSeek = -1;
 
     /**
+     * Flag that enables a field-based seeking aggregation in the standard event query. Must be used in conjunction with {@link #eventFieldSeek}
+     */
+    private boolean seekingEventAggregation = false;
+
+    /**
      * The maximum weight for entries in the visitor function cache. The weight is calculated as the total number of characters for each key and value in the
      * cache. Default is 5m characters, which is roughly 10MB
      */
@@ -705,6 +710,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setEventNextSeek(other.getEventNextSeek());
         this.setTfFieldSeek(other.getTfFieldSeek());
         this.setTfNextSeek(other.getTfNextSeek());
+        this.setSeekingEventAggregation(other.isSeekingEventAggregation());
         this.setVisitorFunctionMaxWeight(other.getVisitorFunctionMaxWeight());
         this.setQueryExecutionForPageTimeout(other.getQueryExecutionForPageTimeout());
         this.setLazySetMechanismEnabled(other.isLazySetMechanismEnabled());
@@ -2612,6 +2618,14 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.tfNextSeek = tfNextSeek;
     }
 
+    public boolean isSeekingEventAggregation() {
+        return seekingEventAggregation;
+    }
+
+    public void setSeekingEventAggregation(boolean seekingEventAggregation) {
+        this.seekingEventAggregation = seekingEventAggregation;
+    }
+
     public long getVisitorFunctionMaxWeight() {
         return visitorFunctionMaxWeight;
     }
@@ -2933,6 +2947,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 getEventNextSeek() == that.getEventNextSeek() &&
                 getTfFieldSeek() == that.getTfFieldSeek() &&
                 getTfNextSeek() == that.getTfNextSeek() &&
+                isSeekingEventAggregation() == that.isSeekingEventAggregation() &&
                 getVisitorFunctionMaxWeight() == that.getVisitorFunctionMaxWeight() &&
                 getQueryExecutionForPageTimeout() == that.getQueryExecutionForPageTimeout() &&
                 isLazySetMechanismEnabled() == that.isLazySetMechanismEnabled() &&
@@ -3137,6 +3152,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 getEventNextSeek(),
                 getTfFieldSeek(),
                 getTfNextSeek(),
+                isSeekingEventAggregation(),
                 getVisitorFunctionMaxWeight(),
                 getQueryExecutionForPageTimeout(),
                 isLazySetMechanismEnabled(),

--- a/warehouse/query-core/src/main/java/datawave/query/function/IndexOnlyKeyToDocumentData.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/IndexOnlyKeyToDocumentData.java
@@ -38,9 +38,9 @@ import datawave.webservice.query.exception.QueryException;
  * Fetches index-only tf key/values and outputs them as "standard" field key/value pairs
  */
 public class IndexOnlyKeyToDocumentData extends KeyToDocumentData implements Iterator<Entry<DocumentData,Document>> {
-    private static final Collection<ByteSequence> COLUMN_FAMILIES = Lists.<ByteSequence> newArrayList(new ArrayByteSequence("d"));
+    private static final Collection<ByteSequence> COLUMN_FAMILIES = Lists.newArrayList(new ArrayByteSequence("d"));
 
-    private static Logger LOG = Logger.getLogger(IndexOnlyKeyToDocumentData.class);
+    private static final Logger LOG = Logger.getLogger(IndexOnlyKeyToDocumentData.class);
 
     private static final Entry<Key,Value> INVALID_COLUMNQUALIFIER_FORMAT_KEY = Maps.immutableEntry(new Key("INVALID_COLUMNQUALIFIER_FORMAT_KEY"), EMPTY_VALUE);
 
@@ -159,7 +159,7 @@ public class IndexOnlyKeyToDocumentData extends KeyToDocumentData implements Ite
             // get the document key
             Key docKey = getDocKey(from.getKey());
 
-            // Ensure that we have a non-empty colqual
+            // Ensure that we have a non-empty column qualifier
             final Key stopKey = new Key(from.getKey().getRow().toString(), from.getKey().getColumnFamily().toString(),
                             from.getKey().getColumnQualifier().toString() + '\u0000' + '\uffff');
 

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ParentQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ParentQueryIterator.java
@@ -69,6 +69,15 @@ public class ParentQueryIterator extends QueryIterator {
         return evaluationFilter != null ? evaluationFilter.clone() : null;
     }
 
+    /**
+     * In the Parent case replace the {@link QueryOptions#eventFilter} with an evaluation filter
+     *
+     * @return an evaluation filter
+     */
+    public EventDataQueryFilter getEventFilter() {
+        return getEvaluationFilter();
+    }
+
     @Override
     public Iterator<Entry<Key,Document>> mapDocument(SortedKeyValueIterator<Key,Value> deepSourceCopy, Iterator<Entry<Key,Document>> documents,
                     CompositeMetadata compositeMetadata) {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -759,22 +759,25 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
             if (log.isTraceEnabled()) {
                 log.trace("isFieldIndexSatisfyingQuery");
             }
-            docMapper = new Function<Entry<Key,Document>,Entry<DocumentData,Document>>() {
+            docMapper = new Function<>() {
                 @Nullable
                 @Override
                 public Entry<DocumentData,Document> apply(@Nullable Entry<Key,Document> input) {
-
                     Entry<DocumentData,Document> entry = null;
                     if (input != null) {
-                        entry = Maps.immutableEntry(new DocumentData(input.getKey(), Collections.singleton(input.getKey()), Collections.EMPTY_LIST, true),
+                        entry = Maps.immutableEntry(new DocumentData(input.getKey(), Collections.singleton(input.getKey()), Collections.emptyList(), true),
                                         input.getValue());
                     }
                     return entry;
                 }
             };
         } else {
-            docMapper = new KeyToDocumentData(deepSourceCopy, myEnvironment, documentOptions, getEquality(), getEvaluationFilter(), this.includeHierarchyFields,
-                            this.includeHierarchyFields).withRangeProvider(getRangeProvider()).withAggregationThreshold(getDocAggregationThresholdMs());
+            //  @formatter:off
+            docMapper = new KeyToDocumentData(deepSourceCopy, myEnvironment, documentOptions, getEquality(), getEventFilter(), this.includeHierarchyFields,
+                            this.includeHierarchyFields)
+                            .withRangeProvider(getRangeProvider())
+                            .withAggregationThreshold(getDocAggregationThresholdMs());
+            //  @formatter:on
         }
 
         Iterator<Entry<DocumentData,Document>> sourceIterator = Iterators.transform(documentSpecificSource, from -> {
@@ -1094,9 +1097,12 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
             log.trace("mapDocument " + fieldIndexSatisfiesQuery);
         }
         if (fieldIndexSatisfiesQuery) {
+            //  @formatter:off
             final KeyToDocumentData docMapper = new KeyToDocumentData(deepSourceCopy, this.myEnvironment, this.documentOptions, getEquality(),
-                            getEvaluationFilter(), this.includeHierarchyFields, this.includeHierarchyFields).withRangeProvider(getRangeProvider())
-                                            .withAggregationThreshold(getDocAggregationThresholdMs());
+                            getEventFilter(), this.includeHierarchyFields, this.includeHierarchyFields)
+                            .withRangeProvider(getRangeProvider())
+                            .withAggregationThreshold(getDocAggregationThresholdMs());
+            //  @formatter:on
 
             Iterator<Tuple2<Key,Document>> mappedDocuments = Iterators.transform(documents,
                             new GetDocument(docMapper,

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -268,6 +267,8 @@ public class QueryOptions implements OptionDescriber {
     public static final String TF_FIELD_SEEK = "tf.field.seek";
     public static final String TF_NEXT_SEEK = "tf.next.seek";
 
+    public static final String SEEKING_EVENT_AGGREGATION = "seeking.event.aggregation";
+
     public static final String DOC_AGGREGATION_THRESHOLD_MS = "doc.agg.threshold";
 
     public static final String TERM_FREQUENCY_AGGREGATION_THRESHOLD_MS = "tf.agg.threshold";
@@ -436,6 +437,8 @@ public class QueryOptions implements OptionDescriber {
     private int tfFieldSeek = -1;
     private int tfNextSeek = -1;
 
+    private boolean seekingEventAggregation = false;
+
     // aggregation thresholds
     private int docAggregationThresholdMs = -1;
     private int tfAggregationThresholdMs = -1;
@@ -549,6 +552,8 @@ public class QueryOptions implements OptionDescriber {
         this.eventNextSeek = other.eventNextSeek;
         this.tfFieldSeek = other.tfFieldSeek;
         this.tfNextSeek = other.tfNextSeek;
+
+        this.seekingEventAggregation = other.seekingEventAggregation;
 
         this.docAggregationThresholdMs = other.docAggregationThresholdMs;
         this.tfAggregationThresholdMs = other.tfAggregationThresholdMs;
@@ -790,7 +795,7 @@ public class QueryOptions implements OptionDescriber {
      */
     public EventDataQueryFilter getEventFilter() {
 
-        if (!useAllowListedFields || allowListedFields instanceof UniversalSet) {
+        if (!useAllowListedFields || allowListedFields instanceof UniversalSet || !isSeekingEventAggregation()) {
             return null;
         }
 
@@ -1534,6 +1539,10 @@ public class QueryOptions implements OptionDescriber {
 
         if (options.containsKey(TF_NEXT_SEEK)) {
             this.tfNextSeek = Integer.parseInt(options.get(TF_NEXT_SEEK));
+        }
+
+        if (options.containsKey(SEEKING_EVENT_AGGREGATION)) {
+            this.seekingEventAggregation = Boolean.parseBoolean(options.get(SEEKING_EVENT_AGGREGATION));
         }
 
         if (options.containsKey(DOC_AGGREGATION_THRESHOLD_MS)) {
@@ -2326,5 +2335,9 @@ public class QueryOptions implements OptionDescriber {
             equality = new PrefixEquality(PartialKey.ROW_COLFAM);
         }
         return equality;
+    }
+
+    public boolean isSeekingEventAggregation() {
+        return seekingEventAggregation;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/facets/DynamicFacetIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/facets/DynamicFacetIterator.java
@@ -168,7 +168,7 @@ public class DynamicFacetIterator extends FieldIndexOnlyQueryIterator {
         Iterator<Entry<Key,Document>> documents = null;
 
         if (!configuration.getFacetedFields().isEmpty()) {
-            projection = new EventDataQueryFieldFilter(configuration.getFacetedFields(), Projection.ProjectionType.INCLUDES);
+            projection = new EventDataQueryFieldFilter().withFields(configuration.getFacetedFields());
         }
 
         if (!configuration.hasFieldLimits() || projection != null) {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2296,6 +2296,10 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (config.getTfNextSeek() > 0) {
             addOption(cfg, QueryOptions.TF_NEXT_SEEK, String.valueOf(config.getTfNextSeek()), false);
         }
+
+        if (config.isSeekingEventAggregation()) {
+            addOption(cfg, QueryOptions.SEEKING_EVENT_AGGREGATION, String.valueOf(config.isSeekingEventAggregation()), false);
+        }
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/AncestorEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/AncestorEventDataFilter.java
@@ -36,12 +36,12 @@ public class AncestorEventDataFilter extends EventDataQueryExpressionFilter {
      * @see datawave.query.function.Filter#accept(org.apache.accumulo.core.data.Key)
      */
     @Override
-    public boolean apply(Entry<Key,String> input) {
+    public boolean apply(Entry<Key,String> entry) {
         // if the base document, then accept em all, otherwise defer to the quey field filter
-        if (keep(input.getKey())) {
+        if (keep(entry.getKey())) {
             return true;
         } else {
-            return super.apply(input);
+            return super.apply(entry);
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryExpressionFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryExpressionFilter.java
@@ -72,13 +72,13 @@ public class EventDataQueryExpressionFilter implements EventDataQueryFilter {
     }
 
     @Override
-    public boolean apply(Map.Entry<Key,String> input) {
-        return apply(input.getKey(), true);
+    public boolean apply(Map.Entry<Key,String> entry) {
+        return apply(entry.getKey(), true);
     }
 
     @Override
-    public boolean peek(Map.Entry<Key,String> input) {
-        return apply(input.getKey(), false);
+    public boolean peek(Map.Entry<Key,String> entry) {
+        return apply(entry.getKey(), false);
     }
 
     public boolean peek(Key key) {

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryFieldFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryFieldFilter.java
@@ -2,81 +2,83 @@ package datawave.query.predicate;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.annotation.Nullable;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
-import org.apache.commons.jexl3.parser.ASTIdentifier;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.hadoop.io.Text;
 
-import com.google.common.collect.Sets;
-
+import datawave.query.data.parsers.EventKey;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.predicate.EventDataQueryFilter;
-import datawave.query.predicate.KeyProjection;
-import datawave.query.predicate.Projection;
 
 /**
- * This filter will filter event data keys by only those fields that are required in the specified query.
+ * Inclusive filter that ensures only event keys which match the set of fields to retain are kept for evaluation.
+ * <p>
+ * The fields to retain are built from query fields and user-specified <code>return.fields</code>
+ * <p>
+ * This filter only operates on event keys.
  */
 public class EventDataQueryFieldFilter implements EventDataQueryFilter {
-    private Set<String> nonEventFields;
 
-    private KeyProjection keyProjection;
+    private Key document = null;
+    // the number of times next is called before issuing a seek
+    private int maxNextCount = -1;
+    // track the number of times next is called on the same field
+    private int nextCount;
 
+    // the set of fields to retain
+    private TreeSet<String> fields;
+    private final EventKey parser;
+
+    /**
+     * Default constructor
+     */
+    public EventDataQueryFieldFilter() {
+        this.parser = new EventKey();
+    }
+
+    /**
+     * Copy constructor used by the {@link #clone()} method
+     *
+     * @param other
+     *            an instance of the {@link EventDataQueryFieldFilter}
+     */
     public EventDataQueryFieldFilter(EventDataQueryFieldFilter other) {
-        this.nonEventFields = other.nonEventFields;
         if (other.document != null) {
-            document = new Key(other.document);
+            this.document = new Key(other.document);
         }
-        this.keyProjection = other.getProjection();
+        this.maxNextCount = other.maxNextCount;
+        this.fields = other.fields;
+        this.parser = other.parser;
+        // do not copy nextCount because that is internal state
+        this.nextCount = 0;
     }
 
     /**
-     * Initialize filter with an empty projection
+     * Builder-style method used to set the fields to retain
      *
-     * @param projections
-     *            the projection
-     * @param projectionType
-     *            the projection type
+     * @param fields
+     *            the fields to retain
+     * @return the filter
      */
-    public EventDataQueryFieldFilter(Set<String> projections, Projection.ProjectionType projectionType) {
-        this.keyProjection = new KeyProjection(projections, projectionType);
+    public EventDataQueryFieldFilter withFields(Set<String> fields) {
+        this.fields = new TreeSet<>(fields);
+        return this;
     }
 
     /**
-     * Initiate from a KeyProjection
+     * Builder-style method used to set the maximum next count
      *
-     * @param projection
-     *            the projection
+     * @param maxNextCount
+     *            the max next count
+     * @return the filter
      */
-    public EventDataQueryFieldFilter(KeyProjection projection) {
-        this.keyProjection = projection;
+    public EventDataQueryFieldFilter withMaxNextCount(int maxNextCount) {
+        this.maxNextCount = maxNextCount;
+        return this;
     }
-
-    /**
-     * Initialize the query field filter with all of the fields required to evaluation this query
-     *
-     * @param script
-     *            a script
-     * @param nonEventFields
-     *            a set of non-event fields
-     */
-    @Deprecated
-    public EventDataQueryFieldFilter(ASTJexlScript script, Set<String> nonEventFields) {
-        this.nonEventFields = nonEventFields;
-
-        Set<String> queryFields = Sets.newHashSet();
-        for (ASTIdentifier identifier : JexlASTHelper.getIdentifiers(script)) {
-            queryFields.add(JexlASTHelper.deconstructIdentifier(identifier));
-        }
-
-        this.keyProjection = new KeyProjection(queryFields, Projection.ProjectionType.INCLUDES);
-
-    }
-
-    protected Key document = null;
 
     @Override
     public void startNewDocument(Key document) {
@@ -93,18 +95,39 @@ public class EventDataQueryFieldFilter implements EventDataQueryFilter {
         return true;
     }
 
-    public KeyProjection getProjection() {
-        return keyProjection;
+    @Override
+    public boolean apply(@Nullable Map.Entry<Key,String> entry) {
+        if (entry == null) {
+            return false;
+        }
+        return apply(entry.getKey());
     }
 
     @Override
-    public boolean apply(@Nullable Map.Entry<Key,String> input) {
-        return keyProjection.apply(input);
+    public boolean peek(@Nullable Map.Entry<Key,String> entry) {
+        // equivalent to apply in the event column case, simple redirect
+        return apply(entry);
     }
 
-    @Override
-    public boolean peek(@Nullable Map.Entry<Key,String> input) {
-        return keyProjection.peek(input);
+    /**
+     * The field filter applies if the key's field is in the set of fields to retain
+     *
+     * @param key
+     *            the key
+     * @return true if the key should be retained
+     */
+    private boolean apply(Key key) {
+        parser.parse(key);
+        String field = parser.getField();
+        field = JexlASTHelper.deconstructIdentifier(field);
+
+        if (fields.contains(field)) {
+            nextCount = 0; // reset count
+            return true;
+        } else {
+            nextCount++;
+            return false;
+        }
     }
 
     /**
@@ -120,19 +143,38 @@ public class EventDataQueryFieldFilter implements EventDataQueryFilter {
      */
     @Override
     public Range getSeekRange(Key current, Key endKey, boolean endKeyInclusive) {
-        // not yet implemented
-        return null;
+        if (current == null || maxNextCount == -1 || nextCount < maxNextCount) {
+            return null;
+        }
+
+        parser.parse(current);
+        String higher = fields.higher(parser.getField());
+
+        Text columnQualifier;
+        if (higher == null) {
+            // generate a rollover range
+            Text columnFamily = new Text(current.getColumnFamilyData().toString() + '\u0000');
+            Key start = new Key(current.getRow(), columnFamily);
+            return new Range(start, false, endKey, endKeyInclusive);
+        } else {
+            // seek to next available field
+            columnQualifier = new Text(higher + '\u0000');
+            Key start = new Key(current.getRow(), current.getColumnFamily(), columnQualifier);
+            return new Range(start, false, endKey, endKeyInclusive);
+        }
     }
 
     @Override
     public int getMaxNextCount() {
-        // not yet implemented
+        // while technically implemented, do not return the max next count here. This method is only used
+        // by the ChainableEventDataQueryFilter which does NOT guarantee that the filter will exclusively
+        // be applied to event keys.
         return -1;
     }
 
     @Override
     public Key transform(Key toLimit) {
-        // not yet implemented
+        // not required because the EventDataQueryFieldFilter only operates on event keys
         return null;
     }
 
@@ -140,29 +182,4 @@ public class EventDataQueryFieldFilter implements EventDataQueryFilter {
     public EventDataQueryFilter clone() {
         return new EventDataQueryFieldFilter(this);
     }
-
-    /**
-     * Configure the delegate {@link Projection} with the fields to exclude
-     *
-     * @param excludes
-     *            the set of fields to exclude
-     * @deprecated This method is deprecated and should no longer be used.
-     */
-    @Deprecated
-    public void setExcludes(Set<String> excludes) {
-        this.keyProjection.setExcludes(excludes);
-    }
-
-    /**
-     * Set the delegate {@link Projection} with the fields to include
-     *
-     * @param includedFields
-     *            the sorted set of fields to include
-     * @deprecated This method is deprecated and should no longer be used.
-     */
-    @Deprecated
-    public void setIncludes(Set<String> includedFields) {
-        this.keyProjection.setIncludes(includedFields);
-    }
-
 }

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryFieldFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryFieldFilter.java
@@ -27,6 +27,8 @@ public class EventDataQueryFieldFilter implements EventDataQueryFilter {
     private int maxNextCount = -1;
     // track the number of times next is called on the same field
     private int nextCount;
+    // track the current field
+    private String currentField = null;
 
     // the set of fields to retain
     private TreeSet<String> fields;
@@ -52,8 +54,9 @@ public class EventDataQueryFieldFilter implements EventDataQueryFilter {
         this.maxNextCount = other.maxNextCount;
         this.fields = other.fields;
         this.parser = other.parser;
-        // do not copy nextCount because that is internal state
+        // do not copy nextCount or currentField because that is internal state
         this.nextCount = 0;
+        this.currentField = null;
     }
 
     /**
@@ -125,7 +128,14 @@ public class EventDataQueryFieldFilter implements EventDataQueryFilter {
             nextCount = 0; // reset count
             return true;
         } else {
-            nextCount++;
+            if (currentField != null && currentField.equals(field)) {
+                // only increment the count for consecutive misses within the same field
+                nextCount++;
+            } else {
+                // new field means new count
+                currentField = field;
+                nextCount = 0;
+            }
             return false;
         }
     }

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/EventDataQueryFilter.java
@@ -5,12 +5,9 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Range;
-
-import datawave.query.attributes.Document;
 
 /**
- * This filter will filter event data keys by only those fields that are required in the specified query.
+ * Filters event keys to only the fields required by the specific query.
  */
 public interface EventDataQueryFilter extends PeekingPredicate<Map.Entry<Key,String>>, Filter, SeekingFilter, TransformingFilter, Cloneable {
 
@@ -24,21 +21,21 @@ public interface EventDataQueryFilter extends PeekingPredicate<Map.Entry<Key,Str
 
     /**
      * The apply method is used to determine what gets put into the resulting document and subsequently the jexl context for evaluation. Note that this must
-     * also return those fields that will be eventually returned to the user. The keep method below will filter out that subset. The only caviat to this note is
+     * also return those fields that will be eventually returned to the user. The keep method below will filter out that subset. The only caveat to this note is
      * that if this is being used with a query logic that completely throws away this document in order to return another (e.g.
      * ParentQueryIterator.mapDocument), then this method only needs to allow those fields required for evaluation.
      *
      * @see com.google.common.base.Predicate#apply(Object)
      *
-     * @param var1
+     * @param entry
      *            a map entry
      * @return true if keeping this field for the jexl context
      */
     @Override
-    boolean apply(@Nullable Map.Entry<Key,String> var1);
+    boolean apply(@Nullable Map.Entry<Key,String> entry);
 
     @Override
-    boolean peek(@Nullable Map.Entry<Key,String> var1);
+    boolean peek(@Nullable Map.Entry<Key,String> entry);
 
     /**
      * The keep method is used to filter out those fields returned from the apply method above that will be returned to the user.

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
@@ -154,18 +154,18 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
      * client. If a Key returns true but keep() returns false the document will be used for context evaluation, but will not be returned to the client. If a Key
      * returns true and keep() returns true the key will be used for context evaluation and returned to the client.
      *
-     * @param input
+     * @param entry
      *            an input
      * @return true if Key should be added to context, false otherwise
      */
     @Override
-    public boolean apply(Entry<Key,String> input) {
-        return apply(input, true);
+    public boolean apply(Entry<Key,String> entry) {
+        return apply(entry, true);
     }
 
     @Override
-    public boolean peek(Entry<Key,String> input) {
-        return apply(input, false);
+    public boolean peek(Entry<Key,String> entry) {
+        return apply(entry, false);
     }
 
     private boolean apply(Entry<Key,String> input, boolean update) {

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDFieldIndexQueryFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDFieldIndexQueryFilter.java
@@ -46,24 +46,24 @@ public class TLDFieldIndexQueryFilter implements EventDataQueryFilter {
     /**
      * Always returns true.
      *
-     * @param var1
+     * @param entry
      *            an entry of type Key-Value
      * @return true, always
      */
     @Override
-    public boolean apply(@Nullable Map.Entry<Key,String> var1) {
+    public boolean apply(@Nullable Map.Entry<Key,String> entry) {
         return true;
     }
 
     /**
      * Always returns true
      *
-     * @param var1
+     * @param entry
      *            an entry of type Key-Value
      * @return true, always
      */
     @Override
-    public boolean peek(@Nullable Map.Entry<Key,String> var1) {
+    public boolean peek(@Nullable Map.Entry<Key,String> entry) {
         return true;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilter.java
@@ -10,8 +10,8 @@ import javax.annotation.Nullable;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 
-import datawave.query.attributes.Document;
 import datawave.query.data.parsers.DatawaveKey;
+import datawave.query.jexl.JexlASTHelper;
 
 /**
  * An EventDataQueryFilter for TermFrequencies, for use in a TLDQuery
@@ -19,11 +19,11 @@ import datawave.query.data.parsers.DatawaveKey;
 public class TLDTermFrequencyEventDataQueryFilter implements EventDataQueryFilter {
 
     private final Set<String> indexOnlyFields;
-    private final EventDataQueryFilter attrFilter;
+    private final Set<String> fields;
 
-    public TLDTermFrequencyEventDataQueryFilter(Set<String> indexOnlyFields, EventDataQueryFilter attrFilter) {
+    public TLDTermFrequencyEventDataQueryFilter(Set<String> indexOnlyFields, Set<String> fields) {
         this.indexOnlyFields = indexOnlyFields;
-        this.attrFilter = attrFilter;
+        this.fields = fields;
     }
 
     @Override
@@ -32,13 +32,13 @@ public class TLDTermFrequencyEventDataQueryFilter implements EventDataQueryFilte
     }
 
     @Override
-    public boolean apply(@Nullable Map.Entry<Key,String> var1) {
+    public boolean apply(@Nullable Map.Entry<Key,String> entry) {
         // accept all
         return true;
     }
 
     @Override
-    public boolean peek(@Nullable Map.Entry<Key,String> var1) {
+    public boolean peek(@Nullable Map.Entry<Key,String> entry) {
         // accept all
         return true;
     }
@@ -53,7 +53,13 @@ public class TLDTermFrequencyEventDataQueryFilter implements EventDataQueryFilte
     @Override
     public boolean keep(Key k) {
         DatawaveKey key = new DatawaveKey(k);
-        return (!TLDEventDataFilter.isRootPointer(k) || indexOnlyFields.contains(key.getFieldName())) && attrFilter.peek(new SimpleEntry(k, null));
+        return (!TLDEventDataFilter.isRootPointer(k) || indexOnlyFields.contains(key.getFieldName())) && fieldMatches(k);
+    }
+
+    private boolean fieldMatches(Key key) {
+        DatawaveKey parser = new DatawaveKey(key);
+        String fieldName = JexlASTHelper.deconstructIdentifier(parser.getFieldName());
+        return fields.contains(fieldName);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -1523,6 +1523,14 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
         getConfig().setTfNextSeek(tfNextSeek);
     }
 
+    public boolean isSeekingEventAggregation() {
+        return getConfig().isSeekingEventAggregation();
+    }
+
+    public void setSeekingEventAggregation(boolean seekingEventAggregation) {
+        getConfig().setSeekingEventAggregation(seekingEventAggregation);
+    }
+
     public String getdisallowlistedFieldsString() {
         return getConfig().getDisallowlistedFieldsAsString();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDIndexBuildingVisitor.java
@@ -200,20 +200,19 @@ public class TLDIndexBuildingVisitor extends IteratorBuildingVisitor {
      *
      * @param identifier
      *            the field to be aggregated
-     * @param filter
+     * @param filterChain
      *            a {@link ChainableEventDataQueryFilter}
      * @param maxNextCount
      *            the maximum number of next calls before a seek is issued
      * @return a {@link TermFrequencyAggregator} loaded with the provided filter
      */
     @Override
-    protected TermFrequencyAggregator buildTermFrequencyAggregator(String identifier, ChainableEventDataQueryFilter filter, int maxNextCount) {
-
-        filter.addFilter(new TLDTermFrequencyEventDataQueryFilter(indexOnlyFields, attrFilter));
+    protected TermFrequencyAggregator buildTermFrequencyAggregator(String identifier, ChainableEventDataQueryFilter filterChain, int maxNextCount) {
 
         Set<String> toAggregate = fieldsToAggregate.contains(identifier) ? Collections.singleton(identifier) : Collections.emptySet();
+        filterChain.addFilter(new TLDTermFrequencyEventDataQueryFilter(indexOnlyFields, toAggregate));
 
-        return new TLDTermFrequencyAggregator(toAggregate, filter, tfNextSeek);
+        return new TLDTermFrequencyAggregator(toAggregate, filterChain, tfNextSeek);
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDQueryIterator.java
@@ -31,6 +31,7 @@ import datawave.query.function.TLDEquality;
 import datawave.query.function.TLDRangeProvider;
 import datawave.query.iterator.NestedIterator;
 import datawave.query.iterator.QueryIterator;
+import datawave.query.iterator.QueryOptions;
 import datawave.query.iterator.SourcedOptions;
 import datawave.query.iterator.logic.IndexIterator;
 import datawave.query.jexl.functions.FieldIndexAggregator;
@@ -133,6 +134,15 @@ public class TLDQueryIterator extends QueryIterator {
                             limitFieldsPreQueryEvaluation ? limitFieldsMap : Collections.emptyMap(), limitFieldsField, getNonEventFields());
         }
         return this.evaluationFilter != null ? evaluationFilter.clone() : null;
+    }
+
+    /**
+     * In the TLD case replace the {@link QueryOptions#eventFilter} with an evaluation filter
+     *
+     * @return an evaluation filter
+     */
+    public EventDataQueryFilter getEventFilter() {
+        return getEvaluationFilter();
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/LongRunningQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LongRunningQueryTest.java
@@ -6,13 +6,11 @@ import static org.junit.Assert.assertTrue;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -22,9 +20,6 @@ import org.apache.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 import datawave.core.common.connection.AccumuloConnectionFactory;
@@ -36,8 +31,6 @@ import datawave.marking.MarkingFunctions;
 import datawave.microservice.query.QueryImpl;
 import datawave.microservice.query.config.QueryExpirationProperties;
 import datawave.microservice.querymetric.QueryMetricFactoryImpl;
-import datawave.query.attributes.UniqueFields;
-import datawave.query.attributes.UniqueGranularity;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.DateIndexHelperFactory;

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -478,6 +478,8 @@ public class ShardQueryConfigurationTest {
         updatedValues.put("tfFieldSeek", 14);
         defaultValues.put("tfNextSeek", -1);
         updatedValues.put("tfNextSeek", 15);
+        defaultValues.put("seekingEventAggregation", false);
+        updatedValues.put("seekingEventAggregation", true);
         defaultValues.put("visitorFunctionMaxWeight", 5000000L);
         updatedValues.put("visitorFunctionMaxWeight", 1000000L);
         defaultValues.put("lazySetMechanismEnabled", false);

--- a/warehouse/query-core/src/test/java/datawave/query/function/KeyToDocumentDataTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/KeyToDocumentDataTest.java
@@ -23,8 +23,6 @@ import datawave.query.data.parsers.EventKey;
 import datawave.query.iterator.aggregation.DocumentData;
 import datawave.query.predicate.EventDataQueryFieldFilter;
 import datawave.query.predicate.EventDataQueryFilter;
-import datawave.query.predicate.KeyProjection;
-import datawave.query.predicate.Projection;
 
 public class KeyToDocumentDataTest {
 
@@ -49,15 +47,13 @@ public class KeyToDocumentDataTest {
 
     @Test
     public void testEventData_defaultEquality_withFilter() {
-        KeyProjection projection = new KeyProjection(Set.of("FIELD_A", "FIELD_B"), Projection.ProjectionType.INCLUDES);
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(projection);
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A", "FIELD_B"));
         KeyToDocumentData data = new KeyToDocumentData(getSource(), equality, filter, false, false).withRangeProvider(rangeProvider);
         drive(data, getEntry(), 2);
         assertFields(Set.of("FIELD_A", "FIELD_B"));
 
         // exclusive filter should result with nothing
-        projection = new KeyProjection(Set.of("FIELD_Z"), Projection.ProjectionType.INCLUDES);
-        filter = new EventDataQueryFieldFilter(projection);
+        filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_Z"));
         data = new KeyToDocumentData(getSource(), equality, filter, false, false).withRangeProvider(rangeProvider);
         drive(data, getEntry(), 0);
         assertFields(Set.of());
@@ -72,8 +68,7 @@ public class KeyToDocumentDataTest {
 
     @Test
     public void testEventData_TLDEquality_withFilter() {
-        KeyProjection projection = new KeyProjection(Set.of("FIELD_A", "FIELD_B"), Projection.ProjectionType.INCLUDES);
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(projection);
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A", "FIELD_B"));
         KeyToDocumentData data = new KeyToDocumentData(getSource(), tldEquality, filter, false, false).withRangeProvider(rangeProvider);
         drive(data, getEntry(), 2);
         assertFields(Set.of("FIELD_A", "FIELD_B"));
@@ -89,8 +84,7 @@ public class KeyToDocumentDataTest {
 
     @Test
     public void testTLDData_defaultEquality_withFilter() {
-        KeyProjection projection = new KeyProjection(Set.of("FIELD_A", "FIELD_B"), Projection.ProjectionType.INCLUDES);
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(projection);
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A", "FIELD_B"));
         KeyToDocumentData data = new KeyToDocumentData(getTLDSource(), equality, filter, false, false).withRangeProvider(tldRangeProvider);
         drive(data, getEntry(), 2);
         assertFields(Set.of("FIELD_A", "FIELD_B"));
@@ -105,8 +99,7 @@ public class KeyToDocumentDataTest {
 
     @Test
     public void testTLDData_TLDEquality_withFilter() {
-        KeyProjection projection = new KeyProjection(Set.of("FIELD_A", "FIELD_B"), Projection.ProjectionType.INCLUDES);
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(projection);
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A", "FIELD_B"));
         KeyToDocumentData data = new KeyToDocumentData(getTLDSource(), tldEquality, filter, false, false).withRangeProvider(tldRangeProvider);
         drive(data, getEntry(), 4);
         assertFields(Set.of("FIELD_A", "FIELD_B"));

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
@@ -6,10 +6,13 @@ import static datawave.query.iterator.QueryOptions.EVENT_NEXT_SEEK;
 import static datawave.query.iterator.QueryOptions.FI_FIELD_SEEK;
 import static datawave.query.iterator.QueryOptions.FI_NEXT_SEEK;
 import static datawave.query.iterator.QueryOptions.QUERY;
+import static datawave.query.iterator.QueryOptions.SEEKING_EVENT_AGGREGATION;
 import static datawave.query.iterator.QueryOptions.TERM_FREQUENCY_AGGREGATION_THRESHOLD_MS;
 import static datawave.query.iterator.QueryOptions.TF_FIELD_SEEK;
 import static datawave.query.iterator.QueryOptions.TF_NEXT_SEEK;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -127,6 +130,7 @@ public class QueryOptionsTest {
         optionsMap.put(EVENT_NEXT_SEEK, "13");
         optionsMap.put(TF_FIELD_SEEK, "14");
         optionsMap.put(TF_NEXT_SEEK, "15");
+        optionsMap.put(SEEKING_EVENT_AGGREGATION, "true");
 
         QueryOptions options = new QueryOptions();
 
@@ -137,6 +141,7 @@ public class QueryOptionsTest {
         assertEquals(-1, options.getEventNextSeek());
         assertEquals(-1, options.getTfFieldSeek());
         assertEquals(-1, options.getTfNextSeek());
+        assertFalse(options.isSeekingEventAggregation());
 
         options.validateOptions(optionsMap);
 
@@ -147,6 +152,7 @@ public class QueryOptionsTest {
         assertEquals(13, options.getEventNextSeek());
         assertEquals(14, options.getTfFieldSeek());
         assertEquals(15, options.getTfNextSeek());
+        assertTrue(options.isSeekingEventAggregation());
     }
 
     @Test
@@ -177,7 +183,7 @@ public class QueryOptionsTest {
     }
 
     @Test
-    public void testSimple() throws IOException {
+    public void testSimple() {
         Map<String,Set<String>> expected = new HashMap<>();
 
         expected.put("FIELD1", new HashSet<>(Arrays.asList("norm1", "norm2")));

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/TermFrequencyAggregatorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/TermFrequencyAggregatorTest.java
@@ -17,21 +17,17 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
-import org.apache.commons.jexl3.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import datawave.query.Constants;
 import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
 import datawave.query.data.parsers.DatawaveKey;
-import datawave.query.jexl.JexlASTHelper;
 import datawave.query.predicate.EventDataQueryFieldFilter;
 import datawave.query.predicate.EventDataQueryFilter;
-import datawave.query.predicate.Projection;
 import datawave.query.util.TypeMetadata;
 
 public class TermFrequencyAggregatorTest {
@@ -57,7 +53,7 @@ public class TermFrequencyAggregatorTest {
         Set<String> keepFields = new HashSet<>();
         keepFields.add("FIELD2");
 
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(Sets.newHashSet("FIELD1"), Projection.ProjectionType.EXCLUDES);
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Collections.singleton("FIELD1"));
 
         aggregator = new TermFrequencyAggregator(keepFields, filter, -1);
         Key result = aggregator.apply(itr, doc, attributeFactory);
@@ -74,7 +70,7 @@ public class TermFrequencyAggregatorTest {
     }
 
     @Test
-    public void apply_buildDocKeep() throws IOException, ParseException {
+    public void apply_buildDocKeep() throws IOException {
         Document doc = new Document();
         AttributeFactory attributeFactory = new AttributeFactory(new TypeMetadata());
 
@@ -88,7 +84,7 @@ public class TermFrequencyAggregatorTest {
         Set<String> keepFields = new HashSet<>();
         keepFields.add("FIELD1");
 
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(JexlASTHelper.parseJexlQuery("FIELD1 == 'VALUE1'"), Collections.emptySet());
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Collections.singleton("FIELD1"));
         aggregator = new TermFrequencyAggregator(keepFields, filter, -1);
         Key result = aggregator.apply(itr, doc, attributeFactory);
 
@@ -111,7 +107,7 @@ public class TermFrequencyAggregatorTest {
     }
 
     @Test
-    public void apply_buildDocKeepFilteredOut() throws IOException, ParseException {
+    public void apply_buildDocKeepFilteredOut() throws IOException {
         Document doc = new Document();
         AttributeFactory attributeFactory = new AttributeFactory(new TypeMetadata());
 
@@ -125,7 +121,7 @@ public class TermFrequencyAggregatorTest {
         Set<String> keepFields = new HashSet<>();
         keepFields.add("FIELD2");
 
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(JexlASTHelper.parseJexlQuery("FIELD2 == 'VALUE1'"), Collections.EMPTY_SET);
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Collections.singleton("FIELD2"));
         aggregator = new TermFrequencyAggregator(keepFields, filter, -1);
         Key result = aggregator.apply(itr, doc, attributeFactory);
 

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/EventDataQueryFieldFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/EventDataQueryFieldFilterTest.java
@@ -1,0 +1,99 @@
+package datawave.query.predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.junit.jupiter.api.Test;
+
+public class EventDataQueryFieldFilterTest {
+
+    @Test
+    public void testFieldAccept() {
+        EventDataQueryFieldFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A"));
+
+        assertTrue(filter.apply(createEntry("FIELD_A")));
+        assertTrue(filter.apply(createEntry("FIELD_A")));
+        assertTrue(filter.apply(createEntry("FIELD_A")));
+    }
+
+    @Test
+    public void testFieldRejection_sameFieldRepeated() {
+        EventDataQueryFieldFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A"));
+
+        Map.Entry<Key,String> entry = createEntry("FIELD_B");
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+        assertNull(filter.getSeekRange(entry.getKey(), null, false));
+    }
+
+    @Test
+    public void testFieldRejection_differentFieldRepeated() {
+        EventDataQueryFieldFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A"));
+
+        Map.Entry<Key,String> entry = createEntry("FIELD_B");
+        assertFalse(filter.apply(createEntry("FIELD_B")));
+        assertFalse(filter.apply(createEntry("FIELD_C")));
+        assertFalse(filter.apply(createEntry("FIELD_D")));
+        assertNull(filter.getSeekRange(entry.getKey(), null, false));
+    }
+
+    // tests the case where no key is accepted and the filter seeks to the first field
+    @Test
+    public void testGetSeekRange_seekForwardToFirstField() {
+        EventDataQueryFieldFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_B")).withMaxNextCount(1);
+
+        Map.Entry<Key,String> entry = createEntry("FIELD_A");
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+
+        Range range = filter.getSeekRange(entry.getKey(), null, false);
+        assertSeekRangeStartKey(range, new Key("row", "datatype\0uid", "FIELD_B\0"));
+    }
+
+    // tests the case where some keys were accepted and the filter seeks to the second field
+    @Test
+    public void testGetSeekRange_seekToSecondField() {
+        EventDataQueryFieldFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_B", "FIELD_D")).withMaxNextCount(1);
+
+        Map.Entry<Key,String> entry = createEntry("FIELD_C");
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+
+        Range range = filter.getSeekRange(entry.getKey(), null, false);
+        assertSeekRangeStartKey(range, new Key("row", "datatype\0uid", "FIELD_D\0"));
+    }
+
+    @Test
+    public void testGetSeekRange_rolloverRange() {
+        EventDataQueryFieldFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD_A", "FIELD_B")).withMaxNextCount(1);
+
+        Map.Entry<Key,String> entry = createEntry("FIELD_C");
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+        assertFalse(filter.apply(entry));
+
+        Range range = filter.getSeekRange(entry.getKey(), null, false);
+        assertSeekRangeStartKey(range, new Key("row", "datatype\0uid\0"));
+    }
+
+    private Map.Entry<Key,String> createEntry(String field) {
+        Key key = new Key("row", "datatype\u0000uid", field + "\u0000value");
+        return new AbstractMap.SimpleEntry<>(key, "");
+    }
+
+    private void assertSeekRangeStartKey(Range range, Key expected) {
+        assertEquals(expected, range.getStartKey());
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilterTest.java
@@ -7,13 +7,9 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
-import org.apache.commons.jexl3.parser.ParseException;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
-
-import datawave.query.jexl.JexlASTHelper;
 
 public class TLDTermFrequencyEventDataQueryFilterTest {
 
@@ -26,14 +22,9 @@ public class TLDTermFrequencyEventDataQueryFilterTest {
     private final Key childField3 = new Key("row", "fi\0FIELD3", "value\0datatype\0d8zay2.-3pnndm.-anolok.45");
 
     @Test
-    public void testTLDTermFrequencyEventDataQueryFilter() throws ParseException {
-
-        String query = "FIELD1 == 'value'";
-        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(query);
-        EventDataQueryFieldFilter fieldFilter = new EventDataQueryFieldFilter(script, Collections.emptySet());
-
+    public void testTLDTermFrequencyEventDataQueryFilter() {
         Set<String> indexOnlyFields = Sets.newHashSet("FIELD1", "FIELD2");
-        TLDTermFrequencyEventDataQueryFilter filter = new TLDTermFrequencyEventDataQueryFilter(indexOnlyFields, fieldFilter);
+        TLDTermFrequencyEventDataQueryFilter filter = new TLDTermFrequencyEventDataQueryFilter(indexOnlyFields, Set.of("FIELD1"));
 
         // retain query index-only fields in the tld
         assertTrue(filter.keep(tldField1));

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/QueryLogicTestHarness.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/QueryLogicTestHarness.java
@@ -12,7 +12,6 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.log4j.Logger;

--- a/warehouse/query-core/src/test/java/datawave/query/tld/TLDTermFrequencyAggregatorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tld/TLDTermFrequencyAggregatorTest.java
@@ -22,7 +22,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
-import org.apache.commons.jexl3.parser.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +32,6 @@ import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.TypeAttribute;
 import datawave.query.data.parsers.DatawaveKey;
-import datawave.query.jexl.JexlASTHelper;
 import datawave.query.predicate.EventDataQueryFieldFilter;
 import datawave.query.predicate.EventDataQueryFilter;
 import datawave.query.util.TypeMetadata;
@@ -47,7 +45,7 @@ public class TLDTermFrequencyAggregatorTest {
     }
 
     @Test
-    public void apply_buildDocNotKeep() throws IOException, ParseException {
+    public void apply_buildDocNotKeep() throws IOException {
         Document doc = new Document();
         AttributeFactory attributeFactory = new AttributeFactory(new TypeMetadata());
 
@@ -72,7 +70,7 @@ public class TLDTermFrequencyAggregatorTest {
         Set<String> keepFields = new HashSet<>();
         keepFields.add("FIELD2");
 
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(JexlASTHelper.parseJexlQuery("FIELD2 == 'abc'"), Collections.emptySet());
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Collections.singleton("FIELD2"));
         aggregator = new TLDTermFrequencyAggregator(keepFields, filter, -1);
         Key result = aggregator.apply(itr, doc, attributeFactory);
 
@@ -88,7 +86,7 @@ public class TLDTermFrequencyAggregatorTest {
     }
 
     @Test
-    public void apply_buildDocKeep() throws IOException, ParseException {
+    public void apply_buildDocKeep() throws IOException {
         Document doc = new Document();
         AttributeFactory attributeFactory = new AttributeFactory(new TypeMetadata());
 
@@ -114,8 +112,7 @@ public class TLDTermFrequencyAggregatorTest {
         keepFields.add("FIELD1");
         keepFields.add("FIELD2");
 
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(JexlASTHelper.parseJexlQuery("FIELD1 == 'VALUE1' && FIELD2 == 'VALUE2'"),
-                        Collections.emptySet());
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Set.of("FIELD1", "FIELD2"));
         aggregator = new TLDTermFrequencyAggregator(keepFields, filter, -1);
         Key result = aggregator.apply(itr, doc, attributeFactory);
 
@@ -159,7 +156,7 @@ public class TLDTermFrequencyAggregatorTest {
     }
 
     @Test
-    public void apply_buildDocOnlyKeepToKeep() throws IOException, ParseException {
+    public void apply_buildDocOnlyKeepToKeep() throws IOException {
         Document doc = new Document();
         AttributeFactory attributeFactory = new AttributeFactory(new TypeMetadata());
 
@@ -174,7 +171,7 @@ public class TLDTermFrequencyAggregatorTest {
         Set<String> keepFields = new HashSet<>();
         keepFields.add("FIELD2");
 
-        EventDataQueryFilter filter = new EventDataQueryFieldFilter(JexlASTHelper.parseJexlQuery("FIELD2 == 'VALUE1'"), Collections.emptySet());
+        EventDataQueryFilter filter = new EventDataQueryFieldFilter().withFields(Collections.singleton("FIELD2"));
         aggregator = new TLDTermFrequencyAggregator(keepFields, filter, -1);
         Key result = aggregator.apply(itr, doc, attributeFactory);
 

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -128,6 +128,7 @@
         <property name="queryPlanner" ref="DefaultQueryPlanner" />
         <!--<property name="queryMacroFunction" ref="queryMacroFunction" />-->
         <property name="markingFunctions" ref="markingFunctions" />
+        <property name="eventFieldSeek" value="3" />
     </bean>
 
     <util:list id="IvaratorCacheDirConfigs">

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -242,7 +242,7 @@
         <!--   variables that control when a seek is issued     -->
         <property name="fiFieldSeek" value="-1" />
         <property name="fiNextSeek" value="-1" />
-        <property name="eventFieldSeek" value="-1" />
+        <property name="eventFieldSeek" value="3" />
         <property name="eventNextSeek" value="-1" />
         <property name="tfFieldSeek" value="-1" />
         <property name="tfNextSeek" value="-1" />


### PR DESCRIPTION
- EventDataQueryFieldFilter now supports seeking aggregation when possible
- feature flagged this behavior, default is to not seek
- option is configurable via the query logic factory, including lookup uuid tune profiles
- refactored a bunch of stuff to support