### PR TITLE
Fixed to actually use the dev profile by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2061,9 +2061,6 @@
         </profile>
         <profile>
             <id>kubernetes</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
             <properties>
                 <build.env>kubernetes</build.env>
                 <env>kubernetes</env>

--- a/pom.xml
+++ b/pom.xml
@@ -1433,8 +1433,10 @@
                             <file>${maven.multiModuleProjectDirectory}/properties</file>
                             <file>${user.home}/.m2/datawave/properties</file>
                         </directories>
-                        <files combine.children="append">
+                        <files>
                             <file>default.properties</file>
+                            <file>dev.properties</file>
+                            <file>dev-passwords.properties</file>
                         </files>
                     </configuration>
                     <executions>
@@ -2032,32 +2034,6 @@
             </modules>
         </profile>
         <profile>
-            <id>dev</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <build.env>dev</build.env>
-                <env>dev</env>
-            </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>gov.nsa.datawave.plugins</groupId>
-                            <artifactId>read-properties</artifactId>
-                            <configuration>
-                                <files>
-                                    <file>dev.properties</file>
-                                    <file>dev-passwords.properties</file>
-                                </files>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
             <id>compose</id>
             <properties>
                 <build.env>compose</build.env>
@@ -2071,6 +2047,7 @@
                             <artifactId>read-properties</artifactId>
                             <configuration>
                                 <files>
+                                    <file>default.properties</file>
                                     <file>compose.properties</file>
                                 </files>
                             </configuration>
@@ -2096,6 +2073,7 @@
                             <artifactId>read-properties</artifactId>
                             <configuration>
                                 <files>
+                                    <file>default.properties</file>
                                     <file>kubernetes.properties</file>
                                     <file>kubernetes-passwords.properties</file>
                                 </files>
@@ -2133,6 +2111,7 @@
                             <artifactId>read-properties</artifactId>
                             <configuration>
                                 <files>
+                                    <file>default.properties</file>
                                     <file>dev.properties</file>
                                     <file>dev-passwords.properties</file>
                                     <file>bamboo.properties</file>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
     </distributionManagement>
     <properties>
         <argLine />
+        <!-- build.env and env should get overridden if any other read-properties profile is specified (e.g. comnpose)compose -->
+        <build.env>dev</build.env>
+        <env>dev</env>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The one concession is that the "default.properties" will need to be added to any other other "read-properties" environments as done in the top level pom.xml

As it turns out the dev profile was never actually activated by default because we always have other profiles activated based on undefined properties.  Now that the build requires some set of read-properties files to be defined, this will fix that glitch.