### PR TITLE
Type now supports Kryo serialization

### DIFF
--- a/core/cached-results/pom.xml
+++ b/core/cached-results/pom.xml
@@ -27,6 +27,10 @@
                     <groupId>jakarta.validation</groupId>
                     <artifactId>jakarta.validation-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>gov.nsa.datawave.microservice</groupId>
+                    <artifactId>type-utils</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/core/utils/type-utils/pom.xml
+++ b/core/utils/type-utils/pom.xml
@@ -17,6 +17,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.esotericsoftware.kryo</groupId>
+                <artifactId>kryo</artifactId>
+                <version>${version.kryo}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-net</groupId>
                 <artifactId>commons-net</artifactId>
                 <version>${version.commons-net}</version>
@@ -35,6 +40,10 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>com.esotericsoftware.kryo</groupId>
+            <artifactId>kryo</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>

--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -4,6 +4,10 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 import datawave.webservice.query.data.ObjectSizeOf;
 
@@ -171,5 +175,23 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
         }
         size += STATIC_SIZE + (2L * normalizedValue.length()) + ObjectSizeOf.Sizer.getObjectSize(delegate);
         return size;
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        try {
+            setDelegateFromString(delegateString);
+        } catch (Exception e) {
+            // if there was some problem with setting the delegate for the specific Type, then
+            // set the normalized value to the input string. This effectively mimics falling back
+            // to a NoOpType
+            setNormalizedValue(delegateString);
+        }
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
@@ -44,7 +44,7 @@ public class DateType extends BaseType<Date> {
      */
     @Override
     public long sizeInBytes() {
-        return STATIC_SIZE + (2L * normalizedValue.length());
+        return STATIC_SIZE + (2L * normalizedValue.length()) + getDelegateAsString().length();
     }
 
     @Override

--- a/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
@@ -1,13 +1,23 @@
 package datawave.data.type;
 
+import static datawave.data.normalizer.DateNormalizer.ISO_8601_FORMAT_STRING;
+
+import java.text.ParseException;
 import java.util.Date;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import datawave.data.normalizer.DateNormalizer;
 import datawave.data.normalizer.Normalizer;
 
 public class DateType extends BaseType<Date> {
 
     private static final long serialVersionUID = 936566410691643144L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + PrecomputedSizes.DATE_STATIC_REF + Sizer.REFERENCE;
+
+    private String normalizedDelegate = null;
 
     public DateType() {
         super(Normalizer.DATE_NORMALIZER);
@@ -20,8 +30,11 @@ public class DateType extends BaseType<Date> {
 
     @Override
     public String getDelegateAsString() {
-        // the normalized form of the date preserves milliseconds
-        return normalizer.normalizeDelegateType(getDelegate());
+        if (normalizedDelegate == null) {
+            // the normalized form of the date preserves milliseconds
+            normalizedDelegate = normalizer.normalizeDelegateType(getDelegate());
+        }
+        return normalizedDelegate;
     }
 
     /**
@@ -32,5 +45,25 @@ public class DateType extends BaseType<Date> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2L * normalizedValue.length());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeString(getNormalizedValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        String normalizedValue = input.readString();
+        try {
+            // the method call to getDelegateAsString() uses the ISO 8601 format so in practice
+            // this should never trigger an exception.
+            this.delegate = DateNormalizer.getParser(ISO_8601_FORMAT_STRING).parse(delegateString);
+        } catch (ParseException e) {
+            throw new RuntimeException("Input should have been ISO 8601 normalized: " + delegateString, e);
+        }
+        this.normalizedValue = normalizedValue;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/DateType.java
@@ -1,21 +1,21 @@
 package datawave.data.type;
 
-import static datawave.data.normalizer.DateNormalizer.ISO_8601_FORMAT_STRING;
+import static com.esotericsoftware.kryo.serializers.DefaultSerializers.DateSerializer;
 
-import java.text.ParseException;
 import java.util.Date;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
-import datawave.data.normalizer.DateNormalizer;
 import datawave.data.normalizer.Normalizer;
 
 public class DateType extends BaseType<Date> {
 
     private static final long serialVersionUID = 936566410691643144L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + PrecomputedSizes.DATE_STATIC_REF + Sizer.REFERENCE;
+
+    private static final DateSerializer serializer = new DateSerializer();
 
     private String normalizedDelegate = null;
 
@@ -49,21 +49,13 @@ public class DateType extends BaseType<Date> {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        output.writeString(getDelegateAsString());
+        kryo.writeObject(output, delegate, serializer);
         output.writeString(getNormalizedValue());
     }
 
     @Override
     public void read(Kryo kryo, Input input) {
-        String delegateString = input.readString();
-        String normalizedValue = input.readString();
-        try {
-            // the method call to getDelegateAsString() uses the ISO 8601 format so in practice
-            // this should never trigger an exception.
-            this.delegate = DateNormalizer.getParser(ISO_8601_FORMAT_STRING).parse(delegateString);
-        } catch (ParseException e) {
-            throw new RuntimeException("Input should have been ISO 8601 normalized: " + delegateString, e);
-        }
-        this.normalizedValue = normalizedValue;
+        this.delegate = kryo.readObject(input, Date.class);
+        this.normalizedValue = input.readString();
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/GeoLatType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/GeoLatType.java
@@ -1,5 +1,9 @@
 package datawave.data.type;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
 public class GeoLatType extends BaseType<String> {
@@ -19,5 +23,19 @@ public class GeoLatType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeString(getNormalizedValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        String normalizedValue = input.readString();
+        this.delegate = delegateString;
+        this.normalizedValue = normalizedValue;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/GeoLonType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/GeoLonType.java
@@ -1,5 +1,9 @@
 package datawave.data.type;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
 public class GeoLonType extends BaseType<String> {
@@ -19,5 +23,19 @@ public class GeoLonType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeString(getNormalizedValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        String normalizedValue = input.readString();
+        this.delegate = delegateString;
+        this.normalizedValue = normalizedValue;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/HexStringType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/HexStringType.java
@@ -1,5 +1,9 @@
 package datawave.data.type;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
 public class HexStringType extends BaseType<String> {
@@ -19,5 +23,19 @@ public class HexStringType extends BaseType<String> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2L * normalizedValue.length()) + (2L * delegate.length());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeString(getNormalizedValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        String normalizedValue = input.readString();
+        this.delegate = delegateString;
+        this.normalizedValue = normalizedValue;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/LcNoDiacriticsListType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/LcNoDiacriticsListType.java
@@ -1,5 +1,11 @@
 package datawave.data.type;
 
+import java.util.ArrayList;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
 public class LcNoDiacriticsListType extends ListType {
@@ -10,6 +16,25 @@ public class LcNoDiacriticsListType extends ListType {
 
     public LcNoDiacriticsListType(String delegateString) {
         super(delegateString, Normalizer.LC_NO_DIACRITICS_NORMALIZER);
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeInt(normalizedValues.size(), true);
+        for (String normalizedValue : normalizedValues) {
+            output.writeString(normalizedValue);
+        }
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        this.delegate = input.readString();
+        int size = input.readInt(true);
+        normalizedValues = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            normalizedValues.add(input.readString());
+        }
     }
 
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/LcNoDiacriticsType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/LcNoDiacriticsType.java
@@ -1,7 +1,14 @@
 package datawave.data.type;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
+/**
+ * Note: there were no significant optimizations found with overriding the Kryo {@link #read(Kryo, Input)} and {@link #write(Kryo, Output)} methods
+ */
 public class LcNoDiacriticsType extends BaseType<String> {
 
     private static final long serialVersionUID = -6219894926244790742L;

--- a/core/utils/type-utils/src/main/java/datawave/data/type/LcType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/LcType.java
@@ -1,7 +1,14 @@
 package datawave.data.type;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
+/**
+ * Note: there were no significant optimizations found with overriding the Kryo {@link #read(Kryo, Input)} and {@link #write(Kryo, Output)} methods
+ */
 public class LcType extends BaseType<String> {
 
     private static final long serialVersionUID = -5102714749195917406L;

--- a/core/utils/type-utils/src/main/java/datawave/data/type/NumberListType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/NumberListType.java
@@ -1,5 +1,11 @@
 package datawave.data.type;
 
+import java.util.ArrayList;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
 public class NumberListType extends ListType {
@@ -15,5 +21,26 @@ public class NumberListType extends ListType {
     @Override
     public boolean expandAtQueryTime() {
         return true;
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeInt(normalizedValues.size(), true);
+        for (String normalizedValue : normalizedValues) {
+            output.writeString(normalizedValue);
+        }
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        delegate = input.readString();
+
+        normalizedValues = new ArrayList<>();
+        int size = input.readInt(true);
+        for (int i = 0; i < size; i++) {
+            String normalizedValue = input.readString();
+            normalizedValues.add(normalizedValue);
+        }
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/NumberType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/NumberType.java
@@ -2,6 +2,10 @@ package datawave.data.type;
 
 import java.math.BigDecimal;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 
 public class NumberType extends BaseType<BigDecimal> {
@@ -23,5 +27,19 @@ public class NumberType extends BaseType<BigDecimal> {
     @Override
     public long sizeInBytes() {
         return STATIC_SIZE + (2L * normalizedValue.length());
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeString(getNormalizedValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        String normalizedValue = input.readString();
+        this.delegate = new BigDecimal(delegateString);
+        this.normalizedValue = normalizedValue;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/PointType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/PointType.java
@@ -1,5 +1,9 @@
 package datawave.data.type;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.normalizer.Normalizer;
 import datawave.data.type.util.Point;
 
@@ -8,7 +12,45 @@ import datawave.data.type.util.Point;
  */
 public class PointType extends AbstractGeometryType<Point> {
 
+    private String toString;
+    private String delegateString;
+
     public PointType() {
         super(Normalizer.POINT_NORMALIZER);
+    }
+
+    @Override
+    public String getDelegateAsString() {
+        if (delegateString == null) {
+            // this also calls AbstractGeometry#toString() which calls Geometry#toText()
+            // which creates a new WKTWriter per call
+            delegateString = super.getDelegateAsString();
+        }
+        return delegateString;
+    }
+
+    @Override
+    public String toString() {
+        if (toString == null) {
+            // this is an expensive call to AbstractGeometry#toString() which itself calls Geometry#toText()
+            // which creates a new WKTWriter per call
+            toString = super.toString();
+        }
+        return toString;
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(getDelegateAsString());
+        output.writeString(getNormalizedValue());
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        String delegateString = input.readString();
+        String normalizedValue = input.readString();
+
+        this.delegate = normalizer.denormalize(delegateString);
+        this.normalizedValue = normalizedValue;
     }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/PointType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/PointType.java
@@ -53,4 +53,9 @@ public class PointType extends AbstractGeometryType<Point> {
         this.delegate = normalizer.denormalize(delegateString);
         this.normalizedValue = normalizedValue;
     }
+
+    @Override
+    public long sizeInBytes() {
+        return super.sizeInBytes() + toString().length() + getDelegateAsString().length();
+    }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/Type.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/Type.java
@@ -2,7 +2,9 @@ package datawave.data.type;
 
 import java.util.Collection;
 
-public interface Type<T extends Comparable<T>> extends Comparable<Type<T>> {
+import com.esotericsoftware.kryo.KryoSerializable;
+
+public interface Type<T extends Comparable<T>> extends Comparable<Type<T>>, KryoSerializable {
 
     String normalize();
 

--- a/core/utils/type-utils/src/main/java/datawave/data/type/util/Point.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/util/Point.java
@@ -14,4 +14,13 @@ public class Point extends AbstractGeometry<org.locationtech.jts.geom.Point> imp
     public int compareTo(Point o) {
         return jtsGeom.compareTo(o.jtsGeom);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Point) {
+            Point p = (Point) o;
+            return jtsGeom.equals(p.jtsGeom);
+        }
+        return false;
+    }
 }

--- a/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
+++ b/warehouse/ingest-core/src/main/java/datawave/IdentityDataType.java
@@ -2,6 +2,10 @@ package datawave;
 
 import java.util.Collection;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
 import datawave.data.type.Type;
 
 public class IdentityDataType implements Type<String> {
@@ -87,6 +91,16 @@ public class IdentityDataType implements Type<String> {
 
     @Override
     public int compareTo(Type<String> o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
         throw new UnsupportedOperationException();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -154,7 +154,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
             output.writeString(datawaveType.getClass().getName());
         }
         super.writeMetadata(kryo, output);
-        output.writeString(this.datawaveType.getDelegateAsString());
+        this.datawaveType.write(kryo, output);
         output.writeBoolean(this.toKeep);
     }
 
@@ -172,21 +172,13 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
             }
             setDatawaveType(clazzName);
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
-            log.warn("could not read datawateType from input: " + e);
+            log.warn("could not read DatawaveType from input: " + e);
         }
         super.readMetadata(kryo, input);
-        if (datawaveType == null)
+        if (datawaveType == null) {
             datawaveType = (Type) new NoOpType();
-        String delegateString = input.readString();
-        try {
-            datawaveType.setDelegateFromString(delegateString);
-        } catch (Exception ex) {
-            // there was some problem with setting the delegate as the declared type.
-            // Instead of letting this exception fail the query, make this a NoOpType containing the string value from the input
-            log.warn("Was unable to make a " + datawaveType + " to contain a delegate created from input:" + delegateString + "  Making a NoOpType instead.");
-            datawaveType = (Type) new NoOpType();
-            datawaveType.setDelegateFromString(delegateString);
         }
+        this.datawaveType.read(kryo, input);
         this.toKeep = input.readBoolean();
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -133,7 +133,7 @@ public class DocumentTest {
         d.put("NUM", createAttribute("NUM", "25"));
         d.put("NUM_LIST", createAttribute("NUM_LIST", "22,23,24"));
         d.put("POINT", createAttribute("POINT", "POINT(10 10)"));
-        roundTrip(MAX_ITERATIONS, 767);
+        roundTrip(MAX_ITERATIONS, 750);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class DocumentTest {
 
     @Test
     public void testSingleFieldedRoundTrips() {
-        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 22564);
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18314);
         roundTrip("GEO_LAT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
         roundTrip("GEO_LON", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
         roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11563);
@@ -185,7 +185,8 @@ public class DocumentTest {
     public void testDateRoundTrip() {
         // original size: 16564
         // kryo optimization: 22564
-        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 22564);
+        // using default DateSerializer dropped the read time by 50%
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18314);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -1,9 +1,12 @@
 package datawave.query.attributes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.AbstractMap;
 import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -12,10 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import datawave.data.type.DateType;
+import datawave.data.type.GeoLatType;
+import datawave.data.type.GeoLonType;
+import datawave.data.type.GeoType;
+import datawave.data.type.GeometryType;
 import datawave.data.type.HexStringType;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.LcType;
+import datawave.data.type.NoOpType;
+import datawave.data.type.NumberListType;
 import datawave.data.type.NumberType;
+import datawave.data.type.PointType;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.function.serializer.KryoDocumentSerializer;
 import datawave.query.util.TypeMetadata;
@@ -32,92 +43,150 @@ public class DocumentTest {
     private final KryoDocumentSerializer serializer = new KryoDocumentSerializer();
     private final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
 
-    private static final int max_iterations = 100;
+    private final long startTimeMillis = System.currentTimeMillis();
+    private final Random rand = new Random();
 
-    private AttributeFactory attributeFactory;
+    private static final int MAX_ITERATIONS = 250;
+    private static final int DOCUMENT_SIZE = 250;
 
     private Document d;
+    private AttributeFactory attributeFactory;
 
     @BeforeEach
     public void setup() {
         TypeMetadata typeMetadata = new TypeMetadata();
-        typeMetadata.put("LC", datatype, LcType.class.getTypeName());
-        typeMetadata.put("LC_NO_DIACRITICS", datatype, LcNoDiacriticsType.class.getTypeName());
-        typeMetadata.put("NUMBER", datatype, NumberType.class.getTypeName());
+        typeMetadata.put("DATE", datatype, DateType.class.getTypeName());
+        typeMetadata.put("GEO_LAT", datatype, GeoLatType.class.getTypeName());
+        typeMetadata.put("GEO_LON", datatype, GeoLonType.class.getTypeName());
+        typeMetadata.put("GEOMETRY", datatype, GeometryType.class.getTypeName());
+        typeMetadata.put("GEO", datatype, GeoType.class.getTypeName());
         typeMetadata.put("HEX", datatype, HexStringType.class.getTypeName());
+        typeMetadata.put("LC", datatype, LcType.class.getTypeName());
+        typeMetadata.put("LC_ND", datatype, LcNoDiacriticsType.class.getTypeName());
+        typeMetadata.put("NO_OP", datatype, NoOpType.class.getTypeName());
+        typeMetadata.put("NUM", datatype, NumberType.class.getTypeName());
+        typeMetadata.put("NUM_LIST", datatype, NumberListType.class.getTypeName());
+        typeMetadata.put("POINT", datatype, PointType.class.getTypeName());
 
-        attributeFactory = new AttributeFactory(typeMetadata);
         d = new Document(documentKey, true);
+        attributeFactory = new AttributeFactory(typeMetadata);
     }
 
     @Test
     public void testEmptyDocument() {
-        roundTrip(max_iterations, 16);
+        roundTrip(MAX_ITERATIONS, 16);
     }
 
     @Test
     public void testDocumentWithLcType() {
         Attribute<?> attr = createAttribute("LC", "value");
         d.put("LC", attr);
-        roundTrip(max_iterations, 66);
+        roundTrip(MAX_ITERATIONS, 66);
     }
 
     @Test
     public void testDocumentWithLcNoDiacriticsType() {
-        Attribute<?> attr = createAttribute("LC_NO_DIACRITICS", "value");
-        d.put("LC_NO_DIACRITICS", attr);
-        roundTrip(max_iterations, 80);
+        Attribute<?> attr = createAttribute("LC_ND", "value");
+        d.put("LC_ND", attr);
+        roundTrip(MAX_ITERATIONS, 69);
     }
 
     @Test
     public void testDocumentWithHexType() {
         Attribute<?> attr = createAttribute("HEX", "a1b2c3");
         d.put("HEX", attr);
-        roundTrip(max_iterations, 68);
+        roundTrip(MAX_ITERATIONS, 74);
     }
 
     @Test
     public void testDocumentWithNumberType() {
-        Attribute<?> attr = createAttribute("NUMBER", "12");
-        d.put("NUMBER", attr);
-        roundTrip(max_iterations, 67);
+        Attribute<?> attr = createAttribute("NUM", "12");
+        d.put("NUM", attr);
+        roundTrip(MAX_ITERATIONS, 70);
     }
 
     @Test
     public void testDocumentWithNumberTypeNormalizedValue() {
-        Attribute<?> attr = createAttribute("NUMBER", "+bE1.2");
-        d.put("NUMBER", attr);
-        roundTrip(max_iterations, 67);
+        Attribute<?> attr = createAttribute("NUM", "+bE1.2");
+        d.put("NUM", attr);
+        roundTrip(MAX_ITERATIONS, 70);
     }
 
     @Test
     public void testDocumentWithNumberTypeLargeValue() {
-        Attribute<?> attr = createAttribute("NUMBER", "12456789.987654321");
-        d.put("NUMBER", attr);
-        roundTrip(max_iterations, 83);
+        Attribute<?> attr = createAttribute("NUM", "12456789.987654321");
+        d.put("NUM", attr);
+        roundTrip(MAX_ITERATIONS, 101);
     }
 
     @Test
     public void testOneOfEverything() {
         Attribute<?> attr1 = createAttribute("LC", "value-1");
-        Attribute<?> attr2 = createAttribute("LC_NO_DIACRITICS", "value-2");
-        Attribute<?> attr3 = createAttribute("NUMBER", "25");
+        Attribute<?> attr2 = createAttribute("NC_ND", "value-2");
+        Attribute<?> attr3 = createAttribute("NUM", "25");
         Attribute<?> attr4 = createAttribute("HEX", "a1b2c3");
         d.put("LC", attr1);
-        d.put("LC_NO_DIACRITICS", attr2);
-        d.put("NUMBER", attr3);
+        d.put("NC_ND", attr2);
+        d.put("NUM", attr3);
         d.put("HEX", attr4);
-        roundTrip(max_iterations, 234);
+        roundTrip(MAX_ITERATIONS, 232);
     }
 
     @Test
     public void testLargeDocument() {
-        int size = 100_000;
+        int size = 10_000;
         for (int i = 0; i < size; i++) {
             Attribute<?> attr = createAttribute("LC", "value-" + i);
             d.put("LC", attr);
         }
-        roundTrip(max_iterations, 5288956);
+        roundTrip(MAX_ITERATIONS, 518952);
+    }
+
+    @Test
+    public void testSingleFieldedRoundTrips() {
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 22564);
+        roundTrip("GEO_LAT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
+        roundTrip("GEO_LON", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
+        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11563);
+        roundTrip("LC", DOCUMENT_SIZE, MAX_ITERATIONS, 12702);
+        roundTrip("LC_ND", DOCUMENT_SIZE, MAX_ITERATIONS, 12705);
+        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12806);
+        roundTrip("POINT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
+    }
+
+    @Test
+    public void testHexRoundTrip() {
+        // original size: 11063
+        // post hex serialization changes: 11563
+        // read times cut by about 35%
+        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11563);
+    }
+
+    @Test
+    public void testNumberRoundTrip() {
+        // original size: 11213
+        // post number serialization: 12806
+        // attribute write times remained the same, attribute read times were cut by about 50%
+        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12806);
+    }
+
+    @Test
+    public void testNumberListRoundTrip() {
+        // original size: 12994
+        // kryo optimization: 18030
+        roundTrip("NUM_LIST", DOCUMENT_SIZE, MAX_ITERATIONS, 18030);
+    }
+
+    @Test
+    public void testDateRoundTrip() {
+        // original size: 16564
+        // kryo optimization: 22564
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 22564);
+    }
+
+    @Test
+    public void testPointRoundTrip() {
+        roundTrip("POINT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
     }
 
     protected void roundTrip(int max, int serializedLength) {
@@ -131,10 +200,100 @@ public class DocumentTest {
         }
     }
 
+    /**
+     * Test both read and writes for a single fielded document. Should provide a rough comparison of Type serialization performance
+     *
+     * @param field
+     *            the field, corresponds to a Type
+     * @param documentSize
+     *            the size of the document to create
+     * @param maxIterations
+     *            the number of iterations
+     * @param serializedLength
+     *            the expected length of the serialized document
+     */
+    protected void roundTrip(String field, int documentSize, int maxIterations, int serializedLength) {
+        long readTime = 0;
+        long writeTime = 0;
+        Document d = createDocumentForField(field, documentSize);
+
+        Entry<Key,Value> entry = null;
+        writeTime = System.nanoTime();
+        for (int i = 0; i < maxIterations; i++) {
+            entry = serialize(d);
+        }
+        writeTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - writeTime);
+        assertNotNull(entry);
+
+        if (serializedLength > 0) {
+            // some tests rely on random inputs, do not assert the serialized length in those cases
+            assertEquals(serializedLength, entry.getValue().getSize());
+        }
+
+        for (int i = 0; i < maxIterations; i++) {
+            long start = System.nanoTime();
+            Entry<Key,Document> result = deserialize(entry);
+            readTime += System.nanoTime() - start;
+            Document d2 = result.getValue();
+            assertEquals(d, d2);
+        }
+        readTime = TimeUnit.NANOSECONDS.toMillis(readTime);
+
+        log.info("{} read: {} write: {}", field, readTime, writeTime);
+    }
+
+    protected Document createDocumentForField(String field, int size) {
+        d = new Document(documentKey, true);
+        for (int i = 0; i < size; i++) {
+            Attribute<?> attr = createAttribute(field, i);
+            d.put(field, attr);
+        }
+        return d;
+    }
+
+    protected Attribute<?> createAttribute(String field, int index) {
+        String value = createValueForFieldAndIndex(field, index);
+        return createAttribute(field, value);
+    }
+
     protected Attribute<?> createAttribute(String field, String value) {
         Attribute<?> attr = attributeFactory.create(field, value, documentKey, datatype, true);
         attr.clearMetadata();
         return attr;
+    }
+
+    protected String createValueForFieldAndIndex(String field, int index) {
+        switch (field) {
+            case "DATE":
+                return Long.toString(startTimeMillis + index);
+            case "GEO_LAT":
+                return String.valueOf(-90 + rand.nextInt(180));
+            case "GEO_LON":
+                return String.valueOf(-180 + rand.nextInt(360));
+            case "GEOMETRY":
+            case "GEO":
+            case "HEX":
+                return Integer.toHexString(index);
+            case "HIT_TERM":
+            case "IP":
+            case "IPV4":
+                return "192.168.1.1";
+            case "LC_ND_LIST":
+            case "LC_ND":
+            case "LC":
+                return "value-" + index;
+            case "NO_OP":
+            case "NUM_LIST":
+                return index + "," + (index + 1) + "," + (index + 2);
+            case "NUM":
+                return Integer.toString(index);
+            case "POINT":
+                int x = -10 + rand.nextInt(20);
+                int y = -10 + rand.nextInt(20);
+                return "POINT(" + x + " " + y + ")";
+            default:
+                throw new IllegalArgumentException("Unknown field: " + field);
+        }
     }
 
     protected Entry<Key,Value> serialize(Document d) {

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -121,15 +121,19 @@ public class DocumentTest {
 
     @Test
     public void testOneOfEverything() {
-        Attribute<?> attr1 = createAttribute("LC", "value-1");
-        Attribute<?> attr2 = createAttribute("NC_ND", "value-2");
-        Attribute<?> attr3 = createAttribute("NUM", "25");
-        Attribute<?> attr4 = createAttribute("HEX", "a1b2c3");
-        d.put("LC", attr1);
-        d.put("NC_ND", attr2);
-        d.put("NUM", attr3);
-        d.put("HEX", attr4);
-        roundTrip(MAX_ITERATIONS, 232);
+        d.put("DATE", createAttribute("DATE", String.valueOf(System.currentTimeMillis())));
+        d.put("GEO_LAT", createAttribute("GEO_LAT", "-90"));
+        d.put("GEO_LON", createAttribute("GEO_LON", "-180"));
+        d.put("HEX", createAttribute("HEX", "a1b2c3"));
+        d.put("IP", createAttribute("IP", "192.168.1.1"));
+        d.put("IPV4", createAttribute("IPV4", "192.168.1.1"));
+        d.put("LC", createAttribute("LC", "value-1"));
+        d.put("NC_ND", createAttribute("NC_ND", "value-2"));
+        d.put("NC_ND_LIST", createAttribute("NC_ND", "value-2"));
+        d.put("NUM", createAttribute("NUM", "25"));
+        d.put("NUM_LIST", createAttribute("NUM_LIST", "22,23,24"));
+        d.put("POINT", createAttribute("POINT", "POINT(10 10)"));
+        roundTrip(MAX_ITERATIONS, 767);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeIT.java
@@ -173,13 +173,14 @@ public abstract class TypeAttributeIT {
 
             // validate delegate and normalized
             String deserializedDelegate = deserialized.getType().getDelegateAsString();
-            String deserializedNormalized = deserialized.getType().getNormalizedValue();
             assertEquals(delegateValue, deserializedDelegate);
-            assertEquals(normalizedValue, deserializedNormalized);
 
             if (deserialized.getType() instanceof ListType) {
                 assertNotNull(normalizedValues, "delegate Type produced normalized values, but none were expected");
                 assertEquals(normalizedValues, ((ListType) deserialized.getType()).getNormalizedValues());
+            } else {
+                String deserializedNormalized = deserialized.getType().getNormalizedValue();
+                assertEquals(normalizedValue, deserializedNormalized);
             }
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
@@ -73,8 +73,9 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 62
         // serializing type name index: 36
-        verifyKryoPreservesValue(createNormalizedAttribute(), 36);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 36);
+        // kryo serialization: 60
+        verifyKryoPreservesValue(createNormalizedAttribute(), 60);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 60);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
@@ -73,9 +73,9 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 62
         // serializing type name index: 36
-        // kryo serialization: 60
-        verifyKryoPreservesValue(createNormalizedAttribute(), 60);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 60);
+        // kryo serialization: 43
+        verifyKryoPreservesValue(createNormalizedAttribute(), 43);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 43);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
@@ -66,8 +66,9 @@ public class GeoLatTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 44, 42
         // serializing type name index: 16, 14
-        verifyKryoPreservesValue(createNormalizedAttribute(), 16);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 14);
+        // kryo optimization: 20, 18
+        verifyKryoPreservesValue(createNormalizedAttribute(), 20);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
@@ -66,8 +66,9 @@ public class GeoLonTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 46, 42
         // serializing type name index: 18, 14
-        verifyKryoPreservesValue(createNormalizedAttribute(), 18);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 14);
+        // kryo optimization: 24, 18
+        verifyKryoPreservesValue(createNormalizedAttribute(), 24);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
@@ -49,6 +49,7 @@ public class HexTypeAttributeIT extends TypeAttributeIT {
 
     @Test
     public void testKryoReadWrite() {
+        // individual serialization times remained the same after optimizing kryo serialization to avoid normalizers
         testKryoReadWriteTimes(NORMALIZED, createNormalizedAttribute());
         testKryoReadWriteTimes(NON_NORMALIZED, createNonNormalizedAttribute());
     }
@@ -57,8 +58,9 @@ public class HexTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 49
         // serializing type name index: 18
-        verifyKryoPreservesValue(createNormalizedAttribute(), 18);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
+        // post kryo optimization: 24
+        verifyKryoPreservesValue(createNormalizedAttribute(), 24);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 24);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
@@ -64,8 +64,9 @@ public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 60, 63
         // serializing type name index: 20, 23
-        verifyKryoPreservesValue(createNormalizedAttribute(), 20);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
+        // kryo optimization: 27, 30
+        verifyKryoPreservesValue(createNormalizedAttribute(), 27);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 30);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
@@ -44,8 +44,9 @@ public class NumberListTypeAttributeIT extends TypeAttributeIT {
     public void testKryoReadWrite() {
         // serializing full type name: 64, 52
         // serializing type name index: 32, 20
-        verifyKryoPreservesValue(createNormalizedAttribute(), 32);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 20);
+        // kryo optimization: 51, 39
+        verifyKryoPreservesValue(createNormalizedAttribute(), 51);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 39);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
@@ -53,8 +53,9 @@ public class NumberTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 42
         // serializing type name index: 14
-        verifyKryoPreservesValue(createNormalizedAttribute(), 14);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 14);
+        // post kryo optimization: 20
+        verifyKryoPreservesValue(createNormalizedAttribute(), 20);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 20);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
@@ -60,8 +60,9 @@ public class PointTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 50
         // serializing type name index: 23
-        verifyKryoPreservesValue(createNormalizedAttribute(), 23);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
+        // kryo optimization: 41
+        verifyKryoPreservesValue(createNormalizedAttribute(), 41);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 41);
     }
 
     @Test


### PR DESCRIPTION
BaseType and extending classes now support Kryo serialization. 

Specific implementations now optimize the read/write of delegate values to avoid expensive calls to normalizers.