### PR TITLE
Removing unused reduced response from various Attribute methods

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -160,7 +160,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         metadata = null;
     }
 
-    protected void writeMetadata(DataOutput out, Boolean reducedResponse) throws IOException {
+    protected void writeMetadata(DataOutput out) throws IOException {
         out.writeBoolean(isMetadataSet());
         if (isMetadataSet()) {
             byte[] cvBytes = getColumnVisibility().getExpression();
@@ -172,7 +172,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         }
     }
 
-    protected void writeMetadata(Kryo kryo, Output output, Boolean reducedResponse) {
+    protected void writeMetadata(Kryo kryo, Output output) {
         output.writeBoolean(isMetadataSet());
         if (isMetadataSet()) {
             byte[] cvBytes = getColumnVisibility().getExpression();
@@ -324,9 +324,9 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         }
     }
 
-    public abstract void write(DataOutput output, boolean reducedResponse) throws IOException;
+    public abstract void write(DataOutput output) throws IOException;
 
-    public abstract void write(Kryo kryo, Output output, Boolean reducedResponse);
+    public abstract void write(Kryo kryo, Output output);
 
     public abstract Object getData();
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
@@ -111,11 +111,6 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
         WritableUtils.writeVInt(out, _count);
         out.writeBoolean(trackSizes);
         // Write out the number of Attributes we're going to store
@@ -126,7 +121,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
             WritableUtils.writeString(out, attr.getClass().getName());
 
             // Defer to the concrete instance to write() itself
-            attr.write(out, reducedResponse);
+            attr.write(out);
         }
     }
 
@@ -284,11 +279,6 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
         output.writeInt(this._count, true);
         output.writeBoolean(this.trackSizes);
         // Write out the number of Attributes we're going to store
@@ -299,7 +289,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
             output.writeString(attr.getClass().getName());
 
             // Defer to the concrete instance to write() itself
-            attr.write(kryo, output, reducedResponse);
+            attr.write(kryo, output);
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
@@ -146,6 +146,7 @@ public class Cardinality extends Attribute<Cardinality> {
 
     @Override
     public void write(Kryo kryo, Output output) {
+        super.writeMetadata(kryo, output);
         output.writeString(this.content.fieldName);
         output.writeString(this.content.lower);
         output.writeString(this.content.upper);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
@@ -62,12 +62,7 @@ public class Cardinality extends Attribute<Cardinality> {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, content.fieldName);
         WritableUtils.writeString(out, content.lower);
         WritableUtils.writeString(out, content.upper);
@@ -151,12 +146,6 @@ public class Cardinality extends Attribute<Cardinality> {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
         output.writeString(this.content.fieldName);
         output.writeString(this.content.lower);
         output.writeString(this.content.upper);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
@@ -62,18 +62,13 @@ public class Content extends Attribute<Content> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, content);
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
         out.writeBoolean(source != null);
         if (source != null) {
             WritableUtils.writeString(out, source.getClass().getCanonicalName());
-            source.write(out, reducedResponse);
+            source.write(out);
         }
     }
 
@@ -137,18 +132,13 @@ public class Content extends Attribute<Content> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         output.writeString(this.content);
         output.writeBoolean(this.toKeep);
         output.writeBoolean(this.source != null);
         if (source != null) {
             output.writeString(this.source.getClass().getCanonicalName());
-            source.write(kryo, output, reducedResponse);
+            source.write(kryo, output);
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DateContent.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DateContent.java
@@ -102,12 +102,7 @@ public class DateContent extends Attribute<DateContent> implements Serializable 
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, normalizer.parseToString(this.value.getTime()));
     }
 
@@ -160,12 +155,7 @@ public class DateContent extends Attribute<DateContent> implements Serializable 
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(normalizer.parseToString(this.value.getTime()));
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DiacriticContent.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DiacriticContent.java
@@ -51,12 +51,7 @@ public class DiacriticContent extends Attribute<DiacriticContent> implements Ser
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, content);
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -108,12 +103,7 @@ public class DiacriticContent extends Attribute<DiacriticContent> implements Ser
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(this.content);
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -546,11 +546,6 @@ public class Document extends AttributeBag<Document> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
         WritableUtils.writeVInt(out, _count);
         out.writeBoolean(trackSizes);
         WritableUtils.writeVLong(out, _bytes);
@@ -782,11 +777,6 @@ public class Document extends AttributeBag<Document> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
         output.writeInt(this._count, true);
         output.writeBoolean(trackSizes);
         output.writeLong(this._bytes, true);
@@ -801,7 +791,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
 
             Attribute<?> attribute = entry.getValue();
             output.writeString(attribute.getClass().getName());
-            attribute.write(kryo, output, reducedResponse);
+            attribute.write(kryo, output);
         }
 
         output.writeLong(this.shardTimestamp);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -238,7 +238,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
     }
 
     public void put(String key, Attribute<?> value) {
-        put(key, value, false, false);
+        put(key, value, false);
     }
 
     /**
@@ -250,10 +250,8 @@ public class Document extends AttributeBag<Document> implements Serializable {
      *            a value
      * @param includeGroupingContext
      *            flag to include grouping context
-     * @param reducedResponse
-     *            flag for reducedResponse
      */
-    public void replace(String key, Attribute<?> value, Boolean includeGroupingContext, boolean reducedResponse) {
+    public void replace(String key, Attribute<?> value, Boolean includeGroupingContext) {
         dict.put(key, value);
     }
 
@@ -268,10 +266,8 @@ public class Document extends AttributeBag<Document> implements Serializable {
      *            the attribute value
      * @param includeGroupingContext
      *            flag to include grouping context
-     * @param reducedResponse
-     *            flag for reducedResponse
      */
-    public void put(String key, Attribute<?> value, Boolean includeGroupingContext, boolean reducedResponse) {
+    public void put(String key, Attribute<?> value, Boolean includeGroupingContext) {
 
         if (0 == value.size()) {
             if (log.isTraceEnabled()) {
@@ -383,25 +379,16 @@ public class Document extends AttributeBag<Document> implements Serializable {
 
     public void put(Entry<String,Attribute<? extends Comparable<?>>> entry, Boolean includeGroupingContext) {
         // No grouping context in the document.
-        this.put(entry.getKey(), entry.getValue(), includeGroupingContext, false);
-    }
-
-    public void put(Entry<String,Attribute<? extends Comparable<?>>> entry, Boolean includeGroupingContext, boolean reducedResponse) {
-        // No grouping context in the document.
-        this.put(entry.getKey(), entry.getValue(), includeGroupingContext, reducedResponse);
+        this.put(entry.getKey(), entry.getValue(), includeGroupingContext);
     }
 
     public void putAll(Iterator<Entry<String,Attribute<? extends Comparable<?>>>> iterator, Boolean includeGroupingContext) {
-        putAll(iterator, includeGroupingContext, false);
-    }
-
-    public void putAll(Iterator<Entry<String,Attribute<? extends Comparable<?>>>> iterator, Boolean includeGroupingContext, boolean reducedResponse) {
         if (null == iterator) {
             return;
         }
 
         while (iterator.hasNext()) {
-            put(iterator.next(), includeGroupingContext, reducedResponse);
+            put(iterator.next(), includeGroupingContext);
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DocumentKey.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DocumentKey.java
@@ -85,12 +85,7 @@ public class DocumentKey extends Attribute<DocumentKey> implements Serializable 
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, getShardId());
         WritableUtils.writeString(out, getDataType());
         WritableUtils.writeString(out, getUid());
@@ -133,12 +128,7 @@ public class DocumentKey extends Attribute<DocumentKey> implements Serializable 
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         output.writeString(this.getShardId());
         output.writeString(this.getDataType());
         output.writeString(this.getUid());

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/GeoPoint.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/GeoPoint.java
@@ -60,12 +60,7 @@ public class GeoPoint extends Attribute<GeoPoint> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, this.point);
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -134,12 +129,7 @@ public class GeoPoint extends Attribute<GeoPoint> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(this.point);
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Geometry.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Geometry.java
@@ -75,12 +75,7 @@ public class Geometry extends Attribute<Geometry> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeCompressedByteArray(out, write());
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -154,12 +149,7 @@ public class Geometry extends Attribute<Geometry> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeBoolean(this.toKeep);
         byte[] wellKnownBinary = write();
         output.writeInt(wellKnownBinary.length);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/IpAddress.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/IpAddress.java
@@ -61,12 +61,7 @@ public class IpAddress extends Attribute<IpAddress> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, this.value.toString());
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -122,12 +117,7 @@ public class IpAddress extends Attribute<IpAddress> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(this.value.toString());
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Latitude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Latitude.java
@@ -61,12 +61,7 @@ public class Latitude extends Attribute<Latitude> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, this.latitude);
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -134,12 +129,7 @@ public class Latitude extends Attribute<Latitude> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(this.latitude);
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Longitude.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Longitude.java
@@ -61,12 +61,7 @@ public class Longitude extends Attribute<Longitude> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, this.longitude);
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -134,12 +129,7 @@ public class Longitude extends Attribute<Longitude> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(this.longitude);
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
@@ -110,12 +110,7 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, normalizedValue);
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -173,12 +168,7 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        writeMetadata(kryo, output, reducedResponse);
+        writeMetadata(kryo, output);
         output.writeString(this.normalizedValue);
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/PreNormalizedAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/PreNormalizedAttribute.java
@@ -77,12 +77,7 @@ public class PreNormalizedAttribute extends Attribute<PreNormalizedAttribute> im
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         output.writeString(this.value);
         output.writeBoolean(this.toKeep);
     }
@@ -96,12 +91,7 @@ public class PreNormalizedAttribute extends Attribute<PreNormalizedAttribute> im
 
     @Override
     public void write(DataOutput output) throws IOException {
-        write(output, false);
-    }
-
-    @Override
-    public void write(DataOutput output, boolean reducedResponse) throws IOException {
-        super.writeMetadata(output, reducedResponse);
+        super.writeMetadata(output);
         WritableUtils.writeString(output, this.value);
         WritableUtils.writeVInt(output, toKeep ? 1 : 0);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -58,13 +58,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public void write(DataOutput out) throws IOException {
-        write(out, false);
-    }
-
-    @Override
-    public void write(DataOutput out, boolean reducedResponse) throws IOException {
         WritableUtils.writeString(out, datawaveType.getClass().toString());
-        writeMetadata(out, reducedResponse);
+        writeMetadata(out);
         WritableUtils.writeString(out, datawaveType.getDelegateAsString());
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -131,13 +126,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public void write(Kryo kryo, Output output) {
-        write(kryo, output, false);
-    }
-
-    @Override
-    public void write(Kryo kryo, Output output, Boolean reducedResponse) {
         output.writeString(datawaveType.getClass().getName());
-        super.writeMetadata(kryo, output, reducedResponse);
+        super.writeMetadata(kryo, output);
         output.writeString(this.datawaveType.getDelegateAsString());
         output.writeBoolean(this.toKeep);
     }

--- a/warehouse/query-core/src/main/java/datawave/query/function/DataTypeAsField.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/DataTypeAsField.java
@@ -29,7 +29,7 @@ public class DataTypeAsField implements Function<Entry<Key,Document>,Entry<Key,D
     @Override
     public Entry<Key,Document> apply(Entry<Key,Document> from) {
         Content dataType = extractDataType(from.getKey(), from.getValue().isToKeep());
-        from.getValue().put(key, dataType, false, false);
+        from.getValue().put(key, dataType, false);
         return from;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/function/DocumentProjection.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/DocumentProjection.java
@@ -121,7 +121,7 @@ public class DocumentProjection implements DocumentPermutation {
                         Document newSubDoc = trim((Document) attr);
 
                         if (0 < newSubDoc.size()) {
-                            newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext, this.reducedResponse);
+                            newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext);
                         }
 
                         continue;
@@ -129,7 +129,7 @@ public class DocumentProjection implements DocumentPermutation {
                         Attributes subAttrs = trim((Attributes) attr, fieldName);
 
                         if (0 < subAttrs.size()) {
-                            newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext, this.reducedResponse);
+                            newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext);
                         }
 
                         continue;
@@ -137,7 +137,7 @@ public class DocumentProjection implements DocumentPermutation {
                 }
 
                 // We just want to add this subtree
-                newDoc.put(fieldName, (Attribute<?>) attr.copy(), this.includeGroupingContext, this.reducedResponse);
+                newDoc.put(fieldName, (Attribute<?>) attr.copy(), this.includeGroupingContext);
 
             } else if (!projection.isUseExcludes()) {
                 // excludes will completely exclude a subtree, but an includes may
@@ -147,16 +147,16 @@ public class DocumentProjection implements DocumentPermutation {
                     Document newSubDoc = trim((Document) attr);
 
                     if (0 < newSubDoc.size()) {
-                        newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext, this.reducedResponse);
+                        newDoc.put(fieldName, newSubDoc.copy(), this.includeGroupingContext);
                     }
                 } else if (attr instanceof Attributes) {
-                    // Since Document instances can be nested under attributes and vice-versa
+                    // Since Document instances can be nested under attributes and vice versa
                     // all the way down, we need to pass along the fieldName so that when we
                     // have come up with a nested document it can be evaluated by its own name
                     Attributes subAttrs = trim((Attributes) attr, fieldName);
 
                     if (0 < subAttrs.size()) {
-                        newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext, this.reducedResponse);
+                        newDoc.put(fieldName, subAttrs.copy(), this.includeGroupingContext);
                     }
                 }
             }

--- a/warehouse/query-core/src/main/java/datawave/query/function/FacetedGrouping.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/FacetedGrouping.java
@@ -142,7 +142,7 @@ public class FacetedGrouping implements Function<Entry<Key,Document>,Entry<Key,D
         if (log.isTraceEnabled())
             log.trace("entries" + newDocumentAttributes.entries());
         for (Entry<String,Attribute<?>> newAttr : newDocumentAttributes.entries()) {
-            currentDoc.replace(newAttr.getKey(), newAttr.getValue(), false, false);
+            currentDoc.replace(newAttr.getKey(), newAttr.getValue(), false);
         }
         if (log.isTraceEnabled())
             log.trace("currentDoc" + currentDoc);

--- a/warehouse/query-core/src/main/java/datawave/query/function/GroupFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/GroupFields.java
@@ -83,7 +83,7 @@ public class GroupFields implements Function<Entry<Key,Document>,Entry<Key,Docum
             for (Entry<String,Integer> groupFieldCountEntry : groupFieldsMap.entrySet()) {
                 Attribute<?> removedAttr = doc.remove(groupFieldCountEntry.getKey());
                 log.debug("removed from document:" + groupFieldCountEntry.getKey());
-                doc.put(groupFieldCountEntry.getKey(), new Numeric(groupFieldCountEntry.getValue(), doc.getMetadata(), removedAttr.isToKeep()), true, false);
+                doc.put(groupFieldCountEntry.getKey(), new Numeric(groupFieldCountEntry.getValue(), doc.getMetadata(), removedAttr.isToKeep()), true);
                 log.debug("added to document:" + groupFieldCountEntry.getKey() + " with count of " + groupFieldCountEntry.getValue());
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/function/KryoCVAwareSerializableSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/KryoCVAwareSerializableSerializer.java
@@ -25,7 +25,7 @@ public class KryoCVAwareSerializableSerializer extends KryoSerializableSerialize
     @Override
     public void write(Kryo kryo, Output output, KryoSerializable object) {
         if (object instanceof Document) {
-            ((Document) object).write(kryo, output, getReducedResponse());
+            ((Document) object).write(kryo, output);
         } else {
             object.write(kryo, output);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/LimitFields.java
@@ -259,7 +259,7 @@ public class LimitFields implements Function<Entry<Key,Document>,Entry<Key,Docum
                 int keepers = countKeepersForFieldMap.get(keyNoGrouping);
                 int originalCount = countForFieldMap.get(keyNoGrouping);
                 if (originalCount > keepers) {
-                    document.put(keyNoGrouping + ORIGINAL_COUNT_SUFFIX, new Numeric(originalCount, document.getMetadata(), document.isToKeep()), true, false);
+                    document.put(keyNoGrouping + ORIGINAL_COUNT_SUFFIX, new Numeric(originalCount, document.getMetadata(), document.isToKeep()), true);
 
                     // some sanity checks
                     int missesRemaining = countMissesRemainingForFieldMap.get(keyNoGrouping);

--- a/warehouse/query-core/src/main/java/datawave/query/function/RemoveGroupingContext.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/RemoveGroupingContext.java
@@ -34,7 +34,7 @@ public class RemoveGroupingContext implements Function<Entry<Key,Document>,Entry
         }
         // put them all back without the grouping context
         for (Entry<String,Attribute<? extends Comparable<?>>> goner : toRemove) {
-            entry.getValue().put(goner.getKey(), goner.getValue(), false, false);
+            entry.getValue().put(goner.getKey(), goner.getValue(), false);
         }
         return entry;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/function/serializer/WritableDocumentSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/serializer/WritableDocumentSerializer.java
@@ -26,7 +26,7 @@ public class WritableDocumentSerializer extends DocumentSerializer {
         DataOutputStream dos = new DataOutputStream(baos);
 
         try {
-            doc.write(dos, reducedResponse);
+            doc.write(dos);
         } catch (IOException e) {
             throw new RuntimeException("Could not convert Document through write().", e);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/GroupingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/GroupingIterator.java
@@ -194,7 +194,7 @@ public class GroupingIterator implements Iterator<Map.Entry<Key,Document>> {
                 attribute.setColumnVisibility(entry.getValue().getColumnVisibility());
                 // Call copy() on the GroupingTypeAttribute to get a plain TypeAttribute instead of a GroupingTypeAttribute that is package protected and won't
                 // serialize.
-                flattened.put(entry.getKey() + "." + Integer.toHexString(context).toUpperCase(), (TypeAttribute) attribute.copy(), true, false);
+                flattened.put(entry.getKey() + "." + Integer.toHexString(context).toUpperCase(), (TypeAttribute) attribute.copy(), true);
             }
             // Increment the context by one.
             context++;

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ContentTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ContentTransform.java
@@ -38,7 +38,7 @@ public class ContentTransform extends DocumentTransform.DefaultDocumentTransform
                     Attribute<?> contentField = document.remove(contentFieldName);
                     if (contentField.getData().toString().equalsIgnoreCase("true")) {
                         Content c = new Content(uid, contentField.getMetadata(), document.isToKeep());
-                        document.put(contentFieldName, c, false, this.reducedResponse);
+                        document.put(contentFieldName, c, false);
                     }
                 }
             }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/FieldMappingTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/FieldMappingTransform.java
@@ -33,7 +33,7 @@ public class FieldMappingTransform extends DocumentTransform.DefaultDocumentTran
                 if (!document.containsKey(primaryField)) {
                     for (String secondaryField : this.primaryToSecondaryFieldMap.get(primaryField)) {
                         if (document.containsKey(secondaryField)) {
-                            document.put(primaryField, document.get(secondaryField), includeGroupingContext, this.reducedResponse);
+                            document.put(primaryField, document.get(secondaryField), includeGroupingContext);
                             break;
                         }
                     }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/FieldRenameTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/FieldRenameTransform.java
@@ -60,7 +60,7 @@ public class FieldRenameTransform extends DocumentTransform.DefaultDocumentTrans
                     for (String mappedField : mappedFields) {
                         if (!mappedField.equals(baseField)) {
                             String newField = field.replace(baseField, mappedField);
-                            document.put(newField, document.get(field), this.includeGroupingContext, this.reducedResponse);
+                            document.put(newField, document.get(field), this.includeGroupingContext);
                         }
                     }
                     if (!mappedFields.contains(baseField)) {

--- a/warehouse/query-core/src/test/java/datawave/query/common/grouping/DocumentGrouperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/common/grouping/DocumentGrouperTest.java
@@ -1163,9 +1163,9 @@ public class DocumentGrouperTest {
             if (attributes.isEmpty()) {
                 throw new IllegalArgumentException("No attributes set for document entry");
             } else if (attributes.size() == 1) {
-                document.put(fieldName, this.attributes.get(0), true, false);
+                document.put(fieldName, this.attributes.get(0), true);
             } else {
-                document.put(fieldName, new Attributes(this.attributes, true), true, false);
+                document.put(fieldName, new Attributes(this.attributes, true), true);
             }
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/FieldRenameTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/FieldRenameTransformTest.java
@@ -106,9 +106,9 @@ public class FieldRenameTransformTest {
         fieldMap.add("field1=field6");
 
         Document d = new Document();
-        d.put("field1.field.11", new Numeric("1", key, true), true, false);
-        d.put("field2.field.12", new Numeric("2", key, true), true, false);
-        d.put("field3.field.13", new Numeric("3", key, true), true, false);
+        d.put("field1.field.11", new Numeric("1", key, true), true);
+        d.put("field2.field.12", new Numeric("2", key, true), true);
+        d.put("field3.field.13", new Numeric("3", key, true), true);
 
         DocumentTransform transformer = new FieldRenameTransform(fieldMap, true, false);
 

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformTest.java
@@ -598,7 +598,7 @@ public class UniqueTransformTest {
         }
 
         InputDocumentBuilder withKeyValue(String key, String value) {
-            document.put(key, new DiacriticContent(value, document.getMetadata(), true), true, false);
+            document.put(key, new DiacriticContent(value, document.getMetadata(), true), true);
             return this;
         }
 


### PR DESCRIPTION
Picking up where #1458 left off due to staleness. This seeks to remove unused reducedResponse parameters from some of the Attribute uses across the codebase. 