### PR TITLE
stop logging big documents at error level

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -210,27 +210,8 @@ public class Document extends AttributeBag<Document> implements Serializable {
     }
 
     public void debugDocumentSize(Key docKey) {
-        long bytes = sizeInBytes();
-        // if more than 100M, then error
-        if (bytes > (ONE_HUNDRED_M)) {
-            log.error("Document " + docKey + "; size = " + size() + "; bytes = " + bytes);
-        }
-        // if more than 10M, then warn
-        // else if (bytes > (1024l * 1000 * 10)) {
-        // log.warn("Document " + docKey + "; size = " + size() + "; bytes = " + bytes);
-        // }
-
-        // if more than 1M, then info
-        else if (bytes > (ONE_M)) {
-            log.info("Document " + docKey + "; size = " + size() + "; bytes = " + bytes);
-        }
-        // if more than 500K, then debug
-        else if (bytes > (FIVE_HUNDRED_K) && log.isDebugEnabled()) {
-            log.debug("Document " + docKey + "; size = " + size() + "; bytes = " + bytes);
-        }
-        // trace everything
-        else if (log.isTraceEnabled()) {
-            log.trace("Document " + docKey + "; size = " + size() + "; bytes = " + bytes);
+        if (log.isDebugEnabled()) {
+            log.debug("Document " + docKey + "; size = " + size() + "; bytes = " + sizeInBytes());
         }
     }
 


### PR DESCRIPTION
stop logging big documents at error level. there is no reason to.