### PR TITLE
Fix Node Lineage in ExpandCompositeTerms

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandCompositeTerms.java
@@ -296,16 +296,6 @@ public class ExpandCompositeTerms extends RebuildingVisitor {
         return node;
     }
 
-    // only descend into delayed predicates or bounded ranges
-    @Override
-    public Object visit(ASTReferenceExpression node, Object data) {
-        if (QueryPropertyMarker.findInstance(node).isAnyTypeExcept(DELAYED, BOUNDED_RANGE)) {
-            return copy(node);
-        }
-
-        return super.visit(node, data);
-    }
-
     /**
      * Attempts to create composites using both the leaf nodes and the anded nodes from our ancestors. Each of the composites created must contain at least one
      * of the leaf nodes in order to be valid. The used leaf nodes are passed back via the usedLeafNodes param. The used anded nodes are passed back via the

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -81,7 +81,7 @@ public class ExpandCompositeTermsTest {
         validator.setValidateLineage(true);
         validator.setValidateJunctions(true);
         validator.setValidateQueryPropertyMarkers(true);
-        validator.setValidateReferenceExpressions(true);   //  one day
+        validator.setValidateReferenceExpressions(false); // one day
     }
 
     @Test
@@ -345,7 +345,7 @@ public class ExpandCompositeTermsTest {
 
         String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '"
                         + Normalizer.NUMBER_NORMALIZER.normalize("12345") + "'))";
-        String expected = "((((((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO <= '020d,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO <= '0335,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO <= '0483,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO <= '050355,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO <= '1f36c71c71c71c71c7,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))))";
+        String expected = "((((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO <= '020d,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO <= '0335,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO <= '0483,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO <= '050355,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))) || (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO <= '1f36c71c71c71c71c7,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -996,8 +996,8 @@ public class ExpandCompositeTermsTest {
 
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
-        String expected = "((((((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO < '020d,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO < '0335,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO < '0483,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO < '050355,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO < '1f36c71c71c71c71c7,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
+        String expected = "(((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO < '020d,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO < '0335,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO < '0483,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO < '050355,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO < '1f36c71c71c71c71c7,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1019,8 +1019,8 @@ public class ExpandCompositeTermsTest {
         Set<String> indexedFields = new HashSet<>();
         indexedFields.add("GEO");
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
-        String expected = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
+        String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1044,8 +1044,8 @@ public class ExpandCompositeTermsTest {
 
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
-        String expected = "((((((_Bounded_ = true) && (GEO_WKT >= '0202,+AE0' && GEO_WKT < '020d,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO_WKT >= '030a,+AE0' && GEO_WKT < '0335,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO_WKT >= '0428,+AE0' && GEO_WKT < '0483,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO_WKT >= '0500aa,+AE0' && GEO_WKT < '050355,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))) || (((((_Bounded_ = true) && (GEO_WKT >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO_WKT < '1f36c71c71c71c71c7,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))))))))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
+        String expected = "(((_Bounded_ = true) && (GEO_WKT >= '0202,+AE0' && GEO_WKT < '020d,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO_WKT >= '030a,+AE0' && GEO_WKT < '0335,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO_WKT >= '0428,+AE0' && GEO_WKT < '0483,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO_WKT >= '0500aa,+AE0' && GEO_WKT < '050355,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))) || ((_Bounded_ = true) && (GEO_WKT >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO_WKT < '1f36c71c71c71c71c7,+bE4')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1065,9 +1065,8 @@ public class ExpandCompositeTermsTest {
 
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))))";
-        String expected = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))))";
-
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))";
+        String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))";
         runTestQuery(query, expected, indexedFields, conf);
     }
 
@@ -1088,8 +1087,8 @@ public class ExpandCompositeTermsTest {
         Set<String> indexedFields = new HashSet<>();
         indexedFields.add("GEO");
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
-        String expected = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
+        String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+bE4'))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1124,8 +1123,8 @@ public class ExpandCompositeTermsTest {
 
         String query = "(GEO == '0202' || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335'))) && WKT == '" + normNum + "'";
         String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '0202," + normNum + "')) && ((_Eval_ = true) && (GEO == '0202' && WKT == '"
-                        + normNum + "'))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335," + normNum
-                        + "')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '" + normNum + "'))))";
+                        + normNum + "'))) || (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335," + normNum
+                        + "')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '" + normNum + "')))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1231,30 +1230,23 @@ public class ExpandCompositeTermsTest {
 
     void runTestQuery(String query, String expected, Set<String> indexedFields, ShardQueryConfiguration conf) throws ParseException {
         ASTJexlScript original = JexlASTHelper.parseJexlQuery(query);
+        validateIt(original, "original");
 
-        try {
-            assertTrue(validator.isValid(original));
-        } catch (InvalidQueryTreeException e) {
-            fail("Initial query tree failed validation: " + e.getMessage());
-        }
+        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(expected);
+        validateIt(expectedScript, "expected");
 
         MockMetadataHelper helper = new MockMetadataHelper();
         helper.setIndexedFields(indexedFields);
 
         ASTJexlScript expand = FunctionIndexQueryExpansionVisitor.expandFunctions(conf, helper, DateIndexHelper.getInstance(), original);
         expand = ExpandCompositeTerms.expandTerms(conf, expand);
+        validateIt(expand, "expanded");
 
         // Verify the script is as expected, and has a valid lineage.
         JexlNodeAssert.assertThat(expand).isEqualTo(expected).hasValidLineage();
 
         // Verify the original script was not modified, and still has a valid lineage.
         JexlNodeAssert.assertThat(original).isEqualTo(query).hasValidLineage();
-
-        try {
-            assertTrue(validator.isValid(expand));
-        } catch (InvalidQueryTreeException e) {
-            fail("Expanded query tree failed validation: " + e.getMessage());
-        }
     }
 
     void workIt(String query) throws Exception {
@@ -1274,6 +1266,14 @@ public class ExpandCompositeTermsTest {
         PrintingVisitor.printQuery(script);
         System.err.println(JexlStringBuildingVisitor.buildQuery(script));
         System.err.println();
+    }
+
+    void validateIt(ASTJexlScript script, String stage) {
+        try {
+            assertTrue(validator.isValid(script));
+        } catch (InvalidQueryTreeException e) {
+            fail("query tree failed validation [" + stage + "] " + e.getMessage());
+        }
     }
 
     private static class MockDiscreteIndexType extends BaseType<String> implements DiscreteIndexType<String> {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandCompositeTermsTest.java
@@ -1,5 +1,8 @@
 package datawave.query.jexl.visitors;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -28,7 +31,9 @@ import datawave.data.type.DiscreteIndexType;
 import datawave.data.type.GeometryType;
 import datawave.data.type.Type;
 import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.exceptions.InvalidQueryTreeException;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.validate.ASTValidator;
 import datawave.query.util.DateIndexHelper;
 import datawave.query.util.MockMetadataHelper;
 import datawave.test.JexlNodeAssert;
@@ -42,6 +47,8 @@ public class ExpandCompositeTermsTest {
     private static Map<String,String> compositeFieldSeparators;
 
     private ShardQueryConfiguration conf;
+
+    private final ASTValidator validator = new ASTValidator();
 
     @BeforeClass
     public static void beforeClass() {
@@ -70,6 +77,11 @@ public class ExpandCompositeTermsTest {
         conf = new ShardQueryConfiguration();
         conf.setCompositeToFieldMap(compositeToFieldMap);
         conf.setCompositeFieldSeparators(compositeFieldSeparators);
+
+        validator.setValidateLineage(true);
+        validator.setValidateJunctions(true);
+        validator.setValidateQueryPropertyMarkers(true);
+        validator.setValidateReferenceExpressions(true);   //  one day
     }
 
     @Test
@@ -102,7 +114,7 @@ public class ExpandCompositeTermsTest {
 
     @Test
     public void test4b() throws Exception {
-        String query = "WINNER=='blue' && (TEAM=='gold') && (NAME=='gold-8') && ((_Bounded_ = true) && (POINTS > 10 && POINTS <= 11))";
+        String query = "WINNER=='blue' && TEAM=='gold' && NAME=='gold-8' && ((_Bounded_ = true) && (POINTS > 10 && POINTS <= 11))";
         String expected = "WINNER == 'blue' && ((_Bounded_ = true) && (TEAM_NAME_POINTS > 'gold,gold-8,10' && TEAM_NAME_POINTS <= 'gold,gold-8,11')) && ((_Eval_ = true) && (TEAM == 'gold' && NAME == 'gold-8' && ((_Bounded_ = true) && (POINTS > 10 && POINTS <= 11))))";
         runTestQuery(query, expected);
     }
@@ -331,8 +343,8 @@ public class ExpandCompositeTermsTest {
 
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))))) && (((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '"
-                        + Normalizer.NUMBER_NORMALIZER.normalize("12345") + "')))";
+        String query = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '"
+                        + Normalizer.NUMBER_NORMALIZER.normalize("12345") + "'))";
         String expected = "((((((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO <= '020d,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '030a,+AE0' && GEO <= '0335,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '0428,+AE0' && GEO <= '0483,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '0500aa,+AE0' && GEO <= '050355,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))) || (((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa,+AE0' && GEO <= '1f36c71c71c71c71c7,+eE1.2345')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')) && ((_Bounded_ = true) && (WKT_BYTE_LENGTH >= '+AE0' && WKT_BYTE_LENGTH <= '+eE1.2345'))))))))";
 
         runTestQuery(query, expected, indexedFields, conf);
@@ -477,22 +489,22 @@ public class ExpandCompositeTermsTest {
 
         // EQ to GE, use GE
         // EQ to LE, use LE
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO <= '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GE, use GE
         // EQ to LT, use LT
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO >= '0202,+AE0' && GEO < '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GT, use GT
         // EQ to LE, use LE
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO > '0202,+AE0' && GEO <= '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GT, use GT
         // EQ to LT, use LT
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO > '0202,+AE0' && GEO < '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
 
@@ -682,22 +694,22 @@ public class ExpandCompositeTermsTest {
 
         // EQ to GE, use GE
         // EQ to LE, use LE
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO >= '0202' && GEO <= '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GE, use GE
         // EQ to LT, use LT
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO >= '0202' && GEO < '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GT, use GT
         // EQ to LE, use LE
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO >= '0202' && GEO <= '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GT, use GT
         // EQ to LT, use LT
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO >= '0202' && GEO < '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
 
@@ -881,22 +893,22 @@ public class ExpandCompositeTermsTest {
 
         // EQ to GE, use GE
         // EQ to LE, use LE
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO_WKT >= '0202,+AE0' && GEO_WKT <= '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT <= '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GE, use GE
         // EQ to LT, use LT
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO_WKT >= '0202,+AE0' && GEO_WKT < '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT >= '+AE0' && WKT < '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GT, use GT
         // EQ to LE, use LE
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO_WKT > '0202,+AE0' && GEO_WKT <= '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT <= '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
         // EQ to GT, use GT
         // EQ to LT, use LT
-        query = "(GEO == '0202') && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '" + upperBound + "'))";
+        query = "GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '" + upperBound + "'))";
         expected = "((_Bounded_ = true) && (GEO_WKT > '0202,+AE0' && GEO_WKT < '0202,+eE1.2345')) && ((_Eval_ = true) && (GEO == '0202' && ((_Bounded_ = true) && (WKT > '+AE0' && WKT < '+eE1.2345'))))";
         runTestQuery(query, expected, indexedFields, conf);
 
@@ -959,8 +971,8 @@ public class ExpandCompositeTermsTest {
 
         conf.getFieldToDiscreteIndexTypes().put("GEO", new GeometryType());
 
-        String query = "(((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) || ((((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')))) || ((((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')))) || ((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7')))))";
-        String expected = "((((((_Bounded_ = true) && (GEO >= '0202' && GEO < '020e'))))) || (((((_Bounded_ = true) && (GEO >= '030a' && GEO < '0336'))))) || (((((_Bounded_ = true) && (GEO >= '0428' && GEO < '0484'))))) || (((((_Bounded_ = true) && (GEO >= '0500aa' && GEO < '050356'))))) || (((((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO < '1f36c71c71c71c71c8'))))))";
+        String query = "((_Bounded_ = true) && (GEO >= '0202' && GEO <= '020d')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO <= '0483')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO <= '1f36c71c71c71c71c7'))";
+        String expected = "((_Bounded_ = true) && (GEO >= '0202' && GEO < '020e')) || ((_Bounded_ = true) && (GEO >= '030a' && GEO < '0336')) || ((_Bounded_ = true) && (GEO >= '0428' && GEO < '0484')) || ((_Bounded_ = true) && (GEO >= '0500aa' && GEO < '050356')) || ((_Bounded_ = true) && (GEO >= '1f0aaaaaaaaaaaaaaa' && GEO < '1f36c71c71c71c71c8'))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1110,10 +1122,10 @@ public class ExpandCompositeTermsTest {
 
         String normNum = Normalizer.NUMBER_NORMALIZER.normalize("55");
 
-        String query = "(GEO == '0202' || (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) && WKT == '" + normNum + "'";
-        String expected = "((((_Bounded_ = true) && (GEO >= '0202' && GEO <= '0202," + normNum + "')) && ((_Eval_ = true) && (GEO == '0202' && WKT == '"
+        String query = "(GEO == '0202' || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335'))) && WKT == '" + normNum + "'";
+        String expected = "(((_Bounded_ = true) && (GEO >= '0202' && GEO <= '0202," + normNum + "')) && ((_Eval_ = true) && (GEO == '0202' && WKT == '"
                         + normNum + "'))) || ((((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335," + normNum
-                        + "')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '" + normNum + "')))))";
+                        + "')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '" + normNum + "'))))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1139,8 +1151,8 @@ public class ExpandCompositeTermsTest {
 
         String normNum = Normalizer.NUMBER_NORMALIZER.normalize("55");
 
-        String query = "(GEO == '0202' || (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')))) && WKT == '" + normNum + "'";
-        String expected = "(GEO == '0202,+bE5.5' || ((((_Bounded_ = true) && (GEO >= '030a,+bE5.5' && GEO <= '0335,+bE5.5')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '+bE5.5')))))";
+        String query = "(GEO == '0202' || ((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335'))) && WKT == '" + normNum + "'";
+        String expected = "(GEO == '0202,+bE5.5' || (((_Bounded_ = true) && (GEO >= '030a,+bE5.5' && GEO <= '0335,+bE5.5')) && ((_Eval_ = true) && (((_Bounded_ = true) && (GEO >= '030a' && GEO <= '0335')) && WKT == '+bE5.5'))))";
 
         runTestQuery(query, expected, indexedFields, conf);
     }
@@ -1220,6 +1232,12 @@ public class ExpandCompositeTermsTest {
     void runTestQuery(String query, String expected, Set<String> indexedFields, ShardQueryConfiguration conf) throws ParseException {
         ASTJexlScript original = JexlASTHelper.parseJexlQuery(query);
 
+        try {
+            assertTrue(validator.isValid(original));
+        } catch (InvalidQueryTreeException e) {
+            fail("Initial query tree failed validation: " + e.getMessage());
+        }
+
         MockMetadataHelper helper = new MockMetadataHelper();
         helper.setIndexedFields(indexedFields);
 
@@ -1231,6 +1249,12 @@ public class ExpandCompositeTermsTest {
 
         // Verify the original script was not modified, and still has a valid lineage.
         JexlNodeAssert.assertThat(original).isEqualTo(query).hasValidLineage();
+
+        try {
+            assertTrue(validator.isValid(expand));
+        } catch (InvalidQueryTreeException e) {
+            fail("Expanded query tree failed validation: " + e.getMessage());
+        }
     }
 
     void workIt(String query) throws Exception {


### PR DESCRIPTION
While working https://github.com/NationalSecurityAgency/datawave/pull/2879 I discovered an instance of broken node lineage. Node links were correct traversing the tree from the root to the leaves, but node links were missing when ascending the tree. 

The bug was ultimately due to improper use of the RebuildingVisitor.

While in this section of code I also removed as many extra reference expressions as possible from unit tests, there is one outstanding unit test that adds an extra reference expressions: this prevents us from enabling reference expression validation for the ExpandCompositeTerms test. Maybe one day.