### PR TITLE
disable broken tests

### DIFF
--- a/microservices/services/query/service/src/test/java/datawave/microservice/query/lookup/LookupServiceTest.java
+++ b/microservices/services/query/service/src/test/java/datawave/microservice/query/lookup/LookupServiceTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -421,7 +422,8 @@ public class LookupServiceTest extends AbstractQueryServiceTest {
     }
     
     // Test is randomly failing so disabling for now
-    // @Test
+    @Test
+    @Disabled
     public void testBatchLookupContentUUIDSuccess() throws Exception {
         DatawaveUserDetails authUser = createUserDetails();
         

--- a/microservices/services/query/service/src/test/java/datawave/microservice/query/lookup/LookupServiceTest.java
+++ b/microservices/services/query/service/src/test/java/datawave/microservice/query/lookup/LookupServiceTest.java
@@ -420,7 +420,8 @@ public class LookupServiceTest extends AbstractQueryServiceTest {
         // @formatter:on
     }
     
-    @Test
+    // Test is randomly failing so disabling for now
+    // @Test
     public void testBatchLookupContentUUIDSuccess() throws Exception {
         DatawaveUserDetails authUser = createUserDetails();
         

--- a/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
@@ -30,6 +30,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -265,7 +266,8 @@ public abstract class UniqueTest {
     }
 
     // Test is randomly failing so disabling for now
-    // @Test
+    @Test
+    @Ignore
     public void testUniquenessWithMissingField() throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");

--- a/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
@@ -264,7 +264,8 @@ public abstract class UniqueTest {
         runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
     }
 
-    @Test
+    // Test is randomly failing so disabling for now
+    // @Test
     public void testUniquenessWithMissingField() throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");


### PR DESCRIPTION
disable tests that are randomly failing until the team can look into it. our CI pipelines are really slow (hours) because of the retries.