### PR TITLE
Integrate type-utils updates for more efficient serialization and deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.datawave.metrics-reporter>3.0.0</version.datawave.metrics-reporter>
         <version.datawave.query-api>1.0.0</version.datawave.query-api>
         <version.datawave.query-metric-api>4.0.7</version.datawave.query-metric-api>
-        <version.datawave.type-utils>3.1.2</version.datawave.type-utils>
+        <version.datawave.type-utils>3.1.2-serialization</version.datawave.type-utils>
         <version.deltaspike>1.9.0</version.deltaspike>
         <version.easymock>5.2.0</version.easymock>
         <version.eclipse.emf>2.15.0</version.eclipse.emf>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.datawave.metrics-reporter>3.0.0</version.datawave.metrics-reporter>
         <version.datawave.query-api>1.0.0</version.datawave.query-api>
         <version.datawave.query-metric-api>4.0.7</version.datawave.query-metric-api>
-        <version.datawave.type-utils>3.1.2-serialization</version.datawave.type-utils>
+        <version.datawave.type-utils>3.1.3-serialization-2</version.datawave.type-utils>
         <version.deltaspike>1.9.0</version.deltaspike>
         <version.easymock>5.2.0</version.easymock>
         <version.eclipse.emf>2.15.0</version.eclipse.emf>

--- a/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
+++ b/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
@@ -51,6 +51,11 @@ public class IdentityDataType implements Type<String> {
     }
 
     @Override
+    public void setNormalizedValueFromDelegate() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getDelegateAsString() {
         throw new UnsupportedOperationException();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/AttributeFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/AttributeFactory.java
@@ -70,12 +70,10 @@ public class AttributeFactory {
     }
 
     public Attribute<?> create(String fieldName, String data, Key key, boolean toKeep) {
-
         return this.create(fieldName, data, key, extractIngestDataTypeFromKey(key), toKeep, false);
     }
 
     public Attribute<?> create(String fieldName, String data, Key key, boolean toKeep, boolean isComposite) {
-
         return this.create(fieldName, data, key, extractIngestDataTypeFromKey(key), toKeep, isComposite);
     }
 
@@ -135,18 +133,19 @@ public class AttributeFactory {
     protected Attribute<?> getAttribute(Class<?> dataTypeClass, String fieldName, String data, Key key, boolean toKeep) throws Exception {
         Type<?> type = (Type<?>) dataTypeClass.newInstance();
         try {
+            // cannot assume data is normalized. In the future provide an alternative entry point for normalized data.
             type.setDelegateFromString(data);
-            return new TypeAttribute(type, key, toKeep);
+            type.setNormalizedValueFromDelegate();
+            return new TypeAttribute<>(type, key, toKeep);
         } catch (Exception ex) {
 
             if (ex instanceof IllegalArgumentException) {
                 log.warn("Could not parse " + fieldName + " = '" + data + "', resorting to a NoOpType");
-                return new TypeAttribute(new NoOpType(data), key, toKeep);
+                return new TypeAttribute<>(new NoOpType(data), key, toKeep);
             } else {
                 log.error("Could not create Attribute for " + fieldName + " and " + data, ex);
                 throw new IllegalArgumentException("Could not create Attribute for " + fieldName + " and " + data, ex);
             }
-
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -153,7 +153,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
         } catch (Exception ex) {
             // there was some problem with setting the delegate as the declared type.
             // Instead of letting this exception fail the query, make this a NoOpType containing the string value from the input
-            log.warn("Was unable to make a " + datawaveType + " to contain a delegate created from input:" + normalizedValue + "  Making a NoOpType instead.");
+            log.warn("Was unable to make a " + datawaveType.getClass().getSimpleName() + " to contain a delegate created from input:" + normalizedValue
+                            + "  Making a " + NoOpType.class.getSimpleName() + " instead.");
             datawaveType = (Type) new NoOpType();
             datawaveType.setDelegateFromString(normalizedValue);
             datawaveType.setNormalizedValue(normalizedValue);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -60,6 +60,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
     public void write(DataOutput out) throws IOException {
         WritableUtils.writeString(out, datawaveType.getClass().toString());
         writeMetadata(out);
+
         WritableUtils.writeString(out, datawaveType.getDelegateAsString());
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -134,23 +135,28 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public void read(Kryo kryo, Input input) {
+
         try {
             setDatawaveType(input.readString());
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
             log.warn("could not read datawateType from input: " + e);
         }
         super.readMetadata(kryo, input);
-        if (datawaveType == null)
+        if (datawaveType == null) {
             datawaveType = (Type) new NoOpType();
-        String delegateString = input.readString();
+        }
+
+        String normalizedValue = input.readString();
         try {
-            datawaveType.setDelegateFromString(delegateString);
+            datawaveType.setDelegateFromString(normalizedValue);
+            datawaveType.setNormalizedValue(normalizedValue);
         } catch (Exception ex) {
             // there was some problem with setting the delegate as the declared type.
             // Instead of letting this exception fail the query, make this a NoOpType containing the string value from the input
-            log.warn("Was unable to make a " + datawaveType + " to contain a delegate created from input:" + delegateString + "  Making a NoOpType instead.");
+            log.warn("Was unable to make a " + datawaveType + " to contain a delegate created from input:" + normalizedValue + "  Making a NoOpType instead.");
             datawaveType = (Type) new NoOpType();
-            datawaveType.setDelegateFromString(delegateString);
+            datawaveType.setDelegateFromString(normalizedValue);
+            datawaveType.setNormalizedValue(normalizedValue);
         }
         this.toKeep = input.readBoolean();
     }
@@ -166,8 +172,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
      * @see Attribute#deepCopy()
      */
     @Override
-    public TypeAttribute copy() {
-        return new TypeAttribute(this.getType(), this.getMetadata(), this.isToKeep());
+    public TypeAttribute<T> copy() {
+        return new TypeAttribute<>(this.getType(), this.getMetadata(), this.isToKeep());
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingUtils.java
+++ b/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingUtils.java
@@ -109,6 +109,7 @@ public class GroupingUtils {
         // Add an attribute for the count.
         NumberType type = new NumberType();
         type.setDelegate(new BigDecimal(group.getCount()));
+        type.setNormalizedValue(String.valueOf(group.getCount()));
         TypeAttribute<BigDecimal> attr = new TypeAttribute<>(type, new Key("count"), true);
         document.put("COUNT", attr);
 
@@ -172,6 +173,7 @@ public class GroupingUtils {
     private static void addSumAggregation(Document document, String field, SumAggregator aggregator, MarkingFunctions markingFunctions) {
         NumberType type = new NumberType();
         type.setDelegate(aggregator.getAggregation());
+        type.normalizeAndSetNormalizedValue(aggregator.getAggregation());
         TypeAttribute<BigDecimal> sumAttribute = new TypeAttribute<>(type, new Key(field + "_sum"), true);
         sumAttribute.setColumnVisibility(combineVisibilities(aggregator.getColumnVisibilities(), markingFunctions, false));
         document.put(field + DocumentGrouper.FIELD_SUM_SUFFIX, sumAttribute);
@@ -192,6 +194,7 @@ public class GroupingUtils {
     private static void addCountAggregation(Document document, String field, CountAggregator aggregator, MarkingFunctions markingFunctions) {
         NumberType type = new NumberType();
         type.setDelegate(BigDecimal.valueOf(aggregator.getAggregation()));
+        type.normalizeAndSetNormalizedValue(BigDecimal.valueOf(aggregator.getAggregation()));
         TypeAttribute<BigDecimal> sumAttribute = new TypeAttribute<>(type, new Key(field + "_count"), true);
         Set<ColumnVisibility> columnVisibilities = aggregator.getColumnVisibilities();
         if (!columnVisibilities.isEmpty()) {
@@ -243,6 +246,7 @@ public class GroupingUtils {
     private static void addAverage(Document document, String field, AverageAggregator aggregator, MarkingFunctions markingFunctions) {
         NumberType type = new NumberType();
         type.setDelegate(aggregator.getAggregation());
+        type.setNormalizedValue(aggregator.getAggregation().toString());
         TypeAttribute<BigDecimal> attribute = new TypeAttribute<>(type, new Key(field + "_average"), true);
         attribute.setColumnVisibility(combineVisibilities(aggregator.getColumnVisibilities(), markingFunctions, false));
         document.put(field + DocumentGrouper.FIELD_AVERAGE_SUFFIX, attribute);
@@ -266,6 +270,7 @@ public class GroupingUtils {
         // Add an attribute for the average's numerator. This is required to properly combine additional aggregations in future groupings.
         NumberType numeratorType = new NumberType();
         numeratorType.setDelegate(aggregator.getNumerator());
+        numeratorType.setNormalizedValue(aggregator.getNumerator().toString());
         TypeAttribute<BigDecimal> sumAttribute = new TypeAttribute<>(numeratorType, new Key(field + "_average_numerator"), true);
         sumAttribute.setColumnVisibility(visibility);
         document.put(field + DocumentGrouper.FIELD_AVERAGE_NUMERATOR_SUFFIX, sumAttribute);
@@ -273,6 +278,7 @@ public class GroupingUtils {
         // Add an attribute for the average's divisor. This is required to properly combine additional aggregations in future groupings.
         NumberType divisorType = new NumberType();
         divisorType.setDelegate(aggregator.getDivisor());
+        divisorType.setNormalizedValue(aggregator.getDivisor().toString());
         TypeAttribute<BigDecimal> countAttribute = new TypeAttribute<>(divisorType, new Key(field + "_average_divisor"), true);
         countAttribute.setColumnVisibility(visibility);
         document.put(field + DocumentGrouper.FIELD_AVERAGE_DIVISOR_SUFFIX, countAttribute);

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -9,6 +9,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import datawave.data.type.HexStringType;
 import datawave.data.type.LcNoDiacriticsType;
@@ -22,6 +24,8 @@ import datawave.query.util.TypeMetadata;
  * Test document serialization with various attributes
  */
 public class DocumentTest {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentTest.class);
 
     private final String datatype = "datatype";
     private final Key documentKey = new Key("row", "datatype\0uid");
@@ -118,7 +122,7 @@ public class DocumentTest {
 
     protected void roundTrip(int max) {
         Entry<Key,Value> entry = serialize(d);
-        System.out.println("size: " + entry.getValue().getSize());
+        log.trace("size: {}", entry.getValue().getSize());
         for (int i = 0; i < max; i++) {
             Entry<Key,Document> result = deserialize(entry);
             Document d2 = result.getValue();

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -1,0 +1,143 @@
+package datawave.query.attributes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.AbstractMap;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.data.type.HexStringType;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.LcType;
+import datawave.data.type.NumberType;
+import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.function.serializer.KryoDocumentSerializer;
+import datawave.query.util.TypeMetadata;
+
+/**
+ * Test document serialization with various attributes
+ */
+public class DocumentTest {
+
+    private final String datatype = "datatype";
+    private final Key documentKey = new Key("row", "datatype\0uid");
+    private final KryoDocumentSerializer serializer = new KryoDocumentSerializer();
+    private final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
+
+    private static final int max_iterations = 1;
+
+    private AttributeFactory attributeFactory;
+
+    private Document d;
+
+    @BeforeEach
+    public void setup() {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        typeMetadata.put("LC", datatype, LcType.class.getTypeName());
+        typeMetadata.put("LC_NO_DIACRITICS", datatype, LcNoDiacriticsType.class.getTypeName());
+        typeMetadata.put("NUMBER", datatype, NumberType.class.getTypeName());
+        typeMetadata.put("HEX", datatype, HexStringType.class.getTypeName());
+
+        attributeFactory = new AttributeFactory(typeMetadata);
+        d = new Document(documentKey, true);
+    }
+
+    @Test
+    public void testEmptyDocument() {
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithLcType() {
+        Attribute<?> attr = createAttribute("LC", "value");
+        d.put("LC", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithLcNoDiacriticsType() {
+        Attribute<?> attr = createAttribute("LC_NO_DIACRITICS", "value");
+        d.put("LC_NO_DIACRITICS", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithHexType() {
+        Attribute<?> attr = createAttribute("HEX", "a1b2c3");
+        d.put("HEX", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithNumberType() {
+        Attribute<?> attr = createAttribute("NUMBER", "12");
+        d.put("NUMBER", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithNumberTypeNormalizedValue() {
+        Attribute<?> attr = createAttribute("NUMBER", "+bE1.2");
+        d.put("NUMBER", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithNumberTypeLargeValue() {
+        Attribute<?> attr = createAttribute("NUMBER", "12456789.987654321");
+        d.put("NUMBER", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testOneOfEverything() {
+        Attribute<?> attr1 = createAttribute("LC", "value-1");
+        Attribute<?> attr2 = createAttribute("LC_NO_DIACRITICS", "value-2");
+        Attribute<?> attr3 = createAttribute("NUMBER", "25");
+        Attribute<?> attr4 = createAttribute("HEX", "a1b2c3");
+        d.put("LC", attr1);
+        d.put("LC_NO_DIACRITICS", attr2);
+        d.put("NUMBER", attr3);
+        d.put("HEX", attr4);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testLargeDocument() {
+        int size = 100_000;
+        for (int i = 0; i < size; i++) {
+            Attribute<?> attr = createAttribute("LC", "value-" + i);
+            d.put("LC", attr);
+        }
+        roundTrip(max_iterations);
+    }
+
+    protected void roundTrip(int max) {
+        Entry<Key,Value> entry = serialize(d);
+        System.out.println("size: " + entry.getValue().getSize());
+        for (int i = 0; i < max; i++) {
+            Entry<Key,Document> result = deserialize(entry);
+            Document d2 = result.getValue();
+            assertEquals(d, d2);
+        }
+    }
+
+    protected Attribute<?> createAttribute(String field, String value) {
+        Attribute<?> attr = attributeFactory.create(field, value, documentKey, datatype, true);
+        attr.clearMetadata();
+        return attr;
+    }
+
+    protected Entry<Key,Value> serialize(Document d) {
+        Entry<Key,Document> entry = new AbstractMap.SimpleEntry<>(documentKey, d);
+        return serializer.apply(entry);
+    }
+
+    protected Entry<Key,Document> deserialize(Entry<Key,Value> entry) {
+        return deserializer.apply(entry);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
@@ -1,7 +1,16 @@
 package datawave.query.attributes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.ByteArrayOutputStream;
+
 import org.apache.accumulo.core.data.Key;
 import org.junit.Test;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 
 import datawave.data.type.NoOpType;
 
@@ -17,5 +26,26 @@ public class TypeAttributeTest extends AttributeTest {
 
         attr = new TypeAttribute<>(type, docKey, true);
         testToKeep(attr, true);
+    }
+
+    @Test
+    public void testExceptionLeadsToNoOpType() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Output output = new Output(baos);
+
+        // note: if further changes are made to serialization this test will need to be updated
+        output.writeString("MrMcDoesn'tExist");
+        output.writeBoolean(false); // write metadata when not set
+        output.writeString("delegate value as string");
+        output.writeBoolean(false); // to keep false
+        output.flush();
+
+        Input input = new Input(baos.toByteArray());
+        TypeAttribute<?> type = new TypeAttribute<>();
+        type.read(new Kryo(), input);
+
+        assertInstanceOf(TypeAttribute.class, type);
+        assertInstanceOf(NoOpType.class, type.getType());
+        assertEquals("delegate value as string", type.getData().toString());
     }
 }


### PR DESCRIPTION
Note: this depends on a temporary tag. 

Once https://github.com/NationalSecurityAgency/datawave/pull/2839 is merged and part of the 3.1.3 tag this branch can be updated.