### PR TITLE
More bugfixes for tag clouds / keyword extraction

### DIFF
--- a/warehouse/core/src/main/java/datawave/webservice/query/util/LookupUUIDConstants.java
+++ b/warehouse/core/src/main/java/datawave/webservice/query/util/LookupUUIDConstants.java
@@ -5,4 +5,6 @@ public interface LookupUUIDConstants {
     String EMPTY_STRING = "";
 
     int DEFAULT_BATCH_LOOKUP_UPPER_LIMIT = 100;
+
+    int DEFAULT_TAG_CLOUD_LOOKUP_UPPER_LIMIT = 500;
 }

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
@@ -2,7 +2,6 @@ package datawave.util.keyword;
 
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -61,8 +60,10 @@ public class KeywordExtractor {
 
         parseOptions(options);
 
+        this.language = language;
         YakeLanguage yakeLanguage = YakeLanguage.Registry.find(language);
-        this.language = yakeLanguage.getLanguageName().toUpperCase(Locale.ROOT);
+
+        logger.debug("Input language was {}, resolved language for YAKE extraction is {}", this.language, yakeLanguage.getLanguageName());
 
         //@formatter:off
         yakeKeywordExtractor = new YakeKeywordExtractor.Builder()

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
@@ -69,6 +69,8 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
 
         q.addParameter(KeywordQueryLogic.TAG_CLOUD_CREATE, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_CREATE).getParameterValue());
         q.addParameter(KeywordQueryLogic.PREFERRED_VIEW_NAMES, initialQuery.findParameter(KeywordQueryLogic.PREFERRED_VIEW_NAMES).getParameterValue());
+        q.addParameter(KeywordQueryLogic.TAG_CLOUD_MAX, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_MAX).getParameterValue());
+        q.addParameter(KeywordQueryLogic.TAG_CLOUD_LANGUAGE, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_LANGUAGE).getParameterValue());
 
         return q;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -97,7 +97,7 @@ public class KeywordQueryLogicFunctionalTest {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzua";
 
         addExpectedResult(
-                        "{\"source\":\"20130101_0/test/-cvy0gj.tlf59s.-duxzua\",\"view\":\"CONTENT\",\"language\":\"ENGLISH\",\"visibility\":\"ALL\",\"keywords\":{\"get much\":0.5903,\"kind\":0.2546,\"kind word\":0.2052,\"kind word alone\":0.4375,\"much farther\":0.5903,\"word\":0.2857,\"word alone\":0.534}}");
+                        "{\"source\":\"20130101_0/test/-cvy0gj.tlf59s.-duxzua\",\"view\":\"CONTENT\",\"language\":\"\",\"visibility\":\"ALL\",\"keywords\":{\"get much\":0.5903,\"kind\":0.2546,\"kind word\":0.2052,\"kind word alone\":0.4375,\"much farther\":0.5903,\"word\":0.2857,\"word alone\":0.534}}");
 
         runTestQuery(queryString);
     }

--- a/web-services/query/src/main/java/datawave/webservice/query/configuration/LookupUUIDConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/configuration/LookupUUIDConfiguration.java
@@ -20,8 +20,20 @@ public class LookupUUIDConfiguration {
     protected Map<String,String> contentLookupTypes = null;
 
     protected int batchLookupUpperLimit = LookupUUIDConstants.DEFAULT_BATCH_LOOKUP_UPPER_LIMIT;
+
+    protected int tagCloudLookupUpperLimit = LookupUUIDConstants.DEFAULT_TAG_CLOUD_LOOKUP_UPPER_LIMIT;
+
     protected String beginDate = null;
     protected String columnVisibility;
+
+    /**
+     * Returns the maximum number of UUIDs allowed for tag cloud id lookup. A zero or negative value is interpreted as unlimited. The default value is 500.
+     *
+     * @return the maximum number of UUIDs allowed for tag cloud id lookup
+     */
+    public int getTagCloudLookupUpperLimit() {
+        return this.tagCloudLookupUpperLimit;
+    }
 
     /**
      * Returns the maximum number of UUIDs allowed for batch lookup. A zero or negative value is interpreted as unlimited. The default value is 100.
@@ -56,6 +68,16 @@ public class LookupUUIDConfiguration {
      */
     public void setBatchLookupUpperLimit(int batchLookupUpperLimit) {
         this.batchLookupUpperLimit = batchLookupUpperLimit;
+    }
+
+    /**
+     * Sets the maximum number of UUIDs allowed for tag cloud id lookup. A zero or negative value is interpreted as unlimited.
+     *
+     * @param tagCloudLookupUpperLimit
+     *            the maximum number of UUIDs allowed for tag cloud lookup
+     */
+    public void setTagCloudLookupUpperLimit(int tagCloudLookupUpperLimit) {
+        this.tagCloudLookupUpperLimit = tagCloudLookupUpperLimit;
     }
 
     public void setBeginDate(String beginDate) {

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -2781,6 +2781,7 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.lookupUUIDConfiguration.getUuidTypes()).andReturn(null);
         expect(this.lookupUUIDConfiguration.getBeginDate()).andReturn("not a date");
         expect(this.lookupUUIDConfiguration.getBatchLookupUpperLimit()).andReturn(0);
+        expect(this.lookupUUIDConfiguration.getTagCloudLookupUpperLimit()).andReturn(0);
         expect(this.lookupUUIDConfiguration.getContentLookupTypes()).andReturn(Collections.emptyMap());
         expect(this.context.getCallerPrincipal()).andReturn(this.principal).anyTimes();
         LookupUUIDConfiguration tmpCfg = new LookupUUIDConfiguration();

--- a/web-services/query/src/test/java/datawave/webservice/query/util/LookupUUIDUtilTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/util/LookupUUIDUtilTest.java
@@ -49,6 +49,7 @@ public class LookupUUIDUtilTest {
         expect(configuration.getUuidTypes()).andReturn(Collections.singletonList(new UUIDType("ID", "LuceneUUIDEventQuery", 28)));
         expect(configuration.getBeginDate()).andReturn("20230101");
         expect(configuration.getBatchLookupUpperLimit()).andReturn(10);
+        expect(configuration.getTagCloudLookupUpperLimit()).andReturn(50);
         MultivaluedMap<String,String> defaultParams = new MultivaluedMapImpl<>();
         defaultParams.putSingle("foo", "bar");
         defaultParams.putSingle("foo2", "default");


### PR DESCRIPTION
* Fixed issue where the max tags per cloud parameter was not propogated to the backend.
* Fixed issue where a small page size on the id lookup portion of the query led to the creation of multiple tag clouds for a single language.
* Fixed issue where the language used for keyword extraction was used to group tag clouds instead of the language marked on the input document
* Fixed issue where we couldn't input the required number of document ids for tag clouds because lookup was limited to 100 ids. Tag cloud lookup can now perform to 500 lookups instead.