### PR TITLE
upgrade dnsjava to 3.6.3 and refactor its dependency management

### DIFF
--- a/core/connection-pool/pom.xml
+++ b/core/connection-pool/pom.xml
@@ -11,15 +11,6 @@
     <properties>
         <version.dnsjava>2.1.8</version.dnsjava>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>dnsjava</groupId>
-                <artifactId>dnsjava</artifactId>
-                <version>${version.dnsjava}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
         <version.caffeine>3.1.0</version.caffeine>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
         <version.commons-cli>1.4</version.commons-cli>
-        <version.dnsjava>3.6.3</version.dnsjava>
         <version.commons-codec>1.12</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-collections4>4.3</version.commons-collections4>
@@ -81,6 +80,7 @@
         <version.datawave.query-api>1.0.0</version.datawave.query-api>
         <version.datawave.query-metric-api>4.0.7</version.datawave.query-metric-api>
         <version.deltaspike>1.9.0</version.deltaspike>
+        <version.dnsjava>3.6.3</version.dnsjava>
         <version.easymock>5.2.0</version.easymock>
         <version.eclipse.emf>2.15.0</version.eclipse.emf>
         <version.geoserver>2.25.2</version.geoserver>
@@ -252,11 +252,6 @@
                 <version>${version.mysql-connector}</version>
             </dependency>
             <dependency>
-                <groupId>dnsjava</groupId>
-                <artifactId>dnsjava</artifactId>
-                <version>${version.dnsjava}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>dns</artifactId>
                 <version>${version.spotify-dns}</version>
@@ -358,6 +353,11 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+                <version>${version.dnsjava}</version>
             </dependency>
             <dependency>
                 <groupId>gov.nsa.datawave</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <version.caffeine>3.1.0</version.caffeine>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>
         <version.commons-cli>1.4</version.commons-cli>
+        <version.dnsjava>3.6.3</version.dnsjava>
         <version.commons-codec>1.12</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-collections4>4.3</version.commons-collections4>
@@ -249,6 +250,11 @@
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
                 <version>${version.mysql-connector}</version>
+            </dependency>
+            <dependency>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+                <version>${version.dnsjava}</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>

--- a/web-services/pom.xml
+++ b/web-services/pom.xml
@@ -46,7 +46,6 @@
         <version.commons-dbutils>1.7</version.commons-dbutils>
         <version.commons-digester>3.2</version.commons-digester>
         <version.commons-net>3.9.0</version.commons-net>
-        <version.dnsjava>2.1.8</version.dnsjava>
         <version.geronimo-activation>1.1</version.geronimo-activation>
         <version.geronimo-stax>1.0.1</version.geronimo-stax>
         <version.jms>1.1</version.jms>


### PR DESCRIPTION
Address security alert and clean up downstream applications. https://github.com/NationalSecurityAgency/datawave/security/dependabot/106

It is annoying having datawave use two different versions of dnsjava