### PR TITLE
Specify release flag to build on newer JDKs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: true
   
 env:
-  JAVA_VERSION: '11'
-  JAVA_DISTRIBUTION: 'zulu' #This is the default on v1 of the action for 1.8
+  JAVA_VERSION: '17'
+  JAVA_DISTRIBUTION: 'adopt'
   MAVEN_OPTS: "-Djansi.force=true -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true -XX:ThreadStackSize=1m"
 
 jobs:

--- a/microservices/configcheck/pom.xml
+++ b/microservices/configcheck/pom.xml
@@ -13,9 +13,9 @@
         </repository>
     </distributionManagement>
     <properties>
-        <java.version>11</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spotbugs.excludes.file />
@@ -266,10 +266,6 @@
                 <configuration>
                     <configFile>eclipse/Eclipse-Datawave-Codestyle.xml</configFile>
                     <lineEnding>LF</lineEnding>
-                    <removeTrailingWhitespace>true</removeTrailingWhitespace>
-                    <compilerSource>${maven.compiler.source}</compilerSource>
-                    <compilerCompliance>${maven.compiler.source}</compilerCompliance>
-                    <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <url>https://code.nsa.gov/datawave</url>
     <licenses>
         <license>
-            <name>The Apache License, Version 2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
     <modules>
@@ -37,9 +37,12 @@
         <argLine />
         <!-- build.env and env should get overridden if any other read-properties profile is specified (e.g. comnpose)compose -->
         <build.env>dev</build.env>
+        <!-- suppress noise about missing javadocs, but keep other javadoc warnings -->
+        <doclint>all,-missing</doclint>
         <env>dev</env>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.exclusions>**/StandardLexer.java,**/*.js,**/*.css,**/*.html</sonar.exclusions>
@@ -1685,10 +1688,6 @@
                     <configuration>
                         <configFile>eclipse/Eclipse-Datawave-Codestyle.xml</configFile>
                         <lineEnding>LF</lineEnding>
-                        <removeTrailingWhitespace>true</removeTrailingWhitespace>
-                        <compilerSource>${maven.compiler.source}</compilerSource>
-                        <compilerCompliance>${maven.compiler.source}</compilerCompliance>
-                        <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
                     </configuration>
                     <dependencies>
                         <dependency>
@@ -1761,11 +1760,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.14.0</version>
                     <configuration>
-                        <encoding>UTF-8</encoding>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
                         <compilerArgs>
                             <arg>-Xlint:all</arg>
                             <arg>-Xlint:-processing</arg>
@@ -1899,7 +1895,6 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                     <configuration>
-                        <encoding>UTF-8</encoding>
                         <escapeString>\</escapeString>
                     </configuration>
                     <dependencies>
@@ -1995,10 +1990,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
@@ -2127,7 +2118,6 @@
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>
-                                    <encoding>UTF-8</encoding>
                                     <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
                                     <additionalJOption>-J-Xmx768m</additionalJOption>
                                     <tags>

--- a/warehouse/ingest-ssdeep/pom.xml
+++ b/warehouse/ingest-ssdeep/pom.xml
@@ -8,8 +8,9 @@
     </parent>
     <artifactId>datawave-ingest-ssdeep</artifactId>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/warehouse/query-core/src/main/java/datawave/query/common/grouping/DocumentGrouper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/common/grouping/DocumentGrouper.java
@@ -36,8 +36,8 @@ import datawave.query.attributes.TypeAttribute;
 /**
  * This class provides the primary functionality needed to group documents and aggregate field values within identified groups (regardless if done server or
  * client-side).
- * <H2>Grouping</H2>
- * <P>
+ * <h2>Grouping</h2>
+ * <p>
  * Grouping fields across documents will result in groupings of distinct value groupings for each specified field to group, as well as the total number of times
  * each particular grouping combination was seen. Fields to group by can be specified by the following options:
  * <ul>
@@ -57,11 +57,11 @@ import datawave.query.attributes.TypeAttribute;
  * Values of fields with the same context and instance are considered direct one-to-one grouping matches, and will be placed within the same groupings. Direct
  * matches cannot be determined for values of fields that do not have a context, and as such they will be combined with each possible grouping, effectively a
  * cartesian product. Direct matches are prioritized and found first before indirect matches are combined with them.
- * <H2>Aggregation</H2>
- * <P>
+ * <h2>Aggregation</h2>
+ * <p>
  * Once all valid groupings have been identified and counted, aggregation can be performed on the values of any specified fields for each grouping. The
  * aggregation fields can differ from the group-by fields. The following aggregation operations are supported:
- * <P>
+ * <p>
  * <strong>SUM</strong>: Sum up all the values for specified fields across groupings. This operation is limited to fields with numerical values. Fields may be
  * specified via:
  * <ul>
@@ -94,8 +94,8 @@ import datawave.query.attributes.TypeAttribute;
  * <li>The JEXL function {@code f:average()}.</li>
  * <li>The query parameter {@code average.fields}.</li>
  * </ul>
- * <H2>Model Mapping Notes</H2>
- * <P>
+ * <h2>Model Mapping Notes</h2>
+ * <p>
  * It is possible to supply a mapping model mappings derived from the query model. If supplied, the field names of entries will be mapped to their respective
  * root model mapping (if one exists) before they are grouped or aggregated. It is important to note that it is possible for multiple fields in a document to be
  * mapped to the same root model mapping. In this case, if multiple fields with the same value in a document are mapped to the same root model mapping, they

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -133,7 +133,7 @@ import datawave.util.StringUtils;
  *
  * <br>
  *
- * <h1>Document Keys</h1>
+ * <h2>Document Keys</h2>
  * <p>
  * The source of Document Keys is one of the following:
  * <ol>
@@ -145,7 +145,7 @@ import datawave.util.StringUtils;
  *
  * <br>
  *
- * <h1>Transformations/Predicates</h1>
+ * <h2>Transformations/Predicates</h2>
  * <p>
  * The following transformations/predicates are applied (order sensitive):
  * <ol>

--- a/warehouse/query-core/src/main/java/datawave/query/tables/BaseRemoteQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/BaseRemoteQueryLogic.java
@@ -25,7 +25,7 @@ import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.GenericResponse;
 
 /**
- * <h1>Overview</h1> This is a base query logic implementation that can handle delegating to a remote query logic
+ * <h2>Overview</h2> This is a base query logic implementation that can handle delegating to a remote query logic
  */
 public abstract class BaseRemoteQueryLogic<T> extends BaseQueryLogic<T> implements RemoteQueryLogic<T> {
 

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEdgeQueryLogic.java
@@ -23,7 +23,7 @@ import datawave.webservice.query.result.edge.EdgeBase;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 
 /**
- * <h1>Overview</h1> This is a query logic implementation that can handle delegating to a remote edge query logic (i.e. one that returns an extension of
+ * <h2>Overview</h2> This is a query logic implementation that can handle delegating to a remote edge query logic (i.e. one that returns an extension of
  * EdgeQueryResponseBase).
  */
 public class RemoteEdgeQueryLogic extends BaseRemoteQueryLogic<EdgeBase> implements RemoteQueryLogic<EdgeBase> {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEventQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RemoteEventQueryLogic.java
@@ -23,7 +23,7 @@ import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.EventQueryResponseBase;
 
 /**
- * <h1>Overview</h1> This is a query logic implementation that can handle delegating to a remote event query logic (i.e. one that returns an extension of
+ * <h2>Overview</h2> This is a query logic implementation that can handle delegating to a remote event query logic (i.e. one that returns an extension of
  * EventQueryResponseBase).
  */
 public class RemoteEventQueryLogic extends BaseRemoteQueryLogic<EventBase> {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -126,7 +126,7 @@ import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.QueryValidationResponse;
 
 /**
- * <h1>Overview</h1> QueryTable implementation that works with the JEXL grammar. This QueryTable uses the DATAWAVE metadata, global index, and sharded event
+ * <h2>Overview</h2> QueryTable implementation that works with the JEXL grammar. This QueryTable uses the DATAWAVE metadata, global index, and sharded event
  * table to return results based on the query. The runServerQuery method is the main method that is called from the web service, and it contains the logic used
  * to run the queries against ACCUMULO. Example queries:
  *
@@ -153,10 +153,10 @@ import datawave.webservice.result.QueryValidationResponse;
  * Custom functions can be created and registered with the Jexl engine. The functions can be used in the queries in conjunction with other supported operators.
  * A sample function has been created, called between, and is bound to the 'f' namespace. An example using this function is : "f:between(LATITUDE,60.0, 70.0)"
  *
- * <h1>Constraints on Query Structure</h1> Queries that are sent to this class need to be formatted such that there is a space on either side of the operator.
+ * <h2>Constraints on Query Structure</h2> Queries that are sent to this class need to be formatted such that there is a space on either side of the operator.
  * We are rewriting the query in some cases and the current implementation is expecting a space on either side of the operator.
  *
- * <h1>Notes on Optimization</h1> Queries that meet any of the following criteria will perform a full scan of the events in the sharded event table:
+ * <h2>Notes on Optimization</h2> Queries that meet any of the following criteria will perform a full scan of the events in the sharded event table:
  *
  * <pre>
  *  1. An 'or' conjunction exists in the query but not all of the terms are indexed.
@@ -164,7 +164,7 @@ import datawave.webservice.result.QueryValidationResponse;
  *  3. An unsupported operator exists in the query
  * </pre>
  *
- * <h1>Notes on Features</h1>
+ * <h2>Notes on Features</h2>
  *
  * <pre>
  *  1. If there is no type specified for a field in the metadata table, then it defaults to using the NoOpType. The default

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/QueryJexl.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/QueryJexl.java
@@ -42,7 +42,6 @@ import datawave.query.jexl.JexlASTHelper;
  * Provides for the parsing and execution of a Jexl query string for test execution only. The {@link #evaluate()} method should produce the same results that
  * are produced from the production code base.
  * <p>
- * </P>
  * <b>Current Limitations</b><br>
  * <ul>
  * <li>Differences in the manner in which the Datawave Interpreter and the Jexl Interpreter work may result in the results. One difference in with multivalue

--- a/warehouse/ssdeep-common/pom.xml
+++ b/warehouse/ssdeep-common/pom.xml
@@ -8,8 +8,9 @@
     </parent>
     <artifactId>datawave-ssdeep-common</artifactId>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>

--- a/web-services/client/src/main/java/datawave/webservice/result/QueryWizardResultResponse.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/QueryWizardResultResponse.java
@@ -90,9 +90,9 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
         StringBuilder builder = new StringBuilder();
 
         builder.append("<br/><br/>");
-        builder.append("<H2>Query ID : " + queryId + "</H2><br/><br/>");
+        builder.append("<h2>Query ID : " + queryId + "</h2><br/><br/>");
         if (response == null || !response.getHasResults()) {
-            builder.append("<H2>There aren't anymore results</H2>");
+            builder.append("<h2>There aren't anymore results</h2>");
             return builder.toString();
         }
 
@@ -180,11 +180,11 @@ public class QueryWizardResultResponse extends BaseResponse implements HtmlProvi
         builder.append("</div>\n");
         builder.append("</div>");
 
-        builder.append("<FORM id=\"queryform\" action=\"/DataWave/BasicQuery/" + queryId
+        builder.append("<form id=\"queryform\" action=\"/DataWave/BasicQuery/" + queryId
                         + "/showQueryWizardResults\"  method=\"get\" target=\"_self\" enctype=\"application/x-www-form-urlencoded\">");
         builder.append("<center><input type=\"submit\" value=\"Next\" align=\"left\" width=\"50\" /></center>");
 
-        builder.append("</FORM>");
+        builder.append("</form>");
 
         return builder.toString();
     }

--- a/web-services/client/src/main/java/datawave/webservice/result/QueryWizardStep1Response.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/QueryWizardStep1Response.java
@@ -61,8 +61,8 @@ public class QueryWizardStep1Response extends BaseResponse implements HtmlProvid
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder();
-        builder.append("<H1>Query Wizard Step 1 - Choose Query Type</H1>");
-        builder.append("<FORM id=\"queryform\" action=\"/DataWave/BasicQuery/showQueryWizardStep2\"  method=\"post\" target=\"_self\" enctype=\"application/x-www-form-urlencoded\">");
+        builder.append("<h1>Query Wizard Step 1 - Choose Query Type</h1>");
+        builder.append("<form id=\"queryform\" action=\"/DataWave/BasicQuery/showQueryWizardStep2\"  method=\"post\" target=\"_self\" enctype=\"application/x-www-form-urlencoded\">");
         builder.append("<br/>");
         builder.append("<select form=\"queryform\" name=\"queryType\" align=\"left\">");
 
@@ -73,7 +73,7 @@ public class QueryWizardStep1Response extends BaseResponse implements HtmlProvid
 
         builder.append("</select><br/><br/>\n");
         builder.append("<input type=\"submit\" value=\"Submit\"  align=\"center\">");
-        builder.append("</FORM>");
+        builder.append("</form>");
 
         return builder.toString();
     }

--- a/web-services/client/src/main/java/datawave/webservice/result/QueryWizardStep2Response.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/QueryWizardStep2Response.java
@@ -67,14 +67,14 @@ public class QueryWizardStep2Response extends BaseResponse implements HtmlProvid
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder();
-        builder.append("<H1>DataWave Query Form</H1>");
-        builder.append("<FORM id=\"queryform\" action=\"/DataWave/BasicQuery/" + theQLD.getName()
+        builder.append("<h1>DataWave Query Form</h1>");
+        builder.append("<form id=\"queryform\" action=\"/DataWave/BasicQuery/" + theQLD.getName()
                         + "/showQueryWizardStep3\"  method=\"post\" target=\"_self\" enctype=\"application/x-www-form-urlencoded\">");
         builder.append("<br/>");
         builder.append("<br/>");
-        builder.append("<H2>" + theQLD.getName() + " (" + theQLD.getLogicDescription() + ")</H2>");
+        builder.append("<h2>" + theQLD.getName() + " (" + theQLD.getLogicDescription() + ")</h2>");
         builder.append("<br/>");
-        builder.append("<H2>Required parameters</H2>");
+        builder.append("<h2>Required parameters</h2>");
         builder.append("<br/><br/>");
         builder.append("<table>");
         builder.append("<tr><td align=\"left\" width=\"10%\">Query Name:</td><td width=\"90%\"> <input type=\"text\" name=\"queryName\" placeholder=\"Enter value\" align=\"left\" size=\"150\" /></td><tr>");
@@ -107,7 +107,7 @@ public class QueryWizardStep2Response extends BaseResponse implements HtmlProvid
 
             builder.append("<br/><br/>\n");
 
-            builder.append("<H2>" + theQLD.getName() + " Supported parameters</H2>");
+            builder.append("<h2>" + theQLD.getName() + " Supported parameters</h2>");
             builder.append("<table>");
 
             for (String optional : theQLD.getSupportedParams()) {
@@ -130,7 +130,7 @@ public class QueryWizardStep2Response extends BaseResponse implements HtmlProvid
         }
 
         builder.append("<input type=\"submit\" value=\"Submit\"  align=\"center\">");
-        builder.append("</FORM>");
+        builder.append("</form>");
 
         /*
          * if (theQLD != null) { // There aren't any example queries so this doesn't look good in the UI builder.append("Example Queries: ");

--- a/web-services/client/src/main/java/datawave/webservice/result/QueryWizardStep3Response.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/QueryWizardStep3Response.java
@@ -64,27 +64,27 @@ public class QueryWizardStep3Response extends BaseResponse implements HtmlProvid
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder();
-        builder.append("<H1>DataWave Query Plan</H1>");
+        builder.append("<h1>DataWave Query Plan</h1>");
         builder.append("<br/>");
         builder.append("<br/>");
         if (plan != null)
-            builder.append("<H2>The query plan: " + plan + "</H2>");
+            builder.append("<h2>The query plan: " + plan + "</h2>");
         else {
-            builder.append("<H2>Datawave could not generate a plan for the query");
+            builder.append("<h2>Datawave could not generate a plan for the query</h2>");
             if (errorMessage != null && !errorMessage.isEmpty()) {
-                builder.append("<br><H3>" + errorMessage + "</H3>");
+                builder.append("<br><h3>" + errorMessage + "</h3>");
             }
             return builder.toString();
         }
 
         builder.append("<br/>");
-        builder.append("<H2>Results</H2>");
+        builder.append("<h2>Results</h2>");
         builder.append("<br/><br/>");
-        builder.append("<FORM id=\"queryform\" action=\"/DataWave/BasicQuery/" + queryId
+        builder.append("<form id=\"queryform\" action=\"/DataWave/BasicQuery/" + queryId
                         + "/showQueryWizardResults\"  method=\"get\" target=\"_self\" enctype=\"application/x-www-form-urlencoded\">");
         builder.append("<center><input type=\"submit\" value=\"Next\" align=\"left\" width=\"50\" /></center>");
 
-        builder.append("</FORM>");
+        builder.append("</form>");
 
         return builder.toString();
     }

--- a/web-services/examples/http-client/pom.xml
+++ b/web-services/examples/http-client/pom.xml
@@ -65,10 +65,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
* Add maven.compiler.release option to force correct cross-compilation to Java 11 when building with a JDK newer than 11, such as JDK 17
* Remove unnecessary java source, target, and encoding config from plugins when those are already specified by properties
* Fix submodule for core/in-memory-accumulo to point to in-memory-accumulo's main branch instead of the one being developed for the accumulo4 branch
* Also fix the license name for Apache-2.0 (the recommended name is the SPDX name) and drop .txt from the license URL