### PR TITLE
Fixes to resuming Ivarators after yield; always persist after fillSortedSets; log ivaratorCacheDirs

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
@@ -1274,6 +1275,16 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
                     canResume = false;
                     break;
                 }
+            }
+        }
+
+        if (previousIvarator != null) {
+            Set<String> currentUriSet = this.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
+            Set<String> previousUriSet = previousIvarator.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
+            // this condition doesn't fail the resumeFromIvaratorFutures call, but is cause for concern and should be investigated
+            if (!currentUriSet.equals(previousUriSet)) {
+                log.warn(String.format("Resuming Ivarator %s suspicious condition - currentUriSet != previousUriSet, %s != %s", ivaratorInfo, currentUriSet,
+                                previousUriSet));
             }
         }
 

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
@@ -1288,18 +1287,6 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
                     canResume = false;
                     break;
                 }
-            }
-        }
-
-        if (previousIvarator != null) {
-            Set<String> currentUriSet = this.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
-            Set<String> previousUriSet = previousIvarator.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
-            // ivaratorCacheDirs must be the same. If they are different, we probably have multiple copies of identical Ivarators from
-            // different sequenced terms in the same query. If this happens and that is not the case, then it should be investigated.
-            if (!currentUriSet.equals(previousUriSet)) {
-                log.debug(String.format("Resuming Ivarator %s failed - currentUriSet != previousUriSet, %s != %s", ivaratorInfo, currentUriSet,
-                                previousUriSet));
-                canResume = false;
             }
         }
 

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
@@ -865,8 +864,8 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
                     throw new RuntimeException("Ivarator query was cancelled");
                 }
 
-                // if we have any persisted data or we have scanned a significant number of keys, then persist it completely
-                if (this.set != null && (this.set.hasPersistedData() || (this.scannedKeys.get() >= this.scanThreshold))) {
+                // persist set to disk so we can reuse it on a rebuild or yield
+                if (this.set != null) {
                     forcePersistence();
                 }
 
@@ -890,24 +889,17 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
 
     private void fillSortedSets() throws IOException {
         String sourceRow = this.fiRow.toString();
-        // if we are running fillSortedSets as part of a re-seek after yield, then the fillSet threads would not have
-        // completed when a WaitWindowOverrunException was thrown and therefore the set would not have been marked as
-        // complete when setupRowBasedHdfsBackedSet was called at the top of this method. We will try to copy the
-        // RowBasedHdfsBackedSet from the previously used Ivarator and resume processing.
-        // If this re-seek is from an Ivarator yielding, the startKey will have a yield marker in either the
-        // colFam (for a shard range) or colQual (for a document range)
-        boolean usePreviousSortedSet = WaitWindowObserver.hasMarker(this.lastRangeSeeked.getStartKey());
-        if (usePreviousSortedSet) {
-            if (!resumeFromPreviousCall()) {
-                // if resuming from the previous call fails, then set usePreviousSortedSet=false
-                // to force setup of a new HDFS backed set
-                usePreviousSortedSet = false;
-            }
-        }
-        if (!usePreviousSortedSet) {
+        // If we are running fillSortedSets as part of a re-seek after yield, then the fillSet threads would not have
+        // completed when a WaitWindowOverrunException was thrown. Therefore, the set will not have been marked as
+        // complete when setupRowBasedHdfsBackedSet is called. We will try to copy the RowBasedHdfsBackedSet from
+        // the previously used Ivarator and resume processing.
+        boolean resumeFromIvaratorFutures = resumeFromIvaratorFutures();
+        if (!resumeFromIvaratorFutures) {
+            // If resuming from IvaratorFutures fails, then create and try to reuse a previous HDFS backed set.
             setupRowBasedHdfsBackedSet(sourceRow);
-            // if keys is not null, then we already had a completed set which was loaded in setupRowBasedHdfsBackedSet
-            if (keys != null) {
+            // If this.keys != null, then we have a persisted and completed set from a previous Ivarator call.
+            // We are done with fillSortedSet for this row and should advance this.fiRow or set it to null
+            if (this.keys != null) {
                 moveToNextRow();
                 return;
             }
@@ -917,7 +909,6 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         if (log.isDebugEnabled()) {
             log.debug("Processing " + this.boundingFiRanges + " for " + this);
         }
-        long startFillSets = System.currentTimeMillis();
 
         TotalResults totalResults = new TotalResults(this.maxResults);
 
@@ -928,7 +919,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
             // For each range, get either a new or pre-existing IvaratorFuture
             futures.add(fillSet(range, totalResults));
         }
-        if (!usePreviousSortedSet) {
+        if (!resumeFromIvaratorFutures) {
             log.info(String.format("Started Ivarator %s IvaratorRunnables created:%d", getIvaratorInfo(fiRow.toString(), true), futures.size()));
         }
 
@@ -1010,11 +1001,6 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         if (failed) {
             log.error(String.format("Failed Ivarator %s fillSortedSets: %s", ivaratorInfo, result), exception);
             throw new IvaratorException("Failed Ivarator fillSortedSets: " + result, exception);
-        }
-
-        if (usePreviousSortedSet) {
-            forcePersistence();
-            setupRowBasedHdfsBackedSet(sourceRow);
         }
 
         // now reset the current source to the next viable range
@@ -1246,18 +1232,16 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
     }
 
     /**
-     * Clear out the current row based hdfs backed set
+     * Clear out the current row-based hdfs backed set
      *
-     * @throws IOException
-     *             for issues with read/write
      */
-    protected void clearRowBasedHdfsBackedSet() throws IOException {
+    protected void clearRowBasedHdfsBackedSet() {
         this.keys = null;
         this.currentRow = null;
         this.set = null;
     }
 
-    protected boolean resumeFromPreviousCall() throws IOException {
+    protected boolean resumeFromIvaratorFutures() {
         boolean canResume = true;
         String ivaratorInfo = getIvaratorInfo(this.fiRow.toString(), true);
         // Only copy previous Ivarator's RowBasedHdfsBackedSet if all futures are available
@@ -1290,16 +1274,6 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
                     canResume = false;
                     break;
                 }
-            }
-        }
-
-        if (previousIvarator != null) {
-            Set<String> currentUriSet = this.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
-            Set<String> previousUriSet = previousIvarator.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
-            // ivaratorCacheDirs is declared final, but must be the same
-            if (!currentUriSet.equals(previousUriSet)) {
-                log.error(String.format("Resuming Ivarator %s failed - currentUriSet != previousUriSet", ivaratorInfo));
-                canResume = false;
             }
         }
 
@@ -1361,15 +1335,16 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
 
         try {
             // for each of the ivarator cache dirs
-            for (IvaratorCacheDir ivaratorCacheDir : this.ivaratorCacheDirs) {
-                // get the row specific dir
-                Path rowDir = getRowDir(new Path(ivaratorCacheDir.getPathURI()), row);
+            if (!this.allowDirReuse) {
+                for (IvaratorCacheDir ivaratorCacheDir : this.ivaratorCacheDirs) {
+                    // get the row specific dir
+                    Path rowDir = getRowDir(new Path(ivaratorCacheDir.getPathURI()), row);
+                    FileSystem fs = ivaratorCacheDir.getFs();
 
-                FileSystem fs = ivaratorCacheDir.getFs();
-
-                // if we are not allowing reuse of directories, then delete it
-                if (!this.allowDirReuse && fs.exists(rowDir)) {
-                    fs.delete(rowDir, true);
+                    // if we are not allowing reuse of directories, then delete it
+                    if (fs.exists(rowDir)) {
+                        fs.delete(rowDir, true);
+                    }
                 }
             }
 
@@ -1395,8 +1370,12 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
             if (!this.setControl.isCompleteAndPersisted(row)) {
                 this.set.clear();
                 this.keys = null;
+                log.info(String.format("Creating empty HdfsBackedSortedSet for Ivarator %s with ivaratorCacheDirs %s", getIvaratorInfo(row, false),
+                                ivaratorCacheDirs));
             } else {
                 this.keys = new CachingIterator<>(this.set.iterator());
+                log.info(String.format("Reusing completed HdfsBackedSortedSet for Ivarator %s with ivaratorCacheDirs %s", getIvaratorInfo(row, false),
+                                ivaratorCacheDirs));
             }
 
             // reset the keyValues counter as we have a new set here

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -93,6 +93,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         private PartialKey returnKeyType = DEFAULT_RETURN_KEY_TYPE;
         private int maxRangeSplit = 11;
         private List<IvaratorCacheDir> ivaratorCacheDirs;
+        private int termNumber;
         private QueryLock queryLock;
         private boolean allowDirReuse;
         private long maxResults = -1;
@@ -209,6 +210,11 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
             return self();
         }
 
+        public B withTermNumber(int termNumber) {
+            this.termNumber = termNumber;
+            return self();
+        }
+
         public B withQueryLock(QueryLock queryLock) {
             this.queryLock = queryLock;
             return self();
@@ -305,6 +311,8 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
 
     // The configured ivarator cache paths
     private final List<IvaratorCacheDir> ivaratorCacheDirs;
+    // The number in-order that this term was in the query when built
+    private final int termNumber;
     // The control filesystem to use for this ivarator
     private final FileSystem controlFs;
     // The control directory to use for this ivarator
@@ -402,6 +410,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         this.datatypeFilter = null;
 
         this.ivaratorCacheDirs = null;
+        this.termNumber = 0;
         this.controlFs = null;
         this.controlDir = null;
         this.queryLock = null;
@@ -446,6 +455,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         this.datatypeFilter = builder.datatypeFilter;
 
         this.ivaratorCacheDirs = builder.ivaratorCacheDirs;
+        this.termNumber = builder.termNumber;
 
         // Note: We have already selected the control directory at random in the DefaultQueryPlanner
         // @see DefaultQueryPlanner#getShuffledIvaratoCacheDirConfigs(ShardQueryConfiguration)
@@ -498,6 +508,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         this.negated = other.negated;
 
         this.ivaratorCacheDirs = other.ivaratorCacheDirs == null ? null : new ArrayList<>(other.ivaratorCacheDirs);
+        this.termNumber = other.termNumber;
         this.controlFs = other.controlFs;
         this.controlDir = other.controlDir;
         this.queryLock = other.queryLock;
@@ -1215,6 +1226,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         sb.append(" queryId:").append(queryId);
         sb.append(" fiRow:").append(fiRow);
         sb.append(" iHash:").append(getIHash(fiRow));
+        sb.append(" termNumber:").append(termNumber);
         sb.append(" rangeHash:").append(Math.abs(boundingFiRange.hashCode() / 2));
         return sb.toString();
     }
@@ -1268,6 +1280,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
                     canResume = false;
                     break;
                 }
+                // All IvaratorRunnables from the previous execution must reference the same Ivarator or something is wrong
                 if (previousIvarator == null) {
                     previousIvarator = ivaratorRunnable.getIvarator();
                 } else if (previousIvarator != ivaratorRunnable.getIvarator()) {
@@ -1281,10 +1294,12 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
         if (previousIvarator != null) {
             Set<String> currentUriSet = this.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
             Set<String> previousUriSet = previousIvarator.ivaratorCacheDirs.stream().map(d -> d.getPathURI()).collect(Collectors.toSet());
-            // this condition doesn't fail the resumeFromIvaratorFutures call, but is cause for concern and should be investigated
+            // ivaratorCacheDirs must be the same. If they are different, we probably have multiple copies of identical Ivarators from
+            // different sequenced terms in the same query. If this happens and that is not the case, then it should be investigated.
             if (!currentUriSet.equals(previousUriSet)) {
-                log.warn(String.format("Resuming Ivarator %s suspicious condition - currentUriSet != previousUriSet, %s != %s", ivaratorInfo, currentUriSet,
+                log.debug(String.format("Resuming Ivarator %s failed - currentUriSet != previousUriSet, %s != %s", ivaratorInfo, currentUriSet,
                                 previousUriSet));
+                canResume = false;
             }
         }
 
@@ -1519,8 +1534,10 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
      *             for issues with read/write
      */
     protected void forcePersistence() throws IOException {
-        if (this.set != null && !this.set.isPersisted()) {
-            this.set.persist();
+        if (this.set != null) {
+            if (!this.set.isPersisted()) {
+                this.set.persist();
+            }
             // declare the persisted set complete
             this.setControl.setCompleteAndPersisted(this.currentRow);
         }
@@ -1765,9 +1782,9 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
 
     public String getIvaratorInfo(String row, boolean includeToString) {
         if (includeToString) {
-            return String.format("queryId:%s fiRow:%s iHash:%s %s", queryId, row, getIHash(row), toStringNoQueryId());
+            return String.format("queryId:%s fiRow:%s iHash:%s termNumber:%d %s", queryId, row, getIHash(row), termNumber, toStringNoQueryId());
         } else {
-            return String.format("queryId:%s fiRow:%s iHash:%s", queryId, row, getIHash(row));
+            return String.format("queryId:%s fiRow:%s iHash:%s termNumber:%d", queryId, row, getIHash(row), termNumber);
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryIterator.java
@@ -376,8 +376,9 @@ public class QueryIterator extends QueryOptions implements YieldingKeyValueItera
         // preserve the original range for use with the Final Document tracking iterator because it is placed after the ResultCountingIterator
         // so the FinalDocumentTracking iterator needs the start key with the count already appended
         this.originalRange = range;
+        this.waitWindowObserver.setSeekRange(range);
         if (WaitWindowObserver.getNumYields(range.getStartKey(), this.collectTimingDetails) < this.maxYields) {
-            this.waitWindowObserver.start(this.queryId, range, this.yieldThresholdMs);
+            this.waitWindowObserver.start(this.queryId, this.yieldThresholdMs);
         }
         getActiveQueryLog().get(this.queryId).beginCall(this.originalRange, ActiveQuery.CallType.SEEK);
         ActiveQueryLog.getInstance().get(getQueryId()).beginCall(this.originalRange, ActiveQuery.CallType.SEEK);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexFilterIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexFilterIteratorBuilder.java
@@ -80,6 +80,7 @@ public class IndexFilterIteratorBuilder extends IvaratorBuilder implements Itera
                         .withMaxOpenFiles(ivaratorMaxOpenFiles)
                         .withMaxResults(maxIvaratorResults)
                         .withIvaratorCacheDirs(ivaratorCacheDirs)
+                        .withTermNumber(termNumber)
                         .withNumRetries(ivaratorNumRetries)
                         .withPersistOptions(ivaratorPersistOptions)
                         .withQueryLock(queryLock)

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexListIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexListIteratorBuilder.java
@@ -86,6 +86,7 @@ public class IndexListIteratorBuilder extends IvaratorBuilder implements Iterato
                         .withMaxRangeSplit(maxRangeSplit)
                         .withMaxOpenFiles(ivaratorMaxOpenFiles)
                         .withIvaratorCacheDirs(ivaratorCacheDirs)
+                        .withTermNumber(termNumber)
                         .withNumRetries(ivaratorNumRetries)
                         .withPersistOptions(ivaratorPersistOptions)
                         .withMaxResults(maxIvaratorResults)

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRangeIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRangeIteratorBuilder.java
@@ -81,6 +81,7 @@ public class IndexRangeIteratorBuilder extends IvaratorBuilder implements Iterat
                         .withMaxRangeSplit(maxRangeSplit)
                         .withMaxOpenFiles(ivaratorMaxOpenFiles)
                         .withIvaratorCacheDirs(ivaratorCacheDirs)
+                        .withTermNumber(termNumber)
                         .withNumRetries(ivaratorNumRetries)
                         .withPersistOptions(ivaratorPersistOptions)
                         .withMaxResults(maxIvaratorResults)

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRegexIteratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IndexRegexIteratorBuilder.java
@@ -63,6 +63,7 @@ public class IndexRegexIteratorBuilder extends IvaratorBuilder implements Iterat
                         .withMaxOpenFiles(ivaratorMaxOpenFiles)
                         .withMaxResults(maxIvaratorResults)
                         .withIvaratorCacheDirs(ivaratorCacheDirs)
+                        .withTermNumber(termNumber)
                         .withNumRetries(ivaratorNumRetries)
                         .withPersistOptions(ivaratorPersistOptions)
                         .withQueryLock(queryLock)

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IvaratorBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/builder/IvaratorBuilder.java
@@ -40,6 +40,7 @@ public abstract class IvaratorBuilder extends IndexIteratorBuilder {
     protected CompositeMetadata compositeMetadata;
     protected int compositeSeekThreshold;
     protected GenericObjectPool<SortedKeyValueIterator<Key,Value>> ivaratorSourcePool;
+    protected int termNumber;
 
     protected void validateIvaratorControlDir(IvaratorCacheDir ivaratorCacheDir) {
         String ivaratorCacheDirURI = ivaratorCacheDir.getPathURI();
@@ -64,6 +65,14 @@ public abstract class IvaratorBuilder extends IndexIteratorBuilder {
 
     public void setIvaratorCacheDirs(List<IvaratorCacheDir> ivaratorCacheDirs) {
         this.ivaratorCacheDirs = ivaratorCacheDirs;
+    }
+
+    public void setTermNumber(int termNumber) {
+        this.termNumber = termNumber;
+    }
+
+    public int getTermNumber() {
+        return termNumber;
     }
 
     public String getHdfsFileCompressionCodec() {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
@@ -29,4 +29,9 @@ public class IvaratorCacheDir {
     public String getPathURI() {
         return pathURI;
     }
+
+    @Override
+    public String toString() {
+        return pathURI;
+    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/waitwindow/WaitWindowObserver.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/waitwindow/WaitWindowObserver.java
@@ -118,9 +118,9 @@ public class WaitWindowObserver {
     }
 
     /*
-     * Set seekRange, remainingTimeMs, endOfWaitWindow and start the Timer
+     * Set seekRange
      */
-    public void start(String queryId, Range seekRange, long yieldThresholdMs) {
+    public void setSeekRange(Range seekRange) {
         Key startKey = seekRange.getStartKey();
         if (startKey == null) {
             startKey = convertInfiniteStartKey(startKey);
@@ -128,6 +128,12 @@ public class WaitWindowObserver {
         } else {
             this.seekRange = seekRange;
         }
+    }
+
+    /*
+     * Set remainingTimeMs, endOfWaitWindow and start the Timer
+     */
+    public void start(String queryId, long yieldThresholdMs) {
         this.queryId = queryId;
         if (yieldThresholdMs > 0 && yieldThresholdMs < Long.MAX_VALUE) {
             this.remainingTimeMs.set(yieldThresholdMs);

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -1043,11 +1043,11 @@ public class IteratorBuildingVisitor extends BaseVisitor {
      * @throws IOException
      *             for issues with read/write
      */
-    private List<IvaratorCacheDir> getIvaratorCacheDirs() throws IOException {
+    private List<IvaratorCacheDir> getIvaratorCacheDirs(int termNumber) throws IOException {
         List<IvaratorCacheDir> pathAndFs = new ArrayList<>();
 
-        // first lets increment the count for a unique subdirectory
-        String subdirectory = ivaratorCacheSubDirPrefix + "term" + Integer.toString(++ivaratorCount);
+        // use the ivaratorCount / term number to create a unique subdirectory
+        String subdirectory = ivaratorCacheSubDirPrefix + "term" + termNumber;
 
         if (ivaratorCacheDirConfigs != null && !ivaratorCacheDirConfigs.isEmpty()) {
             for (IvaratorCacheDirConfig config : ivaratorCacheDirConfigs) {
@@ -1442,6 +1442,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
      *             for issues with read/write
      */
     public void ivarate(IvaratorBuilder builder, JexlNode rootNode, JexlNode sourceNode, Object data) throws IOException {
+        this.ivaratorCount++;
         builder.setQueryId(queryId);
         builder.setScanId(scanId);
         builder.setWaitWindowObserver(waitWindowObserver);
@@ -1452,7 +1453,8 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         builder.setCompositeSeekThreshold(compositeSeekThreshold);
         builder.setDatatypeFilter(getDatatypeFilter());
         builder.setKeyTransform(getFiAggregator());
-        builder.setIvaratorCacheDirs(getIvaratorCacheDirs());
+        builder.setIvaratorCacheDirs(getIvaratorCacheDirs(this.ivaratorCount));
+        builder.setTermNumber(this.ivaratorCount);
         builder.setHdfsFileCompressionCodec(hdfsFileCompressionCodec);
         builder.setQueryLock(queryLock);
         builder.setIvaratorCacheBufferSize(ivaratorCacheBufferSize);

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -347,7 +347,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         // verify we still get our expected results
         runTest(query, expect);
         // and verify that the ivarators indeed persisted
-        assertEquals(1, countComplete(dirs));
+        assertEquals(3, countComplete(dirs));
     }
 
     private int countComplete(List<String> dirs) throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -346,8 +346,8 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         this.logic.setMaxIvaratorResults(1);
         // verify we still get our expected results
         runTest(query, expect);
-        // and verify that the ivarators indeed did not complete (i.e. failed)
-        assertEquals(0, countComplete(dirs));
+        // and verify that the ivarators indeed persisted
+        assertEquals(1, countComplete(dirs));
     }
 
     private int countComplete(List<String> dirs) throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/WaitWindowQueryIterator.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/WaitWindowQueryIterator.java
@@ -3,7 +3,6 @@ package datawave.query.iterator;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,8 +57,8 @@ public class WaitWindowQueryIterator extends QueryIterator {
 
         // this only gets called if we have not exceeded maxYields
         @Override
-        public void start(String queryId, Range seekRange, long yieldThresholdMs) {
-            super.start(queryId, seekRange, Long.MAX_VALUE);
+        public void start(String queryId, long yieldThresholdMs) {
+            super.start(queryId, Long.MAX_VALUE);
             reset();
         }
 


### PR DESCRIPTION
Fixes to resuming Ivarators after yield; always persist after fillSortedSets; log ivaratorCacheDirs