### PR TITLE
Fix case where slop wasn't reduced when removing query tokens

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
@@ -349,7 +349,7 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
     public QueryNode createNewQueryNode(String field, String tokenizedText, int slopNeeded) {
         QueryNode newQueryNode = new QuotedFieldQueryNode(field, new UnescapedCharSequence(tokenizedText), -1, -1);
         newQueryNode.setTag(NODE_PROCESSED, Boolean.TRUE); // don't process this node again.
-        if (slopNeeded > 0) {
+        if (slopNeeded != Integer.MIN_VALUE) {
             newQueryNode = new SlopQueryNode(newQueryNode, slopNeeded);
             newQueryNode.setTag(NODE_PROCESSED, Boolean.TRUE); // don't process this node again.
         }
@@ -366,24 +366,27 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
      *            the text of the original query.
      * @param positionsObserved
      *            the number of positions observed in the tokenized text.
-     * @return the amount of slop we need to add to our new query clauses.
+     * @return the amount of slop we need to add to our new query clauses, Integer.MIN_VALUE if there should be no changes to the
+     *   original node.
      */
     private int calculateSlopNeeded(QueryNode node, String text, int positionsObserved) {
         int slopNeeded = positionsObserved;
 
-        final boolean originalWasQuoted = QuotedFieldQueryNode.class.isAssignableFrom(node.getClass());
-        final int originalSlop = node.getTag(ORIGINAL_SLOP) != null ? (Integer) node.getTag(ORIGINAL_SLOP) : 0;
-
-        if ((useSlopForTokenizedTerms && !originalWasQuoted) || originalSlop > 0) {
-            // Adjust the slop needed based on the slop in the original query.
+        // Adjust the slop based on the difference between the original
+        // slop minus the original token count (based on whitespace)
+        int originalSlop = 0;
+        if (node.getTag(ORIGINAL_SLOP) != null) {
+            originalSlop = (Integer) node.getTag(ORIGINAL_SLOP);
             final int delta = originalSlop - text.split("\\s+").length;
-            if (delta > 0) {
-                slopNeeded += delta;
-            }
-        } else {
-            slopNeeded = 0;
+            slopNeeded += delta;
         }
-        return slopNeeded;
+
+        final boolean originalWasQuoted = QuotedFieldQueryNode.class.isAssignableFrom(node.getClass());
+        if ((useSlopForTokenizedTerms && !originalWasQuoted) || originalSlop > 0) {
+            return slopNeeded;
+        }
+
+        return Integer.MIN_VALUE;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/language/processor/lucene/CustomAnalyzerQueryNodeProcessor.java
@@ -366,8 +366,7 @@ public class CustomAnalyzerQueryNodeProcessor extends QueryNodeProcessorImpl {
      *            the text of the original query.
      * @param positionsObserved
      *            the number of positions observed in the tokenized text.
-     * @return the amount of slop we need to add to our new query clauses, Integer.MIN_VALUE if there should be no changes to the
-     *   original node.
+     * @return the amount of slop we need to add to our new query clauses, Integer.MIN_VALUE if there should be no changes to the original node.
      */
     private int calculateSlopNeeded(QueryNode node, String text, int positionsObserved) {
         int slopNeeded = positionsObserved;

--- a/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParserVariants.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/parser/jexl/TestLuceneToJexlQueryParserVariants.java
@@ -121,6 +121,12 @@ public class TestLuceneToJexlQueryParserVariants {
         assertEquals(expected, parseQuery("TOKFIELD:\"from foo@bar.com to bar@foo.com address\""));
     }
 
+    @Test
+    public void testDroppedTokenSlop() throws ParseException {
+        String expected = "(content:within(TOKFIELD, 5, termOffsetMap, 'often', 'my', 'dog', '-', 'likes', 'scratches') || content:within(TOKFIELD, 4, termOffsetMap, 'often', 'my', 'dog', 'likes', 'scratches'))";
+        assertEquals(expected, parseQuery("TOKFIELD:\"often my dog - likes scratches\"~5"));
+    }
+
     private String parseQuery(String query) throws ParseException {
         String parsedQuery = null;
         try {


### PR DESCRIPTION
There was a issue in 7.10 where the fix for #2629 introduced a regression. The net result was that slop for certain phrase queries was too large if the input phrases contained a token that would be dropped entirely (e.g., '-')
