### PR TITLE
FederatedQueryPlanner.getSubQueryDateRanges can return an illegal range and is skipping some time periods

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/planner/FederatedQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/FederatedQueryPlanner.java
@@ -484,7 +484,7 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
             Iterator<Pair<Date,Date>> it = mergedHoles.iterator();
 
             // If the start of the first index hole occurs after the configured start date, add a range spanning from
-            // the beginDate to one day before the start of the first index hole.
+            // the beginDate to one millisecond before the start of the first index hole.
             Pair<Date,Date> firstHole = it.next();
             // Track the end of the previous range.
             Date endOfPrevRange;
@@ -711,7 +711,7 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
     }
 
     /**
-     * Return one day before the given date.
+     * Return one millisecond before the given date.
      */
     private Date oneMsBefore(Date date) {
         Calendar calendar = Calendar.getInstance();

--- a/warehouse/query-core/src/main/java/datawave/query/planner/FederatedQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/FederatedQueryPlanner.java
@@ -1,7 +1,6 @@
 package datawave.query.planner;
 
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Collection;
@@ -45,7 +44,6 @@ import datawave.query.util.MetadataHelper;
 import datawave.query.util.QueryStopwatch;
 import datawave.util.time.TraceStopwatch;
 import datawave.webservice.query.exception.DatawaveErrorCode;
-import datawave.webservice.query.exception.NotFoundQueryException;
 import datawave.webservice.query.exception.QueryException;
 
 /**
@@ -62,7 +60,6 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
     private static final Logger log = ThreadConfigurableLogger.getLogger(FederatedQueryPlanner.class);
 
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd");
-    private final Calendar calendar = Calendar.getInstance();
 
     // we want a unique set of plans, but maintain insertion order (facilitates easier testing)
     private final Set<String> plans = new LinkedHashSet<>();
@@ -323,13 +320,13 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
         ShardQueryConfiguration firstConfigCopy = null;
         UUID queryId = originalConfig.getQuery().getId();
         for (Pair<Date,Date> dateRange : dateRanges) {
-            // Format the start and end date of the current sub-query to execute.
-            String subStartDate = dateFormat.format(dateRange.getLeft());
+            // Format the beginDate and endDate of the current sub-query to execute.
+            String subBeginDate = dateFormat.format(dateRange.getLeft());
             String subEndDate = dateFormat.format(dateRange.getRight());
 
             // Start a new stopwatch.
             TraceStopwatch stopwatch = originalConfig.getTimers().newStartedStopwatch("FederatedQueryPlanner - Executing sub-plan [" + totalProcessed + " of "
-                            + dateRanges.size() + "] against date range (" + subStartDate + "-" + subEndDate + ")");
+                            + dateRanges.size() + "] against date range (" + subBeginDate + "-" + subEndDate + ")");
 
             // Set the new date range in a copy of the config.
             ShardQueryConfiguration configCopy = new ShardQueryConfiguration(originalConfig);
@@ -347,13 +344,13 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
                 CloseableIterable<QueryData> queryData = subPlan.process(configCopy, query, settings, scannerFactory);
                 results.addIterable(queryData);
             } catch (Exception e) {
-                log.warn("Exception occured when processing sub-plan [" + totalProcessed + " of " + dateRanges.size() + "] against date range (" + subStartDate
+                log.warn("Exception occured when processing sub-plan [" + totalProcessed + " of " + dateRanges.size() + "] against date range (" + subBeginDate
                                 + "-" + subEndDate + ")", e);
                 // If an exception occurs, ensure that the planned script and the original config are updated before allowing the exception to bubble up.
                 plans.add(subPlan.plannedScript);
                 updatePlannedScript();
 
-                // Copy over any changes in the sub-config to the original config. This will not affect the start date, end date, or timers of the original
+                // Copy over any changes in the sub-config to the original config. This will not affect the beginDate, endDate, or timers of the original
                 // config.
                 copySubConfigPropertiesToOriginal(originalConfig, configCopy);
                 throw e;
@@ -383,7 +380,7 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
         // Update the planned script.
         updatePlannedScript();
 
-        // Copy over any changes from the first sub-config to the original config. This will not affect the start date, end date, or timers of the original
+        // Copy over any changes from the first sub-config to the original config. This will not affect the beginDate, endDate, or timers of the original
         // config.
         copySubConfigPropertiesToOriginal(originalConfig, firstConfigCopy);
 
@@ -433,7 +430,7 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
      * Return the set of date ranges that sub-queries should be created for. Each date range will have a consistent index state, meaning that within each date
      * range, we can expect to either encounter no field index holes, or to always encounter a field index hole.
      */
-    private SortedSet<Pair<Date,Date>> getSubQueryDateRanges(ShardQueryConfiguration config, String query, ScannerFactory scannerFactory)
+    protected SortedSet<Pair<Date,Date>> getSubQueryDateRanges(ShardQueryConfiguration config, String query, ScannerFactory scannerFactory)
                     throws DatawaveQueryException {
         // Fetch the field index holes for the specified fields and datatypes, using the configured minimum threshold.
         MetadataHelper metadataHelper = queryPlanner.getMetadataHelper();
@@ -482,79 +479,110 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
         } else {
             // Otherwise, get the valid date ranges. First, Merge any overlaps.
             SortedSet<Pair<Date,Date>> mergedHoles = mergeRanges(relevantHoles);
+            // Adjust the index holes so that they span from 00:00:00.000 on the first day to 23:59:59.999 on the last day
+            mergedHoles = spanEntireDays(mergedHoles);
             Iterator<Pair<Date,Date>> it = mergedHoles.iterator();
 
-            // If the start of the first hole occurs after the configured start date, add a range spanning from the start date to one day before the start
-            // of the first hole.
+            // If the start of the first index hole occurs after the configured start date, add a range spanning from
+            // the beginDate to one day before the start of the first index hole.
             Pair<Date,Date> firstHole = it.next();
-            if (firstHole.getLeft().getTime() > config.getBeginDate().getTime()) {
-                subDateRanges.add(Pair.of(new Date(config.getBeginDate().getTime()), oneDayBefore(firstHole.getLeft())));
-                // If the end of the first hole occurs before or on the configured end date, add the entire span for the first hole.
+            // Track the end of the previous range.
+            Date endOfPrevRange;
+            if (firstHole.getLeft().getTime() >= config.getBeginDate().getTime()) {
+                if (firstHole.getLeft().getTime() > config.getBeginDate().getTime()) {
+                    // Add a range from the configured beginDate to just before
+                    // the start of the first index hole. This date range is indexed
+                    subDateRanges.add(Pair.of(new Date(config.getBeginDate().getTime()), oneMsBefore(firstHole.getLeft())));
+                }
+
+                // the start of the first index hole is on or after the configured beginDate
                 if (firstHole.getRight().getTime() <= config.getEndDate().getTime()) {
+                    // If the end of the first index hole occurs before or on the configured endDate,
+                    // add the entire span for the first index hole. This date range is not indexed
                     subDateRanges.add(firstHole);
+                    endOfPrevRange = firstHole.getRight();
                 } else {
-                    // Otherwise, add a range from the start of the first hole to the configured end date.
+                    // Otherwise, add a range from the start of the first index hole to
+                    // the configured endDate. This date range is not indexed
                     subDateRanges.add(Pair.of(firstHole.getLeft(), new Date(config.getEndDate().getTime())));
+                    endOfPrevRange = config.getEndDate();
                 }
-                // If the start of the first hole is equal to the configured start date, check if the entire hole falls within the query's date range.
-            } else if (firstHole.getLeft().getTime() == config.getBeginDate().getTime()) {
-                // If the end of the first hole occurs before or on the configured end date, add the entire span for the first hole.
+            } else {
+                // the start of the first index hole is before the configured beginDate
                 if (firstHole.getRight().getTime() <= config.getEndDate().getTime()) {
-                    subDateRanges.add(firstHole);
-                } else {
-                    // Otherwise, the first hole spans over the query's date range.
-                    subDateRanges.add(Pair.of(new Date(config.getBeginDate().getTime()), new Date(config.getEndDate().getTime())));
-                }
-                // If the start of the first hole occurs before the configured start date, check how much of the hole falls within the query's date range.
-            } else if (firstHole.getLeft().getTime() < config.getBeginDate().getTime()) {
-                // If the end of the first hole occurs before or on the configured end date, add a range spanning from the configured start date to the end of
-                // the first hole.
-                if (firstHole.getRight().getTime() <= config.getEndDate().getTime()) {
+                    // If the end of the first index hole occurs before or on the configured endDate, add a range spanning
+                    // from the configured beginDate to the end of the first index hole. This date range is not indexed
                     subDateRanges.add(Pair.of(new Date(config.getBeginDate().getTime()), firstHole.getRight()));
+                    endOfPrevRange = firstHole.getRight();
                 } else {
-                    // Otherwise, the first hole spans over the query's date range.
+                    // Otherwise, the first index hole spans over the query's date range. This date range is not indexed
                     subDateRanges.add(Pair.of(new Date(config.getBeginDate().getTime()), new Date(config.getEndDate().getTime())));
+                    endOfPrevRange = config.getEndDate();
                 }
             }
 
-            // Track the end of the previous hole.
-            Date endOfPrevHole = firstHole.getRight();
-            while (it.hasNext()) {
-                // The start of the next hole is guaranteed to fall within the original query's target date range. Add a target date range from one day after
-                // the end of the previous hole to one day before the start of the next hole.
+            while (it.hasNext() && (endOfPrevRange.getTime() < config.getEndDate().getTime())) {
+                // The start of the next index hole is guaranteed to fall within the original query's target date range. Add a date range from
+                // one millisecond after the end of the previous index hole to one millisecond before the start of the next index hole.
+                // This date range is between index holes and is indexed
                 Pair<Date,Date> currentHole = it.next();
-                subDateRanges.add(Pair.of(oneDayAfter(endOfPrevHole), oneDayBefore(currentHole.getLeft())));
+                subDateRanges.add(Pair.of(oneMsAfter(endOfPrevRange), oneMsBefore(currentHole.getLeft())));
 
-                // If there is another hole, the current hole is guaranteed to fall within the original target's date range. Add it to the sub ranges.
                 if (it.hasNext()) {
+                    // If there is another index hole, the current index hole is guaranteed to fall within the original
+                    // target's date range. Add it to the sub ranges. This date range is not indexed
                     subDateRanges.add(currentHole);
+                    endOfPrevRange = currentHole.getRight();
                 } else {
-                    // If this is the last hole, it is possible that the end date falls outside the original query's target date range. If so, shorten it to end
-                    // at the original target end date.
+                    // If this is the last hole, it is possible that the endDate falls outside the original query's target date range.
+                    // If so, shorten it to end at the original query endDate. This date range is not indexed
                     if (currentHole.getRight().getTime() > config.getEndDate().getTime()) {
                         subDateRanges.add(Pair.of(currentHole.getLeft(), config.getEndDate()));
+                        endOfPrevRange = config.getEndDate();
                     } else {
                         // If it does not fall outside the target date range, include it as is.
                         subDateRanges.add(currentHole);
+                        endOfPrevRange = currentHole.getRight();
                     }
                 }
-                endOfPrevHole = currentHole.getRight();
             }
 
-            // If the last hole we saw ended before the end of the original query's target date range, add a target date range from one day after the end of the
-            // last hole to the original target end date.
-            if (endOfPrevHole.getTime() < config.getEndDate().getTime()) {
-                subDateRanges.add(Pair.of(oneDayAfter(endOfPrevHole), new Date(config.getEndDate().getTime())));
+            // If the last hole we saw ended before the end of the original query's target date range, add date range from one
+            // millisecond after the end of the last index hole to the original query endDate.
+            if (endOfPrevRange.getTime() < config.getEndDate().getTime()) {
+                subDateRanges.add(Pair.of(oneMsAfter(endOfPrevRange), config.getEndDate()));
             }
         }
 
         return subDateRanges;
     }
 
+    private SortedSet<Pair<Date,Date>> spanEntireDays(Collection<Pair<Date,Date>> holes) {
+        SortedSet<Pair<Date,Date>> holesThatSpanEntireDays = new TreeSet<>();
+        holes.stream().forEach(p -> holesThatSpanEntireDays.add(spanEntireDays(p)));
+        return holesThatSpanEntireDays;
+    }
+
+    private Pair<Date,Date> spanEntireDays(Pair<Date,Date> hole) {
+        Calendar begin = Calendar.getInstance();
+        begin.setTime(hole.getLeft());
+        begin.set(Calendar.HOUR, 0);
+        begin.set(Calendar.MINUTE, 0);
+        begin.set(Calendar.SECOND, 0);
+        begin.set(Calendar.MILLISECOND, 0);
+        Calendar end = Calendar.getInstance();
+        end.setTime(hole.getRight());
+        end.set(Calendar.HOUR, 23);
+        end.set(Calendar.MINUTE, 59);
+        end.set(Calendar.SECOND, 59);
+        end.set(Calendar.MILLISECOND, 999);
+        return Pair.of(begin.getTime(), end.getTime());
+    }
+
     /**
      * Return the set of fields in the query.
      */
-    private Set<String> getFieldsForQuery(ShardQueryConfiguration config, String query, ScannerFactory scannerFactory) throws NoResultsException {
+    protected Set<String> getFieldsForQuery(ShardQueryConfiguration config, String query, ScannerFactory scannerFactory) throws NoResultsException {
         // Parse the query.
         ASTJexlScript queryTree = queryPlanner.parseQueryAndValidatePattern(query, null);
 
@@ -673,9 +701,30 @@ public class FederatedQueryPlanner extends QueryPlanner implements Cloneable {
     }
 
     /**
+     * Return one millisecond after the given date.
+     */
+    private Date oneMsAfter(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date(date.getTime()));
+        calendar.add(Calendar.MILLISECOND, 1);
+        return calendar.getTime();
+    }
+
+    /**
+     * Return one day before the given date.
+     */
+    private Date oneMsBefore(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date(date.getTime()));
+        calendar.add(Calendar.MILLISECOND, -1);
+        return calendar.getTime();
+    }
+
+    /**
      * Return the given date with the number of dates added to it.
      */
     private Date addDays(Date date, int daysToAdd) {
+        Calendar calendar = Calendar.getInstance();
         calendar.setTime(new Date(date.getTime()));
         calendar.add(Calendar.DATE, daysToAdd);
         return calendar.getTime();

--- a/warehouse/query-core/src/test/java/datawave/query/planner/FederatedQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/FederatedQueryTest.java
@@ -1,40 +1,5 @@
 package datawave.query.planner;
 
-import com.google.common.collect.Lists;
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
-import datawave.core.query.iterator.DatawaveTransformIterator;
-import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.QueryTestTableHelper;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
-import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
-import datawave.query.transformer.DocumentTransformer;
-import datawave.query.util.FieldIndexHoleDataIngest;
-import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
-import datawave.webservice.query.result.event.EventBase;
-import datawave.webservice.result.DefaultEventQueryResponse;
-import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import javax.inject.Inject;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -53,6 +18,44 @@ import java.util.StringJoiner;
 import java.util.TimeZone;
 import java.util.TreeSet;
 import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.Lists;
+
+import datawave.configuration.spring.SpringBean;
+import datawave.core.query.configuration.GenericQueryConfiguration;
+import datawave.core.query.iterator.DatawaveTransformIterator;
+import datawave.helpers.PrintUtility;
+import datawave.ingest.data.TypeRegistry;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.QueryTestTableHelper;
+import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.transformer.DocumentTransformer;
+import datawave.query.util.FieldIndexHoleDataIngest;
+import datawave.util.TableName;
+import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
+import datawave.webservice.query.result.event.EventBase;
+import datawave.webservice.result.DefaultEventQueryResponse;
 
 /**
  * Tests usage of {@link FederatedQueryPlanner} in queries.

--- a/warehouse/query-core/src/test/java/datawave/query/planner/FederatedQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/FederatedQueryTest.java
@@ -1,26 +1,25 @@
 package datawave.query.planner;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.StringJoiner;
-import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
-
+import com.google.common.collect.Lists;
+import datawave.configuration.spring.SpringBean;
+import datawave.core.query.configuration.GenericQueryConfiguration;
+import datawave.core.query.iterator.DatawaveTransformIterator;
+import datawave.helpers.PrintUtility;
+import datawave.ingest.data.TypeRegistry;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.QueryTestTableHelper;
+import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.transformer.DocumentTransformer;
+import datawave.query.util.FieldIndexHoleDataIngest;
+import datawave.util.TableName;
+import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
+import datawave.webservice.query.result.event.EventBase;
+import datawave.webservice.result.DefaultEventQueryResponse;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.log4j.Level;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,26 +34,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.google.common.collect.Lists;
-
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
-import datawave.core.query.iterator.DatawaveTransformIterator;
-import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.QueryTestTableHelper;
-import datawave.query.RebuildingScannerTestHelper;
-import datawave.query.function.JexlEvaluation;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
-import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
-import datawave.query.transformer.DocumentTransformer;
-import datawave.query.util.FieldIndexHoleDataIngest;
-import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
-import datawave.webservice.query.result.event.EventBase;
-import datawave.webservice.result.DefaultEventQueryResponse;
+import javax.inject.Inject;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.StringJoiner;
+import java.util.TimeZone;
+import java.util.TreeSet;
+import java.util.UUID;
 
 /**
  * Tests usage of {@link FederatedQueryPlanner} in queries.
@@ -131,7 +129,8 @@ public abstract class FederatedQueryTest {
     protected ShardQueryLogic logic;
     protected KryoDocumentDeserializer deserializer;
 
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
+    private final DateFormat formatDate = new SimpleDateFormat("yyyyMMdd");
+    private final DateFormat formatDateTime = new SimpleDateFormat("yyyyMMdd HHmmss");
     private final List<FieldIndexHoleDataIngest.EventConfig> eventConfigs = new ArrayList<>();
     private final Map<String,String> queryParameters = new HashMap<>();
     private final Set<Event> expectedEvents = new HashSet<>();
@@ -192,11 +191,19 @@ public abstract class FederatedQueryTest {
     }
 
     private void givenStartDate(String date) throws ParseException {
-        this.startDate = format.parse(date);
+        if (date.length() == 8) {
+            this.startDate = formatDate.parse(date);
+        } else {
+            this.startDate = formatDateTime.parse(date);
+        }
     }
 
     private void givenEndDate(String date) throws ParseException {
-        this.endDate = format.parse(date);
+        if (date.length() == 8) {
+            this.endDate = formatDate.parse(date);
+        } else {
+            this.endDate = formatDateTime.parse(date);
+        }
     }
 
     private void givenFieldIndexMinThreshold(double threshold) {
@@ -216,6 +223,90 @@ public abstract class FederatedQueryTest {
         PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
         PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         return client;
+    }
+
+    private Date addDays(Date date, int days) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date(date.getTime()));
+        calendar.add(Calendar.DATE, days);
+        return calendar.getTime();
+    }
+
+    private Date midnight(Date date) {
+        Calendar midnight = Calendar.getInstance();
+        midnight.setTime(date);
+        midnight.set(Calendar.HOUR, 0);
+        midnight.set(Calendar.MINUTE, 0);
+        midnight.set(Calendar.SECOND, 0);
+        midnight.set(Calendar.MILLISECOND, 0);
+        return midnight.getTime();
+    }
+
+    /*
+     * ensure that each subRange has all days with holes or all days with no holes ensure that all milliseconds in the original date range are covered
+     */
+    private void assertSubrangesCorrect() throws Exception {
+        FederatedQueryPlanner queryPlanner = (FederatedQueryPlanner) logic.getQueryPlanner();
+
+        // Ensure that each subRange has all days with holes or all days with no holes
+        Set<String> fieldsInQuery = queryPlanner.getFieldsForQuery(this.logic.getConfig(), this.query, logic.getScannerFactory());
+        Set<Date> datesWithHoles = new HashSet<>();
+        Set<Date> datesWithoutHoles = new HashSet<>();
+        this.eventConfigs.forEach(config -> {
+            if (config.getTime() >= this.startDate.getTime() && config.getTime() <= this.endDate.getTime()) {
+                // field has to be in the query and fieldIndexHoleMinThreshold != null and index / frequency < fieldIndexHoleMinThreshold
+                boolean hasHoles = config.getMetadataCounts().entrySet().stream().filter(e -> fieldsInQuery.contains(e.getKey()))
+                                .anyMatch(e -> this.fieldIndexHoleMinThreshold != null && ((double) (e.getValue().getValue1())
+                                                / ((double) e.getValue().getValue0())) < this.fieldIndexHoleMinThreshold);
+                if (hasHoles) {
+                    datesWithHoles.add(new Date(config.getTime()));
+                } else {
+                    datesWithoutHoles.add(new Date(config.getTime()));
+                }
+            }
+        });
+
+        SortedSet<Pair<Date,Date>> subRanges = queryPlanner.getSubQueryDateRanges(logic.getConfig(), this.query, logic.getScannerFactory());
+        // Subranges are sorted and should begin with the query beginDate and end with the query endDate
+        Pair<Date,Date> firstSubRange = subRanges.stream().findFirst().get();
+        Assert.assertNotNull("firstSubRange should not be null", firstSubRange);
+        Assert.assertEquals("begin of lastSubRange should equal query beginDate", this.startDate.getTime(), firstSubRange.getLeft().getTime());
+        Pair<Date,Date> lastSubRange = subRanges.stream().reduce((first, second) -> second).get();
+        Assert.assertNotNull("lastSubRange should not be null", lastSubRange);
+        Assert.assertEquals("end of lastSubRange should equal query endDate", this.endDate.getTime(), lastSubRange.getRight().getTime());
+
+        Pair<Date,Date> previousPair = null;
+        for (Pair<Date,Date> range : subRanges) {
+            Set<String> datesWithHolesInRange = new TreeSet<>();
+            Set<String> datesWithoutHolesInRange = new TreeSet<>();
+            // adding 24 hours to b is guaranteed to fall on the next sequential date until we are outside the range
+            for (Date b = new Date(range.getLeft().getTime()); b.getTime() <= range.getRight().getTime(); b = addDays(b, 1)) {
+                if (datesWithHoles.contains(midnight(b))) {
+                    datesWithHolesInRange.add(formatDate.format(b));
+                }
+                if (datesWithoutHoles.contains(midnight(b))) {
+                    datesWithoutHolesInRange.add(formatDate.format(b));
+                }
+            }
+            // adding 24 hours to b is guaranteed to fall on the next sequential date, but this might miss
+            // the range end date so perform the same check on the range end date here
+            if (datesWithHoles.contains(midnight(range.getRight()))) {
+                datesWithHolesInRange.add(formatDate.format(range.getRight()));
+            }
+            if (datesWithoutHoles.contains(midnight(range.getRight()))) {
+                datesWithoutHolesInRange.add(formatDate.format(range.getRight()));
+            }
+
+            Assert.assertFalse("Subrange " + range + " must have all days with holes or all days with no holes: hasHoles:" + datesWithHolesInRange
+                            + " hasNoHoles:" + datesWithoutHolesInRange, !datesWithHolesInRange.isEmpty() && !datesWithoutHolesInRange.isEmpty());
+
+            // check that there is one millisecond difference between the end of one range and the beginning of the next
+            if (previousPair != null) {
+                long difference = range.getLeft().getTime() - previousPair.getRight().getTime();
+                Assert.assertEquals("Expected difference of 1ms, got " + difference, 1, difference);
+            }
+            previousPair = range;
+        }
     }
 
     private void assertQueryResults() throws Exception {
@@ -298,6 +389,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -321,6 +413,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130104", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -345,6 +438,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -368,6 +462,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130104", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -392,6 +487,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -416,6 +512,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -440,6 +537,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -464,6 +562,29 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
+    }
+
+    @Test
+    public void testFieldIndexHolesAtEndOfRange() throws Exception {
+        configureEvent(FieldIndexHoleDataIngest.EventConfig.forDate("20130101"));
+        configureEvent(FieldIndexHoleDataIngest.EventConfig.forDate("20130102").withMetadataCount("UUID", 10L, 1L));
+        configureEvent(FieldIndexHoleDataIngest.EventConfig.forDate("20130103"));
+        configureEvent(FieldIndexHoleDataIngest.EventConfig.forDate("20130104").withMetadataCount("UUID", 10L, 1L));
+        configureEvent(FieldIndexHoleDataIngest.EventConfig.forDate("20130105").withMetadataCount("UUID", 10L, 1L));
+
+        givenQuery("UUID =~ '^[CS].*'");
+        givenStartDate("20120101");
+        givenEndDate("20130105 120000");
+
+        expectEvents("20130101", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
+        expectEvents("20130102", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
+        expectEvents("20130103", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
+        expectEvents("20130104", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
+        expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
+
+        assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -489,6 +610,7 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 
     /**
@@ -514,5 +636,6 @@ public abstract class FederatedQueryTest {
         expectEvents("20130105", FieldIndexHoleDataIngest.corleoneUID, FieldIndexHoleDataIngest.caponeUID, FieldIndexHoleDataIngest.sopranoUID);
 
         assertQueryResults();
+        assertSubrangesCorrect();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/FieldIndexHoleDataIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/FieldIndexHoleDataIngest.java
@@ -115,6 +115,10 @@ public class FieldIndexHoleDataIngest {
         public Pair<Long,Long> getMetadataCounts(String field) {
             return metadataCounts.get(field);
         }
+
+        public Map<String,Pair<Long,Long>> getMetadataCounts() {
+            return metadataCounts;
+        }
     }
 
     public static void writeItAll(AccumuloClient client, Range range, List<EventConfig> eventConfigs) throws Exception {


### PR DESCRIPTION
FederatedQueryPlanner.getSubQueryDateRanges can return an illegal range and is skipping some time periods (#2679)

Because the index holes are all time midnight, when the final index hole is on the same day as the query endDate but the query endDate is not midnight, the FederatedQueryPlanner is returning a Pair<Date,Date> where the beginDate > endDate

The current logic is also uses oneDayBefore and oneDayAfter in places where oneMsBefore and oneMsAfter are required. This is causing whole days to be missed when generating subRanges to cover a query date range.

The oneDayBefore and oneDayAfter logic is also causing small periods on the edge of the subRanges to violate the purpose of the method -- that all sub ranges contain all dates with no index holes or all dates with index holes.

In FederatedQueryPlanner, usages of Calendar were moved to local variables rather than a class variable to avoid the possibility of thread un-safe access.

Added more robust testing to verify fixes and prevent regression