### PR TITLE
Change file-provider-service conflicted ports in docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -424,8 +424,8 @@ services:
       - --spring.cloud.consul.host=consul
       - --spring.cloud.consul.discovery.instance-id=$${spring.application.name}:$${random.value}
     ports:
-      - "8280:8080"
-      - "8643:8443"
+      - "8580:8080"
+      - "8943:8443"
     volumes:
       - ${PKI_DIR:-./pki}:/etc/pki:ro
       - ./logs:/logs


### PR DESCRIPTION
The file-provider service was using ports already given to the dictionary service. This caused a conflict and would not allow the docker-compose to properly start when bringing all services up.

The ports no longer conflict and the docker-compose works when bringing up all services.