### PR TITLE
Replace usage of Collections.EMPTY_SET with Collections.emptySet()

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/EventMapper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/EventMapper.java
@@ -396,7 +396,7 @@ public class EventMapper<K1,V1 extends RawRecordContainer,K2,V2> extends StatsDE
                 }
             }).collect(Collectors.toSet());
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/processor/AbstractSliceDistributor.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/processor/AbstractSliceDistributor.java
@@ -73,7 +73,7 @@ public abstract class AbstractSliceDistributor<S extends Comparable<S>> implemen
         }
 
         if (totalMaps == 0)
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         HashSet<InputFile> flagFiles = new HashSet<>();
         if (totalMaps < fc.getMaxFlags()) {
             // get everything

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/processor/SimpleFlagDistributor.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/processor/SimpleFlagDistributor.java
@@ -48,7 +48,7 @@ public class SimpleFlagDistributor implements FlagDistributor {
     public Collection<InputFile> next(SizeValidator validator) {
         int size = inputs.size();
         if (size == 0)
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         Collection<InputFile> list = new HashSet<>();
         if (size < fc.getMaxFlags()) {
             list.addAll(inputs);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DescendentFilterIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DescendentFilterIterator.java
@@ -53,7 +53,7 @@ public class DescendentFilterIterator extends SkippingIterator implements Option
 
     private Range prevRange = new Range();
     @SuppressWarnings("unchecked")
-    private Collection<ByteSequence> columnFamilies = (Set<ByteSequence>) Collections.EMPTY_SET;
+    private Collection<ByteSequence> columnFamilies = Collections.emptySet();
     private boolean colfInclusive = false;
 
     private final Text prevRow = new Text();

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
@@ -211,7 +211,7 @@ public class IteratorBuildingVisitorTest {
         source.add(new AbstractMap.SimpleEntry(
                         new Key("row", "fi" + Constants.NULL + "F1", "v1" + Constants.NULL + "dataType" + Constants.NULL + "123.345.456"), new Value()));
 
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, Collections.EMPTY_SET, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, Collections.emptySet(), Collections.emptySet(),
                         Collections.singleton("F2"));
 
     }
@@ -228,7 +228,7 @@ public class IteratorBuildingVisitorTest {
         source.add(new AbstractMap.SimpleEntry(
                         new Key("row", "fi" + Constants.NULL + "F2", "v2" + Constants.NULL + "dataType" + Constants.NULL + "123.345.456"), new Value()));
 
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, Collections.EMPTY_SET, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, Collections.emptySet(), Collections.emptySet(),
                         Collections.singleton("F2"));
     }
 
@@ -244,7 +244,7 @@ public class IteratorBuildingVisitorTest {
         source.add(new AbstractMap.SimpleEntry(
                         new Key("row", "fi" + Constants.NULL + "F2", "v3" + Constants.NULL + "dataType" + Constants.NULL + "123.345.456"), new Value()));
 
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, Collections.EMPTY_SET, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, Collections.emptySet(), Collections.emptySet(),
                         Collections.singleton("F2"));
     }
 
@@ -264,7 +264,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values are within the bounds
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
 
         List<String> expected = new ArrayList<>();
@@ -292,7 +292,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values are within the bounds
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         termFrequencyFields);
 
         List<String> expected = new ArrayList<>();
@@ -320,7 +320,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values are within the bounds
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
 
         List<String> expected = new ArrayList<>();
@@ -348,7 +348,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values are within the bounds
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         termFrequencyFields);
 
         List<String> expected = new ArrayList<>();
@@ -376,7 +376,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values are within the bounds
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
 
         List<String> expected = new ArrayList<>();
@@ -404,7 +404,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values are within the bounds
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         termFrequencyFields);
 
         List<String> expected = new ArrayList<>();
@@ -431,7 +431,7 @@ public class IteratorBuildingVisitorTest {
 
         // create bounded range filter
         // value outside upper bound so no document found
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
     }
 
@@ -450,7 +450,7 @@ public class IteratorBuildingVisitorTest {
 
         // create bounded range filter
         // value outside upper bound so no document found
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.emptySet(),
                         termFrequencyFields);
     }
 
@@ -469,7 +469,7 @@ public class IteratorBuildingVisitorTest {
 
         // create bounded range filter
         // value outside lower bound so no document found
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
     }
 
@@ -488,7 +488,7 @@ public class IteratorBuildingVisitorTest {
 
         // create bounded range filter
         // value outside lower bound so no document found
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, null, source, false, null, termFrequencyFields, Collections.emptySet(),
                         termFrequencyFields);
     }
 
@@ -508,7 +508,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values that match regex
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
     }
 
@@ -528,7 +528,7 @@ public class IteratorBuildingVisitorTest {
 
         // must have doc to get tf field values that match regex
         // aggregation fields are not set so no document is created
-        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.EMPTY_SET,
+        vistAnd_ExceededValueThesholdMarkerJexlNode_termFrequencyTest(script, hit, source, false, null, termFrequencyFields, Collections.emptySet(),
                         Collections.emptySet());
     }
 

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -289,7 +289,7 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(persister.create(principal.getUserDN().subjectDN(), dnList, (SecurityMarking) Whitebox.getField(bean.getClass(), "marking").get(bean),
                         queryLogicName, (QueryParameters) Whitebox.getField(bean.getClass(), "qp").get(bean), optionalParameters)).andReturn(q);
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
-        EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.EMPTY_SET);
+        EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.emptySet());
         EasyMock.expect(logic.getConnectionPriority()).andReturn(AccumuloConnectionFactory.Priority.NORMAL);
         EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
@@ -379,7 +379,7 @@ public class QueryExecutorBeanTest {
         EasyMock.expect(logic.getResultLimit(anyObject(QueryImpl.class))).andReturn(-1L);
 
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
-        EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.EMPTY_SET);
+        EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.emptySet());
         EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
         EasyMock.expect(logic.getAuditType(EasyMock.<Query> anyObject())).andReturn(AuditType.ACTIVE).anyTimes();
@@ -437,7 +437,7 @@ public class QueryExecutorBeanTest {
                         queryLogicName, (QueryParameters) Whitebox.getField(bean.getClass(), "qp").get(bean), optionalParameters)).andReturn(q);
 
         EasyMock.expect(queryLogicFactory.getQueryLogic(queryLogicName, principal)).andReturn(logic);
-        EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.EMPTY_SET);
+        EasyMock.expect(logic.getRequiredQueryParameters()).andReturn(Collections.emptySet());
         EasyMock.expect(logic.containsDNWithAccess(dnList)).andReturn(true);
         EasyMock.expect(logic.getMaxPageSize()).andReturn(0);
 


### PR DESCRIPTION
Replace usages of Collections.EMPTY_SET with Collections.emptySet() where we are returning/instantiating a set. This allows for inferred generic types.