### PR TITLE
Log the results of index expansion in a standardized way

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
@@ -11,9 +11,9 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.INDEX_HOL
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl3.parser.ASTAndNode;
 import org.apache.commons.jexl3.parser.JexlNode;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import datawave.core.common.logging.ThreadConfigurableLogger;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.IllegalRangeArgumentException;
 import datawave.query.jexl.JexlASTHelper;
@@ -30,7 +30,7 @@ import datawave.query.util.MetadataHelper;
  * Visits a Jexl tree, looks for bounded ranges, and replaces them with concrete values from the index
  */
 public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor {
-    private static final Logger log = ThreadConfigurableLogger.getLogger(BoundedRangeIndexExpansionVisitor.class);
+    private static final Logger log = LoggerFactory.getLogger(BoundedRangeIndexExpansionVisitor.class);
 
     private final JexlASTHelper.RangeFinder rangeFinder;
 
@@ -104,7 +104,39 @@ public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor
         JexlNode currentNode = futureJexlNode.getOrigNode();
         IndexLookupMap fieldsToTerms = futureJexlNode.getLookup().lookup();
 
+        if (log.isDebugEnabled()) {
+            logResult(currentNode, fieldsToTerms);
+        }
+
         futureJexlNode.setRebuiltNode(JexlNodeFactory.createNodeTreeFromFieldsToValues(JexlNodeFactory.ContainerType.OR_NODE, false, currentNode, fieldsToTerms,
                         expandFields, expandValues, futureJexlNode.isKeepOriginalNode()));
+    }
+
+    /**
+     * Log the result of index expansion for the provided term.
+     *
+     * @param node
+     *            the term
+     * @param lookupMap
+     *            the result of the lookup
+     */
+    protected void logResult(JexlNode node, IndexLookupMap lookupMap) {
+        String field = JexlASTHelper.getIdentifier(node);
+
+        if (lookupMap == null) {
+            log.debug("Lookup map was null for term [{}]", JexlStringBuildingVisitor.buildQuery(node));
+            return;
+        }
+
+        if (lookupMap.containsKey(field)) {
+            String term = JexlStringBuildingVisitor.buildQuery(node);
+            if (lookupMap.get(field).isEmpty()) {
+                log.debug("range expansion for term [{}] failed (no data)", term);
+            } else if (lookupMap.get(field).isThresholdExceeded()) {
+                log.debug("range expansion for term [{}] failed (threshold)", term);
+            } else {
+                log.debug("range expansion for term [{}] success ({} values)", term, lookupMap.get(field).size());
+            }
+        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
@@ -40,6 +40,7 @@ public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor
         super(config, scannerFactory, helper, "BoundedRangeIndexExpansion");
 
         rangeFinder = JexlASTHelper.findRange().indexedOnly(this.config.getDatatypeFilter(), this.helper).notDelayed();
+        this.stage = "range";
     }
 
     /**
@@ -110,33 +111,5 @@ public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor
 
         futureJexlNode.setRebuiltNode(JexlNodeFactory.createNodeTreeFromFieldsToValues(JexlNodeFactory.ContainerType.OR_NODE, false, currentNode, fieldsToTerms,
                         expandFields, expandValues, futureJexlNode.isKeepOriginalNode()));
-    }
-
-    /**
-     * Log the result of index expansion for the provided term.
-     *
-     * @param node
-     *            the term
-     * @param lookupMap
-     *            the result of the lookup
-     */
-    protected void logResult(JexlNode node, IndexLookupMap lookupMap) {
-        String field = JexlASTHelper.getIdentifier(node);
-
-        if (lookupMap == null) {
-            log.debug("Lookup map was null for term [{}]", JexlStringBuildingVisitor.buildQuery(node));
-            return;
-        }
-
-        if (lookupMap.containsKey(field)) {
-            String term = JexlStringBuildingVisitor.buildQuery(node);
-            if (lookupMap.get(field).isEmpty()) {
-                log.debug("range expansion for term [{}] failed (no data)", term);
-            } else if (lookupMap.get(field).isThresholdExceeded()) {
-                log.debug("range expansion for term [{}] failed (threshold)", term);
-            } else {
-                log.debug("range expansion for term [{}] success ({} values)", term, lookupMap.get(field).size());
-            }
-        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
@@ -28,7 +28,8 @@ import org.apache.commons.jexl3.parser.ASTReference;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.JexlNodes;
 import org.apache.commons.jexl3.parser.ParserTreeConstants;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -55,7 +56,7 @@ import datawave.query.util.MetadataHelper;
  * Visits a Jexl tree, looks for regex terms, and replaces them with concrete values from the index
  */
 public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
-    private static final Logger log = ThreadConfigurableLogger.getLogger(RegexIndexExpansionVisitor.class);
+    private static final Logger log = LoggerFactory.getLogger(RegexIndexExpansionVisitor.class);
 
     protected boolean expandUnfieldedNegations;
 
@@ -210,7 +211,7 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
                 // already did this expansion
                 return node;
             } else if (!nonEvent && evalOnly) {
-                // no need to expand its going to come out of the event
+                // no need to expand it is going to come out of the event
                 return node;
             }
         }
@@ -238,12 +239,12 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
             // expand this regex because it would be more efficient to do so
             if (!shouldProcessRegexFromCost(node)) {
 
-                if (log.isDebugEnabled()) {
-                    log.debug("Determined we don't need to process regex node:");
+                if (log.isTraceEnabled()) {
+                    log.trace("Determined we don't need to process regex node:");
                     for (String line : PrintingVisitor.formattedQueryStringList(node)) {
-                        log.debug(line);
+                        log.trace(line);
                     }
-                    log.debug("");
+                    log.trace("");
                 }
                 if (markedParents != null) {
                     for (JexlNode markedParent : markedParents) {
@@ -255,17 +256,14 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
                 return QueryPropertyMarker.create(node, DELAYED); // wrap in a delayed predicate to avoid using in RangeStream
             }
         } else {
-            if (config.getMaxIndexScanTimeMillis() != Long.MAX_VALUE)
-                log.debug("Skipping cost estimation since we have a timeout ");
+            if (config.getMaxIndexScanTimeMillis() != Long.MAX_VALUE) {
+                log.trace("Skipping cost estimation because there is a timeout configured for index expansion");
+            }
         }
 
         try {
             if (!helper.isIndexed(fieldName, config.getDatatypeFilter())) {
-                log.debug("Not expanding regular expression node as the field is not indexed");
-                for (String logLine : PrintingVisitor.formattedQueryStringList(node)) {
-                    log.info(logLine);
-                }
-
+                log.debug("Not expanding regex [{}] because the field is not indexed", JexlStringBuildingVisitor.buildQuery(node));
                 return node;
             }
         } catch (TableNotFoundException e) {
@@ -634,13 +632,10 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
             Cost childCost = costAnalysis.computeCostForSubtree(child);
 
             if (log.isDebugEnabled()) {
-                log.debug("Computed cost of " + childCost + " for:");
-                for (String logLine : PrintingVisitor.formattedQueryStringList(child)) {
-                    log.debug(logLine);
-                }
+                log.debug("cost for term [{}] is {}", JexlStringBuildingVisitor.buildQuery(child), childCost);
             }
 
-            // Use this child's cost if we have no current cost or it's less than the current cost
+            // Use this child's cost if we have no current cost, or it's less than the current cost
             if (0 != childCost.getOtherCost()) {
                 if (0 != c.getOtherCost()) {
                     if (childCost.getOtherCost() < c.getOtherCost()) {
@@ -687,7 +682,13 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         JexlNode currentNode = futureJexlNode.getOrigNode();
         IndexLookupMap fieldsToTerms = futureJexlNode.getLookup().lookup();
 
+        if (log.isDebugEnabled()) {
+            logResult(currentNode, fieldsToTerms);
+        }
+
         if (futureJexlNode.isIgnoreComposites()) {
+            // composites should be removed prior to building the index expansion iterators
+            // and should never be returned to the webservice
             removeCompositeFields(fieldsToTerms);
         }
 
@@ -695,14 +696,6 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
 
         // If we have no children, it's impossible to find any records, so this query returns no results
         if (fieldsToTerms.isEmpty()) {
-            if (log.isDebugEnabled()) {
-                try {
-                    log.debug("Failed to expand _ANYFIELD_ node because of no mappings for {\"term\": \"" + JexlASTHelper.getLiteral(currentNode) + "\"}");
-                } catch (Exception ex) {
-                    // it's just a debug statement
-                }
-            }
-
             // simply replace the _ANYFIELD_ with _NOFIELD_ denoting that there was no expansion. This will naturally evaluate correctly when applying
             // the query against the document
             for (ASTIdentifier id : JexlASTHelper.getIdentifiers(currentNode)) {
@@ -725,5 +718,33 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         }
 
         futureJexlNode.setRebuiltNode(newNode);
+    }
+
+    /**
+     * Log the result of index expansion for the provided term.
+     *
+     * @param node
+     *            the term
+     * @param lookupMap
+     *            the result of the lookup
+     */
+    protected void logResult(JexlNode node, IndexLookupMap lookupMap) {
+        String field = JexlASTHelper.getIdentifier(node);
+
+        if (lookupMap == null) {
+            log.debug("Lookup map was null for term [{}]", JexlStringBuildingVisitor.buildQuery(node));
+            return;
+        }
+
+        if (lookupMap.containsKey(field)) {
+            String term = JexlStringBuildingVisitor.buildQuery(node);
+            if (lookupMap.get(field).isEmpty()) {
+                log.debug("regex expansion for term [{}] failed (no data)", term);
+            } else if (lookupMap.get(field).isThresholdExceeded()) {
+                log.debug("regex expansion for term [{}] failed (threshold)", term);
+            } else {
+                log.debug("regex expansion for term [{}] success ({} values)", term, lookupMap.get(field).size());
+            }
+        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
@@ -95,6 +95,7 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         } else {
             this.onlyUseThese = null;
         }
+        this.stage = "regex";
     }
 
     /**
@@ -718,33 +719,5 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         }
 
         futureJexlNode.setRebuiltNode(newNode);
-    }
-
-    /**
-     * Log the result of index expansion for the provided term.
-     *
-     * @param node
-     *            the term
-     * @param lookupMap
-     *            the result of the lookup
-     */
-    protected void logResult(JexlNode node, IndexLookupMap lookupMap) {
-        String field = JexlASTHelper.getIdentifier(node);
-
-        if (lookupMap == null) {
-            log.debug("Lookup map was null for term [{}]", JexlStringBuildingVisitor.buildQuery(node));
-            return;
-        }
-
-        if (lookupMap.containsKey(field)) {
-            String term = JexlStringBuildingVisitor.buildQuery(node);
-            if (lookupMap.get(field).isEmpty()) {
-                log.debug("regex expansion for term [{}] failed (no data)", term);
-            } else if (lookupMap.get(field).isThresholdExceeded()) {
-                log.debug("regex expansion for term [{}] failed (threshold)", term);
-            } else {
-                log.debug("regex expansion for term [{}] success ({} values)", term, lookupMap.get(field).size());
-            }
-        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
@@ -18,15 +18,17 @@ import org.apache.commons.jexl3.parser.ASTNRNode;
 import org.apache.commons.jexl3.parser.ASTOrNode;
 import org.apache.commons.jexl3.parser.ASTReferenceExpression;
 import org.apache.commons.jexl3.parser.JexlNode;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import datawave.core.common.logging.ThreadConfigurableLogger;
 import datawave.data.type.Type;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.lookups.IndexLookup;
+import datawave.query.jexl.lookups.IndexLookupMap;
 import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.tables.ScannerFactory;
@@ -38,7 +40,7 @@ import datawave.webservice.query.exception.NotFoundQueryException;
  * Visits a Jexl tree, looks for unfielded terms, and replaces them with fielded terms from the index
  */
 public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
-    private static final Logger log = ThreadConfigurableLogger.getLogger(UnfieldedIndexExpansionVisitor.class);
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedIndexExpansionVisitor.class);
 
     protected Set<String> expansionFields;
     protected Set<Type<?>> allTypes;
@@ -91,7 +93,7 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
     private static <T extends JexlNode> T ensureTreeNotEmpty(T script) throws EmptyUnfieldedTermExpansionException {
         if (script.jjtGetNumChildren() == 0) {
             NotFoundQueryException qe = new NotFoundQueryException(DatawaveErrorCode.NO_UNFIELDED_TERM_EXPANSION_MATCH);
-            log.warn(qe);
+            log.warn("Empty script", qe);
             throw new EmptyUnfieldedTermExpansionException(qe);
         }
         return script;
@@ -223,6 +225,35 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
             return ShardIndexQueryTableStaticMethods.normalizeQueryTerm(node, config, scannerFactory, expansionFields, allTypes, helper, executor);
         } catch (TableNotFoundException e) {
             throw new DatawaveFatalQueryException(e);
+        }
+    }
+
+    /**
+     * Log the result of index expansion for the provided term.
+     *
+     * @param node
+     *            the term
+     * @param lookupMap
+     *            the result of the lookup
+     */
+    @Override
+    protected void logResult(JexlNode node, IndexLookupMap lookupMap) {
+        String field = JexlASTHelper.getIdentifier(node);
+
+        if (lookupMap == null) {
+            log.debug("Lookup map was null for term [{}]", JexlStringBuildingVisitor.buildQuery(node));
+            return;
+        }
+
+        if (lookupMap.containsKey(field)) {
+            String term = JexlStringBuildingVisitor.buildQuery(node);
+            if (lookupMap.get(field).isEmpty()) {
+                log.debug("field expansion for term [{}] failed (no data)", term);
+            } else if (lookupMap.get(field).isThresholdExceeded()) {
+                log.debug("field expansion for term [{}] failed (threshold)", term);
+            } else {
+                log.debug("field expansion for term [{}] success ({} values)", term, lookupMap.get(field).size());
+            }
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
@@ -56,6 +56,7 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
         }
 
         this.allTypes = helper.getAllDatatypes();
+        this.stage = "field";
     }
 
     /**
@@ -225,35 +226,6 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
             return ShardIndexQueryTableStaticMethods.normalizeQueryTerm(node, config, scannerFactory, expansionFields, allTypes, helper, executor);
         } catch (TableNotFoundException e) {
             throw new DatawaveFatalQueryException(e);
-        }
-    }
-
-    /**
-     * Log the result of index expansion for the provided term.
-     *
-     * @param node
-     *            the term
-     * @param lookupMap
-     *            the result of the lookup
-     */
-    @Override
-    protected void logResult(JexlNode node, IndexLookupMap lookupMap) {
-        String field = JexlASTHelper.getIdentifier(node);
-
-        if (lookupMap == null) {
-            log.debug("Lookup map was null for term [{}]", JexlStringBuildingVisitor.buildQuery(node));
-            return;
-        }
-
-        if (lookupMap.containsKey(field)) {
-            String term = JexlStringBuildingVisitor.buildQuery(node);
-            if (lookupMap.get(field).isEmpty()) {
-                log.debug("field expansion for term [{}] failed (no data)", term);
-            } else if (lookupMap.get(field).isThresholdExceeded()) {
-                log.debug("field expansion for term [{}] failed (threshold)", term);
-            } else {
-                log.debug("field expansion for term [{}] success ({} values)", term, lookupMap.get(field).size());
-            }
         }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BoundedRangeIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BoundedRangeIndexLookupTest.java
@@ -1,14 +1,11 @@
 package datawave.query.jexl.lookups;
 
-import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.powermock.api.easymock.PowerMock.replayAll;
-import static org.powermock.api.easymock.PowerMock.verifyAll;
 
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;


### PR DESCRIPTION
Standardize the logging for index expansion so that at the debug level the result of the expansion is recorded, and if the expansion fails we know which type (threshold exceeded or no hits)