### PR TITLE
Add batch support and streaming deduping to SSDeepChainedDiscoveryQueryLogic

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -37,6 +37,8 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     private Multimap<NGramTuple,SSDeepHash> queryMap;
 
+    private boolean dedupe = true;
+
     public SSDeepSimilarityQueryConfiguration() {
         super();
         setQuery(new QueryImpl());
@@ -68,6 +70,7 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         setQueryMap(other.getQueryMap());
         setQueryThreads(other.getQueryThreads());
         setRanges(other.getRanges());
+        setDedupe(other.isDedupe());
     }
 
     public Collection<Range> getRanges() {
@@ -140,5 +143,13 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     public void setBucketEncodingLength(int bucketEncodingLength) {
         this.bucketEncodingLength = bucketEncodingLength;
+    }
+
+    public boolean isDedupe() {
+        return this.dedupe;
+    }
+
+    public void setDedupe(boolean dedupe) {
+        this.dedupe = dedupe;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -1,15 +1,5 @@
 package datawave.query.config;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.accumulo.core.data.Range;
-
-import com.google.common.collect.Multimap;
-
 import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.core.query.logic.BaseQueryLogic;
 import datawave.microservice.query.QueryImpl;
@@ -18,7 +8,6 @@ import datawave.util.ssdeep.BucketAccumuloKeyGenerator;
 import datawave.util.ssdeep.ChunkSizeEncoding;
 import datawave.util.ssdeep.IntegerEncoding;
 import datawave.util.ssdeep.NGramGenerator;
-import datawave.util.ssdeep.NGramTuple;
 import datawave.util.ssdeep.SSDeepHash;
 
 public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguration {

--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -42,12 +42,32 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         setQuery(new QueryImpl());
     }
 
+    public SSDeepSimilarityQueryConfiguration(SSDeepSimilarityQueryConfiguration other) {
+        copyFrom(other);
+    }
+
     public SSDeepSimilarityQueryConfiguration(BaseQueryLogic<?> configuredLogic) {
         super(configuredLogic);
     }
 
     public static SSDeepSimilarityQueryConfiguration create() {
         return new SSDeepSimilarityQueryConfiguration();
+    }
+
+    public void copyFrom(SSDeepSimilarityQueryConfiguration other) {
+        super.copyFrom(other);
+
+        this.bucketEncoder = other.bucketEncoder;
+        this.chunkSizeEncoder = other.chunkSizeEncoder;
+        setBucketEncodingBase(other.getBucketEncodingBase());
+        setBucketEncodingLength(other.getBucketEncodingLength());
+        setIndexBuckets(other.getIndexBuckets());
+        setMaxRepeatedCharacters(other.getMaxRepeatedCharacters());
+        setMinHashSize(other.getMinHashSize());
+        setNGramSize(other.getNGramSize());
+        setQueryMap(other.getQueryMap());
+        setQueryThreads(other.getQueryThreads());
+        setRanges(other.getRanges());
     }
 
     public Collection<Range> getRanges() {

--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -37,16 +37,6 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     private Multimap<NGramTuple,SSDeepHash> queryMap;
 
-    /**
-     * The number of hashes the query logic will accept, -1 indicates unlimited
-     */
-    private int maxHashes = -1;
-
-    /**
-     * The max number of hashes to be generated per ngram, -1 indicates unlimited
-     */
-    private int maxHashesPerNGram = -1;
-
     public SSDeepSimilarityQueryConfiguration() {
         super();
         setQuery(new QueryImpl());
@@ -58,33 +48,6 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     public static SSDeepSimilarityQueryConfiguration create() {
         return new SSDeepSimilarityQueryConfiguration();
-    }
-
-    public static SSDeepSimilarityQueryConfiguration create(SSDeepSimilarityQueryConfiguration other) {
-        SSDeepSimilarityQueryConfiguration config = new SSDeepSimilarityQueryConfiguration();
-        config.copyFrom(other);
-        return config;
-    }
-
-    public void clearState() {
-        queryMap = null;
-        ranges = null;
-    }
-
-    public void copyFrom(SSDeepSimilarityQueryConfiguration other) {
-        super.copyFrom(other);
-
-        setRanges(other.getRanges());
-        setQueryMap(other.getQueryMap());
-        setIndexBuckets(other.getIndexBuckets());
-        setQueryThreads(other.getQueryThreads());
-        setNGramSize(other.getNGramSize());
-        setMaxRepeatedCharacters(other.getMaxRepeatedCharacters());
-        setMinHashSize(other.getMinHashSize());
-        setBucketEncodingBase(other.getBucketEncodingBase());
-        setBucketEncodingLength(other.getBucketEncodingLength());
-        setMaxHashes(other.getMaxHashes());
-        setMaxHashesPerNGram(other.getMaxHashesPerNGram());
     }
 
     public Collection<Range> getRanges() {
@@ -157,21 +120,5 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     public void setBucketEncodingLength(int bucketEncodingLength) {
         this.bucketEncodingLength = bucketEncodingLength;
-    }
-
-    public int getMaxHashes() {
-        return maxHashes;
-    }
-
-    public void setMaxHashes(int maxHashes) {
-        this.maxHashes = maxHashes;
-    }
-
-    public int getMaxHashesPerNGram() {
-        return maxHashesPerNGram;
-    }
-
-    public void setMaxHashesPerNGram(int maxHashesPerNGram) {
-        this.maxHashesPerNGram = maxHashesPerNGram;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -1,6 +1,10 @@
 package datawave.query.config;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.accumulo.core.data.Range;
 
@@ -8,7 +12,6 @@ import com.google.common.collect.Multimap;
 
 import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.core.query.logic.BaseQueryLogic;
-import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
 import datawave.util.ssdeep.BucketAccumuloKeyGenerator;
 import datawave.util.ssdeep.ChunkSizeEncoding;
@@ -33,11 +36,35 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
     /** Used to encode the chunk size as a character which is included in the ranges used to retrieve ngram tuples */
     private ChunkSizeEncoding chunkSizeEncoder;
 
+    /**
+     * The number of hashes the query logic will accept, -1 indicates unlimited
+     */
+    private int maxHashes = -1;
+
+    /**
+     * Dedupe matching hashes matched inside the SSDeepScoringFunction. When true only process a matching hash one regardless of how many times an ngram may
+     * match it
+     */
+    private boolean dedupeSimilarityHashes = true;
+
+    /**
+     * The max number of hashes to be retrieved per ngram, -1 indicates unlimited
+     */
+    private int maxHashesPerNGram = -1;
+
+    // start of query state objections
     private Collection<Range> ranges;
 
+    /**
+     * The query map, which relates SSDeep hash ngrams with the original query hashes, so that the SSDeep hashes from Accumulo can be married up with the
+     * original queries that caused them to be retrieved.
+     */
     private Multimap<NGramTuple,SSDeepHash> queryMap;
 
-    private boolean dedupe = true;
+    private Set<Integer> seenHashes = new HashSet<>();
+
+    private Map<String,Long> ngramCountMap = new HashMap<>();
+    // end of query state objects
 
     public SSDeepSimilarityQueryConfiguration() {
         super();
@@ -70,7 +97,11 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         setQueryMap(other.getQueryMap());
         setQueryThreads(other.getQueryThreads());
         setRanges(other.getRanges());
-        setDedupe(other.isDedupe());
+        setDedupeSimilarityHashes(other.isDedupeSimilarityHashes());
+        setMaxHashes(other.getMaxHashes());
+        setMaxHashesPerNGram(other.getMaxHashesPerNGram());
+        setSeenHashes(other.getSeenHashes());
+        setNgramCountMap(other.getNgramCountMap());
     }
 
     public Collection<Range> getRanges() {
@@ -145,11 +176,43 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         this.bucketEncodingLength = bucketEncodingLength;
     }
 
-    public boolean isDedupe() {
-        return this.dedupe;
+    public boolean isDedupeSimilarityHashes() {
+        return this.dedupeSimilarityHashes;
     }
 
-    public void setDedupe(boolean dedupe) {
-        this.dedupe = dedupe;
+    public void setDedupeSimilarityHashes(boolean dedupeSimilarityHashes) {
+        this.dedupeSimilarityHashes = dedupeSimilarityHashes;
+    }
+
+    public int getMaxHashes() {
+        return maxHashes;
+    }
+
+    public void setMaxHashes(int maxHashes) {
+        this.maxHashes = maxHashes;
+    }
+
+    public int getMaxHashesPerNGram() {
+        return maxHashesPerNGram;
+    }
+
+    public void setMaxHashesPerNGram(int maxHashesPerNGram) {
+        this.maxHashesPerNGram = maxHashesPerNGram;
+    }
+
+    public Set<Integer> getSeenHashes() {
+        return seenHashes;
+    }
+
+    public void setSeenHashes(Set<Integer> seenHashes) {
+        this.seenHashes = seenHashes;
+    }
+
+    public Map<String,Long> getNgramCountMap() {
+        return ngramCountMap;
+    }
+
+    public void setNgramCountMap(Map<String,Long> ngramCountMap) {
+        this.ngramCountMap = ngramCountMap;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Multimap;
 import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.core.query.logic.BaseQueryLogic;
 import datawave.microservice.query.QueryImpl;
+import datawave.query.tables.ssdeep.SSDeepSimilarityQueryState;
 import datawave.util.ssdeep.BucketAccumuloKeyGenerator;
 import datawave.util.ssdeep.ChunkSizeEncoding;
 import datawave.util.ssdeep.IntegerEncoding;
@@ -42,7 +43,7 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
     private int maxHashes = -1;
 
     /**
-     * Dedupe matching hashes matched inside the SSDeepScoringFunction. When true only process a matching hash one regardless of how many times an ngram may
+     * Dedupe matching hashes matched inside the SSDeepScoringFunction. When true only process a matching hash once regardless of how many times an ngram may
      * match it
      */
     private boolean dedupeSimilarityHashes = true;
@@ -52,23 +53,12 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
      */
     private int maxHashesPerNGram = -1;
 
-    // start of query state objections
-    private Collection<Range> ranges;
-
-    /**
-     * The query map, which relates SSDeep hash ngrams with the original query hashes, so that the SSDeep hashes from Accumulo can be married up with the
-     * original queries that caused them to be retrieved.
-     */
-    private Multimap<NGramTuple,SSDeepHash> queryMap;
-
-    private Set<Integer> seenHashes = new HashSet<>();
-
-    private Map<String,Long> ngramCountMap = new HashMap<>();
-    // end of query state objects
+    private SSDeepSimilarityQueryState state;
 
     public SSDeepSimilarityQueryConfiguration() {
         super();
         setQuery(new QueryImpl());
+        setState(new SSDeepSimilarityQueryState());
     }
 
     public SSDeepSimilarityQueryConfiguration(SSDeepSimilarityQueryConfiguration other) {
@@ -94,30 +84,11 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         setMaxRepeatedCharacters(other.getMaxRepeatedCharacters());
         setMinHashSize(other.getMinHashSize());
         setNGramSize(other.getNGramSize());
-        setQueryMap(other.getQueryMap());
         setQueryThreads(other.getQueryThreads());
-        setRanges(other.getRanges());
         setDedupeSimilarityHashes(other.isDedupeSimilarityHashes());
         setMaxHashes(other.getMaxHashes());
         setMaxHashesPerNGram(other.getMaxHashesPerNGram());
-        setSeenHashes(other.getSeenHashes());
-        setNgramCountMap(other.getNgramCountMap());
-    }
-
-    public Collection<Range> getRanges() {
-        return ranges;
-    }
-
-    public void setRanges(Collection<Range> ranges) {
-        this.ranges = ranges;
-    }
-
-    public Multimap<NGramTuple,SSDeepHash> getQueryMap() {
-        return queryMap;
-    }
-
-    public void setQueryMap(Multimap<NGramTuple,SSDeepHash> queryMap) {
-        this.queryMap = queryMap;
+        setState(other.getState());
     }
 
     public int getIndexBuckets() {
@@ -200,19 +171,11 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         this.maxHashesPerNGram = maxHashesPerNGram;
     }
 
-    public Set<Integer> getSeenHashes() {
-        return seenHashes;
+    public void setState(SSDeepSimilarityQueryState state) {
+        this.state = state;
     }
 
-    public void setSeenHashes(Set<Integer> seenHashes) {
-        this.seenHashes = seenHashes;
-    }
-
-    public Map<String,Long> getNgramCountMap() {
-        return ngramCountMap;
-    }
-
-    public void setNgramCountMap(Map<String,Long> ngramCountMap) {
-        this.ngramCountMap = ngramCountMap;
+    public SSDeepSimilarityQueryState getState() {
+        return this.state;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
@@ -29,7 +29,7 @@ import datawave.query.tables.chained.strategy.FullChainStrategy;
 public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSSDeepPair,DiscoveredSSDeep> {
     private static final Logger log = Logger.getLogger(FullSSDeepDiscoveryChainStrategy.class);
 
-    private final ThreadLocal<Multimap<String,ScoredSSDeepPair>> scoredMatches = new ThreadLocal<>();
+    private Multimap<String,ScoredSSDeepPair> scoredMatches;
 
     @Override
     protected Query buildLatterQuery(Query initialQuery, Iterator<ScoredSSDeepPair> initialQueryResults, String latterLogicName) {
@@ -37,11 +37,11 @@ public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSS
 
         // track the scored matches we've seen while traversing the initial query results.
         // this has to be case-insensitive because the CHECKSUM_SSDEEP index entries are most likely downcased.
-        scoredMatches.set(TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, ScoredSSDeepPair.NATURAL_ORDER));
+        scoredMatches = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, ScoredSSDeepPair.NATURAL_ORDER);
 
-        String queryString = captureScoredMatchesAndBuildQuery(initialQueryResults, scoredMatches.get());
+        String queryString = captureScoredMatchesAndBuildQuery(initialQueryResults, scoredMatches);
 
-        if (scoredMatches.get().isEmpty()) {
+        if (scoredMatches.isEmpty()) {
             log.info("Did not receive scored matches from initial query, returning null latter query");
             return null;
         }
@@ -60,7 +60,11 @@ public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSS
                     Iterator<ScoredSSDeepPair> initialQueryResults, QueryLogic<DiscoveredSSDeep> latterQueryLogic) throws Exception {
         final Iterator<DiscoveredSSDeep> it = super.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
 
-        return getEnrichedDiscoveredSSDeepIterator(it, scoredMatches.get());
+        // Create a defensive copy of the score map because stream evaluation may be delayed.
+        final Multimap<String,ScoredSSDeepPair> localScoredMatches = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, ScoredSSDeepPair.NATURAL_ORDER);
+        localScoredMatches.putAll(scoredMatches);
+
+        return getEnrichedDiscoveredSSDeepIterator(it, localScoredMatches);
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
@@ -1,6 +1,9 @@
 package datawave.query.tables.ssdeep;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -9,8 +12,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.Multimap;
@@ -29,90 +34,75 @@ import datawave.query.tables.chained.strategy.FullChainStrategy;
 public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSSDeepPair,DiscoveredSSDeep> {
     private static final Logger log = Logger.getLogger(FullSSDeepDiscoveryChainStrategy.class);
 
-    private Multimap<String,ScoredSSDeepPair> scoredMatches;
+    /**
+     * configurable batch size in the chain, -1 is no batching
+     */
+    private int batchSize = -1;
+
+    /**
+     * should matchingHashes be deduped in the chain strategy?
+     */
+    private boolean dedupe = true;
 
     @Override
     protected Query buildLatterQuery(Query initialQuery, Iterator<ScoredSSDeepPair> initialQueryResults, String latterLogicName) {
-        log.debug("buildLatterQuery() called...");
-
-        // track the scored matches we've seen while traversing the initial query results.
-        // this has to be case-insensitive because the CHECKSUM_SSDEEP index entries are most likely downcased.
-        scoredMatches = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, ScoredSSDeepPair.NATURAL_ORDER);
-
-        String queryString = captureScoredMatchesAndBuildQuery(initialQueryResults, scoredMatches);
-
-        if (scoredMatches.isEmpty()) {
-            log.info("Did not receive scored matches from initial query, returning null latter query");
-            return null;
-        }
-
-        Query q = new QueryImpl(); // TODO, need to use a factory? don't hardcode this.
-        q.setQuery(queryString);
-        q.setId(UUID.randomUUID());
-        q.setPagesize(Integer.MAX_VALUE); // TODO: choose something reasonable.
-        q.setQueryAuthorizations(initialQuery.getQueryAuthorizations());
-        q.setUserDN(initialQuery.getUserDN());
-        return q;
+        throw new UnsupportedOperationException("Should be delegating to StatefulSSDeepDiscoveryChainStrategy");
     }
 
     @Override
     public Iterator<DiscoveredSSDeep> runChainedQuery(AccumuloClient client, Query initialQuery, Set<Authorizations> auths,
                     Iterator<ScoredSSDeepPair> initialQueryResults, QueryLogic<DiscoveredSSDeep> latterQueryLogic) throws Exception {
-        final Iterator<DiscoveredSSDeep> it = super.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
+        Iterator<DiscoveredSSDeep> wrapped = new Iterator<>() {
+            private Iterator<DiscoveredSSDeep> batchIterator;
+            /**
+             * Keep track of what has already come off the Similarity query and prevent duplicate hashes from being used
+             */
+            private final HashSet<Integer> seenHashes = dedupe ? new HashSet<>() : null;
 
-        // Create a defensive copy of the score map because stream evaluation may be delayed.
-        final Multimap<String,ScoredSSDeepPair> localScoredMatches = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, ScoredSSDeepPair.NATURAL_ORDER);
-        localScoredMatches.putAll(scoredMatches);
+            @Override
+            public boolean hasNext() {
+                if (batchIterator == null || !batchIterator.hasNext()) {
+                    try {
+                        StatefulSSDeepDiscoveryChainStrategy statefulChainStrategy = new StatefulSSDeepDiscoveryChainStrategy();
+                        statefulChainStrategy.setBatchSize(batchSize);
+                        statefulChainStrategy.setSeenHashes(seenHashes);
+                        batchIterator = statefulChainStrategy.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
 
-        return getEnrichedDiscoveredSSDeepIterator(it, localScoredMatches);
+                        return batchIterator.hasNext();
+                    } catch (Exception e) {
+                        throw new DatawaveFatalQueryException("Failed to create next chained query", e);
+                    }
+                }
+
+                // the iterator exists and has more, so always true
+                return true;
+            }
+
+            @Override
+            public DiscoveredSSDeep next() {
+                return batchIterator.next();
+            }
+        };
+
+        // prime the iterator to make sure latterQueryLogic is configured
+        wrapped.hasNext();
+
+        return wrapped;
     }
 
-    /**
-     *
-     * @param initialQueryResults
-     *            an iterator of scored ssdeep pairs that represent the results of the initial ssdeep similarity query.
-     * @param scoredMatches
-     *            used to capture the scored matches contained within the initialQueryResults
-     * @return the query string for the next stage of the query.
-     */
-    public static String captureScoredMatchesAndBuildQuery(Iterator<ScoredSSDeepPair> initialQueryResults,
-                    final Multimap<String,ScoredSSDeepPair> scoredMatches) {
-        // extract the matched ssdeeps from the query results and generate the discovery query.
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(initialQueryResults, Spliterator.ORDERED), false)
-                        .filter(queryResult -> scoredMatches.put(queryResult.getMatchingHash().toString(), queryResult))
-                        .map(queryResult -> queryResult.getMatchingHash().toString()).distinct().peek(ssdeep -> log.debug("Added new ssdeep " + ssdeep))
-                        .map(ssdeep -> "CHECKSUM_SSDEEP:\"" + ssdeep + "\"").collect(Collectors.joining(" OR ", "", ""));
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
     }
 
-    /**
-     * Given an iterator of DiscoveredSSDeep objects that have no matching query or weighted score, lookup the potential queries that returned them and the
-     * weighted score associated with that query and use them to produce enriched results.
-     *
-     * @param resultsIterator
-     *            an iterator of unenrched DiscoveredSSDeep's that don't have query or score info.
-     * @param scoredMatches
-     *            the colletion of matchin hashes and the original queries that lead them to be returned.
-     * @return an iterator of DiscoveredSSDeep's enriched with the queries that returned them.
-     */
-    public static Iterator<DiscoveredSSDeep> getEnrichedDiscoveredSSDeepIterator(Iterator<DiscoveredSSDeep> resultsIterator,
-                    final Multimap<String,ScoredSSDeepPair> scoredMatches) {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(resultsIterator, Spliterator.ORDERED), false)
-                        .flatMap(discoveredSSdeep -> enrichDiscoveredSSDeep(discoveredSSdeep, scoredMatches)).iterator();
+    public int getBatchSize() {
+        return batchSize;
     }
 
-    /**
-     * Given a single discovered ssdeep, use the scoredMatches map to determine which queries it is related to. This will return zero to many new
-     * DiscoveredSSDeep entries for each query that the matching ssdeep hash appeared in.
-     *
-     * @param discoveredSSDeep
-     *            the ssdeep discovery information a single matched hash
-     * @param scoredMatches
-     *            the set of scored matches from the ssdeep similarity logic, used to look up score and query info for the matched hash.
-     * @return a stream of DiscoveredSSDeep objects that align discovery information with the original query hashes.
-     */
-    public static Stream<DiscoveredSSDeep> enrichDiscoveredSSDeep(DiscoveredSSDeep discoveredSSDeep, final Multimap<String,ScoredSSDeepPair> scoredMatches) {
-        final DiscoveredThing discoveredThing = discoveredSSDeep.getDiscoveredThing();
-        final String term = discoveredThing.getTerm();
-        return scoredMatches.get(term).stream().map(scoredPair -> new DiscoveredSSDeep(scoredPair, discoveredThing));
+    public void setDedupe(boolean dedupe) {
+        this.dedupe = dedupe;
+    }
+
+    public boolean isDedupe() {
+        return this.dedupe;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
@@ -43,7 +43,7 @@ public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSS
             /**
              * Keep track of what has already come off the Similarity query and prevent duplicate hashes from being used
              */
-            private final HashSet<Integer> seenHashes = dedupe ? new HashSet<>() : null;
+            private final Set<Integer> seenHashes = dedupe ? new HashSet<>() : null;
 
             @Override
             public boolean hasNext() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategy.java
@@ -1,30 +1,16 @@
 package datawave.query.tables.ssdeep;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
-
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
 
 import datawave.core.query.logic.QueryLogic;
 import datawave.microservice.query.Query;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.discovery.DiscoveredThing;
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.chained.strategy.FullChainStrategy;
 
 /**
@@ -61,21 +47,19 @@ public class FullSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSS
 
             @Override
             public boolean hasNext() {
-                if (batchIterator == null || !batchIterator.hasNext()) {
+                while (batchIterator == null || (!batchIterator.hasNext() && initialQueryResults.hasNext())) {
                     try {
                         StatefulSSDeepDiscoveryChainStrategy statefulChainStrategy = new StatefulSSDeepDiscoveryChainStrategy();
                         statefulChainStrategy.setBatchSize(batchSize);
                         statefulChainStrategy.setSeenHashes(seenHashes);
                         batchIterator = statefulChainStrategy.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
-
-                        return batchIterator.hasNext();
                     } catch (Exception e) {
                         throw new DatawaveFatalQueryException("Failed to create next chained query", e);
                     }
                 }
 
                 // the iterator exists and has more, so always true
-                return true;
+                return batchIterator.hasNext();
             }
 
             @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepMaxHashPerNGramFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepMaxHashPerNGramFilter.java
@@ -1,0 +1,50 @@
+package datawave.query.tables.ssdeep;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.apache.log4j.Logger;
+
+import datawave.query.config.SSDeepSimilarityQueryConfiguration;
+import datawave.util.ssdeep.NGramTuple;
+import datawave.util.ssdeep.SSDeepHash;
+
+public class SSDeepMaxHashPerNGramFilter implements Predicate<Map.Entry<NGramTuple,SSDeepHash>> {
+    private static final Logger log = Logger.getLogger(SSDeepMaxHashPerNGramFilter.class);
+    private final int maxHashesPerNGram;
+    private final Map<String,Long> countMap;
+
+    public SSDeepMaxHashPerNGramFilter(SSDeepSimilarityQueryConfiguration config) {
+        this.maxHashesPerNGram = config.getMaxHashesPerNGram();
+        this.countMap = config.getState().getNgramCountMap();
+    }
+
+    @Override
+    public boolean test(Map.Entry<NGramTuple,SSDeepHash> entry) {
+        String ngram = entry.getKey().getChunk();
+        Long count = countMap.get(ngram);
+        if (count == null) {
+            // first seen
+            count = 0L;
+        }
+
+        if (count + 1 > maxHashesPerNGram) {
+            // exceeded count the first time
+            log.warn("Exceeded " + maxHashesPerNGram + " hashes for " + ngram + " ignoring remaining hashes");
+            countMap.put(ngram, -1L);
+            return false;
+        } else if (count < 0) {
+            // exceeded count beyond the first time, go negative for tracking purposes
+            countMap.put(ngram, count - 1);
+            return false;
+        }
+        // increment count
+        countMap.put(ngram, count + 1);
+
+        return true;
+    }
+
+    public Map<String,Long> getCountMap() {
+        return this.countMap;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepParsingFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepParsingFunction.java
@@ -1,0 +1,67 @@
+package datawave.query.tables.ssdeep;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import datawave.query.config.SSDeepSimilarityQueryConfiguration;
+import datawave.util.ssdeep.ChunkSizeEncoding;
+import datawave.util.ssdeep.IntegerEncoding;
+import datawave.util.ssdeep.NGramTuple;
+import datawave.util.ssdeep.SSDeepHash;
+
+public class SSDeepParsingFunction implements Function<Map.Entry<Key,Value>,Map.Entry<NGramTuple,SSDeepHash>> {
+    /** Used to encode the chunk size as a character which is included in the ranges used to retrieve ngram tuples */
+    private final ChunkSizeEncoding chunkSizeEncoding;
+
+    /** Used to encode buckets as characters which are prepended to the ranges used to retrieve ngram tuples */
+    private final IntegerEncoding bucketEncoder;
+
+    /**
+     * the position where the ngram will start in the generated ranges, determined at construction time based on the bucketEncoder parameters
+     */
+    private final int chunkStart;
+
+    /**
+     * the position where the query ngram will end in the generate ranges, determined based on the bucketEncoder and chunkSizeEncoding parameters
+     */
+
+    private final int chunkEnd;
+
+    public SSDeepParsingFunction(SSDeepSimilarityQueryConfiguration config) {
+        this.chunkSizeEncoding = new ChunkSizeEncoding();
+        this.bucketEncoder = new IntegerEncoding(config.getBucketEncodingBase(), config.getBucketEncodingLength());
+
+        this.chunkStart = bucketEncoder.getLength();
+        this.chunkEnd = chunkStart + chunkSizeEncoding.getLength();
+    }
+
+    @Override
+    public Map.Entry<NGramTuple,SSDeepHash> apply(Map.Entry<Key,Value> entry) {
+        // We will receive entries like the following that follow the SSDeep bucket index format:
+        // +++//thPkK 3:3:yionv//thPkKlDtn/rXScG2/uDlhl2UE9FQEul/lldDpZflsup:6v/lhPkKlDtt/6TIPFQEqRDpZ+up []
+        // see: https://github.com/NationalSecurityAgency/datawave/wiki/SSDeep-In-Datawave#ssdeep-table-structure-bucketed
+        // generally, the rowid consists of a:
+        // - bucket; first two characters based on a hash of the original ssdeep
+        // - chunk; third character,
+        // - ngram; the rest of the rowid.
+        // the column family holds the chunk size.
+        // the column qualifier holds the original ssdeep hash from which the ngram was extracted.
+        final Key k = entry.getKey();
+        final String row = k.getRow().toString();
+
+        // strip off the bucketing to extract the matching ngram and chunk size from the rowId.
+        int chunkSize = chunkSizeEncoding.decode(row.substring(chunkStart, chunkEnd));
+        String ngram = row.substring(chunkEnd);
+
+        // extract the matching ssdeep hash from the column qualifier
+        final String matchingHashString = k.getColumnQualifier().toString();
+        final SSDeepHash matchingHash = SSDeepHash.parse(matchingHashString);
+
+        final NGramTuple matchingNgram = new NGramTuple(chunkSize, ngram);
+        return new AbstractMap.SimpleEntry<>(matchingNgram, matchingHash);
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -25,26 +25,10 @@ import datawave.util.ssdeep.SSDeepHashScorer;
 import datawave.util.ssdeep.SSDeepNGramOverlapScorer;
 
 /** A function that transforms entries retrieved from Accumulo into Scored SSDeep hash matches */
-public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stream<ScoredSSDeepPair>> {
+public class SSDeepScoringFunction implements Function<Map.Entry<NGramTuple,SSDeepHash>,Stream<ScoredSSDeepPair>> {
 
     public static final String MIN_SSDEEP_SCORE_PARAMETER = "minScore";
     private static final Logger log = Logger.getLogger(SSDeepScoringFunction.class);
-
-    /** Used to encode the chunk size as a character which is included in the ranges used to retrieve ngram tuples */
-    private final ChunkSizeEncoding chunkSizeEncoding;
-
-    /** Used to encode buckets as characters which are prepended to the ranges used to retrieve ngram tuples */
-    private final IntegerEncoding bucketEncoder;
-
-    /**
-     * the position where the ngram will start in the generated ranges, determined at construction time based on the bucketEncoder parameters
-     */
-    private final int chunkStart;
-    /**
-     * the position where the query ngram will end in the generate ranges, determined based on the bucketEncoder and chunkSizeEncoding parameters
-     */
-
-    private final int chunkEnd;
 
     /** The maximum number of repeated characters allowed in a ssdeep hash - used to perform normalization for scoring */
     private final int maxRepeatedCharacters;
@@ -56,17 +40,11 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
     private final SSDeepHashScorer<Set<NGramTuple>> ngramOverlapScorer;
 
-    private final SSDeepSimilarityQueryConfiguration config;
+    private final SSDeepSimilarityQueryState queryState;
 
     public SSDeepScoringFunction(SSDeepSimilarityQueryConfiguration config) {
-        this.config = config;
+        this.queryState = config.getState();
         this.maxRepeatedCharacters = config.getMaxRepeatedCharacters();
-
-        this.bucketEncoder = new IntegerEncoding(config.getBucketEncodingBase(), config.getBucketEncodingLength());
-        this.chunkSizeEncoding = new ChunkSizeEncoding();
-
-        this.chunkStart = bucketEncoder.getLength();
-        this.chunkEnd = chunkStart + chunkSizeEncoding.getLength();
 
         this.minScoreThreshold = readOptionalMinScoreThreshold(config.getQuery());
 
@@ -111,59 +89,12 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
      * @return A Stream of scored SSDeep pairs related to the row returned by Accumulo.
      */
     @Override
-    public Stream<ScoredSSDeepPair> apply(Map.Entry<Key,Value> entry) {
-        // We will receive entries like the following that follow the SSDeep bucket index format:
-        // +++//thPkK 3:3:yionv//thPkKlDtn/rXScG2/uDlhl2UE9FQEul/lldDpZflsup:6v/lhPkKlDtt/6TIPFQEqRDpZ+up []
-        // see: https://github.com/NationalSecurityAgency/datawave/wiki/SSDeep-In-Datawave#ssdeep-table-structure-bucketed
-        // generally, the rowid consists of a:
-        // - bucket; first two characters based on a hash of the original ssdeep
-        // - chunk; third character,
-        // - ngram; the rest of the rowid.
-        // the column family holds the chunk size.
-        // the column qualifier holds the original ssdeep hash from which the ngram was extracted.
-        final Key k = entry.getKey();
-        final String row = k.getRow().toString();
-
-        // strip off the bucketing to extract the matching ngram and chunk size from the rowId.
-        int chunkSize = chunkSizeEncoding.decode(row.substring(chunkStart, chunkEnd));
-        String ngram = row.substring(chunkEnd);
-
-        // extract the matching ssdeep hash from the column qualifier
-        final String matchingHashString = k.getColumnQualifier().toString();
-        final SSDeepHash matchingHash = SSDeepHash.parse(matchingHashString);
-
-        if (config.isDedupeSimilarityHashes()) {
-            int hashcode = matchingHash.hashCode();
-            if (config.getSeenHashes().contains(hashcode)) {
-                return Stream.empty();
-            }
-            config.getSeenHashes().add(hashcode);
-        }
-
-        if (config.getMaxHashesPerNGram() != -1) {
-            Long count = config.getNgramCountMap().get(ngram);
-            if (count == null) {
-                // first seen
-                count = 0L;
-            }
-
-            if (count + 1 > config.getMaxHashesPerNGram()) {
-                // exceeded count the first time
-                log.warn("Exceeded " + config.getMaxHashesPerNGram() + " hashes for " + ngram + " ignoring remaining hashes");
-                config.getNgramCountMap().put(ngram, -1L);
-                return Stream.empty();
-            } else if (count < 0) {
-                // exceeded count beyond the first time, go negative for tracking purposes
-                config.getNgramCountMap().put(ngram, count - 1);
-                return Stream.empty();
-            }
-            // increment count
-            config.getNgramCountMap().put(ngram, count + 1);
-        }
+    public Stream<ScoredSSDeepPair> apply(Map.Entry<NGramTuple,SSDeepHash> entry) {
+        NGramTuple ngram = entry.getKey();
+        SSDeepHash matchingHash = entry.getValue();
 
         // extract the query ssdeeps that contained this ngram from the query map.
-        final NGramTuple matchingNgram = new NGramTuple(chunkSize, ngram);
-        Collection<SSDeepHash> queryHashes = config.getQueryMap().get(matchingNgram);
+        Collection<SSDeepHash> queryHashes = queryState.getQueryMap().get(ngram);
 
         // score the match between each query ssdeep and matching hash, keep those that exceed the match
         // threshold.

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -1,6 +1,7 @@
 package datawave.query.tables.ssdeep;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -61,6 +62,8 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
     private final SSDeepHashScorer<Set<NGramTuple>> ngramOverlapScorer;
 
+    private HashSet<Integer> seenHashes;
+
     public SSDeepScoringFunction(SSDeepSimilarityQueryConfiguration config) {
         this.queryMap = config.getQueryMap();
         this.maxRepeatedCharacters = config.getMaxRepeatedCharacters();
@@ -75,6 +78,10 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
         this.editDistanceScorer = new SSDeepHashEditDistanceScorer(maxRepeatedCharacters);
         this.ngramOverlapScorer = new SSDeepNGramOverlapScorer(config.getNGramSize(), maxRepeatedCharacters, config.getMinHashSize());
+
+        if (config.isDedupe()) {
+            seenHashes = new HashSet<>();
+        }
     }
 
     /**
@@ -134,6 +141,14 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
         // extract the matching ssdeep hash from the column qualifier
         final String matchingHashString = k.getColumnQualifier().toString();
         final SSDeepHash matchingHash = SSDeepHash.parse(matchingHashString);
+
+        if (seenHashes != null) {
+            int hashcode = matchingHash.hashCode();
+            if (seenHashes.contains(hashcode)) {
+                return Stream.empty();
+            }
+            seenHashes.add(hashcode);
+        }
 
         // extract the query ssdeeps that contained this ngram from the query map.
         final NGramTuple matchingNgram = new NGramTuple(chunkSize, ngram);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -1,23 +1,16 @@
 package datawave.query.tables.ssdeep;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
 import org.apache.log4j.Logger;
-
-import com.google.common.collect.Multimap;
 
 import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
 import datawave.query.config.SSDeepSimilarityQueryConfiguration;
-import datawave.util.ssdeep.ChunkSizeEncoding;
-import datawave.util.ssdeep.IntegerEncoding;
 import datawave.util.ssdeep.NGramTuple;
 import datawave.util.ssdeep.SSDeepHash;
 import datawave.util.ssdeep.SSDeepHashEditDistanceScorer;

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -1,7 +1,6 @@
 package datawave.query.tables.ssdeep;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -16,7 +15,6 @@ import com.google.common.collect.Multimap;
 import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
 import datawave.query.config.SSDeepSimilarityQueryConfiguration;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.util.ssdeep.ChunkSizeEncoding;
 import datawave.util.ssdeep.IntegerEncoding;
 import datawave.util.ssdeep.NGramTuple;
@@ -63,15 +61,7 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
     private final SSDeepHashScorer<Set<NGramTuple>> ngramOverlapScorer;
 
-    private final long maxResults;
-    private long totalResults = 0;
-
-    private final int maxHashesPerNGram;
-    private Map<String,Long> ngramCountMap;
-
-    public SSDeepScoringFunction(SSDeepSimilarityQueryConfiguration config, long maxResults, int maxHashesPerNGram) {
-        this.maxResults = maxResults;
-        this.maxHashesPerNGram = maxHashesPerNGram;
+    public SSDeepScoringFunction(SSDeepSimilarityQueryConfiguration config) {
         this.queryMap = config.getQueryMap();
         this.maxRepeatedCharacters = config.getMaxRepeatedCharacters();
 
@@ -85,8 +75,6 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
         this.editDistanceScorer = new SSDeepHashEditDistanceScorer(maxRepeatedCharacters);
         this.ngramOverlapScorer = new SSDeepNGramOverlapScorer(config.getNGramSize(), maxRepeatedCharacters, config.getMinHashSize());
-
-        this.ngramCountMap = new HashMap<>();
     }
 
     /**
@@ -143,24 +131,6 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
         int chunkSize = chunkSizeEncoding.decode(row.substring(chunkStart, chunkEnd));
         String ngram = row.substring(chunkEnd);
 
-        if (maxHashesPerNGram > -1) {
-            Long count = ngramCountMap.get(ngram);
-            if (count == null) {
-                count = 0L;
-            }
-
-            if (count + 1 > maxHashesPerNGram) {
-                log.warn("Exceeded " + maxHashesPerNGram + " hashes for " + ngram + " ignoring remaining hashes");
-                ngramCountMap.put(ngram, -1L);
-                return Stream.empty();
-            } else if (count < 0) {
-                ngramCountMap.put(ngram, count - 1);
-                // no need to warn again, but keep a count for stats
-                return Stream.empty();
-            }
-            ngramCountMap.put(ngram, count + 1);
-        }
-
         // extract the matching ssdeep hash from the column qualifier
         final String matchingHashString = k.getColumnQualifier().toString();
         final SSDeepHash matchingHash = SSDeepHash.parse(matchingHashString);
@@ -168,13 +138,6 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
         // extract the query ssdeeps that contained this ngram from the query map.
         final NGramTuple matchingNgram = new NGramTuple(chunkSize, ngram);
         Collection<SSDeepHash> queryHashes = queryMap.get(matchingNgram);
-
-        if (maxResults != -1) {
-            totalResults += queryHashes.size();
-            if (totalResults > maxResults) {
-                throw new DatawaveFatalQueryException("Total similarity results exceeded max of " + maxResults);
-            }
-        }
 
         // score the match between each query ssdeep and matching hash, keep those that exceed the match
         // threshold.
@@ -189,7 +152,4 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
         });
     }
 
-    public Map<String,Long> getNgramCountMap() {
-        return ngramCountMap;
-    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -49,12 +49,6 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
     /** The maximum number of repeated characters allowed in a ssdeep hash - used to perform normalization for scoring */
     private final int maxRepeatedCharacters;
 
-    /**
-     * The query map, which relates SSDeep hash ngrams with the original query hashes, so that the SSDeep hashes from Accumulo can be married up with the
-     * original queries that caused them to be retrieved.
-     */
-    private final Multimap<NGramTuple,SSDeepHash> queryMap;
-
     /** We'll toss out any matches that have scores less than this value. If set to 0 or less we'll keep all hashes */
     private final int minScoreThreshold;
 
@@ -62,10 +56,10 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
     private final SSDeepHashScorer<Set<NGramTuple>> ngramOverlapScorer;
 
-    private HashSet<Integer> seenHashes;
+    private final SSDeepSimilarityQueryConfiguration config;
 
     public SSDeepScoringFunction(SSDeepSimilarityQueryConfiguration config) {
-        this.queryMap = config.getQueryMap();
+        this.config = config;
         this.maxRepeatedCharacters = config.getMaxRepeatedCharacters();
 
         this.bucketEncoder = new IntegerEncoding(config.getBucketEncodingBase(), config.getBucketEncodingLength());
@@ -78,10 +72,6 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
 
         this.editDistanceScorer = new SSDeepHashEditDistanceScorer(maxRepeatedCharacters);
         this.ngramOverlapScorer = new SSDeepNGramOverlapScorer(config.getNGramSize(), maxRepeatedCharacters, config.getMinHashSize());
-
-        if (config.isDedupe()) {
-            seenHashes = new HashSet<>();
-        }
     }
 
     /**
@@ -142,17 +132,38 @@ public class SSDeepScoringFunction implements Function<Map.Entry<Key,Value>,Stre
         final String matchingHashString = k.getColumnQualifier().toString();
         final SSDeepHash matchingHash = SSDeepHash.parse(matchingHashString);
 
-        if (seenHashes != null) {
+        if (config.isDedupeSimilarityHashes()) {
             int hashcode = matchingHash.hashCode();
-            if (seenHashes.contains(hashcode)) {
+            if (config.getSeenHashes().contains(hashcode)) {
                 return Stream.empty();
             }
-            seenHashes.add(hashcode);
+            config.getSeenHashes().add(hashcode);
+        }
+
+        if (config.getMaxHashesPerNGram() != -1) {
+            Long count = config.getNgramCountMap().get(ngram);
+            if (count == null) {
+                // first seen
+                count = 0L;
+            }
+
+            if (count + 1 > config.getMaxHashesPerNGram()) {
+                // exceeded count the first time
+                log.warn("Exceeded " + config.getMaxHashesPerNGram() + " hashes for " + ngram + " ignoring remaining hashes");
+                config.getNgramCountMap().put(ngram, -1L);
+                return Stream.empty();
+            } else if (count < 0) {
+                // exceeded count beyond the first time, go negative for tracking purposes
+                config.getNgramCountMap().put(ngram, count - 1);
+                return Stream.empty();
+            }
+            // increment count
+            config.getNgramCountMap().put(ngram, count + 1);
         }
 
         // extract the query ssdeeps that contained this ngram from the query map.
         final NGramTuple matchingNgram = new NGramTuple(chunkSize, ngram);
-        Collection<SSDeepHash> queryHashes = queryMap.get(matchingNgram);
+        Collection<SSDeepHash> queryHashes = config.getQueryMap().get(matchingNgram);
 
         // score the match between each query ssdeep and matching hash, keep those that exceed the match
         // threshold.

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSeenFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSeenFunction.java
@@ -1,0 +1,32 @@
+package datawave.query.tables.ssdeep;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import datawave.util.ssdeep.NGramTuple;
+import datawave.util.ssdeep.SSDeepHash;
+
+public class SSDeepSeenFunction implements Predicate<Map.Entry<NGramTuple,SSDeepHash>> {
+    private final Set<Integer> seen;
+
+    public SSDeepSeenFunction() {
+        this(new HashSet<>());
+    }
+
+    public SSDeepSeenFunction(Set<Integer> seen) {
+        this.seen = seen;
+    }
+
+    @Override
+    public boolean test(Map.Entry<NGramTuple,SSDeepHash> entry) {
+        int hashCode = entry.getValue().hashCode();
+        if (seen.contains(hashCode)) {
+            return false;
+        }
+        seen.add(hashCode);
+
+        return true;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
@@ -2,10 +2,10 @@ package datawave.query.tables.ssdeep;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,6 +64,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
     @Override
     public GenericQueryConfiguration initialize(AccumuloClient accumuloClient, Query settings, Set<Authorizations> auths) throws Exception {
         final SSDeepSimilarityQueryConfiguration config = new SSDeepSimilarityQueryConfiguration(getConfig());
+        config.setState(new SSDeepSimilarityQueryState());
         config.setQuery(settings);
         config.setClient(accumuloClient);
         config.setAuthorizations(auths);
@@ -84,14 +85,35 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), config.getQueryThreads(),
                             config.getQuery());
 
-            scanner.setRanges(config.getRanges());
+            scanner.setRanges(config.getState().getRanges());
+
+            final SSDeepParsingFunction parsingFunction = new SSDeepParsingFunction(config);
+            Stream<Map.Entry<NGramTuple,SSDeepHash>> parsedStream = scanner.stream().map(parsingFunction);
+
+            if (config.isDedupeSimilarityHashes()) {
+                final SSDeepSeenFunction ssDeepDedupeFunction = new SSDeepSeenFunction();
+                parsedStream = parsedStream.filter(ssDeepDedupeFunction);
+            }
+
+            if (config.getMaxHashesPerNGram() > -1) {
+                final SSDeepMaxHashPerNGramFilter maxHashPerNGramLimiter = new SSDeepMaxHashPerNGramFilter(config);
+                parsedStream = parsedStream.filter(maxHashPerNGramLimiter);
+            }
+
+            if (getMaxResults() > -1) {
+                final AtomicLong count = new AtomicLong();
+                parsedStream = parsedStream.peek(entry -> {
+                    if (count.incrementAndGet() > getMaxResults()) {
+                        throw new DatawaveFatalQueryException("Exceeded max work");
+                    }
+                });
+            }
 
             // must be called after setRanges so that we get the query map from the config.
             final SSDeepScoringFunction scoringFunction = new SSDeepScoringFunction(config);
+            Stream<ScoredSSDeepPair> scoredStream = parsedStream.flatMap(scoringFunction);
 
-            Stream<ScoredSSDeepPair> stream = scanner.stream().flatMap(scoringFunction);
-
-            this.iterator = stream.iterator();
+            this.iterator = scoredStream.iterator();
             this.scanner = scanner;
 
         } catch (TableNotFoundException e) {
@@ -156,8 +178,8 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             log.debug("Query map is: " + queryMap);
             log.debug("Ranges are: " + ranges);
         }
-        config.setRanges(ranges);
-        config.setQueryMap(queryMap);
+        config.getState().setRanges(ranges);
+        config.getState().setQueryMap(queryMap);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -59,7 +60,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
 
     @Override
     public GenericQueryConfiguration initialize(AccumuloClient accumuloClient, Query settings, Set<Authorizations> auths) throws Exception {
-        final SSDeepSimilarityQueryConfiguration config = getConfig();
+        final SSDeepSimilarityQueryConfiguration config = new SSDeepSimilarityQueryConfiguration(getConfig());
         config.setQuery(settings);
         config.setClient(accumuloClient);
         config.setAuthorizations(auths);
@@ -74,7 +75,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             throw new QueryException("Did not receive a SSDeepSimilarityQueryConfiguration instance!!");
         }
 
-        this.config = (SSDeepSimilarityQueryConfiguration) genericConfig;
+        final SSDeepSimilarityQueryConfiguration config = (SSDeepSimilarityQueryConfiguration) genericConfig;
 
         try {
             final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), config.getQueryThreads(),
@@ -85,7 +86,9 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             // must be called after setRanges so that we get the query map from the config.
             final SSDeepScoringFunction scoringFunction = new SSDeepScoringFunction(config);
 
-            this.iterator = scanner.stream().flatMap(scoringFunction).distinct().iterator();
+            Stream<ScoredSSDeepPair> stream = scanner.stream().flatMap(scoringFunction);
+
+            this.iterator = stream.iterator();
             this.scanner = scanner;
 
         } catch (TableNotFoundException e) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
@@ -2,6 +2,8 @@ package datawave.query.tables.ssdeep;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -24,6 +26,7 @@ import datawave.core.query.logic.BaseQueryLogic;
 import datawave.core.query.logic.QueryLogicTransformer;
 import datawave.microservice.query.Query;
 import datawave.query.config.SSDeepSimilarityQueryConfiguration;
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.ssdeep.ChunkSizeEncoding;
 import datawave.util.ssdeep.IntegerEncoding;
@@ -118,6 +121,11 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
         if (maxRepeatedCharacters > 0) {
             log.info("Normalizing SSDeepHashes to remove long runs of consecutive characters");
             queries = queries.stream().map(h -> h.normalize(maxRepeatedCharacters)).collect(Collectors.toSet());
+        }
+
+        if (config.getMaxHashes() != -1 && config.getMaxHashes() < queries.size()) {
+            log.error("Query exceeds max hash limit of " + config.getMaxHashes() + " count: " + queries.size());
+            throw new DatawaveFatalQueryException("Query exceeds max hash limit of " + config.getMaxHashes() + " count: " + queries.size());
         }
 
         final Multimap<NGramTuple,SSDeepHash> queryMap = nGramEngine.preprocessQueries(queries);
@@ -220,5 +228,29 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
 
     public void setBucketEncodingLength(int bucketEncodingLength) {
         getConfig().setBucketEncodingLength(bucketEncodingLength);
+    }
+
+    public void setMaxHashes(int maxHashes) {
+        getConfig().setMaxHashes(maxHashes);
+    }
+
+    public int getMaxHashes() {
+        return getConfig().getMaxHashes();
+    }
+
+    public void setMaxHashesPerNGram(int maxHashesPerNGram) {
+        getConfig().setMaxHashesPerNGram(maxHashesPerNGram);
+    }
+
+    public int getMaxHashesPerNGram() {
+        return getConfig().getMaxHashesPerNGram();
+    }
+
+    public void setDedupeSimilarityHashes(boolean dedupeSimilarityHashes) {
+        getConfig().setDedupeSimilarityHashes(dedupeSimilarityHashes);
+    }
+
+    public boolean isDedupeSimilarityHashes() {
+        return getConfig().isDedupeSimilarityHashes();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
@@ -2,7 +2,6 @@ package datawave.query.tables.ssdeep;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -24,7 +23,6 @@ import datawave.core.query.logic.BaseQueryLogic;
 import datawave.core.query.logic.QueryLogicTransformer;
 import datawave.microservice.query.Query;
 import datawave.query.config.SSDeepSimilarityQueryConfiguration;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.ssdeep.ChunkSizeEncoding;
 import datawave.util.ssdeep.IntegerEncoding;
@@ -61,8 +59,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
 
     @Override
     public GenericQueryConfiguration initialize(AccumuloClient accumuloClient, Query settings, Set<Authorizations> auths) throws Exception {
-        final SSDeepSimilarityQueryConfiguration config = SSDeepSimilarityQueryConfiguration.create(getConfig());
-        config.clearState();
+        final SSDeepSimilarityQueryConfiguration config = getConfig();
         config.setQuery(settings);
         config.setClient(accumuloClient);
         config.setAuthorizations(auths);
@@ -77,7 +74,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             throw new QueryException("Did not receive a SSDeepSimilarityQueryConfiguration instance!!");
         }
 
-        final SSDeepSimilarityQueryConfiguration config = (SSDeepSimilarityQueryConfiguration) genericConfig;
+        this.config = (SSDeepSimilarityQueryConfiguration) genericConfig;
 
         try {
             final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), config.getQueryThreads(),
@@ -86,7 +83,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             scanner.setRanges(config.getRanges());
 
             // must be called after setRanges so that we get the query map from the config.
-            final SSDeepScoringFunction scoringFunction = new SSDeepScoringFunction(config, getMaxResults(), getMaxHashesPerNGram());
+            final SSDeepScoringFunction scoringFunction = new SSDeepScoringFunction(config);
 
             this.iterator = scanner.stream().flatMap(scoringFunction).distinct().iterator();
             this.scanner = scanner;
@@ -118,11 +115,6 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
         if (maxRepeatedCharacters > 0) {
             log.info("Normalizing SSDeepHashes to remove long runs of consecutive characters");
             queries = queries.stream().map(h -> h.normalize(maxRepeatedCharacters)).collect(Collectors.toSet());
-        }
-
-        if (config.getMaxHashes() != -1 && config.getMaxHashes() < queries.size()) {
-            log.error("Query exceeds max hash limit of " + config.getMaxHashes() + " count: " + queries.size());
-            throw new DatawaveFatalQueryException("Query exceeds max hash limit of " + config.getMaxHashes() + " count: " + queries.size());
         }
 
         final Multimap<NGramTuple,SSDeepHash> queryMap = nGramEngine.preprocessQueries(queries);
@@ -225,21 +217,5 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
 
     public void setBucketEncodingLength(int bucketEncodingLength) {
         getConfig().setBucketEncodingLength(bucketEncodingLength);
-    }
-
-    public void setMaxHashes(int maxHashes) {
-        getConfig().setMaxHashes(maxHashes);
-    }
-
-    public int getMaxHashes() {
-        return getConfig().getMaxHashes();
-    }
-
-    public void setMaxHashesPerNGram(int maxHashesPerNGram) {
-        getConfig().setMaxHashesPerNGram(maxHashesPerNGram);
-    }
-
-    public int getMaxHashesPerNGram() {
-        return getConfig().getMaxHashesPerNGram();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryState.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryState.java
@@ -1,0 +1,60 @@
+package datawave.query.tables.ssdeep;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Range;
+
+import com.google.common.collect.Multimap;
+
+import datawave.util.ssdeep.NGramTuple;
+import datawave.util.ssdeep.SSDeepHash;
+
+public class SSDeepSimilarityQueryState {
+    private Collection<Range> ranges;
+
+    /**
+     * The query map, which relates SSDeep hash ngrams with the original query hashes, so that the SSDeep hashes from Accumulo can be married up with the
+     * original queries that caused them to be retrieved.
+     */
+    private Multimap<NGramTuple,SSDeepHash> queryMap;
+
+    private Set<Integer> seenHashes = new HashSet<>();
+
+    private Map<String,Long> ngramCountMap = new HashMap<>();
+
+    public Collection<Range> getRanges() {
+        return ranges;
+    }
+
+    public void setRanges(Collection<Range> ranges) {
+        this.ranges = ranges;
+    }
+
+    public Multimap<NGramTuple,SSDeepHash> getQueryMap() {
+        return queryMap;
+    }
+
+    public void setQueryMap(Multimap<NGramTuple,SSDeepHash> queryMap) {
+        this.queryMap = queryMap;
+    }
+
+    public Set<Integer> getSeenHashes() {
+        return seenHashes;
+    }
+
+    public void setSeenHashes(Set<Integer> seenHashes) {
+        this.seenHashes = seenHashes;
+    }
+
+    public Map<String,Long> getNgramCountMap() {
+        return ngramCountMap;
+    }
+
+    public void setNgramCountMap(Map<String,Long> ngramCountMap) {
+        this.ngramCountMap = ngramCountMap;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/StatefulSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/StatefulSSDeepDiscoveryChainStrategy.java
@@ -23,11 +23,15 @@ import datawave.microservice.query.QueryImpl;
 import datawave.query.discovery.DiscoveredThing;
 import datawave.query.tables.chained.strategy.FullChainStrategy;
 
+/**
+ * Converts batches of ScoredSSDeepPair into the latterQueryLogic in batches. Maintain batch scored state to enrich discovered results for each batch. A batch
+ * size of -1 will force a single batch. When seenHashes is set ScoredSSDeepPair matchingHash will be deduped.
+ */
 public class StatefulSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSSDeepPair,DiscoveredSSDeep> {
     private static final Logger log = Logger.getLogger(StatefulSSDeepDiscoveryChainStrategy.class);
 
     private int batchSize = -1;
-    private HashSet<Integer> seenHashes;
+    private Set<Integer> seenHashes;
     private Multimap<String,ScoredSSDeepPair> scoredMatches;
 
     @Override
@@ -125,7 +129,7 @@ public class StatefulSSDeepDiscoveryChainStrategy extends FullChainStrategy<Scor
         this.batchSize = batchSize;
     }
 
-    public void setSeenHashes(HashSet<Integer> seenHashes) {
+    public void setSeenHashes(Set<Integer> seenHashes) {
         this.seenHashes = seenHashes;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/StatefulSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/StatefulSSDeepDiscoveryChainStrategy.java
@@ -1,18 +1,5 @@
 package datawave.query.tables.ssdeep;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.TreeMultimap;
-import datawave.core.query.logic.QueryLogic;
-import datawave.microservice.query.Query;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.discovery.DiscoveredThing;
-import datawave.query.tables.chained.strategy.FullChainStrategy;
-import it.unimi.dsi.fastutil.Hash;
-import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -22,6 +9,19 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+
+import datawave.core.query.logic.QueryLogic;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.discovery.DiscoveredThing;
+import datawave.query.tables.chained.strategy.FullChainStrategy;
 
 public class StatefulSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSSDeepPair,DiscoveredSSDeep> {
     private static final Logger log = Logger.getLogger(StatefulSSDeepDiscoveryChainStrategy.class);
@@ -56,15 +56,15 @@ public class StatefulSSDeepDiscoveryChainStrategy extends FullChainStrategy<Scor
 
     @Override
     public Iterator<DiscoveredSSDeep> runChainedQuery(AccumuloClient client, Query initialQuery, Set<Authorizations> auths,
-                                                      Iterator<ScoredSSDeepPair> initialQueryResults, QueryLogic<DiscoveredSSDeep> latterQueryLogic) throws Exception {
+                    Iterator<ScoredSSDeepPair> initialQueryResults, QueryLogic<DiscoveredSSDeep> latterQueryLogic) throws Exception {
         Iterator<DiscoveredSSDeep> itr = super.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
         itr = getEnrichedDiscoveredSSDeepIterator(itr, scoredMatches);
 
         return itr;
     }
 
-    public String captureScoredMatchesAndBuildQuery(Iterator<ScoredSSDeepPair> initialQueryResults,
-                                                           final Multimap<String,ScoredSSDeepPair> scoredMatches, int batchSize) {
+    public String captureScoredMatchesAndBuildQuery(Iterator<ScoredSSDeepPair> initialQueryResults, final Multimap<String,ScoredSSDeepPair> scoredMatches,
+                    int batchSize) {
         int count = 0;
         Set<String> hashes = new HashSet<>();
         while (initialQueryResults.hasNext() && (batchSize == -1 || count < batchSize)) {
@@ -100,9 +100,9 @@ public class StatefulSSDeepDiscoveryChainStrategy extends FullChainStrategy<Scor
      * @return an iterator of DiscoveredSSDeep's enriched with the queries that returned them.
      */
     public Iterator<DiscoveredSSDeep> getEnrichedDiscoveredSSDeepIterator(Iterator<DiscoveredSSDeep> resultsIterator,
-                                                                                 final Multimap<String,ScoredSSDeepPair> scoredMatches) {
+                    final Multimap<String,ScoredSSDeepPair> scoredMatches) {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(resultsIterator, Spliterator.ORDERED), false)
-                .flatMap(discoveredSSdeep -> enrichDiscoveredSSDeep(discoveredSSdeep, scoredMatches)).iterator();
+                        .flatMap(discoveredSSdeep -> enrichDiscoveredSSDeep(discoveredSSdeep, scoredMatches)).iterator();
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/StatefulSSDeepDiscoveryChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/StatefulSSDeepDiscoveryChainStrategy.java
@@ -1,0 +1,131 @@
+package datawave.query.tables.ssdeep;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+import datawave.core.query.logic.QueryLogic;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.discovery.DiscoveredThing;
+import datawave.query.tables.chained.strategy.FullChainStrategy;
+import it.unimi.dsi.fastutil.Hash;
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.UUID;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+
+public class StatefulSSDeepDiscoveryChainStrategy extends FullChainStrategy<ScoredSSDeepPair,DiscoveredSSDeep> {
+    private static final Logger log = Logger.getLogger(StatefulSSDeepDiscoveryChainStrategy.class);
+
+    private int batchSize = -1;
+    private HashSet<Integer> seenHashes;
+    private Multimap<String,ScoredSSDeepPair> scoredMatches;
+
+    @Override
+    protected Query buildLatterQuery(Query initialQuery, Iterator<ScoredSSDeepPair> initialQueryResults, String latterLogicName) {
+        log.debug("buildLatterQuery() called...");
+
+        // track the scored matches we've seen while traversing the initial query results.
+        // this has to be case-insensitive because the CHECKSUM_SSDEEP index entries are most likely downcased.
+        scoredMatches = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, ScoredSSDeepPair.NATURAL_ORDER);
+
+        String queryString = captureScoredMatchesAndBuildQuery(initialQueryResults, scoredMatches, batchSize);
+
+        if (scoredMatches.isEmpty()) {
+            log.info("Did not receive scored matches from initial query, returning null latter query");
+            return null;
+        }
+
+        Query q = new QueryImpl(); // TODO, need to use a factory? don't hardcode this.
+        q.setQuery(queryString);
+        q.setId(UUID.randomUUID());
+        q.setPagesize(Integer.MAX_VALUE); // TODO: choose something reasonable.
+        q.setQueryAuthorizations(initialQuery.getQueryAuthorizations());
+        q.setUserDN(initialQuery.getUserDN());
+        return q;
+    }
+
+    @Override
+    public Iterator<DiscoveredSSDeep> runChainedQuery(AccumuloClient client, Query initialQuery, Set<Authorizations> auths,
+                                                      Iterator<ScoredSSDeepPair> initialQueryResults, QueryLogic<DiscoveredSSDeep> latterQueryLogic) throws Exception {
+        Iterator<DiscoveredSSDeep> itr = super.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
+        itr = getEnrichedDiscoveredSSDeepIterator(itr, scoredMatches);
+
+        return itr;
+    }
+
+    public String captureScoredMatchesAndBuildQuery(Iterator<ScoredSSDeepPair> initialQueryResults,
+                                                           final Multimap<String,ScoredSSDeepPair> scoredMatches, int batchSize) {
+        int count = 0;
+        Set<String> hashes = new HashSet<>();
+        while (initialQueryResults.hasNext() && (batchSize == -1 || count < batchSize)) {
+            ScoredSSDeepPair pair = initialQueryResults.next();
+            // do hash checking if configured
+            if (seenHashes != null) {
+                int hashCode = pair.getMatchingHash().hashCode();
+                if (seenHashes.contains(hashCode)) {
+                    // already saw this hash, skip it
+                    continue;
+                }
+
+                // add the hash so its never processed again
+                seenHashes.add(hashCode);
+            }
+
+            scoredMatches.put(pair.getMatchingHash().toString(), pair);
+            log.debug("Added new ssdeep " + pair.getMatchingHash());
+            hashes.add("CHECKSUM_SSDEEP:\"" + pair.getMatchingHash().toString() + "\"");
+            count++;
+        }
+        return StringUtils.join(hashes, " OR ");
+    }
+
+    /**
+     * Given an iterator of DiscoveredSSDeep objects that have no matching query or weighted score, lookup the potential queries that returned them and the
+     * weighted score associated with that query and use them to produce enriched results.
+     *
+     * @param resultsIterator
+     *            an iterator of unenrched DiscoveredSSDeep's that don't have query or score info.
+     * @param scoredMatches
+     *            the colletion of matchin hashes and the original queries that lead them to be returned.
+     * @return an iterator of DiscoveredSSDeep's enriched with the queries that returned them.
+     */
+    public Iterator<DiscoveredSSDeep> getEnrichedDiscoveredSSDeepIterator(Iterator<DiscoveredSSDeep> resultsIterator,
+                                                                                 final Multimap<String,ScoredSSDeepPair> scoredMatches) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(resultsIterator, Spliterator.ORDERED), false)
+                .flatMap(discoveredSSdeep -> enrichDiscoveredSSDeep(discoveredSSdeep, scoredMatches)).iterator();
+    }
+
+    /**
+     * Given a single discovered ssdeep, use the scoredMatches map to determine which queries it is related to. This will return zero to many new
+     * DiscoveredSSDeep entries for each query that the matching ssdeep hash appeared in.
+     *
+     * @param discoveredSSDeep
+     *            the ssdeep discovery information a single matched hash
+     * @param scoredMatches
+     *            the set of scored matches from the ssdeep similarity logic, used to look up score and query info for the matched hash.
+     * @return a stream of DiscoveredSSDeep objects that align discovery information with the original query hashes.
+     */
+    public Stream<DiscoveredSSDeep> enrichDiscoveredSSDeep(DiscoveredSSDeep discoveredSSDeep, final Multimap<String,ScoredSSDeepPair> scoredMatches) {
+        final DiscoveredThing discoveredThing = discoveredSSDeep.getDiscoveredThing();
+        final String term = discoveredThing.getTerm();
+        return scoredMatches.get(term).stream().map(scoredPair -> new DiscoveredSSDeep(scoredPair, discoveredThing));
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setSeenHashes(HashSet<Integer> seenHashes) {
+        this.seenHashes = seenHashes;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/FullSSDeepDiscoveryChainStrategyTest.java
@@ -1,0 +1,240 @@
+package datawave.query.tables.ssdeep;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.easymock.Capture;
+import org.easymock.EasyMockSupport;
+import org.glassfish.jersey.internal.guava.Iterators;
+import org.junit.Before;
+import org.junit.Test;
+
+import datawave.core.query.logic.QueryLogic;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.discovery.DiscoveredThing;
+import datawave.util.ssdeep.SSDeepHash;
+
+public class FullSSDeepDiscoveryChainStrategyTest extends EasyMockSupport {
+    private AccumuloClient mockAccumulo;
+    private QueryLogic mockLogic;
+    private List<ScoredSSDeepPair> input;
+
+    private Query settings;
+
+    @Before
+    public void setup() {
+        mockAccumulo = createMock(AccumuloClient.class);
+        mockLogic = createMock(QueryLogic.class);
+
+        expect(mockLogic.getLogicName()).andReturn("secondLogic").anyTimes();
+
+        input = new ArrayList<>();
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "abc", "def"), new SSDeepHash(3, "asdf", "gfs"), Collections.emptySet(), 234));
+
+        settings = new QueryImpl();
+    }
+
+    @Test
+    public void noInputTest() throws Exception {
+        FullSSDeepDiscoveryChainStrategy strategy = new FullSSDeepDiscoveryChainStrategy();
+
+        replayAll();
+
+        Iterator<DiscoveredSSDeep> result = strategy.runChainedQuery(mockAccumulo, settings, null, Iterators.emptyIterator(), mockLogic);
+
+        verifyAll();
+
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    public void singleInputTest() throws Exception {
+        FullSSDeepDiscoveryChainStrategy strategy = new FullSSDeepDiscoveryChainStrategy();
+        Capture<Query> intermediateSettings = Capture.newInstance();
+        DiscoveredThing thing = createMock(DiscoveredThing.class);
+
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+
+        expect(mockLogic.iterator()).andReturn(List.of(new DiscoveredSSDeep(input.get(0), thing)).iterator());
+        expect(thing.getTerm()).andReturn("3:asdf:gfs");
+
+        replayAll();
+
+        Iterator<DiscoveredSSDeep> result = strategy.runChainedQuery(mockAccumulo, settings, null, input.iterator(), mockLogic);
+
+        verifyAll();
+
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfs\"", intermediateSettings.getValue().getQuery());
+
+        assertTrue(result.hasNext());
+        DiscoveredSSDeep next = result.next();
+        assertEquals(234, next.getScoredSSDeepPair().getWeightedScore());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    public void dualInputSingleBatchTest() throws Exception {
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "def", "def"), new SSDeepHash(3, "asdf", "gfq"), Collections.emptySet(), 101));
+
+        FullSSDeepDiscoveryChainStrategy strategy = new FullSSDeepDiscoveryChainStrategy();
+        Capture<Query> intermediateSettings = Capture.newInstance();
+        DiscoveredThing thing = createMock(DiscoveredThing.class);
+
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+
+        expect(mockLogic.iterator()).andReturn(List.of(new DiscoveredSSDeep(input.get(0), thing)).iterator());
+        expect(thing.getTerm()).andReturn("3:asdf:gfs");
+
+        replayAll();
+
+        Iterator<DiscoveredSSDeep> result = strategy.runChainedQuery(mockAccumulo, settings, null, input.iterator(), mockLogic);
+
+        verifyAll();
+
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfs\" OR CHECKSUM_SSDEEP:\"3:asdf:gfq\"", intermediateSettings.getValue().getQuery());
+
+        assertTrue(result.hasNext());
+        DiscoveredSSDeep next = result.next();
+        assertEquals(234, next.getScoredSSDeepPair().getWeightedScore());
+        assertFalse(result.hasNext());
+    }
+
+    @Test
+    public void dualInputDualBatchTest() throws Exception {
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "def", "def"), new SSDeepHash(3, "asdf", "gfq"), Collections.emptySet(), 101));
+
+        FullSSDeepDiscoveryChainStrategy strategy = new FullSSDeepDiscoveryChainStrategy();
+        strategy.setBatchSize(1);
+
+        Capture<Query> intermediateSettings = Capture.newInstance();
+        Capture<Query> intermediateSettings2 = Capture.newInstance();
+        DiscoveredThing thing = createMock(DiscoveredThing.class);
+
+        // first batch
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(List.of(new DiscoveredSSDeep(input.get(0), thing)).iterator());
+        expect(thing.getTerm()).andReturn("3:asdf:gfs");
+
+        // second batch
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings2), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(Collections.emptyList().iterator());
+
+        replayAll();
+
+        Iterator<DiscoveredSSDeep> result = strategy.runChainedQuery(mockAccumulo, settings, null, input.iterator(), mockLogic);
+
+        assertTrue(result.hasNext());
+        DiscoveredSSDeep next = result.next();
+        assertEquals(234, next.getScoredSSDeepPair().getWeightedScore());
+        assertFalse(result.hasNext());
+
+        verifyAll();
+
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfs\"", intermediateSettings.getValue().getQuery());
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfq\"", intermediateSettings2.getValue().getQuery());
+    }
+
+    @Test
+    public void dupeInputIteratorTest() throws Exception {
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "abc", "def"), new SSDeepHash(3, "asdf", "gfs"), Collections.emptySet(), 234));
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "def", "def"), new SSDeepHash(3, "asdf", "gfq"), Collections.emptySet(), 101));
+
+        FullSSDeepDiscoveryChainStrategy strategy = new FullSSDeepDiscoveryChainStrategy();
+        strategy.setBatchSize(1);
+        strategy.setDedupe(true);
+
+        Capture<Query> intermediateSettings = Capture.newInstance();
+        Capture<Query> intermediateSettings2 = Capture.newInstance();
+        DiscoveredThing thing = createMock(DiscoveredThing.class);
+
+        // first batch
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(List.of(new DiscoveredSSDeep(input.get(0), thing)).iterator());
+        expect(thing.getTerm()).andReturn("3:asdf:gfs");
+
+        // second batch
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings2), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(Collections.emptyList().iterator());
+
+        replayAll();
+
+        Iterator<DiscoveredSSDeep> result = strategy.runChainedQuery(mockAccumulo, settings, null, input.iterator(), mockLogic);
+
+        assertTrue(result.hasNext());
+        DiscoveredSSDeep next = result.next();
+        assertEquals(234, next.getScoredSSDeepPair().getWeightedScore());
+        assertFalse(result.hasNext());
+
+        verifyAll();
+
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfs\"", intermediateSettings.getValue().getQuery());
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfq\"", intermediateSettings2.getValue().getQuery());
+    }
+
+    @Test
+    public void noDupeInputIteratorTest() throws Exception {
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "abc", "def"), new SSDeepHash(3, "asdf", "gfs"), Collections.emptySet(), 234));
+        input.add(new ScoredSSDeepPair(new SSDeepHash(3, "def", "def"), new SSDeepHash(3, "asdf", "gfq"), Collections.emptySet(), 101));
+
+        FullSSDeepDiscoveryChainStrategy strategy = new FullSSDeepDiscoveryChainStrategy();
+        strategy.setBatchSize(1);
+        strategy.setDedupe(false);
+
+        Capture<Query> intermediateSettings = Capture.newInstance();
+        Capture<Query> intermediateSettings2 = Capture.newInstance();
+        Capture<Query> intermediateSettings3 = Capture.newInstance();
+        DiscoveredThing thing = createMock(DiscoveredThing.class);
+
+        // first batch
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(List.of(new DiscoveredSSDeep(input.get(0), thing)).iterator());
+        expect(thing.getTerm()).andReturn("3:asdf:gfs");
+
+        // second batch (dupe)
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings2), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(List.of(new DiscoveredSSDeep(input.get(0), thing)).iterator());
+        expect(thing.getTerm()).andReturn("3:asdf:gfs");
+
+        // second batch
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings3), eq(null))).andReturn(null);
+        mockLogic.setupQuery(null);
+        expect(mockLogic.iterator()).andReturn(Collections.emptyList().iterator());
+
+        replayAll();
+
+        Iterator<DiscoveredSSDeep> result = strategy.runChainedQuery(mockAccumulo, settings, null, input.iterator(), mockLogic);
+
+        assertTrue(result.hasNext());
+        DiscoveredSSDeep next = result.next();
+        assertEquals(234, next.getScoredSSDeepPair().getWeightedScore());
+        assertTrue(result.hasNext());
+        next = result.next();
+        assertEquals(234, next.getScoredSSDeepPair().getWeightedScore());
+        assertFalse(result.hasNext());
+
+        verifyAll();
+
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfs\"", intermediateSettings.getValue().getQuery());
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfs\"", intermediateSettings2.getValue().getQuery());
+        assertEquals("CHECKSUM_SSDEEP:\"3:asdf:gfq\"", intermediateSettings3.getValue().getQuery());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
@@ -148,7 +148,9 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
         EventQueryResponseBase response = runSSDeepQuery(query, similarityQueryLogic, 0);
 
         List<EventBase> events = response.getEvents();
-        Assert.assertEquals(1, events.size());
+        Assert.assertEquals(40, events.size());
+        // TODO show how this is deduped later
+
         Map<String,Map<String,String>> observedEvents = extractObservedEvents(events);
 
         SSDeepTestUtil.assertSSDeepSimilarityMatch(testSSDeep, testSSDeep, "40", expectedOverlaps, "100", observedEvents);
@@ -182,16 +184,19 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
     @Test
     public void testChainedSSDeepDiscovery() throws Exception {
+        ((FullSSDeepDiscoveryChainStrategy)this.similarityDiscoveryQueryLogic.getChainStrategy()).setBatchSize(1);
+
         log.info("------ testChainedSSDeepDiscovery ------");
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504---";
+        String testSSDeep2 = "192:1s---FXYvPToUCpabe0qHEbM0NkaA80W---ixZzS7:1r4X6oU6ZHEbp1biW7";
         String targetSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
-        String query = "CHECKSUM_SSDEEP:" + testSSDeep;
+        String query = "CHECKSUM_SSDEEP:" + testSSDeep + " OR CHECKSUM_SSDEEP:" + testSSDeep2;
         String expectedOverlaps = "384:+u5QT4Z, 384:/fP9FmW, 384:2aTgSO+, 384:4ZE1PIV, 384:5QT4ZE1, 384:9FmWVMd, 384:Fj2aTgS, 384:FmWVMdR, 384:MdRFj2a, 384:O+u5QT4, 384:P9FmWVM, 384:QT4ZE1P, 384:RFj2aTg, 384:SO+u5QT, 384:T4ZE1PI, 384:TgSO+u5, 384:VMdRFj2, 384:WVMdRFj, 384:ZE1PIVS, 384:aTgSO+u, 384:dRFj2aT, 384:fP9FmWV, 384:gSO+u5Q, 384:j2aTgSO, 384:mWVMdRF, 384:nv/fP9F, 384:u5QT4ZE, 384:v/fP9Fm, 768:DmWOdRF, 768:FNTTs50, 768:NTTs504, 768:OdRFNTT, 768:RFNTTs5, 768:WOdRFNT, 768:dRFNTTs, 768:mWOdRFN, 768:nDmWOdR";
 
         EventQueryResponseBase response = runSSDeepQuery(query, similarityDiscoveryQueryLogic, 0);
 
         List<EventBase> events = response.getEvents();
-        Assert.assertEquals(1, events.size());
+        Assert.assertEquals(2, events.size());
         Map<String,Map<String,String>> observedEvents = extractObservedEvents(events);
 
         Map.Entry<String,Map<String,String>> result = observedEvents.entrySet().iterator().next();

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
@@ -140,7 +140,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
     @SuppressWarnings("rawtypes")
     @Test
     public void testSSDeepSimilarity() throws Exception {
-        similarityQueryLogic.getConfig().setDedupe(false);
+        similarityQueryLogic.getConfig().setDedupeSimilarityHashes(false);
         log.info("------ testSSDeepSimilarity ------");
         @SuppressWarnings("SpellCheckingInspection")
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
@@ -156,7 +156,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
         SSDeepTestUtil.assertSSDeepSimilarityMatch(testSSDeep, testSSDeep, "40", expectedOverlaps, "100", observedEvents);
 
         // now repeat with dedupe true
-        similarityQueryLogic.getConfig().setDedupe(true);
+        similarityQueryLogic.getConfig().setDedupeSimilarityHashes(true);
         response = runSSDeepQuery(query, similarityQueryLogic, 0);
 
         events = response.getEvents();

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
@@ -140,6 +140,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
     @SuppressWarnings("rawtypes")
     @Test
     public void testSSDeepSimilarity() throws Exception {
+        similarityQueryLogic.getConfig().setDedupe(false);
         log.info("------ testSSDeepSimilarity ------");
         @SuppressWarnings("SpellCheckingInspection")
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504cQS";
@@ -149,9 +150,19 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
         List<EventBase> events = response.getEvents();
         Assert.assertEquals(40, events.size());
-        // TODO show how this is deduped later
 
         Map<String,Map<String,String>> observedEvents = extractObservedEvents(events);
+
+        SSDeepTestUtil.assertSSDeepSimilarityMatch(testSSDeep, testSSDeep, "40", expectedOverlaps, "100", observedEvents);
+
+        // now repeat with dedupe true
+        similarityQueryLogic.getConfig().setDedupe(true);
+        response = runSSDeepQuery(query, similarityQueryLogic, 0);
+
+        events = response.getEvents();
+        Assert.assertEquals(1, events.size());
+
+        observedEvents = extractObservedEvents(events);
 
         SSDeepTestUtil.assertSSDeepSimilarityMatch(testSSDeep, testSSDeep, "40", expectedOverlaps, "100", observedEvents);
     }
@@ -184,7 +195,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
 
     @Test
     public void testChainedSSDeepDiscovery() throws Exception {
-        ((FullSSDeepDiscoveryChainStrategy)this.similarityDiscoveryQueryLogic.getChainStrategy()).setBatchSize(1);
+        ((FullSSDeepDiscoveryChainStrategy) this.similarityDiscoveryQueryLogic.getChainStrategy()).setBatchSize(1);
 
         log.info("------ testChainedSSDeepDiscovery ------");
         String testSSDeep = "384:nv/fP9FmWVMdRFj2aTgSO+u5QT4ZE1PIVS:nDmWOdRFNTTs504---";

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
@@ -7,6 +7,8 @@ import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_2_OVER
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_3_OVERLAPS;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_4_OVERLAPS;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.TEST_SSDEEPS;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -38,6 +40,7 @@ import datawave.ingest.mapreduce.handler.ssdeep.SSDeepIndexHandler;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.query.QueryImpl;
 import datawave.microservice.querymetric.QueryMetricFactoryImpl;
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.ssdeep.util.SSDeepTestUtil;
 import datawave.query.testframework.AbstractDataTypeConfig;
 import datawave.security.authorization.DatawavePrincipal;
@@ -104,6 +107,38 @@ public class SSDeepSimilarityQueryTest {
     @Test
     public void testSingleQueryMinScore() throws Exception {
         runSingleQuery(true);
+    }
+
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testMaxResultsLimit() throws Exception {
+        logic.setMaxResults(2);
+        runSingleQuery(false);
+    }
+
+    @Test(expected = DatawaveFatalQueryException.class)
+    public void testMaxHashLimit() throws Exception {
+        logic.setMaxHashes(1);
+        String query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2] + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[3];
+        runSSDeepQuery(query, 0);
+    }
+
+    @Test
+    public void testMaxHashesPerNGram() throws Exception {
+        // block all hashes
+        logic.setMaxHashesPerNGram(0);
+        // this normally would have results [see below]
+        String query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2];
+        // no ngrams in similarity means no results
+        EventQueryResponseBase response = runSSDeepQuery(query, 0);
+        assertNull(response.getEvents());
+
+        // verify with the value reset its fine
+        logic.setMaxHashesPerNGram(10);
+        // provate this now has results
+        query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2];
+        // no ngrams in similarity means no results
+        response = runSSDeepQuery(query, 0);
+        assertNotNull(response.getEvents());
     }
 
     private static void logSSDeepTestData() throws TableNotFoundException {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
@@ -98,11 +98,13 @@ public class SSDeepSimilarityQueryTest {
 
     @Test
     public void testSingleQueryNoMinScore() throws Exception {
+        // TODO now returns duplicates
         runSingleQuery(false);
     }
 
     @Test
     public void testSingleQueryMinScore() throws Exception {
+        // TODO now returns duplicates
         runSingleQuery(true);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
@@ -98,13 +98,11 @@ public class SSDeepSimilarityQueryTest {
 
     @Test
     public void testSingleQueryNoMinScore() throws Exception {
-        // TODO now returns duplicates
         runSingleQuery(false);
     }
 
     @Test
     public void testSingleQueryMinScore() throws Exception {
-        // TODO now returns duplicates
         runSingleQuery(true);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
@@ -7,8 +7,6 @@ import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_2_OVER
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_3_OVERLAPS;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.EXPECTED_2_4_OVERLAPS;
 import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.TEST_SSDEEPS;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,7 +38,6 @@ import datawave.ingest.mapreduce.handler.ssdeep.SSDeepIndexHandler;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.query.QueryImpl;
 import datawave.microservice.querymetric.QueryMetricFactoryImpl;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.ssdeep.util.SSDeepTestUtil;
 import datawave.query.testframework.AbstractDataTypeConfig;
 import datawave.security.authorization.DatawavePrincipal;
@@ -107,38 +104,6 @@ public class SSDeepSimilarityQueryTest {
     @Test
     public void testSingleQueryMinScore() throws Exception {
         runSingleQuery(true);
-    }
-
-    @Test(expected = DatawaveFatalQueryException.class)
-    public void testMaxResultsLimit() throws Exception {
-        logic.setMaxResults(1);
-        runSingleQuery(false);
-    }
-
-    @Test(expected = DatawaveFatalQueryException.class)
-    public void testMaxHashLimit() throws Exception {
-        logic.getConfig().setMaxHashes(1);
-        String query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2] + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[3];
-        runSSDeepQuery(query, 0);
-    }
-
-    @Test
-    public void testMaxHashesPerNGram() throws Exception {
-        // don't allow any ngrams through
-        logic.getConfig().setMaxHashesPerNGram(0);
-        // this normally would have results [see below]
-        String query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2];
-        // no ngrams in similarity means no results
-        EventQueryResponseBase response = runSSDeepQuery(query, 0);
-        assertNull(response.getEvents());
-
-        // verify with the value reset its fine
-        logic.getConfig().setMaxHashesPerNGram(10);
-        // provate this now has results
-        query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2];
-        // no ngrams in similarity means no results
-        response = runSSDeepQuery(query, 0);
-        assertNotNull(response.getEvents());
     }
 
     private static void logSSDeepTestData() throws TableNotFoundException {


### PR DESCRIPTION
* Shift state to config where possible
* Add configurable hash deduping at both similarity and chaining layers
* Lazily stream off the similarity iterator when batching is enabled
* Add batch options to chain strategy