### PR TITLE
ScanResult now supports partial intersections.

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/DocIdQueryIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/next/DocIdQueryIterator.java
@@ -40,6 +40,7 @@ public class DocIdQueryIterator implements SortedKeyValueIterator<Key,Value> {
 
     public static final String BATCH_SIZE = "batch.size";
     public static final String SCAN_TIMEOUT = "scan.timeout";
+    public static final String PARTIAL_INTERSECTIONS = "partial.intersections";
 
     private Range range;
     private ASTJexlScript script;
@@ -53,6 +54,7 @@ public class DocIdQueryIterator implements SortedKeyValueIterator<Key,Value> {
     private IteratorEnvironment env;
     private int batchSize = 1;
     private long scanTimeout = -1;
+    private boolean allowPartialIntersections = true;
 
     private Key tk;
     private Value tv = new Value();
@@ -127,6 +129,10 @@ public class DocIdQueryIterator implements SortedKeyValueIterator<Key,Value> {
 
         if (options.containsKey(SCAN_TIMEOUT)) {
             scanTimeout = Long.parseLong(options.get(SCAN_TIMEOUT));
+        }
+
+        if (options.containsKey(PARTIAL_INTERSECTIONS)) {
+            allowPartialIntersections = Boolean.parseBoolean(options.get(PARTIAL_INTERSECTIONS));
         }
     }
 
@@ -226,6 +232,9 @@ public class DocIdQueryIterator implements SortedKeyValueIterator<Key,Value> {
             DocIdIteratorVisitor visitor = new DocIdIteratorVisitor(source, range, datatypeFilter, timeFilter, indexedFields);
             if (scanTimeout > 0) {
                 visitor.setMaxScanTimeMillis(scanTimeout);
+            }
+            if (allowPartialIntersections) {
+                visitor.setAllowPartialIntersections(allowPartialIntersections);
             }
 
             Set<Key> docIds = visitor.getDocIds(script);

--- a/warehouse/query-core/src/main/java/datawave/next/ScanResult.java
+++ b/warehouse/query-core/src/main/java/datawave/next/ScanResult.java
@@ -149,7 +149,7 @@ public class ScanResult {
      * @return true if the candidate should be removed
      */
     private boolean nominate(Key candidate, Key min, Key max, Set<Key> otherResults) {
-        return candidate.compareTo(min) < 0 || candidate.compareTo(max) <= 0 && !otherResults.contains(candidate);
+        return candidate.compareTo(min) < 0 || (candidate.compareTo(max) <= 0 && !otherResults.contains(candidate));
     }
 
     private boolean isIntersectionPossible(ScanResult other) {

--- a/warehouse/query-core/src/main/java/datawave/next/ScanResult.java
+++ b/warehouse/query-core/src/main/java/datawave/next/ScanResult.java
@@ -1,0 +1,247 @@
+package datawave.next;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This class allows us to retain knowledge of the min and max keys from a scan without requiring an expensive sorted set. Future scan ranges are restricted by
+ * the min and max
+ */
+public class ScanResult {
+
+    private static final Logger log = LoggerFactory.getLogger(ScanResult.class);
+
+    private Key min;
+    private Key max;
+    private final Set<Key> results;
+
+    public enum SOURCE {
+        EQ, ER, RANGE, LIST
+    }
+
+    private SOURCE source;
+
+    private boolean timeout = false;
+    private boolean allowPartialIntersections = false;
+
+    /**
+     * Default constructor does not allow partial intersections
+     */
+    public ScanResult() {
+        this(false);
+    }
+
+    /**
+     * Constructor accepts a boolean to enable partial intersections
+     *
+     * @param allowPartialIntersections
+     *            flag to enable partial intersection
+     */
+    public ScanResult(boolean allowPartialIntersections) {
+        this.allowPartialIntersections = allowPartialIntersections;
+        this.results = new HashSet<>();
+    }
+
+    /**
+     * Performs a union with another scan result
+     * <p>
+     * If either scan result is partial (i.e., timed out) then the result is considered partial
+     *
+     * @param other
+     *            another ScanResult
+     */
+    public void union(ScanResult other) {
+        if (other.isTimeout()) {
+            // a union can have one or both sides timeout, the entire union
+            // is considered a timeout
+            this.timeout = true;
+        }
+        addKeys(other.getResults());
+    }
+
+    /**
+     * Performs an intersection with another scan result
+     * <p>
+     * If the other scan result is partial (i.e., timed out) then a partial intersection is performed if sorted order is guaranteed as in the case of an
+     * equality term.
+     *
+     * @param other
+     *            another ScanResult
+     */
+    public void intersect(ScanResult other) {
+
+        Preconditions.checkArgument(!isTimeout(), "Left side of intersection should never be a timeout");
+
+        if (other.isTimeout()) {
+
+            if (allowPartialIntersections) {
+                return;
+            }
+
+            if (other.getSource() != SOURCE.EQ) {
+                // regex, range, list timed out. no partial intersection possible
+                log.trace("Cannot perform partial intersection with {}", other.getSource());
+                return;
+            }
+
+            partialIntersection(other);
+            return;
+        }
+
+        if (!isIntersectionPossible(other)) {
+            log.info("Intersection not possible, skipping");
+            results.clear();
+            return;
+        }
+
+        this.results.retainAll(other.getResults());
+    }
+
+    /**
+     * Attempt a partial intersection with an external set.
+     *
+     * @param other
+     *            the external set
+     */
+    protected void partialIntersection(ScanResult other) {
+
+        // special case where the external set sorts entirely before this one
+        boolean externalFullyBefore = other.getMax().compareTo(this.min) < 0;
+        if (externalFullyBefore) {
+            log.info("Partial external set sorts before first key, no intersection will be done");
+            return;
+        }
+
+        boolean externalFullyAfter = other.getMin().compareTo(this.max) > 0;
+        if (externalFullyAfter) {
+            results.clear();
+            return;
+        }
+
+        int originalSize = results.size();
+        results.removeIf(result -> nominate(result, other.getMin(), other.getMax(), other.getResults()));
+
+        int newSize = results.size();
+        int delta = originalSize - newSize;
+        log.info("Partial intersection eliminated {} candidates", delta);
+    }
+
+    /**
+     * A candidate is nominated for removal if it lies before the start of the external set, or if the candidate is within the bounds of the external set but
+     * not found in the external set.
+     * <p>
+     * A candidate is NOT nominated for removal if it sorts after the end of the external set.
+     *
+     * @param candidate
+     *            the candidate
+     * @param min
+     *            the minimum value of the external set
+     * @param max
+     *            the maximum value of the external set
+     * @param otherResults
+     *            the external set
+     * @return true if the candidate should be removed
+     */
+    private boolean nominate(Key candidate, Key min, Key max, Set<Key> otherResults) {
+        return candidate.compareTo(min) < 0 || candidate.compareTo(max) <= 0 && !otherResults.contains(candidate);
+    }
+
+    private boolean isIntersectionPossible(ScanResult other) {
+        boolean otherMinInBounds = withinBounds(other.getMin());
+        boolean otherMaxInBounds = withinBounds(other.getMax());
+        return otherMinInBounds || otherMaxInBounds;
+    }
+
+    private boolean isFullIntersection(ScanResult other) {
+        boolean otherMinInBounds = withinBounds(other.getMin());
+        boolean otherMaxInBounds = withinBounds(other.getMax());
+        return otherMinInBounds && otherMaxInBounds;
+    }
+
+    private boolean withinBounds(Key key) {
+        return min.compareTo(key) <= 0 && max.compareTo(key) >= 0;
+    }
+
+    /**
+     * Bulk add method
+     *
+     * @param keys
+     *            the set of keys to add
+     */
+    public void addKeys(Set<Key> keys) {
+        for (Key key : keys) {
+            addKey(key);
+        }
+    }
+
+    /**
+     * Adds a key to the result set, checking the key against the existing min or max value.
+     */
+    public void addKey(Key key) {
+        if (min == null) {
+            min = key;
+        } else if (key.compareTo(min) < 0) {
+            min = key;
+        }
+
+        if (max == null) {
+            max = key;
+        } else if (key.compareTo(max) > 0) {
+            max = key;
+        }
+
+        results.add(key);
+    }
+
+    /**
+     * Update the source given an iterator
+     *
+     * @param iter
+     *            an implementation of a {@link BaseDocIdIterator}
+     */
+    public void updateSource(BaseDocIdIterator iter) {
+        if (iter instanceof RegexDocIdIterator) {
+            source = SOURCE.ER;
+        } else if (iter instanceof RangeDocIdIterator) {
+            source = SOURCE.RANGE;
+        } else if (iter instanceof ListDocIdIterator) {
+            source = SOURCE.LIST;
+        } else if (iter instanceof DocIdIterator) {
+            source = SOURCE.EQ;
+        }
+    }
+
+    public SOURCE getSource() {
+        return source;
+    }
+
+    protected void setSource(SOURCE source) {
+        this.source = source;
+    }
+
+    public void setTimeout(boolean timeout) {
+        this.timeout = timeout;
+    }
+
+    public boolean isTimeout() {
+        return timeout;
+    }
+
+    public Key getMin() {
+        return min;
+    }
+
+    public Key getMax() {
+        return max;
+    }
+
+    public Set<Key> getResults() {
+        return results;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/next/ScanResult.java
+++ b/warehouse/query-core/src/main/java/datawave/next/ScanResult.java
@@ -80,7 +80,7 @@ public class ScanResult {
 
         if (other.isTimeout()) {
 
-            if (allowPartialIntersections) {
+            if (!allowPartialIntersections) {
                 return;
             }
 
@@ -227,6 +227,10 @@ public class ScanResult {
 
     public void setTimeout(boolean timeout) {
         this.timeout = timeout;
+    }
+
+    public void setAllowPartialIntersections(boolean allowPartialIntersections) {
+        this.allowPartialIntersections = allowPartialIntersections;
     }
 
     public boolean isTimeout() {

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
@@ -131,6 +131,7 @@ public class DocumentIdProducer implements RunnableWithContext {
             next.addOption(QueryOptions.DATATYPE_FILTER, settings.getOptions().get(QueryOptions.DATATYPE_FILTER));
         }
         next.addOption(DocIdQueryIterator.BATCH_SIZE, String.valueOf(config.getCandidateBatchSize()));
+        next.addOption(DocIdQueryIterator.PARTIAL_INTERSECTIONS, String.valueOf(config.isAllowPartialIntersections()));
         return next;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScannerConfig.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScannerConfig.java
@@ -39,6 +39,7 @@ public class DocumentScannerConfig implements Serializable {
 
     // batch ids to minimize new scanner connections
     private int candidateBatchSize = 1;
+    private boolean allowPartialIntersections = false;
 
     // the number of document ids/result documents to buffer
     private int candidateQueueCapacity = 1;
@@ -405,5 +406,13 @@ public class DocumentScannerConfig implements Serializable {
 
     public void setRetrievalConsistencyLevel(String retrievalConsistencyLevel) {
         this.retrievalConsistencyLevel = retrievalConsistencyLevel;
+    }
+
+    public boolean isAllowPartialIntersections() {
+        return allowPartialIntersections;
+    }
+
+    public void setAllowPartialIntersections(boolean allowPartialIntersections) {
+        this.allowPartialIntersections = allowPartialIntersections;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/next/ScanResultTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/ScanResultTest.java
@@ -239,13 +239,13 @@ public class ScanResultTest {
     }
 
     private void testPartialIntersection(ScanResult left, ScanResult right, int expected) {
-        setPartial(right);
+        setPartial(left, right);
         left.intersect(right);
         assertEquals(expected, left.getResults().size());
     }
 
     private void testPartialIntersection(ScanResult left, ScanResult right, Set<Integer> expected) {
-        setPartial(right);
+        setPartial(left, right);
         left.intersect(right);
         assertResults(expected, left.getResults());
     }
@@ -253,12 +253,16 @@ public class ScanResultTest {
     /**
      * Utility method that configures the ScanResult so it can be considered for a partial intersection
      *
-     * @param scanResult
-     *            the ScanResult
+     * @param left
+     *            the left ScanResult
+     * @param right
+     *            the right ScanResult
      */
-    private void setPartial(ScanResult scanResult) {
-        scanResult.setSource(SOURCE.EQ);
-        scanResult.setTimeout(true);
+    private void setPartial(ScanResult left, ScanResult right) {
+        left.setAllowPartialIntersections(true);
+        right.setAllowPartialIntersections(true);
+        right.setSource(SOURCE.EQ);
+        right.setTimeout(true);
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/next/ScanResultTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/ScanResultTest.java
@@ -1,0 +1,403 @@
+package datawave.next;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.Test;
+
+import datawave.next.ScanResult.SOURCE;
+
+/**
+ * Test for the {@link ScanResult} class.
+ * <p>
+ * Most on exercising the {@link ScanResult#union(ScanResult)} and {@link ScanResult#intersect(ScanResult)} methods.
+ * <p>
+ * Special attention is given to {@link ScanResult#partialIntersection(ScanResult)}.
+ */
+public class ScanResultTest {
+
+    private static final String ROW = "row";
+
+    // a base that allows integer values to appear in sorted order
+    private final int base = 1_000_000;
+
+    @Test
+    public void testAddKeys() {
+        ScanResult result = new ScanResult();
+        Set<Key> keys = createKeys(5);
+        result.addKeys(keys);
+        assertEquals(5, result.getResults().size());
+    }
+
+    @Test
+    public void testMinMax() {
+        ScanResult result = new ScanResult();
+        Set<Key> keys = createKeys(50);
+        result.addKeys(keys);
+
+        assertResult(result.getMin(), 1);
+        assertResult(result.getMax(), 50);
+    }
+
+    @Test
+    public void testUnion() {
+        ScanResult left = createScanResult(1, 3);
+        ScanResult right = createScanResult(2, 4);
+        left.union(right);
+        assertResults(Set.of(1, 2, 3, 4), left.getResults());
+        assertFalse(left.isTimeout());
+        assertFalse(right.isTimeout());
+    }
+
+    @Test
+    public void testUnionOfPartialResult() {
+        ScanResult left = createScanResult(1, 3);
+        ScanResult right = createScanResult(2, 4);
+        right.setTimeout(true);
+        assertFalse(left.isTimeout());
+        assertTrue(right.isTimeout());
+
+        left.union(right);
+        assertResults(Set.of(1, 2, 3, 4), left.getResults());
+        assertTrue(left.isTimeout());
+        assertTrue(right.isTimeout());
+    }
+
+    @Test
+    public void testStandardIntersection_otherSubSet() {
+        ScanResult left = createScanResult(1, 2, 3, 4, 5);
+        ScanResult right = createScanResult(2, 3, 4);
+        testStandardIntersection(left, right, Set.of(2, 3, 4));
+    }
+
+    @Test
+    public void testStandardIntersection_otherSuperSetBefore() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(2, 3, 4);
+        testStandardIntersection(left, right, Set.of(4));
+    }
+
+    @Test
+    public void testStandardIntersection_otherSuperSetAfter() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(6, 7, 8);
+        testStandardIntersection(left, right, Set.of(6));
+    }
+
+    @Test
+    public void testStandardIntersection_otherDisjointSetBefore() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(1, 2, 3);
+        testStandardIntersection(left, right, 0);
+    }
+
+    @Test
+    public void testStandardIntersection_otherDisjointSetAfter() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(7, 8, 9);
+        testStandardIntersection(left, right, 0);
+    }
+
+    // some partial intersections to illustrate the difference
+
+    @Test
+    public void testPartialIntersection_otherSubSet() {
+        ScanResult left = createScanResult(1, 2, 3, 4, 5);
+        ScanResult right = createScanResult(2, 4);
+        // partial intersection should remove element 1 and 3
+        testPartialIntersection(left, right, Set.of(2, 4, 5));
+    }
+
+    @Test
+    public void testPartialIntersection_otherSuperSetBefore() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(2, 3, 4);
+        testPartialIntersection(left, right, Set.of(4, 5, 6));
+    }
+
+    @Test
+    public void testPartialIntersection_otherSuperSetAfter() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(5, 7, 9);
+        // partial intersection should remove 4 and 6, functionally equivalent to a standard intersection
+        testPartialIntersection(left, right, Set.of(5));
+    }
+
+    @Test
+    public void testPartialIntersection_otherDisjointSetBefore() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(1, 2, 3);
+        // partial intersection *might* overlap with the left hand side, left remains intact because of the unknown
+        testPartialIntersection(left, right, Set.of(4, 5, 6));
+    }
+
+    @Test
+    public void testPartialIntersection_otherDisjointSetAfter() {
+        ScanResult left = createScanResult(4, 5, 6);
+        ScanResult right = createScanResult(7, 8, 9);
+        testPartialIntersection(left, right, 0);
+    }
+
+    // test some bulk operations
+
+    @Test
+    public void testBulkPartialIntersection_otherSubSet() {
+        ScanResult left = createScanResultRange(1, 90);
+        ScanResult right = createScanResultRange(21, 30);
+        // partial intersection eliminates [1 to 20]
+        testPartialIntersection(left, right, 70);
+    }
+
+    @Test
+    public void testBulkPartialIntersection_otherSuperSetBefore() {
+        ScanResult left = createScanResultRange(21, 40);
+        ScanResult right = createScanResultRange(11, 30);
+        testPartialIntersection(left, right, 20);
+    }
+
+    @Test
+    public void testBulkPartialIntersection_otherSuperSetAfter() {
+        ScanResult left = createScanResultRange(21, 60);
+        ScanResult right = createScanResultRange(51, 90);
+        // partial intersection removes everything before the first key [21-50]
+        testPartialIntersection(left, right, 10);
+    }
+
+    @Test
+    public void testBulkPartialIntersection_otherDisjointSetBefore() {
+        ScanResult left = createScanResultRange(41, 80);
+        ScanResult right = createScanResultRange(11, 21);
+        // partial intersection *might* overlap with the left hand side, left remains intact because of the unknown
+        testPartialIntersection(left, right, 40);
+    }
+
+    @Test
+    public void testBulkPartialIntersection_otherDisjointSetAfter() {
+        ScanResult left = createScanResultRange(21, 40);
+        ScanResult right = createScanResultRange(51, 60);
+        testPartialIntersection(left, right, 0);
+    }
+
+    @Test
+    public void testPartialIntersectionNotPossibleWithTimeoutRegex() {
+        ScanResult left = createScanResult(3, 4);
+        ScanResult right = createScanResult(1, 2);
+        right.setTimeout(true);
+        right.setSource(SOURCE.ER);
+
+        left.intersect(right);
+
+        // a regex timeout cannot be intersected
+        assertResults(Set.of(3, 4), left.getResults());
+        assertFalse(left.isTimeout());
+        assertTrue(right.isTimeout());
+    }
+
+    @Test
+    public void testPartialIntersectionNotPossibleWithTimeoutRange() {
+        ScanResult left = createScanResult(3, 4);
+        ScanResult right = createScanResult(1, 2);
+        right.setTimeout(true);
+        right.setSource(SOURCE.RANGE);
+
+        left.intersect(right);
+
+        // a bounded range timeout cannot be intersected
+        assertResults(Set.of(3, 4), left.getResults());
+        assertFalse(left.isTimeout());
+        assertTrue(right.isTimeout());
+    }
+
+    @Test
+    public void testPartialIntersectionNotPossibleWithTimeoutList() {
+        ScanResult left = createScanResult(3, 4);
+        ScanResult right = createScanResult(1, 2);
+        right.setTimeout(true);
+        right.setSource(SOURCE.LIST);
+
+        left.intersect(right);
+
+        // a list ivarator timeout cannot be intersected
+        assertResults(Set.of(3, 4), left.getResults());
+        assertFalse(left.isTimeout());
+        assertTrue(right.isTimeout());
+    }
+
+    private void testStandardIntersection(ScanResult left, ScanResult right, int expected) {
+        left.intersect(right);
+        assertEquals(expected, left.getResults().size());
+    }
+
+    private void testStandardIntersection(ScanResult left, ScanResult right, Set<Integer> expected) {
+        left.intersect(right);
+        assertResults(expected, left.getResults());
+    }
+
+    private void testPartialIntersection(ScanResult left, ScanResult right, int expected) {
+        setPartial(right);
+        left.intersect(right);
+        assertEquals(expected, left.getResults().size());
+    }
+
+    private void testPartialIntersection(ScanResult left, ScanResult right, Set<Integer> expected) {
+        setPartial(right);
+        left.intersect(right);
+        assertResults(expected, left.getResults());
+    }
+
+    /**
+     * Utility method that configures the ScanResult so it can be considered for a partial intersection
+     *
+     * @param scanResult
+     *            the ScanResult
+     */
+    private void setPartial(ScanResult scanResult) {
+        scanResult.setSource(SOURCE.EQ);
+        scanResult.setTimeout(true);
+    }
+
+    /**
+     * Creates a ScanResult for the given indices
+     *
+     * @param indices
+     *            a list of indices
+     * @return a ScanResult
+     */
+    private ScanResult createScanResult(int... indices) {
+        ScanResult result = new ScanResult();
+        result.addKeys(createKeys(indices));
+        return result;
+    }
+
+    /**
+     * Creates a ScanResult for the given range
+     *
+     * @param start
+     *            the range start
+     * @param stop
+     *            the range stop
+     * @return a ScanResult
+     */
+    private ScanResult createScanResultRange(int start, int stop) {
+        ScanResult result = new ScanResult();
+        result.addKeys(createKeysForRange(start, stop));
+        return result;
+    }
+
+    /**
+     * Creates a number of keys from 1 to the upper bound
+     *
+     * @param num
+     *            the upper bound
+     * @return a set of Keys
+     */
+    private Set<Key> createKeys(int num) {
+        Set<Key> keys = new HashSet<>();
+        for (int i = 1; i <= num; i++) {
+            keys.add(createKey(i));
+        }
+        return keys;
+    }
+
+    /**
+     * Creates a number of keys, one for each index
+     *
+     * @param indices
+     *            a list of indices
+     * @return a set of Keys
+     */
+    private Set<Key> createKeys(int... indices) {
+        Set<Key> keys = new HashSet<>();
+        for (int i : indices) {
+            keys.add(createKey(i));
+        }
+        return keys;
+    }
+
+    /**
+     * Create a number of keys for the given range
+     *
+     * @param start
+     *            the range start
+     * @param end
+     *            the range stop
+     * @return a set of keys
+     */
+    private Set<Key> createKeysForRange(int start, int end) {
+        Set<Key> keys = new HashSet<>();
+        for (int i = start; i <= end; i++) {
+            keys.add(createKey(i));
+        }
+        return keys;
+    }
+
+    /**
+     * Create a key from the {@link #base} and the provided index
+     *
+     * @param index
+     *            the index
+     * @return a key
+     */
+    private Key createKey(int index) {
+        return new Key(ROW, String.valueOf(base + index));
+    }
+
+    /**
+     * Asserts that the key contains the provided index
+     *
+     * @param key
+     *            the key
+     * @param expected
+     *            the expected index
+     */
+    private void assertResult(Key key, int expected) {
+        int index = indexFromKey(key);
+        assertEquals(expected, index);
+    }
+
+    /**
+     * Assert that the results match the expectation, accounting for the base offset
+     *
+     * @param expected
+     *            the set of expected indices
+     * @param results
+     *            the set of results
+     */
+    private void assertResults(Set<Integer> expected, Set<Key> results) {
+        Set<Integer> resultIds = transformResults(results);
+        assertEquals(expected, resultIds);
+    }
+
+    /**
+     * Transform a set of keys into a set of integer indices
+     *
+     * @param results
+     *            the set of results
+     * @return a set of integers
+     */
+    private Set<Integer> transformResults(Set<Key> results) {
+        Set<Integer> ids = new HashSet<>();
+        for (Key key : results) {
+            int index = indexFromKey(key);
+            ids.add(index);
+        }
+        return ids;
+    }
+
+    /**
+     * Extract the index from the provided key, extracting the base portion
+     *
+     * @param key
+     *            the key
+     * @return the index
+     */
+    private int indexFromKey(Key key) {
+        String cf = key.getColumnFamily().toString();
+        return Integer.parseInt(cf) - base;
+    }
+}

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -216,6 +216,7 @@
         <property name="resultQueueOfferTimeMillis" value="25"/>
         <property name="resultQueuePollTimeMillis" value="5"/>
         <property name="scanTimeoutMillis" value="10000"/>
+        <property name="allowPartialIntersections" value="true" />
         <property name="useQueryIterator" value="true" />
         <!-- execution hints and consistency levels -->
         <property name="searchScanHintTable" value="shard"/>

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -526,6 +526,7 @@
         <property name="resultQueueOfferTimeMillis" value="25"/>
         <property name="resultQueuePollTimeMillis" value="5"/>
         <property name="scanTimeoutMillis" value="10000"/>
+        <property name="allowPartialIntersections" value="true" />
         <property name="useQueryIterator" value="true" />
         <!-- execution hints and consistency levels -->
         <property name="searchScanHintTable" value="shard"/>


### PR DESCRIPTION
A partial intersection is possible when the left hand set is complete and the right hand side is guaranteed to be in sorted order (i.e., an Equality term).

Feature flag partial intersection logic