### PR TITLE
Attribute cache computation of hashcode and sizeInBytes

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -37,6 +37,10 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected boolean toKeep = true; // a flag denoting whether this attribute is to be kept in the returned results (transient or not)
     protected boolean fromIndex = true; // Assume attributes are from the index unless specified otherwise.
 
+    // cache computation to avoid repeated calculation
+    protected int hashcode = Integer.MIN_VALUE;
+    protected long sizeInBytes = Long.MIN_VALUE;
+
     public Attribute() {}
 
     public Attribute(Key metadata, boolean toKeep) {
@@ -244,6 +248,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
 
     @Override
     public int hashCode() {
+        // Note: implementations of Attribute should cache the result of this operation
         HashCodeBuilder hcb = new HashCodeBuilder(145, 11);
         hcb.append(this.isMetadataSet());
         if (isMetadataSet()) {
@@ -285,15 +290,17 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         // 8 for the object overhead
         // 4 for the key reference
         // 1 for the keep boolean
-        // all rounded up to the nearest multiple of 8 to make 16 out of 13 bytes
+        // 4 for the hashcode reference
+        // 8 for the sizeInBytes references
+        // all rounded up to the nearest multiple of 8 to make 32 out of 25 bytes
         size += getMetadataSizeInBytes();
         return size;
     }
 
     // for use by subclasses to estimate size
     protected long sizeInBytes(long extra) {
-        return roundUp(extra + 13) + getMetadataSizeInBytes();
-        // 13 is the base size in bytes (see sizeInBytes(), unrounded and without metadata)
+        return roundUp(extra + 25) + getMetadataSizeInBytes();
+        // 25 is the base size in bytes (see sizeInBytes(), unrounded and without metadata)
     }
 
     // a helper method to return the size of a string

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
@@ -90,8 +90,8 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
     }
 
     public void add(Attribute<? extends Comparable<?>> attr) {
-        if (!this.attributes.contains(attr)) {
-            this.attributes.add(attr);
+        boolean updated = this.attributes.add(attr);
+        if (updated) {
             this._count += attr.size();
             if (trackSizes) {
                 this._bytes += attr.sizeInBytes() + 24 + 24;

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
@@ -43,8 +43,11 @@ public class Content extends Attribute<Content> implements Serializable {
 
     @Override
     public long sizeInBytes() {
-        return sizeInBytes(content) + super.sizeInBytes(4);
-        // 4 for string reference
+        if (sizeInBytes == Long.MIN_VALUE) {
+            // 4 for string reference
+            sizeInBytes = sizeInBytes(content) + super.sizeInBytes(4) + 4;
+        }
+        return sizeInBytes;
     }
 
     public String getContent() {
@@ -119,10 +122,15 @@ public class Content extends Attribute<Content> implements Serializable {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcb = new HashCodeBuilder(2099, 2129);
-        hcb.append(content).append(super.hashCode());
-
-        return hcb.toHashCode();
+        if (hashcode == Integer.MIN_VALUE) {
+            //  @formatter:off
+            hashcode = new HashCodeBuilder(2099, 2129)
+                    .append(content)
+                    .append(super.hashCode())
+                    .toHashCode();
+            //  @formatter:off
+        }
+        return hashcode;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Geometry.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Geometry.java
@@ -47,8 +47,11 @@ public class Geometry extends Attribute<Geometry> implements Serializable {
 
     @Override
     public long sizeInBytes() {
-        return ObjectSizeOf.Sizer.getObjectSize(geometry) + super.sizeInBytes(4);
-        // 4 for geometry reference
+        if (sizeInBytes == Long.MIN_VALUE) {
+            // 4 for geometry reference
+            sizeInBytes = ObjectSizeOf.Sizer.getObjectSize(geometry) + super.sizeInBytes(4);
+        }
+        return sizeInBytes;
     }
 
     private byte[] write() {
@@ -128,10 +131,15 @@ public class Geometry extends Attribute<Geometry> implements Serializable {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcb = new HashCodeBuilder(163, 157);
-        hcb.append(super.hashCode()).append(geometry);
-
-        return hcb.toHashCode();
+        if (hashcode == Integer.MIN_VALUE) {
+            //  @formatter:off
+            hashcode = new HashCodeBuilder(163, 157)
+                    .append(super.hashCode())
+                    .append(geometry)
+                    .toHashCode();
+            //  @formatter:on
+        }
+        return hashcode;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/IpAddress.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/IpAddress.java
@@ -36,8 +36,11 @@ public class IpAddress extends Attribute<IpAddress> implements Serializable {
 
     @Override
     public long sizeInBytes() {
-        return sizeInBytes(value.toString()) + sizeInBytes(normalizedValue) + super.sizeInBytes(8);
-        // 8 for string references
+        if (sizeInBytes == Long.MIN_VALUE) {
+            // 8 for string references
+            sizeInBytes = sizeInBytes(value.toString()) + sizeInBytes(normalizedValue) + super.sizeInBytes(8);
+        }
+        return sizeInBytes;
     }
 
     protected void validate() {
@@ -103,10 +106,15 @@ public class IpAddress extends Attribute<IpAddress> implements Serializable {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcb = new HashCodeBuilder(163, 157);
-        hcb.append(super.hashCode()).append(this.value);
-
-        return hcb.toHashCode();
+        if (hashcode == Integer.MIN_VALUE) {
+            //  @formatter:off
+            hashcode = new HashCodeBuilder(163, 157)
+                    .append(super.hashCode())
+                    .append(this.value)
+                    .toHashCode();
+            //  @formatter:on
+        }
+        return hashcode;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Numeric.java
@@ -49,9 +49,12 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
 
     @Override
     public long sizeInBytes() {
-        return 20 + sizeInBytes(normalizedValue) + super.sizeInBytes(8);
-        // 20 is for a basic int Number
-        // 8 for string references
+        if (sizeInBytes == Long.MIN_VALUE) {
+            // 20 is for a basic int Number
+            // 8 for string references
+            sizeInBytes = 20 + sizeInBytes(normalizedValue) + super.sizeInBytes(8);
+        }
+        return sizeInBytes;
     }
 
     /**
@@ -153,10 +156,15 @@ public class Numeric extends Attribute<Numeric> implements Serializable {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcb = new HashCodeBuilder(113, 127);
-        hcb.append(super.hashCode()).append(value);
-
-        return hcb.toHashCode();
+        if (hashcode == Integer.MIN_VALUE) {
+            //  @formatter:off
+            hashcode = new HashCodeBuilder(113, 127)
+                    .append(super.hashCode())
+                    .append(value)
+                    .toHashCode();
+            //  @formatter:on
+        }
+        return hashcode;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/PreNormalizedAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/PreNormalizedAttribute.java
@@ -40,8 +40,11 @@ public class PreNormalizedAttribute extends Attribute<PreNormalizedAttribute> im
 
     @Override
     public long sizeInBytes() {
-        return sizeInBytes(value) + super.sizeInBytes(4);
-        // 4 for string reference
+        if (sizeInBytes == Long.MIN_VALUE) {
+            // 4 bytes for string reference
+            sizeInBytes = sizeInBytes(value) + super.sizeInBytes(4);
+        }
+        return sizeInBytes;
     }
 
     @Override
@@ -59,10 +62,15 @@ public class PreNormalizedAttribute extends Attribute<PreNormalizedAttribute> im
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcb = new HashCodeBuilder(2141, 2137);
-        hcb.append(super.hashCode()).append(this.getData());
-
-        return hcb.toHashCode();
+        if (hashcode == Integer.MIN_VALUE) {
+            //  @formatter:off
+            hashcode = new HashCodeBuilder(2141, 2137)
+                    .append(super.hashCode())
+                    .append(this.getData())
+                    .toHashCode();
+            //  @formatter:on
+        }
+        return hashcode;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -51,12 +51,11 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public long sizeInBytes() {
-        long size = ObjectSizeOf.Sizer.getObjectSize(datawaveType) + super.sizeInBytes(4) + 2L;
-        if (delegateString != null) {
-            size += (2L + delegateString.length());
+        if (sizeInBytes == Long.MAX_VALUE) {
+            // 4 for datawaveType reference
+            sizeInBytes = ObjectSizeOf.Sizer.getObjectSize(datawaveType) + super.sizeInBytes(4);
         }
-        return size;
-        // 4 for datawaveType reference
+        return sizeInBytes;
     }
 
     public Type<T> getType() {
@@ -135,15 +134,15 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public int hashCode() {
-        if (this.hashCode == Integer.MIN_VALUE) {
+        if (hashcode == Integer.MIN_VALUE) {
             //  @formatter:off
-            this.hashCode = new HashCodeBuilder(2099, 2129)
+            hashcode = new HashCodeBuilder(2099, 2129)
                     .append(datawaveType.getDelegateAsString())
                     .append(super.hashCode())
                     .toHashCode();
             //  @formatter:on
         }
-        return hashCode;
+        return hashcode;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/common/grouping/GroupingAttribute.java
@@ -58,6 +58,21 @@ public class GroupingAttribute<T extends Comparable<T>> extends TypeAttribute<T>
      */
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(2099, 2129).append(getType().getDelegateAsString()).toHashCode();
+        if (hashcode == Integer.MIN_VALUE) {
+            //  @formatter:off
+            hashcode = new HashCodeBuilder(2099, 2129)
+                    .append(getType().getDelegateAsString())
+                    .toHashCode();
+            //  @formatter:on
+        }
+        return hashcode;
+    }
+
+    @Override
+    public long sizeInBytes() {
+        if (sizeInBytes == Long.MIN_VALUE) {
+            sizeInBytes = super.sizeInBytes();
+        }
+        return sizeInBytes;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlASTHelper.java
@@ -699,7 +699,7 @@ public class JexlASTHelper {
                 }
             }
 
-            if (startIndex != 0 || stopLength != -1) {
+            if (startIndex != 0 || stopLength != fieldName.length()) {
                 fieldName = new String(fieldName.getBytes(), startIndex, stopLength);
             }
         }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/AttributeIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/AttributeIT.java
@@ -1,0 +1,208 @@
+package datawave.query.attributes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.util.GeometricShapeFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.data.type.LcType;
+import datawave.query.common.grouping.GroupingAttribute;
+
+/**
+ * This test uses {@link Document#put(String, Attribute)} to verify changes to implementations of {@link Attribute}
+ */
+public abstract class AttributeIT {
+
+    private static final Logger log = LoggerFactory.getLogger(AttributeIT.class);
+
+    protected final int documentSize = 100;
+    protected final int numIterations = 100_000;
+
+    protected Key docKey = new Key("row", "dt\0uid");
+
+    /**
+     * Provides a hook to tell which extending class is exercising the abstract test
+     *
+     * @return the context
+     */
+    protected abstract String getContext();
+
+    /**
+     * Create an attribute from an index
+     *
+     * @param index
+     *            the index
+     * @return an attribute
+     */
+    protected Attribute<?> createAttribute(int index) {
+        return createAttribute("value-" + index);
+    }
+
+    /**
+     * Create an attribute from a value
+     *
+     * @param value
+     *            the value
+     * @return an attribute
+     */
+    protected abstract Attribute<?> createAttribute(String value);
+
+    @Test
+    public void testDocumentPut() {
+        testDocumentPut(documentSize, numIterations);
+    }
+
+    /**
+     * Hook to allow certain tests to run with fewer iterations
+     *
+     * @param documentSize
+     *            the document size
+     * @param numIterations
+     *            the number of iterations
+     */
+    protected void testDocumentPut(int documentSize, int numIterations) {
+        List<Attribute<?>> attributes = new ArrayList<>();
+        for (int i = 0; i < documentSize; i++) {
+            attributes.add(createAttribute(i));
+        }
+
+        long total = 0;
+
+        for (int i = 0; i < numIterations; i++) {
+            final Document d = new Document();
+            long start = System.nanoTime();
+            for (Attribute<?> attribute : attributes) {
+                d.put("FIELD", attribute);
+            }
+            total += System.nanoTime() - start;
+        }
+
+        log.info("{} took {} ms", getContext(), TimeUnit.NANOSECONDS.toMillis(total));
+    }
+
+    static class ContentIT extends AttributeIT {
+
+        @Override
+        protected String getContext() {
+            return "content";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            return new Content(value, docKey, true);
+        }
+    }
+
+    static class GeometryIT extends AttributeIT {
+
+        private final GeometricShapeFactory shapeFactory = new GeometricShapeFactory();
+
+        @Override
+        protected String getContext() {
+            return "geometry";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(int index) {
+            String geometry = createGeometry(index, index);
+            return createAttribute(geometry);
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            return new Geometry(value, docKey, true);
+        }
+
+        private String createGeometry(int x, int y) {
+            shapeFactory.setNumPoints(32);
+            shapeFactory.setCentre(new Coordinate(x, y));
+            shapeFactory.setSize(1.5 * 2);
+            return String.valueOf(shapeFactory.createCircle());
+        }
+    }
+
+    static class GroupingAttributeIT extends AttributeIT {
+
+        @Override
+        protected String getContext() {
+            return "grouping";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            LcType type = new LcType(value);
+            return new GroupingAttribute<>(type, docKey, true);
+        }
+    }
+
+    static class IpAddressIT extends AttributeIT {
+
+        @Override
+        protected String getContext() {
+            return "ipaddress";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(int index) {
+            int third = index / 255;
+            int fourth = index % 255;
+            String ip = "192.168." + third + "." + fourth;
+            return createAttribute(ip);
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            return new IpAddress(value, docKey, true);
+        }
+    }
+
+    static class NumericIT extends AttributeIT {
+
+        @Override
+        protected String getContext() {
+            return "numeric";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(int index) {
+            return createAttribute(String.valueOf(index));
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            return new Numeric(value, docKey, true);
+        }
+    }
+
+    static class PreNormalizedAttributeIT extends AttributeIT {
+        @Override
+        protected String getContext() {
+            return "prenormalized";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            return new PreNormalizedAttribute(value, docKey, true);
+        }
+    }
+
+    static class TypeAttributeIT extends AttributeIT {
+
+        @Override
+        protected String getContext() {
+            return "typeattribute";
+        }
+
+        @Override
+        protected Attribute<?> createAttribute(String value) {
+            LcType type = new LcType(value);
+            return new TypeAttribute<>(type, docKey, true);
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -81,42 +81,42 @@ public class DocumentTest {
     public void testDocumentWithLcType() {
         Attribute<?> attr = createAttribute("LC", "value");
         d.put("LC", attr);
-        roundTrip(MAX_ITERATIONS, 71);
+        roundTrip(MAX_ITERATIONS, 78);
     }
 
     @Test
     public void testDocumentWithLcNoDiacriticsType() {
         Attribute<?> attr = createAttribute("LC_ND", "value");
         d.put("LC_ND", attr);
-        roundTrip(MAX_ITERATIONS, 74);
+        roundTrip(MAX_ITERATIONS, 81);
     }
 
     @Test
     public void testDocumentWithHexType() {
         Attribute<?> attr = createAttribute("HEX", "a1b2c3");
         d.put("HEX", attr);
-        roundTrip(MAX_ITERATIONS, 79);
+        roundTrip(MAX_ITERATIONS, 86);
     }
 
     @Test
     public void testDocumentWithNumberType() {
         Attribute<?> attr = createAttribute("NUM", "12");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 75);
+        roundTrip(MAX_ITERATIONS, 82);
     }
 
     @Test
     public void testDocumentWithNumberTypeNormalizedValue() {
         Attribute<?> attr = createAttribute("NUM", "+bE1.2");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 75);
+        roundTrip(MAX_ITERATIONS, 82);
     }
 
     @Test
     public void testDocumentWithNumberTypeLargeValue() {
         Attribute<?> attr = createAttribute("NUM", "12456789.987654321");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 106);
+        roundTrip(MAX_ITERATIONS, 113);
     }
 
     @Test
@@ -148,13 +148,13 @@ public class DocumentTest {
 
     @Test
     public void testSingleFieldedRoundTrips() {
-        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18314);
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18313);
         roundTrip("GEO_LAT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
         roundTrip("GEO_LON", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
-        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11563);
-        roundTrip("LC", DOCUMENT_SIZE, MAX_ITERATIONS, 12702);
-        roundTrip("LC_ND", DOCUMENT_SIZE, MAX_ITERATIONS, 12705);
-        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12806);
+        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11562);
+        roundTrip("LC", DOCUMENT_SIZE, MAX_ITERATIONS, 12701);
+        roundTrip("LC_ND", DOCUMENT_SIZE, MAX_ITERATIONS, 12704);
+        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12805);
         roundTrip("POINT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
     }
 
@@ -163,7 +163,7 @@ public class DocumentTest {
         // original size: 11063
         // post hex serialization changes: 11563
         // read times cut by about 35%
-        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11563);
+        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11562);
     }
 
     @Test
@@ -171,14 +171,14 @@ public class DocumentTest {
         // original size: 11213
         // post number serialization: 12806
         // attribute write times remained the same, attribute read times were cut by about 50%
-        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12806);
+        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12805);
     }
 
     @Test
     public void testNumberListRoundTrip() {
         // original size: 12994
         // kryo optimization: 18030
-        roundTrip("NUM_LIST", DOCUMENT_SIZE, MAX_ITERATIONS, 18030);
+        roundTrip("NUM_LIST", DOCUMENT_SIZE, MAX_ITERATIONS, 18029);
     }
 
     @Test
@@ -186,7 +186,7 @@ public class DocumentTest {
         // original size: 16564
         // kryo optimization: 22564
         // using default DateSerializer dropped the read time by 50%
-        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18314);
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18313);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/JexlASTHelperTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
@@ -758,59 +759,61 @@ public class JexlASTHelperTest {
     @Test
     public void testIdentifierDeconstructionWithGroupings() {
         // no prefix or grouping
-        testDeconstructionGroupingTrue("FIELD", "FIELD");
+        testDeconstructionGroupingTrue("FIELD", "FIELD", false);
 
         // has a simple grouping, does not have a prefix
-        testDeconstructionGroupingTrue("FIELD.1", "FIELD.1");
+        testDeconstructionGroupingTrue("FIELD.1", "FIELD.1", false);
 
         // has a complex grouping, does not have a prefix
-        testDeconstructionGroupingTrue("FIELD.1.2", "FIELD.1.2");
+        testDeconstructionGroupingTrue("FIELD.1.2", "FIELD.1.2", false);
 
         // has a prefix, does not have a grouping
-        testDeconstructionGroupingTrue("FIELD", "$FIELD");
+        testDeconstructionGroupingTrue("FIELD", "$FIELD", true);
 
         // has a prefix, has a simple grouping
-        testDeconstructionGroupingTrue("FIELD.1", "$FIELD.1");
+        testDeconstructionGroupingTrue("FIELD.1", "$FIELD.1", true);
 
         // has a prefix, has a complex grouping
-        testDeconstructionGroupingTrue("FIELD.1.2", "$FIELD.1.2");
+        testDeconstructionGroupingTrue("FIELD.1.2", "$FIELD.1.2", true);
 
         // empty string should return untouched
-        testDeconstructionGroupingTrue("", "");
+        testDeconstructionGroupingTrue("", "", false);
     }
 
     @Test
     public void testIdentifierDeconstructionWithoutGroupings() {
         // no prefix or grouping
-        testDeconstructionGroupingFalse("FIELD", "FIELD");
+        testDeconstructionGroupingFalse("FIELD", "FIELD", false);
 
         // has a simple grouping, does not have a prefix
-        testDeconstructionGroupingFalse("FIELD", "FIELD.1");
+        testDeconstructionGroupingFalse("FIELD", "FIELD.1", true);
 
         // has a complex grouping, does not have a prefix
-        testDeconstructionGroupingFalse("FIELD", "FIELD.1.2");
+        testDeconstructionGroupingFalse("FIELD", "FIELD.1.2", true);
 
         // has a prefix, does not have a grouping
-        testDeconstructionGroupingFalse("FIELD", "$FIELD");
+        testDeconstructionGroupingFalse("FIELD", "$FIELD", true);
 
         // has a prefix, has a simple grouping
-        testDeconstructionGroupingFalse("FIELD", "$FIELD.1");
+        testDeconstructionGroupingFalse("FIELD", "$FIELD.1", true);
 
         // has a prefix, has a complex grouping
-        testDeconstructionGroupingFalse("FIELD", "$FIELD.1.2");
+        testDeconstructionGroupingFalse("FIELD", "$FIELD.1.2", true);
 
         // empty string should remain untouched
-        testDeconstructionGroupingFalse("", "");
+        testDeconstructionGroupingFalse("", "", false);
     }
 
-    private void testDeconstructionGroupingTrue(String expected, String input) {
+    private void testDeconstructionGroupingTrue(String expected, String input, boolean expectNewObject) {
         String actual = JexlASTHelper.deconstructIdentifier(input, true);
         assertEquals(expected, actual);
+        assertEquals("Expected new object", expectNewObject, !Objects.equals(input, actual));
     }
 
-    private void testDeconstructionGroupingFalse(String expected, String input) {
+    private void testDeconstructionGroupingFalse(String expected, String input, boolean expectNewObject) {
         String actual = JexlASTHelper.deconstructIdentifier(input, false);
         assertEquals(expected, actual);
+        assertEquals("Expected a new object", expectNewObject, !Objects.equals(input, actual));
     }
 
     // Verify the nesting order between 'or' and 'and' in a Jexl query.


### PR DESCRIPTION
- Attribute provides means to cache hashcode and sizeInBytes computation
- Most implementations of Attribute now cache the computation for hashcode and computation.
- Fix bug in JexlASTHelper's deconstructIdentifier method that caused a new String to be built, even when not necessary.