### PR TITLE
Base64 encode the kryo byte array

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/util/count/CountMapSerDe.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/count/CountMapSerDe.java
@@ -2,6 +2,7 @@ package datawave.query.util.count;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -21,7 +22,7 @@ public class CountMapSerDe {
     }
 
     public String serializeToString(CountMap map) {
-        return new String(serialize(map), StandardCharsets.ISO_8859_1);
+        return new String(Base64.getEncoder().encode(serialize(map)), StandardCharsets.ISO_8859_1);
     }
 
     public byte[] serialize(CountMap map) {
@@ -33,7 +34,7 @@ public class CountMapSerDe {
     }
 
     public CountMap deserializeFromString(String data) {
-        return deserialize(data.getBytes(StandardCharsets.ISO_8859_1));
+        return deserialize(Base64.getDecoder().decode(data));
     }
 
     public CountMap deserialize(byte[] data) {

--- a/warehouse/query-core/src/test/java/datawave/query/util/count/CountMapSerDeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/count/CountMapSerDeTest.java
@@ -30,7 +30,7 @@ class CountMapSerDeTest {
         map.put("FIELD_B", 23L);
 
         String s = serDe.serializeToString(map);
-        assertEquals(18, s.length()); // 35 without optimizing integers/longs
+        assertEquals(24, s.length()); // 35 without optimizing integers/longs
         CountMap deserialized = serDe.deserializeFromString(s);
 
         assertMap(map, deserialized);


### PR DESCRIPTION
Requesting term counts broke the output of listscans in certain cases