### PR TITLE
Add utility to assert hit terms

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/test/HitTermAssertions.java
+++ b/warehouse/query-core/src/test/java/datawave/test/HitTermAssertions.java
@@ -258,6 +258,7 @@ public class HitTermAssertions {
 
             if (!found) {
                 log.warn("expected to find at least one of required hits: {}", requiredHits);
+                log.warn("returned hit terms: {}", hits);
                 validated = false;
             }
         }

--- a/warehouse/query-core/src/test/java/datawave/test/HitTermAssertions.java
+++ b/warehouse/query-core/src/test/java/datawave/test/HitTermAssertions.java
@@ -77,6 +77,7 @@ public class HitTermAssertions {
 
     private final Set<String> discovered = new HashSet<>();
 
+    private boolean expectNoHitTerms = true;
     private boolean validated = true;
 
     public HitTermAssertions() {
@@ -93,6 +94,7 @@ public class HitTermAssertions {
         optionalAnyOf.clear();
         discovered.clear();
         validated = true;
+        expectNoHitTerms = false;
     }
 
     /**
@@ -102,6 +104,7 @@ public class HitTermAssertions {
      *            a collection of hit terms
      */
     public void withRequiredAllOf(String... hits) {
+        expectNoHitTerms = false;
         requiredAllOf.add(Set.of(hits));
     }
 
@@ -112,6 +115,7 @@ public class HitTermAssertions {
      *            a collection of hit terms
      */
     public void withRequiredAnyOf(String... hits) {
+        expectNoHitTerms = false;
         requiredAnyOf.add(Set.of(hits));
     }
 
@@ -122,6 +126,7 @@ public class HitTermAssertions {
      *            a collection of hit terms
      */
     public void withOptionalAllOf(String... hits) {
+        expectNoHitTerms = false;
         optionalAllOf.add(Set.of(hits));
     }
 
@@ -132,7 +137,12 @@ public class HitTermAssertions {
      *            a collection of hit terms
      */
     public void withOptionalAnyOf(String... hits) {
+        expectNoHitTerms = false;
         optionalAnyOf.add(Set.of(hits));
+    }
+
+    public void expectNoHitTerms() {
+        expectNoHitTerms = true;
     }
 
     /**
@@ -174,11 +184,27 @@ public class HitTermAssertions {
         discovered.clear();
 
         Preconditions.checkNotNull(document, "Expected document to be non-null");
+
         boolean anyHitTermSet = !requiredAllOf.isEmpty() || !requiredAnyOf.isEmpty() || !optionalAllOf.isEmpty() || !optionalAnyOf.isEmpty();
-        Preconditions.checkArgument(anyHitTermSet, "No expected hit terms set, please check test setup");
+        Preconditions.checkState((expectNoHitTerms != anyHitTermSet), "Invalid configuration: cannot expect hit terms and set expectNoHitTerm to false");
 
         Set<String> hits = extractHitTermsFromDocument(document);
-        if (hits.isEmpty()) {
+
+        if (expectNoHitTerms) {
+            if (!hits.isEmpty()) {
+                validated = false;
+                log.warn("Expected hit terms to be empty, but found {}", hits);
+            }
+            return validated;
+        }
+
+        if (anyHitTermSet && hits.isEmpty()) {
+            log.warn("Expected hit terms but document contained no hit terms");
+            return false;
+        }
+
+        if (!anyHitTermSet && !hits.isEmpty()) {
+            log.warn("No hit terms expected but found hit terms: {}", hits);
             return false;
         }
 
@@ -203,7 +229,9 @@ public class HitTermAssertions {
      */
     private Set<String> extractHitTermsFromDocument(Document document) {
         if (!document.containsKey(HIT_TERM_FIELD)) {
-            log.warn("Document did not contain any hit terms");
+            if (!expectNoHitTerms) {
+                log.warn("Document did not contain any hit terms");
+            }
             return Collections.emptySet();
         }
 

--- a/warehouse/query-core/src/test/java/datawave/test/HitTermAssertions.java
+++ b/warehouse/query-core/src/test/java/datawave/test/HitTermAssertions.java
@@ -1,0 +1,295 @@
+package datawave.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.Attributes;
+import datawave.query.attributes.Content;
+import datawave.query.attributes.Document;
+import datawave.query.function.JexlEvaluation;
+
+/**
+ * Utility class for asserting expected hit terms.
+ * <p>
+ * A hit term takes the form of <code>FIELD:value</code>. This utility can assert hit terms that are either required or optional.
+ * <p>
+ * A required hit term must be present in every result. Each set of required terms can be evaluated as 'all of' or 'any of'
+ * <p>
+ * An optional hit term might be present in any result. Each set of optional terms can be evaluated as 'all of' or 'any of'
+ * <p>
+ * In the single term example: <code>F:1</code>
+ * <ul>
+ * <li>requiredAllOf: {F:1}</li>
+ * </ul>
+ * In the simple intersection example: <code>F:1 and F:2</code>
+ * <ul>
+ * <li>requiredAllOf: {F:1, F:2}</li>
+ * </ul>
+ * In the simple union example: <code>F:1 or F:2</code>
+ * <ul>
+ * <li>requiredAnyOf: {F:1, F:2}</li>
+ * </ul>
+ * In the intersection with nested union case: <code>F:1 and (F:2 or F:3)</code>
+ * <ul>
+ * <li>requiredAllOf: {F:1}</li>
+ * <li>requiredAnyOf: {F:2, F:3}</li>
+ * </ul>
+ * In the union with nested intersection case: <code>F:1 or (F:2 and F:3)</code>
+ * <ul>
+ * <li>optionalAllOf: {F:1}</li>
+ * <li>optionalAllOf: {F:2, F:3}</li>
+ * </ul>
+ * In the double nested intersection case: <code>(F:1 and F:2) or (F:3 and F:4)</code>
+ * <ul>
+ * <li>optionalAllOf: {F:1, F:2}</li>
+ * <li>optionalAllOf: {F:3, F:4}</li>
+ * </ul>
+ * In the double nested union case: <code>(F:1 or F:2) and (F:3 or F:4)</code>
+ * <ul>
+ * <li>optionalAnyOf: {F:1, F:2}</li>
+ * <li>optionalAnyOf: {F:3, F:4}</li>
+ * </ul>
+ * <p>
+ * Google {@link Preconditions} are used instead of JUnit assertions for portability. DataWave currently supports both JUnit 4 and JUnit 5, so preconditions are
+ * used until the codebase converges on a single version of JUnit.
+ */
+public class HitTermAssertions {
+
+    private static final Logger log = LoggerFactory.getLogger(HitTermAssertions.class);
+
+    private static final String HIT_TERM_FIELD = JexlEvaluation.HIT_TERM_FIELD;
+
+    private final List<Set<String>> requiredAllOf = new ArrayList<>();
+    private final List<Set<String>> requiredAnyOf = new ArrayList<>();
+    private final List<Set<String>> optionalAllOf = new ArrayList<>();
+    private final List<Set<String>> optionalAnyOf = new ArrayList<>();
+
+    private final Set<String> discovered = new HashSet<>();
+
+    private boolean validated = true;
+
+    public HitTermAssertions() {
+        // no-op
+    }
+
+    /**
+     * This should be called before or after every test
+     */
+    public void resetState() {
+        requiredAllOf.clear();
+        requiredAnyOf.clear();
+        optionalAllOf.clear();
+        optionalAnyOf.clear();
+        discovered.clear();
+        validated = true;
+    }
+
+    /**
+     * Add a collection of hit terms to the set of required hit terms, evaluated as 'all of'
+     *
+     * @param hits
+     *            a collection of hit terms
+     */
+    public void withRequiredAllOf(String... hits) {
+        requiredAllOf.add(Set.of(hits));
+    }
+
+    /**
+     * Add a collection of hit terms to the set of required hit terms, evaluated as 'any of'
+     *
+     * @param hits
+     *            a collection of hit terms
+     */
+    public void withRequiredAnyOf(String... hits) {
+        requiredAnyOf.add(Set.of(hits));
+    }
+
+    /**
+     * Add a collection of hits to the list of optional hit terms, evaluated as 'all of'
+     *
+     * @param hits
+     *            a collection of hit terms
+     */
+    public void withOptionalAllOf(String... hits) {
+        optionalAllOf.add(Set.of(hits));
+    }
+
+    /**
+     * Add a collection of hits to the list of optional hit terms, evaluated as 'any of'
+     *
+     * @param hits
+     *            a collection of hit terms
+     */
+    public void withOptionalAnyOf(String... hits) {
+        optionalAnyOf.add(Set.of(hits));
+    }
+
+    /**
+     * Method that helps a test determine if a hit term is expected
+     *
+     * @return true if a hit term is expected
+     */
+    public boolean hitTermExpected() {
+        return !requiredAllOf.isEmpty() || !requiredAnyOf.isEmpty() || !optionalAllOf.isEmpty() || !optionalAnyOf.isEmpty();
+    }
+
+    /**
+     * Assert hit terms for the provided collection of documents
+     *
+     * @param documents
+     *            a collection of documents
+     * @return true if all documents are valid
+     */
+    public boolean assertHitTerms(Collection<Document> documents) {
+        boolean allValid = true;
+        for (Document document : documents) {
+            boolean validated = assertHitTerms(document);
+            if (!validated) {
+                allValid = false;
+            }
+        }
+        return allValid;
+    }
+
+    /**
+     * Assert hit terms for a single document
+     *
+     * @param document
+     *            the document
+     * @return true if all documents are valid
+     */
+    public boolean assertHitTerms(Document document) {
+        // reset the discovered hit terms for each document
+        discovered.clear();
+
+        Preconditions.checkNotNull(document, "Expected document to be non-null");
+        boolean anyHitTermSet = !requiredAllOf.isEmpty() || !requiredAnyOf.isEmpty() || !optionalAllOf.isEmpty() || !optionalAnyOf.isEmpty();
+        Preconditions.checkArgument(anyHitTermSet, "No expected hit terms set, please check test setup");
+
+        Set<String> hits = extractHitTermsFromDocument(document);
+        if (hits.isEmpty()) {
+            return false;
+        }
+
+        allRequiredHitTermsFound(hits);
+        atLeastOneRequiredHitTermFound(hits);
+
+        Set<String> extraHits = Sets.difference(hits, discovered);
+        if (!extraHits.isEmpty()) {
+            log.warn("Found unexpected hit terms:: {}", extraHits);
+            Preconditions.checkArgument(extraHits.isEmpty(), "Found unexpected hit terms: " + extraHits);
+        }
+
+        return validated;
+    }
+
+    /**
+     * Extract all HIT_TERMs from the document. Will throw an exception if a hit term is not a Content attribute
+     *
+     * @param document
+     *            the document
+     * @return the set of hit terms
+     */
+    private Set<String> extractHitTermsFromDocument(Document document) {
+        if (!document.containsKey(HIT_TERM_FIELD)) {
+            log.warn("Document did not contain any hit terms");
+            return Collections.emptySet();
+        }
+
+        Attribute<?> attribute = document.get(HIT_TERM_FIELD);
+        Set<String> hits = new HashSet<>();
+        if (attribute instanceof Attributes) {
+            for (Attribute<?> attr : ((Attributes) attribute).getAttributes()) {
+                Preconditions.checkArgument(attr instanceof Content, "HIT_TERM was not a Content attribute");
+                Content content = (Content) attr;
+                hits.add(content.getContent());
+            }
+        } else {
+            Preconditions.checkArgument(attribute instanceof Content, "HIT_TERM was not a Content attribute");
+            Content content = (Content) attribute;
+            hits.add(content.getContent());
+        }
+
+        return hits;
+    }
+
+    /**
+     * Verify that each required hit term is present in the set of extracted hit terms
+     *
+     * @param hits
+     *            the set of extracted hit terms
+     */
+    private void allRequiredHitTermsFound(Set<String> hits) {
+        for (Set<String> requiredHits : requiredAllOf) {
+            if (hits.containsAll(requiredHits)) {
+                discovered.addAll(requiredHits);
+                continue;
+            }
+
+            // otherwise we have a problem
+            validated = false;
+
+            Set<String> found = Sets.union(requiredHits, hits);
+            Set<String> missing = Sets.difference(hits, requiredHits);
+            log.warn("Expected to find all of: {}", requiredHits);
+            log.warn("Found: {}", found);
+            log.warn("Missing: {}", missing);
+        }
+
+        for (Set<String> requiredHits : requiredAnyOf) {
+            boolean found = false;
+            for (String requiredHit : requiredHits) {
+                if (hits.contains(requiredHit)) {
+                    found = true;
+                    discovered.add(requiredHit);
+                }
+            }
+
+            if (!found) {
+                log.warn("expected to find at least one of required hits: {}", requiredHits);
+                validated = false;
+            }
+        }
+    }
+
+    /**
+     * At least one of the optional sets of hit terms must contain a match
+     *
+     * @param hits
+     *            the set of extracted hit terms
+     */
+    private void atLeastOneRequiredHitTermFound(Set<String> hits) {
+        boolean anyOptionalFound = false;
+        for (Set<String> optionalHits : optionalAllOf) {
+            if (hits.containsAll(optionalHits)) {
+                anyOptionalFound = true;
+                discovered.addAll(optionalHits);
+            }
+        }
+
+        for (Set<String> optionalHits : optionalAnyOf) {
+            for (String optionalHit : optionalHits) {
+                if (hits.contains(optionalHit)) {
+                    anyOptionalFound = true;
+                    discovered.add(optionalHit);
+                }
+            }
+        }
+
+        if (requiredAllOf.isEmpty() && requiredAnyOf.isEmpty() && !anyOptionalFound) {
+            // safety check: optional hits are the only hits configured and none were found, fail validation.
+            validated = false;
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/HitTermAssertionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/HitTermAssertionsTest.java
@@ -1,0 +1,186 @@
+package datawave.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.query.attributes.AttributeFactory;
+import datawave.query.attributes.Document;
+import datawave.query.function.JexlEvaluation;
+import datawave.query.jexl.DatawaveJexlContext;
+import datawave.query.jexl.HitListArithmetic;
+import datawave.query.util.Tuple3;
+import datawave.query.util.TypeMetadata;
+
+public class HitTermAssertionsTest {
+
+    private final HitTermAssertions hitTermAssertions = new HitTermAssertions();
+    private final Key documentKey = new Key("row", "datatype\0uid");
+    private final Set<String> fieldNames = Set.of("F");
+
+    private final AttributeFactory attributeFactory = new AttributeFactory(new TypeMetadata());
+
+    private String query;
+
+    @BeforeEach
+    public void setup() {
+        hitTermAssertions.resetState();
+    }
+
+    @Test
+    public void testSingleHitTerm() {
+        withQuery("F == '1'");
+        hitTermAssertions.withRequiredAllOf("F:1");
+
+        Document document = createDocument("F", "1");
+        drive(document);
+    }
+
+    @Test
+    public void testIntersection() {
+        withQuery("F == '1' && F == '2'");
+        hitTermAssertions.withRequiredAllOf("F:1", "F:2");
+        Document document = createDocument("F", "1", "2");
+        drive(document);
+    }
+
+    @Test
+    public void testUnion() {
+        withQuery("F == '1' || F == '2'");
+        hitTermAssertions.withRequiredAnyOf("F:1", "F:2");
+        Document document = createDocument("F", "1", "2");
+        drive(document);
+
+        document = createDocument("F", "1");
+        drive(document);
+
+        document = createDocument("F", "2");
+        drive(document);
+    }
+
+    @Test
+    public void testIntersectionWithNestedUnion() {
+        withQuery("F == '1' && (F == '2' || F == '3')");
+        hitTermAssertions.withRequiredAllOf("F:1");
+        hitTermAssertions.withRequiredAnyOf("F:2", "F:3");
+
+        Document document = createDocument("F", "1", "2", "3");
+        drive(document);
+
+        document = createDocument("F", "1", "2");
+        drive(document);
+
+        document = createDocument("F", "1", "3");
+        drive(document);
+    }
+
+    @Test
+    public void testUnionWithNestedIntersection() {
+        withQuery("F == '1' || (F == '2' && F == '3')");
+        hitTermAssertions.withOptionalAllOf("F:1");
+        hitTermAssertions.withOptionalAllOf("F:2", "F:3");
+
+        Document document = createDocument("F", "1", "2", "3");
+        drive(document);
+
+        document = createDocument("F", "1");
+        drive(document);
+
+        document = createDocument("F", "2", "3");
+        drive(document);
+    }
+
+    @Test
+    public void testDoubleNestedIntersection() {
+        withQuery("(F == '1' && F == '2') || (F == '3' && F == '4')");
+        hitTermAssertions.withOptionalAllOf("F:1", "F:2");
+        hitTermAssertions.withOptionalAllOf("F:3", "F:4");
+
+        Document document = createDocument("F", "1", "2", "3", "4");
+        drive(document);
+
+        document = createDocument("F", "1", "2");
+        drive(document);
+
+        document = createDocument("F", "3", "4");
+        drive(document);
+    }
+
+    @Test
+    public void testDoubleNestedUnion() {
+        withQuery("(F == '1' || F == '2') && (F == '3' || F == '4')");
+        hitTermAssertions.withRequiredAnyOf("F:1", "F:2");
+        hitTermAssertions.withRequiredAnyOf("F:3", "F:4");
+
+        Document document = createDocument("F", "1", "2", "3", "4");
+        drive(document);
+
+        document = createDocument("F", "1", "3");
+        drive(document);
+
+        document = createDocument("F", "2", "4");
+        drive(document);
+    }
+
+    @Test
+    public void testOnlyOptionalHits() {
+        withQuery("F == '1' || F == '2'");
+        hitTermAssertions.withOptionalAnyOf("F:1", "F:2");
+
+        Document document = createDocument("F", "1", "2", "3", "4");
+        drive(document);
+
+        document = createDocument("F", "1");
+        drive(document);
+
+        document = createDocument("F", "2");
+        drive(document);
+
+        document = createDocument("F", "5");
+        drive(document, false);
+    }
+
+    @Test
+    public void testNotEnoughMinerals() {
+        // handles the case where more hit terms were returned than requested
+        withQuery("F == '1' && F == '2'");
+        hitTermAssertions.withRequiredAllOf("F:1");
+
+        // should complain about extra hit term {F:2}
+        Document document = createDocument("F", "1", "2");
+        assertThrows(IllegalArgumentException.class, () -> drive(document));
+    }
+
+    private void drive(Document document) {
+        drive(document, true);
+    }
+
+    private void drive(Document document, boolean expected) {
+        JexlEvaluation evaluation = new JexlEvaluation(query, new HitListArithmetic(true));
+
+        DatawaveJexlContext context = new DatawaveJexlContext();
+        document.visit(fieldNames, context);
+
+        boolean result = evaluation.apply(new Tuple3<>(null, document, context));
+
+        boolean validated = hitTermAssertions.assertHitTerms(document);
+        assertEquals(expected, validated);
+    }
+
+    private void withQuery(String query) {
+        this.query = query;
+    }
+
+    private Document createDocument(String field, String... values) {
+        Document d = new Document();
+        for (String value : values) {
+            d.put(field, attributeFactory.create(field, value, documentKey, true));
+        }
+        return d;
+    }
+}


### PR DESCRIPTION
Added a utility to assert hit terms and migrated one of the hit term tests over to the new utility. This allows developers to describe the expected hit terms for most basic boolean logic expressions. 