### PR TITLE
corresponding updates for type-utils zero regex checks

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -44,7 +44,6 @@ import datawave.core.common.logging.ThreadConfigurableLogger;
 import datawave.data.normalizer.IpAddressNormalizer;
 import datawave.data.type.GeoType;
 import datawave.data.type.IpAddressType;
-import datawave.data.type.NumberType;
 import datawave.data.type.OneToManyNormalizerType;
 import datawave.data.type.Type;
 import datawave.query.Constants;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -333,6 +333,7 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                     boolean failedNormalization = false;
                     boolean regexNode = (node instanceof ASTNRNode || node instanceof ASTERNode);
                     boolean containsLossyRegex = false;
+                    JexlNode lossyRegexNode = null;
                     // Build up a set of normalized terms using each normalizer
                     for (Type<?> normalizer : dataTypes) {
                         try {
@@ -370,10 +371,12 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                                     // if the normalized term is identical to the original term, it cannot be lossy
                                     if (regexNode && !term.equals(normTerm) && normalizer.normalizedRegexIsLossy(term)) {
                                         containsLossyRegex = true;
+                                        lossyRegexNode = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(nodeToReturn, fieldName, term),
+                                                        EVALUATION_ONLY);
 
-                                    } else {
-                                        normalizedNodes.add(normalizedNode);
                                     }
+                                    normalizedNodes.add(normalizedNode);
+
                                 }
                             }
                         } catch (IpAddressNormalizer.Exception ipex) {
@@ -414,13 +417,6 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                             // normalization failures do not matter for ANYFIELD terms
                             failedNormalization = !fieldName.equals(Constants.ANY_FIELD);
                         }
-                    }
-                    // todo: this merits further scrutiny
-                    if (containsLossyRegex) {
-                        JexlNode evalOnly = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(nodeToReturn, fieldName, term), EVALUATION_ONLY);
-                        // now we need to combine these two nodes so that both are required
-                        JexlNode combined = JexlNodeFactory.createAndNode(Arrays.asList(new JexlNode[] {nodeToReturn, evalOnly}));
-                        normalizedNodes = Arrays.asList(combined);
                     }
 
                     // determine if we are marking this term as dropped or evaluation only
@@ -471,6 +467,13 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                         } else {
                             nodeToReturn = JexlNodeFactory.createOrNode(normalizedNodes);
                         }
+                    }
+
+                    // todo: this merits further scrutiny
+                    if (containsLossyRegex) {
+                        // now we need to combine these two nodes so that both are required
+                        JexlNode combined = JexlNodeFactory.createAndNode(Arrays.asList(new JexlNode[] {nodeToReturn, lossyRegexNode}));
+                        nodeToReturn = combined;
                     }
 
                     // wrap the node if required

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Sets;
 
 import datawave.core.common.logging.ThreadConfigurableLogger;
 import datawave.data.normalizer.IpAddressNormalizer;
+import datawave.data.type.GeoType;
 import datawave.data.type.IpAddressType;
 import datawave.data.type.NumberType;
 import datawave.data.type.OneToManyNormalizerType;
@@ -331,11 +332,14 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                     List<JexlNode> normalizedNodes = Lists.newArrayList();
                     boolean failedNormalization = false;
                     boolean regexNode = (node instanceof ASTNRNode || node instanceof ASTERNode);
+                    boolean containsLossyRegex = false;
                     // Build up a set of normalized terms using each normalizer
                     for (Type<?> normalizer : dataTypes) {
                         try {
                             if (normalizer instanceof OneToManyNormalizerType && ((OneToManyNormalizerType<?>) normalizer).expandAtQueryTime()) {
-                                if (regexNode) {
+
+                                // todo: add other one-to-many types for which we should not allow regex
+                                if (regexNode && normalizer instanceof GeoType) {
                                     throw new IllegalArgumentException(
                                                     "OneToManyNormalizers to not handle regex normalization: " + fieldName + " -> " + normalizer.getClass());
                                 }
@@ -363,12 +367,10 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                                     }
                                     normalizedTerms.add(normTerm);
                                     JexlNode normalizedNode = JexlNodeFactory.buildUntypedNode(node, fieldName, normTerm);
-                                    if (regexNode && normalizer.normalizedRegexIsLossy(term)) {
-                                        JexlNode evalOnly = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(node, fieldName, term),
-                                                        EVALUATION_ONLY);
-                                        // now we need to combine these two nodes so that both are required
-                                        JexlNode combined = JexlNodeFactory.createAndNode(Arrays.asList(new JexlNode[] {normalizedNode, evalOnly}));
-                                        normalizedNodes.add(combined);
+                                    // if the normalized term is identical to the original term, it cannot be lossy
+                                    if (regexNode && !term.equals(normTerm) && normalizer.normalizedRegexIsLossy(term)) {
+                                        containsLossyRegex = true;
+
                                     } else {
                                         normalizedNodes.add(normalizedNode);
                                     }
@@ -412,6 +414,13 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                             // normalization failures do not matter for ANYFIELD terms
                             failedNormalization = !fieldName.equals(Constants.ANY_FIELD);
                         }
+                    }
+                    // todo: this merits further scrutiny
+                    if (containsLossyRegex) {
+                        JexlNode evalOnly = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(nodeToReturn, fieldName, term), EVALUATION_ONLY);
+                        // now we need to combine these two nodes so that both are required
+                        JexlNode combined = JexlNodeFactory.createAndNode(Arrays.asList(new JexlNode[] {nodeToReturn, evalOnly}));
+                        normalizedNodes = Arrays.asList(combined);
                     }
 
                     // determine if we are marking this term as dropped or evaluation only

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -368,14 +368,13 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                                     }
                                     normalizedTerms.add(normTerm);
                                     JexlNode normalizedNode = JexlNodeFactory.buildUntypedNode(node, fieldName, normTerm);
-                                    // if the normalized term is identical to the original term, it cannot be lossy
-                                    if (regexNode && !term.equals(normTerm) && normalizer.normalizedRegexIsLossy(term)) {
-                                        containsLossyRegex = true;
-                                        lossyRegexNode = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(nodeToReturn, fieldName, term),
-                                                        EVALUATION_ONLY);
-
-                                    }
                                     normalizedNodes.add(normalizedNode);
+                                }
+                                // if the normalized term is identical to the original term, it cannot be lossy
+                                if (regexNode && !term.equals(normTerm) && normalizer.normalizedRegexIsLossy(term)) {
+                                    containsLossyRegex = true;
+                                    lossyRegexNode = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(nodeToReturn, fieldName, term),
+                                                    EVALUATION_ONLY);
 
                                 }
                             }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1121,6 +1121,10 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             config.setQueryTree(timedExpandAnyFieldRegexNodes(timers, config.getQueryTree(), config, metadataHelper, scannerFactory, settings.getQuery()));
         }
 
+        // Enforce unique terms within an AND or OR expression. For some reason we get duplicate expanded terms from the ExpandAnyFieldRegex. Dedupe them here
+        // until we fix that.
+        config.setQueryTree(timedEnforceUniqueTermsWithinExpressions(timers, config.getQueryTree()));
+
         if (reduceQuery) {
             config.setQueryTree(timedReduce(timers, "Reduce Query After ANYFIELD Expansions", config.getQueryTree()));
         }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -336,7 +336,15 @@ public abstract class ExecutableExpansionVisitorTest {
                         finalQuery);
 
         ASTJexlScript expectedQuery = JexlASTHelper.parseJexlQuery(
-                        "((((_Bounded_ = true) && (NUMBER >= '0' && NUMBER <= '1000')) && geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a') && (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a')) || (((_Bounded_ = true) && (NUMBER >= '0' && NUMBER <= '1000')) && geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a') && (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a'))) && GENDER == 'male' && (NOME == 'this' || NOME == 'that') && !filter:includeRegex(ETA, 'blah') && (LOCATION == 'chicago' || LOCATION == 'newyork' || LOCATION == 'newjersey')");
+                        "GENDER == 'male' && (NOME == 'that' || NOME == 'this') && (LOCATION == 'chicago' || LOCATION == 'newjersey' || LOCATION == 'newyork') && (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f200a80a80a80a80a' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888') && geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && !filter:includeRegex(ETA, 'blah') && ((_Bounded_ = true) && (NUMBER >= '0' && NUMBER <= '1000'))");
+        // "((((_Bounded_ = true) && (NUMBER >= '0' && NUMBER <= '1000')) && geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))')
+        // && (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a') &&
+        // (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a')) ||
+        // (((_Bounded_ = true) && (NUMBER >= '0' && NUMBER <= '1000')) && geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') &&
+        // (GEO == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a') && (GEO
+        // == '00' || GEO == '0202' || GEO == '020b' || GEO == '1f202a02a02a02a02a' || GEO == '1f2088888888888888' || GEO == '1f200a80a80a80a80a'))) && GENDER
+        // == 'male' && (NOME == 'this' || NOME == 'that') && !filter:includeRegex(ETA, 'blah') && (LOCATION == 'chicago' || LOCATION == 'newyork' || LOCATION
+        // == 'newjersey')");
         Assert.assertTrue(TreeEqualityVisitor.isEqual(expectedQuery, logic.getConfig().getQueryTree()));
     }
 
@@ -439,7 +447,7 @@ public abstract class ExecutableExpansionVisitorTest {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
 
-        String expectedQueryStr = "(UUID == 'capone' || UUID == 'soprano') && (((_Eval_ = true) &&  BAIL =~ '\\+[a-zA-Z]E.*?0?\\.?5|![A-Za-z]E.*?9?\\.?5' &&  BAIL =~ '.*?05'))";
+        String expectedQueryStr = "(UUID == 'capone' || UUID == 'soprano') && ((_Eval_ = true) &&  BAIL =~ '\\+[a-zA-Z]E.*?0?\\.?5|![A-Za-z]E.*?9?\\.?5' &&  BAIL =~ '.*?05')";
         String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
         Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
                         TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -392,7 +392,54 @@ public abstract class ExecutableExpansionVisitorTest {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
 
-        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401' || BAIL == '+gE1.234987') && ((_Eval_ = true) && (BAIL =~ '12340.*?'))";
+        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Eval_ = true) && (BAIL =~ '12340.*?'))";
+        String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
+        Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
+                        TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));
+    }
+
+    @Test
+    public void testAnyfieldNumericExpansion() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        // extraParameters.put("query.syntax", "LUCENE");
+
+        if (log.isDebugEnabled()) {
+            log.debug("testMatchesAtLeastCountOf");
+        }
+        String[] queryStrings = {"_ANYFIELD_ =~'12340.*?'"};
+        @SuppressWarnings("unchecked")
+        // SOPRANO is the only one with a 0 after the 1234
+        List<String>[] expectedLists = new List[] {Arrays.asList("SOPRANO")};
+        for (int i = 0; i < queryStrings.length; i++) {
+            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
+        }
+
+        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Eval_ = true) && (_ANYFIELD_ =~ '12340.*?'))";
+        String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
+        Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
+                        TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));
+    }
+
+    @Test
+    public void testLeadingNumericExpansion() throws Exception {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+        // extraParameters.put("query.syntax", "LUCENE");
+
+        if (log.isDebugEnabled()) {
+            log.debug("testMatchesAtLeastCountOf");
+        }
+        String[] queryStrings = {"(UUID == 'capone' || UUID == 'soprano') && BAIL=~'.*?05'"};
+        @SuppressWarnings("unchecked")
+        List<String>[] expectedLists = new List[] {Arrays.asList("CAPONE")};
+        for (int i = 0; i < queryStrings.length; i++) {
+            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
+        }
+
+        String expectedQueryStr = "(UUID == 'capone' || UUID == 'soprano') && (((_Eval_ = true) &&  BAIL =~ '\\+[a-zA-Z]E.*?0?\\.?5|![A-Za-z]E.*?9?\\.?5' &&  BAIL =~ '.*?05'))";
         String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
         Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
                         TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));

--- a/warehouse/query-core/src/test/java/datawave/query/util/WiseGuysIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/WiseGuysIngest.java
@@ -173,7 +173,7 @@ public class WiseGuysIngest {
                             timeStamp + sopranoTimeStampDelta, emptyValue);
             mutation.put(datatype + "\u0000" + sopranoUID, "GEO" + "\u0000" + "POINT(20 20)", columnVisibility, timeStamp + sopranoTimeStampDelta, emptyValue);
 
-            mutation.put(datatype + "\u0000" + caponeUID, "BAIL.0" + "\u0000" + "1234987", columnVisibility, timeStamp + caponeTimeStampDelta, emptyValue);
+            mutation.put(datatype + "\u0000" + caponeUID, "BAIL.0" + "\u0000" + "0.05", columnVisibility, timeStamp + caponeTimeStampDelta, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "NAME.0" + "\u0000" + "ALPHONSE", columnVisibility, timeStamp + caponeTimeStampDelta, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "NAME.1" + "\u0000" + "FRANK", columnVisibility, timeStamp + caponeTimeStampDelta, emptyValue);
             mutation.put(datatype + "\u0000" + caponeUID, "NAME.2" + "\u0000" + "RALPH", columnVisibility, timeStamp + caponeTimeStampDelta, emptyValue);
@@ -311,7 +311,7 @@ public class WiseGuysIngest {
             mutation.put("BAIL".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
             bw.addMutation(mutation);
-            mutation = new Mutation(numberType.normalize("1234987"));
+            mutation = new Mutation(numberType.normalize("0.05"));
             mutation.put("BAIL".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
             bw.addMutation(mutation);
@@ -653,6 +653,19 @@ public class WiseGuysIngest {
                             range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
             bw.addMutation(mutation);
 
+            mutation = new Mutation(new StringBuilder(numberType.normalize("12345")).reverse());
+            mutation.put("BAIL".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            bw.addMutation(mutation);
+            mutation = new Mutation(new StringBuilder(numberType.normalize("123401")).reverse());
+            mutation.put("BAIL".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            bw.addMutation(mutation);
+            mutation = new Mutation(new StringBuilder(numberType.normalize("0.05")).reverse());
+            mutation.put("BAIL".toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
+                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            bw.addMutation(mutation);
+
             // add some index-only fields
             mutation = new Mutation(new StringBuilder("chicago").reverse());
             mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibility, timeStamp,
@@ -726,7 +739,7 @@ public class WiseGuysIngest {
                             emptyValue);
             mutation.put("fi\u0000" + "BAIL", numberType.normalize("123401") + "\u0000" + datatype + "\u0000" + sopranoUID, columnVisibility, timeStamp,
                             emptyValue);
-            mutation.put("fi\u0000" + "BAIL", numberType.normalize("1234987") + "\u0000" + datatype + "\u0000" + caponeUID, columnVisibility, timeStamp,
+            mutation.put("fi\u0000" + "BAIL", numberType.normalize("0.05") + "\u0000" + datatype + "\u0000" + caponeUID, columnVisibility, timeStamp,
                             emptyValue);
 
             // geo
@@ -912,6 +925,8 @@ public class WiseGuysIngest {
             mutation.put(ColumnFamilyConstants.COLF_E, new Text(datatype), emptyValue);
             mutation.put(ColumnFamilyConstants.COLF_F, new Text(datatype + "\u0000" + date), new Value(SummingCombiner.VAR_LEN_ENCODER.encode(12L)));
             mutation.put(ColumnFamilyConstants.COLF_I, new Text(datatype), emptyValue);
+            mutation.put(ColumnFamilyConstants.COLF_RI, new Text(datatype), emptyValue);
+
             mutation.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\u0000" + normalizerForColumn("BAIL")), emptyValue);
             bw.addMutation(mutation);
 


### PR DESCRIPTION
if a regex is lossy add the eval_only node to the group of nodes created by looping through all normalizers

requires: https://github.com/NationalSecurityAgency/datawave-type-utils/pull/41