### PR TITLE
scm and github package repo

### DIFF
--- a/contrib/datawave-utils/assert-properties/pom.xml
+++ b/contrib/datawave-utils/assert-properties/pom.xml
@@ -17,9 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-utils.git</developerConnection>
-        <url>https://github.com/NationalSecurityAgency/datawave-utils</url>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/contrib/datawave-utils/code-style/pom.xml
+++ b/contrib/datawave-utils/code-style/pom.xml
@@ -16,9 +16,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-utils.git</developerConnection>
-        <url>https://github.com/NationalSecurityAgency/datawave-utils</url>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/contrib/datawave-utils/read-properties/pom.xml
+++ b/contrib/datawave-utils/read-properties/pom.xml
@@ -17,9 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-utils.git</developerConnection>
-        <url>https://github.com/NationalSecurityAgency/datawave-utils</url>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/core/base-rest-responses/pom.xml
+++ b/core/base-rest-responses/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-base-rest-responses.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-base-rest-responses.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-base-rest-responses</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/core/in-memory-accumulo/pom.xml
+++ b/core/in-memory-accumulo/pom.xml
@@ -14,10 +14,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-in-memory-accumulo.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-in-memory-accumulo.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-in-memory-accumulo</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/core/metrics-reporter/pom.xml
+++ b/core/metrics-reporter/pom.xml
@@ -76,4 +76,16 @@
             <artifactId>httpclient</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/core/metrics-reporter/pom.xml
+++ b/core/metrics-reporter/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-metrics-reporter.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-metrics-reporter.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-metrics-reporter</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.commons-io>2.6</version.commons-io>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,11 +20,6 @@
         <module>query</module>
         <module>utils</module>
     </modules>
-    <scm>
-        <connection>scm:git:https://fixme/git/core/</connection>
-        <developerConnection>scm:git:ssh://git@fixme/core.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
     <dependencies>
         <dependency>
             <groupId>gov.nsa.datawave</groupId>

--- a/core/utils/accumulo-utils/pom.xml
+++ b/core/utils/accumulo-utils/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-accumulo-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-accumulo-utils.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-accumulo-utils</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.accumulo>2.1.1</version.accumulo>

--- a/core/utils/accumulo-utils/pom.xml
+++ b/core/utils/accumulo-utils/pom.xml
@@ -221,4 +221,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/core/utils/common-utils/pom.xml
+++ b/core/utils/common-utils/pom.xml
@@ -61,4 +61,16 @@
             <artifactId>spring-security-core</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/core/utils/common-utils/pom.xml
+++ b/core/utils/common-utils/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-common-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-common-utils.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-common-utils</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <spotbugs.excludes.file>${project.basedir}/src/main/spotbugs/excludes.xml</spotbugs.excludes.file>

--- a/core/utils/metadata-utils/pom.xml
+++ b/core/utils/metadata-utils/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-metadata-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-metadata-utils.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-metadata-utils</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <spotbugs.excludes.file>${project.basedir}/src/main/spotbugs/excludes.xml</spotbugs.excludes.file>

--- a/core/utils/metadata-utils/pom.xml
+++ b/core/utils/metadata-utils/pom.xml
@@ -153,6 +153,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <pluginManagement>
             <plugins>

--- a/core/utils/type-utils/pom.xml
+++ b/core/utils/type-utils/pom.xml
@@ -171,6 +171,16 @@
     </dependencies>
     <repositories>
         <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+        <repository>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/core/utils/type-utils/pom.xml
+++ b/core/utils/type-utils/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-type-utils.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-type-utils.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-type-utils</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/microservices/microservice-parent/pom.xml
+++ b/microservices/microservice-parent/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-parent.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-parent.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-parent</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <distributionManagement>
         <repository>

--- a/microservices/microservice-service-parent/pom.xml
+++ b/microservices/microservice-service-parent/pom.xml
@@ -12,10 +12,10 @@
     <packaging>pom</packaging>
     <name>DataWave Microservices Spring Boot Service Parent</name>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-service-parent.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-service-parent.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-service-parent</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <resource.delimiter>@</resource.delimiter>

--- a/microservices/microservice-service-parent/pom.xml
+++ b/microservices/microservice-service-parent/pom.xml
@@ -82,6 +82,18 @@
             </exclusions>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <!-- Turn on filtering by default for application properties -->
         <resources>

--- a/microservices/services/accumulo/api/pom.xml
+++ b/microservices/services/accumulo/api/pom.xml
@@ -11,10 +11,10 @@
     <version>4.0.1-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-accumulo-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-accumulo-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-accumulo-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-accumulo-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/microservices/services/accumulo/api/pom.xml
+++ b/microservices/services/accumulo/api/pom.xml
@@ -131,6 +131,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/accumulo/pom.xml
+++ b/microservices/services/accumulo/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/accumulo/pom.xml
+++ b/microservices/services/accumulo/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-accumulo-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-accumulo-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-accumulo-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/accumulo/service/pom.xml
+++ b/microservices/services/accumulo/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Accumulo Microservice</description>
     <url>https://code.nsa.gov/datawave-accumulo-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-accumulo-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-accumulo-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-accumulo-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.accumulo.AccumuloService</start-class>

--- a/microservices/services/accumulo/service/pom.xml
+++ b/microservices/services/accumulo/service/pom.xml
@@ -221,6 +221,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/audit/api/pom.xml
+++ b/microservices/services/audit/api/pom.xml
@@ -97,4 +97,16 @@
             <version>${version.commons}</version>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/services/audit/api/pom.xml
+++ b/microservices/services/audit/api/pom.xml
@@ -11,10 +11,10 @@
     <version>4.0.2-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-audit-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-audit-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-audit-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-audit-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.accumulo>2.1.1</version.accumulo>

--- a/microservices/services/audit/pom.xml
+++ b/microservices/services/audit/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/audit/pom.xml
+++ b/microservices/services/audit/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-audit-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-audit-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-audit-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/audit/service/pom.xml
+++ b/microservices/services/audit/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Auditing Microservice</description>
     <url>https://code.nsa.gov/datawave-audit-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-audit-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-audit-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-audit-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.commons>3.9</version.commons>

--- a/microservices/services/audit/service/pom.xml
+++ b/microservices/services/audit/service/pom.xml
@@ -186,6 +186,18 @@
             </exclusions>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/authorization/api/pom.xml
+++ b/microservices/services/authorization/api/pom.xml
@@ -11,10 +11,10 @@
     <version>4.0.2-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-authorization-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-authorization-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-authorization-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-authorization-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/microservices/services/authorization/api/pom.xml
+++ b/microservices/services/authorization/api/pom.xml
@@ -124,6 +124,18 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/authorization/pom.xml
+++ b/microservices/services/authorization/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/authorization/pom.xml
+++ b/microservices/services/authorization/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-authorization-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-authorization-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-authorization-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/authorization/service/pom.xml
+++ b/microservices/services/authorization/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Authorization Microservice</description>
     <url>https://code.nsa.gov/datawave-authorization-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-authorization-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-authorization-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-authorization-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.authorization.AuthorizationService</start-class>

--- a/microservices/services/authorization/service/pom.xml
+++ b/microservices/services/authorization/service/pom.xml
@@ -89,6 +89,18 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/config/pom.xml
+++ b/microservices/services/config/pom.xml
@@ -56,6 +56,18 @@
             </exclusions>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/config/pom.xml
+++ b/microservices/services/config/pom.xml
@@ -18,10 +18,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-config-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-config-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-config-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.config.server.ConfigServerApplication</start-class>

--- a/microservices/services/dictionary/api/pom.xml
+++ b/microservices/services/dictionary/api/pom.xml
@@ -80,6 +80,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/dictionary/api/pom.xml
+++ b/microservices/services/dictionary/api/pom.xml
@@ -11,10 +11,10 @@
     <version>4.0.6-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-dictionary-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-dictionary-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-dictionary-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-dictionary-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/microservices/services/dictionary/pom.xml
+++ b/microservices/services/dictionary/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/dictionary/pom.xml
+++ b/microservices/services/dictionary/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-dictionary-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-dictionary-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-dictionary-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Dictionary Service</description>
     <url>https://code.nsa.gov/datawave-dictionary-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-dictionary-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-dictionary-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-dictionary-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <node.downloadRoot>https://nodejs.org/dist/</node.downloadRoot>

--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -218,6 +218,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/file-provider/api/pom.xml
+++ b/microservices/services/file-provider/api/pom.xml
@@ -11,10 +11,10 @@
     <version>1.0.0-SNAPSHOT</version>
     <url>https://github.com/NationalSecurityAgency/datawave-file-provider-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-file-provider-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-file-provider-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-file-provider-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <build>
         <resources>

--- a/microservices/services/file-provider/api/pom.xml
+++ b/microservices/services/file-provider/api/pom.xml
@@ -16,6 +16,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/file-provider/pom.xml
+++ b/microservices/services/file-provider/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/file-provider/pom.xml
+++ b/microservices/services/file-provider/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-file-provider-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-file-provider-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-file-provider-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/file-provider/service/pom.xml
+++ b/microservices/services/file-provider/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE File Provider Microservice</description>
     <url>https://github.com/NationalSecurityAgency/datawave-file-provider-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-file-provider-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-file-provider-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-file-provider-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.fileProvider.FileProviderService</start-class>

--- a/microservices/services/file-provider/service/pom.xml
+++ b/microservices/services/file-provider/service/pom.xml
@@ -36,6 +36,18 @@
             <artifactId>spring-boot-starter-datawave</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/hazelcast/client/pom.xml
+++ b/microservices/services/hazelcast/client/pom.xml
@@ -48,4 +48,16 @@
             <artifactId>spring-boot-actuator</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/services/hazelcast/client/pom.xml
+++ b/microservices/services/hazelcast/client/pom.xml
@@ -11,10 +11,10 @@
     <version>4.0.3-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-hazelcast-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-hazelcast-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-hazelcast-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-hazelcast-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave.hazelcast-common>4.0.2</version.datawave.hazelcast-common>

--- a/microservices/services/hazelcast/common/pom.xml
+++ b/microservices/services/hazelcast/common/pom.xml
@@ -49,4 +49,16 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/services/hazelcast/common/pom.xml
+++ b/microservices/services/hazelcast/common/pom.xml
@@ -11,10 +11,10 @@
     <version>4.0.3-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-hazelcast-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-hazelcast-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-hazelcast-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-hazelcast-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave.starter>4.0.5</version.datawave.starter>

--- a/microservices/services/hazelcast/pom.xml
+++ b/microservices/services/hazelcast/pom.xml
@@ -21,6 +21,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/hazelcast/pom.xml
+++ b/microservices/services/hazelcast/pom.xml
@@ -16,10 +16,10 @@
         <module>client</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-hazelcast-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-hazelcast-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-hazelcast-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/hazelcast/service/pom.xml
+++ b/microservices/services/hazelcast/service/pom.xml
@@ -66,6 +66,18 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/hazelcast/service/pom.xml
+++ b/microservices/services/hazelcast/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Hazelcast Server</description>
     <url>https://code.nsa.gov/datawave-hazelcast-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-hazelcast-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-hazelcast-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-hazelcast-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.cached.server.HazelcastService</start-class>

--- a/microservices/services/mapreduce-query/api/pom.xml
+++ b/microservices/services/mapreduce-query/api/pom.xml
@@ -11,9 +11,9 @@
     <version>1.0.1-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-mapreduce-query-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-mapreduce-query-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
 </project>

--- a/microservices/services/mapreduce-query/api/pom.xml
+++ b/microservices/services/mapreduce-query/api/pom.xml
@@ -16,4 +16,16 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/services/mapreduce-query/jobs/core/pom.xml
+++ b/microservices/services/mapreduce-query/jobs/core/pom.xml
@@ -87,6 +87,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/mapreduce-query/jobs/core/pom.xml
+++ b/microservices/services/mapreduce-query/jobs/core/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE MapReduce Query Core Job</description>
     <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-mapreduce-query-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave>7.1.3</version.datawave>

--- a/microservices/services/mapreduce-query/layout-factory/pom.xml
+++ b/microservices/services/mapreduce-query/layout-factory/pom.xml
@@ -25,4 +25,16 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/services/mapreduce-query/layout-factory/pom.xml
+++ b/microservices/services/mapreduce-query/layout-factory/pom.xml
@@ -11,10 +11,10 @@
     <version>1.0.1-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-mapreduce-query-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-mapreduce-query-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties />
     <dependencies>

--- a/microservices/services/mapreduce-query/pom.xml
+++ b/microservices/services/mapreduce-query/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/mapreduce-query/pom.xml
+++ b/microservices/services/mapreduce-query/pom.xml
@@ -15,9 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-mapreduce-query-service.git</developerConnection>
-        <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/mapreduce-query/service/pom.xml
+++ b/microservices/services/mapreduce-query/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE MapReduce Query Microservice</description>
     <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-mapreduce-query-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-mapreduce-query-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.query.mapreduce.MapReduceQueryService</start-class>

--- a/microservices/services/mapreduce-query/service/pom.xml
+++ b/microservices/services/mapreduce-query/service/pom.xml
@@ -166,6 +166,18 @@
             <artifactId>oozie-client</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/modification/api/pom.xml
+++ b/microservices/services/modification/api/pom.xml
@@ -110,4 +110,16 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/services/modification/api/pom.xml
+++ b/microservices/services/modification/api/pom.xml
@@ -11,10 +11,10 @@
     <version>1.0.1-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-modification-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-modification-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-modification-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-modification-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.accumulo>2.1.1</version.accumulo>

--- a/microservices/services/modification/pom.xml
+++ b/microservices/services/modification/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/modification/pom.xml
+++ b/microservices/services/modification/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-modification-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-modification-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-modification-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/modification/service/pom.xml
+++ b/microservices/services/modification/service/pom.xml
@@ -191,6 +191,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/modification/service/pom.xml
+++ b/microservices/services/modification/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Modification Service</description>
     <url>https://code.nsa.gov/datawave-modification-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-modification-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-modification-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-modification-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.modification.ModificationService</start-class>

--- a/microservices/services/query-executor/api/pom.xml
+++ b/microservices/services/query-executor/api/pom.xml
@@ -11,10 +11,10 @@
     <version>1.0.8-SNAPSHOT</version>
     <url>https://github.com/NationalSecurityAgency/datawave-query-executor-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-executor-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-executor-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-executor-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave/v1</datawave.webservice.namespace>

--- a/microservices/services/query-executor/api/pom.xml
+++ b/microservices/services/query-executor/api/pom.xml
@@ -77,6 +77,18 @@
             <artifactId>spring-context</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/query-executor/pom.xml
+++ b/microservices/services/query-executor/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/query-executor/pom.xml
+++ b/microservices/services/query-executor/pom.xml
@@ -15,9 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-executor-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-executor-service.git</developerConnection>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-executor-service</url>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/query-executor/service/pom.xml
+++ b/microservices/services/query-executor/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Query Executor Service</description>
     <url>https://github.com/NationalSecurityAgency/datawave-query-executor-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-executor-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-executor-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-executor-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.query.executor.QueryExecutorService</start-class>

--- a/microservices/services/query-executor/service/pom.xml
+++ b/microservices/services/query-executor/service/pom.xml
@@ -302,6 +302,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/query-metric/api/pom.xml
+++ b/microservices/services/query-metric/api/pom.xml
@@ -11,10 +11,10 @@
     <version>4.1.1-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-query-metric-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-metric-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-metric-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-metric-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/microservices/services/query-metric/api/pom.xml
+++ b/microservices/services/query-metric/api/pom.xml
@@ -211,6 +211,18 @@
             <version>5.3.21</version>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/query-metric/pom.xml
+++ b/microservices/services/query-metric/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/query-metric/pom.xml
+++ b/microservices/services/query-metric/pom.xml
@@ -15,10 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-metric-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-metric-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-metric-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/query-metric/service/pom.xml
+++ b/microservices/services/query-metric/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Query Metric Microservice</description>
     <url>https://code.nsa.gov/datawave-query-metric-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-metric-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-metric-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-metric-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <spotbugs.excludes.file>${basedir}/spotbugs-exclude.xml</spotbugs.excludes.file>

--- a/microservices/services/query-metric/service/pom.xml
+++ b/microservices/services/query-metric/service/pom.xml
@@ -381,6 +381,18 @@
             <artifactId>webjars-locator-core</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/services/query/api/pom.xml
+++ b/microservices/services/query/api/pom.xml
@@ -11,10 +11,10 @@
     <version>1.0.1-SNAPSHOT</version>
     <url>https://github.com/NationalSecurityAgency/datawave-query-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave.nsa/v1</datawave.webservice.namespace>

--- a/microservices/services/query/api/pom.xml
+++ b/microservices/services/query/api/pom.xml
@@ -75,6 +75,18 @@
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/services/query/pom.xml
+++ b/microservices/services/query/pom.xml
@@ -20,6 +20,18 @@
         <tag>HEAD</tag>
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>services</id>

--- a/microservices/services/query/pom.xml
+++ b/microservices/services/query/pom.xml
@@ -15,9 +15,10 @@
         <module>api</module>
     </modules>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-service.git</developerConnection>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-service</url>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <profiles>
         <profile>

--- a/microservices/services/query/service/pom.xml
+++ b/microservices/services/query/service/pom.xml
@@ -12,10 +12,10 @@
     <description>DATAWAVE Query Microservice</description>
     <url>https://github.com/NationalSecurityAgency/datawave-query-service</url>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-query-service.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-query-service.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-query-service</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <start-class>datawave.microservice.query.QueryService</start-class>

--- a/microservices/services/query/service/pom.xml
+++ b/microservices/services/query/service/pom.xml
@@ -252,6 +252,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <plugins>
             <plugin>

--- a/microservices/starters/audit/pom.xml
+++ b/microservices/starters/audit/pom.xml
@@ -60,4 +60,16 @@
             <artifactId>spring-boot-starter-datawave</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/starters/audit/pom.xml
+++ b/microservices/starters/audit/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-audit.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter-audit.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-audit</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave.audit-api>4.0.1</version.datawave.audit-api>

--- a/microservices/starters/cache/pom.xml
+++ b/microservices/starters/cache/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-cache.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter-cache.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-cache</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <dependencies>
         <dependency>

--- a/microservices/starters/cache/pom.xml
+++ b/microservices/starters/cache/pom.xml
@@ -57,4 +57,16 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/starters/cached-results/pom.xml
+++ b/microservices/starters/cached-results/pom.xml
@@ -169,4 +169,16 @@
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/starters/cached-results/pom.xml
+++ b/microservices/starters/cached-results/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-cached-results.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter-cached-results.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-cached-results</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave>7.3.0</version.datawave>

--- a/microservices/starters/datawave/pom.xml
+++ b/microservices/starters/datawave/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.accumulo>2.1.1</version.accumulo>

--- a/microservices/starters/datawave/pom.xml
+++ b/microservices/starters/datawave/pom.xml
@@ -407,4 +407,16 @@
             <artifactId>spring-retry</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/starters/metadata/pom.xml
+++ b/microservices/starters/metadata/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-metadata.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter-metadata.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-metadata</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave>7.1.3</version.datawave>

--- a/microservices/starters/metadata/pom.xml
+++ b/microservices/starters/metadata/pom.xml
@@ -99,4 +99,16 @@
             <artifactId>spring-boot-starter-datawave-cache</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/starters/query-metric/pom.xml
+++ b/microservices/starters/query-metric/pom.xml
@@ -66,4 +66,16 @@
             <artifactId>spring-boot-starter-datawave</artifactId>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
 </project>

--- a/microservices/starters/query-metric/pom.xml
+++ b/microservices/starters/query-metric/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-query-metric.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter-query-metric.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-query-metric</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <version.datawave.authorization-api>4.0.1</version.datawave.authorization-api>

--- a/microservices/starters/query/pom.xml
+++ b/microservices/starters/query/pom.xml
@@ -181,6 +181,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
     <build>
         <resources>
             <resource>

--- a/microservices/starters/query/pom.xml
+++ b/microservices/starters/query/pom.xml
@@ -17,10 +17,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-query.git</connection>
-        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave-spring-boot-starter-query.git</developerConnection>
+        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
+        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
         <tag>HEAD</tag>
-        <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-query</url>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
         <datawave.webservice.namespace>http://webservice.datawave/v1</datawave.webservice.namespace>

--- a/warehouse/pom.xml
+++ b/warehouse/pom.xml
@@ -35,11 +35,6 @@
         <module>ssdeep-common</module>
         <module>ingest-ssdeep</module>
     </modules>
-    <scm>
-        <connection>scm:git:https://fixme/git/warehouse/</connection>
-        <developerConnection>scm:git:ssh://git@fixme/warehouse.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
     <properties>
         <!-- set env property to its default value -->
         <!-- commented this out so profiles other than dev build properly.  May need to put it back.  -->


### PR DESCRIPTION
Adds the GitHub packages repo back so submodules can download a released parent.  

AFAIK the only plugin that uses the scm configuration in the pom is the `maven-release-plugin`.
```
    <scm>
        <connection>scm:git:https://github.com/NationalSecurityAgency/datawave.git</connection>
        <developerConnection>scm:git:git@github.com:NationalSecurityAgency/datawave.git</developerConnection>
        <tag>HEAD</tag>
        <url>https://github.com/NationalSecurityAgency/datawave</url>
    </scm>
```
This PR updates all the standalone projects to use the same scm configuration as the top level pom so we can simply run through the standard maven release commands on those former submodules.
```
mvn release:prepare
mvn release:perform
```