### PR TITLE
Serialize the index instead of the full Attribute class name

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/DatawaveAttributeIndex.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/DatawaveAttributeIndex.java
@@ -1,0 +1,67 @@
+package datawave.query.attributes;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import datawave.query.common.grouping.GroupingAttribute;
+
+/**
+ * A utility class that returns an index for a given Datawave {@link Attribute}
+ */
+public class DatawaveAttributeIndex {
+
+    private DatawaveAttributeIndex() {
+        // static utility
+    }
+
+    private static final Map<String,Integer> classNameIndex = new HashMap<>();
+    static {
+        classNameIndex.put(AttributeBag.class.getTypeName(), 1);
+        classNameIndex.put(Attributes.class.getTypeName(), 2);
+        classNameIndex.put(Cardinality.class.getTypeName(), 3);
+        classNameIndex.put(Content.class.getTypeName(), 4);
+        classNameIndex.put(DiacriticContent.class.getTypeName(), 5);
+        // skip Document
+        classNameIndex.put(DocumentKey.class.getTypeName(), 6);
+        classNameIndex.put(GeoPoint.class.getTypeName(), 7);
+        classNameIndex.put(Geometry.class.getTypeName(), 8);
+        classNameIndex.put(GroupingAttribute.class.getTypeName(), 9);
+        classNameIndex.put(IpAddress.class.getTypeName(), 10);
+        classNameIndex.put(Latitude.class.getTypeName(), 11);
+        classNameIndex.put(Longitude.class.getTypeName(), 12);
+        classNameIndex.put(Metadata.class.getTypeName(), 13);
+        classNameIndex.put(Numeric.class.getTypeName(), 14);
+        classNameIndex.put(PreNormalizedAttribute.class.getTypeName(), 15);
+        classNameIndex.put(TimingMetadata.class.getTypeName(), 16);
+        classNameIndex.put(TypeAttribute.class.getTypeName(), 17);
+        classNameIndex.put(WaitWindowExceededMetadata.class.getTypeName(), 18);
+    }
+
+    private static final Map<Integer,String> indexToClassName;
+    static {
+        indexToClassName = classNameIndex.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
+
+    /**
+     * Get the index of the provided {@link Attribute} class name
+     *
+     * @param className
+     *            the attribute name
+     * @return the index of the attribute name, or zero if no such attribute exists
+     */
+    public static int getAttributeIndex(String className) {
+        return classNameIndex.getOrDefault(className, 0);
+    }
+
+    /**
+     * Get the {@link Attribute} name associated with the provided index
+     *
+     * @param index
+     *            the index
+     * @return the Attribute name or null if no such type name exists
+     */
+    public static String getAttributeClassName(int index) {
+        return indexToClassName.get(index);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -81,42 +81,42 @@ public class DocumentTest {
     public void testDocumentWithLcType() {
         Attribute<?> attr = createAttribute("LC", "value");
         d.put("LC", attr);
-        roundTrip(MAX_ITERATIONS, 78);
+        roundTrip(MAX_ITERATIONS, 40);
     }
 
     @Test
     public void testDocumentWithLcNoDiacriticsType() {
         Attribute<?> attr = createAttribute("LC_ND", "value");
         d.put("LC_ND", attr);
-        roundTrip(MAX_ITERATIONS, 81);
+        roundTrip(MAX_ITERATIONS, 43);
     }
 
     @Test
     public void testDocumentWithHexType() {
         Attribute<?> attr = createAttribute("HEX", "a1b2c3");
         d.put("HEX", attr);
-        roundTrip(MAX_ITERATIONS, 86);
+        roundTrip(MAX_ITERATIONS, 48);
     }
 
     @Test
     public void testDocumentWithNumberType() {
         Attribute<?> attr = createAttribute("NUM", "12");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 82);
+        roundTrip(MAX_ITERATIONS, 44);
     }
 
     @Test
     public void testDocumentWithNumberTypeNormalizedValue() {
         Attribute<?> attr = createAttribute("NUM", "+bE1.2");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 82);
+        roundTrip(MAX_ITERATIONS, 44);
     }
 
     @Test
     public void testDocumentWithNumberTypeLargeValue() {
         Attribute<?> attr = createAttribute("NUM", "12456789.987654321");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 113);
+        roundTrip(MAX_ITERATIONS, 75);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class DocumentTest {
         d.put("NUM", createAttribute("NUM", "25"));
         d.put("NUM_LIST", createAttribute("NUM_LIST", "22,23,24"));
         d.put("POINT", createAttribute("POINT", "POINT(10 10)"));
-        roundTrip(MAX_ITERATIONS, 807);
+        roundTrip(MAX_ITERATIONS, 351);
     }
 
     @Test
@@ -143,18 +143,18 @@ public class DocumentTest {
             Attribute<?> attr = createAttribute("LC", "value-" + i);
             d.put("LC", attr);
         }
-        roundTrip(MAX_ITERATIONS, 568042);
+        roundTrip(MAX_ITERATIONS, 188007);
     }
 
     @Test
     public void testSingleFieldedRoundTrips() {
-        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18313);
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 10028);
         roundTrip("GEO_LAT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
         roundTrip("GEO_LON", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
-        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11562);
-        roundTrip("LC", DOCUMENT_SIZE, MAX_ITERATIONS, 12701);
-        roundTrip("LC_ND", DOCUMENT_SIZE, MAX_ITERATIONS, 12704);
-        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12805);
+        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 3277);
+        roundTrip("LC", DOCUMENT_SIZE, MAX_ITERATIONS, 4256);
+        roundTrip("LC_ND", DOCUMENT_SIZE, MAX_ITERATIONS, 4259);
+        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 4520);
         roundTrip("POINT", DOCUMENT_SIZE, MAX_ITERATIONS, 0);
     }
 
@@ -163,7 +163,8 @@ public class DocumentTest {
         // original size: 11063
         // post hex serialization changes: 11563
         // read times cut by about 35%
-        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 11562);
+        // attribute index optimization: 3277
+        roundTrip("HEX", DOCUMENT_SIZE, MAX_ITERATIONS, 3277);
     }
 
     @Test
@@ -171,14 +172,16 @@ public class DocumentTest {
         // original size: 11213
         // post number serialization: 12806
         // attribute write times remained the same, attribute read times were cut by about 50%
-        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 12805);
+        // attribute index optimization: 4520
+        roundTrip("NUM", DOCUMENT_SIZE, MAX_ITERATIONS, 4520);
     }
 
     @Test
     public void testNumberListRoundTrip() {
         // original size: 12994
         // kryo optimization: 18030
-        roundTrip("NUM_LIST", DOCUMENT_SIZE, MAX_ITERATIONS, 18029);
+        // attribute index optimization: 9731
+        roundTrip("NUM_LIST", DOCUMENT_SIZE, MAX_ITERATIONS, 9731);
     }
 
     @Test
@@ -186,7 +189,8 @@ public class DocumentTest {
         // original size: 16564
         // kryo optimization: 22564
         // using default DateSerializer dropped the read time by 50%
-        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 18313);
+        // attribute index optimization: 10028
+        roundTrip("DATE", DOCUMENT_SIZE, MAX_ITERATIONS, 10028);
     }
 
     @Test


### PR DESCRIPTION
Only serialize the integer index of known Attribute implementations. In testing this significantly reduced the size of the serialized document. 