### PR TITLE
adds system name to query metric pages

### DIFF
--- a/docker/config/querymetric.yml
+++ b/docker/config/querymetric.yml
@@ -41,6 +41,7 @@ datawave:
     description: "REST API provided by the Query Metric Service"
   query:
     metric:
+      system-name: "docker quick-start"
       handler:
         zookeepers: ${warehouse-cluster.accumulo.zookeepers}
         instanceName: ${warehouse-cluster.accumulo.instanceName}

--- a/microservices/services/query-metric/api/src/main/resources/templates/querymetric-horizontal.html
+++ b/microservices/services/query-metric/api/src/main/resources/templates/querymetric-horizontal.html
@@ -24,6 +24,10 @@
     <div th:utext="${header}"></div>
     <h1>Query Metrics</h1>
 
+    <div id ="system-name">
+        <p>Cluster: <span th:text ="${@environment.getProperty('datawave.query.metric.system-name')}"></span></p>
+    </div>
+
     <script th:src="${basePath + '/js/query-interactive-parens.js'}">
     </script>
 

--- a/microservices/services/query-metric/api/src/main/resources/templates/querymetric.html
+++ b/microservices/services/query-metric/api/src/main/resources/templates/querymetric.html
@@ -19,6 +19,10 @@
     <div th:utext="${header}"></div>
     <h1>Query Metrics</h1>
 
+    <div id ="system-name">
+        <p>Cluster: <span th:text ="${@environment.getProperty('datawave.query.metric.system-name')}"></span></p>
+    </div>
+
     <script type="text/javascript">
 
         function toggleVisibility(field, metricNum) {


### PR DESCRIPTION
adds system name to query metric pages

part of fix for #478 