### PR TITLE
Refactor ContentFunctionsDescriptor.fieldsAndTerms()

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypeVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IngestTypeVisitor.java
@@ -391,7 +391,7 @@ public class IngestTypeVisitor extends BaseVisitor {
         if (visitor.namespace().equals(CONTENT_FUNCTION_NAMESPACE)) {
             // all content function fields are added
             ContentFunctionsDescriptor.ContentJexlArgumentDescriptor contentDescriptor = new ContentFunctionsDescriptor().getArgumentDescriptor(node);
-            return contentDescriptor.fieldsAndTerms(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), null)[0];
+            return contentDescriptor.fieldsAndTerms(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), null).getFields();
         } else {
             JexlArgumentDescriptor descriptor = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(node);
             if (descriptor == null) {

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/DocumentKeysFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/DocumentKeysFunction.java
@@ -48,7 +48,7 @@ public class DocumentKeysFunction {
 
         ContentFunctionsDescriptor descriptor = new ContentFunctionsDescriptor();
         ContentJexlArgumentDescriptor argsDescriptor;
-        Set<String>[] fieldsAndTerms;
+        ContentFunctionsDescriptor.FieldTerms fieldsAndTerms;
         JexlNode parent;
         String field;
 
@@ -67,12 +67,12 @@ public class DocumentKeysFunction {
                 // content, tf, and indexed fields are not actually needed to extract fields from the function node
                 fieldsAndTerms = argsDescriptor.fieldsAndTerms(Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), null);
 
-                if (fieldsAndTerms[0].size() != 1) {
+                if (fieldsAndTerms.totalFields() != 1) {
                     throw new IllegalStateException("content function had more than one field");
                 }
 
-                field = JexlASTHelper.deconstructIdentifier(fieldsAndTerms[0].iterator().next());
-                ContentFunction contentFunction = new ContentFunction(field, fieldsAndTerms[1]);
+                field = JexlASTHelper.deconstructIdentifier(fieldsAndTerms.getFields().iterator().next());
+                ContentFunction contentFunction = new ContentFunction(field, fieldsAndTerms.getTerms());
                 contentFunctions.put(contentFunction.getField(), contentFunction);
 
                 if (isFunctionNegated(f)) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionsDescriptorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionsDescriptorTest.java
@@ -88,29 +88,31 @@ class ContentFunctionsDescriptorTest {
     @Test
     @SuppressWarnings("unchecked")
     void testFieldsAndTerms() {
-        assertFieldsAndTerms(getDescriptor(unfieldedPhrase), new Set[] {Set.of(), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(fieldedPhrase), new Set[] {Set.of("FIELD"), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(multiFieldedPhrase), new Set[] {Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar")});
+        assertFieldsAndTerms(getDescriptor(unfieldedPhrase), Set.of(), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(fieldedPhrase), Set.of("FIELD"), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(multiFieldedPhrase), Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar"));
 
-        assertFieldsAndTerms(getDescriptor(unfieldedScoredPhrase), new Set[] {Set.of(), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(fieldedScoredPhrase), new Set[] {Set.of("FIELD"), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(multiFieldedScoredPhrase), new Set[] {Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar")});
+        assertFieldsAndTerms(getDescriptor(unfieldedScoredPhrase), Set.of(), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(fieldedScoredPhrase), Set.of("FIELD"), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(multiFieldedScoredPhrase), Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar"));
 
-        assertFieldsAndTerms(getDescriptor(unfieldedAdjacent), new Set[] {Set.of(), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(fieldedAdjacent), new Set[] {Set.of("FIELD"), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(multiFieldedAdjacent), new Set[] {Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar")});
+        assertFieldsAndTerms(getDescriptor(unfieldedAdjacent), Set.of(), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(fieldedAdjacent), Set.of("FIELD"), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(multiFieldedAdjacent), Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar"));
 
-        assertFieldsAndTerms(getDescriptor(unfieldedWithin), new Set[] {Set.of(), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(fieldedWithin), new Set[] {Set.of("FIELD"), Set.of("foo", "bar")});
-        assertFieldsAndTerms(getDescriptor(multiFieldedWithin), new Set[] {Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar")});
+        assertFieldsAndTerms(getDescriptor(unfieldedWithin), Set.of(), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(fieldedWithin), Set.of("FIELD"), Set.of("foo", "bar"));
+        assertFieldsAndTerms(getDescriptor(multiFieldedWithin), Set.of("FIELD_A", "FIELD_B"), Set.of("foo", "bar"));
     }
 
-    private void assertFieldsAndTerms(ContentJexlArgumentDescriptor jexlDescriptor, Set<String>[] expected) {
-        Set<String>[] fieldsAndTerms = jexlDescriptor.fieldsAndTerms(Set.of(), Set.of(), Set.of(), new MutableBoolean(true));
-        assertArrayEquals(expected, fieldsAndTerms);
+    private void assertFieldsAndTerms(ContentJexlArgumentDescriptor jexlDescriptor, Set<String> fields, Set<String> terms) {
+        ContentFunctionsDescriptor.FieldTerms fieldsAndTerms = jexlDescriptor.fieldsAndTerms(Set.of(), Set.of(), Set.of(), new MutableBoolean(true));
+        assertEquals(fields, fieldsAndTerms.getFields());
+        assertEquals(terms, fieldsAndTerms.getTerms());
 
         fieldsAndTerms = jexlDescriptor.fieldsAndTerms(Set.of(), Set.of(), Set.of(), new MutableBoolean(true), false);
-        assertArrayEquals(expected, fieldsAndTerms);
+        assertEquals(fields, fieldsAndTerms.getFields());
+        assertEquals(terms, fieldsAndTerms.getTerms());
     }
 
     @Test


### PR DESCRIPTION
Refactor the method ContentFunctionsDescriptor.fieldsAndTerms() to reduce the cognitive complexity as measured by SolarLint from 97 to within the target of 15.

Fixes #2456