### PR TITLE
Update QueryIteratorITs

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -935,6 +935,7 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
             // get the function we use for the tf functionality. Note we are
             // getting an additional source deep copy for this function
             final Iterator<Tuple3<Key,Document,Map<String,Object>>> itrWithContext;
+            // TODO: this should be dynamic based on the query fields, not a flag passed to the iterator
             if (this.isTermFrequenciesRequired()) {
 
                 TermFrequencyConfig tfConfig = new TermFrequencyConfig();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -314,6 +314,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
 
             // if we are not limiting the lookup, or not allowing term frequency lookup,
             // or the field is index only but not in the term frequencies, then we must ivarate
+            // TODO: this logic is wrong, it will allow an ivarator against a TF field
             if (!limitLookup || !allowTermFrequencyLookup || (indexOnlyFields.contains(identifier) && !termFrequencyFields.contains(identifier))) {
                 if (source instanceof ASTAndNode) {
                     try {

--- a/warehouse/query-core/src/test/java/datawave/query/ancestor/AncestorQueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ancestor/AncestorQueryIteratorIT.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.junit.Before;
 
 import datawave.query.iterator.QueryIteratorIT;
+import datawave.query.iterator.QueryOptions;
 
 /**
  * AncestorQueryIterator integration tests. Ancestor Query should find any hits event query finds plus its own unique cases
@@ -14,6 +15,9 @@ public class AncestorQueryIteratorIT extends QueryIteratorIT {
     public void setup() throws IOException {
         super.setup();
         iterator = new AncestorQueryIterator();
+
+        // adding the HIT_LIST option tells the query iterator to use a HitListArithmetic
+        options.put(QueryOptions.HIT_LIST, "true");
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/tld/TLDQueryIteratorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tld/TLDQueryIteratorIT.java
@@ -34,6 +34,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
 
         // update indexed
         options.put(INDEXED_FIELDS, options.get(INDEXED_FIELDS) + ",TF_FIELD3");
+        options.put(TERM_FREQUENCY_FIELDS, options.get(TERM_FREQUENCY_FIELDS) + ",TF_FIELD3");
 
         // update unindexed fields
         String nonIndexedDataTypes = options.get(NON_INDEXED_DATATYPES);
@@ -66,7 +67,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("z");
         expectedDocument.getValue().put("TF_FIELD3", tfField1Hits);
 
-        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", false, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", false, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     @Test
@@ -81,13 +82,13 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("z");
         expectedDocument.getValue().put("TF_FIELD3", tfField1Hits);
 
-        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", false, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        event_test(seekRange, "EVENT_FIELD2 == 'b' && not(TF_FIELD3 == null)", false, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     /**
      * Document specific range given expected from RangePartitioner and EVENT_FIELD1 index lookup. ExceededValueThreshold TF FIELD triggers TF index lookup for
      * evaluation.
-     *
+     * <p>
      * document specific range, tf via TermFrequencyAggregator
      *
      * @throws IOException
@@ -104,14 +105,14 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("r");
         expectedDocument.getValue().put("TF_FIELD1", tfField1Hits);
 
-        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     @Test
     public void tf_exceededValue_leadingWildcard_fullValueMatch_documentSpecific_tld_test() throws IOException {
         // build the seek range for a document specific pull
         Range seekRange = getDocumentRange("123.345.456");
-        String query = "EVENT_FIELD1 =='a' && ((ExceededValueThresholdMarkerJexlNode = true) && (TF_FIELD1 =~ '.*r s'))";
+        String query = "EVENT_FIELD1 =='a' && ((_Value_ = true) && (TF_FIELD1 =~ '.*r s'))";
         Map.Entry<Key,Map<String,List<String>>> expectedDocument = getBaseExpectedEvent("123.345.456");
         List<String> tfField1Hits = new ArrayList<>();
         // from parent
@@ -120,12 +121,12 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add(",,q ,r, ,s,");
         expectedDocument.getValue().put("TF_FIELD1", tfField1Hits);
 
-        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     /**
      * Shard range given expected from RangePartitioner and EVENT_FIELD1 index lookup. ExceededValueThreshold TF FIELD triggers TF index lookup for evaluation.
-     *
+     * <p>
      * fiFullySatisfies query, Create an ivarator for tf
      *
      * @throws IOException
@@ -142,7 +143,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("r");
         expectedDocument.getValue().put("TF_FIELD1", tfField1Hits);
 
-        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     @Test
@@ -150,7 +151,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         // build the seek range for a document specific pull
         Range seekRange = getDocumentRange("123.345.456");
         String query = "EVENT_FIELD1 =='a' && !((_Value_ = true) && (TF_FIELD1 =~ '.*z'))";
-        tf_test(seekRange, query, getBaseExpectedEvent("123.345.456"), configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, getBaseExpectedEvent("123.345.456"), configureTLDTestData(11), Collections.emptyList());
     }
 
     @Test
@@ -158,7 +159,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         // build the seek range for a document specific pull
         Range seekRange = getShardRange();
         String query = "EVENT_FIELD1 =='a' && !((_Value_ = true) && (TF_FIELD1 =~ '.*z'))";
-        tf_test(seekRange, query, getBaseExpectedEvent("123.345.456"), configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, getBaseExpectedEvent("123.345.456"), configureTLDTestData(11), Collections.emptyList());
     }
 
     @Test
@@ -172,7 +173,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("r");
         expectedDocument.getValue().put("TF_FIELD1", tfField1Hits);
 
-        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     @Test
@@ -186,7 +187,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         tfField1Hits.add("r");
         expectedDocument.getValue().put("TF_FIELD1", tfField1Hits);
 
-        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.EMPTY_LIST);
+        tf_test(seekRange, query, expectedDocument, configureTLDTestData(11), Collections.emptyList());
     }
 
     @Override
@@ -194,7 +195,7 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         // not a document range
         if (uid == null) {
             // get the shard range from the super
-            return super.getDocumentRange(row, dataType, uid);
+            return super.getDocumentRange(row, dataType, null);
         }
 
         Key startKey = new Key(row, dataType + Constants.NULL + uid);
@@ -206,30 +207,30 @@ public class TLDQueryIteratorIT extends QueryIteratorIT {
         List<Map.Entry<Key,Value>> listSource = super.configureTestData(eventTime);
 
         // add some indexed TF fields in a child
-        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("TF_FIELD1", ",,q ,r, ,s,", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "q r s", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "q", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "r", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "s", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD1", "q", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD1", "r", "123.345.456.1", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD1", "s", "123.345.456.1", eventTime), new Value()));
+        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("TF_FIELD1", ",,q ,r, ,s,", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "q r s", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "q", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "r", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD1", "s", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD1", "q", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD1", "r", "123.345.456.1", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD1", "s", "123.345.456.1", eventTime), EMPTY_VALUE));
 
-        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("TF_FIELD2", ",d, ,e, ,f,", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "d e f", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "d", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "e", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "f", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD2", "d", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD2", "e", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD2", "f", "123.345.456.2", eventTime), new Value()));
+        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("TF_FIELD2", ",d, ,e, ,f,", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "d e f", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "d", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "e", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD2", "f", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD2", "d", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD2", "e", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getTF("TF_FIELD2", "f", "123.345.456.2", eventTime), EMPTY_VALUE));
 
         // add some event data for children
-        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("EVENT_FIELD7", "1", "123.345.456.1", eventTime), new Value()));
+        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("EVENT_FIELD7", "1", "123.345.456.1", eventTime), EMPTY_VALUE));
 
         // add some non-event data that is unique for children
-        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("TF_FIELD3", "z", "123.345.456.2", eventTime), new Value()));
-        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD3", "z", "123.345.456.2", eventTime), new Value()));
+        listSource.add(new AbstractMap.SimpleEntry<>(getEvent("TF_FIELD3", "z", "123.345.456.2", eventTime), EMPTY_VALUE));
+        listSource.add(new AbstractMap.SimpleEntry<>(getFI("TF_FIELD3", "z", "123.345.456.2", eventTime), EMPTY_VALUE));
 
         return listSource;
     }


### PR DESCRIPTION
Migrate QueryIteratorIT to using field sets for index only and term frequency fields

Corrected exceeded value markers, causing several tests to invert their hitor miss assertion

Add alternate forms of negations, i.e. (value !~) and !(value =~)

Address various warnings, use a static Value instead of creating a new one each time, reuse the KryoDeserializer

Add explanation for change in final assertions