### PR TITLE
fixed python2 and 3 compatibility issues w docker-quickstart scripts

### DIFF
--- a/contrib/datawave-quickstart/bin/query.sh
+++ b/contrib/datawave-quickstart/bin/query.sh
@@ -131,23 +131,8 @@ function setQueryIdFromResponse() {
 }
 
 function prettyPrintJson() {
-    PY_CMD='"from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)"'
-    PY3=$(which python3 2>/dev/null)
-    PY2=$(which python2 2>/dev/null)
-    if [[ ( -n "${PY3}" ) || ( -n "${PY2}" ) ]] ; then
-      echo "${1}" | ( "${PY3}" -c "${PY_CMD}" || "${PY2}" -c "${PY_CMD}" )
-      local exitStatus=$?
-      echo
-      if [ "${exitStatus}" != "0" ] ; then
-        printRawResponse "${1}"
-        warn "Python encountered error. Printed response without formatting"
-        echo
-      fi
-    else
-      printRawResponse "${1}"
-      warn "Couldn't find Python in your environment. Json response was printed without formatting"
-      echo
-    fi
+    PY_CMD='from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)'
+    echo "${1}" | ( "${PY3}" -c "${PY_CMD}" 2>/dev/null || "${PY2}" -c "${PY_CMD}" 2>/dev/null ) || ( warn "Python encountered error. Printed response without formatting" && printRawResponse "${1}" )
 }
 
 function printRawResponse() {

--- a/contrib/datawave-quickstart/bin/query.sh
+++ b/contrib/datawave-quickstart/bin/query.sh
@@ -131,7 +131,7 @@ function setQueryIdFromResponse() {
 }
 
 function prettyPrintJson() {
-    PY_CMD='"from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)"'
+    PY_CMD='from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
     echo "${1}" | ( python3 -c "${PY_CMD}" 2>/dev/null || python2 -c "${PY_CMD}" 2>/dev/null ) || ( warn "Python encountered error. Printed response without formatting" && printRawResponse "${1}" )
 }
 

--- a/contrib/datawave-quickstart/bin/query.sh
+++ b/contrib/datawave-quickstart/bin/query.sh
@@ -131,8 +131,8 @@ function setQueryIdFromResponse() {
 }
 
 function prettyPrintJson() {
-    PY_CMD='from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)'
-    echo "${1}" | ( "${PY3}" -c "${PY_CMD}" 2>/dev/null || "${PY2}" -c "${PY_CMD}" 2>/dev/null ) || ( warn "Python encountered error. Printed response without formatting" && printRawResponse "${1}" )
+    PY_CMD='"from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)"'
+    echo "${1}" | ( python3 -c "${PY_CMD}" 2>/dev/null || python2 -c "${PY_CMD}" 2>/dev/null ) || ( warn "Python encountered error. Printed response without formatting" && printRawResponse "${1}" )
 }
 
 function printRawResponse() {

--- a/contrib/datawave-quickstart/bin/query.sh
+++ b/contrib/datawave-quickstart/bin/query.sh
@@ -131,21 +131,32 @@ function setQueryIdFromResponse() {
 }
 
 function prettyPrintJson() {
-    local PY=$( which python )
-    if [ -n "${PY}" ] ; then
-        echo "${1}" | ${PY} -c 'from __future__ import print_function;import sys,json;data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
-        local exitStatus=$?
-        echo
-        if [ "${exitStatus}" != "0" ] ; then
-           printRawResponse "${1}"
-           warn "Python encountered error. Printed response without formatting"
-           echo
+    PY_CMD='"from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)"'
+        PY3=$(which python3 2>/dev/null)
+        PY2=$(which python2 2>/dev/null)
+        if [ -n "${PY3}" ] ; then
+                echo "${1}" | "${PY3}" -c "${PY_CMD}"
+            local exitStatus=$?
+            echo
+            if [ "${exitStatus}" != "0" ] ; then
+              printRawResponse "${1}"
+              warn "Python encountered error. Printed response without formatting"
+              echo
+            fi
+          elif [ -n "${PY2}" ] ; then
+            echo "${1}" | "${PY2}" -c "${PY_CMD}"
+            local exitStatus=$?
+            echo
+            if [ "${exitStatus}" != "0" ] ; then
+              printRawResponse "${1}"
+              warn "Python encountered error. Printed response without formatting"
+              echo
+            fi
+          else
+            printRawResponse "${1}"
+                warn "Couldn't find Python in your environment. Json response was printed without formatting"
+                echo
         fi
-    else
-        printRawResponse "${1}"
-        warn "Couldn't find python in your environment. Json response was printed without formatting"
-        echo
-    fi
 }
 
 function printRawResponse() {

--- a/contrib/datawave-quickstart/bin/query.sh
+++ b/contrib/datawave-quickstart/bin/query.sh
@@ -132,31 +132,22 @@ function setQueryIdFromResponse() {
 
 function prettyPrintJson() {
     PY_CMD='"from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True)"'
-        PY3=$(which python3 2>/dev/null)
-        PY2=$(which python2 2>/dev/null)
-        if [ -n "${PY3}" ] ; then
-                echo "${1}" | "${PY3}" -c "${PY_CMD}"
-            local exitStatus=$?
-            echo
-            if [ "${exitStatus}" != "0" ] ; then
-              printRawResponse "${1}"
-              warn "Python encountered error. Printed response without formatting"
-              echo
-            fi
-          elif [ -n "${PY2}" ] ; then
-            echo "${1}" | "${PY2}" -c "${PY_CMD}"
-            local exitStatus=$?
-            echo
-            if [ "${exitStatus}" != "0" ] ; then
-              printRawResponse "${1}"
-              warn "Python encountered error. Printed response without formatting"
-              echo
-            fi
-          else
-            printRawResponse "${1}"
-                warn "Couldn't find Python in your environment. Json response was printed without formatting"
-                echo
-        fi
+    PY3=$(which python3 2>/dev/null)
+    PY2=$(which python2 2>/dev/null)
+    if [[ ( -n "${PY3}" ) || ( -n "${PY2}" ) ]] ; then
+      echo "${1}" | ( "${PY3}" -c "${PY_CMD}" || "${PY2}" -c "${PY_CMD}" )
+      local exitStatus=$?
+      echo
+      if [ "${exitStatus}" != "0" ] ; then
+        printRawResponse "${1}"
+        warn "Python encountered error. Printed response without formatting"
+        echo
+      fi
+    else
+      printRawResponse "${1}"
+      warn "Couldn't find Python in your environment. Json response was printed without formatting"
+      echo
+    fi
 }
 
 function printRawResponse() {

--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
@@ -38,15 +38,9 @@ TVMAZE_RESPONSE_STATUS=$( echo ${CURL_RESPONSE} | tr -d '\n' | sed -e 's/.*HTTP_
 [ "${TVMAZE_RESPONSE_STATUS}" != "200" ] && error "api.tvmaze.com returned invalid response status: ${TVMAZE_RESPONSE_STATUS}" && exit 1
 [ -z "${TVMAZE_RESPONSE_BODY}" ] && error "Response body is empty!" && exit 1
 
-PY_CMD="-c 'from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))' "
-PY3="/usr/bin/python3"
-PY2="/usr/bin/python2"
+PY_CMD='from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
 if [ "${PRETTY}" == true ] ; then
-  if [ -d "${PY3}" ]; then
-    echo "${TVMAZE_RESPONSE_BODY}" | "${PY3}" ${PY_CMD}
-  elif [ -d "${PY2}" ]; then
-    echo "${TVMAZE_RESPONSE_BODY}" | "${PY2}" ${PY_CMD}
-  fi
+  echo "${TVMAZE_RESPONSE_BODY}" | ( python3 -c "${PY_CMD}" 2>/dev/null || python2 -c "${PY_CMD}" 2>/dev/null ) || ( warn "Unable to pretty print, Python not detected" && echo "${TVMAZE_RESPONSE_BODY}" )
 else
   echo "${TVMAZE_RESPONSE_BODY}"
 fi

--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
@@ -41,14 +41,14 @@ TVMAZE_RESPONSE_STATUS=$( echo ${CURL_RESPONSE} | tr -d '\n' | sed -e 's/.*HTTP_
 PY_CMD="-c 'from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))' "
 PY3="/usr/bin/python3"
 PY2="/usr/bin/python2"
-  if [ "${PRETTY}" == true ] ; then
-    if [ -d "${PY3}" ]; then
-      echo "${TVMAZE_RESPONSE_BODY}" | "${PY3}" ${PY_CMD}
-    elif [ -d "${PY2}" ]; then
-      echo "${TVMAZE_RESPONSE_BODY}" | "${PY2}" ${PY_CMD}
-    fi
-  else
-    echo "${TVMAZE_RESPONSE_BODY}"
+if [ "${PRETTY}" == true ] ; then
+  if [ -d "${PY3}" ]; then
+    echo "${TVMAZE_RESPONSE_BODY}" | "${PY3}" ${PY_CMD}
+  elif [ -d "${PY2}" ]; then
+    echo "${TVMAZE_RESPONSE_BODY}" | "${PY2}" ${PY_CMD}
   fi
+else
+  echo "${TVMAZE_RESPONSE_BODY}"
+fi
 
 exit 0

--- a/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/ingest-examples/tvmaze-api-query.sh
@@ -38,10 +38,17 @@ TVMAZE_RESPONSE_STATUS=$( echo ${CURL_RESPONSE} | tr -d '\n' | sed -e 's/.*HTTP_
 [ "${TVMAZE_RESPONSE_STATUS}" != "200" ] && error "api.tvmaze.com returned invalid response status: ${TVMAZE_RESPONSE_STATUS}" && exit 1
 [ -z "${TVMAZE_RESPONSE_BODY}" ] && error "Response body is empty!" && exit 1
 
-if [ "${PRETTY}" == true ] ; then
-    echo "${TVMAZE_RESPONSE_BODY}" | python -c 'from __future__ import print_function;import sys,json;data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))'
-else
+PY_CMD="-c 'from __future__ import print_function; import sys,json; data=json.loads(sys.stdin.read()); print(json.dumps(data, indent=2, sort_keys=True))' "
+PY3="/usr/bin/python3"
+PY2="/usr/bin/python2"
+  if [ "${PRETTY}" == true ] ; then
+    if [ -d "${PY3}" ]; then
+      echo "${TVMAZE_RESPONSE_BODY}" | "${PY3}" ${PY_CMD}
+    elif [ -d "${PY2}" ]; then
+      echo "${TVMAZE_RESPONSE_BODY}" | "${PY2}" ${PY_CMD}
+    fi
+  else
     echo "${TVMAZE_RESPONSE_BODY}"
-fi
+  fi
 
 exit 0

--- a/contrib/datawave-quickstart/docker/Dockerfile
+++ b/contrib/datawave-quickstart/docker/Dockerfile
@@ -35,7 +35,7 @@ COPY . /opt/datawave
 
 # Install dependencies, configure password-less/zero-prompt SSH...
 
-RUN dnf -y install gcc-c++ openssl openssh openssh-server openssh-clients openssl-libs which bc wget git java-11-openjdk-devel iproute  && \
+RUN dnf -y install gcc-c++ openssl python3 openssh openssh-server openssh-clients openssl-libs which bc wget git java-11-openjdk-devel iproute  && \
     dnf clean all && \
     ssh-keygen -q -N "" -t rsa -f ~/.ssh/id_rsa && \
     cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys && \


### PR DESCRIPTION
Fixed the scripts within docker-quickstart that used Python, `query.sh` and `tvmaze-api-query.sh` were affected and now support Python2 and Python3. `ingest-tv-shows.sh` now works correctly. Added Python3 to `Dockerfile`

Fixes #2611 