### PR TITLE
DocumentScheduler now supports composite fields

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
@@ -1482,6 +1482,10 @@ public abstract class ShapesTest {
 
     @Test
     public void testNoHitTerms() {
+        if (logic.isUseDocumentScheduler()) {
+            // the document scheduler always uses hit terms by default
+            return;
+        }
         try {
             // disabling evaluation also disables hit term generation
             logic.setDisableEvaluation(true);


### PR DESCRIPTION
- Mark record id attribute as 'to keep'
- Use ValueToAttributes to generates composite fields during event aggregation. ValueToAttributes is now reusable.
- DocumentIterator now supports retaining grouping notation
- Refactor DocumentIterator so that key parsers and aggregation related classes are now in the base DocumentIteratorOptions class.