### PR TITLE
Expand test cases for the SatisfactionVisitor.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -256,9 +256,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                 if (subNode instanceof ASTEQNode) {
                     delayedEqNodes.add(subNode);
                 }
-                if (isQueryFullySatisfied) {
-                    log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-                }
+                checkForSatisfactionError();
                 log.trace("Will not process ASTDelayedPredicate.");
             }
             return null;
@@ -372,9 +370,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                         iterators.addInclude(nested);
                     }
                 } else {
-                    if (isQueryFullySatisfied) {
-                        log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-                    }
+                    checkForSatisfactionError();
                     // if there is no parent
                     if (root == null && data == null) {
                         // make this nested the root node
@@ -616,9 +612,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
 
         // verify that the field exists and is indexed
         if (builder.getField() == null || isUnindexed(builder.getField())) {
-            if (isQueryFullySatisfied) {
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            checkForSatisfactionError();
             return null;
         }
 
@@ -630,11 +624,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                 throw new DatawaveFatalQueryException(qe);
             }
 
-            // SatisfactionVisitor should have already initialized this to false
-            if (isQueryFullySatisfied) {
-                // note: this is different from the ASTEQ method...
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            // FIELD != null should have set satisfied to false
+            checkForSatisfactionError();
             return null;
         }
 
@@ -657,9 +648,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             iterators.addExclude(builder.build());
         } else {
             // SatisfactionVisitor should have already initialized this to false
-            if (isQueryFullySatisfied) {
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            checkForSatisfactionError();
         }
 
         return null;
@@ -679,9 +668,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
 
         // verify that field exists and is indexed
         if (builder.getField() == null || isUnindexed(builder.getField())) {
-            if (isQueryFullySatisfied) {
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            checkForSatisfactionError();
             return null;
         }
 
@@ -722,9 +709,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                 loadBuilder(builder, data, node);
                 iterators.addInclude(builder.build());
             } else {
-                if (isQueryFullySatisfied) {
-                    log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-                }
+                checkForSatisfactionError();
             }
         }
 
@@ -950,9 +935,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
          * If we have an unindexed type enforced, we've been configured to assert whether the field is indexed.
          */
         if (isUnindexed(node)) {
-            if (isQueryFullySatisfied) {
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            checkForSatisfactionError();
             return null;
         }
 
@@ -974,9 +957,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         // A EQNode may be of the form FIELD == null. The evaluation can
         // handle this, so we should just not build an IndexIterator for it.
         if (null == builder.getValue()) {
-            if (isQueryFullySatisfied) {
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            checkForSatisfactionError();
             return null;
         }
 
@@ -1001,9 +982,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             if (isNew && inclusionReference && notExcluded) {
                 iterators.addInclude(builder.build());
             } else {
-                if (isQueryFullySatisfied) {
-                    log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-                }
+                checkForSatisfactionError();
             }
         }
 
@@ -1027,9 +1006,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         }
 
         if (isUnindexed(node)) {
-            if (isQueryFullySatisfied) {
-                log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
-            }
+            checkForSatisfactionError();
         }
 
         return null;
@@ -1508,10 +1485,14 @@ public class IteratorBuildingVisitor extends BaseVisitor {
                             && !excludeReferences.contains(builder.getField())) {
                 iterators.addInclude(builder.build());
             } else {
-                if (isQueryFullySatisfied) {
-                    log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false by the SatisfactionVisitor");
-                }
+                checkForSatisfactionError();
             }
+        }
+    }
+
+    protected void checkForSatisfactionError() {
+        if (isQueryFullySatisfied) {
+            log.warn("Determined that isQueryFullySatisfied should be false, but it was not preset to false in the SatisfactionVisitor");
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/SatisfactionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/SatisfactionVisitor.java
@@ -90,14 +90,20 @@ public class SatisfactionVisitor extends BaseVisitor {
             isQueryFullySatisfied = false;
             return null;
         }
-        String field = JexlASTHelper.getIdentifier(node);
-        final boolean included = includeReferences.contains(field);
-        final boolean excluded = excludeReferences.contains(field);
 
-        if (excluded || !included) {
-            isQueryFullySatisfied = false;
-            return null;
+        String field = JexlASTHelper.getIdentifier(node);
+        // some queries will not have a field, as in the case of
+        // FIELD.max() == 1
+        if (field != null) {
+            final boolean included = includeReferences.contains(field);
+            final boolean excluded = excludeReferences.contains(field);
+
+            if (excluded || !included) {
+                isQueryFullySatisfied = false;
+                return null;
+            }
         }
+
         for (int i = 0; i < node.jjtGetNumChildren(); i++) {
             // visit the kids in case there is a surprise there (like a Method node)
             node.jjtGetChild(i).jjtAccept(this, data);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/SatisfactionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/SatisfactionVisitorTest.java
@@ -1,7 +1,9 @@
 package datawave.query.jexl.visitors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.Set;
@@ -41,5 +43,437 @@ public class SatisfactionVisitorTest {
         SatisfactionVisitor visitor = new SatisfactionVisitor(indexOnlyFields, includeReferences, excludeReferences, true);
         visitor.visit(script, null);
         return visitor.isQueryFullySatisfied;
+    }
+
+    private final Set<String> indexed = Set.of("INDEXED_FIELD", "INDEX_ONLY_FIELD");
+    private final Set<String> indexOnly = Set.of("INDEX_ONLY_FIELD");
+
+    @Test
+    public void testEq() {
+        test(true, "INDEXED_FIELD == 'a'");
+        test(true, "INDEX_ONLY_FIELD == 'a'");
+        test(false, "EVENT_ONLY_FIELD == 'a'");
+    }
+
+    @Test
+    public void testNe() {
+        test(true, "INDEXED_FIELD != 'a'");
+        test(true, "INDEX_ONLY_FIELD != 'a'");
+        test(false, "EVENT_ONLY_FIELD != 'a'");
+    }
+
+    @Test
+    public void testNotEq() {
+        // this term is absolutely executable on the field index
+        test(false, "!(INDEXED_FIELD == 'a')");
+        // this term is absolutely executable on the field index
+        test(false, "!(INDEX_ONLY_FIELD == 'a')");
+        // a special iterator that runs against the event column could be used if we really wanted to, as in the case of tokenized event fields (builds two
+        // iterators on against TF and the other against the event column)
+        test(false, "!(EVENT_ONLY_FIELD == 'a')");
+    }
+
+    @Test
+    public void testEqNullLiteral() {
+        test(false, "INDEXED_FIELD == null");
+        test(false, "INDEX_ONLY_FIELD == null");
+        test(false, "EVENT_ONLY_FIELD == null");
+    }
+
+    @Test
+    public void testNeNullLiteral() {
+        test(false, "INDEXED_FIELD != null");
+        test(false, "INDEX_ONLY_FIELD != null");
+        test(false, "EVENT_ONLY_FIELD != null");
+    }
+
+    @Test
+    public void testNotEqNullLiteral() {
+        test(false, "!(INDEXED_FIELD == null)");
+        test(false, "!(INDEX_ONLY_FIELD == null)");
+        test(false, "!(EVENT_ONLY_FIELD == null)");
+    }
+
+    @Test
+    public void testRangeOperators() {
+        // test LT, GT, LE, GE operators in isolation (not part of a bounded range)
+        test(false, "INDEXED_FIELD < 'a'");
+        test(false, "INDEX_ONLY_FIELD < 'a'");
+        test(false, "EVENT_ONLY_FIELD < 'a'");
+
+        test(false, "INDEXED_FIELD > 'a'");
+        test(false, "INDEX_ONLY_FIELD > 'a'");
+        test(false, "EVENT_ONLY_FIELD > 'a'");
+
+        test(false, "INDEXED_FIELD <= 'a'");
+        test(false, "INDEX_ONLY_FIELD <= 'a'");
+        test(false, "EVENT_ONLY_FIELD <= 'a'");
+
+        test(false, "INDEXED_FIELD >= 'a'");
+        test(false, "INDEX_ONLY_FIELD >= 'a'");
+        test(false, "EVENT_ONLY_FIELD >= 'a'");
+    }
+
+    @Test
+    public void testExceededValueMarker() {
+        // exceeded value regex
+        test(true, "((_Value_ = true) && (INDEXED_FIELD =~ 'ba.*'))");
+        test(true, "((_Value_ = true) && (INDEX_ONLY_FIELD =~ 'ba.*'))");
+        // a regex against an event only field should get marked as evaluation only, but document
+        // the behavior here. This term should return false, but returns true instead.
+        test(true, "((_Value_ = true) && (EVENT_ONLY_FIELD =~ 'ba.*'))");
+
+        test(true, "((_Value_ = true) && ((_Bounded_ = true) && (INDEXED_FIELD > '1' && INDEXED_FIELD < '2')))");
+        test(true, "((_Value_ = true) && ((_Bounded_ = true) && (INDEX_ONLY_FIELD > '1' && INDEX_ONLY_FIELD < '2')))");
+        // this should be false. In practice this will never happen, but if it did the range should be marked _eval_
+        test(true, "((_Value_ = true) && ((_Bounded_ = true) && (EVENT_ONLY_FIELD > '1' && EVENT_ONLY_FIELD < '2')))");
+    }
+
+    @Test
+    public void testDelayedMarker() {
+        test(false, "((_Delayed_ = true) && (INDEXED_FIELD == 'a'))");
+        test(false, "((_Delayed_ = true) && (INDEX_ONLY_FIELD == 'a'))");
+        test(false, "((_Delayed_ = true) && (EVENT_ONLY_FIELD == 'a'))");
+    }
+
+    @Test
+    public void testEvaluationOnlyMarker() {
+        // the only fields that should be marked eval only are event-only fields
+        test(false, "((_Eval_ = true) && (INDEXED_FIELD =~ 'ba.*'))");
+        test(false, "((_Eval_ = true) && (INDEX_ONLY_FIELD =~ 'ba.*'))");
+        test(false, "((_Eval_ = true) && (EVENT_ONLY_FIELD =~ 'ba.*'))");
+    }
+
+    @Test
+    public void testBoundedRangeMarker() {
+        // this is absolutely executable against the field index
+        test(false, "((_Bounded_ = true) && (INDEXED_FIELD > '1' && INDEXED_FIELD < '2'))");
+        // this is absolutely executable against the field index
+        test(false, "((_Bounded_ = true) && (INDEX_ONLY_FIELD > '1' && INDEX_ONLY_FIELD < '2'))");
+        test(false, "((_Bounded_ = true) && (EVENT_ONLY_FIELD > '1' && EVENT_ONLY_FIELD < '2'))");
+    }
+
+    @Test
+    public void testListOrMarker() {
+        test(true, "((_List_ = true) && ((id = 'uuid') && (field = 'INDEXED_FIELD') && (params = '{\"values\":[\"a\",\"b\"]}')))");
+        test(true, "((_List_ = true) && ((id = 'uuid') && (field = 'INDEX_ONLY_FIELD') && (params = '{\"values\":[\"a\",\"b\"]}')))");
+        test(true, "((_List_ = true) && ((id = 'uuid') && (field = 'EVENT_ONLY_FIELD') && (params = '{\"values\":[\"a\",\"b\"]}')))");
+    }
+
+    @Test
+    public void testContentAdjacentFunction() {
+        // unfielded content functions are thing of the past, but record this behavior anyway
+        test(false, "content:adjacent(termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent(INDEXED_FIELD, termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent(INDEX_ONLY_FIELD, termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent(EVENT_ONLY_FIELD, termOffsetMap, 'a', 'b')");
+
+        // in practice multi-fielded content functions are rewritten as a union of single fielded content functions
+        // order should not matter, but we shouldn't make assumptions..
+        test(false, "content:adjacent((INDEXED_FIELD || INDEXED_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent((INDEXED_FIELD || INDEX_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent((INDEXED_FIELD || EVENT_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+
+        test(false, "content:adjacent((INDEX_ONLY_FIELD || INDEXED_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+
+        test(false, "content:adjacent((EVENT_ONLY_FIELD || INDEXED_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:adjacent((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+    }
+
+    @Test
+    public void testContentPhraseFunction() {
+        // unfielded content functions are thing of the past, but record this behavior anyway
+        test(false, "content:phrase(termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase(INDEXED_FIELD, termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase(INDEX_ONLY_FIELD, termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase(EVENT_ONLY_FIELD, termOffsetMap, 'a', 'b')");
+
+        // in practice multi-fielded content functions are rewritten as a union of single fielded content functions
+        // order should not matter, but we shouldn't make assumptions..
+        test(false, "content:phrase((INDEXED_FIELD || INDEXED_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase((INDEXED_FIELD || INDEX_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase((INDEXED_FIELD || EVENT_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+
+        test(false, "content:phrase((INDEX_ONLY_FIELD || INDEXED_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+
+        test(false, "content:phrase((EVENT_ONLY_FIELD || INDEXED_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+        test(false, "content:phrase((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD), termOffsetMap, 'a', 'b')");
+    }
+
+    @Test
+    public void testContentScoredPhraseFunction() {
+        // unfielded content functions are thing of the past, but record this behavior anyway
+        test(false, "content:scoredPhrase(-1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase(INDEXED_FIELD, -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase(INDEX_ONLY_FIELD, -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase(EVENT_ONLY_FIELD, -1.1, termOffsetMap, 'a', 'b')");
+
+        // in practice multi-fielded content functions are rewritten as a union of single fielded content functions
+        // order should not matter, but we shouldn't make assumptions..
+        test(false, "content:scoredPhrase((INDEXED_FIELD || INDEXED_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase((INDEXED_FIELD || INDEX_ONLY_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase((INDEXED_FIELD || EVENT_ONLY_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+
+        test(false, "content:scoredPhrase((INDEX_ONLY_FIELD || INDEXED_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+
+        test(false, "content:scoredPhrase((EVENT_ONLY_FIELD || INDEXED_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+        test(false, "content:scoredPhrase((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD), -1.1, termOffsetMap, 'a', 'b')");
+    }
+
+    @Test
+    public void testContentWithinFunction() {
+        // unfielded content functions are thing of the past, but record this behavior anyway
+        test(false, "content:within(1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within(INDEXED_FIELD, 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within(INDEX_ONLY_FIELD, 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within(EVENT_ONLY_FIELD, 1, termOffsetMap, 'a', 'b')");
+
+        // in practice multi-fielded content functions are rewritten as a union of single fielded content functions
+        // order should not matter, but we shouldn't make assumptions...
+        test(false, "content:within((INDEXED_FIELD || INDEXED_FIELD), 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within((INDEXED_FIELD || INDEX_ONLY_FIELD), 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within((INDEXED_FIELD || EVENT_ONLY_FIELD), 1, termOffsetMap, 'a', 'b')");
+
+        test(false, "content:within((INDEX_ONLY_FIELD || INDEXED_FIELD), 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD), 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD), 1, termOffsetMap, 'a', 'b')");
+
+        test(false, "content:within((EVENT_ONLY_FIELD || INDEXED_FIELD), 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD), 1, termOffsetMap, 'a', 'b')");
+        test(false, "content:within((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD), 1, termOffsetMap, 'a', 'b')");
+    }
+
+    @Test
+    public void testFilterIncludeRegex() {
+        test(false, "filter:includeRegex(INDEXED_FIELD, 'ba.*')");
+        test(false, "filter:includeRegex(INDEX_ONLY_FIELD, 'ba.*')");
+        test(false, "filter:includeRegex(EVENT_ONLY_FIELD, 'ba.*')");
+
+        test(false, "filter:includeRegex((INDEXED_FIELD || INDEXED_FIELD), 'ba.*')");
+        test(false, "filter:includeRegex((INDEXED_FIELD || INDEX_ONLY_FIELD), 'ba.*')");
+        test(false, "filter:includeRegex((INDEXED_FIELD || EVENT_ONLY_FIELD), 'ba.*')");
+
+        test(false, "filter:includeRegex((INDEX_ONLY_FIELD || INDEXED_FIELD), 'ba.*')");
+        test(false, "filter:includeRegex((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD), 'ba.*')");
+        test(false, "filter:includeRegex((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD), 'ba.*')");
+
+        test(false, "filter:includeRegex((EVENT_ONLY_FIELD || INDEXED_FIELD), 'ba.*')");
+        test(false, "filter:includeRegex((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD), 'ba.*')");
+        test(false, "filter:includeRegex((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD), 'ba.*')");
+    }
+
+    @Test
+    public void testFilterExcludeRegex() {
+        test(false, "filter:excludeRegex(INDEXED_FIELD, 'ba.*')");
+        test(false, "filter:excludeRegex(INDEX_ONLY_FIELD, 'ba.*')");
+        test(false, "filter:excludeRegex(EVENT_ONLY_FIELD, 'ba.*')");
+
+        test(false, "filter:excludeRegex((INDEXED_FIELD || INDEXED_FIELD), 'ba.*')");
+        test(false, "filter:excludeRegex((INDEXED_FIELD || INDEX_ONLY_FIELD), 'ba.*')");
+        test(false, "filter:excludeRegex((INDEXED_FIELD || EVENT_ONLY_FIELD), 'ba.*')");
+
+        test(false, "filter:excludeRegex((INDEX_ONLY_FIELD || INDEXED_FIELD), 'ba.*')");
+        test(false, "filter:excludeRegex((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD), 'ba.*')");
+        test(false, "filter:excludeRegex((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD), 'ba.*')");
+
+        test(false, "filter:excludeRegex((EVENT_ONLY_FIELD || INDEXED_FIELD), 'ba.*')");
+        test(false, "filter:excludeRegex((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD), 'ba.*')");
+        test(false, "filter:excludeRegex((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD), 'ba.*')");
+    }
+
+    @Test
+    public void testFilterIsNull() {
+        // in practice isNull/isNotNull functions are rewritten into a union of 'FIELD == null' terms
+        // we still support these functions in the interpreter, so record behavior here
+        test(false, "filter:isNull(INDEXED_FIELD)");
+        test(false, "filter:isNull(INDEX_ONLY_FIELD)");
+        test(false, "filter:isNull(EVENT_ONLY_FIELD)");
+
+        test(false, "filter:isNull((INDEXED_FIELD || INDEXED_FIELD))");
+        test(false, "filter:isNull((INDEXED_FIELD || INDEX_ONLY_FIELD))");
+        test(false, "filter:isNull((INDEXED_FIELD || EVENT_ONLY_FIELD))");
+
+        test(false, "filter:isNull((INDEX_ONLY_FIELD || INDEXED_FIELD))");
+        test(false, "filter:isNull((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD))");
+        test(false, "filter:isNull((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD))");
+
+        test(false, "filter:isNull((EVENT_ONLY_FIELD || INDEXED_FIELD))");
+        test(false, "filter:isNull((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD))");
+        test(false, "filter:isNull((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD))");
+    }
+
+    @Test
+    public void testFilterIsNotNull() {
+        // in practice isNull/isNotNull functions are rewritten into a union of 'FIELD == null' terms
+        // we still support these functions in the interpreter, so record behavior here
+        test(false, "filter:isNotNull(INDEXED_FIELD)");
+        test(false, "filter:isNotNull(INDEX_ONLY_FIELD)");
+        test(false, "filter:isNotNull(EVENT_ONLY_FIELD)");
+
+        test(false, "filter:isNotNull((INDEXED_FIELD || INDEXED_FIELD))");
+        test(false, "filter:isNotNull((INDEXED_FIELD || INDEX_ONLY_FIELD))");
+        test(false, "filter:isNotNull((INDEXED_FIELD || EVENT_ONLY_FIELD))");
+
+        test(false, "filter:isNotNull((INDEX_ONLY_FIELD || INDEXED_FIELD))");
+        test(false, "filter:isNotNull((INDEX_ONLY_FIELD || INDEX_ONLY_FIELD))");
+        test(false, "filter:isNotNull((INDEX_ONLY_FIELD || EVENT_ONLY_FIELD))");
+
+        test(false, "filter:isNotNull((EVENT_ONLY_FIELD || INDEXED_FIELD))");
+        test(false, "filter:isNotNull((EVENT_ONLY_FIELD || INDEX_ONLY_FIELD))");
+        test(false, "filter:isNotNull((EVENT_ONLY_FIELD || EVENT_ONLY_FIELD))");
+    }
+
+    @Test
+    public void testFilterOccurrence() {
+        test(false, "filter:occurrence(INDEXED_FIELD, '==', 3)");
+        test(false, "filter:occurrence(INDEX_ONLY_FIELD, '==', 3)");
+        test(false, "filter:occurrence(EVENT_ONLY_FIELD, '==', 3)");
+
+        test(false, "filter:occurrence(INDEXED_FIELD, '>', 3)");
+        test(false, "filter:occurrence(INDEX_ONLY_FIELD, '>', 3)");
+        test(false, "filter:occurrence(EVENT_ONLY_FIELD, '>', 3)");
+    }
+
+    @Test
+    public void testFilterMatchesAtLeastCountOf() {
+        test(false, "filter:occurrence(2, INDEXED_FIELD, INDEXED_FIELD)");
+        test(false, "filter:occurrence(2, INDEXED_FIELD, INDEX_ONLY_FIELD)");
+        test(false, "filter:occurrence(2, INDEXED_FIELD, EVENT_ONLY_FIELD)");
+
+        test(false, "filter:occurrence(2, INDEX_ONLY_FIELD, INDEXED_FIELD)");
+        test(false, "filter:occurrence(2, INDEX_ONLY_FIELD, INDEX_ONLY_FIELD)");
+        test(false, "filter:occurrence(2, INDEX_ONLY_FIELD, EVENT_ONLY_FIELD)");
+
+        test(false, "filter:occurrence(2, EVENT_ONLY_FIELD, INDEXED_FIELD)");
+        test(false, "filter:occurrence(2, EVENT_ONLY_FIELD, INDEX_ONLY_FIELD)");
+        test(false, "filter:occurrence(2, EVENT_ONLY_FIELD, EVENT_ONLY_FIELD)");
+    }
+
+    @Test
+    public void testFilterTimeFunction() {
+        test(false, "filter:timeFunction(INDEXED_FIELD,INDEXED_FIELD,'-','>',2522880000000L)");
+        test(false, "filter:timeFunction(INDEXED_FIELD,INDEX_ONLY_FIELD,'-','>',2522880000000L)");
+        test(false, "filter:timeFunction(INDEXED_FIELD,EVENT_ONLY_FIELD,'-','>',2522880000000L)");
+
+        test(false, "filter:timeFunction(INDEX_ONLY_FIELD,INDEXED_FIELD,'-','>',2522880000000L)");
+        test(false, "filter:timeFunction(INDEX_ONLY_FIELD,INDEX_ONLY_FIELD,'-','>',2522880000000L)");
+        test(false, "filter:timeFunction(INDEX_ONLY_FIELD,EVENT_ONLY_FIELD,'-','>',2522880000000L)");
+
+        test(false, "filter:timeFunction(EVENT_ONLY_FIELD,INDEXED_FIELD,'-','>',2522880000000L)");
+        test(false, "filter:timeFunction(EVENT_ONLY_FIELD,INDEX_ONLY_FIELD,'-','>',2522880000000L)");
+        test(false, "filter:timeFunction(EVENT_ONLY_FIELD,EVENT_ONLY_FIELD,'-','>',2522880000000L)");
+
+    }
+
+    @Test
+    public void testFilterGetMaxTime() {
+        test(false, "filter:getMaxTime(INDEXED_FIELD) < 123456L");
+        test(false, "filter:getMaxTime(INDEX_ONLY_FIELD) < 123456L");
+        test(false, "filter:getMaxTime(EVENT_ONLY_FIELD) < 123456L");
+    }
+
+    @Test
+    public void testFieldArithmetic() {
+        test(false, "INDEXED_FIELD.min() > 10");
+        test(false, "INDEX_ONLY_FIELD.min() > 10");
+        test(false, "EVENT_ONLY_FIELD.min() > 10");
+
+        test(false, "INDEXED_FIELD.max() > 10");
+        test(false, "INDEX_ONLY_FIELD.max() > 10");
+        test(false, "EVENT_ONLY_FIELD.max() > 10");
+    }
+
+    @Test
+    public void testFieldMethodArithmetic() {
+        test(false, "INDEXED_FIELD.greaterThan(10).size() == 1");
+        test(false, "INDEX_ONLY_FIELD.greaterThan(10).size() == 1");
+        test(false, "EVENT_ONLY_FIELD.greaterThan(10).size() == 1");
+
+        test(false, "INDEXED_FIELD.max() > 10");
+        test(false, "INDEX_ONLY_FIELD.max() > 10");
+        test(false, "EVENT_ONLY_FIELD.max() > 10");
+    }
+
+    @Test
+    public void testMethodsAsArguments() {
+        test(false, "INDEXED_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(INDEXED_FIELD, 'a')).isEmpty() == false");
+        test(false, "INDEXED_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(INDEX_ONLY_FIELD, 'a')).isEmpty() == false");
+        test(false, "INDEXED_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(EVENT_ONLY_FIELD, 'a')).isEmpty() == false");
+
+        test(false, "INDEX_ONLY_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(INDEXED_FIELD, 'a')).isEmpty() == false");
+        test(false, "INDEX_ONLY_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(INDEX_ONLY_FIELD, 'a')).isEmpty() == false");
+        test(false, "INDEX_ONLY_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(EVENT_ONLY_FIELD, 'a')).isEmpty() == false");
+
+        test(false, "EVENT_ONLY_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(INDEXED_FIELD, 'a')).isEmpty() == false");
+        test(false, "EVENT_ONLY_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(INDEX_ONLY_FIELD, 'a')).isEmpty() == false");
+        test(false, "EVENT_ONLY_FIELD.getValuesForGroups(grouping:getGroupsForMatchesInGroup(EVENT_ONLY_FIELD, 'a')).isEmpty() == false");
+    }
+
+    @Test
+    public void testAndNot() {
+        // this should be true
+        test(false, "INDEXED_FIELD == 'a' && !(INDEXED_FIELD == 'b')");
+        // this should be true
+        test(false, "INDEXED_FIELD == 'a' && !(INDEX_ONLY_FIELD == 'b')");
+        // this is technically satisfiable if we run an iterator against the event column
+        test(false, "INDEXED_FIELD == 'a' && !(EVENT_ONLY_FIELD == 'b')");
+
+        // this should be true
+        test(false, "INDEX_ONLY_FIELD == 'a' && !(INDEXED_FIELD == 'b')");
+        // this should be true
+        test(false, "INDEX_ONLY_FIELD == 'a' && !(INDEX_ONLY_FIELD == 'b')");
+        // this is technically satisfiable if we run an iterator against the event column
+        test(false, "INDEX_ONLY_FIELD == 'a' && !(EVENT_ONLY_FIELD == 'b')");
+
+        // this is technically a full table scan and should never reach the query iterator, document for posterity
+        test(false, "EVENT_ONLY_FIELD == 'a' && !(INDEXED_FIELD == 'b')");
+        test(false, "EVENT_ONLY_FIELD == 'a' && !(INDEX_ONLY_FIELD == 'b')");
+        test(false, "EVENT_ONLY_FIELD == 'a' && !(EVENT_ONLY_FIELD == 'b')");
+    }
+
+    /**
+     * Assert the outcome of applying the {@link SatisfactionVisitor} to the provided query
+     *
+     * @param expected
+     *            the expected outcome
+     * @param query
+     *            the query
+     */
+    private void test(boolean expected, String query) {
+        ASTJexlScript script = parse(query);
+        // in practice the set of exclude fields is never used
+        SatisfactionVisitor visitor = new SatisfactionVisitor(indexOnly, indexed, Collections.emptySet(), true);
+        visitor.visit(script, null);
+        assertEquals(expected, visitor.isQueryFullySatisfied());
+
+        // this method of calling the visitor is used by the delayed non-event context
+        SatisfactionVisitor pessimistic = new SatisfactionVisitor(indexOnly, indexed, Collections.emptySet(), false);
+        pessimistic.visit(script, null);
+        assertFalse(pessimistic.isQueryFullySatisfied());
+    }
+
+    /**
+     * Utility method to parse a query without forcing every test to throw a parse exception
+     *
+     * @param query
+     *            the query string
+     * @return a JexlScript
+     */
+    private ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query);
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
SatisfactionVisitor can now handle nodes with null fields.

Discovered error condition for arithmetic queries that would cause a field to be null, this wasn't discovered because other unit tests that contain these queries were executed as full table scans and thus skipped the SatisfactionVisitor.