### PR TITLE
Ingest field configuration helper cache

### DIFF
--- a/warehouse/ingest-core/pom.xml
+++ b/warehouse/ingest-core/pom.xml
@@ -212,6 +212,21 @@
             <artifactId>javassist</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
@@ -1,0 +1,75 @@
+package datawave.ingest.data.config;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.commons.collections4.map.LRUMap;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class CachedFieldConfigHelper implements FieldConfigHelper {
+    private final FieldConfigHelper underlyingHelper;
+    private final Map<String,ResultEntry> resultCache;
+
+    enum AttributeType {
+        INDEXED_FIELD, REVERSE_INDEXED_FIELD, TOKENIZED_FIELD, REVERSE_TOKENIZED_FIELD, STORED_FIELD, INDEXED_ONLY
+    }
+
+    public CachedFieldConfigHelper(FieldConfigHelper helper, int limit) {
+        if (limit < 1) {
+            throw new IllegalArgumentException("Limit must be a positive integer");
+        }
+        this.underlyingHelper = helper;
+        this.resultCache = new LRUMap<>(limit);
+    }
+
+    @Override
+    public boolean isStoredField(String fieldName) {
+        return getOrEvaluate(AttributeType.STORED_FIELD, fieldName, underlyingHelper::isStoredField);
+    }
+
+    @Override
+    public boolean isIndexedField(String fieldName) {
+        return getOrEvaluate(AttributeType.INDEXED_FIELD, fieldName, underlyingHelper::isIndexedField);
+    }
+
+    @Override
+    public boolean isIndexOnlyField(String fieldName) {
+        return getOrEvaluate(AttributeType.INDEXED_ONLY, fieldName, underlyingHelper::isIndexOnlyField);
+    }
+
+    @Override
+    public boolean isReverseIndexedField(String fieldName) {
+        return getOrEvaluate(AttributeType.REVERSE_INDEXED_FIELD, fieldName, underlyingHelper::isReverseIndexedField);
+    }
+
+    @Override
+    public boolean isTokenizedField(String fieldName) {
+        return getOrEvaluate(AttributeType.TOKENIZED_FIELD, fieldName, underlyingHelper::isTokenizedField);
+    }
+
+    @Override
+    public boolean isReverseTokenizedField(String fieldName) {
+        return getOrEvaluate(AttributeType.REVERSE_TOKENIZED_FIELD, fieldName, underlyingHelper::isReverseTokenizedField);
+    }
+
+    @VisibleForTesting
+    boolean getOrEvaluate(AttributeType attributeType, String fieldName, Function<String,Boolean> evaluateFn) {
+        return resultCache.computeIfAbsent(fieldName, ResultEntry::new).resolveResult(attributeType, evaluateFn);
+    }
+
+    private static class ResultEntry {
+        private final String fieldName;
+        private final EnumMap<AttributeType,Boolean> resultMap;
+
+        ResultEntry(String fieldName) {
+            this.fieldName = fieldName;
+            this.resultMap = new EnumMap<>(AttributeType.class);
+        }
+
+        boolean resolveResult(AttributeType attributeType, Function<String,Boolean> evaluateFn) {
+            return resultMap.computeIfAbsent(attributeType, (t) -> evaluateFn.apply(fieldName));
+        }
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
@@ -1,26 +1,36 @@
 package datawave.ingest.data.config;
 
-import com.google.common.annotations.VisibleForTesting;
+import static java.lang.Thread.NORM_PRIORITY;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Predicate;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class CachedFieldConfigHelper implements FieldConfigHelper {
     private final static Logger log = LoggerFactory.getLogger(CachedFieldConfigHelper.class);
 
     private final static float DEFAULT_LRU_LF = 0.75f;
-    private final static int EMIT_OVER_LIMIT_THRESHOLD = 100;
+    private final static int DEFAULT_DEBUG_STATE_SECS = 30;
 
     private final FieldConfigHelper underlyingHelper;
-    private final Map<String,CachedEntry> resultCache;
-    private final Function<String,CachedEntry> resultEntryFn;
-
-    private long fieldComputes;
-    private boolean fieldLimitExceeded;
+    private final LruCache<String,CachedEntry> resultCache;
+    private final boolean debugLimitsEnabled;
+    private final int limit;
+    private final Set<String> debugFieldUnique;
+    private final ScheduledExecutorService debugStateExecutor;
+    private final AtomicLong debugFieldComputes;
 
     enum AttributeType {
         INDEXED_FIELD, REVERSE_INDEXED_FIELD, TOKENIZED_FIELD, REVERSE_TOKENIZED_FIELD, STORED_FIELD, INDEX_ONLY_FIELD
@@ -30,20 +40,31 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
         this(helper, limit, false);
     }
 
-    public CachedFieldConfigHelper(FieldConfigHelper helper, int limit, boolean debugLimitExceeded) {
+    public CachedFieldConfigHelper(FieldConfigHelper helper, int limit, boolean debugLimitEnabled) {
         if (limit < 1) {
             throw new IllegalArgumentException("Limit must be a positive integer");
         }
         this.underlyingHelper = helper;
-        this.resultCache = lruCache(limit);
-        this.resultEntryFn = !debugLimitExceeded ? CachedEntry::new : (String f) -> {
-            fieldComputes++;
-            if (fieldComputes >= limit && ((fieldComputes == limit) || (fieldComputes % EMIT_OVER_LIMIT_THRESHOLD) == 0)) {
-                fieldLimitExceeded = true;
-                log.info("Field cache limit exceeded [val: {}, size={}, limit={}]", f, fieldComputes, limit);
-            }
-            return new CachedEntry(f);
-        };
+        this.resultCache = new LruCache<>(limit);
+        this.limit = limit;
+        this.debugLimitsEnabled = debugLimitEnabled;
+        this.debugFieldUnique = new HashSet<>();
+        this.debugFieldComputes = new AtomicLong();
+
+        if (debugLimitEnabled) {
+            this.debugStateExecutor = Executors.newSingleThreadScheduledExecutor(
+            // @formatter:off
+                new ThreadFactoryBuilder()
+                    .setPriority(NORM_PRIORITY)
+                    .setDaemon(true)
+                    .setNameFormat("CachedFieldConfigHelper.DebugState")
+                    .build()
+                // formatter:off
+            );
+            this.debugStateExecutor.scheduleAtFixedRate(this::debugLogState, DEFAULT_DEBUG_STATE_SECS, DEFAULT_DEBUG_STATE_SECS, SECONDS);
+        } else {
+            this.debugStateExecutor = null;
+        }
     }
 
     @Override
@@ -78,22 +99,51 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
 
     @VisibleForTesting
     boolean getFieldResult(AttributeType attributeType, String fieldName, Predicate<String> fn) {
-        return resultCache.computeIfAbsent(fieldName, resultEntryFn).get(attributeType).getResultOrEvaluate(fn);
+        CachedEntry ce = !debugLimitsEnabled ?
+            resultCache.computeIfAbsent(fieldName, CachedEntry::new) :
+            resultCache.computeIfAbsent(fieldName, this::debugCachedEntryCreation);
+        return ce.get(attributeType).getResultOrEvaluate(fn);
     }
 
     @VisibleForTesting
     boolean hasLimitExceeded() {
-        return fieldLimitExceeded;
+        return resultCache.hasLimitExceeded();
     }
 
-    private static <K,V> Map<K,V> lruCache(final int maxSize) {
-        // Testing showed slightly better or same performance of LRU implementation below
-        // when compared to Apache Commons LRUMap
-        return new LinkedHashMap<>((int) (maxSize / DEFAULT_LRU_LF) + 1, DEFAULT_LRU_LF, true) {
-            protected boolean removeEldestEntry(Map.Entry<K,V> eldest) {
-                return size() > maxSize;
+    private CachedEntry debugCachedEntryCreation(String fieldName) {
+        debugFieldComputes.incrementAndGet();
+        debugFieldUnique.add(fieldName);
+        return new CachedEntry(fieldName);
+    }
+
+    private void debugLogState() {
+        if (resultCache.hasLimitExceeded()) {
+            log.info("Field cache LRU limit exceeded [limit={}, debug={}, size={}, uniq={}]",
+                limit, debugFieldComputes.get(), debugFieldUnique.size(), debugLimitsEnabled);
+        }
+    }
+
+    private static class LruCache<K,V> extends LinkedHashMap<K,V> {
+        private final int maxSize;
+        private volatile boolean limitExceeded;
+
+        LruCache(int maxSize) {
+            super((int)(maxSize / DEFAULT_LRU_LF) + 1, DEFAULT_LRU_LF, true);
+            this.maxSize = maxSize;
+        }
+
+        boolean hasLimitExceeded() {
+            // thread-safe
+            return limitExceeded;
+        }
+
+        protected boolean removeEldestEntry(Map.Entry<K,V> eldest) {
+            boolean localLimitExceeded = size() > maxSize;
+            if (localLimitExceeded) {
+                limitExceeded = true;
             }
-        };
+            return localLimitExceeded;
+        }
     }
 
     private static class CachedEntry {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
@@ -104,7 +104,7 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
 
         CachedEntry.MemoizedResult memoizedResult = cachedEntry.get(attributeType);
 
-        // when trace state is enabled - emit a message if the field limit has been exceeded
+        // when diagnostic is enabled - emit a message if the field limit has been exceeded
         // the intent is to help adjust the size required for the cache
         if (diagnosticEnabled && clock.epochMillis() > diagnosticEmitNextMillis) {
             diagnosticEmitted = true;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
@@ -1,27 +1,49 @@
 package datawave.ingest.data.config;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class CachedFieldConfigHelper implements FieldConfigHelper {
+    private final static Logger log = LoggerFactory.getLogger(CachedFieldConfigHelper.class);
+
     private final static float DEFAULT_LRU_LF = 0.75f;
+    private final static int EMIT_OVER_LIMIT_THRESHOLD = 100;
 
     private final FieldConfigHelper underlyingHelper;
     private final Map<String,CachedEntry> resultCache;
+    private final Function<String,CachedEntry> resultEntryFn;
+
+    private long fieldComputes;
+    private boolean fieldLimitExceeded;
 
     enum AttributeType {
         INDEXED_FIELD, REVERSE_INDEXED_FIELD, TOKENIZED_FIELD, REVERSE_TOKENIZED_FIELD, STORED_FIELD, INDEX_ONLY_FIELD
     }
 
     public CachedFieldConfigHelper(FieldConfigHelper helper, int limit) {
+        this(helper, limit, false);
+    }
+
+    public CachedFieldConfigHelper(FieldConfigHelper helper, int limit, boolean debugLimitExceeded) {
         if (limit < 1) {
             throw new IllegalArgumentException("Limit must be a positive integer");
         }
         this.underlyingHelper = helper;
         this.resultCache = lruCache(limit);
+        this.resultEntryFn = !debugLimitExceeded ? CachedEntry::new : (String f) -> {
+            fieldComputes++;
+            if (fieldComputes >= limit && ((fieldComputes == limit) || (fieldComputes % EMIT_OVER_LIMIT_THRESHOLD) == 0)) {
+                fieldLimitExceeded = true;
+                log.info("Field cache limit exceeded [val: {}, size={}, limit={}]", f, fieldComputes, limit);
+            }
+            return new CachedEntry(f);
+        };
     }
 
     @Override
@@ -56,10 +78,15 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
 
     @VisibleForTesting
     boolean getFieldResult(AttributeType attributeType, String fieldName, Predicate<String> fn) {
-        return resultCache.computeIfAbsent(fieldName, CachedEntry::new).get(attributeType).getResultOrEvaluate(fn);
+        return resultCache.computeIfAbsent(fieldName, resultEntryFn).get(attributeType).getResultOrEvaluate(fn);
     }
 
-    static <K,V> Map<K,V> lruCache(final int maxSize) {
+    @VisibleForTesting
+    boolean hasLimitExceeded() {
+        return fieldLimitExceeded;
+    }
+
+    private static <K,V> Map<K,V> lruCache(final int maxSize) {
         // Testing showed slightly better or same performance of LRU implementation below
         // when compared to Apache Commons LRUMap
         return new LinkedHashMap<>((int) (maxSize / DEFAULT_LRU_LF) + 1, DEFAULT_LRU_LF, true) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
@@ -1,13 +1,14 @@
 package datawave.ingest.data.config;
 
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import org.apache.commons.collections4.map.LRUMap;
-
-import com.google.common.annotations.VisibleForTesting;
-
 public class CachedFieldConfigHelper implements FieldConfigHelper {
+    private final static float DEFAULT_LRU_LF = 0.75f;
+
     private final FieldConfigHelper underlyingHelper;
     private final Map<String,CachedEntry> resultCache;
 
@@ -20,7 +21,7 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
             throw new IllegalArgumentException("Limit must be a positive integer");
         }
         this.underlyingHelper = helper;
-        this.resultCache = new LRUMap<>(limit);
+        this.resultCache = lruCache(limit);
     }
 
     @Override
@@ -56,6 +57,16 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
     @VisibleForTesting
     boolean getFieldResult(AttributeType attributeType, String fieldName, Predicate<String> fn) {
         return resultCache.computeIfAbsent(fieldName, CachedEntry::new).get(attributeType).getResultOrEvaluate(fn);
+    }
+
+    static <K,V> Map<K,V> lruCache(final int maxSize) {
+        // Testing showed slightly better or same performance of LRU implementation below
+        // when compared to Apache Commons LRUMap
+        return new LinkedHashMap<>((int) (maxSize / DEFAULT_LRU_LF) + 1, DEFAULT_LRU_LF, true) {
+            protected boolean removeEldestEntry(Map.Entry<K,V> eldest) {
+                return size() > maxSize;
+            }
+        };
     }
 
     private static class CachedEntry {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CachedFieldConfigHelper.java
@@ -1,70 +1,65 @@
 package datawave.ingest.data.config;
 
-import static java.lang.Thread.NORM_PRIORITY;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class CachedFieldConfigHelper implements FieldConfigHelper {
     private final static Logger log = LoggerFactory.getLogger(CachedFieldConfigHelper.class);
 
     private final static float DEFAULT_LRU_LF = 0.75f;
-    private final static int DEFAULT_DEBUG_STATE_SECS = 30;
+    private final static int DEFAULT_DIAGNOSTIC_SECS = 30;
 
     private final FieldConfigHelper underlyingHelper;
     private final LruCache<String,CachedEntry> resultCache;
-    private final boolean debugLimitsEnabled;
     private final int limit;
-    private final Set<String> debugFieldUnique;
-    private final ScheduledExecutorService debugStateExecutor;
-    private final AtomicLong debugFieldComputes;
+    private final boolean diagnosticEnabled;
+    private final Set<String> diagnosticUniqueFields;
+    private Clock clock;
+    private boolean limitMessageEmitted;
+    private long diagnosticFieldCompute;
+    private long diagnosticEmitIntervalMillis;
+    private long diagnosticEmitNextMillis;
+    private boolean diagnosticEmitted;
 
     enum AttributeType {
         INDEXED_FIELD, REVERSE_INDEXED_FIELD, TOKENIZED_FIELD, REVERSE_TOKENIZED_FIELD, STORED_FIELD, INDEX_ONLY_FIELD
+    }
+
+    interface Clock {
+        default long epochMillis() {
+            return System.currentTimeMillis();
+        }
+
+        static Clock defaultClock() {
+            return new Clock() {};
+        }
     }
 
     public CachedFieldConfigHelper(FieldConfigHelper helper, int limit) {
         this(helper, limit, false);
     }
 
-    public CachedFieldConfigHelper(FieldConfigHelper helper, int limit, boolean debugLimitEnabled) {
+    public CachedFieldConfigHelper(FieldConfigHelper helper, int limit, boolean diagnosticEnabled) {
         if (limit < 1) {
             throw new IllegalArgumentException("Limit must be a positive integer");
         }
+        this.clock = Clock.defaultClock();
         this.underlyingHelper = helper;
         this.resultCache = new LruCache<>(limit);
         this.limit = limit;
-        this.debugLimitsEnabled = debugLimitEnabled;
-        this.debugFieldUnique = new HashSet<>();
-        this.debugFieldComputes = new AtomicLong();
-
-        if (debugLimitEnabled) {
-            this.debugStateExecutor = Executors.newSingleThreadScheduledExecutor(
-            // @formatter:off
-                new ThreadFactoryBuilder()
-                    .setPriority(NORM_PRIORITY)
-                    .setDaemon(true)
-                    .setNameFormat("CachedFieldConfigHelper.DebugState")
-                    .build()
-                // formatter:off
-            );
-            this.debugStateExecutor.scheduleAtFixedRate(this::debugLogState, DEFAULT_DEBUG_STATE_SECS, DEFAULT_DEBUG_STATE_SECS, SECONDS);
-        } else {
-            this.debugStateExecutor = null;
-        }
+        this.diagnosticEnabled = diagnosticEnabled;
+        this.diagnosticUniqueFields = new HashSet<>();
+        this.diagnosticEmitIntervalMillis = SECONDS.toMillis(DEFAULT_DIAGNOSTIC_SECS);
     }
 
     @Override
@@ -99,10 +94,28 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
 
     @VisibleForTesting
     boolean getFieldResult(AttributeType attributeType, String fieldName, Predicate<String> fn) {
-        CachedEntry ce = !debugLimitsEnabled ?
-            resultCache.computeIfAbsent(fieldName, CachedEntry::new) :
-            resultCache.computeIfAbsent(fieldName, this::debugCachedEntryCreation);
-        return ce.get(attributeType).getResultOrEvaluate(fn);
+        CachedEntry cachedEntry = resultCache.computeIfAbsent(fieldName, (key) -> {
+            if (diagnosticEnabled) {
+                diagnosticFieldCompute++;
+                diagnosticUniqueFields.add(key);
+            }
+            return new CachedEntry(key);
+        });
+
+        CachedEntry.MemoizedResult memoizedResult = cachedEntry.get(attributeType);
+
+        // when trace state is enabled - emit a message if the field limit has been exceeded
+        // the intent is to help adjust the size required for the cache
+        if (diagnosticEnabled && clock.epochMillis() > diagnosticEmitNextMillis) {
+            diagnosticEmitted = true;
+            diagnosticEmitNextMillis = clock.epochMillis() + diagnosticEmitIntervalMillis;
+            log.info("Field cache LRU [limit={}, computed={}, size={}, uniq={}]", limit, diagnosticFieldCompute, diagnosticUniqueFields.size(),
+                            diagnosticUniqueFields);
+        } else if (resultCache.hasLimitExceeded() && !limitMessageEmitted) {
+            log.info("Field cache LRU limit exceeded: [limit={}, field={}]", limit, fieldName);
+            limitMessageEmitted = true;
+        }
+        return memoizedResult.getResultOrEvaluate(fn);
     }
 
     @VisibleForTesting
@@ -110,30 +123,51 @@ public class CachedFieldConfigHelper implements FieldConfigHelper {
         return resultCache.hasLimitExceeded();
     }
 
-    private CachedEntry debugCachedEntryCreation(String fieldName) {
-        debugFieldComputes.incrementAndGet();
-        debugFieldUnique.add(fieldName);
-        return new CachedEntry(fieldName);
+    @VisibleForTesting
+    Set<String> getCachedFields() {
+        return resultCache.keySet();
     }
 
-    private void debugLogState() {
-        if (resultCache.hasLimitExceeded()) {
-            log.info("Field cache LRU limit exceeded [limit={}, debug={}, size={}, uniq={}]",
-                limit, debugFieldComputes.get(), debugFieldUnique.size(), debugLimitsEnabled);
-        }
+    @VisibleForTesting
+    boolean getDiagnosticEmitted() {
+        return diagnosticEmitted;
+    }
+
+    @VisibleForTesting
+    Set<String> getDiagnosticUniqueFields() {
+        return diagnosticUniqueFields;
+    }
+
+    @VisibleForTesting
+    long getDiagnosticFieldCompute() {
+        return diagnosticFieldCompute;
+    }
+
+    @VisibleForTesting
+    long getDiagnosticEmitNextMillis() {
+        return diagnosticEmitNextMillis;
+    }
+
+    @VisibleForTesting
+    void setDiagnosticEmitIntervalMillis(long intervalMillis) {
+        this.diagnosticEmitIntervalMillis = intervalMillis;
+    }
+
+    @VisibleForTesting
+    void setClock(Clock clock) {
+        this.clock = clock;
     }
 
     private static class LruCache<K,V> extends LinkedHashMap<K,V> {
         private final int maxSize;
-        private volatile boolean limitExceeded;
+        private boolean limitExceeded;
 
         LruCache(int maxSize) {
-            super((int)(maxSize / DEFAULT_LRU_LF) + 1, DEFAULT_LRU_LF, true);
+            super((int) (maxSize / DEFAULT_LRU_LF) + 1, DEFAULT_LRU_LF, true);
             this.maxSize = maxSize;
         }
 
         boolean hasLimitExceeded() {
-            // thread-safe
             return limitExceeded;
         }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -140,8 +140,8 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
 
     public static final String FIELD_CONFIG_FILE = ".data.category.field.config.file";
     public static final String FIELD_CONFIG_CACHE_ENABLED = ".data.category.field.config.cache.enabled";
-    public static final String FIELD_CONFIG_CACHE_KEY_LIMIT = ".data.category.field.config.cache.limit";
-    public static final String FIELD_CONFIG_CACHE_KEY_LIMIT_DEBUG = ".data.category.field.config.cache.limit.debug";
+    public static final String FIELD_CONFIG_CACHE_LIMIT = ".data.category.field.config.cache.limit";
+    public static final String FIELD_CONFIG_CACHE_DIAGNOSTIC = ".data.category.field.config.cache.diagnostic";
 
     private static final Logger log = ThreadConfigurableLogger.getLogger(BaseIngestHelper.class);
 
@@ -260,19 +260,19 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         final String fieldConfigFile = config.get(this.getType().typeName() + FIELD_CONFIG_FILE);
         if (fieldConfigFile != null) {
             final boolean fieldConfigCacheEnabled = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_ENABLED, false);
-            final boolean fieldConfigCacheLimitDebug = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT_DEBUG, false);
-            final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT, 100);
+            final boolean fieldConfigCacheLimitDiagnostic = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_DIAGNOSTIC, false);
+            final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_LIMIT, 100);
             if (log.isDebugEnabled()) {
                 log.debug("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
             }
             log.info("Field config cache enabled: " + fieldConfigCacheEnabled);
             if (fieldConfigCacheEnabled) {
                 log.info("Field config cache limit: " + fieldConfigCacheLimit);
-                log.info("Field config cache limit debug: " + fieldConfigCacheLimitDebug);
+                log.info("Field config cache limit diagnostic: " + fieldConfigCacheLimitDiagnostic);
             }
             fieldConfigHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
             if (fieldConfigCacheEnabled) {
-                fieldConfigHelper = new CachedFieldConfigHelper(fieldConfigHelper, fieldConfigCacheLimit, fieldConfigCacheLimitDebug);
+                fieldConfigHelper = new CachedFieldConfigHelper(fieldConfigHelper, fieldConfigCacheLimit, fieldConfigCacheLimitDiagnostic);
             }
         }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -262,13 +262,11 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
             final boolean fieldConfigCacheEnabled = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_ENABLED, false);
             final boolean fieldConfigCacheLimitDebug = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT_DEBUG, false);
             final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT, 100);
-            if (log.isDebugEnabled()) {
-                log.debug("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
-                log.debug("Field config cache enabled: " + fieldConfigCacheEnabled);
-                if (fieldConfigCacheEnabled) {
-                    log.debug("Field config cache limit: " + fieldConfigCacheLimit);
-                    log.debug("Field config cache limit debug: " + fieldConfigCacheLimitDebug);
-                }
+            log.info("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
+            log.info("Field config cache enabled: " + fieldConfigCacheEnabled);
+            if (fieldConfigCacheEnabled) {
+                log.info("Field config cache limit: " + fieldConfigCacheLimit);
+                log.info("Field config cache limit debug: " + fieldConfigCacheLimitDebug);
             }
             fieldConfigHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
             if (fieldConfigCacheEnabled) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -141,11 +141,9 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
     public static final String FIELD_CONFIG_FILE = ".data.category.field.config.file";
     public static final String FIELD_CONFIG_CACHE_ENABLED = ".data.category.field.config.cache.enabled";
     public static final String FIELD_CONFIG_CACHE_KEY_LIMIT = ".data.category.field.config.cache.limit";
+    public static final String FIELD_CONFIG_CACHE_KEY_LIMIT_DEBUG = ".data.category.field.config.cache.limit.debug";
 
     private static final Logger log = ThreadConfigurableLogger.getLogger(BaseIngestHelper.class);
-
-    private static final boolean DEFAULT_FIELD_CACHE_ENABLED = false;
-    private static final int DEFAULT_FIELD_CACHE_LIMIT = 100;
 
     private Multimap<String,datawave.data.type.Type<?>> typeFieldMap = null;
     private Multimap<String,datawave.data.type.Type<?>> typePatternMap = null;
@@ -261,17 +259,21 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         // Load the field helper, which takes precedence over the individual field configurations
         final String fieldConfigFile = config.get(this.getType().typeName() + FIELD_CONFIG_FILE);
         if (fieldConfigFile != null) {
-            final boolean fieldConfigCacheEnabled = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_ENABLED, DEFAULT_FIELD_CACHE_ENABLED);
-            final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT, DEFAULT_FIELD_CACHE_LIMIT);
+            final boolean fieldConfigCacheEnabled = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_ENABLED, false);
+            final boolean fieldConfigCacheLimitDebug = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT_DEBUG, false);
+            final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT, 100);
             if (log.isDebugEnabled()) {
                 log.debug("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
                 log.debug("Field config cache enabled: " + fieldConfigCacheEnabled);
                 if (fieldConfigCacheEnabled) {
                     log.debug("Field config cache limit: " + fieldConfigCacheLimit);
+                    log.debug("Field config cache limit debug: " + fieldConfigCacheLimitDebug);
                 }
             }
-            final FieldConfigHelper baseHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
-            fieldConfigHelper = fieldConfigCacheEnabled ? new CachedFieldConfigHelper(baseHelper, fieldConfigCacheLimit) : baseHelper;
+            fieldConfigHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
+            if (fieldConfigCacheEnabled) {
+                fieldConfigHelper = new CachedFieldConfigHelper(fieldConfigHelper, fieldConfigCacheLimit, fieldConfigCacheLimitDebug);
+            }
         }
 
         // Process the indexed fields

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -33,6 +33,7 @@ import datawave.ingest.config.IngestConfiguration;
 import datawave.ingest.config.IngestConfigurationFactory;
 import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
+import datawave.ingest.data.config.CachedFieldConfigHelper;
 import datawave.ingest.data.config.DataTypeHelperImpl;
 import datawave.ingest.data.config.FieldConfigHelper;
 import datawave.ingest.data.config.MarkingsHelper;
@@ -138,8 +139,13 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
     public static final String FIELD_FAILED_NORMALIZATION_POLICY = ".data.field.normalization.failure.policy";
 
     public static final String FIELD_CONFIG_FILE = ".data.category.field.config.file";
+    public static final String FIELD_CONFIG_CACHE_ENABLED = ".data.category.field.config.cache.enabled";
+    public static final String FIELD_CONFIG_CACHE_KEY_LIMIT = ".data.category.field.config.cache.limit";
 
     private static final Logger log = ThreadConfigurableLogger.getLogger(BaseIngestHelper.class);
+
+    private static final boolean DEFAULT_FIELD_CACHE_ENABLED = false;
+    private static final int DEFAULT_FIELD_CACHE_LIMIT = 100;
 
     private Multimap<String,datawave.data.type.Type<?>> typeFieldMap = null;
     private Multimap<String,datawave.data.type.Type<?>> typePatternMap = null;
@@ -255,10 +261,17 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         // Load the field helper, which takes precedence over the individual field configurations
         final String fieldConfigFile = config.get(this.getType().typeName() + FIELD_CONFIG_FILE);
         if (fieldConfigFile != null) {
+            final boolean fieldConfigCacheEnabled = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_ENABLED, DEFAULT_FIELD_CACHE_ENABLED);
+            final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT, DEFAULT_FIELD_CACHE_LIMIT);
             if (log.isDebugEnabled()) {
                 log.debug("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
+                log.debug("Field config cache enabled: " + fieldConfigCacheEnabled);
+                if (fieldConfigCacheEnabled) {
+                    log.debug("Field config cache limit: " + fieldConfigCacheLimit);
+                }
             }
-            this.fieldConfigHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
+            final FieldConfigHelper baseHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
+            fieldConfigHelper = fieldConfigCacheEnabled ? new CachedFieldConfigHelper(baseHelper, fieldConfigCacheLimit) : baseHelper;
         }
 
         // Process the indexed fields

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -262,7 +262,9 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
             final boolean fieldConfigCacheEnabled = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_ENABLED, false);
             final boolean fieldConfigCacheLimitDebug = config.getBoolean(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT_DEBUG, false);
             final int fieldConfigCacheLimit = config.getInt(this.getType().typeName() + FIELD_CONFIG_CACHE_KEY_LIMIT, 100);
-            log.info("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
+            if (log.isDebugEnabled()) {
+                log.debug("Field config file " + fieldConfigFile + " specified for: " + this.getType().typeName() + FIELD_CONFIG_FILE);
+            }
             log.info("Field config cache enabled: " + fieldConfigCacheEnabled);
             if (fieldConfigCacheEnabled) {
                 log.info("Field config cache limit: " + fieldConfigCacheLimit);

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class CachingFieldConfigHelperTest {
+public class CachedFieldConfigHelperTest {
     @Test
     public void testCachingBehaviorWillCallBaseMethods() {
         String fieldName = "test";

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
@@ -1,5 +1,7 @@
 package datawave.ingest.data.config;
 
+import static datawave.ingest.data.config.CachedFieldConfigHelper.AttributeType.INDEXED_FIELD;
+import static datawave.ingest.data.config.CachedFieldConfigHelper.AttributeType.STORED_FIELD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Test;
@@ -82,36 +85,66 @@ public class CachedFieldConfigHelperTest {
         // 3. limit blocks results to return if exceeded
         // 4. limit functions across attribute-types
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field1", innerHelper::isStoredField);
         assertEquals(1, storedCounter.get(), "field1 should compute result (new field)");
+        assertEquals(Set.of("field1"), helper.getCachedFields());
         assertFalse(helper.hasLimitExceeded());
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field1", innerHelper::isStoredField);
         assertEquals(1, storedCounter.get(), "field1 repeated (existing field)");
+        assertEquals(Set.of("field1"), helper.getCachedFields());
         assertFalse(helper.hasLimitExceeded());
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field2", innerHelper::isStoredField);
         assertEquals(2, storedCounter.get(), "field2 should compute result (new field)");
+        assertEquals(Set.of("field1", "field2"), helper.getCachedFields());
         assertFalse(helper.hasLimitExceeded());
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field2", innerHelper::isStoredField);
         assertEquals(2, storedCounter.get(), "field2 repeated (existing)");
+        assertEquals(Set.of("field1", "field2"), helper.getCachedFields());
         assertFalse(helper.hasLimitExceeded());
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.INDEXED_FIELD, "field1", innerHelper::isIndexedField);
+        helper.getFieldResult(INDEXED_FIELD, "field1", innerHelper::isIndexedField);
         assertEquals(1, indexCounter.get(), "field1 should compute result (new attribute)");
+        assertEquals(Set.of("field1", "field2"), helper.getCachedFields());
         assertFalse(helper.hasLimitExceeded());
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field3", innerHelper::isStoredField);
         assertEquals(3, storedCounter.get(), "field3 exceeded limit (new field)");
+        assertEquals(Set.of("field1", "field3"), helper.getCachedFields());
         assertTrue(helper.hasLimitExceeded());
 
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field3", innerHelper::isStoredField);
         assertEquals(3, storedCounter.get(), "field3 exceeded limit (existing field)");
+        assertEquals(Set.of("field1", "field3"), helper.getCachedFields());
 
         // LRU map should evict field #2
         // we access field #1 above which has more accesses over field #2
-        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
+        helper.getFieldResult(STORED_FIELD, "field2", innerHelper::isStoredField);
+        assertEquals(Set.of("field2", "field3"), helper.getCachedFields());
         assertEquals(4, storedCounter.get(), "field1 exceeded limit (new field/eviction)");
+    }
+
+    @Test
+    public void testCacheHelperDiagnosticMessage() {
+        CachedFieldConfigHelper.Clock clock = mock(CachedFieldConfigHelper.Clock.class);
+        FieldConfigHelper innerHelper = mock(FieldConfigHelper.class);
+        CachedFieldConfigHelper helper = new CachedFieldConfigHelper(innerHelper, 2, true);
+
+        // set the clock so that the trace emit
+        // should fire as soon as the limit is exceeded
+        // expected below by the very last test-case
+        when(clock.epochMillis()).thenReturn(1L);
+        helper.setDiagnosticEmitIntervalMillis(1);
+        helper.setClock(clock);
+
+        assertEquals(0, helper.getDiagnosticEmitNextMillis(), "expected trace interval to be zero");
+
+        helper.isStoredField("field1");
+        assertEquals(1, helper.getDiagnosticFieldCompute());
+        assertEquals(Set.of("field1"), helper.getDiagnosticUniqueFields(), "field1 uniq fields");
+        assertTrue(helper.getDiagnosticEmitted(), "field1 should have caused a trace emit");
+        assertEquals(2, helper.getDiagnosticEmitNextMillis(), "expected trace emit interval to increase");
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
@@ -1,7 +1,9 @@
 package datawave.ingest.data.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -62,7 +64,7 @@ public class CachedFieldConfigHelperTest {
         AtomicLong storedCounter = new AtomicLong();
         AtomicLong indexCounter = new AtomicLong();
         FieldConfigHelper innerHelper = mock(FieldConfigHelper.class);
-        CachedFieldConfigHelper helper = new CachedFieldConfigHelper(innerHelper, 2);
+        CachedFieldConfigHelper helper = new CachedFieldConfigHelper(innerHelper, 2, true);
 
         when(innerHelper.isStoredField(any())).then((a) -> {
             storedCounter.incrementAndGet();
@@ -82,12 +84,15 @@ public class CachedFieldConfigHelperTest {
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", innerHelper::isStoredField);
         assertEquals(1, storedCounter.get(), "field1 should compute result (new field)");
+        assertFalse(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", innerHelper::isStoredField);
         assertEquals(1, storedCounter.get(), "field1 repeated (existing field)");
+        assertFalse(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
         assertEquals(2, storedCounter.get(), "field2 should compute result (new field)");
+        assertTrue(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
         assertEquals(2, storedCounter.get(), "field2 repeated (existing)");

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachedFieldConfigHelperTest.java
@@ -92,16 +92,19 @@ public class CachedFieldConfigHelperTest {
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
         assertEquals(2, storedCounter.get(), "field2 should compute result (new field)");
-        assertTrue(helper.hasLimitExceeded());
+        assertFalse(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
         assertEquals(2, storedCounter.get(), "field2 repeated (existing)");
+        assertFalse(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.INDEXED_FIELD, "field1", innerHelper::isIndexedField);
         assertEquals(1, indexCounter.get(), "field1 should compute result (new attribute)");
+        assertFalse(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", innerHelper::isStoredField);
         assertEquals(3, storedCounter.get(), "field3 exceeded limit (new field)");
+        assertTrue(helper.hasLimitExceeded());
 
         helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", innerHelper::isStoredField);
         assertEquals(3, storedCounter.get(), "field3 exceeded limit (existing field)");

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachingFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachingFieldConfigHelperTest.java
@@ -1,16 +1,18 @@
 package datawave.ingest.data.config;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class CachingFieldConfigHelperTest {
@@ -45,14 +47,32 @@ public class CachingFieldConfigHelperTest {
         assertThrows(IllegalArgumentException.class, () -> new CachedFieldConfigHelper(mock(FieldConfigHelper.class), limit));
     }
 
+    @SuppressWarnings("ClassEscapesDefinedScope")
+    @ParameterizedTest
+    @EnumSource(CachedFieldConfigHelper.AttributeType.class)
+    public void testAttributeTypesDoNotThrow(CachedFieldConfigHelper.AttributeType attributeType) {
+        String fieldName = "test";
+        FieldConfigHelper mockHelper = mock(FieldConfigHelper.class);
+        CachedFieldConfigHelper cachedHelper = new CachedFieldConfigHelper(mockHelper, 1);
+        cachedHelper.getFieldResult(attributeType, fieldName, (f) -> true);
+    }
+
     @Test
     public void testCachingLimitsBetweenFieldsAndAttributeTypes() {
-        AtomicLong counter = new AtomicLong();
-        CachedFieldConfigHelper helper = new CachedFieldConfigHelper(mock(FieldConfigHelper.class), 2);
-        Function<String,Boolean> fn = (f) -> {
-            counter.incrementAndGet();
+        AtomicLong storedCounter = new AtomicLong();
+        AtomicLong indexCounter = new AtomicLong();
+        FieldConfigHelper innerHelper = mock(FieldConfigHelper.class);
+        CachedFieldConfigHelper helper = new CachedFieldConfigHelper(innerHelper, 2);
+
+        when(innerHelper.isStoredField(any())).then((a) -> {
+            storedCounter.incrementAndGet();
             return true;
-        };
+        });
+
+        when(innerHelper.isIndexedField(any())).then((a) -> {
+            indexCounter.incrementAndGet();
+            return true;
+        });
 
         // following ensures that:
         // 1. fields are computed, where appropriate per attribute-type
@@ -60,30 +80,30 @@ public class CachingFieldConfigHelperTest {
         // 3. limit blocks results to return if exceeded
         // 4. limit functions across attribute-types
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", fn);
-        Assertions.assertEquals(1, counter.get(), "field1 should compute result (new field)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", innerHelper::isStoredField);
+        assertEquals(1, storedCounter.get(), "field1 should compute result (new field)");
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", fn);
-        Assertions.assertEquals(1, counter.get(), "field1 repeated (existing field)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", innerHelper::isStoredField);
+        assertEquals(1, storedCounter.get(), "field1 repeated (existing field)");
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", fn);
-        Assertions.assertEquals(2, counter.get(), "field2 should compute result (new field)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
+        assertEquals(2, storedCounter.get(), "field2 should compute result (new field)");
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", fn);
-        Assertions.assertEquals(2, counter.get(), "field2 repeated (existing)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
+        assertEquals(2, storedCounter.get(), "field2 repeated (existing)");
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.INDEXED_FIELD, "field1", fn);
-        Assertions.assertEquals(3, counter.get(), "field1 should compute result (new attribute)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.INDEXED_FIELD, "field1", innerHelper::isIndexedField);
+        assertEquals(1, indexCounter.get(), "field1 should compute result (new attribute)");
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", fn);
-        Assertions.assertEquals(4, counter.get(), "field3 exceeded limit (new field)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", innerHelper::isStoredField);
+        assertEquals(3, storedCounter.get(), "field3 exceeded limit (new field)");
 
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", fn);
-        Assertions.assertEquals(4, counter.get(), "field3 exceeded limit (existing field)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", innerHelper::isStoredField);
+        assertEquals(3, storedCounter.get(), "field3 exceeded limit (existing field)");
 
         // LRU map should evict field #2
         // we access field #1 above which has more accesses over field #2
-        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", fn);
-        Assertions.assertEquals(5, counter.get(), "field1 exceeded limit (new field/eviction)");
+        helper.getFieldResult(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", innerHelper::isStoredField);
+        assertEquals(4, storedCounter.get(), "field1 exceeded limit (new field/eviction)");
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachingFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachingFieldConfigHelperTest.java
@@ -1,0 +1,99 @@
+package datawave.ingest.data.config;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CachingFieldConfigHelperTest {
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCachingBehaviorWillCallBaseMethods() {
+        // @formatter:off
+        Stream.of(new Object[][] {
+            new Object[] {
+                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isIndexOnlyField,
+                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isIndexOnlyField(eq(f)),
+                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isIndexedField,
+                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isIndexedField(eq(f)),
+                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isTokenizedField,
+                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isTokenizedField(eq(f)),
+                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isStoredField,
+                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isStoredField(eq(f)),
+                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isReverseIndexedField,
+                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isReverseIndexedField(eq(f)),
+                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isReverseTokenizedField,
+                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isReverseTokenizedField(eq(f)),
+            }
+        }).forEach(arg -> {
+            // param[0] = helper method
+            // param[1] = validation method
+            String fieldName = "testField";
+            BiConsumer<FieldConfigHelper, String> testAction = (BiConsumer<FieldConfigHelper, String>) arg[0];
+            BiConsumer<FieldConfigHelper, String> verifyAction = (BiConsumer<FieldConfigHelper, String>) arg[1];
+            FieldConfigHelper mockHelper = mock(FieldConfigHelper.class);
+            FieldConfigHelper cachedHelper = new CachedFieldConfigHelper(mockHelper, 1);
+            testAction.accept(cachedHelper, fieldName);
+            verifyAction.accept(mockHelper, fieldName);
+        });
+        // @formatter:on
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    public void testConstructorWithNonPositiveLimitWillThrow(int limit) {
+        assertThrows(IllegalArgumentException.class, () -> new CachedFieldConfigHelper(mock(FieldConfigHelper.class), limit));
+    }
+
+    @Test
+    public void testCachingLimitsBetweenFieldsAndAttributeTypes() {
+        AtomicLong counter = new AtomicLong();
+        CachedFieldConfigHelper helper = new CachedFieldConfigHelper(mock(FieldConfigHelper.class), 2);
+        Function<String,Boolean> fn = (f) -> {
+            counter.incrementAndGet();
+            return true;
+        };
+
+        // following ensures that:
+        // 1. fields are computed, where appropriate per attribute-type
+        // 2. limit allows cache results to return
+        // 3. limit blocks results to return if exceeded
+        // 4. limit functions across attribute-types
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", fn);
+        Assertions.assertEquals(1, counter.get(), "field1 should compute result (new field)");
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field1", fn);
+        Assertions.assertEquals(1, counter.get(), "field1 repeated (existing field)");
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", fn);
+        Assertions.assertEquals(2, counter.get(), "field2 should compute result (new field)");
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", fn);
+        Assertions.assertEquals(2, counter.get(), "field2 repeated (existing)");
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.INDEXED_FIELD, "field1", fn);
+        Assertions.assertEquals(3, counter.get(), "field1 should compute result (new attribute)");
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", fn);
+        Assertions.assertEquals(4, counter.get(), "field3 exceeded limit (new field)");
+
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field3", fn);
+        Assertions.assertEquals(4, counter.get(), "field3 exceeded limit (existing field)");
+
+        // LRU map should evict field #2
+        // we access field #1 above which has more accesses over field #2
+        helper.getOrEvaluate(CachedFieldConfigHelper.AttributeType.STORED_FIELD, "field2", fn);
+        Assertions.assertEquals(5, counter.get(), "field1 exceeded limit (new field/eviction)");
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachingFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CachingFieldConfigHelperTest.java
@@ -6,9 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -16,37 +14,29 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class CachingFieldConfigHelperTest {
-    @SuppressWarnings("unchecked")
     @Test
     public void testCachingBehaviorWillCallBaseMethods() {
-        // @formatter:off
-        Stream.of(new Object[][] {
-            new Object[] {
-                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isIndexOnlyField,
-                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isIndexOnlyField(eq(f)),
-                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isIndexedField,
-                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isIndexedField(eq(f)),
-                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isTokenizedField,
-                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isTokenizedField(eq(f)),
-                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isStoredField,
-                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isStoredField(eq(f)),
-                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isReverseIndexedField,
-                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isReverseIndexedField(eq(f)),
-                (BiConsumer<FieldConfigHelper, String>) FieldConfigHelper::isReverseTokenizedField,
-                    (BiConsumer<FieldConfigHelper, String>) (h, f) -> verify(h).isReverseTokenizedField(eq(f)),
-            }
-        }).forEach(arg -> {
-            // param[0] = helper method
-            // param[1] = validation method
-            String fieldName = "testField";
-            BiConsumer<FieldConfigHelper, String> testAction = (BiConsumer<FieldConfigHelper, String>) arg[0];
-            BiConsumer<FieldConfigHelper, String> verifyAction = (BiConsumer<FieldConfigHelper, String>) arg[1];
-            FieldConfigHelper mockHelper = mock(FieldConfigHelper.class);
-            FieldConfigHelper cachedHelper = new CachedFieldConfigHelper(mockHelper, 1);
-            testAction.accept(cachedHelper, fieldName);
-            verifyAction.accept(mockHelper, fieldName);
-        });
-        // @formatter:on
+        String fieldName = "test";
+        FieldConfigHelper mockHelper = mock(FieldConfigHelper.class);
+        FieldConfigHelper cachedHelper = new CachedFieldConfigHelper(mockHelper, 1);
+
+        cachedHelper.isIndexOnlyField(fieldName);
+        verify(mockHelper).isIndexOnlyField(eq(fieldName));
+
+        cachedHelper.isIndexedField(fieldName);
+        verify(mockHelper).isIndexedField(eq(fieldName));
+
+        cachedHelper.isTokenizedField(fieldName);
+        verify(mockHelper).isTokenizedField(eq(fieldName));
+
+        cachedHelper.isStoredField(fieldName);
+        verify(mockHelper).isStoredField(eq(fieldName));
+
+        cachedHelper.isReverseIndexedField(fieldName);
+        verify(mockHelper).isReverseIndexedField(eq(fieldName));
+
+        cachedHelper.isReverseTokenizedField(fieldName);
+        verify(mockHelper).isReverseTokenizedField(eq(fieldName));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Implementation of a field helper cache using an LRU map. 
* The cache can be optionally enabled on the `BaseIngestHelper` instance and will wrap an existing `FieldConfigHelper` implementation.
* By default the cache is disabled and must be enabled via configuration.

As part of the work, there was also a factory implementation in separate branch which would allow an implementation to be specified by configuration, which may be preferrable.

Closes #2612 