### PR TITLE
adds system name to modelbean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.datawave.authorization-api>4.0.0</version.datawave.authorization-api>
         <version.datawave.base-rest-responses>4.0.1</version.datawave.base-rest-responses>
         <version.datawave.common-utils>3.0.0</version.datawave.common-utils>
-        <version.datawave.dictionary-api>4.0.5-SNAPSHOT</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.5</version.datawave.dictionary-api>
         <version.datawave.mapreduce-query-api>1.0.0</version.datawave.mapreduce-query-api>
         <version.datawave.metadata-utils>4.0.14</version.datawave.metadata-utils>
         <version.datawave.metrics-reporter>3.0.0</version.datawave.metrics-reporter>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.datawave.authorization-api>4.0.0</version.datawave.authorization-api>
         <version.datawave.base-rest-responses>4.0.1</version.datawave.base-rest-responses>
         <version.datawave.common-utils>3.0.0</version.datawave.common-utils>
-        <version.datawave.dictionary-api>4.0.1</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.5-SNAPSHOT</version.datawave.dictionary-api>
         <version.datawave.mapreduce-query-api>1.0.0</version.datawave.mapreduce-query-api>
         <version.datawave.metadata-utils>4.0.14</version.datawave.metadata-utils>
         <version.datawave.metrics-reporter>3.0.0</version.datawave.metrics-reporter>

--- a/web-services/model/src/main/java/datawave/webservice/query/model/ModelBean.java
+++ b/web-services/model/src/main/java/datawave/webservice/query/model/ModelBean.java
@@ -101,6 +101,10 @@ public class ModelBean {
     @ConfigProperty(name = "dw.cdn.dataTables.uri", defaultValue = "/jquery.dataTables.min.js")
     private String dataTablesUri;
 
+    @Inject
+    @ConfigProperty(name = "dw.model.systemName", defaultValue = "unknown")
+    private String systemName;
+
     @EJB
     private AccumuloConnectionFactory connectionFactory;
 
@@ -133,7 +137,7 @@ public class ModelBean {
             modelTableName = defaultModelTableName;
         }
 
-        ModelList response = new ModelList(jqueryUri, dataTablesUri, modelTableName);
+        ModelList response = new ModelList(jqueryUri, dataTablesUri, modelTableName, systemName);
 
         // Find out who/what called this method
         Principal p = ctx.getCallerPrincipal();
@@ -337,7 +341,7 @@ public class ModelBean {
             modelTableName = defaultModelTableName;
         }
 
-        datawave.webservice.model.Model response = new datawave.webservice.model.Model(jqueryUri, dataTablesUri);
+        datawave.webservice.model.Model response = new datawave.webservice.model.Model(jqueryUri, dataTablesUri, systemName);
 
         // Find out who/what called this method
         Principal p = ctx.getCallerPrincipal();

--- a/web-services/model/src/main/java/datawave/webservice/query/model/ModelBean.java
+++ b/web-services/model/src/main/java/datawave/webservice/query/model/ModelBean.java
@@ -102,7 +102,7 @@ public class ModelBean {
     private String dataTablesUri;
 
     @Inject
-    @ConfigProperty(name = "dw.model.systemName", defaultValue = "unknown")
+    @ConfigProperty(name = "cluster.name", defaultValue = "unknown")
     private String systemName;
 
     @EJB


### PR DESCRIPTION
adds system name to model bean, is used in Model and ModelList
required to be merged in **after** dictionary pages (#2824)

part of fix for #478 