### PR TITLE
Change formatter to fail on diff instead of auto commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,21 +54,10 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" != "merge_group" ]]; then
           mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" clean formatter:format sortpom:sort impsort:sort -Dmaven.build.cache.enabled=false -Pautoformat -Dutils -Dservices -Dstarters
-          git status
-          git diff-index --quiet HEAD || (echo "Modified files found. Creating new commit with formatting fixes" && echo "diffs_found=true" >> "$GITHUB_ENV")
-        else
-          echo "Nothing to do"
-        fi
-    - name: Commit Changes
-      run: |
-        if [[ "$diffs_found" = true && "${{ github.event_name }}" != "merge_group" ]]; then
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "datawave@github.com"
-          git fetch origin
-          git checkout ${{ steps.extract_branch.outputs.branch }}
-          git pull origin ${{ steps.extract_branch.outputs.branch }} --no-rebase
-          git commit -am "GitHub Actions: Fix Formatting"
-          git push origin ${{ steps.extract_branch.outputs.branch }}
+          if ! git diff-index --quiet HEAD; then
+            echo "Code formatting issues detected. Please format locally.";
+            exit 1;
+          fi
         else
           echo "Nothing to do"
         fi

--- a/warehouse/core/src/main/java/datawave/edge/model/EdgeModelFields.java
+++ b/warehouse/core/src/main/java/datawave/edge/model/EdgeModelFields.java
@@ -40,8 +40,8 @@ public class EdgeModelFields implements Serializable {
         return baseFieldMap;
     }
 
-    public void setBaseFieldMap(Map<String,String> baseFieldMap){
-        this.baseFieldMap = baseFieldMap; 
+    public void setBaseFieldMap(Map<String,String> baseFieldMap) {
+        this.baseFieldMap = baseFieldMap;
         updateReverseMap(baseFieldMap);
     }
 

--- a/warehouse/core/src/main/java/datawave/edge/model/EdgeModelFields.java
+++ b/warehouse/core/src/main/java/datawave/edge/model/EdgeModelFields.java
@@ -40,8 +40,8 @@ public class EdgeModelFields implements Serializable {
         return baseFieldMap;
     }
 
-    public void setBaseFieldMap(Map<String,String> baseFieldMap) {
-        this.baseFieldMap = baseFieldMap;
+    public void setBaseFieldMap(Map<String,String> baseFieldMap){
+        this.baseFieldMap = baseFieldMap; 
         updateReverseMap(baseFieldMap);
     }
 


### PR DESCRIPTION
Before this change, PRs would essentially get "stalled" if incorrectly formatted changes were pushed. After the auto commit, there was no way to get the rest of the workflow jobs to run unless another commit was pushed.

This just gets rid of the auto commit and will instead make the user format locally and push their changes.

_An example of it working can be seen in the first commit._