### PR TITLE
Serialize Type Class Index

### DIFF
--- a/core/utils/type-utils/src/main/java/datawave/data/type/DatawaveTypeIndex.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DatawaveTypeIndex.java
@@ -1,0 +1,66 @@
+package datawave.data.type;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class that returns an index for a given Datawave {@link Type}
+ */
+public class DatawaveTypeIndex {
+
+    private DatawaveTypeIndex() {
+        // static utility
+    }
+
+    private static final Map<String,Integer> classNameIndex = new HashMap<>();
+    static {
+        classNameIndex.put(DateType.class.getTypeName(), 1);
+        classNameIndex.put(GeoLatType.class.getTypeName(), 2);
+        classNameIndex.put(GeoLonType.class.getTypeName(), 3);
+        classNameIndex.put(GeometryType.class.getTypeName(), 4);
+        classNameIndex.put(GeoType.class.getTypeName(), 5);
+        classNameIndex.put(HexStringType.class.getTypeName(), 6);
+        classNameIndex.put(HitTermType.class.getTypeName(), 7);
+        classNameIndex.put(IpAddressType.class.getTypeName(), 8);
+        classNameIndex.put(IpV4AddressType.class.getTypeName(), 9);
+        classNameIndex.put(LcNoDiacriticsListType.class.getTypeName(), 10);
+        classNameIndex.put(LcNoDiacriticsType.class.getTypeName(), 11);
+        classNameIndex.put(LcType.class.getTypeName(), 12);
+        classNameIndex.put(MacAddressType.class.getTypeName(), 13);
+        classNameIndex.put(NoOpType.class.getTypeName(), 14);
+        classNameIndex.put(NumberListType.class.getTypeName(), 15);
+        classNameIndex.put(NumberType.class.getTypeName(), 16);
+        classNameIndex.put(PointType.class.getTypeName(), 17);
+        classNameIndex.put(RawDateType.class.getTypeName(), 18);
+        classNameIndex.put(StringType.class.getTypeName(), 19);
+        classNameIndex.put(TrimLeadingZerosType.class.getTypeName(), 20);
+    }
+
+    private static final Map<Integer,String> indexToClassName;
+    static {
+        indexToClassName = classNameIndex.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
+
+    /**
+     * Get the index for the provided {@link Type} name
+     *
+     * @param className
+     *            the Type name
+     * @return the index for the Type name, or zero if no such Type exists
+     */
+    public static int getIndexForTypeName(String className) {
+        return classNameIndex.getOrDefault(className, 0);
+    }
+
+    /**
+     * Get the {@link Type} name associated with the provided index
+     *
+     * @param index
+     *            the index
+     * @return the Type name or null if no such type name exists
+     */
+    public static String getTypeNameForIndex(int index) {
+        return indexToClassName.get(index);
+    }
+}

--- a/core/utils/type-utils/src/test/java/datawave/data/type/DatawaveTypeIndexTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/DatawaveTypeIndexTest.java
@@ -1,0 +1,70 @@
+package datawave.data.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class DatawaveTypeIndexTest {
+
+    @Test
+    public void testGetIndexForTypeName() {
+        assertEquals(1, DatawaveTypeIndex.getIndexForTypeName(DateType.class.getTypeName()));
+        assertEquals(2, DatawaveTypeIndex.getIndexForTypeName(GeoLatType.class.getTypeName()));
+        assertEquals(3, DatawaveTypeIndex.getIndexForTypeName(GeoLonType.class.getTypeName()));
+        assertEquals(4, DatawaveTypeIndex.getIndexForTypeName(GeometryType.class.getTypeName()));
+        assertEquals(5, DatawaveTypeIndex.getIndexForTypeName(GeoType.class.getTypeName()));
+        assertEquals(6, DatawaveTypeIndex.getIndexForTypeName(HexStringType.class.getTypeName()));
+        assertEquals(7, DatawaveTypeIndex.getIndexForTypeName(HitTermType.class.getTypeName()));
+        assertEquals(8, DatawaveTypeIndex.getIndexForTypeName(IpAddressType.class.getTypeName()));
+        assertEquals(9, DatawaveTypeIndex.getIndexForTypeName(IpV4AddressType.class.getTypeName()));
+        assertEquals(10, DatawaveTypeIndex.getIndexForTypeName(LcNoDiacriticsListType.class.getTypeName()));
+        assertEquals(11, DatawaveTypeIndex.getIndexForTypeName(LcNoDiacriticsType.class.getTypeName()));
+        assertEquals(12, DatawaveTypeIndex.getIndexForTypeName(LcType.class.getTypeName()));
+        assertEquals(13, DatawaveTypeIndex.getIndexForTypeName(MacAddressType.class.getTypeName()));
+        assertEquals(14, DatawaveTypeIndex.getIndexForTypeName(NoOpType.class.getTypeName()));
+        assertEquals(15, DatawaveTypeIndex.getIndexForTypeName(NumberListType.class.getTypeName()));
+        assertEquals(16, DatawaveTypeIndex.getIndexForTypeName(NumberType.class.getTypeName()));
+        assertEquals(17, DatawaveTypeIndex.getIndexForTypeName(PointType.class.getTypeName()));
+        assertEquals(18, DatawaveTypeIndex.getIndexForTypeName(RawDateType.class.getTypeName()));
+        assertEquals(19, DatawaveTypeIndex.getIndexForTypeName(StringType.class.getTypeName()));
+        assertEquals(20, DatawaveTypeIndex.getIndexForTypeName(TrimLeadingZerosType.class.getTypeName()));
+    }
+
+    @Test
+    public void testGetTypeNameForIndex() {
+        assertEquals(DateType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(1));
+        assertEquals(GeoLatType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(2));
+        assertEquals(GeoLonType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(3));
+        assertEquals(GeometryType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(4));
+        assertEquals(GeoType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(5));
+        assertEquals(HexStringType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(6));
+        assertEquals(HitTermType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(7));
+        assertEquals(IpAddressType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(8));
+        assertEquals(IpV4AddressType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(9));
+        assertEquals(LcNoDiacriticsListType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(10));
+        assertEquals(LcNoDiacriticsType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(11));
+        assertEquals(LcType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(12));
+        assertEquals(MacAddressType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(13));
+        assertEquals(NoOpType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(14));
+        assertEquals(NumberListType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(15));
+        assertEquals(NumberType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(16));
+        assertEquals(PointType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(17));
+        assertEquals(RawDateType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(18));
+        assertEquals(StringType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(19));
+        assertEquals(TrimLeadingZerosType.class.getTypeName(), DatawaveTypeIndex.getTypeNameForIndex(20));
+    }
+
+    @Test
+    public void testGetIndexForTypeThatDoesNotExist() {
+        assertEquals(0, DatawaveTypeIndex.getIndexForTypeName(BaseType.class.getTypeName()));
+    }
+
+    @Test
+    public void testGetTypeNameForIndexThatDoesNotExist() {
+        assertNull(DatawaveTypeIndex.getTypeNameForIndex(100));
+        assertNull(DatawaveTypeIndex.getTypeNameForIndex(0));
+        assertNull(DatawaveTypeIndex.getTypeNameForIndex(-3));
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -32,7 +32,7 @@ public class DocumentTest {
     private final KryoDocumentSerializer serializer = new KryoDocumentSerializer();
     private final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
 
-    private static final int max_iterations = 1;
+    private static final int max_iterations = 100;
 
     private AttributeFactory attributeFactory;
 
@@ -52,49 +52,49 @@ public class DocumentTest {
 
     @Test
     public void testEmptyDocument() {
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 16);
     }
 
     @Test
     public void testDocumentWithLcType() {
         Attribute<?> attr = createAttribute("LC", "value");
         d.put("LC", attr);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 66);
     }
 
     @Test
     public void testDocumentWithLcNoDiacriticsType() {
         Attribute<?> attr = createAttribute("LC_NO_DIACRITICS", "value");
         d.put("LC_NO_DIACRITICS", attr);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 80);
     }
 
     @Test
     public void testDocumentWithHexType() {
         Attribute<?> attr = createAttribute("HEX", "a1b2c3");
         d.put("HEX", attr);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 68);
     }
 
     @Test
     public void testDocumentWithNumberType() {
         Attribute<?> attr = createAttribute("NUMBER", "12");
         d.put("NUMBER", attr);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 67);
     }
 
     @Test
     public void testDocumentWithNumberTypeNormalizedValue() {
         Attribute<?> attr = createAttribute("NUMBER", "+bE1.2");
         d.put("NUMBER", attr);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 67);
     }
 
     @Test
     public void testDocumentWithNumberTypeLargeValue() {
         Attribute<?> attr = createAttribute("NUMBER", "12456789.987654321");
         d.put("NUMBER", attr);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 83);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class DocumentTest {
         d.put("LC_NO_DIACRITICS", attr2);
         d.put("NUMBER", attr3);
         d.put("HEX", attr4);
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 234);
     }
 
     @Test
@@ -117,12 +117,13 @@ public class DocumentTest {
             Attribute<?> attr = createAttribute("LC", "value-" + i);
             d.put("LC", attr);
         }
-        roundTrip(max_iterations);
+        roundTrip(max_iterations, 5288956);
     }
 
-    protected void roundTrip(int max) {
+    protected void roundTrip(int max, int serializedLength) {
         Entry<Key,Value> entry = serialize(d);
         log.trace("size: {}", entry.getValue().getSize());
+        assertEquals(serializedLength, entry.getValue().getSize());
         for (int i = 0; i < max; i++) {
             Entry<Key,Document> result = deserialize(entry);
             Document d2 = result.getValue();

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeIT.java
@@ -141,6 +141,18 @@ public abstract class TypeAttributeIT {
      *            the TypeAttribute
      */
     protected void readWriteKryo(TypeAttribute<?> attribute) {
+        readWriteKryo(attribute, 1);
+    }
+
+    /**
+     * Read and write the provided {@link TypeAttribute} using Kryo, verifying the delegate and normalized value
+     *
+     * @param attribute
+     *            the TypeAttribute
+     * @param serializedLength
+     *            the length of the serialized object, in bytes
+     */
+    protected void readWriteKryo(TypeAttribute<?> attribute, int serializedLength) {
         // The non-normalized value. Sometimes the input value is normalized but not every normalizer can denormalize.
         String delegateValue = attribute.getType().getDelegateAsString();
         // The normalized value. OneToManyNormalizers will return the original delegate value because of some weirdness.
@@ -156,7 +168,11 @@ public abstract class TypeAttributeIT {
         Output output = new Output(1024);
         attribute.write(kryo, output);
         output.flush();
-        byte[] data = output.getBuffer();
+        byte[] data = output.toBytes();
+
+        if (serializedLength > 0) {
+            assertEquals(serializedLength, data.length);
+        }
 
         try (Input input = new Input(data)) {
             TypeAttribute<?> deserialized = new TypeAttribute<>();
@@ -251,6 +267,18 @@ public abstract class TypeAttributeIT {
      *            the TypeAttribute
      */
     protected void readWriteData(TypeAttribute<?> attribute) {
+        readWriteData(attribute, 1);
+    }
+
+    /**
+     * Read and write the provided {@link TypeAttribute} using DataInput/DataOutput, verifying the delegate and normalized value
+     *
+     * @param attribute
+     *            the TypeAttribute
+     * @param serializedLength
+     *            the length of the serialized object, in bytes
+     */
+    protected void readWriteData(TypeAttribute<?> attribute, int serializedLength) {
 
         // The non-normalized value. Sometimes the input value is normalized but not every normalizer can denormalize.
         String delegateValue = attribute.getType().getDelegateAsString();
@@ -271,6 +299,10 @@ public abstract class TypeAttributeIT {
         } catch (IOException e) {
             fail("Failed to write attribute: " + attribute, e);
             throw new RuntimeException(e);
+        }
+
+        if (serializedLength > 0) {
+            assertEquals(serializedLength, data.length);
         }
 
         try {

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeIT.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.Key;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -30,10 +31,12 @@ import datawave.data.type.Type;
  */
 public abstract class TypeAttributeIT {
 
+    private static final Logger log = LoggerFactory.getLogger(TypeAttributeIT.class);
+
     private static final int MAX_ITERATIONS = 100_000;
 
     // normalization context
-    protected static String NORMALIZED = "normalized";
+    protected static String NORMALIZED = "    normalized";
     protected static String NON_NORMALIZED = "non-normalized";
 
     protected static final Key docKey = new Key("row", "dt\0uid");
@@ -44,6 +47,13 @@ public abstract class TypeAttributeIT {
      * @return the Type
      */
     protected abstract Type<?> getType();
+
+    /**
+     * Provide context for log statements using the Type short name
+     *
+     * @return the Type name
+     */
+    protected abstract String getTypeShortName();
 
     /**
      * Each extending class must provide its own implementation of a normalized attribute
@@ -80,14 +90,10 @@ public abstract class TypeAttributeIT {
      * <p>
      * The elapsed time is logged using the provided logger.
      *
-     * @param context
-     *            data normalization context
      * @param attribute
      *            the TypeAttribute
-     * @param log
-     *            the logger from a subclass
      */
-    protected void writeKryo(String context, TypeAttribute<?> attribute, Logger log) {
+    protected long writeKryo(TypeAttribute<?> attribute) {
         Kryo kryo = new Kryo();
         Output output = new Output(1024);
 
@@ -98,7 +104,7 @@ public abstract class TypeAttributeIT {
             attribute.write(kryo, output);
             elapsed += System.nanoTime() - start;
         }
-        log.info("kryo write ({}): {} ms", context, TimeUnit.NANOSECONDS.toMillis(elapsed));
+        return TimeUnit.NANOSECONDS.toMillis(elapsed);
     }
 
     /**
@@ -107,14 +113,11 @@ public abstract class TypeAttributeIT {
      * <p>
      * The elapsed time is logged using the provided logger.
      *
-     * @param context
-     *            data normalization context
      * @param attribute
      *            the TypeAttribute
-     * @param log
-     *            the logger from a subclass
      */
-    protected void readKryo(String context, TypeAttribute<?> attribute, Logger log) {
+    protected long readKryo(TypeAttribute<?> attribute) {
+
         // first serialize
         Kryo kryo = new Kryo();
         Output output = new Output(1024);
@@ -131,17 +134,7 @@ public abstract class TypeAttributeIT {
                 elapsed += System.nanoTime() - start;
             }
         }
-        log.info("kryo read ({}): {} ms", context, TimeUnit.NANOSECONDS.toMillis(elapsed));
-    }
-
-    /**
-     * Read and write the provided {@link TypeAttribute} using Kryo, verifying the delegate and normalized value
-     *
-     * @param attribute
-     *            the TypeAttribute
-     */
-    protected void readWriteKryo(TypeAttribute<?> attribute) {
-        readWriteKryo(attribute, 1);
+        return TimeUnit.NANOSECONDS.toMillis(elapsed);
     }
 
     /**
@@ -152,7 +145,7 @@ public abstract class TypeAttributeIT {
      * @param serializedLength
      *            the length of the serialized object, in bytes
      */
-    protected void readWriteKryo(TypeAttribute<?> attribute, int serializedLength) {
+    protected void verifyKryoPreservesValue(TypeAttribute<?> attribute, int serializedLength) {
         // The non-normalized value. Sometimes the input value is normalized but not every normalizer can denormalize.
         String delegateValue = attribute.getType().getDelegateAsString();
         // The normalized value. OneToManyNormalizers will return the original delegate value because of some weirdness.
@@ -192,17 +185,41 @@ public abstract class TypeAttributeIT {
     }
 
     /**
+     * Evaluate the read/write times when using {@link Kryo}
+     *
+     * @param context
+     *            the normalization context
+     * @param attribute
+     *            the attribute
+     */
+    protected void testKryoReadWriteTimes(String context, TypeAttribute<?> attribute) {
+        long writeMillis = writeKryo(attribute);
+        long readMillis = readKryo(attribute);
+        log.info("{} kryo {} read: {} write: {} ms", getTypeShortName(), context, readMillis, writeMillis);
+    }
+
+    /**
+     * Evaluate the read/write times when using {@link DataInput} and {@link DataOutput}
+     *
+     * @param context
+     *            the normalization context
+     * @param attribute
+     *            the attribute
+     */
+    protected void testDataReadWriteTimes(String context, TypeAttribute<?> attribute) {
+        long readMillis = readDataInput(attribute);
+        long writeMillis = writeDataOutput(attribute);
+        log.info("{} data {} read: {} write: {} ms", getTypeShortName(), context, readMillis, writeMillis);
+    }
+
+    /**
      * A method that serializes the provided {@link TypeAttribute} using {@link TypeAttribute#write(DataOutput)} a number of times equal to
      * {@link #MAX_ITERATIONS}
      *
-     * @param context
-     *            data normalization context
      * @param attribute
      *            the TypeAttribute
-     * @param log
-     *            the logger from a subclass
      */
-    protected void writeDataOutput(String context, TypeAttribute<?> attribute, Logger log) {
+    protected long writeDataOutput(TypeAttribute<?> attribute) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutput out = new DataOutputStream(baos);
 
@@ -217,21 +234,17 @@ public abstract class TypeAttributeIT {
                 throw new RuntimeException(e);
             }
         }
-        log.info("data write ({}): {}", context, TimeUnit.NANOSECONDS.toMillis(elapsed));
+        return TimeUnit.NANOSECONDS.toMillis(elapsed);
     }
 
     /**
      * A method that deserializes the provided {@link TypeAttribute} using {@link TypeAttribute#readFields(DataInput)} a number of times equal to
      * {@link #MAX_ITERATIONS}
      *
-     * @param context
-     *            data normalization context
      * @param attribute
      *            the TypeAttribute
-     * @param log
-     *            the logger from a subclass
      */
-    protected void readDataInput(String context, TypeAttribute<?> attribute, Logger log) {
+    protected long readDataInput(TypeAttribute<?> attribute) {
         byte[] data;
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             DataOutput out = new DataOutputStream(baos);
@@ -253,7 +266,7 @@ public abstract class TypeAttributeIT {
                 deserialized.readFields(in);
                 elapsed += System.nanoTime() - start;
             }
-            log.info("data read ({}): {}", context, TimeUnit.NANOSECONDS.toMillis(elapsed));
+            return TimeUnit.NANOSECONDS.toMillis(elapsed);
         } catch (IOException e) {
             fail("Failed to read attribute: " + attribute, e);
             throw new RuntimeException(e);
@@ -267,7 +280,7 @@ public abstract class TypeAttributeIT {
      *            the TypeAttribute
      */
     protected void readWriteData(TypeAttribute<?> attribute) {
-        readWriteData(attribute, 1);
+        verifyDataPreservesValue(attribute, 1);
     }
 
     /**
@@ -278,7 +291,7 @@ public abstract class TypeAttributeIT {
      * @param serializedLength
      *            the length of the serialized object, in bytes
      */
-    protected void readWriteData(TypeAttribute<?> attribute, int serializedLength) {
+    protected void verifyDataPreservesValue(TypeAttribute<?> attribute, int serializedLength) {
 
         // The non-normalized value. Sometimes the input value is normalized but not every normalizer can denormalize.
         String delegateValue = attribute.getType().getDelegateAsString();

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
@@ -34,6 +34,7 @@ public class TypeAttributeTest extends AttributeTest {
         Output output = new Output(baos);
 
         // note: if further changes are made to serialization this test will need to be updated
+        output.writeInt(0, true);
         output.writeString("MrMcDoesn'tExist");
         output.writeBoolean(false); // write metadata when not set
         output.writeString("delegate value as string");

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
@@ -76,8 +76,9 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 62, 62
+        readWriteKryo(createNormalizedAttribute(), 36);
+        readWriteKryo(createNonNormalizedAttribute(), 36);
     }
 
     @Test
@@ -94,7 +95,8 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 70, 70
+        readWriteData(createNormalizedAttribute(), 40);
+        readWriteData(createNonNormalizedAttribute(), 40);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
@@ -6,8 +6,6 @@ import java.util.Date;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.DateNormalizer;
 import datawave.data.type.DateType;
@@ -19,8 +17,6 @@ import datawave.query.attributes.TypeAttributeIT;
  * Serialization integration tests for the {@link DateType} which uses the {@link DateNormalizer}
  */
 public class DateTypeAttributeIT extends TypeAttributeIT {
-
-    private static final Logger log = LoggerFactory.getLogger(DateTypeAttributeIT.class);
 
     @BeforeAll
     public static void setupClass() {
@@ -53,6 +49,11 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Override
+    protected String getTypeShortName() {
+        return "DATE";
+    }
+
+    @Override
     protected TypeAttribute<?> createNormalizedAttribute() {
         return createAttribute("2014-10-20T00:00:00.000Z");
     }
@@ -63,40 +64,30 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 62, 62
-        readWriteKryo(createNormalizedAttribute(), 36);
-        readWriteKryo(createNonNormalizedAttribute(), 36);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 62
+        // serializing type name index: 36
+        verifyKryoPreservesValue(createNormalizedAttribute(), 36);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 36);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 70, 70
-        readWriteData(createNormalizedAttribute(), 40);
-        readWriteData(createNonNormalizedAttribute(), 40);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // serializing full type name: 70
+        // serializing type name index: 40
+        verifyDataPreservesValue(createNormalizedAttribute(), 40);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 40);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
@@ -69,8 +69,9 @@ public class GeoLatTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 44, 42
+        readWriteKryo(createNormalizedAttribute(), 16);
+        readWriteKryo(createNonNormalizedAttribute(), 14);
     }
 
     @Test
@@ -87,7 +88,8 @@ public class GeoLatTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 52, 50
+        readWriteData(createNormalizedAttribute(), 20);
+        readWriteData(createNonNormalizedAttribute(), 18);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
@@ -3,8 +3,6 @@ package datawave.query.attributes.it;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.GeoLatNormalizer;
 import datawave.data.normalizer.Normalizer;
@@ -18,11 +16,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class GeoLatTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(GeoLatTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new GeoLatType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "GEO_LAT";
     }
 
     @Override
@@ -56,40 +57,30 @@ public class GeoLatTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 44, 42
-        readWriteKryo(createNormalizedAttribute(), 16);
-        readWriteKryo(createNonNormalizedAttribute(), 14);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 44, 42
+        // serializing type name index: 16, 14
+        verifyKryoPreservesValue(createNormalizedAttribute(), 16);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 14);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 52, 50
-        readWriteData(createNormalizedAttribute(), 20);
-        readWriteData(createNonNormalizedAttribute(), 18);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // serializing full type name: 52, 50
+        // serializing type name index: 20, 18
+        verifyDataPreservesValue(createNormalizedAttribute(), 20);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 18);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
@@ -69,8 +69,9 @@ public class GeoLonTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 46, 42
+        readWriteKryo(createNormalizedAttribute(), 18);
+        readWriteKryo(createNonNormalizedAttribute(), 14);
     }
 
     @Test
@@ -87,7 +88,8 @@ public class GeoLonTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 54, 50
+        readWriteData(createNormalizedAttribute(), 22);
+        readWriteData(createNonNormalizedAttribute(), 18);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
@@ -3,8 +3,6 @@ package datawave.query.attributes.it;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.GeoLonNormalizer;
 import datawave.data.normalizer.Normalizer;
@@ -18,11 +16,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class GeoLonTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(GeoLonTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new GeoLonType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "GEO_LON";
     }
 
     @Override
@@ -56,40 +57,30 @@ public class GeoLonTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 46, 42
-        readWriteKryo(createNormalizedAttribute(), 18);
-        readWriteKryo(createNonNormalizedAttribute(), 14);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 46, 42
+        // serializing type name index: 18, 14
+        verifyKryoPreservesValue(createNormalizedAttribute(), 18);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 14);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 54, 50
-        readWriteData(createNormalizedAttribute(), 22);
-        readWriteData(createNonNormalizedAttribute(), 18);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataPreservesValue() {
+        // serializing full type name: 54, 50
+        // serializing type name index: 22, 18
+        verifyDataPreservesValue(createNormalizedAttribute(), 22);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 18);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
@@ -3,8 +3,6 @@ package datawave.query.attributes.it;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.HexStringNormalizer;
 import datawave.data.type.HexStringType;
@@ -17,11 +15,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class HexTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(HexTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new HexStringType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "HEX";
     }
 
     @Override
@@ -47,40 +48,30 @@ public class HexTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 49, 49
-        readWriteKryo(createNormalizedAttribute(), 18);
-        readWriteKryo(createNonNormalizedAttribute(), 18);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 49
+        // serializing type name index: 18
+        verifyKryoPreservesValue(createNormalizedAttribute(), 18);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 57
-        readWriteData(createNormalizedAttribute(), 22);
-        readWriteData(createNonNormalizedAttribute(), 22);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // serializing full type name: 57
+        // serializing type name index: 22
+        verifyDataPreservesValue(createNormalizedAttribute(), 22);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 22);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
@@ -60,8 +60,9 @@ public class HexTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 49, 49
+        readWriteKryo(createNormalizedAttribute(), 18);
+        readWriteKryo(createNonNormalizedAttribute(), 18);
     }
 
     @Test
@@ -78,7 +79,8 @@ public class HexTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 57
+        readWriteData(createNormalizedAttribute(), 22);
+        readWriteData(createNonNormalizedAttribute(), 22);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/IpAddressTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/IpAddressTypeAttributeIT.java
@@ -57,8 +57,9 @@ public class IpAddressTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 54, 54
+        readWriteKryo(createNormalizedAttribute(), 23);
+        readWriteKryo(createNonNormalizedAttribute(), 23);
     }
 
     @Test
@@ -75,7 +76,8 @@ public class IpAddressTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 62, 62
+        readWriteData(createNormalizedAttribute(), 27);
+        readWriteData(createNonNormalizedAttribute(), 27);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/IpAddressTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/IpAddressTypeAttributeIT.java
@@ -3,8 +3,6 @@ package datawave.query.attributes.it;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.IpAddressNormalizer;
 import datawave.data.type.IpAddressType;
@@ -16,8 +14,6 @@ import datawave.query.attributes.TypeAttributeIT;
  * Serialization integration test for the {@link IpAddressType} which uses the {@link IpAddressNormalizer}
  */
 public class IpAddressTypeAttributeIT extends TypeAttributeIT {
-
-    private static final Logger log = LoggerFactory.getLogger(IpAddressTypeAttributeIT.class);
 
     private final IpAddressNormalizer normalizer = new IpAddressNormalizer();
 
@@ -34,6 +30,11 @@ public class IpAddressTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Override
+    protected String getTypeShortName() {
+        return "IP";
+    }
+
+    @Override
     protected TypeAttribute<?> createNormalizedAttribute() {
         return createAttribute(normalizer.normalize("192.168.1.1"));
     }
@@ -44,40 +45,30 @@ public class IpAddressTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 54, 54
-        readWriteKryo(createNormalizedAttribute(), 23);
-        readWriteKryo(createNonNormalizedAttribute(), 23);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 54
+        // serializing type name index: 23
+        verifyKryoPreservesValue(createNormalizedAttribute(), 23);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 62, 62
-        readWriteData(createNormalizedAttribute(), 27);
-        readWriteData(createNonNormalizedAttribute(), 27);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataPreservesValues() {
+        // serializing full type name: 62
+        // serializing type name index: 27
+        verifyDataPreservesValue(createNormalizedAttribute(), 27);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 27);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.LcNoDiacriticsNormalizer;
 import datawave.data.type.LcNoDiacriticsListType;
@@ -19,8 +17,6 @@ import datawave.query.attributes.TypeAttributeIT;
  * Serialization integration test for the {@link LcNoDiacriticsListType} is a {@link ListType} and uses the {@link LcNoDiacriticsNormalizer}
  */
 public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
-
-    private static final Logger log = LoggerFactory.getLogger(LcNoDiacriticsListTypeAttributeIT.class);
 
     private final String normalizedData = "ab,cd,ef";
     private final String nonNormalizedData = "âB,cD,ëF";
@@ -44,6 +40,11 @@ public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Override
+    protected String getTypeShortName() {
+        return "LC_ND_LIST";
+    }
+
+    @Override
     protected TypeAttribute<?> createNormalizedAttribute() {
         return createAttribute(normalizedData);
     }
@@ -54,40 +55,30 @@ public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 60, 63
-        readWriteKryo(createNormalizedAttribute(), 20);
-        readWriteKryo(createNonNormalizedAttribute(), 23);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 60, 63
+        // serializing type name index: 20, 23
+        verifyKryoPreservesValue(createNormalizedAttribute(), 20);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 68, 70
-        readWriteData(createNormalizedAttribute(), 24);
-        readWriteData(createNonNormalizedAttribute(), 26);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // serializing full type name: 68, 70
+        // serializing type name index: 24, 26
+        verifyDataPreservesValue(createNormalizedAttribute(), 24);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 26);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
@@ -67,8 +67,9 @@ public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 60, 63
+        readWriteKryo(createNormalizedAttribute(), 20);
+        readWriteKryo(createNonNormalizedAttribute(), 23);
     }
 
     @Test
@@ -85,7 +86,8 @@ public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 68, 70
+        readWriteData(createNormalizedAttribute(), 24);
+        readWriteData(createNonNormalizedAttribute(), 26);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsTypeAttributeIT.java
@@ -46,8 +46,9 @@ public class LcNoDiacriticsTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre type index was 52, 54
+        readWriteKryo(createNormalizedAttribute(), 16);
+        readWriteKryo(createNonNormalizedAttribute(), 18);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsTypeAttributeIT.java
@@ -1,8 +1,6 @@
 package datawave.query.attributes.it;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.LcNoDiacriticsNormalizer;
 import datawave.data.type.LcNoDiacriticsType;
@@ -15,11 +13,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class LcNoDiacriticsTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(LcNoDiacriticsTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new LcNoDiacriticsType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "LC_ND";
     }
 
     @Override
@@ -33,39 +34,29 @@ public class LcNoDiacriticsTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre type index was 52, 54
-        readWriteKryo(createNormalizedAttribute(), 16);
-        readWriteKryo(createNonNormalizedAttribute(), 18);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 52, 54
+        // serializing type name index: 16, 18
+        verifyKryoPreservesValue(createNormalizedAttribute(), 16);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
     }
 
     @Test
     public void testDataReadWrite() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // 20, 21
+        verifyDataPreservesValue(createNormalizedAttribute(), 20);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 21);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcTypeAttributeIT.java
@@ -1,8 +1,6 @@
 package datawave.query.attributes.it;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.LcNormalizer;
 import datawave.data.type.LcType;
@@ -15,11 +13,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class LcTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(LcTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new LcType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "LC";
     }
 
     @Override
@@ -33,40 +34,30 @@ public class LcTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 41
-        readWriteKryo(createNormalizedAttribute(), 17);
-        readWriteKryo(createNonNormalizedAttribute(), 17);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 41
+        // serializing type name index: 17
+        verifyKryoPreservesValue(createNormalizedAttribute(), 17);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 17);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 49
-        readWriteData(createNormalizedAttribute(), 21);
-        readWriteData(createNonNormalizedAttribute(), 21);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // serializing full type name: 49
+        // serializing type name index: 21
+        verifyDataPreservesValue(createNormalizedAttribute(), 21);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 21);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcTypeAttributeIT.java
@@ -46,8 +46,9 @@ public class LcTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 41
+        readWriteKryo(createNormalizedAttribute(), 17);
+        readWriteKryo(createNonNormalizedAttribute(), 17);
     }
 
     @Test
@@ -64,7 +65,8 @@ public class LcTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 49
+        readWriteData(createNormalizedAttribute(), 21);
+        readWriteData(createNonNormalizedAttribute(), 21);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NoOpTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NoOpTypeAttributeIT.java
@@ -72,8 +72,9 @@ public class NoOpTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 43
+        readWriteKryo(createNormalizedAttribute(), 17);
+        readWriteKryo(createNonNormalizedAttribute(), 17);
     }
 
     @Test
@@ -90,7 +91,8 @@ public class NoOpTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 51
+        readWriteData(createNormalizedAttribute(), 21);
+        readWriteData(createNonNormalizedAttribute(), 21);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NoOpTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NoOpTypeAttributeIT.java
@@ -3,8 +3,6 @@ package datawave.query.attributes.it;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.NoOpNormalizer;
 import datawave.data.type.NoOpType;
@@ -17,8 +15,6 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class NoOpTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(NoOpTypeAttributeIT.class);
-
     private final NoOpNormalizer normalizer = new NoOpNormalizer();
 
     /**
@@ -28,6 +24,11 @@ public class NoOpTypeAttributeIT extends TypeAttributeIT {
      */
     protected Type<?> getType() {
         return new NoOpType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "NO_OP";
     }
 
     @Test
@@ -59,40 +60,30 @@ public class NoOpTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 43
-        readWriteKryo(createNormalizedAttribute(), 17);
-        readWriteKryo(createNonNormalizedAttribute(), 17);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testKryoValuePreservation() {
+        // serializing full type name: 43
+        // serializing type name index: 17
+        verifyKryoPreservesValue(createNormalizedAttribute(), 17);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 17);
     }
 
     @Test
     public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataReadWrite() {
-        // pre index was 51
-        readWriteData(createNormalizedAttribute(), 21);
-        readWriteData(createNonNormalizedAttribute(), 21);
+    public void testDataValuePreservation() {
+        // serializing full type name: 51
+        // serializing type name index: 21
+        verifyDataPreservesValue(createNormalizedAttribute(), 21);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 21);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
@@ -47,8 +47,9 @@ public class NumberListTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 64, 52
+        readWriteKryo(createNormalizedAttribute(), 32);
+        readWriteKryo(createNonNormalizedAttribute(), 20);
     }
 
     @Test
@@ -65,7 +66,8 @@ public class NumberListTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 72, 60
+        readWriteData(createNormalizedAttribute(), 36);
+        readWriteData(createNonNormalizedAttribute(), 24);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
@@ -1,8 +1,6 @@
 package datawave.query.attributes.it;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.NumberNormalizer;
 import datawave.data.type.ListType;
@@ -16,11 +14,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class NumberListTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(NumberListTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new NumberListType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "NUM_LIST";
     }
 
     @Override
@@ -35,39 +36,29 @@ public class NumberListTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
     public void testKryoReadWrite() {
-        // pre index was 64, 52
-        readWriteKryo(createNormalizedAttribute(), 32);
-        readWriteKryo(createNonNormalizedAttribute(), 20);
-    }
-
-    @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+        // serializing full type name: 64, 52
+        // serializing type name index: 32, 20
+        verifyKryoPreservesValue(createNormalizedAttribute(), 32);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 20);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 72, 60
-        readWriteData(createNormalizedAttribute(), 36);
-        readWriteData(createNonNormalizedAttribute(), 24);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void verifyDataPreservesValue() {
+        // serializing full type name: 72, 60
+        // serializing type name index: 36, 24
+        verifyDataPreservesValue(createNormalizedAttribute(), 36);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 24);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
@@ -3,8 +3,6 @@ package datawave.query.attributes.it;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.NumberNormalizer;
 import datawave.data.type.NumberType;
@@ -16,8 +14,6 @@ import datawave.query.attributes.TypeAttributeIT;
  * Serialization integration test for the {@link NumberType} which uses the {@link NumberNormalizer}
  */
 public class NumberTypeAttributeIT extends TypeAttributeIT {
-
-    private static final Logger log = LoggerFactory.getLogger(NumberTypeAttributeIT.class);
 
     private final NumberNormalizer normalizer = new NumberNormalizer();
 
@@ -33,6 +29,11 @@ public class NumberTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Override
+    protected String getTypeShortName() {
+        return "NUM";
+    }
+
+    @Override
     protected TypeAttribute<?> createNormalizedAttribute() {
         return createAttribute(normalizer.normalize("25"));
     }
@@ -43,40 +44,30 @@ public class NumberTypeAttributeIT extends TypeAttributeIT {
     }
 
     @Test
-    public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
     public void testKryoReadWrite() {
-        // pre index was 42
-        readWriteKryo(createNormalizedAttribute(), 14);
-        readWriteKryo(createNonNormalizedAttribute(), 14);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 42
+        // serializing type name index: 14
+        verifyKryoPreservesValue(createNormalizedAttribute(), 14);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 14);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 50
-        readWriteData(createNormalizedAttribute(), 18);
-        readWriteData(createNonNormalizedAttribute(), 18);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataValuePreservation() {
+        // serializing full type name: 50
+        // serializing type name index: 18
+        verifyDataPreservesValue(createNormalizedAttribute(), 18);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 18);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
@@ -56,8 +56,9 @@ public class NumberTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 42
+        readWriteKryo(createNormalizedAttribute(), 14);
+        readWriteKryo(createNonNormalizedAttribute(), 14);
     }
 
     @Test
@@ -74,7 +75,8 @@ public class NumberTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 50
+        readWriteData(createNormalizedAttribute(), 18);
+        readWriteData(createNonNormalizedAttribute(), 18);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
@@ -63,8 +63,9 @@ public class PointTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
-        readWriteKryo(createNormalizedAttribute());
-        readWriteKryo(createNonNormalizedAttribute());
+        // pre index was 50
+        readWriteKryo(createNormalizedAttribute(), 23);
+        readWriteKryo(createNonNormalizedAttribute(), 23);
     }
 
     @Test
@@ -81,7 +82,8 @@ public class PointTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testDataReadWrite() {
-        readWriteData(createNormalizedAttribute());
-        readWriteData(createNonNormalizedAttribute());
+        // pre index was 58
+        readWriteData(createNormalizedAttribute(), 27);
+        readWriteData(createNonNormalizedAttribute(), 27);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import datawave.data.normalizer.Normalizer;
 import datawave.data.normalizer.PointNormalizer;
@@ -19,11 +17,14 @@ import datawave.query.attributes.TypeAttributeIT;
  */
 public class PointTypeAttributeIT extends TypeAttributeIT {
 
-    private static final Logger log = LoggerFactory.getLogger(PointTypeAttributeIT.class);
-
     @Override
     protected Type<?> getType() {
         return new PointType();
+    }
+
+    @Override
+    protected String getTypeShortName() {
+        return "POINT";
     }
 
     @Test
@@ -51,39 +52,29 @@ public class PointTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoSerialization() {
-        writeKryo(NORMALIZED, createNormalizedAttribute(), log);
-        writeKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+        testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
 
     @Test
-    public void testKryoDeserialization() {
-        readKryo(NORMALIZED, createNormalizedAttribute(), log);
-        readKryo(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testKryoReadWrite() {
-        // pre index was 50
-        readWriteKryo(createNormalizedAttribute(), 23);
-        readWriteKryo(createNonNormalizedAttribute(), 23);
-    }
-
-    @Test
-    public void testDataSerialization() {
-        writeDataOutput(NORMALIZED, createNormalizedAttribute(), log);
-        writeDataOutput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
-    }
-
-    @Test
-    public void testDataDeserialization() {
-        readDataInput(NORMALIZED, createNormalizedAttribute(), log);
-        readDataInput(NON_NORMALIZED, createNonNormalizedAttribute(), log);
+    public void testKryoValuePreservation() {
+        // serializing full type name: 50
+        // serializing type name index: 23
+        verifyKryoPreservesValue(createNormalizedAttribute(), 23);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
     }
 
     @Test
     public void testDataReadWrite() {
-        // pre index was 58
-        readWriteData(createNormalizedAttribute(), 27);
-        readWriteData(createNonNormalizedAttribute(), 27);
+        testDataReadWriteTimes(NORMALIZED, createNormalizedAttribute());
+        testDataReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
+    }
+
+    @Test
+    public void testDataPreservesValues() {
+        // serializing full type name: 58
+        // serializing type name index: 27
+        verifyDataPreservesValue(createNormalizedAttribute(), 27);
+        verifyDataPreservesValue(createNonNormalizedAttribute(), 27);
     }
 }


### PR DESCRIPTION
Serialize the integer index of a Type class name instead of the full class name for every attribute. 

For attributes that are not found in the DatawaveTypeIndex, such as custom attributes in external projects, the Type class name will still be serialized.