### PR TITLE
Actually exercise document range tests

### DIFF
--- a/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/QueryMetricSplitBrainMergePolicyTest.java
+++ b/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/QueryMetricSplitBrainMergePolicyTest.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 
@@ -33,7 +33,7 @@ public class QueryMetricSplitBrainMergePolicyTest {
     
     private final static QueryMetricFactory queryMetricFactory = new QueryMetricFactoryImpl();
     
-    @Ignore
+    @Disabled
     @Test
     public void testAllPagesMerged() {
         String mapName = HazelcastUtils.randomMapName();
@@ -102,7 +102,7 @@ public class QueryMetricSplitBrainMergePolicyTest {
         h2.shutdown();
     }
     
-    @Ignore
+    @Disabled
     @Test
     public void testFieldsUpdated() {
         String mapName = HazelcastUtils.randomMapName();

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
@@ -87,6 +87,13 @@ public abstract class CompositeFunctionsTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            eventQueryLogic.setCollapseUids(true);
+            tldEventQueryLogic.setCollapseUids(true);
+        }
+
         @AfterClass
         public static void teardown() {
             TypeRegistry.reset();
@@ -124,6 +131,13 @@ public abstract class CompositeFunctionsTest {
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            eventQueryLogic.setCollapseUids(false);
+            tldEventQueryLogic.setCollapseUids(false);
         }
 
         @AfterClass

--- a/warehouse/query-core/src/test/java/datawave/query/ExcerptTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ExcerptTest.java
@@ -73,6 +73,11 @@ public abstract class ExcerptTest {
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
     }
 
     @RunWith(Arquillian.class)
@@ -97,6 +102,11 @@ public abstract class ExcerptTest {
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(false);
+        }
     }
 
     private static final Logger log = Logger.getLogger(datawave.query.ExcerptTest.class);

--- a/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
@@ -71,6 +71,12 @@ public abstract class FunctionalSetTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
             super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client);
@@ -91,6 +97,12 @@ public abstract class FunctionalSetTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedCommonalityTokenTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedCommonalityTokenTest.java
@@ -75,6 +75,12 @@ public abstract class HitsAreAlwaysIncludedCommonalityTokenTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParms, Collection<String> goodResults)
                         throws Exception {
@@ -97,6 +103,12 @@ public abstract class HitsAreAlwaysIncludedCommonalityTokenTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -113,6 +113,12 @@ public abstract class IfThisTestFailsThenHitTermsAreBroken {
                 PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
             }
         }
+
+        @Before
+        public void setup() throws Exception {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
     }
 
     @RunWith(Arquillian.class)
@@ -130,6 +136,12 @@ public abstract class IfThisTestFailsThenHitTermsAreBroken {
                 PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
                 PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
             }
+        }
+
+        @Before
+        public void setup() throws Exception {
+            super.setup();
+            logic.setCollapseUids(true);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IfThisTestFailsThenHitTermsAreBroken.java
@@ -141,7 +141,7 @@ public abstract class IfThisTestFailsThenHitTermsAreBroken {
         @Before
         public void setup() throws Exception {
             super.setup();
-            logic.setCollapseUids(true);
+            logic.setCollapseUids(false);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/IvaratorInterruptTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IvaratorInterruptTest.java
@@ -144,6 +144,12 @@ public abstract class IvaratorInterruptTest {
         public static void init() throws Exception {
             init(ShardRange.class.getSimpleName(), WiseGuysIngest.WhatKindaRange.SHARD);
         }
+
+        @Before
+        public void setup() throws IOException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
     }
 
     @RunWith(Arquillian.class)
@@ -152,6 +158,12 @@ public abstract class IvaratorInterruptTest {
         @BeforeClass
         public static void init() throws Exception {
             init(DocumentRange.class.getSimpleName(), WiseGuysIngest.WhatKindaRange.DOCUMENT);
+        }
+
+        @Before
+        public void setup() throws IOException {
+            super.setup();
+            logic.setCollapseUids(false);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/LenientFieldsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LenientFieldsTest.java
@@ -81,6 +81,12 @@ public abstract class LenientFieldsTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(List<String> expected, String plan, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
                         throws Exception {
@@ -103,6 +109,12 @@ public abstract class LenientFieldsTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/NumericListQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/NumericListQueryTest.java
@@ -78,6 +78,12 @@ public abstract class NumericListQueryTest {
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(String queryString, String plan, Date startDate, Date endDate, Map<String,String> extraParms,
                         Collection<String> goodResults) throws Exception {
@@ -100,6 +106,12 @@ public abstract class NumericListQueryTest {
             PrintUtility.printTable(connector, auths, TableName.SHARD);
             PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/QueryFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryFunctionQueryTest.java
@@ -88,6 +88,12 @@ public abstract class QueryFunctionQueryTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            eventQueryLogic.setCollapseUids(true);
+        }
+
         @AfterClass
         public static void teardown() {
             TypeRegistry.reset();
@@ -125,6 +131,12 @@ public abstract class QueryFunctionQueryTest {
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            eventQueryLogic.setCollapseUids(false);
         }
 
         @AfterClass

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -29,7 +29,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,11 +68,18 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
             QueryTestTableHelper qtth = new QueryTestTableHelper(ShardRange.class.toString(), log);
             connector = qtth.client;
 
+            MockAccumuloRecordWriter recordWriter = new MockAccumuloRecordWriter();
+            qtth.configureTables(recordWriter);
+
             CommonalityTokenTestDataIngest.writeItAll(connector, CommonalityTokenTestDataIngest.WhatKindaRange.SHARD);
             Authorizations auths = new Authorizations("ALL");
+
+            // set to DEBUG if you want table output
+            Logger.getLogger(PrintUtility.class).setLevel(Level.INFO);
             PrintUtility.printTable(connector, auths, TableName.SHARD);
             PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+
         }
 
         @Before
@@ -97,12 +103,17 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
 
             QueryTestTableHelper qtth = new QueryTestTableHelper(DocumentRange.class.toString(), log);
             connector = qtth.client;
+            MockAccumuloRecordWriter recordWriter = new MockAccumuloRecordWriter();
+            qtth.configureTables(recordWriter);
 
             CommonalityTokenTestDataIngest.writeItAll(connector, CommonalityTokenTestDataIngest.WhatKindaRange.DOCUMENT);
             Authorizations auths = new Authorizations("ALL");
+            // set to DEBUG if you want table output
+            Logger.getLogger(PrintUtility.class).setLevel(Level.INFO);
             PrintUtility.printTable(connector, auths, TableName.SHARD);
             PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+
         }
 
         @Before
@@ -276,7 +287,6 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         }
     }
 
-    @Ignore
     @Test
     public void testOneGroup() throws Exception {
         withParameter("include.grouping.context", "true");

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -29,6 +29,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -75,6 +76,12 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(Collection<String> goodResults) throws Exception {
             super.runTestQuery(connector, goodResults);
@@ -96,6 +103,12 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
             PrintUtility.printTable(connector, auths, TableName.SHARD);
             PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override
@@ -263,6 +276,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         }
     }
 
+    @Ignore
     @Test
     public void testOneGroup() throws Exception {
         withParameter("include.grouping.context", "true");
@@ -276,6 +290,7 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Set<String> goodResults = Sets.newHashSet("CANINE.PET.13:shepherd", "CAT.PET.13:ragdoll", "FISH.PET.13:tetra", "BIRD.PET.13:lovebird",
                         "REPTILE.PET.1:snake", "DOG.WILD.1:coyote", "SIZE.CANINE.3:20,12.5", "SIZE.CANINE.WILD.1:90,26.5");
 
+        // TODO: when executing as a document range no results are found
         runTestQuery(goodResults);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TestLimitReturnedGroupsToHitTermGroups.java
@@ -300,7 +300,6 @@ public abstract class TestLimitReturnedGroupsToHitTermGroups {
         Set<String> goodResults = Sets.newHashSet("CANINE.PET.13:shepherd", "CAT.PET.13:ragdoll", "FISH.PET.13:tetra", "BIRD.PET.13:lovebird",
                         "REPTILE.PET.1:snake", "DOG.WILD.1:coyote", "SIZE.CANINE.3:20,12.5", "SIZE.CANINE.WILD.1:90,26.5");
 
-        // TODO: when executing as a document range no results are found
         runTestQuery(goodResults);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
@@ -82,6 +82,12 @@ public abstract class UniqueTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQueryWithUniqueness(Set<Set<String>> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
                         throws Exception {
@@ -109,6 +115,12 @@ public abstract class UniqueTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UseOccurrenceToCountInJexlContextTest.java
@@ -63,7 +63,7 @@ import datawave.util.TableName;
  * This test confirms that hit terms are found in the correct documents, and only in the correct documents. The test data has fields that will hit in different
  * grouping context levels, and assures that the hits contain the fields with the correct grouping context. It also confirms that an 'or' query that hits
  * different fields in the returned documents will have the correct hit terms.
- *
+ * <p>
  * The same tests are made against document ranges and shard ranges
  *
  */
@@ -87,6 +87,12 @@ public abstract class UseOccurrenceToCountInJexlContextTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
         }
 
+        @Before
+        public void setup() throws Exception {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms,
                         Multimap<String,String> expectedHitTerms) throws Exception {
@@ -108,6 +114,12 @@ public abstract class UseOccurrenceToCountInJexlContextTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() throws Exception {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/HitsAreAlwaysIncludedTest.java
@@ -64,7 +64,6 @@ import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 /**
  * Tests the limit.fields feature to ensure that hit terms are always included and that associated fields at the same grouping context are included along with
  * the field that hit on the query
- *
  */
 public abstract class HitsAreAlwaysIncludedTest {
 
@@ -83,6 +82,12 @@ public abstract class HitsAreAlwaysIncludedTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
         }
 
         @Override
@@ -107,6 +112,12 @@ public abstract class HitsAreAlwaysIncludedTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/GroupingRequiredFilterFunctionsIntegrationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/GroupingRequiredFilterFunctionsIntegrationTest.java
@@ -56,6 +56,12 @@ public abstract class GroupingRequiredFilterFunctionsIntegrationTest {
     @RunWith(Arquillian.class)
     public static class ShardRangeTest extends GroupingRequiredFilterFunctionsIntegrationTest {
 
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected String getRange() {
             return "SHARD";
@@ -64,6 +70,12 @@ public abstract class GroupingRequiredFilterFunctionsIntegrationTest {
 
     @RunWith(Arquillian.class)
     public static class DocumentRangeTest extends GroupingRequiredFilterFunctionsIntegrationTest {
+
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
 
         @Override
         protected String getRange() {
@@ -77,7 +89,7 @@ public abstract class GroupingRequiredFilterFunctionsIntegrationTest {
 
     @Inject
     @SpringBean(name = "EventQuery")
-    private ShardQueryLogic logic;
+    protected ShardQueryLogic logic;
 
     private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
     private final Map<String,String> queryParameters = new HashMap<>();

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -96,6 +96,12 @@ public abstract class ExecutableExpansionVisitorTest {
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
                         throws ParseException, Exception {
@@ -119,6 +125,12 @@ public abstract class ExecutableExpansionVisitorTest {
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
             PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/planner/DatePartitionedQueryPlannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/DatePartitionedQueryPlannerTest.java
@@ -78,6 +78,12 @@ public abstract class DatePartitionedQueryPlannerTest {
     @RunWith(Arquillian.class)
     public static class ShardRange extends DatePartitionedQueryPlannerTest {
 
+        @Before
+        public void setup() throws Exception {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected IndexFieldHoleDataIngest.Range getRange() {
             return IndexFieldHoleDataIngest.Range.SHARD;
@@ -86,6 +92,12 @@ public abstract class DatePartitionedQueryPlannerTest {
 
     @RunWith(Arquillian.class)
     public static class DocumentRange extends DatePartitionedQueryPlannerTest {
+
+        @Before
+        public void setup() throws Exception {
+            super.setup();
+            logic.setCollapseUids(false);
+        }
 
         @Override
         protected IndexFieldHoleDataIngest.Range getRange() {

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
@@ -75,6 +75,12 @@ public abstract class ValueToAttributesTest {
             PrintUtility.printTable(client, auths, BaseEdgeQueryTest.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
             super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client);
@@ -96,6 +102,12 @@ public abstract class ValueToAttributesTest {
             PrintUtility.printTable(client, auths, TableName.SHARD);
             PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(client, auths, BaseEdgeQueryTest.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicTest.java
@@ -85,6 +85,12 @@ public abstract class ShardQueryLogicTest {
         protected String getRange() {
             return WiseGuysIngest.WhatKindaRange.SHARD.name();
         }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
     }
 
     @RunWith(Arquillian.class)
@@ -93,6 +99,12 @@ public abstract class ShardQueryLogicTest {
         @Override
         protected String getRange() {
             return WiseGuysIngest.WhatKindaRange.DOCUMENT.name();
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -84,6 +84,12 @@ public abstract class GroupingTest {
     @RunWith(Arquillian.class)
     public static class ShardRange extends GroupingTest {
 
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected String getRange() {
             return "SHARD";
@@ -92,6 +98,12 @@ public abstract class GroupingTest {
 
     @RunWith(Arquillian.class)
     public static class DocumentRange extends GroupingTest {
+
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(false);
+        }
 
         @Override
         protected String getRange() {

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/NoExpansionTests.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/NoExpansionTests.java
@@ -55,6 +55,12 @@ public abstract class NoExpansionTests {
     @RunWith(Arquillian.class)
     public static class ShardRange extends NoExpansionTests {
 
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
             return VisibilityWiseGuysIngestWithModel.WhatKindaRange.SHARD;
@@ -63,6 +69,12 @@ public abstract class NoExpansionTests {
 
     @RunWith(Arquillian.class)
     public static class DocumentRange extends NoExpansionTests {
+
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(false);
+        }
 
         @Override
         protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/QueryModelExpansionTests.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/QueryModelExpansionTests.java
@@ -54,6 +54,12 @@ public abstract class QueryModelExpansionTests {
     @RunWith(Arquillian.class)
     public static class ShardRange extends QueryModelExpansionTests {
 
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
             return VisibilityWiseGuysIngestWithModel.WhatKindaRange.SHARD;
@@ -62,6 +68,12 @@ public abstract class QueryModelExpansionTests {
 
     @RunWith(Arquillian.class)
     public static class DocumentRange extends QueryModelExpansionTests {
+
+        @Before
+        public void setup() throws ParseException {
+            super.setup();
+            logic.setCollapseUids(false);
+        }
 
         @Override
         protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {

--- a/warehouse/query-core/src/test/java/datawave/query/util/CommonalityTokenTestDataIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/CommonalityTokenTestDataIngest.java
@@ -18,6 +18,7 @@ import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberListType;
 import datawave.data.type.NumberType;
 import datawave.data.type.Type;
+import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
 import datawave.ingest.protobuf.Uid;
 import datawave.query.QueryTestTableHelper;
 import datawave.util.CompositeTimestamp;
@@ -53,10 +54,14 @@ public class CommonalityTokenTestDataIngest {
         String myUID2 = UID.builder().newId("MyUid2".getBytes(), (Date) null).toString();
         String myUID3 = UID.builder().newId("MyUid3".getBytes(), (Date) null).toString();
 
+        long indexTS = ShardedDataTypeHandler.getIndexTimestamp(timeStamp);
+
         long ageOffTimestamp = 1699041441288l;
         long timeStamp2 = CompositeTimestamp.getCompositeTimeStamp(timeStamp, ageOffTimestamp);
+        long indexTS2 = ShardedDataTypeHandler.getIndexTimestamp(timeStamp2);
 
         long timeStamp3 = CompositeTimestamp.getCompositeTimeStamp(ageOffTimestamp, ageOffTimestamp);
+        long indexTS3 = ShardedDataTypeHandler.getIndexTimestamp(timeStamp3);
 
         try {
             // write the shard table :
@@ -143,169 +148,175 @@ public class CommonalityTokenTestDataIngest {
 
             // all the cats
             mutation = new Mutation(lcNoDiacriticsType.normalize("tabby"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp2,
+            bw.addMutation(mutation);
+            mutation = new Mutation(lcNoDiacriticsType.normalize("sphynx"));
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS2,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID2));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp3,
+            bw.addMutation(mutation);
+            mutation = new Mutation(lcNoDiacriticsType.normalize("manx"));
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS3,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID3));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("calico"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("tom"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("siamese"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("cougar"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("tiger"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("leopard"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("puma"));
-            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CAT", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
 
             // all the canines
             mutation = new Mutation(lcNoDiacriticsType.normalize("beagle"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("basset"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("chihuahua"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("dachshund"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("bernese"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("shepherd"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp2,
+            bw.addMutation(mutation);
+            mutation = new Mutation(lcNoDiacriticsType.normalize("doberman"));
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS2,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID2));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp3,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS3,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID3));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("wolf"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("coyote"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("fox"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("dingo"));
-            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("CANINE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation((numberType.normalize("90")));
-            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("26.5"));
-            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation((numberType.normalize("20")));
-            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("12.5"));
-            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("SIZE", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
 
             // all the fish
             mutation = new Mutation(lcNoDiacriticsType.normalize("beta"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("goldfish"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("angelfish"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("guppy"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("shark"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("tuna"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("mackerel"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("salmon"));
-            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("FISH", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
 
             // all the birds
             mutation = new Mutation(lcNoDiacriticsType.normalize("parakeet"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("canary"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("parrot"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("budgie"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("eagle"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("hawk"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("crow"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("buzzard"));
-            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, timeStamp,
+            mutation.put("BIRD", shard + "\u0000" + datatype, columnVisibility, indexTS,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(myUID));
             bw.addMutation(mutation);
 

--- a/warehouse/query-core/src/test/java/datawave/query/util/SummaryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/SummaryTest.java
@@ -69,6 +69,12 @@ public abstract class SummaryTest {
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         }
 
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(true);
+        }
+
         @Override
         protected void runTestQuery(String queryString, Date startDate, Date endDate, Map<String,String> extraParams, Collection<String> goodResults,
                         boolean shouldReturnSomething) throws Exception {
@@ -91,6 +97,12 @@ public abstract class SummaryTest {
             PrintUtility.printTable(connector, auths, TableName.SHARD);
             PrintUtility.printTable(connector, auths, TableName.SHARD_INDEX);
             PrintUtility.printTable(connector, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        }
+
+        @Before
+        public void setup() {
+            super.setup();
+            logic.setCollapseUids(false);
         }
 
         @Override


### PR DESCRIPTION
The test QueryLogicFactory.xml has the collapse uids option set to true. This means that even if the underlying test data contains a uid, that uid will not be persisted as a document range -- effectively turning every document range test into a shard range test. 

All document range tests now explicitly disable the collapse uids option so that document ranges are generated. 

One unit test was ignored because it now returns zero results when using a document range.