### PR TITLE
Implements additional fixes for tag cloud generation

### DIFF
--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
@@ -54,6 +54,7 @@ public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
 
     @Override
     public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores) {
+        // for now, choose the best (smallest) scored version of the tag.
         return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).min(Double::compareTo).orElse(1.0);
 
     }
@@ -65,6 +66,7 @@ public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
 
     @Override
     public int calculateFrequency(Collection<TagCloudEntry.ScoreTuple> sourceScores) {
-        return sourceScores.size();
+        // if multiple 'documents' have the same source identifier, count only once.
+        return (int) sourceScores.stream().map(TagCloudEntry.ScoreTuple::getSource).distinct().count();
     }
 }

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
@@ -115,4 +115,17 @@ public class YakeKeywordExtractorTest {
         assertEquals(4, keywords.size());
         assertEquals(EXPECTED_NEWS_OUTPUT, keywords);
     }
+
+    @Test
+    public void testIsNumber() {
+        //@formatter:off
+        String[] testInput = { "123", "-456", "+789", "12.34", "56,78", ".5", "5.", ",5", "5,", "-0.123", "abc", "123a", "1.2.3", "", null, ".", "+", "-"};
+        boolean[] expected = {  true,  true,   true,   true,    true,    true, true, true, true, true,     false, false,  true,    false, false, false, false, false};
+        //@formatter:on
+
+        for (int i = 0; i < testInput.length; i++) {
+            final String message = "Expected " + testInput[i] + " to be " + expected[i];
+            assertEquals(expected[i], YakeKeywordExtractor.isNumber(testInput[i]), message);
+        }
+    }
 }


### PR DESCRIPTION
Fixed LookupUUIDUtil.generateTagCloud to close query executor when done.

Improved number detection in YakeKeywordExtractor
* Avoids exceptions in Float.parseFloat and an expensive string replace to remove number separators
* Improves number separator detection for multiple locales (e.g., those that done use commas as place separators in numbers)

Adds caching for stopword lists iterator side.
* Avoids multiple reloads of a classpath resource for stopwords by caching the lists on a per-language basis. These don't change often, so no reloading mechanism is required.

Fixed issue where a tag's document frequency score didn't match the unique source count.