### PR TITLE
Adds a new shard table balancer

### DIFF
--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -31,7 +31,7 @@ import com.google.common.primitives.UnsignedBytes;
  * Rendezvous hashing server partitioning balancer. This balancer has the following goals.
  *
  * <ul>
- * <li>Spread tablets in the same group across different host names. If a hostname has multiple tablet severs then avoid placing multiple tablets on that
+ * <li>Spread tablets in the same group across different host names. If a hostname has multiple tablet servers then avoid placing multiple tablets on that
  * host.</li>
  * <li>Allow assigning a group of tablets to a group of tablet servers.</li>
  * <li>Minimize the amount of rebalancing needed when the set of tablet servers changes.</li>

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -168,7 +168,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         outer: for (var tpgEntry : tabletsPerGroup.entrySet()) {
             String tabletGroup = tpgEntry.getKey();
             List<TabletId> tablets = tpgEntry.getValue();
-            Map<String,List<TabletServerId>> tserversForGroup = tabletServerParitioner.apply(tabletGroup);
+            Map<String,List<TabletServerId>> tserversForGroup = tabletServerPartitioner.apply(tabletGroup);
 
             Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, tablets, tserversForGroup, allLocations);
 

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -59,6 +59,10 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
     /**
      * For a given tabletId returns a group name. This balancer places tablets in the same group on different hosts.
+     *
+     * @param tabletId
+     *            the requested tablet id
+     * @return The corresponding tablet group for the tablet id.
      */
     protected abstract String getTabletGroup(TabletId tabletId);
 
@@ -66,7 +70,11 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
     /**
      * Creates a function that determines what tservers should be used for a named group of tablets. The function should map a name returned by
-     * {@link #getTabletGroup()} to a subset of tablet servers. The returned map should be keyed on hostname.
+     * {@link #getTabletGroup(TabletId)} to a subset of tablet servers. The returned map should be keyed on hostname.
+     *
+     * @param allTservers
+     *            set of tservers to use for partitioning
+     * @return The function which will partition the group of tservers
      */
     protected abstract Function<String,Map<String,List<TabletServerId>>> getServerPartitioner(Collection<TabletServerId> allTservers);
 
@@ -124,6 +132,8 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
     /**
      * The amount of time to wait between balancing.
+     *
+     * @return the static time to wait
      */
     protected long getWaitTime() {
         return 60000;
@@ -205,9 +215,15 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
     }
 
     /**
+     * @param tabletGroupName
+     *            Mame of tablet group
+     * @param tabletsInGroup
+     *            List of tablets in the tablet group
      * @param tserversForGroup
-     *            map of tservers that tablets can be assigned to, the map is expected to be keyed on hostname
-     * @return
+     *            Map of tservers that tablets can be assigned to, the map is expected to be keyed on hostname
+     * @param currentLocations
+     *            map of current tablet locations
+     * @return Map of desired locations for a given tablet group name and list of tablets.
      */
     private Map<TabletId,TabletServerId> getDesiredLocationsForTabletGroup(String tabletGroupName, List<TabletId> tabletsInGroup,
                     Map<String,List<TabletServerId>> tserversForGroup, Map<TabletId,TabletServerId> currentLocations) {

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -302,8 +302,8 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
         Map<TabletServerId,Integer> tserverGoalCounts = new LinkedHashMap<>();
 
-        // If rendevous balance was done across host w/ different numbers of tablets, then it would lead to hosts with less tablets getting more tablets per
-        // tservers. To deal with this hosts with different numbers of tablets servers are partitioned. Then rendevous balancing is done across each partition.
+        // If rendezvous balance was done across host w/ different numbers of tablets, then it would lead to hosts with less tservers getting more tablets per
+        // tserver. To deal with this hosts with different numbers of tablets servers are partitioned. Then rendezvous balancing is done across each partition.
         Map<Integer,Integer> tabletsCountsPerHostCount = tserversForGroup.computeTabletAssignmentCountsByHostCount(tabletsInGroup.size());
 
         for (var entry : tabletsCountsPerHostCount.entrySet()) {

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -107,7 +107,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         Map<String,List<TabletId>> tabletsToAssign = groupTablets(lastLocations.keySet());
         Map<String,List<TabletId>> allTabletsGrouped = groupTablets(allLocations.keySet(), tabletsToAssign::containsKey);
 
-        Function<String,Map<String,List<TabletServerId>>> tabletServerParitioner = getServerPartitioner(currentTservers.keySet());
+        Function<String,Map<String,List<TabletServerId>>> tabletServerPartitioner = getServerPartitioner(currentTservers.keySet());
 
         tabletsToAssign.forEach((tabletGroup, tablets) -> {
             Map<String,List<TabletServerId>> tserversForGroup = tabletServerParitioner.apply(tabletGroup);

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -88,7 +88,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         Map<Integer,Map<String,List<TabletServerId>>> tservers = new HashMap<>();
 
         TServers(List<TabletServerId> tabletServers) {
-            Map<String,List<TabletServerId>> tseversPerHost = new HashMap<>();
+            Map<String,List<TabletServerId>> tserversPerHost = new HashMap<>();
             for (var tserver : tabletServers) {
                 tserversPerHost.computeIfAbsent(tserver.getHost(), h -> new ArrayList<>()).add(tserver);
             }

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -1,0 +1,302 @@
+package datawave.ingest.table.balancer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.spi.balancer.BalancerEnvironment;
+import org.apache.accumulo.core.spi.balancer.TabletBalancer;
+import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
+import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
+import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
+
+import com.google.common.base.Preconditions;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.UnsignedBytes;
+
+/**
+ * Rendezvous hashing server partitioning balancer. This balancer has the following goals.
+ *
+ * <ul>
+ * <li>Spread tablets in the same group across different host names. If a hostname has multiple tablet severs then avoid placing multiple tablets on that
+ * host.</li>
+ * <li>Allow assigning a group of tablets to a group of tablet servers.</li>
+ * <li>Minimize the amount of rebalancing needed when the set of tablet servers changes.</li>
+ * <li>Avoid uneven tablet assignment, where the tablets per tserver for a server are significantly different than the average. This balancer uses hashing, so
+ * there should be a small deviation from the average.</li>
+ * </ul>
+ *
+ * <p>
+ * For a given group name (like 20250618) this balancer computes hash(group_name+hostname) for each host and then sorts on the hashes. This gives each group a
+ * consistent and unique ordering across host. Within a host, hash(group_name+hostname+port) is computed for each tserver and sorted by the hashes giving unique
+ * per group order for the tservers on the host..
+ * </p>
+ *
+ */
+public abstract class RendezvousHostBalancer implements TabletBalancer {
+    private BalancerEnvironment env;
+
+    protected final TableId tableIdToBalance;
+
+    protected long lastRunTime = 0;
+
+    public RendezvousHostBalancer(TableId tableId) {
+        this.tableIdToBalance = tableId;
+    }
+
+    /**
+     * For a given tabletId returns a group name. This balancer places tablets in the same group on different hosts.
+     */
+    protected abstract String getTabletGroup(TabletId tabletId);
+
+    protected abstract int getMaxMigrations();
+
+    /**
+     * Creates a function that determines what tservers should be used for a named group of tablets. The function should map a name returned by
+     * {@link #getTabletGroup()} to a subset of tablet servers. The returned map should be keyed on hostname.
+     */
+    protected abstract Function<String,Map<String,List<TabletServerId>>> getServerPartitioner(Collection<TabletServerId> allTservers);
+
+    @Override
+    public void init(BalancerEnvironment balancerEnvironment) {
+        this.env = balancerEnvironment;
+    }
+
+    @Override
+    public void getAssignments(AssignmentParameters assignmentParameters) {
+
+        var currentTservers = assignmentParameters.currentStatus();
+        if (currentTservers.isEmpty()) {
+            return;
+        }
+
+        Map<String,TabletServerId> tserverHostPortMap = new HashMap<>();
+
+        currentTservers.keySet().forEach(tserverId -> {
+            tserverHostPortMap.put(tserverId.getHost() + ":" + tserverId.getPort(), tserverId);
+        });
+
+        // FOLLOW_ON this reads all tablet locations because that is the only option. Should read only the tablet locations related to the tablet groups that
+        // are being assigned. This would require Accumulo changes.
+        Map<TabletId,TabletServerId> allLocations = new HashMap<>(env.listTabletLocations(tableIdToBalance));
+        Map<TabletId,TabletServerId> lastLocations = assignmentParameters.unassignedTablets();
+        lastLocations.forEach((tablet, last) -> {
+            allLocations.put(tablet, last == null ? null : tserverHostPortMap.get(last.getHost() + ":" + last.getPort()));
+        });
+        Map<String,List<TabletId>> tabletsToAssign = groupTablets(lastLocations.keySet());
+        Map<String,List<TabletId>> allTabletsGrouped = groupTablets(allLocations.keySet(), tabletsToAssign::containsKey);
+
+        Function<String,Map<String,List<TabletServerId>>> tabletServerParitioner = getServerPartitioner(currentTservers.keySet());
+
+        tabletsToAssign.forEach((tabletGroup, tablets) -> {
+            Map<String,List<TabletServerId>> tserversForGroup = tabletServerParitioner.apply(tabletGroup);
+
+            // Must pass the set of all tablets for the group to compute the desired location, not just the subset of tablets being assigned
+            var allTablets = allTabletsGrouped.get(tabletGroup);
+            Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, allTablets, tserversForGroup, allLocations);
+
+            tablets.forEach(tabletId -> {
+                assignmentParameters.addAssignment(tabletId, desiredLocs.get(tabletId));
+            });
+        });
+
+    }
+
+    private boolean shouldBalance(SortedMap<TabletServerId,TServerStatus> current, Set<TabletId> migrations) {
+        if (current.size() < 2) {
+            return false;
+        }
+        return migrations.stream().noneMatch(t -> t.getTable().equals(tableIdToBalance));
+    }
+
+    /**
+     * The amount of time to wait between balancing.
+     */
+    protected long getWaitTime() {
+        return 60000;
+    }
+
+    @Override
+    public long balance(BalanceParameters balanceParameters) {
+        var currentTservers = balanceParameters.currentStatus();
+
+        if (!shouldBalance(currentTservers, balanceParameters.currentMigrations())) {
+            return 5000;
+        }
+
+        if (System.currentTimeMillis() - lastRunTime < getWaitTime()) {
+            return 5000;
+        }
+
+        if (currentTservers.isEmpty()) {
+            return 5000;
+        }
+
+        Map<TabletId,TabletServerId> allLocations = env.listTabletLocations(tableIdToBalance);
+
+        Map<String,List<TabletId>> tabletsPerGroup = groupTablets(allLocations.keySet());
+
+        Function<String,Map<String,List<TabletServerId>>> tabletServerParitioner = getServerPartitioner(balanceParameters.currentStatus().keySet());
+
+        // read once so a consistent max is used for the entire balance call
+        final int maxMigrations = getMaxMigrations();
+
+        int migrationsAdded = 0;
+        outer: for (var tpgEntry : tabletsPerGroup.entrySet()) {
+            String tabletGroup = tpgEntry.getKey();
+            List<TabletId> tablets = tpgEntry.getValue();
+            Map<String,List<TabletServerId>> tserversForGroup = tabletServerParitioner.apply(tabletGroup);
+
+            Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, tablets, tserversForGroup, allLocations);
+
+            for (var dlEntry : desiredLocs.entrySet()) {
+                TabletId tabletId = dlEntry.getKey();
+                TabletServerId tabletServerId = dlEntry.getValue();
+                // This code could handle assigning tablets w/o a location, however the balancer framework does not support this so ignore tablets w/o a
+                // location. Normally accumulo will only call the balancer when all tablets are assigned. However if a tablet becomes unassigned during
+                // balancing a null location may be seen.
+                var currTsever = allLocations.get(tabletId);
+                if (currTsever != null && !currTsever.equals(tabletServerId)) {
+                    balanceParameters.migrationsOut().add(new TabletMigration(tabletId, currTsever, tabletServerId));
+                    migrationsAdded++;
+                    if (migrationsAdded >= maxMigrations) {
+                        break outer;
+                    }
+                }
+            }
+        }
+
+        lastRunTime = System.currentTimeMillis();
+
+        return 5000;
+    }
+
+    private Map<String,List<TabletId>> groupTablets(Set<TabletId> tablets) {
+        Map<String,List<TabletId>> tabletsPerGroup = new HashMap<>();
+        tablets.forEach(tabletId -> {
+            var group = getTabletGroup(tabletId);
+            tabletsPerGroup.computeIfAbsent(group, g -> new ArrayList<>()).add(tabletId);
+        });
+        return tabletsPerGroup;
+    }
+
+    private Map<String,List<TabletId>> groupTablets(Set<TabletId> tablets, Predicate<String> groupFilter) {
+        Map<String,List<TabletId>> tabletsPerGroup = new HashMap<>();
+        tablets.forEach(tabletId -> {
+            var group = getTabletGroup(tabletId);
+            if (groupFilter.test(group)) {
+                tabletsPerGroup.computeIfAbsent(group, g -> new ArrayList<>()).add(tabletId);
+            }
+        });
+        return tabletsPerGroup;
+    }
+
+    /**
+     * @param tserversForGroup
+     *            map of tservers that tablets can be assigned to, the map is expected to be keyed on hostname
+     * @return
+     */
+    private Map<TabletId,TabletServerId> getDesiredLocationsForTabletGroup(String tabletGroupName, List<TabletId> tabletsInGroup,
+                    Map<String,List<TabletServerId>> tserversForGroup, Map<TabletId,TabletServerId> currentLocations) {
+
+        // Use rendezvous hashing to first determine the goal number of tablets that each hostname should have
+        Map<String,Integer> hostGoalCounts = getGoalCounts(tabletGroupName, tabletsInGroup.size(), tserversForGroup.keySet(), h -> h);
+        // For each hostname, use rendezvous hashing to determine how many tablets each tserver on that host should have
+        Map<TabletServerId,Integer> tserverGoalCounts = new LinkedHashMap<>();
+        hostGoalCounts.forEach((hostname, goalTablets) -> {
+            var goalCounts = getGoalCounts(tabletGroupName, goalTablets, tserversForGroup.get(hostname), tsi -> tsi.getHost() + ":" + tsi.getPort());
+            Preconditions.checkState(Collections.disjoint(tserverGoalCounts.keySet(), goalCounts.keySet()));
+            tserverGoalCounts.putAll(goalCounts);
+        });
+
+        Map<TabletId,TabletServerId> desiredLocations = new HashMap<>();
+        // find all tablets that can remain at their current or last location
+        for (var tabletId : tabletsInGroup) {
+            var currentTserverId = currentLocations.get(tabletId);
+            if (currentTserverId != null) {
+                int goalCount = tserverGoalCounts.getOrDefault(currentTserverId, 0);
+                if (goalCount > 0) {
+                    desiredLocations.put(tabletId, currentTserverId);
+                    goalCount--;
+                    if (goalCount == 0) {
+                        tserverGoalCounts.remove(currentTserverId);
+                    } else {
+                        tserverGoalCounts.put(currentTserverId, goalCount);
+                    }
+                }
+            }
+        }
+
+        if (desiredLocations.size() == tabletsInGroup.size()) {
+            Preconditions.checkState(tserverGoalCounts.isEmpty());
+            return desiredLocations;
+        }
+
+        // assign tablets to new locations
+        for (var tabletId : tabletsInGroup) {
+            if (!desiredLocations.containsKey(tabletId)) {
+                var iter = tserverGoalCounts.entrySet().iterator();
+                Map.Entry<TabletServerId,Integer> next = iter.next();
+                TabletServerId nextTserver = next.getKey();
+                int nextCount = next.getValue();
+                Preconditions.checkState(nextCount > 0);
+                desiredLocations.put(tabletId, nextTserver);
+                nextCount--;
+                if (nextCount > 0) {
+                    next.setValue(nextCount);
+                } else {
+                    iter.remove();
+                }
+            }
+        }
+
+        Preconditions.checkState(tserverGoalCounts.isEmpty());
+
+        return desiredLocations;
+    }
+
+    private <T> Map<T,Integer> getGoalCounts(String tabletGroup, int numTablets, Collection<T> destinations, Function<T,String> destToStringFunction) {
+        List<Map.Entry<HashCode,T>> hashCodes = new ArrayList<>(destinations.size());
+
+        // Compute rendezvous hashes
+        for (T dest : destinations) {
+            var destString = destToStringFunction.apply(dest);
+            HashCode hashCode = Hashing.murmur3_128().hashString(destString + ":" + tabletGroup, StandardCharsets.UTF_8);
+            hashCodes.add(new AbstractMap.SimpleImmutableEntry<>(hashCode, dest));
+        }
+
+        // order by rendezvous hashes
+        var comparator = UnsignedBytes.lexicographicalComparator();
+        hashCodes.sort((e1, e2) -> comparator.compare(e1.getKey().asBytes(), e2.getKey().asBytes()));
+
+        int numTabletsOnAll = numTablets / destinations.size();
+        int numDestinationsWithOneMore = numTablets % destinations.size();
+
+        Map<T,Integer> goalCounts = new LinkedHashMap<>();
+
+        for (int i = 0; i < numDestinationsWithOneMore; i++) {
+            goalCounts.put(hashCodes.get(i).getValue(), numTabletsOnAll + 1);
+        }
+
+        if (numTabletsOnAll > 0) {
+            for (int i = numDestinationsWithOneMore; i < hashCodes.size(); i++) {
+                goalCounts.put(hashCodes.get(i).getValue(), numTabletsOnAll);
+            }
+        }
+
+        return goalCounts;
+    }
+}

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -159,7 +159,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
         Map<String,List<TabletId>> tabletsPerGroup = groupTablets(allLocations.keySet());
 
-        Function<String,Map<String,List<TabletServerId>>> tabletServerParitioner = getServerPartitioner(balanceParameters.currentStatus().keySet());
+        Function<String,Map<String,List<TabletServerId>>> tabletServerPartitioner = getServerPartitioner(balanceParameters.currentStatus().keySet());
 
         // read once so a consistent max is used for the entire balance call
         final int maxMigrations = getMaxMigrations();

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -70,17 +70,87 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
     /**
      * Creates a function that determines what tservers should be used for a named group of tablets. The function should map a name returned by
-     * {@link #getTabletGroup(TabletId)} to a subset of tablet servers. The returned map should be keyed on hostname.
+     * {@link #getTabletGroup(TabletId)} to a subset of tablet servers.
      *
      * @param allTservers
      *            set of tservers to use for partitioning
      * @return The function which will partition the group of tservers
      */
-    protected abstract Function<String,Map<String,List<TabletServerId>>> getServerPartitioner(Collection<TabletServerId> allTservers);
+    protected abstract Function<String,List<TabletServerId>> getServerPartitioner(Collection<TabletServerId> allTservers);
 
     @Override
     public void init(BalancerEnvironment balancerEnvironment) {
         this.env = balancerEnvironment;
+    }
+
+    private static class TServers {
+
+        Map<Integer,Map<String,List<TabletServerId>>> tservers = new HashMap<>();
+
+        TServers(List<TabletServerId> tabletServers) {
+            Map<String,List<TabletServerId>> tseversPerHost = new HashMap<>();
+            for (var tserver : tabletServers) {
+                tseversPerHost.computeIfAbsent(tserver.getHost(), h -> new ArrayList<>()).add(tserver);
+            }
+
+            tseversPerHost.forEach((host, tsList) -> {
+                tservers.computeIfAbsent(tsList.size(), s -> new HashMap<>()).put(host, tsList);
+            });
+        }
+
+        Map<String,List<TabletServerId>> getTserverWithNHost(int numHost) {
+            return tservers.get(numHost);
+        }
+
+        int getTotalNumberOfTservers() {
+            int total = 0;
+            for (var entry : tservers.entrySet()) {
+                total += entry.getKey() * entry.getValue().size();
+            }
+            return total;
+        }
+
+        /**
+         * If there are 1000 tablets and there are 40 hosts with 5 tservers and 10 hosts with 4 tservers then this function will do the following
+         *
+         * <ul>
+         * <li>compute there are a total of 40*5+10*4 = 240 tablet servers.</li>
+         * <li>For the 40 host with 5 tservers, they are 200/240=83.33% of the tservers. So give 833 of the 1000 tablets to this set of tservers.</li>
+         * <li>For the 10 host with 4 tservers, they are 40/240=16.66% of the tservers. So give 167 of the 1000 tablets to this set of tservers.</li>
+         * </ul>
+         *
+         * <p>
+         * For the example above would return Map.of(5, 833, 4, 167);
+         */
+        public Map<Integer,Integer> computeTabletAssignmentCountsByHostCount(int numTablets) {
+            if (tservers.size() == 1) {
+                return Map.of(tservers.keySet().iterator().next(), numTablets);
+            }
+
+            Map<Integer,Integer> counts = new HashMap<>();
+
+            double totalTservers = getTotalNumberOfTservers();
+
+            int tabletsLeft = numTablets;
+
+            for (var entry : tservers.entrySet()) {
+                int tserversPerHost = entry.getKey();
+                int numHost = entry.getValue().size();
+                double numTservers = tserversPerHost * numHost;
+
+                double percent = numTservers / totalTservers;
+
+                int tablets = Math.min(tabletsLeft, (int) Math.round(numTablets * percent));
+                if (tablets > 0) {
+                    counts.put(tserversPerHost, tablets);
+                    tabletsLeft -= tablets;
+                }
+            }
+
+            Preconditions.checkState(tabletsLeft == 0);
+
+            return counts;
+        }
     }
 
     @Override
@@ -107,10 +177,11 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         Map<String,List<TabletId>> tabletsToAssign = groupTablets(lastLocations.keySet());
         Map<String,List<TabletId>> allTabletsGrouped = groupTablets(allLocations.keySet(), tabletsToAssign::containsKey);
 
-        Function<String,Map<String,List<TabletServerId>>> tabletServerPartitioner = getServerPartitioner(currentTservers.keySet());
+        Function<String,List<TabletServerId>> tabletServerPartitioner = getServerPartitioner(currentTservers.keySet());
+        Map<String,TServers> computedTservers = new HashMap<>();
 
         tabletsToAssign.forEach((tabletGroup, tablets) -> {
-            Map<String,List<TabletServerId>> tserversForGroup = tabletServerPartitioner.apply(tabletGroup);
+            TServers tserversForGroup = computedTservers.computeIfAbsent(tabletGroup, g -> new TServers(tabletServerPartitioner.apply(tabletGroup)));
 
             // Must pass the set of all tablets for the group to compute the desired location, not just the subset of tablets being assigned
             var allTablets = allTabletsGrouped.get(tabletGroup);
@@ -159,7 +230,8 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
         Map<String,List<TabletId>> tabletsPerGroup = groupTablets(allLocations.keySet());
 
-        Function<String,Map<String,List<TabletServerId>>> tabletServerPartitioner = getServerPartitioner(balanceParameters.currentStatus().keySet());
+        Function<String,List<TabletServerId>> tabletServerPartitioner = getServerPartitioner(currentTservers.keySet());
+        Map<String,TServers> computedTservers = new HashMap<>();
 
         // read once so a consistent max is used for the entire balance call
         final int maxMigrations = getMaxMigrations();
@@ -168,7 +240,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         outer: for (var tpgEntry : tabletsPerGroup.entrySet()) {
             String tabletGroup = tpgEntry.getKey();
             List<TabletId> tablets = tpgEntry.getValue();
-            Map<String,List<TabletServerId>> tserversForGroup = tabletServerPartitioner.apply(tabletGroup);
+            TServers tserversForGroup = computedTservers.computeIfAbsent(tabletGroup, g -> new TServers(tabletServerPartitioner.apply(tabletGroup)));
 
             Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, tablets, tserversForGroup, allLocations);
 
@@ -225,18 +297,31 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
      *            map of current tablet locations
      * @return Map of desired locations for a given tablet group name and list of tablets.
      */
-    private Map<TabletId,TabletServerId> getDesiredLocationsForTabletGroup(String tabletGroupName, List<TabletId> tabletsInGroup,
-                    Map<String,List<TabletServerId>> tserversForGroup, Map<TabletId,TabletServerId> currentLocations) {
+    private Map<TabletId,TabletServerId> getDesiredLocationsForTabletGroup(String tabletGroupName, List<TabletId> tabletsInGroup, TServers tserversForGroup,
+                    Map<TabletId,TabletServerId> currentLocations) {
 
-        // Use rendezvous hashing to first determine the goal number of tablets that each hostname should have
-        Map<String,Integer> hostGoalCounts = getGoalCounts(tabletGroupName, tabletsInGroup.size(), tserversForGroup.keySet(), h -> h);
-        // For each hostname, use rendezvous hashing to determine how many tablets each tserver on that host should have
         Map<TabletServerId,Integer> tserverGoalCounts = new LinkedHashMap<>();
-        hostGoalCounts.forEach((hostname, goalTablets) -> {
-            var goalCounts = getGoalCounts(tabletGroupName, goalTablets, tserversForGroup.get(hostname), tsi -> tsi.getHost() + ":" + tsi.getPort());
-            Preconditions.checkState(Collections.disjoint(tserverGoalCounts.keySet(), goalCounts.keySet()));
-            tserverGoalCounts.putAll(goalCounts);
-        });
+
+        // If rendevous balance was done across host w/ different numbers of tablets, then it would lead to hosts with less tablets getting more tablets per
+        // tservers. To deal with this hosts with different numbers of tablets servers are partitioned. Then rendevous balancing is done across each partition.
+        Map<Integer,Integer> tabletsCountsPerHostCount = tserversForGroup.computeTabletAssignmentCountsByHostCount(tabletsInGroup.size());
+
+        for (var entry : tabletsCountsPerHostCount.entrySet()) {
+            int tserversPerHost = entry.getKey();
+            // the number of tablets for this
+            int numTablets = entry.getValue();
+            // all of the tservers that have this number of tablets per host
+            Map<String,List<TabletServerId>> tabletServers = tserversForGroup.getTserverWithNHost(tserversPerHost);
+
+            // Use rendezvous hashing to first determine the goal number of tablets that each hostname should have
+            Map<String,Integer> hostGoalCounts = getGoalCounts(tabletGroupName, numTablets, tabletServers.keySet(), h -> h);
+            // For each hostname, use rendezvous hashing to determine how many tablets each tserver on that host should have
+            hostGoalCounts.forEach((hostname, goalTablets) -> {
+                var goalCounts = getGoalCounts(tabletGroupName, goalTablets, tabletServers.get(hostname), tsi -> tsi.getHost() + ":" + tsi.getPort());
+                Preconditions.checkState(Collections.disjoint(tserverGoalCounts.keySet(), goalCounts.keySet()));
+                tserverGoalCounts.putAll(goalCounts);
+            });
+        }
 
         Map<TabletId,TabletServerId> desiredLocations = new HashMap<>();
         // find all tablets that can remain at their current or last location

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -90,7 +90,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         TServers(List<TabletServerId> tabletServers) {
             Map<String,List<TabletServerId>> tseversPerHost = new HashMap<>();
             for (var tserver : tabletServers) {
-                tseversPerHost.computeIfAbsent(tserver.getHost(), h -> new ArrayList<>()).add(tserver);
+                tserversPerHost.computeIfAbsent(tserver.getHost(), h -> new ArrayList<>()).add(tserver);
             }
 
             tserversPerHost.forEach((host, tsList) -> {

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -93,7 +93,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
                 tseversPerHost.computeIfAbsent(tserver.getHost(), h -> new ArrayList<>()).add(tserver);
             }
 
-            tseversPerHost.forEach((host, tsList) -> {
+            tserversPerHost.forEach((host, tsList) -> {
                 tservers.computeIfAbsent(tsList.size(), s -> new HashMap<>()).put(host, tsList);
             });
         }

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -110,7 +110,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         Function<String,Map<String,List<TabletServerId>>> tabletServerPartitioner = getServerPartitioner(currentTservers.keySet());
 
         tabletsToAssign.forEach((tabletGroup, tablets) -> {
-            Map<String,List<TabletServerId>> tserversForGroup = tabletServerParitioner.apply(tabletGroup);
+            Map<String,List<TabletServerId>> tserversForGroup = tabletServerPartitioner.apply(tabletGroup);
 
             // Must pass the set of all tablets for the group to compute the desired location, not just the subset of tablets being assigned
             var allTablets = allTabletsGrouped.get(tabletGroup);

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -216,7 +216,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
 
     /**
      * @param tabletGroupName
-     *            Mame of tablet group
+     *            Name of tablet group
      * @param tabletsInGroup
      *            List of tablets in the tablet group
      * @param tserversForGroup

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
@@ -166,7 +166,7 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
             var daysBack = getDaysBack(configuredTiers, tabletServerId);
             if (!daysBack.isEmpty()) {
                 for (var db : daysBack) {
-                    log.trace(" daysBack:{} tserver:{}", daysBack, tabletServerId);
+                    log.trace(" daysBack:{} tserver:{}", db, tabletServerId);
                     serverPartitioningMap.computeIfAbsent(db, ub -> new HashMap<>()).computeIfAbsent(tabletServerId.getHost(), h -> new ArrayList<>())
                                     .add(tabletServerId);
                 }

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
@@ -1,0 +1,226 @@
+package datawave.ingest.table.balancer;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.accumulo.core.conf.Property;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.spi.balancer.BalancerEnvironment;
+import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.ingest.table.volumeChoosers.ShardedTableDateBasedTieredVolumeChooser;
+
+/**
+ * An alternative to the #ShardedTableTabletBalancer for balancing the shard table. There are four key differences with this balancer. First, it balances each
+ * day independently using rendezvous hashing, the advantage of this is that adding/removing/changing one day does not impact the balancing decisions for all
+ * other days. Second, it evens the shards in a day out across host and then tablet servers on a host. Third, it makes the same decisions when computing
+ * assignments and balancing, the #ShardedTableTabletBalancer can make different decisions in computing assignments that balance computation will undo. Fourth,
+ * it allows partitioning the tablets servers and tablets by time, for example can assign tablets that are from 0 to 20 days old to tablet server group1
+ * (defined by a regex) and tablets older than 20 days to tablet server group2.
+ *
+ * <p>
+ * Since this balancer uses rendezvous hashing it will not achieve exactly num_tablets/num_tservers tablet per tserver. In testing 70% of tservers had a tablet
+ * count within one standard deviation of num_tablets/num_tservers. 95% of tservers had a tablet count within two standard deviations of
+ * num_tablets/num_tservers.
+ * </p>
+ *
+ * <p>
+ * Configuration of this balancer builds on the configuration of the {@link ShardedTableDateBasedTieredVolumeChooser}
+ * </p>
+ * balancer by interleaving tserver properties within its properties. Below is an example of configuring this balancer to use tablet severs that match the regex
+ * {@code host0000.*} for shards 0 to 20 days old. Tablet servers that match the regex {@code host000[1-9].*} are used for shards over 20 days old. The host
+ * selected by the regex for each tier do not have to be disjoint. Tablets within each tier will only use the host that match the regex, but it does not care if
+ * another tier uses those hosts.
+ *
+ * <pre>
+ *         table.custom.volume.tier.names=t1,t2
+ *         table.custom.volume.tiered.t1.days.back=0
+ *         table.custom.volume.tiered.t1.tservers=host0000.*
+ *         table.custom.volume.tiered.t2.days.back=20
+ *         table.custom.volume.tiered.t2.tservers=host000[1-9].*
+ *         table.custom.sharded.balancer.max.migrations=1000
+ * </pre>
+ */
+public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
+
+    private static final Logger log = LoggerFactory.getLogger(ShardRendezvousHostBalancer.class);
+
+    static final ShardedTableTabletBalancer.ShardDayPartitioner PARTITIONER = new ShardedTableTabletBalancer.ShardDayPartitioner();
+    private static final String TSERVERS_PREFIX = ".tservers";
+    private static final String SHARDED_PROPERTY_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "sharded.balancer.";
+    public static final String SHARDED_MAX_MIGRATIONS = SHARDED_PROPERTY_PREFIX + "max.migrations";
+    public static final int MAX_MIGRATIONS_DEFAULT = 10000;
+
+    private Configuration tableConfig;
+
+    public ShardRendezvousHostBalancer(TableId tableId) {
+        super(tableId);
+    }
+
+    @Override
+    public void init(BalancerEnvironment balancerEnvironment) {
+        super.init(balancerEnvironment);
+        this.tableConfig = balancerEnvironment.getConfiguration(tableIdToBalance);
+    }
+
+    @Override
+    protected String getTabletGroup(TabletId tabletId) {
+        return PARTITIONER.apply(tabletId);
+    }
+
+    @Override
+    protected int getMaxMigrations() {
+        return getMaxMigrations(() -> tableConfig);
+    }
+
+    public static int getMaxMigrations(Supplier<Configuration> tableConfig) {
+        int maxMigrations = MAX_MIGRATIONS_DEFAULT;
+        try {
+            String maxMigrationsProp = tableConfig.get().get(SHARDED_MAX_MIGRATIONS);
+            if (maxMigrationsProp != null && !maxMigrationsProp.isEmpty()) {
+                try {
+                    maxMigrations = Integer.parseInt(maxMigrationsProp);
+                } catch (Exception e) {
+                    log.error("Unable to parse {} value ({}}) as an integer.  Defaulting to {}", SHARDED_MAX_MIGRATIONS, maxMigrationsProp, maxMigrations);
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get {}}.  Defaulting to {}", SHARDED_MAX_MIGRATIONS, maxMigrations, e);
+        }
+        return maxMigrations;
+    }
+
+    private List<Map.Entry<Long,Matcher>> getTiers(Configuration tableConfig) {
+        List<Map.Entry<Long,Matcher>> configuredTiers = new ArrayList<>();
+        Set<String> tiers = ShardedTableDateBasedTieredVolumeChooser.listTiers(tableIdToBalance, tableConfig);
+        for (String tier : tiers) {
+            long daysBack = ShardedTableDateBasedTieredVolumeChooser.getTierDaysBack(tableIdToBalance, tableConfig, tier);
+            String regex = ShardedTableDateBasedTieredVolumeChooser.getTierProperty(tableIdToBalance, tableConfig, tier, TSERVERS_PREFIX);
+            var pattern = Pattern.compile(regex);
+            configuredTiers.add(new AbstractMap.SimpleImmutableEntry<>(daysBack, pattern.matcher("")));
+        }
+        return configuredTiers;
+    }
+
+    protected List<Long> getDaysBack(List<Map.Entry<Long,Matcher>> configuredTiers, TabletServerId tabletServerId) {
+        ArrayList<Long> db = new ArrayList<>();
+        for (var entry : configuredTiers) {
+            long daysBack = entry.getKey();
+            Matcher matcher = entry.getValue();
+            matcher.reset(tabletServerId.getHost() + ":" + tabletServerId.getPort());
+            if (matcher.matches()) {
+                db.add(daysBack);
+            }
+        }
+        return db;
+    }
+
+    protected LocalDate today() {
+        return LocalDate.now();
+    }
+
+    public static LocalDate parse(String date) {
+        try {
+            return LocalDate.parse(date, FORMATTER);
+        } catch (DateTimeParseException e) {
+            log.warn("Shard: {} is not formatted correctly", date);
+            return LocalDate.EPOCH;
+        }
+
+    }
+
+    private static final String DATE_PATTERN = "yyyyMMdd";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_PATTERN);
+
+    @Override
+    protected Function<String,Map<String,List<TabletServerId>>> getServerPartitioner(Collection<TabletServerId> allTservers) {
+
+        final List<Map.Entry<Long,Matcher>> configuredTiers = getTiers(tableConfig);
+
+        if (configuredTiers.isEmpty()) {
+            throw new IllegalStateException("Tier configuration is not set");
+        }
+
+        TreeMap<Long,Map<String,List<TabletServerId>>> serverPartitioningMap = new TreeMap<>();
+
+        allTservers.forEach(tabletServerId -> {
+            var daysBack = getDaysBack(configuredTiers, tabletServerId);
+            if (!daysBack.isEmpty()) {
+                for (var db : daysBack) {
+                    log.trace(" daysBack:{} tserver:{}", daysBack, tabletServerId);
+                    serverPartitioningMap.computeIfAbsent(db, ub -> new HashMap<>()).computeIfAbsent(tabletServerId.getHost(), h -> new ArrayList<>())
+                                    .add(tabletServerId);
+                }
+            } else {
+                log.warn("Tserver {} did not match any tiers", tabletServerId);
+            }
+        });
+
+        serverPartitioningMap.forEach((daysBack, servers) -> {
+            Map<Integer,Integer> perHostHistogram = new HashMap<>();
+            for (var tservers : servers.values()) {
+                perHostHistogram.merge(tservers.size(), 1, Integer::sum);
+            }
+            // This is the most common count for tservers per host
+            int maxHistogramValue = perHostHistogram.values().stream().mapToInt(i -> i).max().getAsInt();
+            int tmp = 0;
+            for (var entry : perHostHistogram.entrySet()) {
+                if (entry.getValue() == maxHistogramValue) {
+                    tmp = entry.getKey();
+                }
+            }
+            int expectedTserversPerHost = tmp;
+
+            // If a hostA has 1 tablet server and all other host have 3, then the single tserver on hostA would get 3x the tablets as tservers on other host. To
+            // avoid this problem any host that differs in the number of tablet servers is ignored.
+            servers.entrySet().removeIf(e -> {
+                String host = e.getKey();
+                List<TabletServerId> tservers = e.getValue();
+                if (tservers.size() != expectedTserversPerHost) {
+                    log.warn("Ignoring all tservers on host {} because it has {} tservers and not {}", host, tservers.size(), expectedTserversPerHost);
+                    return true;
+                }
+                return false;
+            });
+
+            log.debug(" daysBack:{} numHosts:{}", daysBack, servers.size());
+        });
+
+        // grab this once outside the lambda so the lambda always makes consistent decisions.
+        var today = today();
+
+        return tabletGroup -> {
+            LocalDate rowDate = tabletGroup.equals("null") ? today : parse(tabletGroup);
+            long days = DAYS.between(rowDate, today);
+            var entry = serverPartitioningMap.floorEntry(days);
+            if (entry == null) {
+                if (days < 0) {
+                    // This date is in the future
+                    entry = serverPartitioningMap.firstEntry();
+                } else {
+                    entry = serverPartitioningMap.lastEntry();
+                }
+            }
+            return entry == null ? Map.of() : entry.getValue();
+        };
+    }
+}

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
@@ -8,7 +8,6 @@ import java.time.format.DateTimeParseException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -152,7 +151,7 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_PATTERN);
 
     @Override
-    protected Function<String,Map<String,List<TabletServerId>>> getServerPartitioner(Collection<TabletServerId> allTservers) {
+    protected Function<String,List<TabletServerId>> getServerPartitioner(Collection<TabletServerId> allTservers) {
 
         final List<Map.Entry<Long,Matcher>> configuredTiers = getTiers(tableConfig);
 
@@ -160,49 +159,18 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
             throw new IllegalStateException("Tier configuration is not set");
         }
 
-        TreeMap<Long,Map<String,List<TabletServerId>>> serverPartitioningMap = new TreeMap<>();
+        TreeMap<Long,List<TabletServerId>> serverPartitioningMap = new TreeMap<>();
 
         allTservers.forEach(tabletServerId -> {
             var daysBack = getDaysBack(configuredTiers, tabletServerId);
             if (!daysBack.isEmpty()) {
                 for (var db : daysBack) {
                     log.trace(" daysBack:{} tserver:{}", db, tabletServerId);
-                    serverPartitioningMap.computeIfAbsent(db, ub -> new HashMap<>()).computeIfAbsent(tabletServerId.getHost(), h -> new ArrayList<>())
-                                    .add(tabletServerId);
+                    serverPartitioningMap.computeIfAbsent(db, ub -> new ArrayList<>()).add(tabletServerId);
                 }
             } else {
                 log.warn("Tserver {} did not match any tiers", tabletServerId);
             }
-        });
-
-        serverPartitioningMap.forEach((daysBack, servers) -> {
-            Map<Integer,Integer> perHostHistogram = new HashMap<>();
-            for (var tservers : servers.values()) {
-                perHostHistogram.merge(tservers.size(), 1, Integer::sum);
-            }
-            // This is the most common count for tservers per host
-            int maxHistogramValue = perHostHistogram.values().stream().mapToInt(i -> i).max().getAsInt();
-            int tmp = 0;
-            for (var entry : perHostHistogram.entrySet()) {
-                if (entry.getValue() == maxHistogramValue) {
-                    tmp = entry.getKey();
-                }
-            }
-            int expectedTserversPerHost = tmp;
-
-            // If a hostA has 1 tablet server and all other host have 3, then the single tserver on hostA would get 3x the tablets as tservers on other host. To
-            // avoid this problem any host that differs in the number of tablet servers is ignored.
-            servers.entrySet().removeIf(e -> {
-                String host = e.getKey();
-                List<TabletServerId> tservers = e.getValue();
-                if (tservers.size() != expectedTserversPerHost) {
-                    log.warn("Ignoring all tservers on host {} because it has {} tservers and not {}", host, tservers.size(), expectedTserversPerHost);
-                    return true;
-                }
-                return false;
-            });
-
-            log.debug(" daysBack:{} numHosts:{}", daysBack, servers.size());
         });
 
         // grab this once outside the lambda so the lambda always makes consistent decisions.
@@ -220,7 +188,7 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
                     entry = serverPartitioningMap.lastEntry();
                 }
             }
-            return entry == null ? Map.of() : entry.getValue();
+            return entry == null ? List.of() : entry.getValue();
         };
     }
 }

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardedTableTabletBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardedTableTabletBalancer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
@@ -82,9 +83,13 @@ public class ShardedTableTabletBalancer extends GroupBalancer {
 
     @Override
     protected int getMaxMigrations() {
+        return getMaxMigrations(this::getTableConfiguration);
+    }
+
+    static int getMaxMigrations(Supplier<Configuration> tableConfig) {
         int maxMigrations = MAX_MIGRATIONS_DEFAULT;
         try {
-            String maxMigrationsProp = getTableConfiguration().get(SHARDED_MAX_MIGRATIONS);
+            String maxMigrationsProp = tableConfig.get().get(SHARDED_MAX_MIGRATIONS);
             if (maxMigrationsProp != null && !maxMigrationsProp.isEmpty()) {
                 try {
                     maxMigrations = Integer.parseInt(maxMigrationsProp);
@@ -116,7 +121,7 @@ public class ShardedTableTabletBalancer extends GroupBalancer {
      * Partitions extents into groups according to the "day" portion of the end row. That is, the end row is expected to be in the form yyyymmdd_x, and the
      * partitioner returns yyyymmdd.
      */
-    protected static class ShardDayPartitioner implements Function<TabletId,String> {
+    static class ShardDayPartitioner implements Function<TabletId,String> {
         @Override
         public String apply(TabletId t) {
             String date = "null"; // Don't return null

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
@@ -320,14 +320,6 @@ public class ShardRendezvousHostBalancerTest {
         migrations.clear();
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
         assertTrue(migrations.isEmpty());
-
-        // add some host that have less tabletservers than the other host... should ignore these host
-        generateTabletServers(32, 1, 2).forEach(testTServers::addTServer);
-        generateTabletServers(33, 1, 1).forEach(testTServers::addTServer);
-        migrations.clear();
-        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
-        assertTrue(migrations.isEmpty());
-
     }
 
     @Test
@@ -624,54 +616,69 @@ public class ShardRendezvousHostBalancerTest {
     }
 
     @Test
-    public void testHostWithUncommonTserverCount() throws Exception {
-        generateTabletServers(0, 10, 3).forEach(testTServers::addTServer);
+    public void testHostWithVaryingTserverCount() throws Exception {
+        generateTabletServers(0, 7, 3).forEach(testTServers::addTServer);
         // Create a few that differs from the norm of 3 tservers per host
-        generateTabletServers(10, 1, 1).forEach(testTServers::addTServer);
-        generateTabletServers(11, 1, 2).forEach(testTServers::addTServer);
-        generateTabletServers(12, 1, 4).forEach(testTServers::addTServer);
+        generateTabletServers(10, 2, 1).forEach(testTServers::addTServer);
+        generateTabletServers(12, 5, 2).forEach(testTServers::addTServer);
+        generateTabletServers(17, 1, 4).forEach(testTServers::addTServer);
 
-        generateTabletServers(20, 20, 4).forEach(testTServers::addTServer);
+        generateTabletServers(20, 11, 4).forEach(testTServers::addTServer);
         // For the 2nd group of tservers, create a few that differs from the norm of 4 tservers per host
-        generateTabletServers(40, 2, 2).forEach(testTServers::addTServer);
+        generateTabletServers(40, 5, 2).forEach(testTServers::addTServer);
 
-        tablets.addAll(createShards(tableId, "20010101", 30, 31));
-        today.set(parseDay("20010130"));
+        tablets.addAll(createShards(tableId, "20010101", 31, 31));
+        today.set(parseDay("20010131"));
 
         tableProps.clear();
         tableProps.put("table.custom.volume.tier.names", "t1,t2");
         tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
         tableProps.put("table.custom.volume.tiered.t1.tservers", "host000[01].*");
         tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
-        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[234].*");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[2345].*");
 
         balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
         testTServers.applyAssignments(aout);
 
-        var shardStats = ShardStats.compute(filter("host000[01].*", testTServers.getLocationProvider()));
-        // should ignore three host that do not have the most common tserver per host count
-        shardStats.check(20, 31, 10, 3);
-        // should ignore two host that do not have the most common tserver per host count
-        shardStats = ShardStats.compute(filter("host000[234].*", testTServers.getLocationProvider()));
-        shardStats.check(10, 31, 20, 4);
+        /*
+         * There are 37 tservers in tier t1.
+         *
+         * There are 7 host with 3 tservers, these make up 7*3/37=.5676 of all tservers. For each day w/ 31 tablets they will get round(.5676*31)=18 tablets.
+         * That is why shards per day is set to 18 below. The 2 host w/ 1 tservers will get round(2/37*31)=2 of the 31 shards for each day. The 5 host w/ 2
+         * tservers will get round(5*2/37*31)=8 of the 31 shards for each day. The 1 host w/ 4 tservers will get round(4/37*31)=3 of the 31 shards for each day.
+         */
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 18, 7, 3);
+        shardStats = ShardStats.compute(filter("host0001[01].*", testTServers.getLocationProvider()));
+        shardStats.check(20, 2, 2, 1);
+        shardStats = ShardStats.compute(filter("host0001[23456].*", testTServers.getLocationProvider()));
+        shardStats.check(20, 8, 5, 2);
+        shardStats = ShardStats.compute(filter("host00017.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 3, 1, 4);
 
-        // double check the test assumptions, ensure the regexes match more host than tablet were assigned to
-        assertEquals(13, testTServers.tservers.stream().map(TabletServerId::getHost).filter(h -> h.matches("host000[01].*")).distinct().count());
-        assertEquals(22, testTServers.tservers.stream().map(TabletServerId::getHost).filter(h -> h.matches("host000[234].*")).distinct().count());
+        /*
+         * There are a total of 54 tservers in tier t2. The 11 host w/ 4 tservers will get round(11*4/54*31)=25 of the 31 shards per day. The 5 host w/ 2
+         * tsevers will get round(5*2/54*31)=6 of the 31 shards per day
+         */
+        shardStats = ShardStats.compute(filter("host000[23].*", testTServers.getLocationProvider()));
+        shardStats.check(11, 25, 11, 4);
+        shardStats = ShardStats.compute(filter("host0004.*", testTServers.getLocationProvider()));
+        shardStats.check(11, 6, 5, 2);
 
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
         assertEquals(0, migrations.size());
 
-        // add a few tablet servers to test that balancing ignore the host w/ an uncommon number of tservers
-        generateTabletServers(42, 3, 4).forEach(testTServers::addTServer);
+        // add a few tablet servers
+        generateTabletServers(50, 1, 3).forEach(testTServers::addTServer);
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.stream().map(tm -> tm.getNewTabletServer().getHost()).noneMatch(h -> h.matches("host000[01].*")));
         testTServers.applyMigrations(migrations);
-        shardStats = ShardStats.compute(filter("host000[01].*", testTServers.getLocationProvider()));
-        shardStats.check(20, 31, 10, 3);
-        shardStats = ShardStats.compute(filter("host000[234].*", testTServers.getLocationProvider()));
-        shardStats.check(10, 31, 23, 4);
-        assertEquals(25, testTServers.tservers.stream().map(TabletServerId::getHost).filter(h -> h.matches("host000[234].*")).distinct().count());
-
+        shardStats = ShardStats.compute(filter("host000[23].*", testTServers.getLocationProvider()));
+        shardStats.check(11, 24, 11, 4);
+        shardStats = ShardStats.compute(filter("host0004.*", testTServers.getLocationProvider()));
+        shardStats.check(11, 5, 5, 2);
+        shardStats = ShardStats.compute(filter("host0005.*", testTServers.getLocationProvider()));
+        shardStats.check(11, 2, 1, 3);
     }
 
     private static String getDay(TabletId tabletId) {

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
@@ -681,6 +681,44 @@ public class ShardRendezvousHostBalancerTest {
         shardStats.check(11, 2, 1, 3);
     }
 
+    @Test
+    public void testHostWithVaryingTserverCountZero() throws Exception {
+        tablets.addAll(createShards(tableId, "20000101", 395, 31));
+        today.set(parseDay("20010130"));
+        generateTabletServers(0, 100, 5).forEach(testTServers::addTServer);
+        generateTabletServers(200, 2, 1).forEach(testTServers::addTServer);
+
+        tableProps.clear();
+        tableProps.put("table.custom.volume.tier.names", "t1");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", "host.*");
+
+        // There are 502 total tserver. The two host with one tserver should have round(2/502*31)=0 tablets from the 31 shards per day assigned to them. All
+        // tablets should go to the 100 host with 5 tservers.
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host000.*", testTServers.getLocationProvider()));
+        shardStats.check(395, 31, 100, 5);
+
+        String regex = "host002.*";
+        // nothing should have been assigned to the two host with a single tserver.
+        assertEquals(Map.of(), filter(regex, testTServers.getLocationProvider()));
+        // check the regex used above
+        assertEquals(2, testTServers.getCurrent().keySet().stream().filter(tabletServerId -> tabletServerId.getHost().matches(regex)).count());
+        assertEquals(502, testTServers.getCurrent().keySet().size());
+
+        // Add 98 host with 1 tserver. For the 31 shards per day the should now partition as round(500/600*31)=26 and round(100/600*31)=5.
+        generateTabletServers(202, 98, 1).forEach(testTServers::addTServer);
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        testTServers.applyMigrations(migrations);
+        shardStats = ShardStats.compute(filter("host000.*", testTServers.getLocationProvider()));
+        shardStats.check(395, 26, 100, 5);
+        shardStats = ShardStats.compute(filter("host002.*", testTServers.getLocationProvider()));
+        shardStats.check(395, 5, 100, 1);
+
+    }
+
     private static String getDay(TabletId tabletId) {
         return ShardRendezvousHostBalancer.PARTITIONER.apply(tabletId);
     }

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
@@ -1,0 +1,879 @@
+package datawave.ingest.table.balancer;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.TableId;
+import org.apache.accumulo.core.data.TabletId;
+import org.apache.accumulo.core.dataImpl.KeyExtent;
+import org.apache.accumulo.core.dataImpl.TabletIdImpl;
+import org.apache.accumulo.core.manager.balancer.TabletServerIdImpl;
+import org.apache.accumulo.core.spi.balancer.BalancerEnvironment;
+import org.apache.accumulo.core.spi.balancer.TabletBalancer;
+import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
+import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
+import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
+import org.apache.accumulo.core.spi.balancer.data.TabletStatistics;
+import org.apache.accumulo.core.spi.common.ServiceEnvironment;
+import org.apache.hadoop.io.Text;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import com.google.common.base.Preconditions;
+
+public class ShardRendezvousHostBalancerTest {
+
+    static class TestTServers {
+        private final Set<TabletServerId> tservers = new HashSet<>();
+        private final SortedMap<TabletId,TabletServerId> tabletLocs = new TreeMap<>();
+
+        public void addTServer(TabletServerId tsi) {
+            tservers.add(tsi);
+        }
+
+        public void removeTservers(Predicate<TabletServerId> tserverPedicate) {
+            tservers.removeIf(tserverPedicate);
+            tabletLocs.values().removeIf(tserverPedicate);
+
+        }
+
+        public void applyAssignments(Map<TabletId,TabletServerId> assignments) {
+            for (Map.Entry<TabletId,TabletServerId> entry : assignments.entrySet()) {
+                TabletId extentToAssign = entry.getKey();
+                TabletServerId assignedServer = entry.getValue();
+                assertTrue("Assignments list has server instance " + entry.getValue() + " that isn't in our servers list.", tservers.contains(assignedServer));
+                tabletLocs.put(extentToAssign, assignedServer);
+            }
+        }
+
+        public void applyMigrations(List<TabletMigration> migrationsOut) {
+            for (TabletMigration migration : migrationsOut) {
+                tabletLocs.put(migration.getTablet(), migration.getNewTabletServer());
+            }
+        }
+
+        public SortedMap<TabletServerId,TServerStatus> getCurrent() {
+            SortedMap<TabletServerId,TServerStatus> current = new TreeMap<>();
+            for (TabletServerId tserver : tservers) {
+                // Currently the balancer only used the key set of this map. Place a strict moock that will fail if the values of the map are used.
+                current.put(tserver, EasyMock.strictMock(TServerStatus.class));
+            }
+            return current;
+        }
+
+        public Map<TabletId,TabletServerId> getLocationProvider() {
+            return tabletLocs;
+        }
+
+        public Map<TabletId,TabletServerId> getUnassigned(Collection<TabletId> allTablets) {
+            Map<TabletId,TabletServerId> unassigned = new HashMap<>();
+            for (var tid : allTablets) {
+                if (tabletLocs.get(tid) == null) {
+                    unassigned.put(tid, null);
+                }
+            }
+
+            return unassigned;
+        }
+
+        public void clearLocation(TabletId tablet) {
+            tabletLocs.remove(tablet);
+        }
+
+        public void clear() {
+            tservers.clear();
+            tabletLocs.clear();
+        }
+
+        public void setLocation(TabletId tablet, TabletServerId tserver) {
+            tabletLocs.put(tablet, tserver);
+        }
+    }
+
+    private AtomicReference<LocalDate> today = new AtomicReference<>();
+    private List<TabletId> tablets = new ArrayList<>();
+    private final TableId tableId = TableId.of("1");
+    private final TestTServers testTServers = new TestTServers();
+    private final Map<String,String> tableProps = new TreeMap<>();
+    private ShardRendezvousHostBalancer balancer;
+    private final Map<TabletId,TabletServerId> aout = new HashMap<>();
+    private final List<TabletMigration> migrations = new ArrayList<>();
+
+    @Before
+    public void setup() {
+
+        tablets.clear();
+        tableProps.clear();
+        testTServers.clear();
+        aout.clear();
+        migrations.clear();
+
+        balancer = new ShardRendezvousHostBalancer(tableId) {
+            @Override
+            protected LocalDate today() {
+                return today.get();
+            }
+
+            @Override
+            protected long getWaitTime() {
+                return 0;
+            }
+        };
+
+        tableProps.put("table.custom.volume.tier.names", "t1,t2");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", "host0000.*");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[1-9].*");
+        tableProps.put("table.custom.sharded.balancer.max.migrations", "1000");
+
+        balancer.init(new MyBalancerEnvironment(tableId, tablets, testTServers, tableProps));
+    }
+
+    public static class TestAssignmentParams implements TabletBalancer.AssignmentParameters {
+
+        private final SortedMap<TabletServerId,TServerStatus> currentStatus;
+        private final Map<TabletId,TabletServerId> unassigned;
+        private final Map<TabletId,TabletServerId> assignments;
+
+        public TestAssignmentParams(SortedMap<TabletServerId,TServerStatus> currentStatus, Map<TabletId,TabletServerId> unassigned,
+                        Map<TabletId,TabletServerId> assignments) {
+            this.currentStatus = currentStatus;
+            this.unassigned = unassigned;
+            this.assignments = assignments;
+        }
+
+        @Override
+        public SortedMap<TabletServerId,TServerStatus> currentStatus() {
+            return currentStatus;
+        }
+
+        @Override
+        public Map<TabletId,TabletServerId> unassignedTablets() {
+            return unassigned;
+        }
+
+        @Override
+        public void addAssignment(TabletId tabletId, TabletServerId tabletServerId) {
+            assignments.put(tabletId, tabletServerId);
+        }
+    }
+
+    private static class TestBalanceParams implements TabletBalancer.BalanceParameters {
+
+        private final SortedMap<TabletServerId,TServerStatus> currentStatus;
+        private final Set<TabletId> migrations;
+        private final List<TabletMigration> migrationsOut;
+
+        private TestBalanceParams(SortedMap<TabletServerId,TServerStatus> currentStatus, Set<TabletId> migrations, List<TabletMigration> migrationsOut) {
+            this.currentStatus = currentStatus;
+            this.migrations = migrations;
+            this.migrationsOut = migrationsOut;
+        }
+
+        @Override
+        public SortedMap<TabletServerId,TServerStatus> currentStatus() {
+            return currentStatus;
+        }
+
+        @Override
+        public Set<TabletId> currentMigrations() {
+            return migrations;
+        }
+
+        @Override
+        public List<TabletMigration> migrationsOut() {
+            return migrationsOut;
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+
+        // nothing changed so should not migrate anything
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        Assertions.assertEquals(0, migrations.size());
+
+        // move forward by one day, should cause tablets to move
+        today.set(parseDay("20010131"));
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        // should migrate all shards in a single day
+        Assertions.assertEquals(31, migrations.size());
+        testTServers.applyMigrations(migrations);
+        // The first set of tservers should loose a day
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(19, 31, 10, 3);
+        // The second set of tserers should gain a day
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(11, 31, 19, 3);
+        // should be stable now
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        // add two tservers
+        generateTabletServers(30, 2, 3).forEach(testTServers::addTServer);
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        testTServers.applyMigrations(migrations);
+        // The first set of tservers should stay the same
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(19, 31, 10, 3);
+        // The second set of tservers should balance days across the 2 new tservers
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(11, 31, 21, 3);
+        // should be stable now
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        // remove a tablet server for case where there are more shards per day than tservers
+        var tabletsOnH09 = testTServers.getLocationProvider().values().stream().filter(tabletServerId -> tabletServerId.getHost().equals("host00009")).count();
+        assertTrue(tabletsOnH09 > 0);
+        testTServers.removeTservers(tabletServerId -> tabletServerId.getHost().equals("host00009"));
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        // balancing will not migrate unassigned tablet, so this should be a noop
+        assertTrue(migrations.isEmpty());
+        aout.clear();
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        assertEquals(tabletsOnH09, aout.size());
+        testTServers.applyAssignments(aout);
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        // assignment should have put everything in its place such that balancing was not needed
+        assertTrue(migrations.isEmpty());
+        // The first set of tservers lost a tserver, so should balance tablets across the remaining
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(19, 31, 9, 3);
+        // The second set of tservers should stay the same
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(11, 31, 21, 3);
+        // should be stable now
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        // remove a tablet server for case where there are more tservers than shards per day
+        var tabletsOnH19 = testTServers.getLocationProvider().values().stream().filter(tabletServerId -> tabletServerId.getHost().equals("host00019")).count();
+        assertTrue(tabletsOnH19 > 0);
+        testTServers.removeTservers(tabletServerId -> tabletServerId.getHost().equals("host00019"));
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        // balancing will not migrate unassigned tablet, so this should be a noop
+        assertTrue(migrations.isEmpty());
+        aout.clear();
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        assertEquals(tabletsOnH19, aout.size());
+        testTServers.applyAssignments(aout);
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        // assignment should have put everything in its place such that balancing was not needed
+        assertTrue(migrations.isEmpty());
+        // The first set of tablet servers should stay the same
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(19, 31, 9, 3);
+        // The second set of tservers lost a tserver and should change
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(11, 31, 20, 3);
+        // should be stable now
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        // add some host that have less tabletservers than the other host... should ignore these host
+        generateTabletServers(32, 1, 2).forEach(testTServers::addTServer);
+        generateTabletServers(33, 1, 1).forEach(testTServers::addTServer);
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+    }
+
+    @Test
+    public void testOverlappingServers() throws Exception {
+        tableProps.clear();
+
+        // Create tiers w/ overlapping sets of tablet servers
+        tableProps.put("table.custom.volume.tier.names", "t1,t2");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", ".*");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[1-9].*");
+        tableProps.put("table.custom.sharded.balancer.max.migrations", "1000");
+
+        balancer.init(new MyBalancerEnvironment(tableId, tablets, testTServers, tableProps));
+
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        testTServers.applyAssignments(aout);
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(
+                        filter(tabletId -> tabletId.getEndRow().toString().matches("2001011[1-9].*|200101[23].*"), testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 29, 3);
+        shardStats = ShardStats
+                        .compute(filter(tabletId -> tabletId.getEndRow().toString().matches("2001010.*|20010110.*"), testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+    }
+
+    @Test
+    public void testFutureDate() throws Exception {
+        tablets.addAll(createShards(tableId, "20010101", 40, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        // The 10 days in the future should go to the tier w/ the lowest days back
+        shardStats.check(30, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+    }
+
+    @Test
+    public void testChangingConfig() throws Exception {
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        assertEquals(1000, balancer.getMaxMigrations());
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+
+        // Change the table config, should cause tablets to move around
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "10");
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertEquals(310, migrations.size());
+        testTServers.applyMigrations(migrations);
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 19, 3);
+
+        // lower max migrations and cause tablets to move again
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+        tableProps.put("table.custom.sharded.balancer.max.migrations", "100");
+        for (int i = 0; i < 3; i++) {
+            migrations.clear();
+            balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+            assertEquals(100, migrations.size());
+            testTServers.applyMigrations(migrations);
+        }
+        migrations.clear();
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertEquals(10, migrations.size());
+        testTServers.applyMigrations(migrations);
+
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+
+        assertEquals(100, balancer.getMaxMigrations());
+    }
+
+    @Test
+    public void testMissingConfig() throws Exception {
+
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        tableProps.clear();
+
+        Assertions.assertThrows(IllegalStateException.class,
+                        () -> balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout)));
+        Assertions.assertThrows(IllegalStateException.class, () -> balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations)));
+
+        // set the config and it should start working
+        tableProps.put("table.custom.volume.tier.names", "t1,t2");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", "host0000.*");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[1-9].*");
+        tableProps.put("table.custom.sharded.balancer.max.migrations", "1000");
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        assertEquals(1000, balancer.getMaxMigrations());
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+    }
+
+    @Test
+    public void testInvalidConfig() throws Exception {
+
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        // set an invalid regex
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[1-9).*");
+        assertThrows(PatternSyntaxException.class,
+                        () -> balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout)));
+        assertThrows(PatternSyntaxException.class, () -> balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations)));
+
+        // fix regex and set invalid day
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "twenty");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[1-9].*");
+        assertThrows(NumberFormatException.class,
+                        () -> balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout)));
+        assertThrows(NumberFormatException.class, () -> balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations)));
+
+        // fix the config and it should start working
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        assertEquals(1000, balancer.getMaxMigrations());
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+
+    }
+
+    @Test
+    public void testNoTservers() throws Exception {
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        assertTrue(aout.isEmpty());
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+    }
+
+    @Test
+    public void testLast() throws Exception {
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        var tservers = generateTabletServers(0, 29, 3);
+        tservers.forEach(testTServers::addTServer);
+
+        var tablet20010103 = tablets.stream().filter(tabletId -> tabletId.getEndRow().toString().startsWith("20010103")).findFirst().orElseThrow();
+        var tablet20010105 = tablets.stream().filter(tabletId -> tabletId.getEndRow().toString().startsWith("20010105")).findFirst().orElseThrow();
+        var tablet20010114 = tablets.stream().filter(tabletId -> tabletId.getEndRow().toString().startsWith("20010114")).findFirst().orElseThrow();
+        var tablet20010127 = tablets.stream().filter(tabletId -> tabletId.getEndRow().toString().startsWith("20010127")).findFirst().orElseThrow();
+
+        var unassigned = testTServers.getUnassigned(tablets);
+
+        var tserver0003 = tservers.stream().filter(tserver -> tserver.getHost().equals("host00003")).findFirst().orElseThrow();
+        var tserver0006 = tservers.stream().filter(tserver -> tserver.getHost().equals("host00006")).findFirst().orElseThrow();
+        var tserver0013 = tservers.stream().filter(tserver -> tserver.getHost().equals("host00013")).findFirst().orElseThrow();
+        var tserver0025 = tservers.stream().filter(tserver -> tserver.getHost().equals("host00025")).findFirst().orElseThrow();
+
+        // set some last locations
+        unassigned.put(tablet20010103, tserver0003); // should not be assigned here
+        unassigned.put(tablet20010105, tserver0013); // should be assigned here
+        unassigned.put(tablet20010114, tserver0006); // should be assigned here
+        unassigned.put(tablet20010127, tserver0025); // should not be assigned here
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), unassigned, aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[1-9].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+
+        assertNotEquals(tserver0003, testTServers.getLocationProvider().get(tablet20010103));
+        assertEquals(tserver0013, testTServers.getLocationProvider().get(tablet20010105));
+        assertEquals(tserver0006, testTServers.getLocationProvider().get(tablet20010114));
+        assertNotEquals(tserver0025, testTServers.getLocationProvider().get(tablet20010127));
+    }
+
+    @Test
+    public void testInvalidShardRow() throws Exception {
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+        generateTabletServers(0, 29, 3).forEach(testTServers::addTServer);
+        generateTabletServers(30, 3, 1).forEach(testTServers::addTServer);
+
+        // Configure a tier for really old data
+        tableProps.put("table.custom.volume.tier.names", "t1,t2,t3");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", "host0000.*");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[12].*");
+        tableProps.put("table.custom.volume.tiered.t3.days.back", "6000");
+        tableProps.put("table.custom.volume.tiered.t3.tservers", "host0003.*");
+        tableProps.put("table.custom.sharded.balancer.max.migrations", "1000");
+
+        // make some invalid tablets
+        var tablet1 = makeTablet(tableId, "2001a_09");
+        tablets.add(tablet1);
+        tablets.add(makeTablet(tableId, "2001a_90"));
+        tablets.add(makeTablet(tableId, "2001a_33"));
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[12].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+        // The three bad tablets should all group into the tier for really old data
+        shardStats = ShardStats.compute(filter("host0003.*", testTServers.getLocationProvider()));
+        shardStats.check(1, 3, 3, 1);
+
+        // move one of the bad tablets to a tserver that is not designated for bad tablets
+        var tserver1 = testTServers.tservers.stream().filter(tabletServerId -> tabletServerId.getHost().matches("host0000.*")).findFirst().orElseThrow();
+        testTServers.setLocation(tablet1, tserver1);
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertEquals(Set.of(tserver1.getHost()),
+                        migrations.stream().map(TabletMigration::getOldTabletServer).map(TabletServerId::getHost).collect(Collectors.toSet()));
+        assertEquals(Set.of(tablet1), migrations.stream().map(TabletMigration::getTablet).collect(Collectors.toSet()));
+        testTServers.applyMigrations(migrations);
+
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[12].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+        shardStats = ShardStats.compute(filter("host0003.*", testTServers.getLocationProvider()));
+        shardStats.check(1, 3, 3, 1);
+
+        // add another bad tablet
+        tablets.add(makeTablet(tableId, "2001$#%^&@$0101_33"));
+        aout.clear();
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[12].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 19, 3);
+        // should see one more shard for the epoch day
+        shardStats = ShardStats.compute(filter("host0003.*", testTServers.getLocationProvider()));
+        shardStats.check(1, 4, 3, 1);
+
+    }
+
+    @Test
+    public void testHostWithUncommonTserverCount() throws Exception {
+        generateTabletServers(0, 10, 3).forEach(testTServers::addTServer);
+        // Create a few that differs from the norm of 3 tservers per host
+        generateTabletServers(10, 1, 1).forEach(testTServers::addTServer);
+        generateTabletServers(11, 1, 2).forEach(testTServers::addTServer);
+        generateTabletServers(12, 1, 4).forEach(testTServers::addTServer);
+
+        generateTabletServers(20, 20, 4).forEach(testTServers::addTServer);
+        // For the 2nd group of tservers, create a few that differs from the norm of 4 tservers per host
+        generateTabletServers(40, 2, 2).forEach(testTServers::addTServer);
+
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+
+        tableProps.clear();
+        tableProps.put("table.custom.volume.tier.names", "t1,t2");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", "host000[01].*");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "host000[234].*");
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host000[01].*", testTServers.getLocationProvider()));
+        // should ignore three host that do not have the most common tserver per host count
+        shardStats.check(20, 31, 10, 3);
+        // should ignore two host that do not have the most common tserver per host count
+        shardStats = ShardStats.compute(filter("host000[234].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 20, 4);
+
+        // double check the test assumptions, ensure the regexes match more host than tablet were assigned to
+        assertEquals(13, testTServers.tservers.stream().map(TabletServerId::getHost).filter(h -> h.matches("host000[01].*")).distinct().count());
+        assertEquals(22, testTServers.tservers.stream().map(TabletServerId::getHost).filter(h -> h.matches("host000[234].*")).distinct().count());
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertEquals(0, migrations.size());
+
+        // add a few tablet servers to test that balancing ignore the host w/ an uncommon number of tservers
+        generateTabletServers(42, 3, 4).forEach(testTServers::addTServer);
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        testTServers.applyMigrations(migrations);
+        shardStats = ShardStats.compute(filter("host000[01].*", testTServers.getLocationProvider()));
+        shardStats.check(20, 31, 10, 3);
+        shardStats = ShardStats.compute(filter("host000[234].*", testTServers.getLocationProvider()));
+        shardStats.check(10, 31, 23, 4);
+        assertEquals(25, testTServers.tservers.stream().map(TabletServerId::getHost).filter(h -> h.matches("host000[234].*")).distinct().count());
+
+    }
+
+    private static String getDay(TabletId tabletId) {
+        return ShardRendezvousHostBalancer.PARTITIONER.apply(tabletId);
+    }
+
+    private static LocalDate parseDay(String day) {
+        return ShardRendezvousHostBalancer.parse(day);
+    }
+
+    private static Map<TabletId,TabletServerId> filter(String regex, Map<TabletId,TabletServerId> locations) {
+        var copy = new HashMap<>(locations);
+        copy.values().removeIf(tserver -> !tserver.getHost().matches(regex));
+        return copy;
+    }
+
+    private static Map<TabletId,TabletServerId> filter(Predicate<TabletId> tabletIdPredicate, Map<TabletId,TabletServerId> locations) {
+        var copy = new HashMap<>(locations);
+        copy.keySet().removeIf(tabletId -> !tabletIdPredicate.test(tabletId));
+        return copy;
+    }
+
+    private static class ShardStats {
+
+        final LongSummaryStatistics dayStats;
+        final LongSummaryStatistics hostStats;
+        final LongSummaryStatistics tserverStats;
+        final LongSummaryStatistics hgStats;
+
+        public ShardStats(LongSummaryStatistics dayStats, LongSummaryStatistics hostStats, LongSummaryStatistics tserverStats, LongSummaryStatistics hgStats) {
+            this.dayStats = dayStats;
+            this.hostStats = hostStats;
+            this.tserverStats = tserverStats;
+            this.hgStats = hgStats;
+        }
+
+        static ShardStats compute(Map<TabletId,TabletServerId> assignedLocations) {
+            Map<String,Long> hostGroupCounts = new HashMap<>();
+            Map<String,Long> perDayCounts = new HashMap<>();
+            Map<String,Long> perHostCounts = new HashMap<>();
+            Map<String,Long> perTserverCounts = new HashMap<>();
+
+            var formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+            assignedLocations.forEach((tabletId, tabletServerId) -> {
+                var day = parseDay(getDay(tabletId)).format(formatter);
+                String host = tabletServerId.getHost();
+                hostGroupCounts.merge(host + " " + day, 1L, Long::sum);
+                perDayCounts.merge(day, 1L, Long::sum);
+                perHostCounts.merge(host, 1L, Long::sum);
+                perTserverCounts.merge(tabletServerId.getHost() + ":" + tabletServerId.getPort(), 1L, Long::sum);
+            });
+
+            var hgStats = hostGroupCounts.values().stream().mapToLong(l -> l).summaryStatistics();
+            var dayStats = perDayCounts.values().stream().mapToLong(l -> l).summaryStatistics();
+            var hostStats = perHostCounts.values().stream().mapToLong(l -> l).summaryStatistics();
+            var tserverStats = perTserverCounts.values().stream().mapToLong(l -> l).summaryStatistics();
+
+            return new ShardStats(dayStats, hostStats, tserverStats, hgStats);
+        }
+
+        void check(long days, long shardsPerDay, long hosts, long tabletServersPerHost) {
+            long mingHostGroupCount;
+            long maxHostGroupCount;
+            if (shardsPerDay < hosts) {
+                // This special case exists because the hgStats map does not store zeros for host+day pairs that do not exist in the data. This throws the
+                // general calculation off.
+                mingHostGroupCount = 1;
+                maxHostGroupCount = 1;
+            } else {
+                mingHostGroupCount = shardsPerDay / hosts;
+                maxHostGroupCount = mingHostGroupCount + (shardsPerDay % hosts > 0 ? 1 : 0);
+            }
+
+            assertEquals(days, dayStats.getCount(), dayStats::toString);
+            assertEquals(hosts, hostStats.getCount(), hostStats::toString);
+            assertEquals(hosts * tabletServersPerHost, tserverStats.getCount(), tserverStats::toString);
+
+            // ensure hosts do not have too many or too little days
+            assertEquals(mingHostGroupCount, hgStats.getMin(), hgStats::toString);
+            assertEquals(maxHostGroupCount, hgStats.getMax(), hgStats::toString);
+
+            // every tablet for a day should be assigned
+            assertEquals(shardsPerDay, dayStats.getMin(), dayStats::toString);
+            assertEquals(shardsPerDay, dayStats.getMax(), dayStats::toString);
+
+            // ensure tablets spread evenly across hosts
+            double totalTablets = days * shardsPerDay;
+            assertEquals(totalTablets, dayStats.getSum(), dayStats::toString);
+            assertEquals(totalTablets, hostStats.getSum(), hostStats::toString);
+            assertEquals(totalTablets, hgStats.getSum(), hgStats::toString);
+            assertEquals(totalTablets, tserverStats.getSum(), tserverStats::toString);
+        }
+    }
+
+    private static List<TabletServerId> generateTabletServers(int startHost, int numHosts, int tserversPerHosts) {
+        var all = new ArrayList<TabletServerId>();
+        for (int h = 0; h < numHosts; h++) {
+            String host = String.format("host%05d", startHost + h);
+
+            for (int p = 0; p < tserversPerHosts; p++) {
+                all.add(new TabletServerIdImpl(host, p + 9997, "1234"));
+            }
+        }
+        return all;
+    }
+
+    private static List<TabletId> createShards(TableId tableId, String startDate, int days, int shardsPerDay) throws Exception {
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd");
+        var date = fmt.parse(startDate);
+        GregorianCalendar cal = new GregorianCalendar();
+        cal.set(date.getYear() + 1900, date.getMonth(), date.getDate());
+
+        var shards = new ArrayList<TabletId>(days * shardsPerDay);
+
+        for (int d = 0; d < days; d++) {
+            var prefix = fmt.format(cal.getTime());
+            for (int s = 0; s < shardsPerDay; s++) {
+                shards.add(makeTablet(tableId, prefix + "_" + s));
+            }
+            cal.add(Calendar.DAY_OF_YEAR, 1);
+        }
+
+        return shards;
+    }
+
+    private static TabletId makeTablet(TableId tableId, String endRow) {
+        return new TabletIdImpl(new KeyExtent(tableId, endRow == null ? null : new Text(endRow), null));
+    }
+
+    private static class MyBalancerEnvironment implements BalancerEnvironment {
+        private final TableId tableId;
+        private final List<TabletId> tablets;
+        private final TestTServers testTServers;;
+        private final Map<String,String> tableProps;
+
+        public MyBalancerEnvironment(TableId tableId, List<TabletId> tablets, TestTServers testTServers, Map<String,String> tableProps) {
+            this.tableId = tableId;
+            this.tablets = tablets;
+            this.testTServers = testTServers;
+            this.tableProps = tableProps;
+        }
+
+        @Override
+        public Configuration getConfiguration() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Configuration getConfiguration(TableId tableId) {
+            Configuration mock = EasyMock.mock(ServiceEnvironment.Configuration.class);
+            EasyMock.expect(mock.get(EasyMock.anyString())).andAnswer(() -> tableProps.get((String) EasyMock.getCurrentArgument(0))).anyTimes();
+            EasyMock.expect(mock.getTableCustom(EasyMock.anyString()))
+                            .andAnswer(() -> tableProps.get("table.custom." + (String) EasyMock.getCurrentArgument(0))).anyTimes();
+            EasyMock.replay(mock);
+            return mock;
+        }
+
+        @Override
+        public String getTableName(TableId tableId) throws TableNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T instantiate(String className, Class<T> base) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T instantiate(TableId tableId, String className, Class<T> base) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String,TableId> getTableIdMap() {
+            return Map.of("shard", tableId);
+        }
+
+        @Override
+        public boolean isTableOnline(TableId tableId) {
+            return true;
+        }
+
+        @Override
+        public Map<TabletId,TabletServerId> listTabletLocations(TableId tableId) {
+            Preconditions.checkArgument(this.tableId.equals(tableId));
+            Map<TabletId,TabletServerId> allTablets = new HashMap<>();
+            tablets.forEach(tabletId -> allTablets.put(tabletId, null));
+            allTablets.putAll(testTServers.getLocationProvider());
+            return allTablets;
+        }
+
+        @Override
+        public List<TabletStatistics> listOnlineTabletsForTable(TabletServerId tabletServerId, TableId tableId)
+                        throws AccumuloException, AccumuloSecurityException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String tableContext(TableId tableId) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a new optional balancer for the shard table that supports balancing by host then tserver using rendevous hashing.  See the class level javadoc on ShardRendezvousHostBalancer for an overview of what the new balancer offers.