### PR TITLE
adds system name to dictionary pages

### DIFF
--- a/docker/config/dictionary.yml
+++ b/docker/config/dictionary.yml
@@ -18,6 +18,8 @@ datawave:
       instance-name: '${accumulo.instanceName}'
       username: '${accumulo.username}'
       password: '${accumulo.password}'
+    system:
+      system-name: "docker quick-start"
     edge:
       metadata-table-name: ${metadata.table.name:datawave.metadata}
       num-threads: 8

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     profiles:
       - quickstart
     # To run the wildfly webservice, change `--accumulo` to `--web`
-    command: ["datawave-bootstrap.sh", "--web"]
+    command: ["datawave-bootstrap.sh", "--accumulo"]
     image: datawave/quickstart-compose
     environment:
       - DW_CONTAINER_HOST=quickstart

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     profiles:
       - quickstart
     # To run the wildfly webservice, change `--accumulo` to `--web`
-    command: ["datawave-bootstrap.sh", "--accumulo"]
+    command: ["datawave-bootstrap.sh", "--web"]
     image: datawave/quickstart-compose
     environment:
       - DW_CONTAINER_HOST=quickstart

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
@@ -22,6 +22,10 @@ public abstract class DataDictionaryBase<T,M extends MetadataFieldBase> extends 
     
     public abstract void setFields(Collection<M> fields);
     
+    public abstract String getDataDictionarySystem();
+    
+    public abstract void setDataDictionarySystem(String dataDictionarySystem);
+    
     public abstract void setTotalResults(long totalResults);
     
     public abstract long getTotalResults();

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
@@ -35,6 +35,7 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
     
     private static final long serialVersionUID = 1L;
     private static final String TITLE = "Data Dictionary", EMPTY_STR = "", SEP = ", ";
+    private String dataDictionarySystem = null;
     
     /*
      * Loads jQuery, DataTables, some CSS elements for DataTables, and executes `.dataTables()` on the HTML table in the payload.
@@ -82,6 +83,14 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
     
     public void setFields(Collection<DefaultMetadataField> fields) {
         this.fields = Lists.newArrayList(fields);
+    }
+    
+    public String getDataDictionarySystem() {
+        return dataDictionarySystem == null ? null : dataDictionarySystem;
+    }
+    
+    public void setDataDictionarySystem(String dataDictionarySystem) {
+        this.dataDictionarySystem = dataDictionarySystem;
     }
     
     public static Schema<DefaultDataDictionary> getSchema() {
@@ -200,6 +209,7 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder(2048);
+        builder.append("<div id = \"system-name\"><p>Cluster: ").append(dataDictionarySystem).append("</p></div>");
         builder.append("<div>");
         builder.append("<p style=\"width:60%; margin-left: auto; margin-right: auto;\">When a value is present in the forward index types, this means that a field is indexed and informs you how your ");
         builder.append("query terms will be treated (e.g. text, number, IPv4 address, etc). The same applies for the reverse index types with ");

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/edge/DefaultEdgeDictionary.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/edge/DefaultEdgeDictionary.java
@@ -33,6 +33,7 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     
     private static final long serialVersionUID = 1L;
     private static final String TITLE = "Edge Dictionary", SEP = ", ";
+    private String edgeDictionarySystem = null;
     
     @XmlElementWrapper(name = "EdgeMetadata")
     @XmlElement(name = "Metadata")
@@ -57,6 +58,14 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     @Override
     public List<? extends MetadataBase<DefaultMetadata>> getMetadataList() {
         return metadataList == null ? null : Collections.unmodifiableList(metadataList);
+    }
+    
+    public String getEdgeDictionarySystem() {
+        return edgeDictionarySystem == null ? null : edgeDictionarySystem;
+    }
+    
+    public void setEdgeDictionarySystem(String edgeDictionarySystem) {
+        this.edgeDictionarySystem = edgeDictionarySystem;
     }
     
     public static Schema<DefaultEdgeDictionary> getSchema() {
@@ -187,6 +196,7 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder(2048);
+        builder.append("<div id = \"system-name\"><p>Cluster: ").append(edgeDictionarySystem).append("</p></div>");
         builder.append("<div><ul>").append("<li class=\"left\">Edge Type: Defined either by Datawave Configuration files or Edge enrichment field.</li>")
                         .append("<li class=\"left\">Edge Relationship: Defined by Datawave Configuration files</li>")
                         .append("<li class=\"left\">Edge Attribute1 Source: Defined by Datawave Configuration files and optional attributes Attribute2 and Attribute3</li>")

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/edge/EdgeDictionaryBase.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/dictionary/edge/EdgeDictionaryBase.java
@@ -17,6 +17,10 @@ public abstract class EdgeDictionaryBase<T,F extends MetadataBase<F>> extends Ba
     
     public abstract List<? extends MetadataBase<F>> getMetadataList();
     
+    public abstract String getEdgeDictionarySystem();
+    
+    public abstract void setEdgeDictionarySystem(String edgeDictionarySystem);
+    
     public abstract void setTotalResults(long totalResults);
     
     public abstract long getTotalResults();

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/Model.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/Model.java
@@ -41,7 +41,10 @@ public class Model extends BaseResponse implements Serializable, HtmlProvider {
         this.jqueryUri = jqueryUri;
         this.dataTablesUri = datatablesUri;
         this.systemName = systemName;
-        
+    }
+    
+    public Model(String jqueryUri, String datatablesUri) {
+        this(jqueryUri, datatablesUri, "unknown");
     }
     
     // Only used in ModelBeanTest now

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/Model.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/Model.java
@@ -30,15 +30,17 @@ public class Model extends BaseResponse implements Serializable, HtmlProvider {
     private static final long serialVersionUID = 1L;
     private String jqueryUri;
     private String dataTablesUri;
+    private String systemName;
     private static final String TITLE = "Model Description", EMPTY = "";
     private static final String DATA_TABLES_TEMPLATE = "<script type=''text/javascript'' src=''{0}''></script>\n"
                     + "<script type=''text/javascript'' src=''{1}''></script>\n" + "<script type=''text/javascript''>\n"
                     + "$(document).ready(function() '{' $(''#myTable'').dataTable('{'\"bPaginate\": false, \"aaSorting\": [[3, \"asc\"]], \"bStateSave\": true'}') '}')\n"
                     + "</script>\n";
     
-    public Model(String jqueryUri, String datatablesUri) {
+    public Model(String jqueryUri, String datatablesUri, String systemName) {
         this.jqueryUri = jqueryUri;
         this.dataTablesUri = datatablesUri;
+        this.systemName = systemName;
         
     }
     
@@ -131,7 +133,7 @@ public class Model extends BaseResponse implements Serializable, HtmlProvider {
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder();
-        
+        builder.append("<div id = \"system-name\"><p>Cluster: ").append(systemName).append("</p></div>");
         builder.append("<div>\n");
         builder.append("<div id=\"myTable_wrapper\" class=\"dataTables_wrapper no-footer\">\n");
         builder.append("<table id=\"myTable\" class=\"dataTable no-footer\" role=\"grid\" aria-describedby=\"myTable_info\">\n");

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/ModelList.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/ModelList.java
@@ -23,6 +23,7 @@ public class ModelList extends BaseResponse implements Serializable, HtmlProvide
     private String jqueryUri;
     private String dataTablesUri;
     private String modelTableName;
+    private String systemName;
     
     private static final long serialVersionUID = 1L;
     private static final String TITLE = "Model Names";
@@ -31,10 +32,11 @@ public class ModelList extends BaseResponse implements Serializable, HtmlProvide
                     + "$(document).ready(function() '{' $(''#myTable'').dataTable('{'\"bPaginate\": false, \"aaSorting\": [[0, \"asc\"]], \"bStateSave\": true'}') '}')\n"
                     + "</script>\n";
     
-    public ModelList(String jqueryUri, String datatablesUri, String modelTableName) {
+    public ModelList(String jqueryUri, String datatablesUri, String modelTableName, String systemName) {
         this.jqueryUri = jqueryUri;
         this.dataTablesUri = datatablesUri;
         this.modelTableName = modelTableName;
+        this.systemName = systemName;
     }
     
     @XmlElementWrapper(name = "ModelNames")
@@ -82,6 +84,7 @@ public class ModelList extends BaseResponse implements Serializable, HtmlProvide
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder();
+        builder.append("<div id = \"system-name\"><p>Cluster: ").append(systemName).append("</p></div>");
         
         if (this.getNames() == null || this.getNames().isEmpty()) {
             builder.append("No models available.");

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/ModelList.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/ModelList.java
@@ -26,7 +26,6 @@ public class ModelList extends BaseResponse implements Serializable, HtmlProvide
     private String systemName;
     
     private static final long serialVersionUID = 1L;
-    // private static final String DEFAULT_SYS = "unknown";
     private static final String TITLE = "Model Names";
     private static final String DATA_TABLES_TEMPLATE = "<script type=''text/javascript'' src=''{0}''></script>\n"
                     + "<script type=''text/javascript'' src=''{1}''></script>\n" + "<script type=''text/javascript''>\n"

--- a/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/ModelList.java
+++ b/microservices/services/dictionary/api/src/main/java/datawave/webservice/model/ModelList.java
@@ -26,6 +26,7 @@ public class ModelList extends BaseResponse implements Serializable, HtmlProvide
     private String systemName;
     
     private static final long serialVersionUID = 1L;
+    // private static final String DEFAULT_SYS = "unknown";
     private static final String TITLE = "Model Names";
     private static final String DATA_TABLES_TEMPLATE = "<script type=''text/javascript'' src=''{0}''></script>\n"
                     + "<script type=''text/javascript'' src=''{1}''></script>\n" + "<script type=''text/javascript''>\n"
@@ -37,6 +38,10 @@ public class ModelList extends BaseResponse implements Serializable, HtmlProvide
         this.dataTablesUri = datatablesUri;
         this.modelTableName = modelTableName;
         this.systemName = systemName;
+    }
+    
+    public ModelList(String jqueryUri, String datatablesUri, String modelTableName) {
+        this(jqueryUri, datatablesUri, modelTableName, "unknown");
     }
     
     @XmlElementWrapper(name = "ModelNames")

--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -26,7 +26,7 @@
         <start-class>datawave.microservice.dictionary.DictionaryService</start-class>
         <version.accumulo>2.1.1</version.accumulo>
         <version.curator>5.2.0</version.curator>
-        <version.datawave.dictionary-api>4.0.3</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.5-SNAPSHOT</version.datawave.dictionary-api>
         <version.datawave.starter>4.0.2</version.datawave.starter>
         <version.datawave.starter-metadata>3.0.2</version.datawave.starter-metadata>
         <version.in-memory-accumulo>4.0.0</version.in-memory-accumulo>

--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -26,7 +26,7 @@
         <start-class>datawave.microservice.dictionary.DictionaryService</start-class>
         <version.accumulo>2.1.1</version.accumulo>
         <version.curator>5.2.0</version.curator>
-        <version.datawave.dictionary-api>4.0.5-SNAPSHOT</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.3</version.datawave.dictionary-api>
         <version.datawave.starter>4.0.2</version.datawave.starter>
         <version.datawave.starter-metadata>3.0.2</version.datawave.starter-metadata>
         <version.in-memory-accumulo>4.0.0</version.in-memory-accumulo>

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
@@ -8,6 +8,10 @@ export interface Banner {
   styleBottom?: string;
 }
 
+export interface System {
+  systemName: string;
+}
+
 export const columns: QTableProps['columns'] = [
   {
     label: 'Field Name',

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -24,6 +24,7 @@
     </div>
     <div class="row" style="width: 100%; height: 80%">
       <p class="information">
+        Cluster: {{ system?.systemName }} <br />
         When a value is present in the forward index types, this means that a
         field is indexed and informs you how your query terms will be treated
         (e.g. text, number, IPv4 address, etc). The same applies for the reverse
@@ -163,7 +164,7 @@ import { onMounted, ref } from 'vue';
 import { QTable, QTableProps, exportFile, useQuasar, Notify } from 'quasar';
 import { useToggle, useDark } from '@vueuse/core';
 import { api } from '../boot/axios';
-import { Banner, columns } from '../functions/components';
+import { Banner, columns, System } from '../functions/components';
 import * as Formatters from '../functions/formatters';
 import * as Wrapper from '../functions/csvWrapper';
 import * as Feature from '../functions/features';
@@ -175,6 +176,7 @@ const loading = ref(true);
 const filter = ref('');
 const changeFilter = ref('');
 const banner = ref<Banner>();
+const system = ref<System>();
 let rows: QTableProps['rows'] = [];
 const paginationFront = ref({
   rowsPerPage: 200,
@@ -186,9 +188,11 @@ const paginationFront = ref({
 onMounted(() => {
   let endpointData = '';
   let bannerData = 'banner';
+  let systemData = 'system';
   if (process.env.DEV) {
     endpointData = 'data/v2/'
     bannerData = 'data/v2/banner/'
+    systemData = 'data/v2/system/'
   }
 
   api
@@ -198,6 +202,15 @@ onMounted(() => {
   })
   .catch((reason) => {
     console.error('Could not fetch banner: ' + reason);
+  });
+
+  api
+  .get(systemData)
+  .then((response) => {
+    system.value = response.data as System;
+  })
+  .catch((reason) => {
+    console.error('Could not fetch system name: ' + reason);
   });
 
   api

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerLogic.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerLogic.java
@@ -83,7 +83,6 @@ public class DataDictionaryControllerLogic<DESC extends DescriptionBase<DESC>,DI
         DICT dataDictionary = responseObjectFactory.getDataDictionary();
         dataDictionary.setFields(fields);
         dataDictionary.setDataDictionarySystem(dictionaryServiceConfiguration.getSystem().systemName);
-        // dataDictionary.setDataDictionarySystem(dataDictionaryConfiguration.getSystemName());
         // Ensure that empty internal field names will be set to the field name instead.
         dataDictionary.transformFields(TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES);
         

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerLogic.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerLogic.java
@@ -18,6 +18,7 @@ import datawave.microservice.AccumuloConnectionService;
 import datawave.microservice.Connection;
 import datawave.microservice.authorization.user.DatawaveUserDetails;
 import datawave.microservice.dictionary.config.DataDictionaryProperties;
+import datawave.microservice.dictionary.config.DictionaryServiceProperties;
 import datawave.microservice.dictionary.config.ResponseObjectFactory;
 import datawave.microservice.dictionary.data.DataDictionary;
 import datawave.webservice.dictionary.data.DataDictionaryBase;
@@ -32,6 +33,7 @@ public class DataDictionaryControllerLogic<DESC extends DescriptionBase<DESC>,DI
     private final DataDictionary<META,DESC,FIELD> dataDictionary;
     private final ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory;
     private final AccumuloConnectionService accumuloConnectionService;
+    private final DictionaryServiceProperties dictionaryServiceConfiguration;
     
     private final Consumer<META> TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES = meta -> {
         if (meta.getInternalFieldName() == null || meta.getInternalFieldName().isEmpty()) {
@@ -40,11 +42,13 @@ public class DataDictionaryControllerLogic<DESC extends DescriptionBase<DESC>,DI
     };
     
     public DataDictionaryControllerLogic(DataDictionaryProperties dataDictionaryConfiguration, DataDictionary<META,DESC,FIELD> dataDictionary,
-                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService) {
+                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService,
+                    DictionaryServiceProperties dictionaryServiceProperties) {
         this.dataDictionaryConfiguration = dataDictionaryConfiguration;
         this.dataDictionary = dataDictionary;
         this.responseObjectFactory = responseObjectFactory;
         this.accumuloConnectionService = accumloConnectionService;
+        this.dictionaryServiceConfiguration = dictionaryServiceProperties;
         dataDictionary.setNormalizationMap(dataDictionaryConfiguration.getNormalizerMap());
     }
     
@@ -78,6 +82,8 @@ public class DataDictionaryControllerLogic<DESC extends DescriptionBase<DESC>,DI
         Collection<META> fields = dataDictionary.getFields(connection, dataTypes, dataDictionaryConfiguration.getNumThreads());
         DICT dataDictionary = responseObjectFactory.getDataDictionary();
         dataDictionary.setFields(fields);
+        dataDictionary.setDataDictionarySystem(dictionaryServiceConfiguration.getSystem().systemName);
+        // dataDictionary.setDataDictionarySystem(dataDictionaryConfiguration.getSystemName());
         // Ensure that empty internal field names will be set to the field name instead.
         dataDictionary.transformFields(TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES);
         
@@ -298,5 +304,9 @@ public class DataDictionaryControllerLogic<DESC extends DescriptionBase<DESC>,DI
      */
     public DataDictionaryProperties.Banner retrieveBanner() {
         return dataDictionaryConfiguration.getBanner();
+    }
+    
+    public DictionaryServiceProperties.System retrieveSystem() {
+        return dictionaryServiceConfiguration.getSystem();
     }
 }

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerV1.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerV1.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.annotation.Timed;
 import datawave.microservice.AccumuloConnectionService;
 import datawave.microservice.authorization.user.DatawaveUserDetails;
 import datawave.microservice.dictionary.config.DataDictionaryProperties;
+import datawave.microservice.dictionary.config.DictionaryServiceProperties;
 import datawave.microservice.dictionary.config.ResponseObjectFactory;
 import datawave.microservice.dictionary.data.DataDictionary;
 import datawave.webservice.dictionary.data.DataDictionaryBase;
@@ -45,9 +46,10 @@ public class DataDictionaryControllerV1<DESC extends DescriptionBase<DESC>,DICT 
     private DataDictionaryControllerLogic dataDictionaryControllerLogic;
     
     public DataDictionaryControllerV1(DataDictionaryProperties dataDictionaryConfiguration, DataDictionary<META,DESC,FIELD> dataDictionary,
-                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService) {
+                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService,
+                    DictionaryServiceProperties dictionaryServiceProperties) {
         dataDictionaryControllerLogic = new DataDictionaryControllerLogic<>(dataDictionaryConfiguration, dataDictionary, responseObjectFactory,
-                        accumloConnectionService);
+                        accumloConnectionService, dictionaryServiceProperties);
     }
     
     @GetMapping("/")

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerV2.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerV2.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.annotation.Timed;
 import datawave.microservice.AccumuloConnectionService;
 import datawave.microservice.authorization.user.DatawaveUserDetails;
 import datawave.microservice.dictionary.config.DataDictionaryProperties;
+import datawave.microservice.dictionary.config.DictionaryServiceProperties;
 import datawave.microservice.dictionary.config.ResponseObjectFactory;
 import datawave.microservice.dictionary.data.DataDictionary;
 import datawave.webservice.dictionary.data.DataDictionaryBase;
@@ -45,9 +46,10 @@ public class DataDictionaryControllerV2<DESC extends DescriptionBase<DESC>,DICT 
     private DataDictionaryControllerLogic dataDictionaryControllerLogic;
     
     public DataDictionaryControllerV2(DataDictionaryProperties dataDictionaryConfiguration, DataDictionary<META,DESC,FIELD> dataDictionary,
-                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService) {
+                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService,
+                    DictionaryServiceProperties dictionaryServiceProperties) {
         dataDictionaryControllerLogic = new DataDictionaryControllerLogic<>(dataDictionaryConfiguration, dataDictionary, responseObjectFactory,
-                        accumloConnectionService);
+                        accumloConnectionService, dictionaryServiceProperties);
     }
     
     @GetMapping("/")
@@ -108,6 +110,12 @@ public class DataDictionaryControllerV2<DESC extends DescriptionBase<DESC>,DICT 
     @Timed(name = "dw.dictionary.data.banner", absolute = true)
     public DataDictionaryProperties.Banner banner() {
         return dataDictionaryControllerLogic.retrieveBanner();
+    }
+    
+    @GetMapping(value = "/system", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed(name = "dw.dictionary.system", absolute = true)
+    public DictionaryServiceProperties.System system() {
+        return dataDictionaryControllerLogic.retrieveSystem();
     }
     
     @Secured({"Administrator", "JBossAdministrator"})

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryController.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryController.java
@@ -16,6 +16,7 @@ import com.codahale.metrics.annotation.Timed;
 import datawave.accumulo.util.security.UserAuthFunctions;
 import datawave.microservice.AccumuloConnectionService;
 import datawave.microservice.authorization.user.DatawaveUserDetails;
+import datawave.microservice.dictionary.config.DictionaryServiceProperties;
 import datawave.microservice.dictionary.config.EdgeDictionaryProperties;
 import datawave.microservice.dictionary.edge.EdgeDictionary;
 import datawave.webservice.dictionary.edge.EdgeDictionaryBase;
@@ -39,13 +40,16 @@ public class EdgeDictionaryController<EDGE extends EdgeDictionaryBase<EDGE,META>
     private final EdgeDictionary<EDGE,META> edgeDictionary;
     private final UserAuthFunctions userAuthFunctions;
     private final AccumuloConnectionService accumuloConnectionService;
+    private final DictionaryServiceProperties dictionaryServiceConfiguration;
     
     public EdgeDictionaryController(EdgeDictionaryProperties edgeDictionaryProperties, EdgeDictionary<EDGE,META> edgeDictionary,
-                    UserAuthFunctions userAuthFunctions, AccumuloConnectionService accumloConnectionService) {
+                    UserAuthFunctions userAuthFunctions, AccumuloConnectionService accumloConnectionService,
+                    DictionaryServiceProperties dictionaryServiceProperties) {
         this.edgeDictionaryProperties = edgeDictionaryProperties;
         this.edgeDictionary = edgeDictionary;
         this.userAuthFunctions = userAuthFunctions;
         this.accumuloConnectionService = accumloConnectionService;
+        this.dictionaryServiceConfiguration = dictionaryServiceProperties;
     }
     
     /**
@@ -71,6 +75,7 @@ public class EdgeDictionaryController<EDGE extends EdgeDictionaryBase<EDGE,META>
         
         EDGE edgeDict = edgeDictionary.getEdgeDictionary(metadataTableName, accumuloConnectionService.getConnection().getAccumuloClient(),
                         accumuloConnectionService.getDowngradedAuthorizations(queryAuthorizations, currentUser), edgeDictionaryProperties.getNumThreads());
+        edgeDict.setEdgeDictionarySystem(dictionaryServiceConfiguration.getSystem().systemName);
         
         log.info("EDGEDICTIONARY: returning edge dictionary");
         return edgeDict;

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/config/DictionaryServiceProperties.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/config/DictionaryServiceProperties.java
@@ -6,14 +6,25 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import datawave.microservice.config.accumulo.AccumuloProperties;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 @ConfigurationProperties(prefix = "datawave.dictionary")
 @Validated
 public class DictionaryServiceProperties {
     @Valid
     private AccumuloProperties accumuloProperties = new AccumuloProperties();
+    private System system = new System();
     
     public AccumuloProperties getAccumuloProperties() {
         return accumuloProperties;
+    }
+    
+    @Getter
+    @Setter
+    public static class System {
+        public String systemName;
     }
 }

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/data/DataDictionary.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/data/DataDictionary.java
@@ -18,6 +18,10 @@ public interface DataDictionary<META extends MetadataFieldBase<META,DESC>,DESC e
     
     void setNormalizationMap(Map<String,String> normalizationMap);
     
+    String getDataDictionarySystem();
+    
+    void setDataDictionarySystem(String dataDictionarySystem);
+    
     Collection<META> getFields(Connection connectionConfig, Collection<String> dataTypeFilters, int numThreads) throws Exception;
     
     void setDescription(Connection connectionConfig, FIELD description) throws Exception;

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/data/DataDictionaryImpl.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/data/DataDictionaryImpl.java
@@ -37,6 +37,7 @@ public class DataDictionaryImpl implements DataDictionary<DefaultMetadataField,D
     private final MetadataHelperFactory metadataHelperFactory;
     private final MetadataDescriptionsHelperFactory<DefaultDescription> metadataDescriptionsHelperFactory;
     private Map<String,String> normalizationMap = Maps.newHashMap();
+    private String dataDictionarySystem = "";
     
     public DataDictionaryImpl(MarkingFunctions markingFunctions,
                     ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> responseObjectFactory,
@@ -55,6 +56,16 @@ public class DataDictionaryImpl implements DataDictionary<DefaultMetadataField,D
     @Override
     public void setNormalizationMap(Map<String,String> normalizationMap) {
         this.normalizationMap = normalizationMap;
+    }
+    
+    @Override
+    public String getDataDictionarySystem() {
+        return dataDictionarySystem;
+    }
+    
+    @Override
+    public void setDataDictionarySystem(String dataDictionarySystem) {
+        this.dataDictionarySystem = dataDictionarySystem;
     }
     
     /**

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/edge/EdgeDictionary.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/edge/EdgeDictionary.java
@@ -12,4 +12,8 @@ public interface EdgeDictionary<EDGE extends EdgeDictionaryBase<EDGE,META>,META 
     char COL_SEPARATOR = '/';
     
     EDGE getEdgeDictionary(String metadataTableName, AccumuloClient accumuloClient, Set<Authorizations> auths, int numThreads) throws Exception;
+    
+    String getEdgeDictionarySystem();
+    
+    void setEdgeDictionarySystem(String edgeDictionarySystem);
 }

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/edge/EdgeDictionaryImpl.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/edge/EdgeDictionaryImpl.java
@@ -28,7 +28,7 @@ import datawave.webservice.dictionary.edge.EventField;
 
 public class EdgeDictionaryImpl implements EdgeDictionary<DefaultEdgeDictionary,DefaultMetadata> {
     private static final Logger log = LoggerFactory.getLogger(EdgeDictionaryImpl.class);
-    
+    private String edgeDictionarySystem = "";
     private final MetadataHelperFactory metadataHelperFactory;
     
     public EdgeDictionaryImpl(MetadataHelperFactory metadataHelperFactory) {
@@ -45,6 +45,16 @@ public class EdgeDictionaryImpl implements EdgeDictionary<DefaultEdgeDictionary,
         
         // Convert them into the DataDictionary response object
         return transformResults(metadataHelper.getEdges());
+    }
+    
+    @Override
+    public String getEdgeDictionarySystem() {
+        return edgeDictionarySystem;
+    }
+    
+    @Override
+    public void setEdgeDictionarySystem(String edgeDictionarySystem) {
+        this.edgeDictionarySystem = edgeDictionarySystem;
     }
     
     // consume the iterator, parse key/value pairs into Metadata stuff

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/model/ModelController.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/model/ModelController.java
@@ -58,6 +58,7 @@ public class ModelController {
     
     private final String dataTablesUri;
     private final String jqueryUri;
+    private final String systemName;
     private final AccumuloConnectionService accumloConnectionService;
     
     public static final String DEFAULT_MODEL_TABLE_NAME = "DatawaveMetadata";
@@ -66,6 +67,7 @@ public class ModelController {
     public ModelController(ModelProperties modelProperties, AccumuloConnectionService accumloConnectionService) {
         this.dataTablesUri = modelProperties.getDataTablesUri();
         this.jqueryUri = modelProperties.getJqueryUri();
+        this.systemName = modelProperties.getSystemName();
         this.accumloConnectionService = accumloConnectionService;
     }
     
@@ -84,7 +86,7 @@ public class ModelController {
     public ModelList listModelNames(@RequestParam(defaultValue = DEFAULT_MODEL_TABLE_NAME) String modelTableName,
                     @AuthenticationPrincipal DatawaveUserDetails currentUser) {
         
-        ModelList response = new ModelList(jqueryUri, dataTablesUri, modelTableName);
+        ModelList response = new ModelList(jqueryUri, dataTablesUri, modelTableName, systemName);
         HashSet<String> modelNames = new HashSet<>();
         List<Key> keys;
         try {
@@ -190,7 +192,7 @@ public class ModelController {
     @GetMapping("/{name}")
     public Model getModel(@PathVariable String name, @RequestParam(defaultValue = DEFAULT_MODEL_TABLE_NAME) String modelTableName,
                     @AuthenticationPrincipal DatawaveUserDetails currentUser) {
-        Model response = new Model(jqueryUri, dataTablesUri);
+        Model response = new Model(jqueryUri, dataTablesUri, systemName);
         List<Key> keys;
         try {
             keys = accumloConnectionService.getKeys(modelTableName, currentUser, name);

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/model/config/ModelProperties.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/model/config/ModelProperties.java
@@ -15,4 +15,5 @@ public class ModelProperties {
     private String defaultTableName;
     private String jqueryUri;
     private String dataTablesUri;
+    private String systemName;
 }

--- a/microservices/services/dictionary/service/src/test/resources/config/application.yml
+++ b/microservices/services/dictionary/service/src/test/resources/config/application.yml
@@ -18,6 +18,7 @@ datawave:
     default-table-name: "DatawaveMetadata"
     jquery-uri: "/jquery.min.js"
     data-tables-uri: "/jquery.dataTables.min.js"
+    system-name: "docker quick-start"
   metadata:
     all-metadata-auths:
       - PRIVATE,PUBLIC

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.datawave.authorization-api>4.0.0</version.datawave.authorization-api>
         <version.datawave.base-rest-responses>4.0.1</version.datawave.base-rest-responses>
         <version.datawave.common-utils>3.0.0</version.datawave.common-utils>
-        <version.datawave.dictionary-api>4.0.5-SNAPSHOT</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.1</version.datawave.dictionary-api>
         <version.datawave.mapreduce-query-api>1.0.0</version.datawave.mapreduce-query-api>
         <version.datawave.metadata-utils>4.0.14</version.datawave.metadata-utils>
         <version.datawave.metrics-reporter>3.0.0</version.datawave.metrics-reporter>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.datawave.authorization-api>4.0.0</version.datawave.authorization-api>
         <version.datawave.base-rest-responses>4.0.1</version.datawave.base-rest-responses>
         <version.datawave.common-utils>3.0.0</version.datawave.common-utils>
-        <version.datawave.dictionary-api>4.0.1</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.5-SNAPSHOT</version.datawave.dictionary-api>
         <version.datawave.mapreduce-query-api>1.0.0</version.datawave.mapreduce-query-api>
         <version.datawave.metadata-utils>4.0.14</version.datawave.metadata-utils>
         <version.datawave.metrics-reporter>3.0.0</version.datawave.metrics-reporter>


### PR DESCRIPTION
adds system name to dictionary pages (edge, data v1/v2/model/modellist)
required to be merged **before** modelbean (#2832) 

part of fix for #478 