### PR TITLE
Fix "check-code-formatting" GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,11 +46,12 @@ jobs:
     - name: Commit Changes
       run: |
         if [ "$diffs_found" = true ]; then
-          git checkout -b ${{ steps.extract_branch.outputs.branch }}
           git config --global user.name "GitHub Actions"
           git config --global user.email "datawave@github.com"
-          git commit -am "Formatting job fix"
-          git push
+          git pull origin ${{ steps.extract_branch.outputs.branch }} --rebase --autostash
+          git checkout -b ${{ steps.extract_branch.outputs.branch }}
+          git commit -am "GitHub Actions: Fix Formatting"
+          git push origin ${{ steps.extract_branch.outputs.branch }}
         else
           echo "Nothing to do"
         fi


### PR DESCRIPTION
The `check-code-formatting` job does not work. It would always fail during the `Commit Changes` stage. This PR fixes this and allows formatting changes to be committed and pushed with GitHub Actions.

Here is a closed PR that I used to test the changes #2647. You can see that the formatting commits by GitHub Actions are now working.