### PR TITLE
DocumentIterator can now aggregate non-event fields

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIterator.java
@@ -2,12 +2,13 @@ package datawave.next.retrieval;
 
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
@@ -16,22 +17,28 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
-import org.apache.commons.jexl3.parser.ParseException;
 import org.apache.hadoop.io.Text;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.TreeMultimap;
+import com.google.protobuf.InvalidProtocolBufferException;
 
+import datawave.ingest.protobuf.TermWeight;
+import datawave.ingest.protobuf.TermWeightPosition;
+import datawave.query.Constants;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.AttributeFactory;
+import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.DocumentKey;
 import datawave.query.data.parsers.EventKey;
-import datawave.query.function.JexlEvaluation;
+import datawave.query.data.parsers.FieldIndexKey;
+import datawave.query.data.parsers.TermFrequencyKey;
 import datawave.query.function.serializer.KryoDocumentSerializer;
-import datawave.query.jexl.DatawaveJexlContext;
-import datawave.query.jexl.HitListArithmetic;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.functions.TermFrequencyList;
+import datawave.query.postprocessing.tf.TermOffsetMap;
 import datawave.query.util.Tuple3;
 
 /**
@@ -95,6 +102,8 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
         EventKey parser = new EventKey();
 
         for (String candidate : candidates) {
+            // must clear state between candidates
+            context.clear();
 
             Range candidateRange = rangeForCandidate(candidate);
             source.seek(candidateRange, excludeCFs, false);
@@ -125,12 +134,13 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
                 d.put(field, attr);
             }
 
-            JexlEvaluation evaluation = new JexlEvaluation(query, new HitListArithmetic());
+            // collect index only fragments
+            collectIndexOnlyFragments(d, attributeFactory, candidate);
 
-            ASTJexlScript queryTree = parse(query);
-            Set<String> identifiers = JexlASTHelper.getIdentifierNames(queryTree);
+            // collect term frequency fragments
+            collectTermFrequencyFragments(d, attributeFactory, candidate);
 
-            DatawaveJexlContext context = new DatawaveJexlContext();
+            // populate context, only pulling in the attributes required by the query
             d.visit(identifiers, context);
 
             boolean matched = evaluation.apply(new Tuple3<>(tk, d, context));
@@ -169,18 +179,118 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
         }
     }
 
-    private ASTJexlScript parse(String query) {
-        try {
-            return JexlASTHelper.parseAndFlattenJexlQuery(query);
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private Range rangeForCandidate(String candidate) {
         Key start = new Key(range.getStartKey().getRow(), new Text(candidate));
         Key stop = start.followingKey(PartialKey.ROW_COLFAM);
         return new Range(start, true, stop, false);
+    }
+
+    private void collectIndexOnlyFragments(Document d, AttributeFactory attributeFactory, String candidate) {
+        if (indexOnlyFieldValues == null) {
+            return;
+        }
+
+        List<Range> ranges = new ArrayList<>();
+        for (String field : indexOnlyFieldValues.keySet()) {
+            for (String value : indexOnlyFieldValues.get(field)) {
+                Text cf = new Text("fi\0" + field);
+                Text cq = new Text(value + "\0" + candidate);
+                Key start = new Key(range.getStartKey().getRow(), cf, cq);
+                Range range = new Range(start, true, start.followingKey(PartialKey.ROW_COLFAM), false);
+                ranges.add(range);
+            }
+        }
+
+        FieldIndexKey fiParser = new FieldIndexKey();
+
+        for (Range range : ranges) {
+            try {
+                source.seek(range, Collections.emptySet(), false);
+                while (source.hasTop()) {
+                    Key key = source.getTopKey();
+                    fiParser.parse(key);
+                    Attribute<?> attribute = attributeFactory.create(fiParser.getField(), fiParser.getValue(), key, fiParser.getDatatype(), true, false);
+                    // I don't remember why this is important, but set the flag
+                    attribute.setFromIndex(true);
+                    d.put(fiParser.getField(), attribute);
+
+                    source.next();
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Error collecting index only fragment", e);
+            }
+        }
+    }
+
+    private void collectTermFrequencyFragments(Document d, AttributeFactory attributeFactory, String candidate) {
+        if (termFrequencyFieldValues == null) {
+            return;
+        }
+
+        Text cf = new Text("tf");
+        List<Range> ranges = new ArrayList<>();
+        for (String field : termFrequencyFieldValues.keySet()) {
+            for (String value : termFrequencyFieldValues.get(field)) {
+                Text cq = new Text(candidate + "\0" + value + "\0" + field);
+                Key start = new Key(range.getStartKey().getRow(), cf, cq);
+                Range range = new Range(start, true, start.followingKey(PartialKey.ROW_COLFAM), false);
+                ranges.add(range);
+            }
+        }
+
+        TermFrequencyKey tfParser = new TermFrequencyKey();
+        Map<String,TermFrequencyList> termOffsetMap = Maps.newHashMap();
+
+        for (Range range : ranges) {
+            try {
+                source.seek(range, Collections.emptySet(), false);
+                while (source.hasTop()) {
+                    Key key = source.getTopKey();
+                    tfParser.parse(key);
+
+                    Content content = new Content(tfParser.getValue(), key, true);
+                    d.put(tfParser.getField(), content);
+
+                    TreeMultimap<TermFrequencyList.Zone,TermWeightPosition> offsets = parseTermFrequencyValue(source.getTopValue(), tfParser.getField(),
+                                    candidate);
+
+                    // First time looking up this term in a field
+                    TermFrequencyList tfl = termOffsetMap.get(tfParser.getValue());
+                    if (null == tfl) {
+                        termOffsetMap.put(tfParser.getValue(), new TermFrequencyList(offsets));
+                    } else {
+                        // Merge in the offsets for the current field+term with all previous
+                        // offsets from other fields in the same term
+                        tfl.addOffsets(offsets);
+                    }
+
+                    source.next();
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Error collecting index only fragment", e);
+            }
+        }
+
+        context.set(Constants.TERM_OFFSET_MAP_JEXL_VARIABLE_NAME, new TermOffsetMap(termOffsetMap));
+    }
+
+    private final TermWeightPosition.Builder position = new TermWeightPosition.Builder();
+
+    private TreeMultimap<TermFrequencyList.Zone,TermWeightPosition> parseTermFrequencyValue(Value value, String field, String recordId) {
+        TreeMultimap<TermFrequencyList.Zone,TermWeightPosition> offsets = TreeMultimap.create();
+        try {
+            TermWeight.Info twInfo = TermWeight.Info.parseFrom(value.get());
+            TermFrequencyList.Zone twZone = new TermFrequencyList.Zone(field, true, recordId);
+
+            for (int i = 0; i < twInfo.getTermOffsetCount(); i++) {
+                position.setTermWeightOffsetInfo(twInfo, i);
+                offsets.put(twZone, position.build());
+                position.reset();
+            }
+        } catch (InvalidProtocolBufferException e) {
+            return offsets;
+        }
+        return offsets;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIteratorOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIteratorOptions.java
@@ -3,10 +3,12 @@ package datawave.next.retrieval;
 import static datawave.query.iterator.QueryOptions.COMPOSITE_METADATA;
 import static datawave.query.iterator.QueryOptions.DISALLOWLISTED_FIELDS;
 import static datawave.query.iterator.QueryOptions.END_TIME;
+import static datawave.query.iterator.QueryOptions.INDEX_ONLY_FIELDS;
 import static datawave.query.iterator.QueryOptions.PROJECTION_FIELDS;
 import static datawave.query.iterator.QueryOptions.QUERY;
 import static datawave.query.iterator.QueryOptions.QUERY_MAPPING_COMPRESS;
 import static datawave.query.iterator.QueryOptions.START_TIME;
+import static datawave.query.iterator.QueryOptions.TERM_FREQUENCY_FIELDS;
 import static datawave.query.iterator.QueryOptions.TYPE_METADATA;
 
 import java.io.ByteArrayInputStream;
@@ -31,13 +33,20 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.OptionDescriber;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ParseException;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
 
 import datawave.next.LongRange;
 import datawave.query.composite.CompositeMetadata;
+import datawave.query.function.JexlEvaluation;
 import datawave.query.iterator.QueryOptions;
+import datawave.query.jexl.DatawaveJexlContext;
+import datawave.query.jexl.HitListArithmetic;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.util.TypeMetadata;
 
 /**
@@ -63,7 +72,19 @@ public class DocumentIteratorOptions implements OptionDescriber {
     protected LongRange timeFilter;
     protected Set<String> includeFields = null;
     protected Set<String> excludeFields = null;
+    protected Set<String> indexOnlyFields = null;
+    protected Set<String> termFrequencyFields = null;
     protected final List<String> candidates = new ArrayList<>();
+
+    // field values to aggregate
+    protected Multimap<String,String> indexOnlyFieldValues;
+    protected Multimap<String,String> termFrequencyFieldValues;
+
+    // evaluation stuff
+    protected final DatawaveJexlContext context = new DatawaveJexlContext();
+    protected JexlEvaluation evaluation;
+    protected ASTJexlScript queryTree;
+    protected Set<String> identifiers;
 
     //  @formatter:off
     protected static final Set<String> optionNames = Set.of(QUERY,
@@ -74,7 +95,9 @@ public class DocumentIteratorOptions implements OptionDescriber {
             COMPOSITE_METADATA,
             PROJECTION_FIELDS,
             DISALLOWLISTED_FIELDS,
-            CANDIDATES);
+            CANDIDATES,
+            INDEX_ONLY_FIELDS,
+            TERM_FREQUENCY_FIELDS);
     //  @formatter:on
 
     public void deepCopy(DocumentIteratorOptions other) {
@@ -112,6 +135,8 @@ public class DocumentIteratorOptions implements OptionDescriber {
         options.put(END_TIME, "the end time");
         options.put(PROJECTION_FIELDS, "the set of fields to include");
         options.put(DISALLOWLISTED_FIELDS, "the set of fields to exclude");
+        options.put(INDEX_ONLY_FIELDS, "the set of index only fields to fetch from the field index");
+        options.put(TERM_FREQUENCY_FIELDS, "the set of tokenized fields to fetch from the term frequency column");
         options.put(CANDIDATES, "the set of candidate record ids to fetch");
         return new IteratorOptions(getClass().getSimpleName(), "Retrieves documents", options, null);
     }
@@ -174,8 +199,7 @@ public class DocumentIteratorOptions implements OptionDescriber {
             // if the user requested everything with a star then leave include fields as null
             // this signifies that all fields are allowed
             if (!option.equals("*")) {
-                includeFields = new HashSet<>();
-                includeFields.addAll(Splitter.on(',').splitToList(option));
+                includeFields = parseOptionToSet(option);
             }
         }
 
@@ -183,11 +207,62 @@ public class DocumentIteratorOptions implements OptionDescriber {
         // options, that is the responsibility of the caller
         if (options.containsKey(QueryOptions.DISALLOWLISTED_FIELDS)) {
             String option = options.get(QueryOptions.DISALLOWLISTED_FIELDS);
-            excludeFields = new HashSet<>();
-            excludeFields.addAll(Splitter.on(',').splitToList(option));
+            excludeFields = parseOptionToSet(option);
+        }
+
+        if (options.containsKey(INDEX_ONLY_FIELDS)) {
+            String option = options.get(INDEX_ONLY_FIELDS);
+            indexOnlyFields = parseOptionToSet(option);
+        }
+
+        if (options.containsKey(TERM_FREQUENCY_FIELDS)) {
+            String option = options.get(TERM_FREQUENCY_FIELDS);
+            termFrequencyFields = parseOptionToSet(option);
+        }
+
+        // finally, setup context variables
+        evaluation = new JexlEvaluation(query, new HitListArithmetic());
+        queryTree = parse(query);
+        identifiers = JexlASTHelper.getIdentifierNames(queryTree);
+
+        // required to fully evaluate a document
+        if (indexOnlyFields != null || termFrequencyFields != null) {
+            IndexOnlyFragmentVisitor visitor = new IndexOnlyFragmentVisitor(indexOnlyFields, termFrequencyFields);
+            queryTree.jjtAccept(visitor, null);
+            indexOnlyFieldValues = visitor.getIndexOnlyFieldValues();
+            termFrequencyFieldValues = visitor.getTokenizedFieldValues();
         }
 
         return true;
+    }
+
+    /**
+     * Parse a query string to an {@link ASTJexlScript}
+     *
+     * @param query
+     *            the query
+     * @return a JexlScript
+     */
+    protected ASTJexlScript parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Parse a comma-delimited option to a set
+     *
+     * @param option
+     *            the option
+     * @return the set, or null if the option is blank
+     */
+    protected Set<String> parseOptionToSet(String option) {
+        if (!option.isBlank()) {
+            return new HashSet<>(Splitter.on(',').omitEmptyStrings().splitToList(option));
+        }
+        return null;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/IndexOnlyFragmentVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/IndexOnlyFragmentVisitor.java
@@ -1,0 +1,63 @@
+package datawave.next.retrieval;
+
+import java.util.Set;
+
+import org.apache.commons.jexl3.parser.ASTEQNode;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.visitors.BaseVisitor;
+
+/**
+ * Visitor that collects the index only and tokenized field-value pairs required for document evaluation
+ * <p>
+ * Note: it is possible and even likely that some tokenized fields are also index only. However, in this context the sets of index only and tokenized fields are
+ * fully exclusive, i.e., there is no duplication between sets.
+ */
+public class IndexOnlyFragmentVisitor extends BaseVisitor {
+
+    private final Set<String> indexOnlyFields;
+    private final Set<String> tokenizedFields;
+
+    private final Multimap<String,String> indexOnlyFieldValues;
+    private final Multimap<String,String> tokenizedFieldValues;
+
+    public IndexOnlyFragmentVisitor(Set<String> indexOnlyFields, Set<String> tokenizedFields) {
+        this.indexOnlyFields = indexOnlyFields;
+        this.tokenizedFields = tokenizedFields;
+
+        this.indexOnlyFieldValues = HashMultimap.create();
+        this.tokenizedFieldValues = HashMultimap.create();
+    }
+
+    @Override
+    public Object visit(ASTEQNode node, Object data) {
+        String field = JexlASTHelper.getIdentifier(node);
+        if (field == null) {
+            return data;
+        }
+
+        Object literal = JexlASTHelper.getLiteralValue(node);
+        if (literal == null) {
+            return data;
+        }
+
+        if (tokenizedFields != null && tokenizedFields.contains(field)) {
+            tokenizedFieldValues.put(field, String.valueOf(literal));
+        } else if (indexOnlyFields != null && indexOnlyFields.contains(field)) {
+            indexOnlyFieldValues.put(field, String.valueOf(literal));
+        }
+
+        return data;
+    }
+
+    public Multimap<String,String> getIndexOnlyFieldValues() {
+        return indexOnlyFieldValues;
+    }
+
+    public Multimap<String,String> getTokenizedFieldValues() {
+        return tokenizedFieldValues;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -61,7 +61,6 @@ import datawave.data.type.Type;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl.Parameter;
-import datawave.next.SimpleQueryVisitor;
 import datawave.next.scanner.DocumentScannerConfig;
 import datawave.next.scanner.DocumentScheduler;
 import datawave.query.CloseableIterable;
@@ -1369,14 +1368,9 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
             QueryPlanner queryPlanner = getQueryPlanner();
             if (planner instanceof DefaultQueryPlanner) {
                 DefaultQueryPlanner dqp = (DefaultQueryPlanner) queryPlanner;
-                boolean simple = SimpleQueryVisitor.validate(config.getQueryTree(), dqp.getIndexedFields(), dqp.getIndexOnlyFields());
-                if (simple) {
-                    DocumentScheduler documentScheduler = new DocumentScheduler(config);
-                    documentScheduler.setVisitorFunction(getVisitorFunction(dqp.getMetadataHelper()));
-                    return documentScheduler;
-                } else {
-                    log.warn("Query was not simple: " + simple + " or scheduler config was null:" + (config.getDocumentScannerConfig() == null));
-                }
+                DocumentScheduler documentScheduler = new DocumentScheduler(config);
+                documentScheduler.setVisitorFunction(getVisitorFunction(dqp.getMetadataHelper()));
+                return documentScheduler;
             }
         }
 

--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -539,7 +539,7 @@ public abstract class ColorsTest {
         withQuery("COLOR == 'red'");
         withRequiredAllOf("COLOR:red");
         withDateRange("20250301", "20250301");
-        withExpectedCount(1);
+        withExpectedCount(ColorsIngest.getNumShards());
         withExpectedDays("20250301");
         withExpectedShards("20250301", ColorsIngest.getNumShards());
         planAndExecuteQuery();
@@ -550,7 +550,7 @@ public abstract class ColorsTest {
         withQuery("COLOR == 'red'");
         withRequiredAllOf("COLOR:red");
         withDateRange("20250331", "20250331");
-        withExpectedCount(2);
+        withExpectedCount(ColorsIngest.getNewShards());
         withExpectedDays("20250331");
         withExpectedShards("20250331", ColorsIngest.getNewShards());
         planAndExecuteQuery();
@@ -561,7 +561,7 @@ public abstract class ColorsTest {
         withQuery("COLOR == 'red'");
         withRequiredAllOf("COLOR:red");
         withDateRange("20250326", "20250327");
-        withExpectedCount(3);
+        withExpectedCount(ColorsIngest.getNumShards() + ColorsIngest.getNewShards());
         withExpectedDays("20250326", "20250327");
         withExpectedShards("20250326", ColorsIngest.getNumShards());
         withExpectedShards("20250327", ColorsIngest.getNewShards());

--- a/warehouse/query-core/src/test/java/datawave/query/util/ColorsIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/ColorsIngest.java
@@ -42,11 +42,13 @@ public class ColorsIngest {
     private static final String startDay = "20250301";
     private static final String endDay = "20250331";
 
-    private static final int NUM_SHARDS = 1;
+    private static final int NUM_SHARDS = 10;
     private static final int NUM_DAYS = 31;
 
-    private static final int NEW_SHARDS = 2;
+    private static final int NEW_SHARDS = 20;
     private static final String NEW_SHARDS_START = "20250327";
+
+    private static final int EVENTS_PER_DAY = 1;
 
     private static final String datatype = "colors";
     private static final ColumnVisibility cv = new ColumnVisibility("ALL");
@@ -57,6 +59,7 @@ public class ColorsIngest {
     protected static String normalizerForField(String field) {
         switch (field) {
             case "COLOR":
+            case "ID":
             default:
                 return LcNoDiacriticsType.class.getName();
         }
@@ -212,6 +215,13 @@ public class ColorsIngest {
             // skipping F column for now
             m.put(ColumnFamilyConstants.COLF_I, new Text(datatype), EMPTY_VALUE);
             m.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\0" + normalizerForField("COLOR")), EMPTY_VALUE);
+            bw.addMutation(m);
+
+            m = new Mutation("ID");
+            m.put(ColumnFamilyConstants.COLF_E, new Text(datatype), EMPTY_VALUE);
+            // skipping F column for now
+            // skip I column
+            m.put(ColumnFamilyConstants.COLF_T, new Text(datatype + "\0" + normalizerForField("ID")), EMPTY_VALUE);
             bw.addMutation(m);
         }
 

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -217,7 +217,7 @@
         <property name="resultQueuePollTimeMillis" value="5"/>
         <property name="scanTimeoutMillis" value="10000"/>
         <property name="allowPartialIntersections" value="true" />
-        <property name="useQueryIterator" value="true" />
+        <property name="useQueryIterator" value="false" />
         <!-- execution hints and consistency levels -->
         <property name="searchScanHintTable" value="shard"/>
         <property name="searchScanHintPool" value="shardTablePool"/>

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -527,7 +527,7 @@
         <property name="resultQueuePollTimeMillis" value="5"/>
         <property name="scanTimeoutMillis" value="10000"/>
         <property name="allowPartialIntersections" value="true" />
-        <property name="useQueryIterator" value="true" />
+        <property name="useQueryIterator" value="false" />
         <!-- execution hints and consistency levels -->
         <property name="searchScanHintTable" value="shard"/>
         <property name="searchScanHintPool" value="shardTablePool"/>


### PR DESCRIPTION
Support for index only and term frequency fragments, limited to equality terms (i.e., regex/range not supported yet).

Clean up DocumentIteratorOption parsing