### PR TITLE
Fix abstract functional query tests

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
@@ -62,6 +62,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -79,6 +80,7 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         FieldConfig generic = new GenericCityFields();
         generic.addReverseIndexField(CityField.STATE.name());
         generic.addReverseIndexField(CityField.CONTINENT.name());
+        CityDataManager.newInstance();
         DataTypeHadoopConfig dataType = new CitiesDataType(CityEntry.generic, generic);
 
         accumuloSetup.setData(FileType.CSV, dataType);

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeQueryTest.java
@@ -22,6 +22,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -54,6 +55,7 @@ public class CompositeQueryTest extends AbstractFunctionalQuery {
         for (String idx : generic.getIndexFields()) {
             generic.addReverseIndexField(idx);
         }
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/CompoundJexlQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompoundJexlQueryTest.java
@@ -21,6 +21,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -39,6 +40,7 @@ public class CompoundJexlQueryTest extends AbstractFunctionalQuery {
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.NUM.name());
         generic.addReverseIndexField(CityField.NUM.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
         dataTypes.add(new CitiesDataType((CityEntry.italy), generic));
 

--- a/warehouse/query-core/src/test/java/datawave/query/CountQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CountQueryTest.java
@@ -23,6 +23,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -48,6 +49,7 @@ public class CountQueryTest extends AbstractFunctionalQuery {
         for (String idx : generic.getIndexFields()) {
             generic.addReverseIndexField(idx);
         }
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/DataTypeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/DataTypeQueryTest.java
@@ -26,6 +26,7 @@ import datawave.query.testframework.BaseRawData;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -52,6 +53,7 @@ public class DataTypeQueryTest extends AbstractFunctionalQuery {
             generic.addReverseIndexField(idx);
         }
 
+        CityDataManager.newInstance();
         for (CityEntry entry : TEST_DATATYPES) {
             dataTypes.add(new CitiesDataType(entry, generic));
         }

--- a/warehouse/query-core/src/test/java/datawave/query/DelayedIndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/DelayedIndexOnlyQueryTest.java
@@ -15,6 +15,7 @@ import datawave.query.tables.ShardQueryLogic;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -48,6 +49,7 @@ public class DelayedIndexOnlyQueryTest extends AbstractFunctionalQuery {
         compositeFields.add(CitiesDataType.CityField.NUM.name());
         generic.addCompositeField(compositeFields);
 
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CitiesDataType.CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/ExpansionThresholdQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ExpansionThresholdQueryTest.java
@@ -20,6 +20,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -46,6 +47,7 @@ public class ExpansionThresholdQueryTest extends AbstractFunctionalQuery {
         for (String field : idx) {
             generic.addReverseIndexField(field);
         }
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/FilterFieldsQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FilterFieldsQueryTest.java
@@ -25,6 +25,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -48,6 +49,7 @@ public class FilterFieldsQueryTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/FilterFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FilterFunctionQueryTest.java
@@ -22,6 +22,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -47,6 +48,7 @@ public class FilterFunctionQueryTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.CODE.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
         dataTypes.add(new CitiesDataType(CityEntry.nullState, generic));
 

--- a/warehouse/query-core/src/test/java/datawave/query/GroupedFlattenQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/GroupedFlattenQueryTest.java
@@ -30,9 +30,9 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.FlattenData;
+import datawave.query.testframework.FlattenDataManager;
 import datawave.query.testframework.FlattenDataType;
 import datawave.query.testframework.FlattenDataType.FlattenBaseFields;
-import datawave.query.testframework.RawDataManager;
 import datawave.query.testframework.RawMetaData;
 
 /**
@@ -47,13 +47,12 @@ public class GroupedFlattenQueryTest extends AbstractFunctionalQuery {
 
     private static final FlattenMode flatMode = FlattenMode.GROUPED;
     private static final FlattenDataType flatten;
-    private static final RawDataManager manager;
 
     static {
         FieldConfig indexes = new GroupedIndexing();
         FlattenData data = new FlattenData(GroupedField.STARTDATE.name(), GroupedField.EVENTID.name(), flatMode, GroupedField.headers,
                         GroupedField.metadataMapping);
-        manager = FlattenDataType.getManager(data);
+        FlattenDataManager.newInstance(data);
         try {
             flatten = new FlattenDataType(FlattenDataType.FlattenEntry.cityFlatten, indexes, data);
         } catch (IOException | URISyntaxException e) {
@@ -68,7 +67,7 @@ public class GroupedFlattenQueryTest extends AbstractFunctionalQuery {
     }
 
     public GroupedFlattenQueryTest() {
-        super(manager);
+        super(FlattenDataType.getManager());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/GroupedNormalFlattenQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/GroupedNormalFlattenQueryTest.java
@@ -31,9 +31,9 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.FlattenData;
+import datawave.query.testframework.FlattenDataManager;
 import datawave.query.testframework.FlattenDataType;
 import datawave.query.testframework.FlattenDataType.FlattenBaseFields;
-import datawave.query.testframework.RawDataManager;
 import datawave.query.testframework.RawMetaData;
 
 /**
@@ -48,13 +48,12 @@ public class GroupedNormalFlattenQueryTest extends AbstractFunctionalQuery {
 
     private static final FlattenMode flatMode = FlattenMode.GROUPED_AND_NORMAL;
     private static final FlattenDataType flatten;
-    private static final RawDataManager manager;
 
     static {
         FieldConfig indexes = new GroupedNormalIndexing();
         FlattenData data = new FlattenData(GroupedNormalField.STARTDATE.name(), GroupedNormalField.EVENTID.name(), flatMode, GroupedNormalField.headers,
                         GroupedNormalField.metadataMapping);
-        manager = FlattenDataType.getManager(data);
+        FlattenDataManager.newInstance(data);
         try {
             flatten = new FlattenDataType(FlattenDataType.FlattenEntry.cityFlatten, indexes, data);
         } catch (IOException | URISyntaxException e) {
@@ -69,7 +68,7 @@ public class GroupedNormalFlattenQueryTest extends AbstractFunctionalQuery {
     }
 
     public GroupedNormalFlattenQueryTest() {
-        super(manager);
+        super(FlattenDataType.getManager());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/GroupsQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/GroupsQueryTest.java
@@ -19,6 +19,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
+import datawave.query.testframework.GroupsDataManager;
 import datawave.query.testframework.GroupsDataType;
 import datawave.query.testframework.GroupsDataType.GroupField;
 import datawave.query.testframework.GroupsDataType.GroupsEntry;
@@ -35,6 +36,7 @@ public class GroupsQueryTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig fields = new GroupsIndexConfiguration();
+        GroupsDataManager.newInstance();
         dataTypes.add(new GroupsDataType(GroupsEntry.cities, fields));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/IndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexOnlyQueryTest.java
@@ -17,6 +17,7 @@ import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
@@ -38,6 +39,7 @@ public class IndexOnlyQueryTest extends AbstractFunctionalQuery {
         generic.addIndexField(CityField.COUNTRY.name());
         generic.addIndexOnlyField(CityField.STATE.name());
 
+        CityDataManager.newInstance();
         accumuloSetup.setData(FileType.CSV, new CitiesDataType(CitiesDataType.CityEntry.generic, generic));
         client = accumuloSetup.loadTables(log);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/IndexValueHoleQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexValueHoleQueryTest.java
@@ -24,6 +24,7 @@ import datawave.query.testframework.BaseShardIdRange;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -51,6 +52,7 @@ public class IndexValueHoleQueryTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         // add two datatypes that contain different indexes - this will create an index hole
         FieldConfig noHoles = new NoHoleFields();
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, noHoles));
 
         // because the CODE field is not indexed the type must be specified in the configuration

--- a/warehouse/query-core/src/test/java/datawave/query/IpAddressQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IpAddressQueryTest.java
@@ -19,6 +19,7 @@ import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.IpAddrFields;
+import datawave.query.testframework.IpAddressDataManager;
 import datawave.query.testframework.IpAddressDataType;
 import datawave.query.testframework.IpAddressDataType.IpAddrEntry;
 import datawave.query.testframework.IpAddressDataType.IpAddrField;
@@ -33,6 +34,7 @@ public class IpAddressQueryTest extends AbstractFunctionalQuery {
     @BeforeClass
     public static void filterSetup() throws Exception {
         FieldConfig fieldInfo = new IpAddrFields();
+        IpAddressDataManager.newInstance();
         DataTypeHadoopConfig dataType = new IpAddressDataType(IpAddrEntry.ipbase, fieldInfo);
         accumuloSetup.setData(FileType.CSV, dataType);
         client = accumuloSetup.loadTables(log);

--- a/warehouse/query-core/src/test/java/datawave/query/IvaratorYieldingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IvaratorYieldingTest.java
@@ -40,6 +40,7 @@ import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -68,6 +69,7 @@ public class IvaratorYieldingTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(NUM.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CitiesDataType.CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/JexlNumericQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/JexlNumericQueryTest.java
@@ -26,6 +26,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -43,6 +44,7 @@ public class JexlNumericQueryTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.NUM.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/LuceneQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LuceneQueryTest.java
@@ -21,6 +21,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.GenericCityFields;
@@ -35,6 +36,7 @@ public class LuceneQueryTest extends AbstractFunctionalQuery {
     @BeforeClass
     public static void filterSetup() throws Exception {
         FieldConfig generic = new GenericCityFields();
+        CityDataManager.newInstance();
         accumuloSetup.setData(FileType.CSV, new CitiesDataType(CityEntry.generic, generic));
         client = accumuloSetup.loadTables(log);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/MatchRegexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MatchRegexTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -41,6 +42,7 @@ public class MatchRegexTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.STATE.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
         dataTypes.add(new CitiesDataType(nullState, generic));
 

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionIndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionIndexOnlyQueryTest.java
@@ -21,6 +21,7 @@ import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -31,7 +32,7 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
     @ClassRule
     public static AccumuloSetup accumuloSetup = new AccumuloSetup();
 
-    private static final Logger log = Logger.getLogger(MaxExpansionRegexQueryTest.class);
+    private static final Logger log = Logger.getLogger(MaxExpansionIndexOnlyQueryTest.class);
 
     @BeforeClass
     public static void filterSetup() throws Exception {
@@ -40,6 +41,7 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         max.addIndexOnlyField(CitiesDataType.CityField.CITY.name());
         max.addIndexOnlyField(CitiesDataType.CityField.STATE.name());
 
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CitiesDataType.CityEntry.maxExp, max));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionQueryTest.java
@@ -24,6 +24,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -49,6 +50,7 @@ public class MaxExpansionQueryTest extends AbstractFunctionalQuery {
         }
         generic.addIndexOnlyField(CityField.COUNTRY.name());
         generic.addIndexOnlyField(CityField.CODE.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
         FieldConfig paris = new GenericCityFields();
         paris.addIndexField(CityField.COUNTRY.name());

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -27,6 +27,7 @@ import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -49,6 +50,7 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig max = new MaxExpandCityFields();
 
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CitiesDataType.CityEntry.maxExp, max));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/MiscQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MiscQueryTest.java
@@ -36,6 +36,7 @@ import datawave.query.testframework.BaseShardIdRange;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -60,6 +61,7 @@ public class MiscQueryTest extends AbstractFunctionalQuery {
         for (String idx : generic.getIndexFields()) {
             generic.addReverseIndexField(idx);
         }
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/MultiValueQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MultiValueQueryTest.java
@@ -18,6 +18,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -38,6 +39,7 @@ public class MultiValueQueryTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig multi = new MultiValueCityFields();
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.multivalue, multi));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/NormalFlattenQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/NormalFlattenQueryTest.java
@@ -31,9 +31,9 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.FlattenData;
+import datawave.query.testframework.FlattenDataManager;
 import datawave.query.testframework.FlattenDataType;
 import datawave.query.testframework.FlattenDataType.FlattenBaseFields;
-import datawave.query.testframework.RawDataManager;
 import datawave.query.testframework.RawMetaData;
 
 /**
@@ -48,13 +48,12 @@ public class NormalFlattenQueryTest extends AbstractFunctionalQuery {
 
     protected static final FlattenMode flatMode = FlattenMode.NORMAL;
     protected static final FlattenDataType flatten;
-    protected static final RawDataManager manager;
 
     static {
         FieldConfig indexes = new NormalIndexing();
         FlattenData data = new FlattenData(NormalField.STARTDATE.name(), NormalField.EVENTID.name(), flatMode, NormalField.headers,
                         NormalField.metadataMapping);
-        manager = FlattenDataType.getManager(data);
+        FlattenDataManager.newInstance(data);
         try {
             flatten = new FlattenDataType(FlattenDataType.FlattenEntry.cityFlatten, indexes, data);
         } catch (IOException | URISyntaxException e) {
@@ -69,7 +68,7 @@ public class NormalFlattenQueryTest extends AbstractFunctionalQuery {
     }
 
     public NormalFlattenQueryTest() {
-        super(manager);
+        super(FlattenDataType.getManager());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/PushdownQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/PushdownQueryTest.java
@@ -20,6 +20,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -40,6 +41,7 @@ public class PushdownQueryTest extends AbstractFunctionalQuery {
         generic.addIndexField(CityField.CODE.name());
         generic.addIndexOnlyField(CityField.CODE.name());
         generic.addReverseIndexField(CityField.CODE.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/QueryAuthsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryAuthsTest.java
@@ -32,6 +32,7 @@ import datawave.query.testframework.BaseRawData;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -49,6 +50,7 @@ public class QueryAuthsTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/QueryPlanTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryPlanTest.java
@@ -26,6 +26,7 @@ import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -59,6 +60,7 @@ public class QueryPlanTest extends AbstractFunctionalQuery {
         generic.addIndexField(CitiesDataType.CityField.STATE.name());
         generic.addReverseIndexField(CitiesDataType.CityField.STATE.name());
         generic.addReverseIndexField(CitiesDataType.CityField.CONTINENT.name());
+        CityDataManager.newInstance();
         DataTypeHadoopConfig dataType = new CitiesDataType(CitiesDataType.CityEntry.generic, generic);
         accumuloSetup.setData(FileType.CSV, dataType);
 

--- a/warehouse/query-core/src/test/java/datawave/query/RangeQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/RangeQueryTest.java
@@ -28,6 +28,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -48,6 +49,7 @@ public class RangeQueryTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.NUM.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/RegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/RegexQueryTest.java
@@ -27,6 +27,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -57,6 +58,7 @@ public class RegexQueryTest extends AbstractFunctionalQuery {
         generic.addIndexField(CityField.COUNTRY.name());
         generic.addIndexOnlyField(CityField.COUNTRY.name());
 
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/ScanConsistencyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ScanConsistencyQueryTest.java
@@ -34,6 +34,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -56,6 +57,7 @@ public class ScanConsistencyQueryTest extends AbstractFunctionalQuery {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.NUM.name());
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/SimpleFlattenQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SimpleFlattenQueryTest.java
@@ -30,9 +30,9 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.FlattenData;
+import datawave.query.testframework.FlattenDataManager;
 import datawave.query.testframework.FlattenDataType;
 import datawave.query.testframework.FlattenDataType.FlattenBaseFields;
-import datawave.query.testframework.RawDataManager;
 import datawave.query.testframework.RawMetaData;
 
 /**
@@ -47,14 +47,12 @@ public class SimpleFlattenQueryTest extends AbstractFunctionalQuery {
 
     private static final FlattenMode flatMode = FlattenMode.SIMPLE;
     private static final FlattenDataType flatten;
-    // each flatten mode will have a separate manager
-    private static final RawDataManager manager;
 
     static {
         FieldConfig indexes = new SimpleIndexing();
         FlattenData data = new FlattenData(SimpleField.STARTDATE.name(), SimpleField.EVENTID.name(), flatMode, SimpleField.headers,
                         SimpleField.metadataMapping);
-        manager = FlattenDataType.getManager(data);
+        FlattenDataManager.newInstance(data);
         try {
             flatten = new FlattenDataType(FlattenDataType.FlattenEntry.cityFlatten, indexes, data);
         } catch (IOException | URISyntaxException e) {
@@ -69,7 +67,7 @@ public class SimpleFlattenQueryTest extends AbstractFunctionalQuery {
     }
 
     public SimpleFlattenQueryTest() {
-        super(manager);
+        super(FlattenDataType.getManager());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/TextFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TextFunctionQueryTest.java
@@ -21,6 +21,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -37,6 +38,7 @@ public class TextFunctionQueryTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/UnevaluatedFieldsQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UnevaluatedFieldsQueryTest.java
@@ -26,6 +26,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -45,6 +46,7 @@ public class UnevaluatedFieldsQueryTest extends AbstractFunctionalQuery {
     public static void filterSetup() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig fldConfig = new UnevaluatedCityFields();
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.generic, fldConfig));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/UnindexedNumericQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UnindexedNumericQueryTest.java
@@ -31,6 +31,7 @@ import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityEntry;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -52,6 +53,7 @@ public class UnindexedNumericQueryTest extends AbstractFunctionalQuery {
         for (String idx : generic.getIndexFields()) {
             generic.addReverseIndexField(idx);
         }
+        CityDataManager.newInstance();
         dataTypes.add(new CitiesDataType(CityEntry.usa, generic));
 
         accumuloSetup.setData(FileType.CSV, dataTypes);

--- a/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
@@ -31,6 +31,7 @@ import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
 import datawave.query.testframework.QueryLogicTestHarness;
+import datawave.query.testframework.cardata.CarDataManager;
 import datawave.query.testframework.cardata.CarsDataType;
 import datawave.query.testframework.cardata.CarsDataType.CarField;
 import datawave.query.testframework.cardata.GenericCarFields;
@@ -60,6 +61,8 @@ public class IndexQueryLogicTest extends AbstractFunctionalQuery {
     public static void setupClass() throws Exception {
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCarFields();
+
+        CarDataManager.newInstance(); // Can I do this dynamically?
         dataTypes.add(new CarsDataType(CarsDataType.CarEntry.tesla, generic));
         dataTypes.add(new CarsDataType(CarsDataType.CarEntry.ford, generic));
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetedQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/facets/FacetedQueryLogicTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import com.google.common.collect.Sets;
 
 import datawave.core.query.result.event.DefaultResponseObjectFactory;
-import datawave.helpers.PrintUtility;
 import datawave.marking.MarkingFunctions;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.RebuildingScannerTestHelper.INTERRUPT;
@@ -38,6 +37,7 @@ import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
 import datawave.query.testframework.CitiesDataType.CityField;
+import datawave.query.testframework.CityDataManager;
 import datawave.query.testframework.DataTypeHadoopConfig;
 import datawave.query.testframework.FieldConfig;
 import datawave.query.testframework.FileType;
@@ -63,10 +63,11 @@ public class FacetedQueryLogicTest extends AbstractFunctionalQuery {
 
     @BeforeClass
     public static void setupClass() throws Exception {
-        Logger.getLogger(PrintUtility.class).setLevel(Level.DEBUG);
+        Logger.getLogger(FacetedQueryLogicTest.class).setLevel(Level.DEBUG);
         Collection<DataTypeHadoopConfig> dataTypes = new ArrayList<>();
         FieldConfig generic = new GenericCityFields();
         generic.addIndexField(CityField.COUNTRY.name());
+        CityDataManager.newInstance();
         dataTypes.add(new FacetedCitiesDataType(CitiesDataType.CityEntry.generic, generic));
         dataTypes.add(new FacetedCitiesDataType(CitiesDataType.CityEntry.usa, generic));
         dataTypes.add(new FacetedCitiesDataType(CitiesDataType.CityEntry.italy, generic));

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/testframework/SSDeepDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/testframework/SSDeepDataManager.java
@@ -28,9 +28,19 @@ import datawave.query.testframework.RawData;
 public class SSDeepDataManager extends AbstractDataManager {
 
     private static final Logger log = Logger.getLogger(SSDeepDataManager.class);
+    private static SSDeepDataManager INSTANCE = new SSDeepDataManager();
 
-    public SSDeepDataManager() {
+    private SSDeepDataManager() {
         super(SSDeepField.EVENT_ID.name(), SSDeepField.PROCESSING_DATE.name(), SSDeepField.getFieldsMetadata());
+    }
+
+    public static SSDeepDataManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized SSDeepDataManager newInstance() {
+        INSTANCE = new SSDeepDataManager();
+        return INSTANCE;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/testframework/SSDeepDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/testframework/SSDeepDataType.java
@@ -24,7 +24,6 @@ import datawave.ingest.mapreduce.handler.ssdeep.SSDeepIndexHandler;
 import datawave.marking.MarkingFunctions;
 import datawave.query.testframework.AbstractDataTypeConfig;
 import datawave.query.testframework.FieldConfig;
-import datawave.query.testframework.RawDataManager;
 import datawave.query.testframework.RawMetaData;
 
 /**
@@ -173,14 +172,6 @@ public class SSDeepDataType extends AbstractDataTypeConfig {
         }
     }
 
-    // ==================================
-    // data manager info
-    private static final RawDataManager ssdeepManager = new SSDeepDataManager();
-
-    public static RawDataManager getManager() {
-        return ssdeepManager;
-    }
-
     /**
      * Creates a ssdeep datatype entry with all the key/value configuration settings.
      *
@@ -212,7 +203,7 @@ public class SSDeepDataType extends AbstractDataTypeConfig {
      *             invalid test data file
      */
     public SSDeepDataType(final String ssdeep, final String ingestFile, final FieldConfig config) throws IOException, URISyntaxException {
-        super(ssdeep, ingestFile, config, ssdeepManager);
+        super(ssdeep, ingestFile, config, SSDeepDataManager.getInstance());
         // NOTE: see super for default settings
 
         // set datatype settings

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractDataTypeConfig.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractDataTypeConfig.java
@@ -57,6 +57,7 @@ public abstract class AbstractDataTypeConfig implements DataTypeHadoopConfig {
     private static final String TEST_VISIBILITY = "public";
     private static final String[] AUTH_VALUES = new String[] {"public", "private", "Euro", "NA"};
     private static final Authorizations TEST_AUTHS = new Authorizations(AUTH_VALUES);
+    private static RawDataManager manager;
 
     /**
      * Retrieves an {@link Authorizations} object to use for query.
@@ -156,6 +157,7 @@ public abstract class AbstractDataTypeConfig implements DataTypeHadoopConfig {
         this.ingestPath = url.toURI();
         this.dataType = dt;
         this.fieldConfig = config;
+        this.manager = manager;
 
         // default Hadoop settings - override if needed
         this.hConf.set(DataTypeHelper.Properties.DATA_NAME, this.dataType);
@@ -273,5 +275,9 @@ public abstract class AbstractDataTypeConfig implements DataTypeHadoopConfig {
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "{" + "dataType='" + dataType + '\'' + ", ingestPath=" + ingestPath + ", fieldConfig=" + fieldConfig + '}';
+    }
+
+    public static RawDataManager getManager() {
+        return manager;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/CitiesDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/CitiesDataType.java
@@ -185,14 +185,6 @@ public class CitiesDataType extends AbstractDataTypeConfig {
         }
     }
 
-    // ==================================
-    // data manager info
-    private static final RawDataManager cityManager = new CityDataManager();
-
-    public static RawDataManager getManager() {
-        return cityManager;
-    }
-
     /**
      * Creates a cities datatype entry with all of the key/value configuration settings.
      *
@@ -224,7 +216,7 @@ public class CitiesDataType extends AbstractDataTypeConfig {
      *             invalid test data file
      */
     public CitiesDataType(final String city, final String ingestFile, final FieldConfig config) throws IOException, URISyntaxException {
-        super(city, ingestFile, config, cityManager);
+        super(city, ingestFile, config, CityDataManager.getInstance());
 
         // NOTE: see super for default settings
         // set datatype settings

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/CityDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/CityDataManager.java
@@ -26,9 +26,19 @@ import datawave.query.testframework.CitiesDataType.CityField;
 public class CityDataManager extends AbstractDataManager {
 
     private static final Logger log = Logger.getLogger(CityDataManager.class);
+    private static CityDataManager INSTANCE = new CityDataManager();
 
-    public CityDataManager() {
+    private CityDataManager() {
         super(CityField.EVENT_ID.name(), CityField.START_DATE.name(), CityField.getFieldsMetadata());
+    }
+
+    public static CityDataManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized CityDataManager newInstance() {
+        INSTANCE = new CityDataManager();
+        return INSTANCE;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/FlattenDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/FlattenDataManager.java
@@ -22,15 +22,25 @@ import datawave.query.testframework.FlattenDataType.FlattenBaseFields;
 public class FlattenDataManager extends AbstractDataManager {
 
     private static final Logger log = Logger.getLogger(FlattenDataManager.class);
+    private static FlattenDataManager INSTANCE;
 
     private final FlattenData flatData;
+
+    public static FlattenDataManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized FlattenDataManager newInstance(final FlattenData data) {
+        INSTANCE = new FlattenDataManager(data);
+        return INSTANCE;
+    }
 
     /**
      *
      * @param data
      *            defines the configuration information for the requested flattener
      */
-    public FlattenDataManager(final FlattenData data) {
+    private FlattenDataManager(final FlattenData data) {
         super(FlattenBaseFields.EVENTID.name(), FlattenBaseFields.STARTDATE.name(), data.getMetadata());
         this.flatData = data;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/FlattenDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/FlattenDataType.java
@@ -2,7 +2,6 @@ package datawave.query.testframework;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -65,22 +64,6 @@ public class FlattenDataType extends AbstractDataTypeConfig {
         }
     }
 
-    // ==================================
-    // data manager for flatten is based upon the flatten mode - metadata may be different for each mode
-    private static volatile Map<FlattenMode,RawDataManager> manager = new EnumMap<>(FlattenMode.class);
-
-    public static RawDataManager getManager(final FlattenData data) {
-        FlattenMode mode = data.getMode();
-        if (!manager.containsKey(mode)) {
-            synchronized (manager) {
-                if (!manager.containsKey(mode)) {
-                    manager.put(mode, new FlattenDataManager(data));
-                }
-            }
-        }
-        return manager.get(mode);
-    }
-
     private static final Map<String,FlattenDataType> flattenTypes = new HashMap<>();
 
     static FlattenDataType getFlattenDataType(final String dataType) {
@@ -128,7 +111,7 @@ public class FlattenDataType extends AbstractDataTypeConfig {
      */
     public FlattenDataType(final String datatype, final String ingestFile, final FieldConfig fieldConfig, final FlattenData flattenData)
                     throws IOException, URISyntaxException {
-        super(datatype, ingestFile, FileType.JSON, fieldConfig, manager.get(flattenData.getMode()));
+        super(datatype, ingestFile, FileType.JSON, fieldConfig, FlattenDataManager.getInstance());
 
         this.flatData = flattenData;
 
@@ -153,8 +136,7 @@ public class FlattenDataType extends AbstractDataTypeConfig {
         // load raw test data into the data manager
         Set<String> anyFieldIndexes = new HashSet<>(fieldConfig.getIndexFields());
         anyFieldIndexes.addAll(fieldConfig.getReverseIndexFields());
-        RawDataManager curMgr = manager.get(flattenData.getMode());
-        curMgr.addTestData(this.ingestPath, this.dataType, anyFieldIndexes);
+        FlattenDataManager.getInstance().addTestData(this.ingestPath, this.dataType, anyFieldIndexes);
 
         log.debug(this.toString());
     }

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/GroupsDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/GroupsDataManager.java
@@ -20,9 +20,19 @@ import datawave.query.testframework.GroupsDataType.GroupField;
 public class GroupsDataManager extends AbstractDataManager {
 
     private static final Logger log = Logger.getLogger(GroupsDataManager.class);
+    private static GroupsDataManager INSTANCE = new GroupsDataManager();
 
-    public GroupsDataManager() {
+    private GroupsDataManager() {
         super(GroupField.EVENT_ID.name(), GroupField.START_DATE.name(), GroupField.getMetadata());
+    }
+
+    public static GroupsDataManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized GroupsDataManager newInstance() {
+        INSTANCE = new GroupsDataManager();
+        return INSTANCE;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/GroupsDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/GroupsDataType.java
@@ -142,14 +142,6 @@ public class GroupsDataType extends AbstractDataTypeConfig {
         }
     }
 
-    // ==================================
-    // data manager info
-    private static final RawDataManager manager = new GroupsDataManager();
-
-    public static RawDataManager getManager() {
-        return manager;
-    }
-
     /**
      * Creates a groups datatype entry with all of the key/value configuration settings.
      *
@@ -181,7 +173,7 @@ public class GroupsDataType extends AbstractDataTypeConfig {
      *             ingest file name error
      */
     public GroupsDataType(final String datatype, final String ingestFile, final FieldConfig config) throws IOException, URISyntaxException {
-        super(datatype, ingestFile, config, manager);
+        super(datatype, ingestFile, config, GroupsDataManager.getInstance());
 
         // NOTE: see super for default settings
         // set datatype settings

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/IpAddressDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/IpAddressDataManager.java
@@ -21,9 +21,19 @@ import datawave.query.testframework.IpAddressDataType.IpAddrField;
 public class IpAddressDataManager extends AbstractDataManager {
 
     private static final Logger log = Logger.getLogger(IpAddressDataManager.class);
+    private static IpAddressDataManager INSTANCE = new IpAddressDataManager();
 
-    public IpAddressDataManager() {
+    private IpAddressDataManager() {
         super(IpAddrField.EVENT_ID.name(), IpAddrField.START_DATE.name(), IpAddrField.getFieldsMetadata());
+    }
+
+    public static IpAddressDataManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized IpAddressDataManager newInstance() {
+        INSTANCE = new IpAddressDataManager();
+        return INSTANCE;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/IpAddressDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/IpAddressDataType.java
@@ -126,14 +126,6 @@ public class IpAddressDataType extends AbstractDataTypeConfig {
         }
     }
 
-    // ==================================
-    // data manager info
-    private static final RawDataManager manager = new IpAddressDataManager();
-
-    public static RawDataManager getManager() {
-        return manager;
-    }
-
     /**
      * Creates an ip address datatype entry with all of the key/value configuration settings.
      *
@@ -165,7 +157,7 @@ public class IpAddressDataType extends AbstractDataTypeConfig {
      *             ingest file name error
      */
     public IpAddressDataType(final String datatype, final String ingestFile, final FieldConfig config) throws IOException, URISyntaxException {
-        super(datatype, ingestFile, config, manager);
+        super(datatype, ingestFile, config, IpAddressDataManager.getInstance());
 
         // NOTE: see super for default settings
         // set datatype settings

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/cardata/CarDataManager.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/cardata/CarDataManager.java
@@ -22,9 +22,19 @@ import datawave.query.testframework.cardata.CarsDataType.CarField;
 public class CarDataManager extends AbstractDataManager {
 
     private static final Logger log = Logger.getLogger(CarDataManager.class);
+    private static CarDataManager INSTANCE = new CarDataManager();
 
-    public CarDataManager() {
+    private CarDataManager() {
         super(CarField.EVENT_ID.name(), CarField.START_DATE.name(), CarField.getFieldsMetadata());
+    }
+
+    public static CarDataManager getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized CarDataManager newInstance() {
+        INSTANCE = new CarDataManager();
+        return INSTANCE;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/cardata/CarsDataType.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/cardata/CarsDataType.java
@@ -23,7 +23,6 @@ import datawave.ingest.input.reader.EventRecordReader;
 import datawave.marking.MarkingFunctions;
 import datawave.query.testframework.AbstractDataTypeConfig;
 import datawave.query.testframework.FieldConfig;
-import datawave.query.testframework.RawDataManager;
 import datawave.query.testframework.RawMetaData;
 
 /**
@@ -181,14 +180,6 @@ public class CarsDataType extends AbstractDataTypeConfig {
         }
     }
 
-    // ==================================
-    // data manager info
-    private static final RawDataManager carManager = new CarDataManager();
-
-    public static RawDataManager getManager() {
-        return carManager;
-    }
-
     /**
      * Creates a cars datatype entry with all of the key/value configuration settings.
      *
@@ -220,7 +211,7 @@ public class CarsDataType extends AbstractDataTypeConfig {
      *             for URI Syntax exceptions
      */
     public CarsDataType(final String car, final String ingestFile, final FieldConfig config) throws IOException, URISyntaxException {
-        super(car, ingestFile, config, carManager);
+        super(car, ingestFile, config, CarDataManager.getInstance());
 
         // NOTE: see super for default settings
         // set datatype settings


### PR DESCRIPTION
The respective DataManager for the associated DataType was a single object referenced as a static variable in the DataType. If more than one Test class runs in the same JVM and loads the same key into the same DataManager a failed assertion will occur. This was already handled by not reusing forks in the surefire configuration. The issue that was recently seen though is related to flaky tests which should probably be investigated specifically at some point. But in any case when a test fails the 1st attempt we now have surefire or failsafe retry the test. But due to the static setup mentioned earlier, the test retries will result in failed assertions since it tries to reload the data into the DataManager. My current solution is to create a new DataManager in the `@BeforeClass` method in all the affected tests.