### PR TITLE
Stop redundant workflow jobs from running after merge queue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,13 +94,21 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean install -Dsurefire.rerunFailingTestsCount=3 -Dutils -Dservices -Dstarters -DskipITs -DskipFormat
+        if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+          echo "Skipping... already ran job in merge queue."
+        else
+          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean install -Dsurefire.rerunFailingTestsCount=3 -Dutils -Dservices -Dstarters -DskipITs -DskipFormat
+        fi
     - name: Run Integration Tests
       env:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples -Dmaven.build.cache.enabled=false -Ddeploy -T1C verify -Dfailsafe.rerunFailingTestsCount=3 -Dutils -Dservices -Dstarters -DskipUTs -DskipFormat -DskipSpotbugs -Denforcer.skip=true -Dcheckstyle.skip=true
+        if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+          echo "Skipping... already ran job in merge queue."
+        else
+          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples -Dmaven.build.cache.enabled=false -Ddeploy -T1C verify -Dfailsafe.rerunFailingTestsCount=3 -Dutils -Dservices -Dstarters -DskipUTs -DskipFormat -DskipSpotbugs -Denforcer.skip=true -Dcheckstyle.skip=true
+        fi
 
   quickstart-build-and-test:
     runs-on: ubuntu-latest
@@ -135,8 +143,12 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
-        contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
+        if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+          echo "Skipping... already ran job in merge queue."
+        else
+          TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
+          contrib/datawave-quickstart/docker/docker-build.sh ${TAG} --docker-opts "${DOCKER_BUILD_OPTS}"
+        fi
 
   compose-build-and-test-latest-snapshots:
     runs-on: ubuntu-latest
@@ -165,45 +177,49 @@ jobs:
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
-          if [[ ${{ steps.extract_branch.outputs.branch }} =~ ^release/version* ]] then
-            echo "Nothing to do since this is a release branch."
+          if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+            echo "Skipping... already ran job in merge queue."
           else
-            # update datawave dependencies to use the latest snapshots
-            mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters versions:update-properties versions:update-parent -DallowSnapshots=true -Dincludes=gov.nsa.*
-          
-            mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Ddeploy -Dtar -DskipTests clean install
-          
-            # free up some space so that we don't run out
-            docker system prune -f
-            mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Ddeploy -Dtar -DskipTests clean
-          
-            cd docker
-            ./bootstrap.sh
-          
-            attempt=0
-            max_attempts=20
-            while [ $attempt -lt $max_attempts ]; do
-              attempt=$((attempt+1))
-          
-              echo "Starting docker compose (Attempt ${attempt}/${max_attempts})"
-              nohup docker compose up -d --no-recreate < /dev/null > compose.out 2>&1 &
-              sleep 60s
-              cat compose.out
-          
-              # check to see if the query service is running
-              QUERY="$(docker compose ps --status running --services | grep query || true)"
-          
-              if [ "$QUERY" == "query" ] ; then
-                echo "Docker compose started successfully"
-                break
-              elif [ $attempt -eq $max_attempts ] ; then
-                echo "Failed to start docker compose"
-                exit 1
-              fi
-            done
-          
-            cd scripts
-            ./testAll.sh
+            if [[ ${{ steps.extract_branch.outputs.branch }} =~ ^release/version* ]] then
+              echo "Nothing to do since this is a release branch."
+            else
+              # update datawave dependencies to use the latest snapshots
+              mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters versions:update-properties versions:update-parent -DallowSnapshots=true -Dincludes=gov.nsa.*
+            
+              mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Ddeploy -Dtar -DskipTests clean install
+            
+              # free up some space so that we don't run out
+              docker system prune -f
+              mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Ddeploy -Dtar -DskipTests clean
+            
+              cd docker
+              ./bootstrap.sh
+            
+              attempt=0
+              max_attempts=20
+              while [ $attempt -lt $max_attempts ]; do
+                attempt=$((attempt+1))
+            
+                echo "Starting docker compose (Attempt ${attempt}/${max_attempts})"
+                nohup docker compose up -d --no-recreate < /dev/null > compose.out 2>&1 &
+                sleep 60s
+                cat compose.out
+            
+                # check to see if the query service is running
+                QUERY="$(docker compose ps --status running --services | grep query || true)"
+            
+                if [ "$QUERY" == "query" ] ; then
+                  echo "Docker compose started successfully"
+                  break
+                elif [ $attempt -eq $max_attempts ] ; then
+                  echo "Failed to start docker compose"
+                  exit 1
+                fi
+              done
+            
+              cd scripts
+              ./testAll.sh
+            fi
           fi
       - name: Dump Logs
         if: failure()
@@ -239,39 +255,43 @@ jobs:
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
-          # set some bogus URLs to trigger dependency download via maven
-          DIST_URLS="-Durl.zookeeper=https://bogus.apache.org/zookeeper/zookeeper-3.7.2/apache-zookeeper-3.7.2-bin.tar.gz.tar.gz \
-                     -Durl.accumulo=https://bogus.apache.org/accumulo/2.1.3/accumulo-2.1.3-bin.tar.gz \
-                     -Durl.wildfly=https://bogus.jboss.org/wildfly/17.0.1.Final/wildfly-17.0.1.Final.tar.gz \
-                     -Durl.hadoop=https://bogus.apache.org/hadoop/common/hadoop-3.3.6/hadoop-3.3.6.tar.gz \
-                     -Durl.maven=https://bogus.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz"
-          
-          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Dquickstart-maven ${DIST_URLS} -Ddeploy -Dtar -DskipTests -Dmaven.build.cache.enabled=false clean install
-          # free up some space so that we don't run out
-          docker system prune -f
-          mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Dquickstart-maven ${DIST_URLS} -Ddeploy -Dtar -DskipTests -Dmaven.build.cache.enabled=false clean
-          cd docker
-          ./bootstrap.sh
-          attempt=0
-          max_attempts=20
-          while [ $attempt -lt $max_attempts ]; do
-            attempt=$((attempt+1))
-            echo "Starting docker compose (Attempt ${attempt}/${max_attempts})"
-            nohup docker compose up -d --no-recreate < /dev/null > compose.out 2>&1 &
-            sleep 60s
-            cat compose.out
-            # check to see if the query service is running
-            QUERY="$(docker compose ps --status running --services | grep query || true)"
-            if [ "$QUERY" == "query" ] ; then
-              echo "Docker compose started successfully"
-              break
-            elif [ $attempt -eq $max_attempts ] ; then
-              echo "Failed to start docker compose"
-              exit 1
-            fi
-          done
-          cd scripts
-          ./testAll.sh
+          if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+            echo "Skipping... already ran job in merge queue."
+          else
+            # set some bogus URLs to trigger dependency download via maven
+            DIST_URLS="-Durl.zookeeper=https://bogus.apache.org/zookeeper/zookeeper-3.7.2/apache-zookeeper-3.7.2-bin.tar.gz.tar.gz \
+                       -Durl.accumulo=https://bogus.apache.org/accumulo/2.1.3/accumulo-2.1.3-bin.tar.gz \
+                       -Durl.wildfly=https://bogus.jboss.org/wildfly/17.0.1.Final/wildfly-17.0.1.Final.tar.gz \
+                       -Durl.hadoop=https://bogus.apache.org/hadoop/common/hadoop-3.3.6/hadoop-3.3.6.tar.gz \
+                       -Durl.maven=https://bogus.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz"
+            
+            mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Dquickstart-maven ${DIST_URLS} -Ddeploy -Dtar -DskipTests -Dmaven.build.cache.enabled=false clean install
+            # free up some space so that we don't run out
+            docker system prune -f
+            mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors -Dutils -Dservices -Dstarters -Pcompose -Dmicroservice-docker -Dquickstart-docker -Dquickstart-maven ${DIST_URLS} -Ddeploy -Dtar -DskipTests -Dmaven.build.cache.enabled=false clean
+            cd docker
+            ./bootstrap.sh
+            attempt=0
+            max_attempts=20
+            while [ $attempt -lt $max_attempts ]; do
+              attempt=$((attempt+1))
+              echo "Starting docker compose (Attempt ${attempt}/${max_attempts})"
+              nohup docker compose up -d --no-recreate < /dev/null > compose.out 2>&1 &
+              sleep 60s
+              cat compose.out
+              # check to see if the query service is running
+              QUERY="$(docker compose ps --status running --services | grep query || true)"
+              if [ "$QUERY" == "query" ] ; then
+                echo "Docker compose started successfully"
+                break
+              elif [ $attempt -eq $max_attempts ] ; then
+                echo "Failed to start docker compose"
+                exit 1
+              fi
+            done
+            cd scripts
+            ./testAll.sh
+          fi
       - name: Dump Logs
         if: failure()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+        if [[ "${{ github.event_name }}" == "push" && "${{ github.triggering_actor }}" == "github-merge-queue" ]]; then
           echo "Skipping... already ran job in merge queue."
         else
           mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples,assemble,spotbugs -Dmaven.build.cache.enabled=false -Ddeploy -Ddist -T1C clean install -Dsurefire.rerunFailingTestsCount=3 -Dutils -Dservices -Dstarters -DskipITs -DskipFormat
@@ -104,7 +104,7 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+        if [[ "${{ github.event_name }}" == "push" && "${{ github.triggering_actor }}" == "github-merge-queue" ]]; then
           echo "Skipping... already ran job in merge queue."
         else
           mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples -Dmaven.build.cache.enabled=false -Ddeploy -T1C verify -Dfailsafe.rerunFailingTestsCount=3 -Dutils -Dservices -Dstarters -DskipUTs -DskipFormat -DskipSpotbugs -Denforcer.skip=true -Dcheckstyle.skip=true
@@ -143,7 +143,7 @@ jobs:
         USER_NAME: ${{ secrets.USER_NAME }}
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       run: |
-        if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+        if [[ "${{ github.event_name }}" == "push" && "${{ github.triggering_actor }}" == "github-merge-queue" ]]; then
           echo "Skipping... already ran job in merge queue."
         else
           TAG=$(mvn -s $GITHUB_WORKSPACE/.github/workflows/settings.xml -q -N -Dmaven.build.cache.enabled=false -Dexec.executable='echo' -Dexec.args='${project.version}' exec:exec)
@@ -177,7 +177,7 @@ jobs:
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.triggering_actor }}" == "github-merge-queue" ]]; then
             echo "Skipping... already ran job in merge queue."
           else
             if [[ ${{ steps.extract_branch.outputs.branch }} =~ ^release/version* ]] then
@@ -255,7 +255,7 @@ jobs:
           USER_NAME: ${{ secrets.USER_NAME }}
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" && contains("${{ github.triggering_actor }}", 'github-merge-queue') ]]; then
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.triggering_actor }}" == "github-merge-queue" ]]; then
             echo "Skipping... already ran job in merge queue."
           else
             # set some bogus URLs to trigger dependency download via maven


### PR DESCRIPTION
Currently, when PRs are merged via the "merge queue" they run jobs within the `test.yml` workflow file twice. Once while in the merge queue, and once when it is then pushed to integration. This is wasteful and takes a long time. 

This PR aims to resolve this issue by checking to see if the user who is triggering the workflow, as a result of a push to certain branches, is the github-merge-queue bot. If it is, it will skip over the intensive parts of the jobs and pass the test (since it has already ran and passed in the merge_group event triggered workflow).