### PR TITLE
Handle case when the set of fields to keep is empty

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/CardinalityAggregator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/CardinalityAggregator.java
@@ -73,7 +73,7 @@ public class CardinalityAggregator extends IdentityAggregator {
             Cardinality card = new Cardinality(fvC, metadata, doc.isToKeep());
 
             // only keep fields that are index only
-            card.setToKeep(fieldsToKeep == null || fieldsToKeep.contains(JexlASTHelper.removeGroupingContext(field)));
+            card.setToKeep(fieldsToKeep == null || fieldsToKeep.isEmpty() || fieldsToKeep.contains(JexlASTHelper.removeGroupingContext(field)));
             doc.put(field, card);
 
             key = nextKey;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/IdentityAggregator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/IdentityAggregator.java
@@ -106,7 +106,8 @@ public class IdentityAggregator extends SeekingAggregator implements FieldIndexA
             for (Tuple2<String,String> fieldNameValue : fieldNameValues) {
                 Attribute<?> attr = attrs.create(fieldNameValue.first(), fieldNameValue.second(), topKey, true);
                 // only keep fields that are index only and pass the attribute filter
-                boolean toKeep = (fieldsToKeep == null || fieldsToKeep.contains(JexlASTHelper.removeGroupingContext(fieldNameValue.first())))
+                boolean toKeep = (fieldsToKeep == null || fieldsToKeep.isEmpty()
+                                || fieldsToKeep.contains(JexlASTHelper.removeGroupingContext(fieldNameValue.first())))
                                 && (filter == null || filter.keep(topKey));
                 attr.setToKeep(toKeep);
 
@@ -128,7 +129,7 @@ public class IdentityAggregator extends SeekingAggregator implements FieldIndexA
     }
 
     protected boolean toKeep(Key topKey, Tuple2<String,String> fieldNameValue) {
-        return (fieldsToKeep == null || fieldsToKeep.contains(JexlASTHelper.removeGroupingContext(fieldNameValue.first())))
+        return (fieldsToKeep == null || fieldsToKeep.isEmpty() || fieldsToKeep.contains(JexlASTHelper.removeGroupingContext(fieldNameValue.first())))
                         && (filter == null || filter.keep(topKey));
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/tld/TLDFieldIndexAggregator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tld/TLDFieldIndexAggregator.java
@@ -51,7 +51,7 @@ public class TLDFieldIndexAggregator extends SeekingAggregator implements FieldI
             Attribute<?> attr = af.create(field, value, key, true);
             // in addition to keeping fields that the filter indicates should be kept, also keep fields that the filter applies. This is due to inconsistent
             // behavior between event/tld queries where an index only field index will be kept except when it is a child of a tld
-            attr.setToKeep((fieldsToAggregate == null || fieldsToAggregate.contains(JexlASTHelper.removeGroupingContext(field)))
+            attr.setToKeep((fieldsToAggregate == null || fieldsToAggregate.isEmpty() || fieldsToAggregate.contains(JexlASTHelper.removeGroupingContext(field)))
                             && (attrFilter == null || attrFilter.keep(key)));
             d.put(field, attr);
 

--- a/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
@@ -405,6 +405,10 @@ public class CompositeIndexTest {
         List<String> wktList = new ArrayList<>();
         wktList.addAll(Arrays.asList(wktLegacyData));
         wktList.addAll(Arrays.asList(wktCompositeData));
+        // there was a bug that prevented normalized data from the field index from being returned due to an
+        // incorrect evaluation of "to keep". The fact that this data is now coming back after the bugfix indicates
+        // that either the test is not configured correctly, or we are not building aggregators correctly
+        wktList.add("050200");
 
         List<Integer> wktByteLengthList = new ArrayList<>();
         wktByteLengthList.addAll(Arrays.asList(wktByteLengthLegacyData));
@@ -425,11 +429,11 @@ public class CompositeIndexTest {
             Assert.assertNotNull(wktByteLength);
 
             // ensure that this is one of the ingested events
-            Assert.assertTrue(wktList.remove(wkt));
+            Assert.assertTrue("tried to remove " + wkt + " from " + wktList + " but could not", wktList.remove(wkt));
             Assert.assertTrue(wktByteLengthList.remove(wktByteLength));
         }
 
-        Assert.assertEquals(11, wktList.size());
+        Assert.assertEquals(12, wktList.size());
         Assert.assertEquals(11, wktByteLengthList.size());
         Assert.assertEquals(1, events.size());
     }


### PR DESCRIPTION
The intent in the aggregator logic is to only keep a field if the field set contains elements. The aggregator will turn into a pass-through if the field set is null. Now that logic is expanded to "pass through if null or empty"