### PR TITLE
Improve TypeAttribute serialization

### DIFF
--- a/core/utils/type-utils/src/main/java/datawave/data/normalizer/NumberNormalizer.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/normalizer/NumberNormalizer.java
@@ -10,7 +10,7 @@ import datawave.data.type.util.NumericalEncoder;
 public class NumberNormalizer extends AbstractNormalizer<BigDecimal> {
 
     private static final long serialVersionUID = -2781476072987375820L;
-    private Logger log = Logger.getLogger(NumberNormalizer.class);
+    private static final Logger log = Logger.getLogger(NumberNormalizer.class);
 
     public String normalize(String fv) {
         if (NumericalEncoder.isPossiblyEncoded(fv)) {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -4,21 +4,31 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
+
 import datawave.data.normalizer.Normalizer;
 import datawave.webservice.query.data.ObjectSizeOf;
 
 public class BaseType<T extends Comparable<T> & Serializable> implements Serializable, Type<T>, ObjectSizeOf {
-
-    private static final long serialVersionUID = 5354270429891763693L;
+    private static final long serialVersionUID = 1261391800060720465L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + Sizer.REFERENCE + Sizer.REFERENCE;
 
     protected T delegate;
     protected String normalizedValue;
     protected final Normalizer<T> normalizer;
 
-    public BaseType(String delegateString, Normalizer<T> normalizer) {
+    /**
+     * Default constructor. Generates the normalized and non-normalized variants of the provided value
+     *
+     * @param value
+     *            the value
+     * @param normalizer
+     *            the normalizer
+     */
+    public BaseType(String value, Normalizer<T> normalizer) {
         this.normalizer = normalizer;
-        setDelegate(normalizer.denormalize(delegateString));
+        this.delegate = normalizer.denormalize(value);
+        this.normalizedValue = normalizer.normalizeDelegateType(delegate);
     }
 
     public BaseType(Normalizer<T> normalizer) {
@@ -33,9 +43,22 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         setDelegate(normalizer.denormalize(in));
     }
 
+    /**
+     * Set the delegate directly with no further operations
+     *
+     * @param delegate
+     *            the delegate Type
+     */
     public void setDelegate(T delegate) {
         this.delegate = delegate;
-        normalizeAndSetNormalizedValue(this.delegate);
+    }
+
+    /**
+     * Use the normalizer and delegate to set the normalized value. Assumes that {@link #setDelegate(Comparable)} has been called.
+     */
+    public void setNormalizedValueFromDelegate() {
+        Preconditions.checkNotNull(delegate, "Tried to set normalized value from delegate, but delegate was null");
+        this.normalizedValue = normalizer.normalizeDelegateType(this.delegate);
     }
 
     public String getNormalizedValue() {
@@ -47,6 +70,12 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         return this.delegate;
     }
 
+    /**
+     * Set the normalized value. This is useful when working with a value that is already normalized
+     *
+     * @param normalizedValue
+     *            the normalized value
+     */
     public void setNormalizedValue(String normalizedValue) {
         this.normalizedValue = normalizedValue;
     }
@@ -85,9 +114,16 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         return normalizer.normalizedRegexIsLossy(in);
     }
 
+    /**
+     * Apply a normalizer to the provided value and store the result.
+     *
+     * @param value
+     *            the value
+     */
     @Override
-    public void normalizeAndSetNormalizedValue(T valueToNormalize) {
-        setNormalizedValue(normalizer.normalizeDelegateType(valueToNormalize));
+    public void normalizeAndSetNormalizedValue(T value) {
+        String normalized = normalizer.normalizeDelegateType(value);
+        setNormalizedValue(normalized);
     }
 
     public void validate() {
@@ -160,7 +196,7 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
      * One string (normalizedValue) one unknown object (delegate) one normalizer (singleton reference) ref to object (4) normalizers will not be counted because
      * they are singletons
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
@@ -169,7 +205,7 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
             List<String> values = ((OneToManyNormalizerType<?>) this).getNormalizedValues();
             size += values.stream().map(String::length).map(length -> 2 * length + ObjectSizeOf.Sizer.REFERENCE).reduce(Integer::sum).orElse(0);
         }
-        size += STATIC_SIZE + (2 * normalizedValue.length()) + ObjectSizeOf.Sizer.getObjectSize(delegate);
+        size += STATIC_SIZE + (2L * normalizedValue.length()) + ObjectSizeOf.Sizer.getObjectSize(delegate);
         return size;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
@@ -7,6 +7,7 @@ import datawave.data.normalizer.Normalizer;
 public class DateType extends BaseType<Date> {
 
     private static final long serialVersionUID = 936566410691643144L;
+
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + PrecomputedSizes.DATE_STATIC_REF + Sizer.REFERENCE;
 
     public DateType() {
@@ -15,6 +16,7 @@ public class DateType extends BaseType<Date> {
 
     public DateType(String dateString) {
         super(Normalizer.DATE_NORMALIZER);
+        super.setNormalizedValue(dateString);
         super.setDelegate(normalizer.denormalize(dateString));
     }
 
@@ -27,10 +29,10 @@ public class DateType extends BaseType<Date> {
     /**
      * One string, one date object, one reference to the normalizer
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length());
+        return STATIC_SIZE + (2L * normalizedValue.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
@@ -16,8 +16,8 @@ public class DateType extends BaseType<Date> {
 
     public DateType(String dateString) {
         super(Normalizer.DATE_NORMALIZER);
-        super.setNormalizedValue(dateString);
-        super.setDelegate(normalizer.denormalize(dateString));
+        this.normalizedValue = normalizer.normalize(dateString);
+        this.delegate = normalizer.denormalize(dateString);
     }
 
     @Override

--- a/core/utils/type-utils/src/main/java/datawave/data/type/GeoType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/GeoType.java
@@ -14,10 +14,10 @@ public class GeoType extends BaseType<String> {
     /**
      * Two String + normalizer reference
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+        return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/GeometryType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/GeometryType.java
@@ -28,8 +28,15 @@ public class GeometryType extends AbstractGeometryType<Geometry> implements OneT
     }
 
     @Override
-    public void normalizeAndSetNormalizedValue(Geometry valueToNormalize) {
-        setNormalizedValues(((OneToManyNormalizer<Geometry>) normalizer).normalizeDelegateTypeToMany(valueToNormalize));
+    public void normalizeAndSetNormalizedValue(Geometry value) {
+        setNormalizedValues(((OneToManyNormalizer<Geometry>) normalizer).normalizeDelegateTypeToMany(value));
+    }
+
+    /**
+     * Assumes that {@link #setDelegate(Comparable)} has been called
+     */
+    public void setNormalizedValueFromDelegate() {
+        setNormalizedValues(((OneToManyNormalizer<Geometry>) normalizer).normalizeDelegateTypeToMany(delegate));
     }
 
     public List<String> getNormalizedValues() {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/IpAddressType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/IpAddressType.java
@@ -26,11 +26,11 @@ public class IpAddressType extends BaseType<IpAddress> {
     /**
      * calculate the size based on the type of ip address type this is. Do not include the normalizer except a reference
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        long base = STATIC_SIZE + (2 * normalizedValue.length());
+        long base = STATIC_SIZE + (2L * normalizedValue.length());
         long ipSize;
         if (delegate instanceof IpV4Address) {
             ipSize = PrecomputedSizes.IPV4ADDRESS_STATIC_REF;

--- a/core/utils/type-utils/src/main/java/datawave/data/type/LcType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/LcType.java
@@ -18,10 +18,10 @@ public class LcType extends BaseType<String> {
     /**
      * Two String + normalizer reference
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+        return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/ListType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/ListType.java
@@ -21,14 +21,11 @@ public abstract class ListType extends BaseType implements OneToManyNormalizerTy
     @Override
     public List<String> normalizeToMany(String in) {
         String[] splits = StringUtils.split(in, delimiter);
-        List<String> strings = new ArrayList(splits.length);
+        List<String> strings = new ArrayList<>(splits.length);
         for (String s : splits) {
-
             String str = normalizer.normalize(s);
             strings.add(str);
-
         }
-
         return strings;
     }
 
@@ -37,6 +34,16 @@ public abstract class ListType extends BaseType implements OneToManyNormalizerTy
         this.normalizedValues = normalizeToMany(in);
         this.delegate = in;
         setNormalizedValue(in);
+    }
+
+    /**
+     * Assumes that {@link #setDelegate(Comparable)} has been called
+     */
+    public void setNormalizedValueFromDelegate() {
+        if (normalizedValue == null) {
+            normalizedValue = getDelegateAsString();
+        }
+        this.normalizedValues = normalizeToMany(this.normalizedValue);
     }
 
     @Override

--- a/core/utils/type-utils/src/main/java/datawave/data/type/NumberType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/NumberType.java
@@ -22,6 +22,6 @@ public class NumberType extends BaseType<BigDecimal> {
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length());
+        return STATIC_SIZE + (2L * normalizedValue.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/RawDateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/RawDateType.java
@@ -13,16 +13,17 @@ public class RawDateType extends BaseType<String> {
 
     public RawDateType(String dateString) {
         super(Normalizer.RAW_DATE_NORMALIZER);
-        super.setDelegate(normalizer.denormalize(dateString));
+        setNormalizedValue(dateString);
+        setDelegate(normalizer.denormalize(dateString));
     }
 
     /**
      * Two String + normalizer reference
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+        return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/StringType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/StringType.java
@@ -14,10 +14,10 @@ public class StringType extends BaseType<String> {
     /**
      * Two String + normalizer reference
      *
-     * @return
+     * @return the size in bytes
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2 * normalizedValue.length()) + (2 * delegate.length());
+        return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/Type.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/Type.java
@@ -22,6 +22,8 @@ public interface Type<T extends Comparable<T>> extends Comparable<Type<T>> {
 
     void setDelegate(T delegate);
 
+    void setNormalizedValueFromDelegate();
+
     /**
      * The string form must preserve all information in the delegate such that setDelegateFromString will recreate this instance correctly.
      */

--- a/core/utils/type-utils/src/test/java/datawave/data/type/GeometryObjectSizeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/GeometryObjectSizeTest.java
@@ -17,8 +17,11 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void pointTest() throws Exception {
+        Point point = new Point((org.locationtech.jts.geom.Point) new WKTReader().read("POINT(0 0)"));
+
         PointType pointType = new PointType();
-        pointType.setDelegate(new Point((org.locationtech.jts.geom.Point) new WKTReader().read("POINT(0 0)")));
+        pointType.setDelegate(point);
+        pointType.setNormalizedValue(point.toString());
 
         long estimatedSizeInBytes = pointType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(pointType);
@@ -28,8 +31,11 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void multiPointTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read("MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10)"));
+
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read("MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10)")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
 
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -39,9 +45,12 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void polygonTest() throws Exception {
+        Geometry geometry = new Geometry(
+                        new WKTReader().read("POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45))"));
+
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(
-                        new WKTReader().read("POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
 
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -51,9 +60,12 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void multiPolygonTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read(
+                        "MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60)))"));
+
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read(
-                        "MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60)))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
 
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -63,8 +75,11 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void lineStringTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read("LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85)"));
+
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read("LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85)")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
 
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -74,9 +89,12 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void multiLineStringTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read(
+                        "MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))"));
+
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read(
-                        "MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
 
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);
@@ -86,9 +104,12 @@ public class GeometryObjectSizeTest {
 
     @Test
     public void geometryCollectionTest() throws Exception {
+        Geometry geometry = new Geometry(new WKTReader().read(
+                        "GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10)), GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))))"));
+
         GeometryType geometryType = new GeometryType();
-        geometryType.setDelegate(new Geometry(new WKTReader().read(
-                        "GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10)), GEOMETRYCOLLECTION(POINT(0 0), MULTIPOINT(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9, 10 10), POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), MULTIPOLYGON(((-180 -90, 180 -90, 180 90, -180 90, -180 -90), (-45 -45, 45 -45, 45 45, -45 45, -45 -45)), ((-60 -60, 60 -60, 60 60, -60 60, -60 -60))), LINESTRING(-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), MULTILINESTRING((-110 -80, -45 -76, -10 -5, 30 10, 40 50, 35 30, 170 85), (0 1, 0 2, 0 3, 0 4, 0 5, 0 6, 0 7, 1 8, 1 9, 1 10))))")));
+        geometryType.setDelegate(geometry);
+        geometryType.normalizeAndSetNormalizedValue(geometry);
 
         long estimatedSizeInBytes = geometryType.sizeInBytes();
         long actualSizeInBytes = sizeInBytes(geometryType);

--- a/core/utils/type-utils/src/test/java/datawave/data/type/ListTypeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/ListTypeTest.java
@@ -15,7 +15,7 @@ public class ListTypeTest {
 
         LcNoDiacriticsListType t = new LcNoDiacriticsListType(str);
         Assert.equals(6, t.normalizeToMany(str).size());
-        List<String> expected = Arrays.asList(new String[] {"1", "2", "3", "a", "b", "c"});
+        List<String> expected = Arrays.asList("1", "2", "3", "a", "b", "c");
         Assert.equals(expected, t.normalizeToMany(str));
     }
 
@@ -25,14 +25,14 @@ public class ListTypeTest {
 
         LcNoDiacriticsListType t = new LcNoDiacriticsListType();
         Assert.equals(6, t.normalizeToMany(str).size());
-        List<String> expected = Arrays.asList(new String[] {"01", "02", "03", "a", "b", "c"});
+        List<String> expected = Arrays.asList("01", "02", "03", "a", "b", "c");
         Assert.equals(expected, t.normalizeToMany(str));
     }
 
     @Test
     public void testNumberList() {
         String str = "1,2,3,5.5";
-        List<String> expected = Arrays.asList(new String[] {"+aE1", "+aE2", "+aE3", "+aE5.5"});
+        List<String> expected = Arrays.asList("+aE1", "+aE2", "+aE3", "+aE5.5");
 
         NumberListType nt = new NumberListType();
         Assert.equals(4, nt.normalizeToMany(str).size());

--- a/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
+++ b/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
@@ -51,6 +51,11 @@ public class IdentityDataType implements Type<String> {
     }
 
     @Override
+    public void setNormalizedValueFromDelegate() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String getDelegateAsString() {
         throw new UnsupportedOperationException();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/AttributeFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/AttributeFactory.java
@@ -70,12 +70,10 @@ public class AttributeFactory {
     }
 
     public Attribute<?> create(String fieldName, String data, Key key, boolean toKeep) {
-
         return this.create(fieldName, data, key, extractIngestDataTypeFromKey(key), toKeep, false);
     }
 
     public Attribute<?> create(String fieldName, String data, Key key, boolean toKeep, boolean isComposite) {
-
         return this.create(fieldName, data, key, extractIngestDataTypeFromKey(key), toKeep, isComposite);
     }
 
@@ -135,18 +133,19 @@ public class AttributeFactory {
     protected Attribute<?> getAttribute(Class<?> dataTypeClass, String fieldName, String data, Key key, boolean toKeep) throws Exception {
         Type<?> type = (Type<?>) dataTypeClass.getDeclaredConstructor().newInstance();
         try {
+            // cannot assume data is normalized. In the future provide an alternative entry point for normalized data.
             type.setDelegateFromString(data);
-            return new TypeAttribute(type, key, toKeep);
+            type.setNormalizedValueFromDelegate();
+            return new TypeAttribute<>(type, key, toKeep);
         } catch (Exception ex) {
 
             if (ex instanceof IllegalArgumentException) {
                 log.warn("Could not parse " + fieldName + " = '" + data + "', resorting to a NoOpType");
-                return new TypeAttribute(new NoOpType(data), key, toKeep);
+                return new TypeAttribute<>(new NoOpType(data), key, toKeep);
             } else {
                 log.error("Could not create Attribute for " + fieldName + " and " + data, ex);
                 throw new IllegalArgumentException("Could not create Attribute for " + fieldName + " and " + data, ex);
             }
-
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -60,6 +60,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
     public void write(DataOutput out) throws IOException {
         WritableUtils.writeString(out, datawaveType.getClass().toString());
         writeMetadata(out);
+
         WritableUtils.writeString(out, datawaveType.getDelegateAsString());
         WritableUtils.writeVInt(out, toKeep ? 1 : 0);
     }
@@ -134,23 +135,29 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public void read(Kryo kryo, Input input) {
+
         try {
             setDatawaveType(input.readString());
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
             log.warn("could not read datawateType from input: " + e);
         }
         super.readMetadata(kryo, input);
-        if (datawaveType == null)
+        if (datawaveType == null) {
             datawaveType = (Type) new NoOpType();
-        String delegateString = input.readString();
+        }
+
+        String normalizedValue = input.readString();
         try {
-            datawaveType.setDelegateFromString(delegateString);
+            datawaveType.setDelegateFromString(normalizedValue);
+            datawaveType.setNormalizedValue(normalizedValue);
         } catch (Exception ex) {
             // there was some problem with setting the delegate as the declared type.
             // Instead of letting this exception fail the query, make this a NoOpType containing the string value from the input
-            log.warn("Was unable to make a " + datawaveType + " to contain a delegate created from input:" + delegateString + "  Making a NoOpType instead.");
+            log.warn("Was unable to make a " + datawaveType.getClass().getSimpleName() + " to contain a delegate created from input:" + normalizedValue
+                            + "  Making a " + NoOpType.class.getSimpleName() + " instead.");
             datawaveType = (Type) new NoOpType();
-            datawaveType.setDelegateFromString(delegateString);
+            datawaveType.setDelegateFromString(normalizedValue);
+            datawaveType.setNormalizedValue(normalizedValue);
         }
         this.toKeep = input.readBoolean();
     }
@@ -166,8 +173,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
      * @see Attribute#deepCopy()
      */
     @Override
-    public TypeAttribute copy() {
-        return new TypeAttribute(this.getType(), this.getMetadata(), this.isToKeep());
+    public TypeAttribute<T> copy() {
+        return new TypeAttribute<>(this.getType(), this.getMetadata(), this.isToKeep());
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingUtils.java
+++ b/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingUtils.java
@@ -109,6 +109,7 @@ public class GroupingUtils {
         // Add an attribute for the count.
         NumberType type = new NumberType();
         type.setDelegate(new BigDecimal(group.getCount()));
+        type.setNormalizedValue(String.valueOf(group.getCount()));
         TypeAttribute<BigDecimal> attr = new TypeAttribute<>(type, new Key("count"), true);
         document.put("COUNT", attr);
 
@@ -172,6 +173,7 @@ public class GroupingUtils {
     private static void addSumAggregation(Document document, String field, SumAggregator aggregator, MarkingFunctions markingFunctions) {
         NumberType type = new NumberType();
         type.setDelegate(aggregator.getAggregation());
+        type.normalizeAndSetNormalizedValue(aggregator.getAggregation());
         TypeAttribute<BigDecimal> sumAttribute = new TypeAttribute<>(type, new Key(field + "_sum"), true);
         sumAttribute.setColumnVisibility(combineVisibilities(aggregator.getColumnVisibilities(), markingFunctions, false));
         document.put(field + DocumentGrouper.FIELD_SUM_SUFFIX, sumAttribute);
@@ -192,6 +194,7 @@ public class GroupingUtils {
     private static void addCountAggregation(Document document, String field, CountAggregator aggregator, MarkingFunctions markingFunctions) {
         NumberType type = new NumberType();
         type.setDelegate(BigDecimal.valueOf(aggregator.getAggregation()));
+        type.normalizeAndSetNormalizedValue(BigDecimal.valueOf(aggregator.getAggregation()));
         TypeAttribute<BigDecimal> sumAttribute = new TypeAttribute<>(type, new Key(field + "_count"), true);
         Set<ColumnVisibility> columnVisibilities = aggregator.getColumnVisibilities();
         if (!columnVisibilities.isEmpty()) {
@@ -243,6 +246,7 @@ public class GroupingUtils {
     private static void addAverage(Document document, String field, AverageAggregator aggregator, MarkingFunctions markingFunctions) {
         NumberType type = new NumberType();
         type.setDelegate(aggregator.getAggregation());
+        type.setNormalizedValue(aggregator.getAggregation().toString());
         TypeAttribute<BigDecimal> attribute = new TypeAttribute<>(type, new Key(field + "_average"), true);
         attribute.setColumnVisibility(combineVisibilities(aggregator.getColumnVisibilities(), markingFunctions, false));
         document.put(field + DocumentGrouper.FIELD_AVERAGE_SUFFIX, attribute);
@@ -266,6 +270,7 @@ public class GroupingUtils {
         // Add an attribute for the average's numerator. This is required to properly combine additional aggregations in future groupings.
         NumberType numeratorType = new NumberType();
         numeratorType.setDelegate(aggregator.getNumerator());
+        numeratorType.setNormalizedValue(aggregator.getNumerator().toString());
         TypeAttribute<BigDecimal> sumAttribute = new TypeAttribute<>(numeratorType, new Key(field + "_average_numerator"), true);
         sumAttribute.setColumnVisibility(visibility);
         document.put(field + DocumentGrouper.FIELD_AVERAGE_NUMERATOR_SUFFIX, sumAttribute);
@@ -273,6 +278,7 @@ public class GroupingUtils {
         // Add an attribute for the average's divisor. This is required to properly combine additional aggregations in future groupings.
         NumberType divisorType = new NumberType();
         divisorType.setDelegate(aggregator.getDivisor());
+        divisorType.setNormalizedValue(aggregator.getDivisor().toString());
         TypeAttribute<BigDecimal> countAttribute = new TypeAttribute<>(divisorType, new Key(field + "_average_divisor"), true);
         countAttribute.setColumnVisibility(visibility);
         document.put(field + DocumentGrouper.FIELD_AVERAGE_DIVISOR_SUFFIX, countAttribute);

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -1,0 +1,147 @@
+package datawave.query.attributes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.AbstractMap;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.data.type.HexStringType;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.LcType;
+import datawave.data.type.NumberType;
+import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.function.serializer.KryoDocumentSerializer;
+import datawave.query.util.TypeMetadata;
+
+/**
+ * Test document serialization with various attributes
+ */
+public class DocumentTest {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentTest.class);
+
+    private final String datatype = "datatype";
+    private final Key documentKey = new Key("row", "datatype\0uid");
+    private final KryoDocumentSerializer serializer = new KryoDocumentSerializer();
+    private final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
+
+    private static final int max_iterations = 1;
+
+    private AttributeFactory attributeFactory;
+
+    private Document d;
+
+    @BeforeEach
+    public void setup() {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        typeMetadata.put("LC", datatype, LcType.class.getTypeName());
+        typeMetadata.put("LC_NO_DIACRITICS", datatype, LcNoDiacriticsType.class.getTypeName());
+        typeMetadata.put("NUMBER", datatype, NumberType.class.getTypeName());
+        typeMetadata.put("HEX", datatype, HexStringType.class.getTypeName());
+
+        attributeFactory = new AttributeFactory(typeMetadata);
+        d = new Document(documentKey, true);
+    }
+
+    @Test
+    public void testEmptyDocument() {
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithLcType() {
+        Attribute<?> attr = createAttribute("LC", "value");
+        d.put("LC", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithLcNoDiacriticsType() {
+        Attribute<?> attr = createAttribute("LC_NO_DIACRITICS", "value");
+        d.put("LC_NO_DIACRITICS", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithHexType() {
+        Attribute<?> attr = createAttribute("HEX", "a1b2c3");
+        d.put("HEX", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithNumberType() {
+        Attribute<?> attr = createAttribute("NUMBER", "12");
+        d.put("NUMBER", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithNumberTypeNormalizedValue() {
+        Attribute<?> attr = createAttribute("NUMBER", "+bE1.2");
+        d.put("NUMBER", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testDocumentWithNumberTypeLargeValue() {
+        Attribute<?> attr = createAttribute("NUMBER", "12456789.987654321");
+        d.put("NUMBER", attr);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testOneOfEverything() {
+        Attribute<?> attr1 = createAttribute("LC", "value-1");
+        Attribute<?> attr2 = createAttribute("LC_NO_DIACRITICS", "value-2");
+        Attribute<?> attr3 = createAttribute("NUMBER", "25");
+        Attribute<?> attr4 = createAttribute("HEX", "a1b2c3");
+        d.put("LC", attr1);
+        d.put("LC_NO_DIACRITICS", attr2);
+        d.put("NUMBER", attr3);
+        d.put("HEX", attr4);
+        roundTrip(max_iterations);
+    }
+
+    @Test
+    public void testLargeDocument() {
+        int size = 100_000;
+        for (int i = 0; i < size; i++) {
+            Attribute<?> attr = createAttribute("LC", "value-" + i);
+            d.put("LC", attr);
+        }
+        roundTrip(max_iterations);
+    }
+
+    protected void roundTrip(int max) {
+        Entry<Key,Value> entry = serialize(d);
+        log.trace("size: {}", entry.getValue().getSize());
+        for (int i = 0; i < max; i++) {
+            Entry<Key,Document> result = deserialize(entry);
+            Document d2 = result.getValue();
+            assertEquals(d, d2);
+        }
+    }
+
+    protected Attribute<?> createAttribute(String field, String value) {
+        Attribute<?> attr = attributeFactory.create(field, value, documentKey, datatype, true);
+        attr.clearMetadata();
+        return attr;
+    }
+
+    protected Entry<Key,Value> serialize(Document d) {
+        Entry<Key,Document> entry = new AbstractMap.SimpleEntry<>(documentKey, d);
+        return serializer.apply(entry);
+    }
+
+    protected Entry<Key,Document> deserialize(Entry<Key,Value> entry) {
+        return deserializer.apply(entry);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
@@ -1,7 +1,16 @@
 package datawave.query.attributes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.ByteArrayOutputStream;
+
 import org.apache.accumulo.core.data.Key;
 import org.junit.Test;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 
 import datawave.data.type.NoOpType;
 
@@ -17,5 +26,26 @@ public class TypeAttributeTest extends AttributeTest {
 
         attr = new TypeAttribute<>(type, docKey, true);
         testToKeep(attr, true);
+    }
+
+    @Test
+    public void testExceptionLeadsToNoOpType() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Output output = new Output(baos);
+
+        // note: if further changes are made to serialization this test will need to be updated
+        output.writeString("MrMcDoesn'tExist");
+        output.writeBoolean(false); // write metadata when not set
+        output.writeString("delegate value as string");
+        output.writeBoolean(false); // to keep false
+        output.flush();
+
+        Input input = new Input(baos.toByteArray());
+        TypeAttribute<?> type = new TypeAttribute<>();
+        type.read(new Kryo(), input);
+
+        assertInstanceOf(TypeAttribute.class, type);
+        assertInstanceOf(NoOpType.class, type.getType());
+        assertEquals("delegate value as string", type.getData().toString());
     }
 }


### PR DESCRIPTION
Types now have setter methods that do not involve normalizers. It is now the callers responsibility to select the correct methods when normalization or denormalization is required to build correct Types

NumberNormalizer's logger is now static final

This merge requests supersedes https://github.com/NationalSecurityAgency/datawave/pull/2839 and  https://github.com/NationalSecurityAgency/datawave/pull/2840