### PR TITLE
Decompose identifiers prior to looking up field normalizers for content functions

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FunctionNormalizationRebuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FunctionNormalizationRebuildingVisitor.java
@@ -216,6 +216,7 @@ public class FunctionNormalizationRebuildingVisitor extends RebuildingVisitor {
                 normalizers.add(NO_OP);
             } else {
                 for (String field : argGroup.getKey()) {
+                    field = JexlASTHelper.deconstructIdentifier(field);
                     normalizers.addAll(allNormalizers.get(field));
                 }
             }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionNormalizationRebuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FunctionNormalizationRebuildingVisitorTest.java
@@ -33,12 +33,14 @@ public class FunctionNormalizationRebuildingVisitorTest {
     @BeforeEach
     public void setup() {
         helper = new MockMetadataHelper();
-        ((MockMetadataHelper) helper).addFields(Set.of("FOO", "NUM"));
-        ((MockMetadataHelper) helper).addTermFrequencyFields(Set.of("FOO", "NUM"));
+        ((MockMetadataHelper) helper).addFields(Set.of("FOO", "NUM", "123_A"));
+        ((MockMetadataHelper) helper).addTermFrequencyFields(Set.of("FOO", "NUM", "123_A"));
 
         normalizers = LinkedListMultimap.create();
         normalizers.putAll("FOO", List.of(new NoOpType(), new LcNoDiacriticsType()));
         normalizers.putAll("NUM", List.of(new NoOpType(), new NumberType()));
+        normalizers.putAll("123_A", List.of(new NoOpType(), new NumberType()));
+
     }
 
     @Test
@@ -99,6 +101,12 @@ public class FunctionNormalizationRebuildingVisitorTest {
 
         query = "content:phrase(NUM, termOffsetMap, '12', '23')";
         test(query, "(content:phrase(NUM, termOffsetMap, '+bE1.2', '+bE2.3') || content:phrase(NUM, termOffsetMap, '12', '23'))");
+    }
+
+    @Test
+    public void testRemoveIdentifiers_Normalized() {
+        String query = "content:phrase($123_A, termOffsetMap, '12', '23')";
+        test(query, "(content:phrase($123_A, termOffsetMap, '+bE1.2', '+bE2.3') || content:phrase($123_A, termOffsetMap, '12', '23'))");
     }
 
     @Test


### PR DESCRIPTION
* Fields names (identifiers) starting with numbers require a leading '$' in JEXL (e.g., $1234_A)
* Datatypes/normalizers for these fields are registered te field without the leading '$' (e.g 1234_A)
* When looking up the normalizers to apply to a field in the context of content functions, the '$' was not being removed from the field names, so the proper normalizers weren't found.

This fix add the call to properly clean the field name before attempting to look up the normalizer.