### PR TITLE
Bounded Range Validation

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -486,6 +486,17 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
         } else if (instance.isType(INDEX_HOLE)) {
             return ScannerStream.delayed(node);
         } else if (instance.isType(BOUNDED_RANGE)) {
+            LiteralRange<?> range = JexlASTHelper.findRange().getRange(node);
+            if (range == null) {
+                throw new RuntimeException("BoundedRange was null");
+            }
+
+            if (isIndexed(range.getFieldName(), config.getIndexedFields())) {
+                JexlNode wrapped = JexlNodes.wrap(node);
+                ShardSpecificIndexIterator iter = new ShardSpecificIndexIterator(wrapped, getNumShardFinder(), config.getBeginDate(), config.getEndDate());
+                return ScannerStream.withData(iter, wrapped);
+            }
+
             // here we must have a bounded range that was not expanded, so it must not be expandable via the index
             return ScannerStream.delayed(node);
         } else {
@@ -908,6 +919,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
             }
             try (Scanner scanner = client.createScanner(TableName.METADATA)) {
                 scanner.setRange(Range.exact(NumShards.NUM_SHARDS, NumShards.NUM_SHARDS_CF));
+                int scannedKeys = 0;
                 for (Map.Entry<Key,Value> entry : scanner) {
                     // num_shards ns:date_shards
                     // num_shards ns:20050207_17
@@ -917,8 +929,13 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                         continue;
                     }
 
+                    scannedKeys++;
                     String[] parts = cq.split("_");
                     cache.put(parts[0], Integer.parseInt(parts[1]));
+                }
+
+                if (scannedKeys == 0) {
+                    log.error("no entries in num_shards cache");
                 }
             } catch (TableNotFoundException | AccumuloException | AccumuloSecurityException e) {
                 // an exception here shouldn't kill the query

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -935,7 +935,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                 }
 
                 if (scannedKeys == 0) {
-                    log.error("no entries in num_shards cache");
+                    log.fatal("no entries in num_shards cache");
                 }
             } catch (TableNotFoundException | AccumuloException | AccumuloSecurityException e) {
                 // an exception here shouldn't kill the query

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -983,6 +983,159 @@ public class JexlASTHelper {
     }
 
     /**
+     * Swaps the original node with the replacement, following rules for reference expressions, single terms and junctions
+     * <p>
+     * This method prevents reference expressions from having a single child.
+     * <p>
+     * This method also allows for merging similar junctions.
+     *
+     * @param original
+     *            the original node
+     * @param replacement
+     *            the replacement node
+     */
+    public static void replaceNodeSafely(JexlNode original, JexlNode replacement) {
+        JexlNode parent = original.jjtGetParent();
+
+        if (parent == null) {
+            return; // cannot do anything in this case
+        }
+
+        boolean multiValue = isJunction(replacement);
+        if (multiValue) {
+            replaceNodeWithMultiValue(parent, original, replacement);
+        } else {
+            replaceNodeWithSingleValue(parent, original, replacement);
+        }
+    }
+
+    /**
+     * This method accepts a multivalued replacement node (ASTAndNode or ASTOrNode) and attempts to merge it cleanly into the parent or grandparent node with a
+     * preference for a reference expression as the new parent.
+     *
+     * @param parent
+     *            the parent node
+     * @param original
+     *            the original node
+     * @param replacement
+     *            the replacement node
+     */
+    private static void replaceNodeWithMultiValue(JexlNode parent, JexlNode original, JexlNode replacement) {
+
+        // similar junctions, merge children
+        if (isEquivalentJunctions(parent, replacement)) {
+            mergeJunctions(parent, original, replacement);
+            return;
+        }
+
+        // if no 'legal' rewrite could occur with the parent, try the grandparent
+        JexlNode grandParent = parent.jjtGetParent();
+        if (grandParent != null) {
+            // reference expression, straight replacement
+            if (grandParent instanceof ASTReferenceExpression) {
+                JexlNodes.replaceChild(grandParent, parent, replacement);
+                return;
+            }
+
+            // similar junctions, merge children
+            if (isEquivalentJunctions(grandParent, replacement)) {
+                mergeJunctions(grandParent, parent, replacement);
+                return;
+            }
+        }
+
+        // if no optimal rewrite occurred, fall back to a simple replacement
+        JexlNodes.replaceChild(parent, original, replacement);
+    }
+
+    /**
+     * This method accepts a single replacement node (leaf node) and attempts to merge it cleanly into the parent or grandparent while avoiding a reference
+     * expression as the new parent.
+     *
+     * @param parent
+     *            the parent node
+     * @param original
+     *            the original node
+     * @param replacement
+     *            the replacement node
+     */
+    private static void replaceNodeWithSingleValue(JexlNode parent, JexlNode original, JexlNode replacement) {
+
+        if (!(parent instanceof ASTReferenceExpression)) {
+            // straight replacement
+            JexlNodes.replaceChild(parent, original, replacement);
+            return;
+        }
+
+        // otherwise we have a reference expression and we need to go up a layer
+        JexlNode grandParent = parent.jjtGetParent();
+
+        if (grandParent != null) {
+            // check for the negated single term case: !(term)
+            // it is also unlikely that two reference expressions would sit next to each other in the tree, but it's
+            // not impossible
+            if (!(grandParent instanceof ASTNotNode) && !(grandParent instanceof ASTReferenceExpression)) {
+                JexlNodes.replaceChild(grandParent, parent, replacement);
+                return;
+            }
+        }
+
+        // if no optimal rewrite occurred fallback to a simple replacement
+        JexlNodes.replaceChild(parent, original, replacement);
+    }
+
+    /**
+     * Determines if the provided JexlNode is a junction
+     *
+     * @param node
+     *            the JexlNode
+     * @return true if the node is a junction
+     */
+    public static boolean isJunction(JexlNode node) {
+        return !QueryPropertyMarker.findInstance(node).isAnyType() && (node instanceof ASTOrNode || node instanceof ASTAndNode);
+    }
+
+    /**
+     * Determines if the two JexlNodes are similar junction types (both And nodes or both Or nodes)
+     *
+     * @param a
+     *            first JexlNode
+     * @param b
+     *            second JexlNode
+     * @return true if the two nodes are equivalent junctions
+     */
+    public static boolean isEquivalentJunctions(JexlNode a, JexlNode b) {
+        if (QueryPropertyMarker.findInstance(a).isAnyType() || QueryPropertyMarker.findInstance(b).isAnyType()) {
+            return false;
+        }
+
+        return (a instanceof ASTOrNode && b instanceof ASTOrNode) || (a instanceof ASTAndNode && b instanceof ASTAndNode);
+    }
+
+    /**
+     * Given two equivalent junctions per {@link #isEquivalentJunctions(JexlNode, JexlNode)}, merges the children for node B into the children of node A
+     *
+     * @param parent
+     *            the parent
+     * @param a
+     *            first JexlNode
+     * @param b
+     *            second JexlNode
+     */
+    public static void mergeJunctions(JexlNode parent, JexlNode a, JexlNode b) {
+        List<JexlNode> nodes = new ArrayList<>();
+        for (JexlNode child : JexlNodes.getChildren(parent)) {
+            if (child == a) {
+                // preserves node order
+                nodes.addAll(List.of(JexlNodes.getChildren(b)));
+            } else {
+                nodes.add(child);
+            }
+        }
+        JexlNodes.setChildren(parent, nodes.toArray(new JexlNode[0]));
+    }
+
+    /**
      * Ranges: A range prior to being "tagged" must be of the form "(term1 &amp;&amp; term2)" where term1 and term2 refer to the same field and denote two sides
      * of the range ((LE or LT) and (GE or GT)). A tagged range is of the form "(BoundedRange=true) &amp;&amp; (term1 &amp;&amp; term2))"
      *
@@ -1796,7 +1949,8 @@ public class JexlASTHelper {
                     JexlNode child = node.jjtGetChild(i);
                     if (child != null) {
                         if (child.jjtGetParent() == null) {
-                            String message = "Tree included child " + child + " with a null parent";
+                            String nodeString = JexlStringBuildingVisitor.buildQuery(child);
+                            String message = "Tree included child " + child + " [" + nodeString + "] with a null parent";
                             recordViolation(message, failHard, validation);
                         } else if (child.jjtGetParent() != node) {
                             String message = "Included a child " + child + " with conflicting parent. Expected " + node + " but was " + child.jjtGetParent();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -1124,7 +1124,7 @@ public class JexlASTHelper {
      * @param b
      *            second JexlNode
      */
-    public static void mergeJunctions(JexlNode parent, JexlNode a, JexlNode b) {
+    private static void mergeJunctions(JexlNode parent, JexlNode a, JexlNode b) {
         List<JexlNode> nodes = new ArrayList<>();
         for (JexlNode child : JexlNodes.getChildren(parent)) {
             if (child == a) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -983,6 +983,8 @@ public class JexlASTHelper {
     }
 
     /**
+     * <b>NOTE: Do NOT use this method with a rebuilding visitor. You cannot guarantee parentage will remain the same.</b>
+     * <p>
      * Swaps the original node with the replacement, following rules for reference expressions, single terms and junctions
      * <p>
      * This method prevents reference expressions from having a single child.

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/LiteralRange.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/LiteralRange.java
@@ -4,16 +4,20 @@ import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
 
 /**
  * The values of T should already be normalized
- *
- *
  *
  * @param <T>
  *            type of the range
  */
 public class LiteralRange<T extends Comparable<T>> implements Comparable<LiteralRange<T>> {
+
+    private static final Logger log = LoggerFactory.getLogger(LiteralRange.class);
 
     public enum NodeOperand {
         OR, AND
@@ -196,6 +200,28 @@ public class LiteralRange<T extends Comparable<T>> implements Comparable<Literal
 
     public boolean isBounded() {
         return this.lower != null && this.upper != null && this.fieldName != null;
+    }
+
+    /**
+     * Convenience method that returns true if the lower and upper bound are equivalent
+     *
+     * @return true if the upper and lower bound are equivalent
+     */
+    public boolean areBoundsEquivalent() {
+        Preconditions.checkNotNull(lower);
+        Preconditions.checkNotNull(upper);
+        return lower.compareTo(upper) == 0;
+    }
+
+    /**
+     * Convenience method that returns true if the lower bound is greater than the upper bound
+     *
+     * @return true if the lower bound is greater than the upper bound
+     */
+    public boolean isLowerBoundGreaterThanUpperBound() {
+        Preconditions.checkNotNull(lower);
+        Preconditions.checkNotNull(upper);
+        return lower.compareTo(upper) > 0;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -15,7 +15,6 @@ import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl3.parser.ASTAndNode;
-import org.apache.commons.jexl3.parser.ASTOrNode;
 import org.apache.commons.jexl3.parser.ASTReferenceExpression;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.JexlNodes;
@@ -119,11 +118,6 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
 
             rebuildFutureJexlNodes();
 
-            // handle the case where the root node was expanded
-            if (rebuiltScript instanceof FutureJexlNode) {
-                rebuiltScript = (T) ((FutureJexlNode) rebuiltScript).getRebuiltNode();
-            }
-
             return rebuiltScript;
         } finally {
             shutdownExecutor();
@@ -163,7 +157,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
      *            whether the original node should be replaced
      * @return a FutureJexlNode
      */
-    protected FutureJexlNode createFutureJexlNode(IndexLookup lookup, JexlNode node, boolean ignoreComposites, boolean keepOriginalNode) {
+    protected JexlNode createFutureJexlNode(IndexLookup lookup, JexlNode node, boolean ignoreComposites, boolean keepOriginalNode) {
         // if this is an asynchronous index lookup, set
         // it up and submit it to the executor service
         if (lookup instanceof AsyncIndexLookup) {
@@ -174,7 +168,8 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
         futureNode.jjtSetParent(node.jjtGetParent());
         futureJexlNodes.add(futureNode);
 
-        return futureNode;
+        // do not embed the FutureJexlNode into the tree. It complicates rewrites.
+        return node;
     }
 
     protected void rebuildFutureJexlNodes() {
@@ -185,27 +180,12 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
 
             rebuildFutureJexlNode(futureJexlNode);
 
-            JexlNode newNode = futureJexlNode.getRebuiltNode();
-
-            // if the parent is not null, replace the child
-            // if the parent is null, this is the root node, and we will handle that in the expand method
-            if (futureJexlNode.jjtGetParent() != null) {
-                if (!(newNode instanceof ASTOrNode || newNode instanceof ASTAndNode)) {
-                    if (isWrappedJunction(futureJexlNode.getOrigNode())) {
-                        JexlNode parent = futureJexlNode.jjtGetParent();
-                        JexlNode grandParent = parent.jjtGetParent();
-                        if (grandParent != null) {
-                            JexlNodes.replaceChild(grandParent, parent, newNode);
-                        } else {
-                            JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
-                        }
-                    } else {
-                        JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
-                    }
-                } else {
-                    JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
-                }
+            if (futureJexlNode.jjtGetParent() == null) {
+                throw new IllegalStateException("Invalid query tree detected during index expansion");
             }
+
+            JexlNode node = futureJexlNode.getOrigNode();
+            JexlNodes.swap(node.jjtGetParent(), node, futureJexlNode.getRebuiltNode());
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -14,6 +14,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.commons.jexl3.parser.ASTAndNode;
+import org.apache.commons.jexl3.parser.ASTOrNode;
+import org.apache.commons.jexl3.parser.ASTReferenceExpression;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.JexlNodes;
 import org.slf4j.Logger;
@@ -187,9 +190,37 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
             // if the parent is not null, replace the child
             // if the parent is null, this is the root node, and we will handle that in the expand method
             if (futureJexlNode.jjtGetParent() != null) {
-                JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
+                if (!(newNode instanceof ASTOrNode || newNode instanceof ASTAndNode)) {
+                    if (isWrappedJunction(futureJexlNode.getOrigNode())) {
+                        JexlNode parent = futureJexlNode.jjtGetParent();
+                        JexlNode grandParent = parent.jjtGetParent();
+                        JexlNodes.replaceChild(grandParent, parent, newNode);
+                    } else {
+                        JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
+                    }
+                } else {
+                    JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
+                }
             }
         }
+    }
+
+    /**
+     * Check for a wrapped junction. This matters when only a single matching term is found because we're left with oddly formed queries like
+     * <code>(term)</code> and a Jexl structure where an {@link ASTAndNode} has a single child which is not proper.
+     *
+     * @param node
+     *            the node
+     * @return true if the node is a wrapped junction
+     */
+    private boolean isWrappedJunction(JexlNode node) {
+        if (node instanceof ASTAndNode) {
+            JexlNode parent = node.jjtGetParent();
+            if (parent instanceof ASTReferenceExpression) {
+                return parent.jjtGetParent() != null;
+            }
+        }
+        return false;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -194,7 +194,11 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
                     if (isWrappedJunction(futureJexlNode.getOrigNode())) {
                         JexlNode parent = futureJexlNode.jjtGetParent();
                         JexlNode grandParent = parent.jjtGetParent();
-                        JexlNodes.replaceChild(grandParent, parent, newNode);
+                        if (grandParent != null) {
+                            JexlNodes.replaceChild(grandParent, parent, newNode);
+                        } else {
+                            JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
+                        }
                     } else {
                         JexlNodes.replaceChild(futureJexlNode.jjtGetParent(), futureJexlNode, newNode);
                     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
@@ -83,6 +83,16 @@ public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor
         else if (instance.isType(BOUNDED_RANGE)) {
             LiteralRange<?> range = rangeFinder.getRange(node);
             if (range != null) {
+
+                if (range.areBoundsEquivalent()) {
+                    log.warn("lower and upper bound are equivalent");
+                }
+
+                if (range.isLowerBoundGreaterThanUpperBound()) {
+                    log.error("lower bound is greater than the upper bound: {}", range);
+                    throw new IllegalStateException("lower bound is greater than upper bound");
+                }
+
                 try {
                     return buildIndexLookup(node, true, false, () -> createLookup(range));
                 } catch (IllegalRangeArgumentException e) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
@@ -85,7 +85,7 @@ public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor
             if (range != null) {
 
                 if (range.areBoundsEquivalent()) {
-                    log.warn("lower and upper bound are equivalent");
+                    log.warn("lower and upper bound are equivalent: {}", range);
                 }
 
                 if (range.isLowerBoundGreaterThanUpperBound()) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExecutableDeterminationVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExecutableDeterminationVisitor.java
@@ -999,9 +999,18 @@ public class ExecutableDeterminationVisitor extends BaseVisitor {
                 output.writeLine(data, node, "( delayed/eval only predicate )", state, true);
             }
         }
-        // if we got to a bounded range, then this was expanded and is not executable against the index
+        // if we got to a bounded range, then it was not expanded via the index but is still executable via
+        // the ShardSpecificIndexIterator
         else if (instance.isType(BOUNDED_RANGE)) {
-            state = STATE.NON_EXECUTABLE;
+            if (isUnindexed(node)) {
+                state = STATE.NON_EXECUTABLE;
+            } else if (isUnOrNoFielded(node)) {
+                // bounded range should not be NO_FIELD or ANY_FIELD
+                state = STATE.ERROR;
+            } else {
+                state = STATE.EXECUTABLE;
+            }
+
             if (output != null) {
                 output.writeLine(data, node, "( bounded range )", state, true);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnmarkedBoundedRangeDetectionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnmarkedBoundedRangeDetectionVisitor.java
@@ -2,8 +2,6 @@ package datawave.query.jexl.visitors;
 
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.BOUNDED_RANGE;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.commons.jexl3.parser.ASTAndNode;
 import org.apache.commons.jexl3.parser.JexlNode;
 
@@ -20,23 +18,28 @@ import datawave.query.jexl.nodes.QueryPropertyMarker.Instance;
  */
 public class UnmarkedBoundedRangeDetectionVisitor extends BaseVisitor {
 
+    private boolean unmarkedBoundedRangeFound = false;
+
     private UnmarkedBoundedRangeDetectionVisitor() {
         // enforce static access
     }
 
     public static boolean findUnmarkedBoundedRanges(JexlNode script) {
         UnmarkedBoundedRangeDetectionVisitor visitor = new UnmarkedBoundedRangeDetectionVisitor();
+        script.jjtAccept(visitor, null);
+        return visitor.foundUnmarkedBoundedRange();
+    }
 
-        AtomicBoolean unmarked = new AtomicBoolean(false);
-        script.jjtAccept(visitor, unmarked);
-
-        return unmarked.get();
+    public boolean foundUnmarkedBoundedRange() {
+        return unmarkedBoundedRangeFound;
     }
 
     @Override
     public Object visit(ASTAndNode node, Object data) {
-        if (data == null) {
-            return null;
+
+        if (unmarkedBoundedRangeFound) {
+            // if we already found an unmarked bounded range there is no need to evaluate other nodes
+            return data;
         }
 
         // check for a bounded marker where the source node is not a range
@@ -44,18 +47,16 @@ public class UnmarkedBoundedRangeDetectionVisitor extends BaseVisitor {
         if (instance.isType(BOUNDED_RANGE)) {
             LiteralRange<?> range = JexlASTHelper.findRange().getRange(node);
             if (range == null) {
-                AtomicBoolean hasBounded = (AtomicBoolean) data;
-                hasBounded.set(true);
+                unmarkedBoundedRangeFound = true;
             }
-            return false;
+            return data;
         }
 
         // check for a range that is not marked
         LiteralRange<?> range = JexlASTHelper.findRange().notDelayed().notMarked().getRange(node);
         if (range != null && range.isBounded()) {
-            AtomicBoolean hasBounded = (AtomicBoolean) data;
-            hasBounded.set(true);
-            return false;
+            unmarkedBoundedRangeFound = true;
+            return data;
         }
 
         return super.visit(node, data);

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnmarkedBoundedRangeDetectionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnmarkedBoundedRangeDetectionVisitor.java
@@ -4,13 +4,25 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.BOUNDED_R
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.jexl3.parser.ASTReference;
+import org.apache.commons.jexl3.parser.ASTAndNode;
 import org.apache.commons.jexl3.parser.JexlNode;
 
+import datawave.data.normalizer.Normalizer;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.LiteralRange;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
+import datawave.query.jexl.nodes.QueryPropertyMarker.Instance;
 
+/**
+ * A visitor that detects invalid ranges as either a bounded marker with invalid source, or a valid source without a marker
+ * <p>
+ * Note: this visitor does NOT validate that the lower bound sorts before the upper bound due to how various {@link Normalizer}s may change the values.
+ */
 public class UnmarkedBoundedRangeDetectionVisitor extends BaseVisitor {
+
+    private UnmarkedBoundedRangeDetectionVisitor() {
+        // enforce static access
+    }
 
     public static boolean findUnmarkedBoundedRanges(JexlNode script) {
         UnmarkedBoundedRangeDetectionVisitor visitor = new UnmarkedBoundedRangeDetectionVisitor();
@@ -22,26 +34,30 @@ public class UnmarkedBoundedRangeDetectionVisitor extends BaseVisitor {
     }
 
     @Override
-    public Object visit(ASTReference node, Object data) {
-        // determine if we have a marked range that is not actually a range
-        if (QueryPropertyMarker.findInstance(node).isType(BOUNDED_RANGE)) {
-            if (null != data && !JexlASTHelper.findRange().isRange(node)) {
+    public Object visit(ASTAndNode node, Object data) {
+        if (data == null) {
+            return null;
+        }
+
+        // check for a bounded marker where the source node is not a range
+        Instance instance = QueryPropertyMarker.findInstance(node);
+        if (instance.isType(BOUNDED_RANGE)) {
+            LiteralRange<?> range = JexlASTHelper.findRange().getRange(node);
+            if (range == null) {
                 AtomicBoolean hasBounded = (AtomicBoolean) data;
                 hasBounded.set(true);
             }
-
             return false;
         }
-        // determine if we have a range that is not marked
-        else if (JexlASTHelper.findRange().notDelayed().notMarked().isRange(node)) {
-            if (null != data) {
-                AtomicBoolean hasBounded = (AtomicBoolean) data;
-                hasBounded.set(true);
-            }
 
+        // check for a range that is not marked
+        LiteralRange<?> range = JexlASTHelper.findRange().notDelayed().notMarked().getRange(node);
+        if (range != null && range.isBounded()) {
+            AtomicBoolean hasBounded = (AtomicBoolean) data;
+            hasBounded.set(true);
             return false;
-        } else {
-            return super.visit(node, data);
         }
+
+        return super.visit(node, data);
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/validate/ValidateBoundedRangeVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/validate/ValidateBoundedRangeVisitor.java
@@ -1,0 +1,52 @@
+package datawave.query.jexl.visitors.validate;
+
+import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.BOUNDED_RANGE;
+
+import org.apache.commons.jexl3.parser.ASTAndNode;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.LiteralRange;
+import datawave.query.jexl.nodes.QueryPropertyMarker;
+import datawave.query.jexl.nodes.QueryPropertyMarker.Instance;
+import datawave.query.jexl.visitors.ShortCircuitBaseVisitor;
+
+/**
+ * Verifies the lower bound sorts before the upper bound for all bounded ranges.
+ * <p>
+ * This visitor must be run after bounded range expansion due to how normalization happens.
+ */
+public class ValidateBoundedRangeVisitor extends ShortCircuitBaseVisitor {
+
+    private static final Logger log = LoggerFactory.getLogger(ValidateBoundedRangeVisitor.class);
+
+    private ValidateBoundedRangeVisitor() {
+        // enforce static access
+    }
+
+    public static <T extends JexlNode> T validate(T node) {
+        ValidateBoundedRangeVisitor visitor = new ValidateBoundedRangeVisitor();
+        node.jjtAccept(visitor, null);
+        return node;
+    }
+
+    @Override
+    public Object visit(ASTAndNode node, Object data) {
+        Instance instance = QueryPropertyMarker.findInstance(node);
+        if (instance.isType(BOUNDED_RANGE)) {
+            LiteralRange<?> range = JexlASTHelper.findRange().getRange(node);
+            if (range != null) {
+                if (range.areBoundsEquivalent()) {
+                    log.warn("lower and upper bound are equivalent, consider rewriting to a single equality node");
+                } else if (range.isLowerBoundGreaterThanUpperBound()) {
+                    throw new IllegalStateException("lower bound was greater than the upper bound: " + range);
+                }
+            }
+            return data;
+        }
+        return super.visit(node, data);
+    }
+
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -154,6 +154,7 @@ import datawave.query.jexl.visitors.ValidComparisonVisitor;
 import datawave.query.jexl.visitors.ValidPatternVisitor;
 import datawave.query.jexl.visitors.ValidateFilterFunctionVisitor;
 import datawave.query.jexl.visitors.order.OrderByCostVisitor;
+import datawave.query.jexl.visitors.validate.ValidateBoundedRangeVisitor;
 import datawave.query.jexl.visitors.whindex.WhindexVisitor;
 import datawave.query.model.QueryModel;
 import datawave.query.planner.async.AbstractQueryPlannerCallable;
@@ -1252,6 +1253,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             }
         }
 
+        // whether bounded ranges were expanded or not, validate all ranges
+        timedValidateBoundedRanges(timers, config.getQueryTree());
+
         // fields may have been added or removed from the query, need to update the field to type map
         timedFetchDatatypes(timers, "Fetch Required Datatypes", config.getQueryTree(), config);
 
@@ -1628,6 +1632,10 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
                     throws DatawaveQueryException {
         return visitorManager.timedVisit(timers, "Validate Filter Functions",
                         () -> (ASTJexlScript) ValidateFilterFunctionVisitor.validate(queryTree, indexOnlyFields));
+    }
+
+    protected ASTJexlScript timedValidateBoundedRanges(QueryStopwatch timers, ASTJexlScript queryTree) throws DatawaveQueryException {
+        return visitorManager.timedVisit(timers, "Validate Bounded Ranges", () -> ValidateBoundedRangeVisitor.validate(queryTree));
     }
 
     protected ASTJexlScript timedRewriteNullFunctions(QueryStopwatch timers, ASTJexlScript queryTree) throws DatawaveQueryException {

--- a/warehouse/query-core/src/test/java/datawave/query/DataTypeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/DataTypeQueryTest.java
@@ -158,7 +158,9 @@ public class DataTypeQueryTest extends AbstractFunctionalQuery {
         qOptions.put(QueryParameters.DATATYPE_FILTER_SET, dtFilter);
 
         for (String num : TEST_NUMS) {
-            String query = CityField.NUM.name() + GTE_OP + num + AND_OP + CityField.NUM.name() + LTE_OP + num;
+            int lower = Integer.parseInt(num);
+            int upper = lower + 1;
+            String query = CityField.NUM.name() + GTE_OP + lower + AND_OP + CityField.NUM.name() + LTE_OP + upper;
             String expect = "(" + query + ")" + AND_OP + BaseRawData.EVENT_DATATYPE + EQ_OP + "'" + CityEntry.generic.getDataType() + "'";
             query = "((_Bounded_ = true) && (" + query + "))";
             runTest(query, expect, qOptions);
@@ -175,7 +177,9 @@ public class DataTypeQueryTest extends AbstractFunctionalQuery {
         qOptions.put(QueryParameters.DATATYPE_FILTER_SET, dtFilter);
 
         for (String num : TEST_NUMS) {
-            String query = CityField.NUM.name() + GTE_OP + num + AND_OP + CityField.NUM.name() + LTE_OP + num;
+            int lower = Integer.parseInt(num);
+            int upper = lower + 1;
+            String query = CityField.NUM.name() + GTE_OP + lower + AND_OP + CityField.NUM.name() + LTE_OP + upper;
             String expect = "(" + query + ")" + AND_OP + BaseRawData.EVENT_DATATYPE + EQ_OP + "'" + CityEntry.generic.getDataType() + "'";
             query = "((_Bounded_ = true) && (" + query + "))";
             runTest(query, expect, qOptions);

--- a/warehouse/query-core/src/test/java/datawave/query/DelayedIndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/DelayedIndexOnlyQueryTest.java
@@ -192,7 +192,7 @@ public class DelayedIndexOnlyQueryTest extends AbstractFunctionalQuery {
     public void testCompositeRangeIndexOnlyEventOnlyDelayed() throws Exception {
         log.info("------  testCompositeRangeIndexOnlyEventOnlyDelayed  ------");
 
-        String query = "STATE == 'ohio' && ((NUM > '0' && NUM < '200' && CITY == 'paris') || STATE == 'ohio' || COUNTRY == 'Italy')";
+        String query = "STATE == 'ohio' && ((((_Bounded_ = true) && (NUM > '0' && NUM < '200')) && CITY == 'paris') || STATE == 'ohio' || COUNTRY == 'Italy')";
         String expectedQuery = "STATE == 'ohio' && ((NUM > '0' && NUM < 200 && CITY == 'paris') || STATE == 'ohio' || COUNTRY == 'Italy')";
         runTest(query, expectedQuery);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
@@ -169,7 +169,7 @@ public abstract class FunctionalSetTest {
         log.debug("query: " + settings.getQuery());
         log.debug("logic: " + settings.getQueryLogicName());
         logic.setMaxEvaluationPipelines(1);
-        logic.setMaxDepthThreshold(6);
+        logic.setMaxDepthThreshold(7);
 
         GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
         logic.setupQuery(config);
@@ -302,9 +302,9 @@ public abstract class FunctionalSetTest {
         // @formatter:off
         String[] queryStrings = {
 
-                "10 <= AG && AG <= 18",
-                "AG <= 18 && AG >= 10",
-                "18 >= AG && 10 <= AG",
+                "((_Bounded_ = true) && (10 <= AG && AG <= 18))",
+                "((_Bounded_ = true) && (AG <= 18 && AG >= 10))",
+                "((_Bounded_ = true) && (18 >= AG && 10 <= AG))",
                 // "AG <= 18",
                 // "18 >= AG",
                 "AG == 18",
@@ -318,22 +318,22 @@ public abstract class FunctionalSetTest {
 
                 // the next one matches Meadow Soprano, age 18, because the 'MAGIC' value is 18 (we don't know/care what the actual value
                 // of MAGIC is, only that whatever it is, it matches AGE in the same group as the other matches)
-                "AG > 10 && AG < 100 && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) == MAGIC",
+                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) == MAGIC",
 
                 // the next one matches Meadow Soprano, GENDER female, age 18 but not Constanza Corleone, Gender female, age 18
                 // the < part of this is what is special. Other comparison operators should work the same way
-                "AG > 10 && AG < 100 && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19",
+                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19",
 
                 // the next 2 queries are equivalent. the reason for the functional query stuff is for when we
                 // want to query with an operator other than '=='
-                "AG > 10 && AG < 100 && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE')) == 30",
-                "AG > 10 && AG < 100 && grouping:matchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE', AG, 30)",
+                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE')) == 30",
+                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && grouping:matchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE', AG, 30)",
 
-                "AG > 10 && AG < 100 && filter:occurrence(AG, '==', filter:getAllMatches(AG, '16').size() + filter:getAllMatches(AG, '18').size())", // will
+                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '16').size() + filter:getAllMatches(AG, '18').size())", // will
                                                                                                                                                      // match
                                                                                                                                                      // only the
                                                                                                                                                      // sopranos
-                "AG > 10 && AG < 100 && filter:occurrence(AG, '==', filter:getAllMatches(AG, '19').size() + filter:getAllMatches(AG, '18').size())" // will
+                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '19').size() + filter:getAllMatches(AG, '18').size())" // will
                                                                                                                                                     // match
                                                                                                                                                     // none
         };
@@ -362,6 +362,9 @@ public abstract class FunctionalSetTest {
         for (int i = 0; i < queryStrings.length; i++) {
             // stat must be reset between each run when pruning ingest types
             logic.getConfig().setDatatypeFilter(Collections.emptySet());
+            logic.getConfig().setIntermediateMaxTermThreshold(25);
+            logic.getConfig().setIndexedMaxTermThreshold(25);
+            logic.getConfig().setFinalMaxTermThreshold(25);
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/JexlNumericQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/JexlNumericQueryTest.java
@@ -12,11 +12,15 @@ import static datawave.query.testframework.RawDataManager.OR_OP;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.apache.commons.jexl3.parser.ASTAndNode;
+import org.apache.commons.jexl3.parser.ASTReference;
 import org.apache.log4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.visitors.UnmarkedBoundedRangeDetectionVisitor;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -83,7 +87,7 @@ public class JexlNumericQueryTest extends AbstractFunctionalQuery {
     @Test
     public void testLteGteBound() throws Exception {
         log.info("------  testLteGteBound  ------");
-        String query = "((_Bounded_ = true) && (" + CityField.NUM.name() + LTE_OP + "20 " + AND_OP + CityField.NUM.name() + GTE_OP + "20))";
+        String query = "((_Bounded_ = true) && (" + CityField.NUM.name() + LTE_OP + "21 " + AND_OP + CityField.NUM.name() + GTE_OP + "20))";
         runTest(query, query);
     }
 
@@ -169,7 +173,14 @@ public class JexlNumericQueryTest extends AbstractFunctionalQuery {
         }
     }
 
-    @Test
+    /**
+     * This test is now expected to fail because the {@link UnmarkedBoundedRangeDetectionVisitor} was corrected to examine {@link ASTAndNode} instead of
+     * {@link ASTReference} nodes.
+     *
+     * @throws Exception
+     *             because the query is wrong
+     */
+    @Test(expected = DatawaveFatalQueryException.class)
     public void testLtGtNotEq() throws Exception {
         log.info("------  testLtGtNotEq  ------");
         for (final TestCities city : TestCities.values()) {

--- a/warehouse/query-core/src/test/java/datawave/query/MiscQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MiscQueryTest.java
@@ -294,7 +294,7 @@ public class MiscQueryTest extends AbstractFunctionalQuery {
         String state = "'ohio'";
         for (TestCities city : TestCities.values()) {
             String query = CityField.CITY.name() + EQ_OP + "'" + city.name() + "'" + AND_OP + "((_Bounded_ = true) && (" + CityField.STATE.name() + LTE_OP
-                            + state + AND_OP + CityField.STATE.name() + GTE_OP + state + "))";
+                            + "'ohio~'" + AND_OP + CityField.STATE.name() + GTE_OP + state + "))";
 
             this.logic.setInitialMaxTermThreshold(3);
             this.logic.setFinalMaxTermThreshold(3);

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -229,9 +229,9 @@ public class RangeStreamQueryTest {
 
     @Test
     public void testQueriesWithBoundedRangeMarkers() throws Exception {
-        test("((_Bounded_ = true) && (FOO > '3' && FOO < 7))", DELAYED);
-        test("(((_Bounded_ = true) && (FOO > '3' && FOO < 7)) && ((_Bounded_ = true) && (FOO2 > '3' && FOO2 < 7)))", DELAYED_INTERSECT);
-        test("(((_Bounded_ = true) && (FOO > '3' && FOO < 7)) || ((_Bounded_ = true) && (FOO2 > '3' && FOO2 < 7)))", DELAYED_UNION);
+        test("((_Bounded_ = true) && (FOO > '3' && FOO < 7))", ANCHOR);
+        test("(((_Bounded_ = true) && (FOO > '3' && FOO < 7)) && ((_Bounded_ = true) && (FOO2 > '3' && FOO2 < 7)))", ANCHOR_INTERSECT);
+        test("(((_Bounded_ = true) && (FOO > '3' && FOO < 7)) || ((_Bounded_ = true) && (FOO2 > '3' && FOO2 < 7)))", ANCHOR_UNION);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.jexl3.parser.ParseException;
 import org.apache.commons.jexl3.parser.ParserTreeConstants;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -37,10 +38,12 @@ import com.google.common.collect.Sets;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberType;
 import datawave.query.attributes.Document;
+import datawave.query.exceptions.InvalidQueryTreeException;
 import datawave.query.function.JexlEvaluation;
 import datawave.query.jexl.JexlNodeFactory.ContainerType;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.jexl.visitors.PrintingVisitor;
+import datawave.query.jexl.visitors.validate.ASTValidator;
 import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
 import datawave.query.util.MockMetadataHelper;
 import datawave.query.util.Tuple3;
@@ -48,6 +51,17 @@ import datawave.query.util.Tuple3;
 public class JexlASTHelperTest {
 
     private static final Logger log = Logger.getLogger(JexlASTHelperTest.class);
+
+    private final ASTValidator validator = new ASTValidator();
+
+    @Before
+    public void beforeEach() {
+        validator.setValidateLineage(true);
+        validator.setValidateFlatten(true);
+        validator.setValidateJunctions(true);
+        validator.setValidateReferenceExpressions(true);
+        validator.setValidateQueryPropertyMarkers(true);
+    }
 
     @Test
     public void test() throws Exception {
@@ -1036,6 +1050,136 @@ public class JexlASTHelperTest {
         } else {
             assertTrue(range.isLowerBoundGreaterThanUpperBound() || range.areBoundsEquivalent());
         }
+    }
+
+    @Test
+    public void testSafeReplacementOfIntersectionChildWithEquality() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' && X == 'x' && C == '3'");
+        JexlNode expansion = parseAndGetRoot("B == '2'");
+        String expected = "A == '1' && B == '2' && C == '3'";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTAndNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTEQNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testSafeReplacementOfIntersectionChildWithUnion() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' && X == 'x' && D == '4'");
+        JexlNode expansion = parseAndGetRoot("B == '2' || C == '3'");
+        String expected = "A == '1' && (B == '2' || C == '3') && D == '4'";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTAndNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTOrNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testSafeReplacementOfIntersectionChildWithIntersection() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' && X == 'x' && D == '4'");
+        JexlNode expansion = parseAndGetRoot("B == '2' && C == '3'");
+        String expected = "A == '1' && B == '2' && C == '3' && D == '4'";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTAndNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTAndNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testSafeReplacementOfUnionChildWithEquality() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' || X == 'x' || C == '3'");
+        JexlNode expansion = parseAndGetRoot("B == '2'");
+        String expected = "A == '1' || B == '2' || C == '3'";
+
+        // intersection initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTOrNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTEQNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testSafeReplacementOfUnionChildWithUnion() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' || X == 'x' || D == '4'");
+        JexlNode expansion = parseAndGetRoot("B == '2' || C == '3'");
+        String expected = "A == '1' || B == '2' || C == '3' || D == '4'";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTOrNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTOrNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testSafeReplacementOfUnionChildWithIntersection() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' || X == 'x' || D == '4'");
+        JexlNode expansion = parseAndGetRoot("B == '2' || C == '3'");
+        String expected = "A == '1' || B == '2' || C == '3' || D == '4'";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTOrNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTOrNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    private JexlNode parseAndGetRoot(String query) {
+        return parse(query).jjtGetChild(0);
     }
 
     private ASTJexlScript parse(String query) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
@@ -2,8 +2,10 @@ package datawave.query.jexl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -999,6 +1001,49 @@ public class JexlASTHelperTest {
         for (JexlNode notNode : notNodes) {
             assertTrue(JexlASTHelper.isDescendantOfNodeType(notNode, ASTOrNode.class));
             assertTrue(JexlASTHelper.isDescendantOfNodeType(notNode, ASTAndNode.class));
+        }
+    }
+
+    @Test
+    public void testStringBoundedRange() {
+        testBoundedRangePermutations("aa", "bb");
+    }
+
+    private void testBoundedRangePermutations(String lower, String upper) {
+        String valid = getQuery(lower, upper);
+        assertBoundedRange(valid, true);
+
+        String invalid = getQuery(upper, lower);
+        assertBoundedRange(invalid, false);
+
+        // technically a valid bounded range, but it would be nice to rewrite this as an equality node
+        String equality = getQuery(lower, lower);
+        assertBoundedRange(equality, false);
+    }
+
+    private String getQuery(String lower, String upper) {
+        return "((_Bounded_ = true) && (F >= '" + lower + "' && F <= '" + upper + "'))";
+    }
+
+    private void assertBoundedRange(String query, boolean valid) {
+        ASTJexlScript script = parse(query);
+        JexlNode child = script.jjtGetChild(0);
+        LiteralRange<?> range = JexlASTHelper.findRange().getRange(child);
+        assertNotNull(range);
+        if (valid) {
+            assertFalse(range.isLowerBoundGreaterThanUpperBound());
+            assertFalse(range.areBoundsEquivalent());
+        } else {
+            assertTrue(range.isLowerBoundGreaterThanUpperBound() || range.areBoundsEquivalent());
+        }
+    }
+
+    private ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query);
+            throw new IllegalStateException("Failed to parse query: " + query, e);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
@@ -17,6 +17,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.commons.jexl3.parser.ASTAndNode;
 import org.apache.commons.jexl3.parser.ASTEQNode;
 import org.apache.commons.jexl3.parser.ASTERNode;
+import org.apache.commons.jexl3.parser.ASTIdentifier;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.ASTNotNode;
 import org.apache.commons.jexl3.parser.ASTNumberLiteral;
@@ -1160,8 +1161,29 @@ public class JexlASTHelperTest {
     @Test
     public void testSafeReplacementOfUnionChildWithIntersection() throws InvalidQueryTreeException {
         ASTJexlScript script = parse("A == '1' || X == 'x' || D == '4'");
+        JexlNode expansion = parseAndGetRoot("B == '2' && C == '3'");
+        String expected = "A == '1' || (B == '2' && C == '3') || D == '4'";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTOrNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(1) instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(2) instanceof ASTEQNode);
+
+        // replacement initial state
+        assertTrue(expansion instanceof ASTAndNode);
+
+        JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testUnhappyNodeTreeReplacementHasNullParent() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1' || X == 'x' || D == '4'");
         JexlNode expansion = parseAndGetRoot("B == '2' || C == '3'");
-        String expected = "A == '1' || B == '2' || C == '3' || D == '4'";
+        String expected = "A == '1' || X == 'x' || D == '4'";
 
         // root initial state
         JexlNode root = script.jjtGetChild(0);
@@ -1173,6 +1195,39 @@ public class JexlASTHelperTest {
         // replacement initial state
         assertTrue(expansion instanceof ASTOrNode);
 
+        // this expansion wil fail because the parent is null
+        JexlNode target = root.jjtGetChild(1);
+        target.jjtSetParent(null);
+        assertNull(target.jjtGetParent());
+
+        JexlASTHelper.replaceNodeSafely(target, expansion);
+        assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
+
+        try {
+            validator.isValid(script);
+            fail("Validation should have failed due to lineage");
+        } catch (InvalidQueryTreeException e) {
+            assertTrue(e.getMessage().equals("Invalid query tree detected outside of normal scope: [Lineage]"));
+        }
+
+        // link target to parent and validate again
+        target.jjtSetParent(root);
+        assertTrue(validator.isValid(script));
+    }
+
+    @Test
+    public void testUnhappyNodeTreeTargetIsLeafNode() throws InvalidQueryTreeException {
+        ASTJexlScript script = parse("A == '1'");
+        JexlNode expansion = parseAndGetRoot("B == '2' && C == '3'");
+        String expected = "A == (B == '2' && C == '3')";
+
+        // root initial state
+        JexlNode root = script.jjtGetChild(0);
+        assertTrue(root instanceof ASTEQNode);
+        assertTrue(root.jjtGetChild(0) instanceof ASTIdentifier);
+        assertTrue(root.jjtGetChild(1) instanceof ASTStringLiteral);
+
+        // this test highlights the danger of blindly replacing a child node without knowing what it is
         JexlASTHelper.replaceNodeSafely(root.jjtGetChild(1), expansion);
         assertEquals(expected, JexlStringBuildingVisitor.buildQuery(script));
         assertTrue(validator.isValid(script));

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitorTest.java
@@ -1,0 +1,171 @@
+package datawave.query.jexl.visitors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ASTOrNode;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.JexlNodes;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.visitors.BaseIndexExpansionVisitor.FutureJexlNode;
+
+/**
+ * Validate different ways the query tree is rewritten after expansion
+ */
+public class BoundedRangeIndexExpansionVisitorTest {
+
+    @Test
+    public void testBoundedRangeExpandsIntoSingleTerm() {
+        String query = "((_Bounded_ = true) && (F >= '2' && F <= '3'))";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode second = first.jjtGetChild(0);
+        assertNode(second, "(_Bounded_ = true) && (F >= '2' && F <= '3')");
+
+        JexlNode expanded = JexlNodeFactory.buildEQNode("F", "2.4");
+        FutureJexlNode futureJexlNode = createFutureJexlNode(second, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "(F == '2.4')");
+    }
+
+    @Test
+    public void testBoundedRangeExpandsIntoMultipleTerms() {
+        String query = "((_Bounded_ = true) && (F >= '2' && F <= '3'))";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode second = first.jjtGetChild(0);
+        assertNode(second, "(_Bounded_ = true) && (F >= '2' && F <= '3')");
+
+        JexlNode expanded = parse("F == '2.4' || F == '2.6'").jjtGetChild(0);
+        assertInstanceOf(ASTOrNode.class, expanded);
+        FutureJexlNode futureJexlNode = createFutureJexlNode(second, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "(F == '2.4' || F == '2.6')");
+    }
+
+    @Test
+    public void testIntersectionWithBoundedRangeExpandsIntoSingleTerm() {
+        String query = "F == 'a' && ((_Bounded_ = true) && (F >= '2' && F <= '3'))";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' && ((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode third = second.jjtGetChild(0);
+        assertNode(third, "(_Bounded_ = true) && (F >= '2' && F <= '3')");
+
+        JexlNode expanded = JexlNodeFactory.buildEQNode("F", "2.4");
+        FutureJexlNode futureJexlNode = createFutureJexlNode(third, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' && (F == '2.4')");
+    }
+
+    @Test
+    public void testUnionWithBoundedRangeExpandsIntoSingleTerm() {
+        String query = "F == 'a' || ((_Bounded_ = true) && (F >= '2' && F <= '3'))";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' || ((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode third = second.jjtGetChild(0);
+        assertNode(third, "(_Bounded_ = true) && (F >= '2' && F <= '3')");
+
+        JexlNode expanded = JexlNodeFactory.buildEQNode("F", "2.4");
+        FutureJexlNode futureJexlNode = createFutureJexlNode(third, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' || (F == '2.4')");
+    }
+
+    @Test
+    public void testIntersectionWithBoundedRangeExpandsIntoMultipleTerms() {
+        String query = "F == 'a' && ((_Bounded_ = true) && (F >= '2' && F <= '3'))";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' && ((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode third = second.jjtGetChild(0);
+        assertNode(third, "(_Bounded_ = true) && (F >= '2' && F <= '3')");
+
+        JexlNode expanded = parse("F == '2.4' || F == '2.6'").jjtGetChild(0);
+        assertInstanceOf(ASTOrNode.class, expanded);
+        FutureJexlNode futureJexlNode = createFutureJexlNode(third, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' && (F == '2.4' || F == '2.6')");
+    }
+
+    @Test
+    public void testUnionWithBoundedRangeExpandsIntoMultipleTerms() {
+        String query = "F == 'a' || ((_Bounded_ = true) && (F >= '2' && F <= '3'))";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' || ((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "((_Bounded_ = true) && (F >= '2' && F <= '3'))");
+
+        JexlNode third = second.jjtGetChild(0);
+        assertNode(third, "(_Bounded_ = true) && (F >= '2' && F <= '3')");
+
+        JexlNode expanded = parse("F == '2.4' || F == '2.6'").jjtGetChild(0);
+        assertInstanceOf(ASTOrNode.class, expanded);
+        FutureJexlNode futureJexlNode = createFutureJexlNode(third, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' || (F == '2.4' || F == '2.6')");
+    }
+
+    private ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private FutureJexlNode createFutureJexlNode(JexlNode orig, JexlNode expanded) {
+        FutureJexlNode futureNode = new FutureJexlNode(orig, null, false, true);
+        futureNode.jjtSetParent(orig.jjtGetParent());
+        futureNode.setRebuiltNode(expanded);
+        return futureNode;
+    }
+
+    private void assertNode(JexlNode node, String expected) {
+        String query = JexlStringBuildingVisitor.buildQuery(node);
+        assertEquals(expected, query);
+    }
+
+    private void connectNode(FutureJexlNode futureNode) {
+        JexlNode node = futureNode.getOrigNode();
+        JexlNodes.replaceChild(node.jjtGetParent(), node, futureNode.getRebuiltNode());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitorTest.java
@@ -1,0 +1,152 @@
+package datawave.query.jexl.visitors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ASTOrNode;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.JexlNodes;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.JexlNodeFactory;
+
+/**
+ * Validate different ways the query tree is rewritten after expansion
+ */
+public class RegexIndexExpansionVisitorTest {
+
+    @Test
+    public void testRegexExpandsIntoSingleTerm() {
+        String query = "F =~ 'a.*'";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F =~ 'a.*'");
+
+        JexlNode expanded = JexlNodeFactory.buildEQNode("F", "ab");
+        BaseIndexExpansionVisitor.FutureJexlNode futureJexlNode = createFutureJexlNode(first, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'ab'");
+    }
+
+    @Test
+    public void testRegexExpandsIntoMultipleTerms() {
+        String query = "F =~ 'a.*'";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F =~ 'a.*'");
+
+        JexlNode expanded = parse("F == 'ab' || F == 'ac'").jjtGetChild(0);
+        assertInstanceOf(ASTOrNode.class, expanded);
+        BaseIndexExpansionVisitor.FutureJexlNode futureJexlNode = createFutureJexlNode(first, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'ab' || F == 'ac'");
+    }
+
+    @Test
+    public void testIntersectionWithRegexExpandsIntoSingleTerm() {
+        String query = "F == 'a' && F =~ 'a.*'";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' && F =~ 'a.*'");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "F =~ 'a.*'");
+
+        JexlNode expanded = JexlNodeFactory.buildEQNode("F", "ab");
+        BaseIndexExpansionVisitor.FutureJexlNode futureJexlNode = createFutureJexlNode(second, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' && F == 'ab'");
+    }
+
+    @Test
+    public void testUnionWithRegexExpandsIntoSingleTerm() {
+        String query = "F == 'a' || F =~ 'a.*'";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' || F =~ 'a.*'");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "F =~ 'a.*'");
+
+        JexlNode expanded = JexlNodeFactory.buildEQNode("F", "ab");
+        BaseIndexExpansionVisitor.FutureJexlNode futureJexlNode = createFutureJexlNode(second, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' || F == 'ab'");
+    }
+
+    @Test
+    public void testIntersectionWithRegexExpandsIntoMultipleTerms() {
+        String query = "F == 'a' && F =~ 'a.*'";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' && F =~ 'a.*'");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "F =~ 'a.*'");
+
+        JexlNode expanded = parse("F == 'ab' || F == 'ac'").jjtGetChild(0);
+        assertInstanceOf(ASTOrNode.class, expanded);
+        BaseIndexExpansionVisitor.FutureJexlNode futureJexlNode = createFutureJexlNode(second, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' && (F == 'ab' || F == 'ac')");
+    }
+
+    @Test
+    public void testUnionWithRegexExpandsIntoMultipleTerms() {
+        String query = "F == 'a' || F =~ 'a.*'";
+        ASTJexlScript script = parse(query);
+
+        JexlNode first = script.jjtGetChild(0);
+        assertNode(first, "F == 'a' || F =~ 'a.*'");
+
+        JexlNode second = first.jjtGetChild(1);
+        assertNode(second, "F =~ 'a.*'");
+
+        JexlNode expanded = parse("F == 'ab' || F == 'ac'").jjtGetChild(0);
+        assertInstanceOf(ASTOrNode.class, expanded);
+        BaseIndexExpansionVisitor.FutureJexlNode futureJexlNode = createFutureJexlNode(second, expanded);
+        connectNode(futureJexlNode);
+
+        assertNode(script, "F == 'a' || F == 'ab' || F == 'ac'");
+    }
+
+    private ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private BaseIndexExpansionVisitor.FutureJexlNode createFutureJexlNode(JexlNode orig, JexlNode expanded) {
+        BaseIndexExpansionVisitor.FutureJexlNode futureNode = new BaseIndexExpansionVisitor.FutureJexlNode(orig, null, false, true);
+        futureNode.jjtSetParent(orig.jjtGetParent());
+        futureNode.setRebuiltNode(expanded);
+        return futureNode;
+    }
+
+    private void assertNode(JexlNode node, String expected) {
+        String query = JexlStringBuildingVisitor.buildQuery(node);
+        assertEquals(expected, query);
+    }
+
+    private void connectNode(BaseIndexExpansionVisitor.FutureJexlNode futureNode) {
+        JexlNode node = futureNode.getOrigNode();
+        JexlNodes.replaceChild(node.jjtGetParent(), node, futureNode.getRebuiltNode());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UnmarkedBoundedRangeDetectionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UnmarkedBoundedRangeDetectionVisitorTest.java
@@ -1,0 +1,66 @@
+package datawave.query.jexl.visitors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.validate.ValidateBoundedRangeVisitor;
+
+public class UnmarkedBoundedRangeDetectionVisitorTest {
+
+    @Test
+    public void testBoundedMarkerWithValidRange() {
+        String query = "((_Bounded_ = true) && (FIELD >= '2' && FIELD <= '3'))";
+        test(false, query);
+    }
+
+    /**
+     * This illegal range is detected by the {@link ValidateBoundedRangeVisitor}
+     */
+    @Test
+    public void testBoundedMarkerWithInvalidRange() {
+        String query = "((_Bounded_ = true) && (FIELD >= '5' && FIELD <= '3'))";
+        test(false, query);
+    }
+
+    @Test
+    public void testBoundedMarkerWithInvalidSource() {
+        String query = "((_Bounded_ = true) && (FIELD == '5' && FIELD == '3'))";
+        // unmarked bounded range will throw an exception
+        assertThrows(DatawaveFatalQueryException.class, () -> test(true, query));
+    }
+
+    @Test
+    public void testNoMarkerValidSource() {
+        String query = "FIELD >= '2' && FIELD <= '3'";
+        test(true, query);
+    }
+
+    @Test
+    public void testNoMarkerInvalidSource() {
+        String query = "FIELD == '2' && FIELD == '3'";
+        test(false, query);
+    }
+
+    private void test(boolean containsUnmarked, String query) {
+        ASTJexlScript script = parse(query);
+        boolean result = UnmarkedBoundedRangeDetectionVisitor.findUnmarkedBoundedRanges(script);
+        assertEquals(containsUnmarked, result);
+    }
+
+    private ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/validate/ValidateBoundedRangeVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/validate/ValidateBoundedRangeVisitorTest.java
@@ -32,14 +32,13 @@ public class ValidateBoundedRangeVisitorTest {
     }
 
     @Test
-    public void testNoMarkerValidSource() {
+    public void testNoMarker() {
+        // 'valid' source node for a bounded range
         String query = "FIELD >= '2' && FIELD <= '3'";
         test(query);
-    }
 
-    @Test
-    public void testNoMarkerInvalidSource() {
-        String query = "FIELD == '2' && FIELD == '3'";
+        // 'invalid' source for a bounded range,
+        query = "FIELD == '2' && FIELD == '3'";
         test(query);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/validate/ValidateBoundedRangeVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/validate/ValidateBoundedRangeVisitorTest.java
@@ -1,0 +1,60 @@
+package datawave.query.jexl.visitors.validate;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.JexlASTHelper;
+
+public class ValidateBoundedRangeVisitorTest {
+
+    @Test
+    public void testBoundedMarkerWithValidRange() {
+        String query = "((_Bounded_ = true) && (FIELD >= '2' && FIELD <= '3'))";
+        test(query);
+    }
+
+    @Test
+    public void testBoundedMarkerWithInvalidRange() {
+        String query = "((_Bounded_ = true) && (FIELD >= '5' && FIELD <= '3'))";
+        assertThrows(IllegalStateException.class, () -> test(query));
+    }
+
+    @Test
+    public void testBoundedMarkerWithInvalidSource() {
+        String query = "((_Bounded_ = true) && (FIELD == '5' && FIELD == '3'))";
+        // unmarked bounded range will throw an exception
+        assertThrows(DatawaveFatalQueryException.class, () -> test(query));
+    }
+
+    @Test
+    public void testNoMarkerValidSource() {
+        String query = "FIELD >= '2' && FIELD <= '3'";
+        test(query);
+    }
+
+    @Test
+    public void testNoMarkerInvalidSource() {
+        String query = "FIELD == '2' && FIELD == '3'";
+        test(query);
+    }
+
+    private void test(String query) {
+        ASTJexlScript script = parse(query);
+        ValidateBoundedRangeVisitor.validate(script);
+    }
+
+    private ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -70,7 +70,6 @@ import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
-import datawave.query.jexl.visitors.TreeFlatteningRebuildingVisitor;
 import datawave.query.planner.DatePartitionedQueryPlanner;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.CountingShardQueryLogic;
@@ -700,10 +699,8 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
             return;
         }
 
-        ASTJexlScript expectedTree = JexlASTHelper.parseJexlQuery(expected);
-        expectedTree = TreeFlatteningRebuildingVisitor.flattenAll(expectedTree);
-        ASTJexlScript queryTree = JexlASTHelper.parseJexlQuery(query);
-        queryTree = TreeFlatteningRebuildingVisitor.flattenAll(queryTree);
+        ASTJexlScript expectedTree = JexlASTHelper.parseAndFlattenJexlQuery(expected);
+        ASTJexlScript queryTree = JexlASTHelper.parseAndFlattenJexlQuery(query);
         TreeEqualityVisitor.Comparison comparison = TreeEqualityVisitor.checkEquality(expectedTree, queryTree);
         if (!comparison.isEqual()) {
             throw new ComparisonFailure(comparison.getReason(), expected, query);

--- a/warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/LimitFieldsTestingIngest.java
@@ -250,6 +250,12 @@ public class LimitFieldsTestingIngest {
                 bw.close();
             }
         }
+
+        try (BatchWriter batchWriter = client.createBatchWriter(TableName.METADATA)) {
+            Mutation m = new Mutation("num_shards");
+            m.put("ns", "20130101_1", new Value());
+            batchWriter.addMutation(m);
+        }
     }
 
     private static Value getValueForBuilderFor(String... in) {


### PR DESCRIPTION
Bounded range now verify that the lower bound sorts before the upper bound.

Because an invalid bounded range may be considered valid after normalization we cannot check bounded ranges immediately. A visitor was added to validate bounded ranges and that is run after terms are expanded from normalizers. 

- Added convenience methods to LiteralRange that compare the lower and upper bounds to test equivalency or error conditions
- UnmarkedBoundedRangeDetectionVisitor no longer operates on reference nodes per Jexl3 changes.
- Corrected many test queries and expected query plans that had improper bounded terms.
- Corrected a condition where a bounded range expands into a single term and would leave an improper node lineage (ref-and-singleterm)
- Added visitor to validate bounded range terms. It will throw an exception for an illegal range, but only warn about ranges with equivalent bounds that could be rewritten as equality terms.

While working this I noticed ExpandCompositeTerms was generating node trees with an invalid lineage, so opened https://github.com/NationalSecurityAgency/datawave/pull/2883 for that.