### PR TITLE
improve GroupBy performance

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
@@ -69,10 +69,23 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
     }
 
     private Number parseToNumber(String value) {
-        Number number = null;
+        // some documents will contain numeric data that is already encoded
+        // in those cases it is faster to check for encoding up front instead
+        // of finding out the hard way via exception.
+        try {
+            if (NumericalEncoder.isPossiblyEncoded(value)) {
+                BigDecimal bigDecimal = NumericalEncoder.decode(value);
+                return bigDecimal.doubleValue();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Number number;
         try {
             number = NumberUtils.createNumber(value);
         } catch (Exception ex) {
+            // alternatively, throw a shallow exception to avoid expensive calls to 'fill in stacktrace'
             BigDecimal bigDecimal = NumericalEncoder.decode(value);
             number = bigDecimal.doubleValue();
         }

--- a/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingUtils.java
+++ b/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingUtils.java
@@ -57,6 +57,8 @@ public class GroupingUtils {
 
     /**
      * Create and return a new {@link Document} with the given group information embedded into it.
+     * <p>
+     * Do not use this method. If you are aggregating a list of keys only to use the most recent, rethink the approach
      *
      * @param group
      *            the group
@@ -68,11 +70,30 @@ public class GroupingUtils {
      *            the format to use when writing aggregated averages to the document
      * @return the new document
      */
+    @Deprecated
     public static Document createDocument(Group group, List<Key> keys, MarkingFunctions markingFunctions, AverageAggregatorWriteFormat averageWriteFormat) {
         Preconditions.checkState(!keys.isEmpty(), "No available keys for grouping results");
 
         // Use the last (most recent) key so a new iterator will know where to start.
         Key key = keys.get(keys.size() - 1);
+        return createDocument(group, key, markingFunctions, averageWriteFormat);
+    }
+
+    /**
+     * Create and return a new {@link Document} with the given group information embedded into it.
+     *
+     * @param group
+     *            the group
+     * @param key
+     *            the docment key
+     * @param markingFunctions
+     *            the marking functions to use when combining column visibilities
+     * @param averageWriteFormat
+     *            the format to use when writing aggregated averages to the document
+     * @return the new document
+     */
+    public static Document createDocument(Group group, Key key, MarkingFunctions markingFunctions, AverageAggregatorWriteFormat averageWriteFormat) {
+        Preconditions.checkNotNull(key, "document key cannot be null");
         Document document = new Document(key, true);
 
         // Set the visibility for the document to the combined visibility of each previous document in which this grouping was seen in.

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/GroupingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/GroupingIterator.java
@@ -3,7 +3,6 @@ package datawave.query.iterator;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -46,10 +45,11 @@ public class GroupingIterator implements Iterator<Map.Entry<Key,Document>> {
      */
     private final Groups groups;
 
-    /**
-     * list of keys that have been read, in order to keep track of where we left off when a new iterator is created
-     */
-    private final List<Key> keys = new ArrayList<>();
+    // the most recent key seen, used to track where we left off
+    private Key mostRecentKey = null;
+
+    // track the number of documents seen by this iterator
+    private long documentCount = 0L;
 
     private final MarkingFunctions markingFunctions;
 
@@ -78,18 +78,20 @@ public class GroupingIterator implements Iterator<Map.Entry<Key,Document>> {
                 Map.Entry<Key,Document> entry = previousIterators.next();
                 if (entry != null) {
                     log.trace("t-server get list key counts for: {}", entry);
-                    keys.add(entry.getKey());
+                    documentCount++;
+                    mostRecentKey = entry.getKey();
                     DocumentGrouper.group(entry, groupFields, groups);
                 }
             } else if (yieldCallback != null && yieldCallback.hasYielded()) {
                 log.trace("hasNext is false because yield was called");
                 if (!groups.isEmpty()) {
                     // reset the yield and use its key in the flattened document prepared below
-                    keys.add(yieldCallback.getPositionAndReset());
+                    mostRecentKey = yieldCallback.getPositionAndReset();
                 }
                 break;
             } else {
                 // in.hasNext() was false and there was no yield
+                log.debug("GroupingIterator saw {} documents producing {} groups", documentCount, groups.getGroups().size());
                 break;
             }
         }
@@ -100,16 +102,17 @@ public class GroupingIterator implements Iterator<Map.Entry<Key,Document>> {
 
         if (!groups.isEmpty()) {
             for (Group group : groups.getGroups()) {
-                documents.add(GroupingUtils.createDocument(group, keys, markingFunctions, GroupingUtils.AverageAggregatorWriteFormat.NUMERATOR_AND_DIVISOR));
+                documents.add(GroupingUtils.createDocument(group, mostRecentKey, markingFunctions,
+                                GroupingUtils.AverageAggregatorWriteFormat.NUMERATOR_AND_DIVISOR));
             }
             document = flatten(documents);
         }
 
         if (document != null) {
             Key key;
-            if (keys.size() > 0) {
+            if (mostRecentKey != null) {
                 // use the last (most recent) key so a new iterator will know where to start
-                key = keys.get(keys.size() - 1);
+                key = mostRecentKey;
             } else {
                 key = document.getMetadata();
             }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/GroupingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/GroupingIterator.java
@@ -91,7 +91,7 @@ public class GroupingIterator implements Iterator<Map.Entry<Key,Document>> {
                 break;
             } else {
                 // in.hasNext() was false and there was no yield
-                log.debug("GroupingIterator saw {} documents producing {} groups", documentCount, groups.getGroups().size());
+                log.trace("GroupingIterator saw {} documents producing {} groups", documentCount, groups.getGroups().size());
                 break;
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/GroupingTransform.java
@@ -2,10 +2,7 @@ package datawave.query.transformer;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
@@ -47,9 +44,14 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
     private final LinkedList<Document> documents = new LinkedList<>();
 
     /**
-     * list of keys that have been read, in order to keep track of where we left off when a new iterator is created
+     * The last key seen, used to build documents
      */
-    private final List<Key> keys = new ArrayList<>();
+    private Key mostRecentKey = null;
+
+    /**
+     * Track the number of documents seen by this transform
+     */
+    private long documentCount = 0L;
 
     /**
      * Length of time in milliseconds that a client will wait while results are collected. If a full page is not collected before the timeout, a blank page will
@@ -87,6 +89,7 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
 
             // If this is a final document, bail without adding to the keys, countingMap or fieldVisibilities.
             if (FinalDocumentTrackingIterator.isFinalDocumentKey(keyDocumentEntry.getKey())) {
+                log.debug("GroupingTransform saw {} documents producing {} groups", documentCount, groups.getGroups().size());
                 return keyDocumentEntry;
             }
 
@@ -94,7 +97,8 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
                 return keyDocumentEntry;
             }
 
-            keys.add(keyDocumentEntry.getKey());
+            documentCount++;
+            mostRecentKey = keyDocumentEntry.getKey();
             log.trace("{} get list key counts for: {}", "web-server", keyDocumentEntry);
             DocumentGrouper.group(keyDocumentEntry, groupFields, groups);
         }
@@ -122,7 +126,7 @@ public class GroupingTransform extends DocumentTransform.DefaultDocumentTransfor
         Document document = null;
         if (!groups.isEmpty()) {
             for (Group group : groups.getGroups()) {
-                documents.add(GroupingUtils.createDocument(group, keys, markingFunctions, GroupingUtils.AverageAggregatorWriteFormat.AVERAGE));
+                documents.add(GroupingUtils.createDocument(group, mostRecentKey, markingFunctions, GroupingUtils.AverageAggregatorWriteFormat.AVERAGE));
             }
         }
 

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/GroupingIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/GroupingIteratorTest.java
@@ -1,0 +1,86 @@
+package datawave.query.iterator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.data.type.NumberType;
+import datawave.marking.MarkingFunctions;
+import datawave.query.attributes.Document;
+import datawave.query.attributes.PreNormalizedAttribute;
+import datawave.query.common.grouping.GroupFields;
+
+public class GroupingIteratorTest {
+
+    private static final Logger log = LoggerFactory.getLogger(GroupingIteratorTest.class);
+    private int uidCount = 0;
+
+    @BeforeAll
+    public static void setup() {
+        MarkingFunctions.Factory.createMarkingFunctions();
+    }
+
+    @Test
+    public void testSingleDocument() {
+        Iterator<Map.Entry<Key,Document>> iter = getDocumentIterator(1);
+        GroupFields groupFields = new GroupFields();
+        groupFields.setCountFields(Set.of("FIELD_A", "FIELD_B"));
+        GroupingIterator groupingIterator = new GroupingIterator(iter, MarkingFunctions.Factory.createMarkingFunctions(), groupFields, 1, null);
+
+        assertTrue(groupingIterator.hasNext());
+        Document d = groupingIterator.next().getValue();
+        assertEquals(3, d.getAttributes().size());
+        assertEquals(1, ((NumberType) d.get("COUNT.0").getData()).getDelegate().intValue());
+        assertEquals(1, ((NumberType) d.get("FIELD_A_COUNT.0").getData()).getDelegate().intValue());
+        assertEquals(1, ((NumberType) d.get("FIELD_B_COUNT.0").getData()).getDelegate().intValue());
+    }
+
+    @Test
+    public void testManyStaticDocuments() {
+        Iterator<Map.Entry<Key,Document>> iter = getDocumentIterator(10_000);
+        GroupFields groupFields = new GroupFields();
+        groupFields.setCountFields(Set.of("FIELD_A", "FIELD_B"));
+        GroupingIterator groupingIterator = new GroupingIterator(iter, MarkingFunctions.Factory.createMarkingFunctions(), groupFields, 100_000, null);
+
+        assertTrue(groupingIterator.hasNext());
+        Document d = groupingIterator.next().getValue();
+        assertEquals(3, d.getAttributes().size());
+        assertEquals(10_000, ((NumberType) d.get("COUNT.0").getData()).getDelegate().intValue());
+        assertEquals(10_000, ((NumberType) d.get("FIELD_A_COUNT.0").getData()).getDelegate().intValue());
+        assertEquals(10_000, ((NumberType) d.get("FIELD_B_COUNT.0").getData()).getDelegate().intValue());
+    }
+
+    private Iterator<Map.Entry<Key,Document>> getDocumentIterator(int count) {
+        List<Map.Entry<Key,Document>> list = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(getDocumentEntry());
+        }
+        return list.iterator();
+    }
+
+    private Map.Entry<Key,Document> getDocumentEntry() {
+        Key key = new Key("row", "dt\0uid-" + uidCount++);
+        Document document = getDocument(key);
+        return new AbstractMap.SimpleEntry<>(key, document);
+    }
+
+    private Document getDocument(Key docKey) {
+        Document d = new Document();
+        d.put("FIELD_A", new PreNormalizedAttribute("value_a", docKey, false));
+        d.put("FIELD_B", new PreNormalizedAttribute("value_b", docKey, false));
+        d.put("FIELD_C", new PreNormalizedAttribute("value_c", docKey, false));
+        return d;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -678,6 +678,37 @@ public abstract class GroupingTest {
     }
 
     /**
+     * Verify that specifying a single field via the lucene function works correctly.
+     */
+    @Test
+    public void testGroupBySingleField() throws Exception {
+        givenNonModelData();
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY(AGE)");
+        givenQueryParameter(QueryParameters.RETURN_FIELDS, "AGE");
+        givenQueryParameter(QueryParameters.HIT_LIST, "true");
+        givenQueryParameter(QueryParameters.INCLUDE_GROUPING_CONTEXT, "true");
+        givenQueryParameter(QueryParameters.LIMIT_FIELDS, "_ANYFIELD_=100");
+        givenQueryParameter(QueryOptions.REDUCED_RESPONSE, "true");
+        logic.setCollectTimingDetails(true);
+        givenLuceneParserForLogic();
+
+        expectGroup(Group.of("16").withCount(1));
+        expectGroup(Group.of("18").withCount(2));
+        expectGroup(Group.of("20").withCount(2));
+        expectGroup(Group.of("22").withCount(2));
+        expectGroup(Group.of("24").withCount(1));
+        expectGroup(Group.of("30").withCount(1));
+        expectGroup(Group.of("34").withCount(1));
+        expectGroup(Group.of("40").withCount(2));
+
+        // Run the test queries and collect their results.
+        collectQueryResults();
+
+        // Verify the results.
+        assertGroups();
+    }
+
+    /**
      * Verify that specifying group fields via a LUCENE function works correctly.
      */
     @Test


### PR DESCRIPTION
- Numeric now checks for encoded values to avoid expensive exception-based error handling.
- GroupingIterator and GroupingTransform no longer keep a list of document keys, instead opting to retain the most recent key.
- GroupingIterator and GroupingTransform now log how many documents were seen at debug level when no more documents exist in the source iterator
- Deprecated GroupingUtils method that builds a document from a list of keys and added a method that builds a document from a single key.