### PR TITLE
Improve check-code-formatting Workflow Job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
   # they are committed back to the branch
   check-code-formatting:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -45,7 +46,7 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat
+        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat -Dutils -Dservices -Dstarters
         git status
         git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
     - name: Commit Changes
@@ -53,8 +54,9 @@ jobs:
         if [ "$diffs_found" = true ]; then
           git config --global user.name "GitHub Actions"
           git config --global user.email "datawave@github.com"
-          git pull origin ${{ steps.extract_branch.outputs.branch }} --rebase --autostash
-          git checkout -b ${{ steps.extract_branch.outputs.branch }}
+          git fetch origin
+          git checkout ${{ steps.extract_branch.outputs.branch }}
+          git pull origin ${{ steps.extract_branch.outputs.branch }} --no-rebase
           git commit -am "GitHub Actions: Fix Formatting"
           git push origin ${{ steps.extract_branch.outputs.branch }}
         else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         cache: 'maven'
     - name: Extract branch name
       shell: bash
-      run: 
+      run: |
         if [ ${{ github.event_name }} == 'merge_group' ]; then
           echo "Does not need to run on merge_group event."
           exit 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,6 @@ jobs:
       if: env.is_merge_queue != 'true'
       shell: bash
       run: |
-        if [ ${{ github.event_name }} == 'merge_group' ]; then
-          echo "Does not need to run on merge_group event."
-          exit 0
-        fi
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Format code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,16 +27,9 @@ jobs:
   check-code-formatting:
     runs-on: ubuntu-latest
     steps:
-    - name: Check for Merge Queue Event
-      run: |
-        if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            echo "is_merge_queue=true" >> $GITHUB_ENV
-        fi
     - name: Checkout Code
-      if: env.is_merge_queue != 'true'
       uses: actions/checkout@v4
     - name: Set up JDK ${{env.JAVA_VERSION}}
-      if: env.is_merge_queue != 'true'
       uses: actions/setup-java@v4
       with:
         distribution: ${{env.JAVA_DISTRIBUTION}}
@@ -44,24 +37,29 @@ jobs:
         maven-version: 3.9.5
         cache: 'maven'
     - name: Extract branch name
-      if: env.is_merge_queue != 'true'
       shell: bash
       run: |
-        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        if [[ "${{ github.event_name }}" != "merge_group" ]]; then
+          echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        else
+          echo "Nothing to do"
+        fi
       id: extract_branch
     - name: Format code
-      if: env.is_merge_queue != 'true'
       env:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat -Dutils -Dservices -Dstarters
-        git status
-        git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
+        if [[ "${{ github.event_name }}" != "merge_group" ]]; then
+          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -V -B -e -ntp "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat -Dutils -Dservices -Dstarters
+          git status
+          git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
+        else
+          echo "Nothing to do"
+        fi
     - name: Commit Changes
-      if: env.is_merge_queue != 'true'
       run: |
-        if [ "$diffs_found" = true ]; then
+        if [[ "$diffs_found" = true && "${{ github.event_name }}" != "merge_group" ]]; then
           git config --global user.name "GitHub Actions"
           git config --global user.email "datawave@github.com"
           git fetch origin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,16 @@ jobs:
   check-code-formatting:
     runs-on: ubuntu-latest
     steps:
+    - name: Check for Merge Queue Event
+      run: |
+        if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "is_merge_queue=true" >> $GITHUB_ENV
+        fi
     - name: Checkout Code
+      if: env.is_merge_queue != 'true'
       uses: actions/checkout@v4
     - name: Set up JDK ${{env.JAVA_VERSION}}
+      if: env.is_merge_queue != 'true'
       uses: actions/setup-java@v4
       with:
         distribution: ${{env.JAVA_DISTRIBUTION}}
@@ -37,6 +44,7 @@ jobs:
         maven-version: 3.9.5
         cache: 'maven'
     - name: Extract branch name
+      if: env.is_merge_queue != 'true'
       shell: bash
       run: |
         if [ ${{ github.event_name }} == 'merge_group' ]; then
@@ -46,6 +54,7 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Format code
+      if: env.is_merge_queue != 'true'
       env:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
@@ -54,6 +63,7 @@ jobs:
         git status
         git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
     - name: Commit Changes
+      if: env.is_merge_queue != 'true'
       run: |
         if [ "$diffs_found" = true ]; then
           git config --global user.name "GitHub Actions"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
   # they are committed back to the branch
   check-code-formatting:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -39,7 +38,12 @@ jobs:
         cache: 'maven'
     - name: Extract branch name
       shell: bash
-      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      run: 
+        if [ ${{ github.event_name }} == 'merge_group' ]; then
+          echo "Does not need to run on merge_group event."
+          exit 0
+        fi
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Format code
       env:

--- a/microservices/services/query/service/src/test/java/datawave/microservice/query/stream/StreamingServiceTest.java
+++ b/microservices/services/query/service/src/test/java/datawave/microservice/query/stream/StreamingServiceTest.java
@@ -1,5 +1,7 @@
 package datawave.microservice.query.stream;
 
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,8 +45,6 @@ import datawave.microservice.query.remote.QueryRequest;
 import datawave.microservice.query.storage.QueryStatus;
 import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.result.DefaultEventQueryResponse;
-
-import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)


### PR DESCRIPTION
Recently there were some issues that occurred with the `check-code-formatting` job when being run with the merge queue event. 

A specific example can be seen here: https://github.com/NationalSecurityAgency/datawave/actions/runs/13444100011

So, this PR aims to resolve this by removing the previous rebasing and skips the test when entering the merge queue.

This PR also broadens the scope of the files to be formatted. This is important now that the submodules were merged.