### PR TITLE
 DO NOT MERGE:   Updated the ability to configure date types for no expansion (#2808)

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -539,12 +539,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private Set<String> noExpansionIfCurrentDateTypes = Collections.emptySet();
 
     /**
-     * Whether the SHARDS_AND_DAYS hint should be allowed for the query. This will be set to false iff the query specified a date type, and the date type is
-     * present in {@link #noExpansionIfCurrentDateTypes}, and the query's end date is the current date.
-     */
-    private boolean shardsAndDaysHintAllowed = true;
-
-    /**
      * Default constructor
      */
     public ShardQueryConfiguration() {
@@ -790,7 +784,6 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setIndexFieldHoleMinThreshold(other.getIndexFieldHoleMinThreshold());
         this.setNoExpansionIfCurrentDateTypes(
                         other.getNoExpansionIfCurrentDateTypes() == null ? null : Sets.newHashSet(other.getNoExpansionIfCurrentDateTypes()));
-        this.setShardsAndDaysHintAllowed(other.isShardsAndDaysHintAllowed());
     }
 
     /**
@@ -3078,8 +3071,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 isSortQueryPostIndexWithTermCounts() == that.isSortQueryPostIndexWithTermCounts() &&
                 isSortQueryPostIndexWithFieldCounts() == that.isSortQueryPostIndexWithFieldCounts() &&
                 getCardinalityThreshold() == that.getCardinalityThreshold() &&
-                Objects.equals(getNoExpansionIfCurrentDateTypes(), that.getNoExpansionIfCurrentDateTypes()) &&
- isShardsAndDaysHintAllowed() == that.isShardsAndDaysHintAllowed();
+                Objects.equals(getNoExpansionIfCurrentDateTypes(), that.getNoExpansionIfCurrentDateTypes());
 
         // @formatter:on
     }
@@ -3288,8 +3280,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 isSortQueryPostIndexWithTermCounts(),
                 isSortQueryPostIndexWithFieldCounts(),
                 getCardinalityThreshold(),
-                getNoExpansionIfCurrentDateTypes(),
-                isShardsAndDaysHintAllowed()
+                getNoExpansionIfCurrentDateTypes()
         );
         // @formatter:on
     }
@@ -3331,13 +3322,5 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setNoExpansionIfCurrentDateTypes(Set<String> noExpansionIfCurrentDateTypes) {
         this.noExpansionIfCurrentDateTypes = noExpansionIfCurrentDateTypes;
-    }
-
-    public boolean isShardsAndDaysHintAllowed() {
-        return shardsAndDaysHintAllowed;
-    }
-
-    public void setShardsAndDaysHintAllowed(boolean shardsAndDaysHintAllowed) {
-        this.shardsAndDaysHintAllowed = shardsAndDaysHintAllowed;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -973,18 +973,15 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             throw new DatawaveFatalQueryException("Found incorrectly marked bounded ranges");
         }
 
-        // Do not add a SHARDS_AND_DAYS hint if it is specifically not allowed. This was checked and updated when timedIncludeDateFilters was called.
-        if (config.isShardsAndDaysHintAllowed()) {
-            if (optionsMap.containsKey(QueryParameters.SHARDS_AND_DAYS)) {
+        if (optionsMap.containsKey(QueryParameters.SHARDS_AND_DAYS)) {
+            config.setQueryTree(timedAddShardsAndDaysFromOptions(timers, config.getQueryTree(), optionsMap));
+        } else {
+            // look for the shards and days hint in the query settings
+            // the shards and days hint cannot always be specified in the query string when using certain query parsers
+            Parameter parameter = settings.findParameter(QueryParameters.SHARDS_AND_DAYS);
+            if (StringUtils.isNotBlank(parameter.getParameterValue())) {
+                optionsMap.put(QueryParameters.SHARDS_AND_DAYS, parameter.getParameterValue());
                 config.setQueryTree(timedAddShardsAndDaysFromOptions(timers, config.getQueryTree(), optionsMap));
-            } else {
-                // look for the shards and days hint in the query settings
-                // the shards and days hint cannot always be specified in the query string when using certain query parsers
-                Parameter parameter = settings.findParameter(QueryParameters.SHARDS_AND_DAYS);
-                if (StringUtils.isNotBlank(parameter.getParameterValue())) {
-                    optionsMap.put(QueryParameters.SHARDS_AND_DAYS, parameter.getParameterValue());
-                    config.setQueryTree(timedAddShardsAndDaysFromOptions(timers, config.getQueryTree(), optionsMap));
-                }
             }
         }
 
@@ -2231,64 +2228,54 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
                                         .collect(Collectors.toSet());
         // @formatter:on
 
-        // If the date type is one marked for no expansion if current, and the query's end date is the current date, do not add any date filters, and do not
-        // allow a SHARDS_AND_DAYS hint to be added later.
-        if (config.getNoExpansionIfCurrentDateTypes().contains(dateType) && DateUtils.isSameDay(new Date(), config.getEndDate())) {
-            log.info("Query end date equals current date and date type " + dateType
-                            + " is marked for no expansion if current. SHARDS_AND_DAYS hint will be forbidden.");
-            config.setShardsAndDaysHintAllowed(false);
-        } else {
-            // If we are using something other than the default of EVENT date time, then we need to modify the query.
-            if (!dateType.equals(defaultDateType)) {
-                log.info("Using the date index for " + dateType);
-                // if no date index helper configured, then we are in error
-                if (dateIndexHelper == null) {
-                    throw new DatawaveQueryException("Requested date range of type " + dateType + " but no date index is configured");
-                }
-                // get all of the fields used for this date type
-                DateIndexHelper.DateTypeDescription dateIndexData = dateIndexHelper.getTypeDescription(dateType, config.getBeginDate(), config.getEndDate(),
-                                config.getDatatypeFilter());
-                if (dateIndexData.getFields().isEmpty()) {
-                    log.warn("The specified date type: " + dateType + " is unknown for the specified data types");
-                    // If this is the case, then essentially we have no dates to search. Adding the filter function with _NO_FIELD_ will have the desired
-                    // effect.
-                    // Also it will be understandable from the plan as to why no results were returned.
-                    dateIndexData.getFields().add(Constants.NO_FIELD);
-                }
-                log.info("Adding date filters for the following fields: " + dateIndexData.getFields());
-                // now for each field, add an expression to filter that date
-                List<JexlNode> andChildren = new ArrayList<>();
-                for (int i = 0; i < queryTree.jjtGetNumChildren(); i++) {
-                    if (queryTree.jjtGetChild(i) instanceof ASTAndNode) {
-                        andChildren.add(queryTree.jjtGetChild(i));
-                    } else {
-                        andChildren.add(JexlNodeFactory.createExpression(queryTree.jjtGetChild(i)));
-                    }
-                }
-                List<JexlNode> orChildren = new ArrayList<>();
-                for (String field : dateIndexData.getFields()) {
-                    orChildren.add(createDateFilter(dateType, field, config.getBeginDate(), config.getEndDate()));
-                }
-                if (orChildren.size() > 1) {
-                    andChildren.add(JexlNodeFactory.createOrNode(orChildren));
-                } else {
-                    andChildren.addAll(orChildren);
-                }
-                JexlNode andNode = JexlNodeFactory.createAndNode(andChildren);
-                JexlNodeFactory.setChildren(queryTree, Collections.singleton(andNode));
-
-                // now lets update the query parameters with the correct start and
-                // end dates
-                log.info("Remapped " + dateType + " dates [" + config.getBeginDate() + "," + config.getEndDate() + "] to EVENT dates "
-                                + dateIndexData.getBeginDate() + "," + dateIndexData.getEndDate());
-
-                // reset the dates in the configuration, no need to reset then in
-                // the Query settings object
-                config.setBeginDate(dateIndexData.getBeginDate());
-                config.setEndDate(dateIndexData.getEndDate());
-            } else {
-                log.info("Date index not needed for this query");
+        // If we are using something other than the default of EVENT date time, then we need to modify the query.
+        if (!dateType.equals(defaultDateType)) {
+            log.info("Using the date index for " + dateType);
+            // if no date index helper configured, then we are in error
+            if (dateIndexHelper == null) {
+                throw new DatawaveQueryException("Requested date range of type " + dateType + " but no date index is configured");
             }
+            // get all of the fields used for this date type
+            DateIndexHelper.DateTypeDescription dateIndexData = dateIndexHelper.getTypeDescription(dateType, config.getBeginDate(), config.getEndDate(),
+                            config.getDatatypeFilter());
+            if (dateIndexData.getFields().isEmpty()) {
+                log.warn("The specified date type: " + dateType + " is unknown for the specified data types");
+                // If this is the case, then essentially we have no dates to search. Adding the filter function with _NO_FIELD_ will have the desired
+                // effect.
+                // Also it will be understandable from the plan as to why no results were returned.
+                dateIndexData.getFields().add(Constants.NO_FIELD);
+            }
+            log.info("Adding date filters for the following fields: " + dateIndexData.getFields());
+            // now for each field, add an expression to filter that date
+            List<JexlNode> andChildren = new ArrayList<>();
+            for (int i = 0; i < queryTree.jjtGetNumChildren(); i++) {
+                if (queryTree.jjtGetChild(i) instanceof ASTAndNode) {
+                    andChildren.add(queryTree.jjtGetChild(i));
+                } else {
+                    andChildren.add(JexlNodeFactory.createExpression(queryTree.jjtGetChild(i)));
+                }
+            }
+            List<JexlNode> orChildren = new ArrayList<>();
+            for (String field : dateIndexData.getFields()) {
+                orChildren.add(createDateFilter(dateType, field, config.getBeginDate(), config.getEndDate()));
+            }
+            if (orChildren.size() > 1) {
+                andChildren.add(JexlNodeFactory.createOrNode(orChildren));
+            } else {
+                andChildren.addAll(orChildren);
+            }
+            JexlNode andNode = JexlNodeFactory.createAndNode(andChildren);
+            JexlNodeFactory.setChildren(queryTree, Collections.singleton(andNode));
+
+            // now lets update the query parameters with the correct start and
+            // end dates
+            log.info("Remapped " + dateType + " dates [" + config.getBeginDate() + "," + config.getEndDate() + "] to EVENT dates "
+                            + dateIndexData.getBeginDate() + "," + dateIndexData.getEndDate());
+
+            // reset the dates in the configuration, no need to reset then in
+            // the Query settings object
+            config.setBeginDate(dateIndexData.getBeginDate());
+            config.setEndDate(dateIndexData.getEndDate());
         }
 
         return queryTree;

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -611,9 +611,6 @@ public class ShardQueryConfigurationTest {
 
         defaultValues.put("noExpansionIfCurrentDateTypes", Collections.emptySet());
         updatedValues.put("noExpansionIfCurrentDateTypes", Collections.singleton("EVENT"));
-
-        defaultValues.put("shardsAndDaysHintAllowed", true);
-        updatedValues.put("shardsAndDaysHintAllowed", false);
     }
 
     private Query createQuery(String query) {

--- a/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
@@ -67,8 +67,8 @@ class DefaultQueryPlannerTest {
 
             ASTJexlScript actual = addDateFilters();
 
+            // no hints or date filter required in this case
             JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertFalse(config.isShardsAndDaysHintAllowed());
             Assertions.assertEquals(beginDate, config.getBeginDate());
             Assertions.assertEquals(endDate, config.getEndDate());
         }
@@ -89,13 +89,15 @@ class DefaultQueryPlannerTest {
             config.setEndDate(endDate);
 
             settings.addParameter(QueryParameters.DATE_RANGE_TYPE, "SPECIAL_EVENT");
+            dateIndexHelper.addEntry("20250101", "SPECIAL_EVENT", "wiki", "FOO", "20250101_shard");
 
             ASTJexlScript actual = addDateFilters();
 
-            JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertFalse(config.isShardsAndDaysHintAllowed());
-            Assertions.assertEquals(beginDate, config.getBeginDate());
-            Assertions.assertEquals(endDate, config.getEndDate());
+            // no hints but the date filter is still used
+            JexlNodeAssert.assertThat(actual).isEqualTo(
+                            "(FOO == 'bar') && filter:betweenDates(FOO, '" + filterFormat.format(beginDate) + "', '" + filterFormat.format(endDate) + "')");
+            Assertions.assertEquals(DateIndexUtil.getBeginDate("20250101"), config.getBeginDate());
+            Assertions.assertEquals(DateIndexUtil.getEndDate("20250101"), config.getEndDate());
         }
 
         /**
@@ -115,8 +117,8 @@ class DefaultQueryPlannerTest {
 
             ASTJexlScript actual = addDateFilters();
 
+            // no hints or date filter required in this case
             JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertTrue(config.isShardsAndDaysHintAllowed());
             Assertions.assertEquals(beginDate, config.getBeginDate());
             Assertions.assertEquals(endDate, config.getEndDate());
         }
@@ -139,9 +141,9 @@ class DefaultQueryPlannerTest {
 
             ASTJexlScript actual = addDateFilters();
 
+            // hints and date filter used in this case
             JexlNodeAssert.assertThat(actual).hasExactQueryString(
                             "(FOO == 'bar') && filter:betweenDates(FOO, '" + filterFormat.format(beginDate) + "', '" + filterFormat.format(endDate) + "')");
-            Assertions.assertTrue(config.isShardsAndDaysHintAllowed());
             Assertions.assertEquals(DateIndexUtil.getBeginDate("20241010"), config.getBeginDate());
             Assertions.assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
         }
@@ -163,8 +165,8 @@ class DefaultQueryPlannerTest {
 
             ASTJexlScript actual = addDateFilters();
 
+            // no hints or date filter required in this case
             JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertTrue(config.isShardsAndDaysHintAllowed());
             Assertions.assertEquals(beginDate, config.getBeginDate());
             Assertions.assertEquals(endDate, config.getEndDate());
         }
@@ -189,9 +191,9 @@ class DefaultQueryPlannerTest {
 
             ASTJexlScript actual = addDateFilters();
 
+            // hints and date filter used in this case
             JexlNodeAssert.assertThat(actual).hasExactQueryString(
                             "(FOO == 'bar') && filter:betweenDates(FOO, '" + filterFormat.format(beginDate) + "', '" + filterFormat.format(endDate) + "')");
-            Assertions.assertTrue(config.isShardsAndDaysHintAllowed());
             Assertions.assertEquals(DateIndexUtil.getBeginDate("20241010"), config.getBeginDate());
             Assertions.assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
         }


### PR DESCRIPTION
* Ensure that the date filter and bounds checks are still added to the query and only the SHARD_AND_DAYS hint is dropped

    Fixes #2636