### PR TITLE
type-utils update to support better serialization

### DIFF
--- a/core/utils/type-utils/src/main/java/datawave/data/normalizer/NumberNormalizer.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/normalizer/NumberNormalizer.java
@@ -10,7 +10,7 @@ import datawave.data.type.util.NumericalEncoder;
 public class NumberNormalizer extends AbstractNormalizer<BigDecimal> {
     
     private static final long serialVersionUID = -2781476072987375820L;
-    private Logger log = Logger.getLogger(NumberNormalizer.class);
+    private static final Logger log = Logger.getLogger(NumberNormalizer.class);
     
     public String normalize(String fv) {
         if (NumericalEncoder.isPossiblyEncoded(fv)) {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
+
 import datawave.data.normalizer.Normalizer;
 import datawave.webservice.query.data.ObjectSizeOf;
 

--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import datawave.data.normalizer.Normalizer;
 import datawave.webservice.query.data.ObjectSizeOf;
 
@@ -56,6 +57,7 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
      * Use the normalizer and delegate to set the normalized value. Assumes that {@link #setDelegate(Comparable)} has been called.
      */
     public void setNormalizedValueFromDelegate() {
+        Preconditions.checkNotNull(delegate, "Tried to set normalized value from delegate, but delegate was null");
         this.normalizedValue = normalizer.normalizeDelegateType(this.delegate);
     }
     

--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -9,16 +9,25 @@ import datawave.webservice.query.data.ObjectSizeOf;
 
 public class BaseType<T extends Comparable<T> & Serializable> implements Serializable, Type<T>, ObjectSizeOf {
     
-    private static final long serialVersionUID = 5354270429891763693L;
+    private static final long serialVersionUID = 1261391800060720465L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + Sizer.REFERENCE + Sizer.REFERENCE;
     
     protected T delegate;
     protected String normalizedValue;
     protected final Normalizer<T> normalizer;
     
-    public BaseType(String delegateString, Normalizer<T> normalizer) {
+    /**
+     * Default constructor. Generates the normalized and non-normalized variants of the provided value
+     * 
+     * @param value
+     *            the value
+     * @param normalizer
+     *            the normalizer
+     */
+    public BaseType(String value, Normalizer<T> normalizer) {
         this.normalizer = normalizer;
-        setDelegate(normalizer.denormalize(delegateString));
+        this.delegate = normalizer.denormalize(value);
+        this.normalizedValue = normalizer.normalize(value);
     }
     
     public BaseType(Normalizer<T> normalizer) {
@@ -33,9 +42,21 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         setDelegate(normalizer.denormalize(in));
     }
     
+    /**
+     * Set the delegate directly with no further operations
+     * 
+     * @param delegate
+     *            the delegate Type
+     */
     public void setDelegate(T delegate) {
         this.delegate = delegate;
-        normalizeAndSetNormalizedValue(this.delegate);
+    }
+    
+    /**
+     * Use the normalizer and delegate to set the normalized value. Assumes that {@link #setDelegate(Comparable)} has been called.
+     */
+    public void setNormalizedValueFromDelegate() {
+        this.normalizedValue = normalizer.normalizeDelegateType(this.delegate);
     }
     
     public String getNormalizedValue() {
@@ -47,6 +68,12 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         return this.delegate;
     }
     
+    /**
+     * Set the normalized value. This is useful when working with a value that is already normalized
+     * 
+     * @param normalizedValue
+     *            the normalized value
+     */
     public void setNormalizedValue(String normalizedValue) {
         this.normalizedValue = normalizedValue;
     }
@@ -85,9 +112,16 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         return normalizer.normalizedRegexIsLossy(in);
     }
     
+    /**
+     * Apply a normalizer to the provided value and store the result.
+     * 
+     * @param value
+     *            the value
+     */
     @Override
-    public void normalizeAndSetNormalizedValue(T valueToNormalize) {
-        setNormalizedValue(normalizer.normalizeDelegateType(valueToNormalize));
+    public void normalizeAndSetNormalizedValue(T value) {
+        String normalized = normalizer.normalizeDelegateType(value);
+        setNormalizedValue(normalized);
     }
     
     public void validate() {
@@ -160,7 +194,7 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
      * One string (normalizedValue) one unknown object (delegate) one normalizer (singleton reference) ref to object (4) normalizers will not be counted because
      * they are singletons
      * 
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
@@ -169,7 +203,7 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
             List<String> values = ((OneToManyNormalizerType<?>) this).getNormalizedValues();
             size += values.stream().map(String::length).map(length -> 2 * length + ObjectSizeOf.Sizer.REFERENCE).reduce(Integer::sum).orElse(0);
         }
-        size += STATIC_SIZE + (2 * normalizedValue.length()) + ObjectSizeOf.Sizer.getObjectSize(delegate);
+        size += STATIC_SIZE + (2L * normalizedValue.length()) + ObjectSizeOf.Sizer.getObjectSize(delegate);
         return size;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -27,7 +27,7 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
     public BaseType(String value, Normalizer<T> normalizer) {
         this.normalizer = normalizer;
         this.delegate = normalizer.denormalize(value);
-        this.normalizedValue = normalizer.normalize(value);
+        this.normalizedValue = normalizer.normalizeDelegateType(delegate);
     }
     
     public BaseType(Normalizer<T> normalizer) {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
@@ -6,7 +6,7 @@ import datawave.data.normalizer.Normalizer;
 
 public class DateType extends BaseType<Date> {
     
-    private static final long serialVersionUID = 936566410691643144L;
+    private static final long serialVersionUID = -1573098589077174678L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + PrecomputedSizes.DATE_STATIC_REF + Sizer.REFERENCE;
     
     public DateType() {
@@ -15,6 +15,7 @@ public class DateType extends BaseType<Date> {
     
     public DateType(String dateString) {
         super(Normalizer.DATE_NORMALIZER);
+        super.setNormalizedValue(dateString);
         super.setDelegate(normalizer.denormalize(dateString));
     }
     
@@ -27,10 +28,10 @@ public class DateType extends BaseType<Date> {
     /**
      * One string, one date object, one reference to the normalizer
      * 
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length());
+        return STATIC_SIZE + (2L * normalizedValue.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/GeometryType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/GeometryType.java
@@ -28,8 +28,15 @@ public class GeometryType extends AbstractGeometryType<Geometry> implements OneT
     }
     
     @Override
-    public void normalizeAndSetNormalizedValue(Geometry valueToNormalize) {
-        setNormalizedValues(((OneToManyNormalizer<Geometry>) normalizer).normalizeDelegateTypeToMany(valueToNormalize));
+    public void normalizeAndSetNormalizedValue(Geometry value) {
+        setNormalizedValues(((OneToManyNormalizer<Geometry>) normalizer).normalizeDelegateTypeToMany(value));
+    }
+    
+    /**
+     * Assumes that {@link #setDelegate(Comparable)} has been called
+     */
+    public void setNormalizedValueFromDelegate() {
+        setNormalizedValues(((OneToManyNormalizer<Geometry>) normalizer).normalizeDelegateTypeToMany(delegate));
     }
     
     public List<String> getNormalizedValues() {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/ListType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/ListType.java
@@ -21,14 +21,11 @@ public abstract class ListType extends BaseType implements OneToManyNormalizerTy
     @Override
     public List<String> normalizeToMany(String in) {
         String[] splits = StringUtils.split(in, delimiter);
-        List<String> strings = new ArrayList(splits.length);
+        List<String> strings = new ArrayList<>(splits.length);
         for (String s : splits) {
-            
             String str = normalizer.normalize(s);
             strings.add(str);
-            
         }
-        
         return strings;
     }
     
@@ -43,8 +40,10 @@ public abstract class ListType extends BaseType implements OneToManyNormalizerTy
      * Assumes that {@link #setDelegate(Comparable)} has been called
      */
     public void setNormalizedValueFromDelegate() {
-        this.normalizedValue = getDelegateAsString();
-        this.normalizedValues = normalizeToMany(getDelegateAsString());
+        if (normalizedValue == null) {
+            normalizedValue = getDelegateAsString();
+        }
+        this.normalizedValues = normalizeToMany(this.normalizedValue);
     }
     
     @Override

--- a/core/utils/type-utils/src/main/java/datawave/data/type/ListType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/ListType.java
@@ -39,6 +39,14 @@ public abstract class ListType extends BaseType implements OneToManyNormalizerTy
         setNormalizedValue(in);
     }
     
+    /**
+     * Assumes that {@link #setDelegate(Comparable)} has been called
+     */
+    public void setNormalizedValueFromDelegate() {
+        this.normalizedValue = getDelegateAsString();
+        this.normalizedValues = normalizeToMany(getDelegateAsString());
+    }
+    
     @Override
     public List<String> getNormalizedValues() {
         return normalizedValues;

--- a/core/utils/type-utils/src/main/java/datawave/data/type/NumberType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/NumberType.java
@@ -22,6 +22,6 @@ public class NumberType extends BaseType<BigDecimal> {
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length());
+        return STATIC_SIZE + (2L * normalizedValue.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/RawDateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/RawDateType.java
@@ -13,16 +13,17 @@ public class RawDateType extends BaseType<String> {
     
     public RawDateType(String dateString) {
         super(Normalizer.RAW_DATE_NORMALIZER);
-        super.setDelegate(normalizer.denormalize(dateString));
+        setNormalizedValue(dateString);
+        setDelegate(normalizer.denormalize(dateString));
     }
     
     /**
      * Two String + normalizer reference
      * 
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+        return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/Type.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/Type.java
@@ -22,6 +22,8 @@ public interface Type<T extends Comparable<T>> extends Comparable<Type<T>> {
     
     void setDelegate(T delegate);
     
+    void setNormalizedValueFromDelegate();
+    
     /**
      * The string form must preserve all information in the delegate such that setDelegateFromString will recreate this instance correctly.
      */

--- a/core/utils/type-utils/src/test/java/datawave/data/type/GeometryObjectSizeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/GeometryObjectSizeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.io.WKTReader;
 
@@ -18,8 +17,11 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void pointTest() throws Exception {
+        Point point = new Point((org.locationtech.jts.geom.Point) new WKTReader().read("POINT(0 0)"));
+        
         PointType pointType = new PointType();
-        pointType.setDelegate(new Point((org.locationtech.jts.geom.Point) new WKTReader().read("POINT(0 0)")));
+        pointType.setDelegate(point);
+        pointType.setNormalizedValue(point.toString());
         
         long estimatedSizeInBytes = pointType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(pointType);
@@ -29,8 +31,11 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void multiPointTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read("MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10)"));
+        
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read("MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10)")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
         
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -40,9 +45,12 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void polygonTest() throws Exception {
+        Geometry geometry = new Geometry(
+                        new WKTReader().read("POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45))"));
+        
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(
-                        new WKTReader().read("POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
         
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -52,9 +60,12 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void multiPolygonTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read(
+                        "MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60)))"));
+        
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read(
-                        "MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60)))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
         
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -64,8 +75,11 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void lineStringTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read("LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85)"));
+        
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read("LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85)")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
         
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -75,9 +89,12 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void multiLineStringTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read(
+                        "MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))"));
+        
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read(
-                        "MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
         
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -87,9 +104,12 @@ public class GeometryObjectSizeTest {
     
     @Test
     public void geometryCollectionTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read(
+                        "GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10)), GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))))"));
+        
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read(
-                        "GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10)), GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
         
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);

--- a/core/utils/type-utils/src/test/java/datawave/data/type/ListTypeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/ListTypeTest.java
@@ -15,7 +15,7 @@ public class ListTypeTest {
         
         LcNoDiacriticsListType t = new LcNoDiacriticsListType(str);
         Assert.equals(6, t.normalizeToMany(str).size());
-        List<String> expected = Arrays.asList(new String[] {"1", "2", "3", "a", "b", "c"});
+        List<String> expected = Arrays.asList("1", "2", "3", "a", "b", "c");
         Assert.equals(expected, t.normalizeToMany(str));
     }
     
@@ -25,14 +25,14 @@ public class ListTypeTest {
         
         LcNoDiacriticsListType t = new LcNoDiacriticsListType();
         Assert.equals(6, t.normalizeToMany(str).size());
-        List<String> expected = Arrays.asList(new String[] {"01", "02", "03", "a", "b", "c"});
+        List<String> expected = Arrays.asList("01", "02", "03", "a", "b", "c");
         Assert.equals(expected, t.normalizeToMany(str));
     }
     
     @Test
     public void testNumberList() {
         String str = "1,2,3,5.5";
-        List<String> expected = Arrays.asList(new String[] {"+aE1", "+aE2", "+aE3", "+aE5.5"});
+        List<String> expected = Arrays.asList("+aE1", "+aE2", "+aE3", "+aE5.5");
         
         NumberListType nt = new NumberListType();
         Assert.equals(4, nt.normalizeToMany(str).size());


### PR DESCRIPTION
Update Types so that setter methods do not make additional calls that involve normalizers.

It is now the callers responsibility to select the correct methods when normalization or denormalization is required to build correct Types.

See https://github.com/NationalSecurityAgency/datawave/pull/2840 for integration