### PR TITLE
Colvis cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <surefire.forkCount>1C</surefire.forkCount>
-        <version.accumulo>2.1.2</version.accumulo>
+        <version.accumulo>2.1.4-SNAPSHOT</version.accumulo>
         <version.arquillian>1.4.1.Final</version.arquillian>
         <version.arquillian-weld-ee-embedded>1.0.0.Final</version.arquillian-weld-ee-embedded>
         <version.assertj>3.20.2</version.assertj>

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -54,7 +54,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     public ColumnVisibility getColumnVisibility() {
         if (isMetadataSet()) {
             Text colVisTxt = metadata.getColumnVisibility();
-            return visibilityCache.get(colVisTxt).deepCopy();
+            return new ColumnVisibility(visibilityCache.get(colVisTxt));
         }
         return Constants.EMPTY_VISIBILITY;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -4,12 +4,15 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
@@ -36,6 +39,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected Key metadata = null;
     protected boolean toKeep = true; // a flag denoting whether this attribute is to be kept in the returned results (transient or not)
     protected boolean fromIndex = true; // Assume attributes are from the index unless specified otherwise.
+    private static final Map<Text,ColumnVisibility> visibilityCache = Collections.synchronizedMap(new LRUMap<>(5000));
 
     public Attribute() {}
 
@@ -50,12 +54,22 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
 
     public ColumnVisibility getColumnVisibility() {
         if (isMetadataSet()) {
-            return metadata.getColumnVisibilityParsed();
+            Text colVisTxt = metadata.getColumnVisibility();
+            if (visibilityCache.containsKey(colVisTxt)) {
+                return visibilityCache.get(colVisTxt).deepCopy();
+            }
+            ColumnVisibility newColvis = new ColumnVisibility(colVisTxt);
+            visibilityCache.put(colVisTxt, newColvis);
+            return newColvis.deepCopy();
         }
         return Constants.EMPTY_VISIBILITY;
     }
 
-    public void setColumnVisibility(ColumnVisibility columnVisibility) {
+    public void setColumnVisibility(ColumnVisibility visibility) {
+        setColumnVisibility(new Text(visibility.getExpression()));
+    }
+
+    private void setColumnVisibility(Text columnVisibility) {
         if (isMetadataSet()) {
             metadata = new Key(metadata.getRow(), metadata.getColumnFamily(), metadata.getColumnQualifier(), columnVisibility, metadata.getTimestamp());
         } else {
@@ -82,7 +96,12 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
      *
      * Set the metadata. This should only be set here or from extended classes.
      */
-    protected void setMetadata(ColumnVisibility vis, long ts) {
+    protected void setMetadata(ColumnVisibility visibility, long ts) {
+        Text vis = new Text(visibility.getExpression());
+        setMetadata(vis, ts);
+    }
+
+    private void setMetadata(Text vis, long ts) {
         if (isMetadataSet()) {
             metadata = new Key(metadata.getRow(), metadata.getColumnFamily(), metadata.getColumnQualifier(), vis, ts);
         } else {
@@ -191,7 +210,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
 
             in.readFully(cvBytes);
 
-            this.setMetadata(new ColumnVisibility(cvBytes), in.readLong());
+            this.setMetadata(new Text(cvBytes), in.readLong());
         } else {
             this.clearMetadata();
         }
@@ -201,7 +220,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         if (input.readBoolean()) {
             int size = input.readInt(true);
 
-            this.setMetadata(new ColumnVisibility(input.readBytes(size)), input.readLong());
+            this.setMetadata(new Text(input.readBytes(size)), input.readLong());
         } else {
             this.clearMetadata();
         }
@@ -301,7 +320,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         if (value == null) {
             return 0;
         } else {
-            return 16 + roundUp(12 + (value.length() * 2));
+            return 16 + roundUp(12 + (value.length() * 2L));
             // 16 for int, array ref, and object overhead
             // 12 for array overhead
         }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -4,15 +4,12 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.collections4.map.LRUMap;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
@@ -23,6 +20,8 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import datawave.query.Constants;
 import datawave.query.jexl.DatawaveJexlContext;
@@ -39,7 +38,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected Key metadata = null;
     protected boolean toKeep = true; // a flag denoting whether this attribute is to be kept in the returned results (transient or not)
     protected boolean fromIndex = true; // Assume attributes are from the index unless specified otherwise.
-    private static final Map<Text,ColumnVisibility> visibilityCache = Collections.synchronizedMap(new LRUMap<>(5000));
+    private static final LoadingCache<Text,ColumnVisibility> visibilityCache = Caffeine.newBuilder().maximumSize(500).build(ColumnVisibility::new);
 
     public Attribute() {}
 
@@ -55,12 +54,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     public ColumnVisibility getColumnVisibility() {
         if (isMetadataSet()) {
             Text colVisTxt = metadata.getColumnVisibility();
-            if (visibilityCache.containsKey(colVisTxt)) {
-                return visibilityCache.get(colVisTxt).deepCopy();
-            }
-            ColumnVisibility newColvis = new ColumnVisibility(colVisTxt);
-            visibilityCache.put(colVisTxt, newColvis);
-            return newColvis.deepCopy();
+            return visibilityCache.get(colVisTxt).deepCopy();
         }
         return Constants.EMPTY_VISIBILITY;
     }


### PR DESCRIPTION
Closes #2699  
Updates Attribute class to use Caffeine cache to store ColumnVisibility objects.  
When the cache is used a copy of the original ColumnVisibility is made and returned to the caller.  
This is made possible by the new copy constructor in Accumulo 2.1.4 so this PR is gated by that release.