### PR TITLE
Preserve token context for term frequency entries to avoid position overlap across multiple field instances

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/EventQueryJexlContentGrouped.test
+++ b/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/EventQueryJexlContentGrouped.test
@@ -1,0 +1,74 @@
+################################################################
+# Grouped content-function tests for tokenized fields in nested JSON
+
+# These tests exercise phrase evaluation over grouped term-frequency
+# entries produced from the tvmaze quickstart sample data.
+
+# In The Big Bang Theory sample document, "Jim Parsons" and
+# "Johnny Galecki" are separate EMBEDDED_CAST_PERSON_NAME values under
+# different CAST elements. A grouped TF-aware phrase query should:
+#   1. match "jim parsons" within one grouped context
+#   2. reject "jim galecki" across two grouped contexts
+
+################################################################
+# Positive phrase query: both terms come from the same grouped value
+
+setCurlData query=$( urlencode "GENRES == 'comedy' && EMBEDDED_CAST_PERSON_NAME_TOKEN == 'jim' && EMBEDDED_CAST_PERSON_NAME_TOKEN == 'parsons' && content:phrase(EMBEDDED_CAST_PERSON_NAME_TOKEN, termOffsetMap, 'jim', 'parsons')" ) \
+        queryName=EventQueryGroupedContentPhrasePositive \
+        begin=19700101 \
+        end=20990101 \
+        pagesize=1 \
+        auths=BAR,FOO,PRIVATE \
+        columnVisibility=PRIVATE \
+        query.syntax=JEXL
+
+configureTest \
+        CreateGroupedContentPhrasePositive \
+        "Creates a grouped content-function query that should match Jim Parsons within one cast entry" \
+        "--header 'Content-Type: application/x-www-form-urlencoded' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Query/EventQuery/create" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest --set-query-id
+
+configureTest \
+        GroupedContentPhrasePositivePage1 \
+        "Gets the first page of results for the grouped positive content-function test in JSON format" \
+        "--header 'Accept: application/json' -X GET ${URI_ROOT}/Query/${DW_QUERY_ID}/next" \
+        application/json \
+        200
+
+runTest
+
+configureCloseQueryTest ${DW_QUERY_ID}
+
+runTest
+
+################################################################
+# Negative phrase query: terms exist in the same base field but in
+# different grouped contexts, so this should not match
+
+setCurlData query=$( urlencode "GENRES == 'comedy' && EMBEDDED_CAST_PERSON_NAME_TOKEN == 'jim' && EMBEDDED_CAST_PERSON_NAME_TOKEN == 'galecki' && content:phrase(EMBEDDED_CAST_PERSON_NAME_TOKEN, termOffsetMap, 'jim', 'galecki')" ) \
+        queryName=EventQueryGroupedContentPhraseNegative \
+        begin=19700101 \
+        end=20990101 \
+        pagesize=1 \
+        auths=BAR,FOO,PRIVATE \
+        columnVisibility=PRIVATE \
+        query.syntax=JEXL
+
+configureTest \
+        CreateGroupedContentPhraseNegative \
+        "Creates a grouped content-function query that should not match across separate cast entries" \
+        "--header 'Content-Type: application/x-www-form-urlencoded' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Query/EventQuery/create" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest --set-query-id
+
+configureTest \
+        GroupedContentPhraseNegative204 \
+        "Returns 204 because Jim and Galecki occur in separate grouped cast contexts" \
+        "--header 'Accept: application/json' -X GET ${URI_ROOT}/Query/${DW_QUERY_ID}/next" \
+        "" \
+        204

--- a/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/EventQueryTokenizedLuceneContentGrouped.test
+++ b/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/EventQueryTokenizedLuceneContentGrouped.test
@@ -1,0 +1,74 @@
+################################################################
+# Grouped TOKENIZED-LUCENE phrase tests for tokenized fields in nested JSON
+
+# These tests validate the TOKENIZED-LUCENE parser path for grouped
+# term-frequency evaluation using the tvmaze quickstart sample data.
+
+# In The Big Bang Theory sample document, "Jim Parsons" and
+# "Johnny Galecki" are separate EMBEDDED_CAST_PERSON_NAME values under
+# different CAST elements. A grouped TF-aware tokenized phrase query should:
+#   1. match EMBEDDED_CAST_PERSON_NAME_TOKEN:"jim parsons"
+#   2. reject EMBEDDED_CAST_PERSON_NAME_TOKEN:"jim galecki"
+
+################################################################
+# Positive phrase query: both terms come from the same grouped value
+
+setCurlData query=$( urlencode "GENRES:comedy AND EMBEDDED_CAST_PERSON_NAME_TOKEN:\"jim parsons\"" ) \
+        queryName=EventQueryTokenizedLuceneGroupedContentPhrasePositive \
+        begin=19700101 \
+        end=20990101 \
+        pagesize=1 \
+        auths=BAR,FOO,PRIVATE \
+        columnVisibility=PRIVATE \
+        query.syntax=TOKENIZED-LUCENE
+
+configureTest \
+        CreateTokenizedLuceneGroupedContentPhrasePositive \
+        "Creates a TOKENIZED-LUCENE grouped phrase query that should match Jim Parsons within one cast entry" \
+        "--header 'Content-Type: application/x-www-form-urlencoded' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Query/EventQuery/create" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest --set-query-id
+
+configureTest \
+        TokenizedLuceneGroupedContentPhrasePositivePage1 \
+        "Gets the first page of results for the grouped TOKENIZED-LUCENE positive phrase test in JSON format" \
+        "--header 'Accept: application/json' -X GET ${URI_ROOT}/Query/${DW_QUERY_ID}/next" \
+        application/json \
+        200
+
+runTest
+
+configureCloseQueryTest ${DW_QUERY_ID}
+
+runTest
+
+################################################################
+# Negative phrase query: terms exist in the same base field but in
+# different grouped contexts, so this should not match
+
+setCurlData query=$( urlencode "GENRES:comedy AND EMBEDDED_CAST_PERSON_NAME_TOKEN:\"jim galecki\"" ) \
+        queryName=EventQueryTokenizedLuceneGroupedContentPhraseNegative \
+        begin=19700101 \
+        end=20990101 \
+        pagesize=1 \
+        auths=BAR,FOO,PRIVATE \
+        columnVisibility=PRIVATE \
+        query.syntax=TOKENIZED-LUCENE
+
+configureTest \
+        CreateTokenizedLuceneGroupedContentPhraseNegative \
+        "Creates a TOKENIZED-LUCENE grouped phrase query that should not match across separate cast entries" \
+        "--header 'Content-Type: application/x-www-form-urlencoded' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Query/EventQuery/create" \
+        "application/xml;charset=UTF-8" \
+        200
+
+runTest --set-query-id
+
+configureTest \
+        TokenizedLuceneGroupedContentPhraseNegative204 \
+        "Returns 204 because Jim and Galecki occur in separate grouped cast contexts" \
+        "--header 'Accept: application/json' -X GET ${URI_ROOT}/Query/${DW_QUERY_ID}/next" \
+        "" \
+        204

--- a/warehouse/core/src/test/java/datawave/data/hash/HashUIDTest.java
+++ b/warehouse/core/src/test/java/datawave/data/hash/HashUIDTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 @SuppressWarnings("deprecation")
 public class HashUIDTest {
 
-    private String data = "20100901: the quick brown fox jumped over the lazy dog";
-    private String data2 = "20100831: the quick brown fox jumped over the lazy dog";
+    private final String data = "20100901: the quick brown fox jumped over the lazy dog";
+    private final String data2 = "20100831: the quick brown fox jumped over the lazy dog";
 
     @Test
     public void testParsing() {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/tokenize/TokenizationHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/tokenize/TokenizationHelper.java
@@ -4,14 +4,14 @@ import static org.apache.lucene.analysis.core.StopAnalyzer.ENGLISH_STOP_WORDS_SE
 
 import java.io.IOException;
 
-import datawave.data.hash.HashUID;
-import datawave.data.hash.UID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import datawave.data.hash.HashUID;
+import datawave.data.hash.UID;
 import datawave.ingest.data.config.DataTypeHelper;
 import datawave.util.ObjectFactory;
 
@@ -397,9 +397,12 @@ public class TokenizationHelper {
         return stopWords;
     }
 
-    /** Obtains a Mumur hash for the specified content. Appended to the field name, so that distinct fields are
-     *  produced based on the content value - and that proximity queries across content contexts don't match.
-     * @param content the content for which to generate the hash
+    /**
+     * Obtains a Mumur hash for the specified content. Appended to the field name, so that distinct fields are produced based on the content value - and that
+     * proximity queries across content contexts don't match.
+     *
+     * @param content
+     *            the content for which to generate the hash
      * @return the string version of the hash. Only the first portion of the HashUID is returned.
      */
     public String getContentContextHash(String content) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/tokenize/TokenizationHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/tokenize/TokenizationHelper.java
@@ -4,6 +4,8 @@ import static org.apache.lucene.analysis.core.StopAnalyzer.ENGLISH_STOP_WORDS_SE
 
 import java.io.IOException;
 
+import datawave.data.hash.HashUID;
+import datawave.data.hash.UID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -143,6 +145,9 @@ public class TokenizationHelper {
     public static final String MAX_URL_DECODES = ".token.interfield.position.increment";
     private int maxUrlDecodes = 2;
 
+    public static final String CONTENT_CONTEXT_ENABLED = ".token.content.context.enabled";
+    private boolean contentContextEnabled = false;
+
     public TokenizationHelper(DataTypeHelper helper, Configuration conf) throws IllegalArgumentException {
         analyzerClassName = conf.get(helper.getType().typeName() + ANALYZER_CLASS, analyzerClassName);
         stopWordList = conf.get(helper.getType().typeName() + STOP_WORD_LIST, stopWordList);
@@ -164,6 +169,7 @@ public class TokenizationHelper {
         tokenizerTimeWarnThresholdMsec = conf.getLong(helper.getType().typeName() + TOKENIZER_TIME_WARN_MSEC, tokenizerTimeWarnThresholdMsec);
         tokenizerTimeErrorThresholdMsec = conf.getLong(helper.getType().typeName() + TOKENIZER_TIME_ERROR_MSEC, tokenizerTimeErrorThresholdMsec);
         interFieldPositionIncrement = conf.getInt(helper.getType().typeName() + INTERFIELD_POSITION_INCREMENT, interFieldPositionIncrement);
+        contentContextEnabled = conf.getBoolean(helper.getType().typeName() + CONTENT_CONTEXT_ENABLED, contentContextEnabled);
 
         final String nameProp = helper.getType().typeName() + TOKENIZER_TIME_THRESHOLD_NAMES;
         final String threshProp = helper.getType().typeName() + TOKENIZER_TIME_THRESHOLDS_MSEC;
@@ -352,6 +358,14 @@ public class TokenizationHelper {
         this.maxUrlDecodes = maxUrlDecodes;
     }
 
+    public boolean isContentContextEnabled() {
+        return contentContextEnabled;
+    }
+
+    public void setContentContextEnabled(boolean contentContextEnabled) {
+        this.contentContextEnabled = contentContextEnabled;
+    }
+
     public TokenSearch configureSearchUtil(TokenSearch searchUtil) {
         searchUtil.setDirtyWordTokensEnabled(isDirtyWordTokensEnabled());
         searchUtil.setFileWordTokensEnabled(isFileWordTokensEnabled());
@@ -381,5 +395,17 @@ public class TokenizationHelper {
             stopWords = ENGLISH_STOP_WORDS_SET;
         }
         return stopWords;
+    }
+
+    /** Obtains a Mumur hash for the specified content. Appended to the field name, so that distinct fields are
+     *  produced based on the content value - and that proximity queries across content contexts don't match.
+     * @param content the content for which to generate the hash
+     * @return the string version of the hash. Only the first portion of the HashUID is returned.
+     */
+    public String getContentContextHash(String content) {
+        UID uid = HashUID.builder().newId(content);
+        String uidString = uid.getBaseUid();
+        int first = uidString.indexOf(".");
+        return uidString.substring(0, first);
     }
 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandler.java
@@ -360,6 +360,10 @@ public abstract class ContentIndexingColumnBasedHandler<KEYIN> extends AbstractC
         String modifiedFieldName = indexedFieldName + tokenFieldNameSuffix;
         String content = nci.getIndexedFieldValue();
 
+        if (tokenHelper.isContentContextEnabled()) {
+            modifiedFieldName = modifiedFieldName + "." + tokenHelper.getContentContextHash(content);
+        }
+
         TokenStream tokenizer = a.tokenStream(indexedFieldName, new StringReader(content));
         tokenizer.reset();
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandlerTest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import datawave.ingest.data.tokenize.TokenizationHelper;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Value;
@@ -39,6 +38,7 @@ import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.ingest.data.config.ingest.BaseIngestHelper;
 import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
+import datawave.ingest.data.tokenize.TokenizationHelper;
 import datawave.ingest.input.reader.EventRecordReader;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.policy.IngestPolicyEnforcer;
@@ -176,10 +176,10 @@ public class ContentIndexingColumnBasedHandlerTest {
                         tokenizedExpectedFieldsWithSpace, tokenizedExpectedIndexWithSpace, tokenizedExpectedReverseWithSpace,
                         tokenizedExpectedTfValuesWithSpace);
         SetExpectedMap(ALPHANUM_LIST + TOKEN_DESIGNATOR + ".kir5i4", tokenizeAlphanumResultsWithSpace, tokenizeAlphanumReverseResultsWithSpace,
-                tokenizedExpectedFieldsWithContext, tokenizedExpectedIndexWithContext, tokenizedExpectedReverseWithContext,
-                tokenizedExpectedTfValuesWithContext);
+                        tokenizedExpectedFieldsWithContext, tokenizedExpectedIndexWithContext, tokenizedExpectedReverseWithContext,
+                        tokenizedExpectedTfValuesWithContext);
         SetExpectedMap(ALPHANUM_LIST, listAlphanumResults, listAlphanumReverseResults, listExpectedAlphanumFields, listExpectedAlphanumIndex,
-                listExpectedAlphanumReverse, listExpectedAlphanumTfValues);
+                        listExpectedAlphanumReverse, listExpectedAlphanumTfValues);
         SetExpectedMap(NUMERIC_LIST, listNumericResults, listNumericReverseResults, listExpectedNumericFields, listExpectedNumericIndex,
                         listExpectedNumericReverse, listExpectedNumericTfValues);
     }
@@ -250,7 +250,7 @@ public class ContentIndexingColumnBasedHandlerTest {
 
         helper.setup(ctx.getConfiguration());
         testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_SPACE, tokenizedExpectedFieldsWithContext, tokenizedExpectedIndexWithContext,
-                tokenizedExpectedReverseWithContext, tokenizedExpectedTfValuesWithContext, true);
+                        tokenizedExpectedReverseWithContext, tokenizedExpectedTfValuesWithContext, true);
     }
 
     @Test

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandlerTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import datawave.ingest.data.tokenize.TokenizationHelper;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Value;
@@ -54,7 +55,7 @@ public class ContentIndexingColumnBasedHandlerTest {
     private static final char INTRA_COL_DELIMETER = '\u0000';
 
     private static final String NUMERIC_LIST = "NUMERIC_LIST";
-    private static final String ALPHANUM_LIST = "APLHANUM_LIST";
+    private static final String ALPHANUM_LIST = "ALPHANUM_LIST";
     private static final String LIST_VALUE = "12.34,56.78";
     private static final String LIST_VALUE_WITH_SPACE = "12.34, 56.78";
     private static final String LIST_VALUE_WITH_EMPTY_ENTRY = "12.34, , 56.78";
@@ -62,34 +63,39 @@ public class ContentIndexingColumnBasedHandlerTest {
     private static final Text SHARD_TABLE_NAME = new Text("shard");
     private static final String TF = "tf";
 
-    private static String[] tokenizeAlphanumResults = {"12", "34", "56", "78", "12.34,56.78"};
-    private static String[] tokenizeAlphanumResultsWithSpace = {"12", "34", "56", "78", "12.34", "56.78"};
-    private static String[] tokenizeAlphanumReverseResults = {"21", "43", "65", "87", "87.65,43.21"};
-    private static String[] tokenizeAlphanumReverseResultsWithSpace = {"21", "43", "65", "87", "87.65", "43.21"};
-    private static String[] listAlphanumResults = {"12.34", "56.78"};
-    private static String[] listAlphanumReverseResults = {"43.21", "87.65"};
-    private static String[] listNumericResults = {"+bE1.234", "+bE5.678"};
-    private static String[] listNumericReverseResults = {"+bE4.321", "+bE8.765"};
+    private static final String[] tokenizeAlphanumResults = {"12", "34", "56", "78", "12.34,56.78"};
+    private static final String[] tokenizeAlphanumResultsWithSpace = {"12", "34", "56", "78", "12.34", "56.78"};
+    private static final String[] tokenizeAlphanumReverseResults = {"21", "43", "65", "87", "87.65,43.21"};
+    private static final String[] tokenizeAlphanumReverseResultsWithSpace = {"21", "43", "65", "87", "87.65", "43.21"};
+    private static final String[] listAlphanumResults = {"12.34", "56.78"};
+    private static final String[] listAlphanumReverseResults = {"43.21", "87.65"};
+    private static final String[] listNumericResults = {"+bE1.234", "+bE5.678"};
+    private static final String[] listNumericReverseResults = {"+bE4.321", "+bE8.765"};
 
-    private static Multimap<String,NormalizedContentInterface> tokenizedExpectedFields = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> tokenizedExpectedIndex = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> tokenizedExpectedReverse = HashMultimap.create();
-    private static Multimap<String,Pair<String,Integer>> tokenizedExpectedTfValues = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedFields = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedIndex = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedReverse = HashMultimap.create();
+    private static final Multimap<String,Pair<String,Integer>> tokenizedExpectedTfValues = HashMultimap.create();
 
-    private static Multimap<String,NormalizedContentInterface> tokenizedExpectedFieldsWithSpace = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> tokenizedExpectedIndexWithSpace = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> tokenizedExpectedReverseWithSpace = HashMultimap.create();
-    private static Multimap<String,Pair<String,Integer>> tokenizedExpectedTfValuesWithSpace = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedFieldsWithSpace = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedIndexWithSpace = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedReverseWithSpace = HashMultimap.create();
+    private static final Multimap<String,Pair<String,Integer>> tokenizedExpectedTfValuesWithSpace = HashMultimap.create();
 
-    private static Multimap<String,NormalizedContentInterface> listExpectedNumericFields = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> listExpectedNumericIndex = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> listExpectedNumericReverse = HashMultimap.create();
-    private static Multimap<String,Pair<String,Integer>> listExpectedNumericTfValues = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedFieldsWithContext = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedIndexWithContext = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> tokenizedExpectedReverseWithContext = HashMultimap.create();
+    private static final Multimap<String,Pair<String,Integer>> tokenizedExpectedTfValuesWithContext = HashMultimap.create();
 
-    private static Multimap<String,NormalizedContentInterface> listExpectedAlpahnumFields = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> listExpectedAlpahnumIndex = HashMultimap.create();
-    private static Multimap<String,NormalizedContentInterface> listExpectedAlpahnumReverse = HashMultimap.create();
-    private static Multimap<String,Pair<String,Integer>> listExpectedAlphanumTfValues = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> listExpectedNumericFields = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> listExpectedNumericIndex = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> listExpectedNumericReverse = HashMultimap.create();
+    private static final Multimap<String,Pair<String,Integer>> listExpectedNumericTfValues = HashMultimap.create();
+
+    private static final Multimap<String,NormalizedContentInterface> listExpectedAlphanumFields = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> listExpectedAlphanumIndex = HashMultimap.create();
+    private static final Multimap<String,NormalizedContentInterface> listExpectedAlphanumReverse = HashMultimap.create();
+    private static final Multimap<String,Pair<String,Integer>> listExpectedAlphanumTfValues = HashMultimap.create();
 
     private RawRecordContainer event = EasyMock.createMock(RawRecordContainer.class);
     private TestContentBaseIngestHelper helper;
@@ -169,8 +175,11 @@ public class ContentIndexingColumnBasedHandlerTest {
         SetExpectedMap(ALPHANUM_LIST + TOKEN_DESIGNATOR, tokenizeAlphanumResultsWithSpace, tokenizeAlphanumReverseResultsWithSpace,
                         tokenizedExpectedFieldsWithSpace, tokenizedExpectedIndexWithSpace, tokenizedExpectedReverseWithSpace,
                         tokenizedExpectedTfValuesWithSpace);
-        SetExpectedMap(ALPHANUM_LIST, listAlphanumResults, listAlphanumReverseResults, listExpectedAlpahnumFields, listExpectedAlpahnumIndex,
-                        listExpectedAlpahnumReverse, listExpectedAlphanumTfValues);
+        SetExpectedMap(ALPHANUM_LIST + TOKEN_DESIGNATOR + ".kir5i4", tokenizeAlphanumResultsWithSpace, tokenizeAlphanumReverseResultsWithSpace,
+                tokenizedExpectedFieldsWithContext, tokenizedExpectedIndexWithContext, tokenizedExpectedReverseWithContext,
+                tokenizedExpectedTfValuesWithContext);
+        SetExpectedMap(ALPHANUM_LIST, listAlphanumResults, listAlphanumReverseResults, listExpectedAlphanumFields, listExpectedAlphanumIndex,
+                listExpectedAlphanumReverse, listExpectedAlphanumTfValues);
         SetExpectedMap(NUMERIC_LIST, listNumericResults, listNumericReverseResults, listExpectedNumericFields, listExpectedNumericIndex,
                         listExpectedNumericReverse, listExpectedNumericTfValues);
     }
@@ -225,6 +234,23 @@ public class ContentIndexingColumnBasedHandlerTest {
         helper.setup(ctx.getConfiguration());
         testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_SPACE, tokenizedExpectedFieldsWithSpace, tokenizedExpectedIndexWithSpace,
                         tokenizedExpectedReverseWithSpace, tokenizedExpectedTfValuesWithSpace, true);
+    }
+
+    @Test
+    public void testHandlerWithContentContextEnabled() throws Exception {
+        ctx.getConfiguration().set("test" + TokenizationHelper.CONTENT_CONTEXT_ENABLED, "true");
+
+        TypeRegistry.reset();
+        TypeRegistry.getInstance(ctx.getConfiguration());
+
+        setupMocks();
+
+        TestContentIndexingColumnBasedHandler handler = new TestContentIndexingColumnBasedHandler();
+        handler.setup(ctx);
+
+        helper.setup(ctx.getConfiguration());
+        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_SPACE, tokenizedExpectedFieldsWithContext, tokenizedExpectedIndexWithContext,
+                tokenizedExpectedReverseWithContext, tokenizedExpectedTfValuesWithContext, true);
     }
 
     @Test
@@ -283,7 +309,7 @@ public class ContentIndexingColumnBasedHandlerTest {
 
         helper.setup(ctx.getConfiguration());
 
-        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE, listExpectedAlpahnumFields, listExpectedAlpahnumIndex, listExpectedAlpahnumReverse,
+        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE, listExpectedAlphanumFields, listExpectedAlphanumIndex, listExpectedAlphanumReverse,
                         listExpectedAlphanumTfValues, false);
     }
 
@@ -303,7 +329,7 @@ public class ContentIndexingColumnBasedHandlerTest {
 
         helper.setup(ctx.getConfiguration());
 
-        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_SPACE, listExpectedAlpahnumFields, listExpectedAlpahnumIndex, listExpectedAlpahnumReverse,
+        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_SPACE, listExpectedAlphanumFields, listExpectedAlphanumIndex, listExpectedAlphanumReverse,
                         listExpectedAlphanumTfValues, false);
     }
 
@@ -323,7 +349,7 @@ public class ContentIndexingColumnBasedHandlerTest {
 
         helper.setup(ctx.getConfiguration());
 
-        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_EMPTY_ENTRY, listExpectedAlpahnumFields, listExpectedAlpahnumIndex, listExpectedAlpahnumReverse,
+        testProcessing(handler, ALPHANUM_LIST, LIST_VALUE_WITH_EMPTY_ENTRY, listExpectedAlphanumFields, listExpectedAlphanumIndex, listExpectedAlphanumReverse,
                         listExpectedAlphanumTfValues, false);
     }
 

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/TermFrequencyIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/TermFrequencyIterator.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Multimap;
 
 import datawave.query.Constants;
 import datawave.query.data.parsers.TermFrequencyKey;
+import datawave.query.jexl.JexlASTHelper;
 
 /**
  * An iterator for the Datawave shard table, it searches TermFrequency keys for a list of terms and values. It is assumed that the range specified includes all
@@ -208,7 +209,21 @@ public class TermFrequencyIterator extends WrappingIterator {
     }
 
     private boolean fieldValueAccepted() {
-        return uidsAndValues.contains(tfKey.getUidAndValue()) && fields.contains(tfKey.getField());
+        return uidsAndValues.contains(tfKey.getUidAndValue()) && fieldMatches(tfKey.getField());
+    }
+
+    private boolean fieldMatches(String candidateField) {
+        if (fields.contains(candidateField)) {
+            return true;
+        }
+
+        for (String field : fields) {
+            if (JexlASTHelper.isGroupedFieldMatch(field, candidateField)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private boolean uidMatches() {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -768,6 +768,11 @@ public class JexlASTHelper {
         return fieldName.indexOf(GROUPING_CHARACTER_SEPARATOR) != -1;
     }
 
+    public static boolean isGroupedFieldMatch(String queryField, String candidateField) {
+        return candidateField.startsWith(queryField) && candidateField.length() > queryField.length()
+                        && candidateField.charAt(queryField.length()) == GROUPING_CHARACTER_SEPARATOR;
+    }
+
     public static Set<String> getFieldNames(ASTFunctionNode function, MetadataHelper metadata, Set<String> datatypeFilter) {
         JexlArgumentDescriptor desc = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(function);
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 
 import datawave.ingest.protobuf.TermWeightPosition;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.postprocessing.tf.TermOffsetMap;
 
 /**
@@ -190,7 +191,7 @@ public abstract class ContentFunctionEvaluator {
 
                 // Iterate over each collection of offsets (grouped by field) and try to find one that satisfies the phrase/adjacency
                 for (String field : offsetsByField.keySet()) {
-                    if (!fields.isEmpty() && !fields.contains(field)) {
+                    if ((fields == null || !fields.isEmpty()) && !isRelevantField(field)) {
                         continue;
                     }
                     List<List<TermWeightPosition>> offsets = offsetsByField.get(field);
@@ -242,6 +243,23 @@ public abstract class ContentFunctionEvaluator {
         }
 
         return Collections.emptySet();
+    }
+
+    /**
+     * Return whether the candidate field should be considered during content-function evaluation. This accepts exact field matches and grouped variants of a
+     * queried base field, e.g. {@code CONTENT} matching {@code CONTENT.1}.
+     *
+     * @param candidateField
+     *            the field found in the term-frequency data
+     * @return true if the field is relevant for evaluation
+     */
+    protected boolean isRelevantField(String candidateField) {
+        for (String field : fields) {
+            if (field.equals(candidateField) || JexlASTHelper.isGroupedFieldMatch(field, candidateField)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/postprocessing/tf/TermOffsetMap.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.functions.TermFrequencyList;
 
 /**
@@ -147,7 +148,21 @@ public class TermOffsetMap {
      * @return true if the field is an excerpt field, or false otherwise
      */
     public boolean isExcerptField(String field) {
-        return excerptFields != null && excerptFields.contains(field);
+        if (excerptFields == null) {
+            return false;
+        }
+
+        if (excerptFields.contains(field)) {
+            return true;
+        }
+
+        for (String excerptField : excerptFields) {
+            if (JexlASTHelper.isGroupedFieldMatch(excerptField, field)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/TermFrequencyIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/TermFrequencyIteratorTest.java
@@ -520,4 +520,35 @@ class TermFrequencyIteratorTest {
         cq = "datatype\0uid\0fi\0eld\0Va\0lue\0fieldName";
         assertEquals("fi\0eld\0Va\0lue", iter.getValueFromParts(cq.split("\0")));
     }
+
+    @Test
+    void testGroupedFieldMatchesBaseFieldQuery() throws IOException {
+        List<Map.Entry<Key,Value>> sourceData = new ArrayList<>();
+        sourceData.add(new SimpleEntry<>(getTfKey("row", "type1", "123.345.456", "CONTENT.1", "cat"), new Value()));
+        sourceData.add(new SimpleEntry<>(getTfKey("row", "type1", "123.345.456", "CONTENT.2", "cat"), new Value()));
+        sourceData.add(new SimpleEntry<>(getTfKey("row", "type1", "123.345.456", "CONTENT", "cat"), new Value()));
+        sourceData.add(new SimpleEntry<>(getTfKey("row", "type1", "123.345.456", "OTHER", "cat"), new Value()));
+
+        SortedKeyValueIterator<Key,Value> source = new SortedListKeyValueIterator(sourceData);
+        Multimap<String,String> fieldValues = buildFieldValues("CONTENT", "cat");
+
+        Set<Key> keys = new TreeSet<>();
+        keys.add(new Key(new Text("row"), new Text("type1\u0000123.345.456")));
+
+        TermFrequencyIterator iter = new TermFrequencyIterator(fieldValues, keys);
+        iter.init(source, null, null);
+
+        Key start = new Key("row", "tf", "type1\u0000123.345.456");
+        Key end = new Key("row", "tf", "type1\u0000123.345.456\uffff");
+        iter.seek(new Range(start, false, end, true), null, true);
+
+        Set<String> matchedFields = new HashSet<>();
+        while (iter.hasTop()) {
+            matchedFields.add(iter.getTopKey().getColumnQualifier().toString());
+            iter.next();
+        }
+
+        assertEquals(Set.of("type1\u0000123.345.456\u0000cat\u0000CONTENT", "type1\u0000123.345.456\u0000cat\u0000CONTENT.1",
+                        "type1\u0000123.345.456\u0000cat\u0000CONTENT.2"), matchedFields);
+    }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/ContentFunctionsTest.java
@@ -219,6 +219,44 @@ public class ContentFunctionsTest {
     }
 
     @Test
+    public void testEvaluationDoesNotCrossGroupedContentContexts() {
+        String query = buildFunction(ContentFunctions.CONTENT_PHRASE_FUNCTION_NAME, "'CONTENT'", Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, "'cat'",
+                        "'bog'");
+        JexlExpression expr = engine.createExpression(query);
+
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Map.entry(new Zone("CONTENT.1", true, eventId), asList(1))));
+        termOffSetMap.putTermFrequencyList("bog", new TermFrequencyList(Map.entry(new Zone("CONTENT.2", true, eventId), asList(2))));
+        termOffSetMap.setGatherPhraseOffsets(true);
+        termOffSetMap.setExcerptFields(Set.of("CONTENT"));
+
+        context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
+        Object o = expr.evaluate(context);
+
+        assertTrue(expect(o, false));
+        assertNoPhraseOffsetsFor("CONTENT");
+        assertNoPhraseOffsetsFor("CONTENT.1");
+        assertNoPhraseOffsetsFor("CONTENT.2");
+    }
+
+    @Test
+    public void testEvaluationMatchesWithinGroupedContentContext() {
+        String query = buildFunction(ContentFunctions.CONTENT_PHRASE_FUNCTION_NAME, "'CONTENT'", Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, "'cat'",
+                        "'mat'");
+        JexlExpression expr = engine.createExpression(query);
+
+        termOffSetMap.putTermFrequencyList("cat", new TermFrequencyList(Map.entry(new Zone("CONTENT.1", true, eventId), asList(1))));
+        termOffSetMap.putTermFrequencyList("mat", new TermFrequencyList(Map.entry(new Zone("CONTENT.1", true, eventId), asList(2))));
+        termOffSetMap.setGatherPhraseOffsets(true);
+        termOffSetMap.setExcerptFields(Set.of("CONTENT"));
+
+        context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, termOffSetMap);
+        Object o = expr.evaluate(context);
+
+        assertTrue(expect(o, true));
+        assertPhraseOffset("CONTENT.1", 1, 2);
+    }
+
+    @Test
     public void forwardSharedTokenIndex() {
         String query = buildFunction(ContentFunctions.CONTENT_PHRASE_FUNCTION_NAME, Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, "'c'", "'b'", "'a'");
         JexlExpression expr = engine.createExpression(query);


### PR DESCRIPTION
In some cases, we receive multiple values that get mapped to the same field name, e.g., CONTENT.  When these fields are received independently in separate ingest passes and then tokenized, we wind up with tokens in the term frequency portion of the shard table that have offsets that overlap. This will become more frequent as we implement annotation indexing.

For example, one CONTENT field value might be CONTENT:"cat mat" and another value might be "dog bog". In this case, it's possible under certain circumstances that a query CONTENT:"cat bog" would hit on this field and require further filtering to determine that it's a false positive. 

This feature adds the ability to employ grouping notation, similar to how it's used on the event fields, to maintain a distinction between the contexts within which a token appears as a part of the term frequency entry.  It will involve modifications to ingest and query to preserve this extra context in the form of dot notation.