### PR TITLE
Replace usage of non-public Accumulo API PeekingIterator

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardLimitingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardLimitingIterator.java
@@ -9,7 +9,7 @@ import java.util.Queue;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.PeekingIterator;
+import org.apache.commons.collections4.iterators.PeekingIterator;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/ShardRangeStream.java
@@ -12,7 +12,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.PeekingIterator;
+import org.apache.commons.collections4.iterators.PeekingIterator;
 import org.apache.commons.jexl3.parser.JexlNode;
 
 import com.google.common.base.Function;

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
@@ -28,7 +28,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.PeekingIterator;
+import org.apache.commons.collections4.iterators.PeekingIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;


### PR DESCRIPTION
org.apache.accumulo.core.util.PeekingIterator is part of Accumulo's non-public API. Replace all usages of it with
org.apache.commons.collections4.iterators.PeekingIterator.

Part of work for #2443