### PR TITLE
task/expandableRows: Create neater drop down variations for Data Type on Dictionary

### DIFF
--- a/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
+++ b/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
@@ -34,6 +34,11 @@
   margin-top: 0.5vh;
 }
 
+.cell-spacing {
+  width: 60px;
+  min-width: 60px
+}
+
 .subtable {
   font-size: x-small;
   margin-bottom: 1em;

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/features.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/features.ts
@@ -2,12 +2,12 @@ import { Notify} from 'quasar';
 import * as Formatters from './formatters';
 
 // Feature - Copies the Label to Clipboard
-export async function copyLabel(colName: string, colValue: any) {
-  await navigator.clipboard.writeText(Formatters.parseVal(colName, colValue));
+export async function copyLabel(colName: string, colValue: any, colDataTypeCount?: any) {
+  await navigator.clipboard.writeText(Formatters.parseVal(colName, colValue, colDataTypeCount));
   Notify.create({
     type: 'info',
     message: Formatters.maxSubstring(
-                  Formatters.parseVal(colName, colValue), 'CopyPaste'
+                  Formatters.parseVal(colName, colValue, colDataTypeCount), 'CopyPaste'
                 ) + ' Copied to Clipboard.',
     color: 'cyan-8',
     icon: 'bi-clipboard-fill'

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -1,5 +1,7 @@
 import { Ref, WritableComputedRef, computed, defineComponent, ref } from 'vue';
 
+const regexDataType = /^[1-9]\d*\s+types?$/;
+
 interface Entry {
   key: string;
   value: string;
@@ -45,7 +47,7 @@ export function parseVal(colName: string, colValue: any, colDataTypeCount?: any)
     const description = firstEntry.decription || '';
 
     return `${marking} ${markingAccess} ${description}`;
-  } else if (colName === 'dataType' && /^[1-9]\d*\s+types?$/.test(colDataTypeCount)) {
+  } else if (colName === 'dataType' && regexDataType.test(colDataTypeCount)) {
     return colDataTypeCount;
   } else {
     return colValue.toString();

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -12,7 +12,7 @@ interface Markings {
 }
 
 interface Record {
-  decription: string;
+  description: string;
   markings: Markings;
 }
 
@@ -44,7 +44,7 @@ export function parseVal(colName: string, colValue: any, colDataTypeCount?: any)
 
     const marking = markingsEntry.length > 0 ? markingsEntry[0].value : '';
     const markingAccess = markingsEntry.length > 1 ? markingsEntry[1].value : '';
-    const description = firstEntry.decription || '';
+    const description = firstEntry.description || '';
 
     return `${marking} ${markingAccess} ${description}`;
   } else if (colName === 'dataType' && regexDataType.test(colDataTypeCount)) {

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -84,6 +84,10 @@ export function toggleVisibility(row: any) {
   row.toggleVisibility();
 }
 
+export function toggleCount(row: any) {
+  row.toggleCount();
+}
+
 // Set the Visibility in DOM, sorts and filters by lastUpdated, and the respective row to render button.
 export function setVisibility(rows: readonly any[]) {
   const fieldVisibility: Map<string, Ref<boolean>> = new Map<
@@ -91,10 +95,18 @@ export function setVisibility(rows: readonly any[]) {
     Ref<boolean>
   >();
   const buttonValues: Map<string, number> = new Map<string, number>();
+  const countValues: Map<string, number> = new Map<string, number>();
 
   for (const row of rows) {
     let rowMostRecentUpdated: number = row.lastUpdated;
     const currentRowInternalFieldName: any = row.internalFieldName;
+    const currentRowDataType: any = row.dataType;
+
+    if (currentRowDataType) {
+      let currentValue = countValues.get(currentRowInternalFieldName) || 0;
+      countValues.set(currentRowInternalFieldName, ++currentValue);
+    }
+
     for (const scan of rows) {
       if (currentRowInternalFieldName === scan.internalFieldName && rowMostRecentUpdated < scan.lastUpdated) {
         rowMostRecentUpdated = scan.lastUpdated;
@@ -112,6 +124,9 @@ export function setVisibility(rows: readonly any[]) {
     ) {
       row['duplicate'] = 0;
       row['button'] = true;
+
+      row['dataTypeBAK'] = row.dataType;
+      row['dataType'] = countValues.get(row.internalFieldName) + ' types';
     }
     // Checks to Render Collapsible Row - Refreshes on Search
     else if (
@@ -138,6 +153,12 @@ export function setVisibility(rows: readonly any[]) {
       visibility!.value = !visibility?.value;
     };
     row['isVisible'] = visibility;
+
+    row['toggleCount'] = () => {
+      const temp = row['dataType'];
+      row['dataType'] = row['dataTypeBAK'];
+      row['dataTypeBAK'] = temp;
+    };
   }
 
   return rows;

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -21,7 +21,7 @@ interface Record {
 *  Specifically, for the descriptions block, it checks to see if the value is undefined/null (doesn't have a description).
 *  Or if the description value has a length of 0 (if something was pulled incorrectly in the JSON).
 */
-export function parseVal(colName: string, colValue: any) : string {
+export function parseVal(colName: string, colValue: any, colDataTypeCount?: any) : string {
   if (colName === 'Types') {
     if (colValue == undefined) {
       return '';
@@ -45,6 +45,8 @@ export function parseVal(colName: string, colValue: any) : string {
     const description = firstEntry.decription || '';
 
     return `${marking} ${markingAccess} ${description}`;
+  } else if (colName === 'dataType' && /^[1-9]\d*\s+types?$/.test(colDataTypeCount)) {
+    return colDataTypeCount;
   } else {
     return colValue.toString();
   }
@@ -84,10 +86,6 @@ export function toggleVisibility(row: any) {
   row.toggleVisibility();
 }
 
-export function toggleCount(row: any) {
-  row.toggleCount();
-}
-
 // Set the Visibility in DOM, sorts and filters by lastUpdated, and the respective row to render button.
 export function setVisibility(rows: readonly any[]) {
   const fieldVisibility: Map<string, Ref<boolean>> = new Map<
@@ -122,11 +120,10 @@ export function setVisibility(rows: readonly any[]) {
       buttonValues.has(row.internalFieldName) &&
       row.lastUpdated == buttonValues.get(row.internalFieldName)
     ) {
-      row['duplicate'] = 0;
+      row['duplicate'] = 1;
       row['button'] = true;
 
-      row['dataTypeBAK'] = row.dataType;
-      row['dataType'] = countValues.get(row.internalFieldName) + ' types';
+      row['dataTypeCount'] = countValues.get(row.internalFieldName) + ' types';
     }
     // Checks to Render Collapsible Row - Refreshes on Search
     else if (
@@ -135,11 +132,15 @@ export function setVisibility(rows: readonly any[]) {
     ) {
       row['duplicate'] = 1;
       row['button'] = false;
+
+      row['dataTypeCount'] = 0 + ' types';
     }
     // Renders a Normal Row (No Button, not Collapsible)
     else {
       row['duplicate'] = 0;
       row['button'] = false;
+
+      row['dataTypeCount'] = 0 + ' types';
     }
 
     const internalFieldName = row.internalFieldName;
@@ -153,12 +154,6 @@ export function setVisibility(rows: readonly any[]) {
       visibility!.value = !visibility?.value;
     };
     row['isVisible'] = visibility;
-
-    row['toggleCount'] = () => {
-      const temp = row['dataType'];
-      row['dataType'] = row['dataTypeBAK'];
-      row['dataTypeBAK'] = temp;
-    };
   }
 
   return rows;

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -104,9 +104,9 @@
         <template v-slot:body="props">
           <q-tr
             :props="props"
-            v-if="Formatters.isVisible(props.row)"
+            v-if="Formatters.buttonParse(props.cols, props.row)"
           >
-            <q-td style="width: 60px; min-width: 60px">
+            <q-td class="cell-spacing">
               <q-btn
                 size="9px"
                 color="cyan-8"
@@ -116,12 +116,37 @@
                   {
                     props.expand = !props.expand;
                     Formatters.toggleVisibility(props.row);
-                    Formatters.toggleCount(props.row);
                   }
                 "
                 :icon="props.row.isVisible.value ? 'remove' : 'add'"
-                v-if="Formatters.buttonParse(props.cols, props.row)"
               />
+            </q-td>
+            <q-td
+              v-for="col in props.cols"
+              :key="col.name"
+              :props="props"
+              :class="{ 'text-bold': col.name === 'dataType'}"
+              style="font-size: 13px;"
+              @click="Feature.copyLabel(col.name, col.value, props.row.dataTypeCount)"
+              >
+                <label style="cursor: pointer;">
+                  {{
+
+                    Formatters.maxSubstring(
+                      Formatters.parseVal(col.name, col.value, props.row.dataTypeCount), col.name
+                    )
+                  }}
+                  <q-tooltip class="tooltip-text" anchor="bottom middle" self="top middle" :offset="[0, 5]">
+                    {{ Formatters.parseVal(col.name, col.value, props.row.dataTypeCount) }}
+                  </q-tooltip>
+                </label>
+              </q-td>
+          </q-tr>
+          <q-tr
+            :props="props"
+            v-if="Formatters.isVisible(props.row)"
+          >
+            <q-td class="cell-spacing">
               <q-icon
                   style="margin-left: 4px;"
                   size="1rem"
@@ -134,9 +159,8 @@
               v-for="col in props.cols"
               :key="col.name"
               :props="props"
-              :class="{ 'text-bold': col.name === 'dataType' && /^\d+\s+types$/.test(col.value) }"
               style="font-size: 13px;"
-              @click="Feature.copyLabel(col.name, col.value)"
+              @click="Feature.copyLabel(col.name, col.value, null)"
             >
               <label style="cursor: pointer;">
                 {{

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -131,7 +131,6 @@
               >
                 <label style="cursor: pointer;">
                   {{
-
                     Formatters.maxSubstring(
                       Formatters.parseVal(col.name, col.value, props.row.dataTypeCount), col.name
                     )

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -116,6 +116,7 @@
                   {
                     props.expand = !props.expand;
                     Formatters.toggleVisibility(props.row);
+                    Formatters.toggleCount(props.row);
                   }
                 "
                 :icon="props.row.isVisible.value ? 'remove' : 'add'"
@@ -133,6 +134,7 @@
               v-for="col in props.cols"
               :key="col.name"
               :props="props"
+              :class="{ 'text-bold': col.name === 'dataType' && /^\d+\s+types$/.test(col.value) }"
               style="font-size: 13px;"
               @click="Feature.copyLabel(col.name, col.value)"
             >
@@ -234,6 +236,7 @@ onMounted(() => {
       }
     });
     rows = Formatters.setVisibility(rows);
+    console.log(rows);
     loading.value = false;
   })
   .catch((reason) => {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -236,7 +236,6 @@ onMounted(() => {
       }
     });
     rows = Formatters.setVisibility(rows);
-    console.log(rows);
     loading.value = false;
   })
   .catch((reason) => {


### PR DESCRIPTION
This creates expandable rows that display the number of types (e.g., '3 types') in bold on the button header. When clicked, the summary text disappears and the individual values are shown in a dropdown format. This is on the 'Data Type' column.