### PR TITLE
datawave-code-style stop indenting blank lines

### DIFF
--- a/contrib/datawave-utils/code-style/pom.xml
+++ b/contrib/datawave-utils/code-style/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>gov.nsa.datawave</groupId>
     <artifactId>datawave-code-style</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>DataWave Code Formatter</name>
     <description>This pom configures the formatter-maven-plugin to format the code

--- a/contrib/datawave-utils/code-style/src/main/resources/eclipse/Eclipse-Datawave-Codestyle.xml
+++ b/contrib/datawave-utils/code-style/src/main/resources/eclipse/Eclipse-Datawave-Codestyle.xml
@@ -159,7 +159,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>


### PR DESCRIPTION
we are removing trailing whitespace in the formatter config which occurs after the formatter rules have been applied so we should stop indenting blank lines in those rules. The `contrib/datawave-utils/code-style/src/main/resources/eclipse/Eclipse-Datawave-Codestyle.xml` can be imported into IntelliJ so the IDE formats the same way as Maven on the command line.  
`Settings -> Editor -> Code Style -> Scheme -> Gear icon -> Import Scheme -> Eclipse XML Profile`