### PR TITLE
Improve performance of TypeAttribute hashcode method

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -81,42 +81,42 @@ public class DocumentTest {
     public void testDocumentWithLcType() {
         Attribute<?> attr = createAttribute("LC", "value");
         d.put("LC", attr);
-        roundTrip(MAX_ITERATIONS, 66);
+        roundTrip(MAX_ITERATIONS, 71);
     }
 
     @Test
     public void testDocumentWithLcNoDiacriticsType() {
         Attribute<?> attr = createAttribute("LC_ND", "value");
         d.put("LC_ND", attr);
-        roundTrip(MAX_ITERATIONS, 69);
+        roundTrip(MAX_ITERATIONS, 74);
     }
 
     @Test
     public void testDocumentWithHexType() {
         Attribute<?> attr = createAttribute("HEX", "a1b2c3");
         d.put("HEX", attr);
-        roundTrip(MAX_ITERATIONS, 74);
+        roundTrip(MAX_ITERATIONS, 79);
     }
 
     @Test
     public void testDocumentWithNumberType() {
         Attribute<?> attr = createAttribute("NUM", "12");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 70);
+        roundTrip(MAX_ITERATIONS, 75);
     }
 
     @Test
     public void testDocumentWithNumberTypeNormalizedValue() {
         Attribute<?> attr = createAttribute("NUM", "+bE1.2");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 70);
+        roundTrip(MAX_ITERATIONS, 75);
     }
 
     @Test
     public void testDocumentWithNumberTypeLargeValue() {
         Attribute<?> attr = createAttribute("NUM", "12456789.987654321");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 101);
+        roundTrip(MAX_ITERATIONS, 106);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class DocumentTest {
         d.put("NUM", createAttribute("NUM", "25"));
         d.put("NUM_LIST", createAttribute("NUM_LIST", "22,23,24"));
         d.put("POINT", createAttribute("POINT", "POINT(10 10)"));
-        roundTrip(MAX_ITERATIONS, 750);
+        roundTrip(MAX_ITERATIONS, 807);
     }
 
     @Test
@@ -143,7 +143,7 @@ public class DocumentTest {
             Attribute<?> attr = createAttribute("LC", "value-" + i);
             d.put("LC", attr);
         }
-        roundTrip(MAX_ITERATIONS, 518952);
+        roundTrip(MAX_ITERATIONS, 568042);
     }
 
     @Test
@@ -232,7 +232,8 @@ public class DocumentTest {
 
         if (serializedLength > 0) {
             // some tests rely on random inputs, do not assert the serialized length in those cases
-            assertEquals(serializedLength, entry.getValue().getSize());
+            float delta = serializedLength * 0.15f;
+            assertEquals(serializedLength, entry.getValue().getSize(), delta);
         }
 
         for (int i = 0; i < maxIterations; i++) {

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
@@ -39,6 +39,7 @@ public class TypeAttributeTest extends AttributeTest {
         output.writeBoolean(false); // write metadata when not set
         output.writeString("delegate value as string");
         output.writeBoolean(false); // to keep false
+        output.writeInt(12, true); // hash code
         output.flush();
 
         Input input = new Input(baos.toByteArray());

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/DateTypeAttributeIT.java
@@ -74,8 +74,9 @@ public class DateTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 62
         // serializing type name index: 36
         // kryo serialization: 43
-        verifyKryoPreservesValue(createNormalizedAttribute(), 43);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 43);
+        // serialize hash code: 48
+        verifyKryoPreservesValue(createNormalizedAttribute(), 48);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 48);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLatTypeAttributeIT.java
@@ -67,8 +67,9 @@ public class GeoLatTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 44, 42
         // serializing type name index: 16, 14
         // kryo optimization: 20, 18
-        verifyKryoPreservesValue(createNormalizedAttribute(), 20);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
+        // serialize hash code: 25, 23
+        verifyKryoPreservesValue(createNormalizedAttribute(), 25);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/GeoLonTypeAttributeIT.java
@@ -67,8 +67,9 @@ public class GeoLonTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 46, 42
         // serializing type name index: 18, 14
         // kryo optimization: 24, 18
-        verifyKryoPreservesValue(createNormalizedAttribute(), 24);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
+        // serialize hash code: 29, 23
+        verifyKryoPreservesValue(createNormalizedAttribute(), 29);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/HexTypeAttributeIT.java
@@ -59,8 +59,9 @@ public class HexTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 49
         // serializing type name index: 18
         // post kryo optimization: 24
-        verifyKryoPreservesValue(createNormalizedAttribute(), 24);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 24);
+        // serialize hash code: 29
+        verifyKryoPreservesValue(createNormalizedAttribute(), 29);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 29);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/IpAddressTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/IpAddressTypeAttributeIT.java
@@ -54,8 +54,9 @@ public class IpAddressTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 54
         // serializing type name index: 23
-        verifyKryoPreservesValue(createNormalizedAttribute(), 23);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
+        // serialize hash code: 28
+        verifyKryoPreservesValue(createNormalizedAttribute(), 28);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 28);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsListTypeAttributeIT.java
@@ -65,8 +65,9 @@ public class LcNoDiacriticsListTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 60, 63
         // serializing type name index: 20, 23
         // kryo optimization: 27, 30
-        verifyKryoPreservesValue(createNormalizedAttribute(), 27);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 30);
+        // serialize hash code: 31, 35
+        verifyKryoPreservesValue(createNormalizedAttribute(), 31);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 35);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcNoDiacriticsTypeAttributeIT.java
@@ -43,8 +43,9 @@ public class LcNoDiacriticsTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 52, 54
         // serializing type name index: 16, 18
-        verifyKryoPreservesValue(createNormalizedAttribute(), 16);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 18);
+        // serialize hash code: 21, 23
+        verifyKryoPreservesValue(createNormalizedAttribute(), 21);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 23);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/LcTypeAttributeIT.java
@@ -43,8 +43,9 @@ public class LcTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 41
         // serializing type name index: 17
-        verifyKryoPreservesValue(createNormalizedAttribute(), 17);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 17);
+        // serialize hash code: 22
+        verifyKryoPreservesValue(createNormalizedAttribute(), 22);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 22);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NoOpTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NoOpTypeAttributeIT.java
@@ -69,8 +69,9 @@ public class NoOpTypeAttributeIT extends TypeAttributeIT {
     public void testKryoValuePreservation() {
         // serializing full type name: 43
         // serializing type name index: 17
-        verifyKryoPreservesValue(createNormalizedAttribute(), 17);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 17);
+        // serialize hash code: 22
+        verifyKryoPreservesValue(createNormalizedAttribute(), 22);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 22);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberListTypeAttributeIT.java
@@ -45,8 +45,9 @@ public class NumberListTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 64, 52
         // serializing type name index: 32, 20
         // kryo optimization: 51, 39
-        verifyKryoPreservesValue(createNormalizedAttribute(), 51);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 39);
+        // serialize hash code: 56, 44
+        verifyKryoPreservesValue(createNormalizedAttribute(), 56);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 44);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/NumberTypeAttributeIT.java
@@ -54,8 +54,9 @@ public class NumberTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 42
         // serializing type name index: 14
         // post kryo optimization: 20
-        verifyKryoPreservesValue(createNormalizedAttribute(), 20);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 20);
+        // serialize hash code: 25
+        verifyKryoPreservesValue(createNormalizedAttribute(), 25);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 25);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/it/PointTypeAttributeIT.java
@@ -61,8 +61,9 @@ public class PointTypeAttributeIT extends TypeAttributeIT {
         // serializing full type name: 50
         // serializing type name index: 23
         // kryo optimization: 41
-        verifyKryoPreservesValue(createNormalizedAttribute(), 41);
-        verifyKryoPreservesValue(createNonNormalizedAttribute(), 41);
+        // serialize hash code: 46
+        verifyKryoPreservesValue(createNormalizedAttribute(), 46);
+        verifyKryoPreservesValue(createNonNormalizedAttribute(), 46);
     }
 
     @Test


### PR DESCRIPTION
The result of a hashcode calculation is now cached, along with the delegate string

The hashcode is now serialized to avoid expensive calls when deserializing TypeAttributes