### PR TITLE
Deduplicate extracted keywords using SequenceMatcher and a configurable similarity threshold

### DIFF
--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
@@ -24,6 +24,7 @@ public class KeywordExtractor {
     public static final String MAX_NGRAMS = "max.ngram.count";
     public static final String MAX_KEYWORDS = "max.keyword.count";
     public static final String MAX_SCORE = "max.score";
+    public static final String MAX_SIMILARITY_THRESHOLD = "max.sim";
 
     private final List<String> preferredViews;
     private final Map<String,VisibleContent> foundContent;
@@ -44,6 +45,9 @@ public class KeywordExtractor {
 
     /** the maximum number of characters to process as input for keyword extraction */
     private int maxContentLength = YakeKeywordExtractor.DEFAULT_MAX_CONTENT_LENGTH;
+
+    /** the max allowed similarity threshold for candidate characters, range [0,1] */
+    private double maxSimilarityThreshold = YakeKeywordExtractor.DEFAULT_MAX_SIMILARITY_THRESHOLD;
 
     /** the source to record for the extraction */
     private final String source;
@@ -72,6 +76,7 @@ public class KeywordExtractor {
                 .withKeywordCount(keywordCount)
                 .withMaxScoreThreshold(maxScoreThreshold)
                 .withMaxContentLength(maxContentLength)
+                .withMaxSimilarityThreshold(maxSimilarityThreshold)
                 .withLanguage(yakeLanguage)
                 .build();
         //@formatter:on
@@ -96,6 +101,10 @@ public class KeywordExtractor {
 
         if (iteratorOptions.containsKey(KeywordExtractor.MAX_CONTENT_CHARS)) {
             maxContentLength = Integer.parseInt(iteratorOptions.get(KeywordExtractor.MAX_CONTENT_CHARS));
+        }
+
+        if (iteratorOptions.containsKey(KeywordExtractor.MAX_SIMILARITY_THRESHOLD)) {
+            maxSimilarityThreshold = Double.parseDouble(iteratorOptions.get(KeywordExtractor.MAX_SIMILARITY_THRESHOLD));
         }
     }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
@@ -28,6 +28,7 @@ public class KeywordExtractor {
     public static final String MAX_SCORE = "max.score";
     public static final String MAX_CONTENT_CHARS = "max.content.chars";
     public static final String KEYWORD_TYPE = "keyword";
+    public static final String MAX_SIMILARITY_THRESHOLD = "max.sim";
 
     private final List<Map.Entry<String,VisibleContent>> orderedContent;
 
@@ -47,6 +48,9 @@ public class KeywordExtractor {
 
     /** the maximum number of characters to process as input for keyword extraction */
     private int maxContentLength = YakeKeywordExtractor.DEFAULT_MAX_CONTENT_LENGTH;
+
+    /** the max allowed similarity threshold for candidate characters, range [0,1] */
+    private double maxSimilarityThreshold = YakeKeywordExtractor.DEFAULT_MAX_SIMILARITY_THRESHOLD;
 
     /** the source to record for the extraction */
     private final String source;
@@ -91,6 +95,7 @@ public class KeywordExtractor {
                 .withKeywordCount(keywordCount)
                 .withMaxScoreThreshold(maxScoreThreshold)
                 .withMaxContentLength(maxContentLength)
+                .withMaxSimilarityThreshold(maxSimilarityThreshold)
                 .withLanguage(yakeLanguage)
                 .build();
         //@formatter:on
@@ -115,6 +120,10 @@ public class KeywordExtractor {
 
         if (iteratorOptions.containsKey(KeywordExtractor.MAX_CONTENT_CHARS)) {
             maxContentLength = Integer.parseInt(iteratorOptions.get(KeywordExtractor.MAX_CONTENT_CHARS));
+        }
+
+        if (iteratorOptions.containsKey(KeywordExtractor.MAX_SIMILARITY_THRESHOLD)) {
+            maxSimilarityThreshold = Double.parseDouble(iteratorOptions.get(KeywordExtractor.MAX_SIMILARITY_THRESHOLD));
         }
     }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
@@ -124,6 +124,7 @@ public class KeywordExtractor {
 
         if (iteratorOptions.containsKey(KeywordExtractor.MAX_SIMILARITY_THRESHOLD)) {
             maxSimilarityThreshold = Double.parseDouble(iteratorOptions.get(KeywordExtractor.MAX_SIMILARITY_THRESHOLD));
+            YakeKeywordExtractor.validateMaxSimilarityThreshold(maxSimilarityThreshold);
         }
     }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/SequenceMatcher.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/SequenceMatcher.java
@@ -1,0 +1,753 @@
+package datawave.util.keyword;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Experimental port of Python difflib's
+ * <a href="https://github.com/python/cpython/blob/e6c3039cb39e68ae9af9ddcaca341c5af8f9cf23/Lib/difflib.py#L44">SequenceMatcher</a> to Java. Where appropriate,
+ * documentation and comments are copied from SequenceMatcher.
+ * <p>
+ * Documentation from SequenceMatcher:
+ * </p>
+ * <p>
+ * SequenceMatcher is a flexible class for comparing pairs of sequences of any type, so long as the sequence elements are hashable. The basic algorithm
+ * predates, and is a little fancier than, an algorithm published in the late 1980's by Ratcliff and Obershelp under the hyperbolic name "gestalt pattern
+ * matching". The basic idea is to find the longest contiguous matching subsequence that contains no "junk" elements (R-O doesn't address junk). The same idea
+ * is then applied recursively to the pieces of the sequences to the left and to the right of the matching subsequence. This does not yield minimal edit
+ * sequences, but does tend to yield matches that "look right" to people.
+ * </p>
+ * <p>
+ * SequenceMatcher tries to compute a "human-friendly diff" between two sequences. Unlike e.g. UNIX(tm) diff, the fundamental notion is the longest *contiguous*
+ * &amp; junk-free matching subsequence. That's what catches peoples' eyes. The Windows(tm) WinDiff has another interesting notion, pairing up elements that
+ * appear uniquely in each sequence. That, and the method here, appear to yield more intuitive difference reports than does diff. This method appears to be the
+ * least vulnerable to syncing up on blocks of "junk lines", though (like blank lines in ordinary text files, or maybe "&lt;P&gt;lines in HTML files). That may
+ * be because this is the only method of the 3 that has a *concept* of "junk" &lt;wink&gt;.
+ * </p>
+ * <p>
+ * {@link #ratio()} returns a float in <code>[0, 1]</code>, measuring the "similarity" of the sequences. As a rule of thumb, a {@link #ratio()} value over 0.6
+ * means the sequences are close matches.
+ * </p>
+ * <p>
+ * If you're only interested in where the sequences match, {@link #getMatchingBlocks()} is handy:
+ * </p>
+ * <p>
+ * Note that the last tuple returned by {@link #getMatchingBlocks()} is always a dummy, <code>(len(a), len(b), 0)</code>, and this is the only case in which the
+ * last tuple element (number of elements matched) is 0.
+ * </p>
+ * <p>
+ * If you want to know how to change the first sequence into the second, use {@link #getOpcodes()}.
+ * </p>
+ * <p>
+ * Timing: Basic R-O is cubic time worst case and quadratic time expected case. SequenceMatcher is quadratic time for the worst case and has expected-case
+ * behavior dependent in a complicated way on how many elements the sequences have in common; best case time is linear.
+ * </p>
+ */
+public class SequenceMatcher {
+
+    /** first sequence */
+    private String a;
+
+    /** second sequence; differences are computed as "what do we need to do to 'a' to change it into 'b'" */
+    private String b;
+
+    /** <code>for x in b, b2j[x]</code> is a list of the indices (into b) at which x appears; junk and popular elements do not appear */
+    private Map<Character,List<Integer>> b2j;
+
+    /** the items in b for which {@link #junkFilter} is True. */
+    private Set<Character> bJunk;
+
+    /** autoJunk should be set to <code>false</code> to disable the "automatic junk heuristic" that treats popular elements as junk. */
+    private final boolean autoJunk;
+
+    /**
+     * a list of <code>(i, j, k)</code> triples, where <code>a[i:i+k] == b[j:j+k]</code>; ascending &amp; non-overlapping in i and in j; terminated by a dummy
+     * <code>(len(a), len(b), 0)</code> sentinel
+     */
+    private List<Match> matchingBlocks;
+
+    /** Reusable maps for {@link #findLongestMatch(int, int, int, int)} to avoid object creation */
+    private final Map<Integer,Integer> j2lenMap1 = new HashMap<>();
+    private final Map<Integer,Integer> j2lenMap2 = new HashMap<>();
+
+    /** Constant empty list to avoid repeated allocation */
+    private static final List<Integer> EMPTY_INT_LIST = Collections.emptyList();
+
+    /** Reusable queue for {@link #getMatchingBlocks()} to reduce int[] allocation */
+    private final List<int[]> reusableQueue = new ArrayList<>();
+    private final List<int[]> availableArrays = new ArrayList<>();
+
+    /**
+     * a list of (tag, i1, i2, j1, j2) tuples, where tag is: one of
+     * <dl>
+     * <dt>replace</dt>
+     * <dd>a[i1:i2] should be replaced by b[j1:j2]</dd>
+     * <dt>delete</dt>
+     * <dd>a[i1:i2] should be deleted</dd>
+     * <dt>insert</dt>
+     * <dd>b[j1:j2] should be inserted</dd>
+     * <dt>equal</dt>
+     * <dd>a[i1:i2] == b[j1:j2]</dd>
+     * </dl>
+     */
+    private List<Opcode> opcodes;
+
+    /**
+     * <code>for x in b</code>, <code>fullBCount[x]</code> equals the number of times x appears in b; only materialized if really needed (used only for
+     * computing {@link #quickRatio()})
+     */
+    private Map<Character,Integer> fullBCount;
+
+    /**
+     * a user-supplied function taking a sequence element and returning true iff the element is "junk". Only {@link #chainB()} uses this. Use
+     * <code>bJunk.contains(...)</code>
+     */
+    private final JunkFilter junkFilter;
+
+    /**
+     * Construct a SequenceMatcher with no junk filter and autoJunk set to true, set the sequences to match with either {@link #setSequences} or
+     * {@link #setSequenceA(String)} and {@link #setSequenceB(String)}
+     */
+    public SequenceMatcher() {
+        this("", "");
+    }
+
+    /**
+     * Construct a SequenceMatcher with no junk filter and autoJunk set to true.
+     *
+     * @param a
+     *            the first of two sequences to be compared. By default, an empty string. The elements of a must be hashable. See also
+     *            {@link #setSequences(String, String)} and {@link #setSequenceA(String)}
+     * @param b
+     *            the second of two sequences to be compared. By default, an empty string. The elements of b must be hashable. See also
+     *            {@link #setSequences(String, String)} and {@link #setSequenceB(String)}.
+     */
+    public SequenceMatcher(String a, String b) {
+        this(a, b, true);
+    }
+
+    /**
+     * Construct a SequenceMatcher with no junk filter.
+     *
+     * @param a
+     *            the first of two sequences to be compared. By default, an empty string. The elements of a must be hashable. See also
+     *            {@link #setSequences(String, String)} and {@link #setSequenceA(String)}
+     * @param b
+     *            the second of two sequences to be compared. By default, an empty string. The elements of b must be hashable. See also
+     *            {@link #setSequences(String, String)} and {@link #setSequenceB(String)}.
+     * @param autoJunk
+     *            set false to disable the "automatic junk heuristic" that treats popular elements as junk
+     *
+     */
+    public SequenceMatcher(String a, String b, boolean autoJunk) {
+        this(null, a, b, autoJunk);
+    }
+
+    /**
+     * Construct a SequenceMatcher.
+     *
+     * @param junkFilter
+     *            a one-argument function that takes a sequence element and returns true iff the element is junk. None is equivalent to passing "lambda x: 0",
+     *            i.e. no elements are considered to be junk. For example, pass lambda x: x in " \\t" if you're comparing lines as sequences of characters, and
+     *            don't want to sync up on blanks or hard tabs.
+     * @param a
+     *            the first of two sequences to be compared. By default, an empty string. The elements of a must be hashable. See also
+     *            {@link #setSequences(String, String)} and {@link #setSequenceA(String)}
+     * @param b
+     *            the second of two sequences to be compared. By default, an empty string. The elements of b must be hashable. See also
+     *            {@link #setSequences(String, String)} and {@link #setSequenceB(String)}.
+     * @param autoJunk
+     *            set false to disable the "automatic junk heuristic" that treats popular elements as junk
+     *
+     */
+    public SequenceMatcher(JunkFilter junkFilter, String a, String b, boolean autoJunk) {
+        this.junkFilter = junkFilter;
+        this.autoJunk = autoJunk;
+        setSequences(a, b);
+    }
+
+    /**
+     * Set the two sequences to be compared
+     *
+     * @param a
+     *            the first sequence to be compared
+     * @param b
+     *            the second sequence to be compared
+     */
+    public void setSequences(String a, String b) {
+        setSequenceA(a);
+        setSequenceB(b);
+    }
+
+    /**
+     * Set the first sequence to be compared.
+     * <p>
+     * The second sequence to be compared is not changed.
+     * </p>
+     *
+     * @param a
+     *            the first sequence to be compared
+     */
+
+    public void setSequenceA(String a) {
+        if (a.equals(this.a)) {
+            return;
+        }
+        this.a = a;
+        this.matchingBlocks = null;
+        this.opcodes = null;
+        this.fullBCount = null;
+    }
+
+    /**
+     * Set the second sequence to be compared.
+     * <p>
+     * The first sequence to be compared is not changed.
+     * </p>
+     *
+     * @param b
+     *            the second sequence to be compared
+     */
+    public void setSequenceB(String b) {
+        if (b.equals(this.b)) {
+            return;
+        }
+        this.b = b;
+        this.matchingBlocks = null;
+        this.opcodes = null;
+        this.fullBCount = null;
+        this.j2lenMap1.clear();
+        this.j2lenMap2.clear();
+        this.reusableQueue.clear();
+        this.availableArrays.clear();
+        chainB();
+    }
+
+    /**
+     * For each element <code>x in b</code>, set <code>b2j[x]</code> to a list of the indices in b where x appears; the indices are in increasing order;
+     * <p>
+     * note that the number of times x appears in b is <code>b2j.get(x).size()</code> ... when isJunk is defined, junk elements don't show up in this map at
+     * all, which stops the central {@link #findLongestMatch(int, int, int, int)} method from starting any matching block at a junk element.
+     * </p>
+     * <p>
+     * <code>b2j</code> also does not contain entries for "popular" elements, meaning elements that account for more than 1 + 1% of the total elements, and when
+     * the sequence is reasonably large (&gt;= 200 elements); this can be viewed as an adaptive notion of semi-junk, and yields an enormous speedup when, e.g.,
+     * comparing program files with hundreds of instances of "return null;" ... note that this is only called when b changes; so for cross-product kinds of
+     * matches, it's best to call {@link #setSequenceB(String)} once, then {@link #setSequenceA(String)} repeatedly.
+     * </p>
+     * <p>
+     * Because junkFilter is a user-defined function, and we test for junk a LOT, it's important to minimize the number of calls. The first trick is to build
+     * b2j ignoring the possibility of junk. I.e., we don't call isJunk at all yet. Throwing out the junk later is much cheaper than building b2j "right" from
+     * the start.
+     * </p>
+     */
+
+    private void chainB() {
+
+        this.b2j = new HashMap<>();
+        for (int i = 0; i < b.length(); i++) {
+            char elt = b.charAt(i);
+            b2j.computeIfAbsent(elt, k -> new ArrayList<>()).add(i);
+        }
+
+        this.bJunk = new HashSet<>();
+        if (junkFilter != null) {
+            for (char elt : b2j.keySet()) {
+                if (junkFilter.isJunk(elt)) {
+                    bJunk.add(elt);
+                }
+            }
+            for (char elt : bJunk) {
+                b2j.remove(elt);
+            }
+        }
+
+        /* nonjunk items in b treated as junk by the heuristic (if used). */
+        Set<Character> bPopular = new HashSet<>();
+        int n = b.length();
+        if (autoJunk && n >= 200) {
+            int nTest = n / 100 + 1;
+            for (Map.Entry<Character,List<Integer>> entry : b2j.entrySet()) {
+                if (entry.getValue().size() > nTest) {
+                    bPopular.add(entry.getKey());
+                }
+            }
+            for (char elt : bPopular) {
+                b2j.remove(elt);
+            }
+        }
+    }
+
+    /**
+     * Find the longest matching block in <code>a[alo:ahi]</code> and <code>b[blo:bhi]</code>.
+     * <p>
+     * By default, it will find the longest match in the entirety of a and b.
+     * </p>
+     * <p>
+     * If <code>junkFilter</code> is not defined:
+     * </p>
+     * <p>
+     * Return <code>(i,j,k)</code> such that <code>a[i:i+k]</code> is equal to <code>b[j:j+k]</code>, where
+     * <code>alo &lt;= i &lt;= i+k &lt;= ahi blo &lt;= j &lt;= j+k &lt;= bhi</code> and for all <code>(i',j',k')</code> meeting those conditions,
+     * <code>k &gt;= k' i &lt;= i'</code> and if <code>i == i', j &lt;= j'</code>.
+     * </p>
+     * <p>
+     * In other words, of all maximal matching blocks, return one that starts earliest in <code>a</code>, and of all those maximal matching blocks that start
+     * earliest in <code>a</code>, return the one that starts earliest in <code>b</code>.
+     * </p>
+     * <p>
+     * If <code>junkFilter</code> is defined, first the longest matching block is determined as above, but with the additional restriction that no junk element
+     * appears in the block. Then that block is extended as far as possible by matching (only) junk elements on both sides. So the resulting block never matches
+     * on junk except as identical junk happens to be adjacent to an "interesting" match.
+     * </p>
+     * <p>
+     * Here's the same example as before, but considering blanks to be junk. That prevents <code>" abcd"</code> from matching the <code>" abcd"</code> at the
+     * tail end of the second sequence directly. Instead, only the <code>"abcd"</code> can match, and matches the leftmost <code>"abcd"</code> in the second
+     * sequence.
+     * </p>
+     * <p>
+     * CAUTION: stripping common prefix or suffix would be incorrect. E.g., ab acab Longest matching block is "ab", but if common prefix is stripped, it's "a"
+     * (tied with "b"). UNIX(tm) diff does so strip, so ends up claiming that ab is changed to acab by inserting "ca" in the middle. That's minimal but
+     * unintuitive: "it's obvious" that someone inserted "ac" at the front. WinDiff ends up at the same place as diff, but by pairing up the unique 'b's and
+     * then matching the first two 'a's.
+     * </p>
+     *
+     * @param alo
+     *            the start index in sequence a
+     * @param ahi
+     *            the end index in sequence a
+     * @param blo
+     *            the start index in sequence b
+     * @param bhi
+     *            the end index in sequence b
+     * @return a Match representing the longest match
+     */
+    public Match findLongestMatch(int alo, int ahi, int blo, int bhi) {
+
+        int besti = alo;
+        int bestj = blo;
+        int bestSize = 0;
+
+        // find the longest junk-free match
+        // during an iteration of the loop, j2len[j] = length of longest
+        // junk-free match ending with a[i-1] and b[j]
+
+        // Use alternating maps to avoid object creation
+        Map<Integer,Integer> j2len = j2lenMap1;
+        Map<Integer,Integer> newj2len = j2lenMap2;
+        j2len.clear();
+        newj2len.clear();
+
+        for (int i = alo; i < ahi; i++) {
+            newj2len.clear();
+            for (int j : b2j.getOrDefault(a.charAt(i), EMPTY_INT_LIST)) {
+                if (j < blo)
+                    continue;
+                if (j >= bhi)
+                    break;
+                int k = j2len.getOrDefault(j - 1, 0) + 1;
+                newj2len.put(j, k);
+                if (k > bestSize) {
+                    besti = i - k + 1;
+                    bestj = j - k + 1;
+                    bestSize = k;
+                }
+            }
+            // Swap references instead of creating new objects
+            Map<Integer,Integer> temp = j2len;
+            j2len = newj2len;
+            newj2len = temp;
+        }
+
+        while (besti > alo && bestj > blo && !bJunk.contains(b.charAt(bestj - 1)) && a.charAt(besti - 1) == b.charAt(bestj - 1)) {
+            besti--;
+            bestj--;
+            bestSize++;
+        }
+        while (besti + bestSize < ahi && bestj + bestSize < bhi && !bJunk.contains(b.charAt(bestj + bestSize))
+                        && a.charAt(besti + bestSize) == b.charAt(bestj + bestSize)) {
+            bestSize++;
+        }
+
+        while (besti > alo && bestj > blo && bJunk.contains(b.charAt(bestj - 1)) && a.charAt(besti - 1) == b.charAt(bestj - 1)) {
+            besti--;
+            bestj--;
+            bestSize++;
+        }
+        while (besti + bestSize < ahi && bestj + bestSize < bhi && bJunk.contains(b.charAt(bestj + bestSize))
+                        && a.charAt(besti + bestSize) == b.charAt(bestj + bestSize)) {
+            bestSize++;
+        }
+
+        return new Match(besti, bestj, bestSize);
+    }
+
+    /**
+     * Return list of triples describing matching subsequences.
+     * <p>
+     * Each triple is of the form <code>(i, j, n)</code>, and means that <code>a[i:i+n] == b[j:j+n]</code>. The triples are monotonically increasing in i and in
+     * j.
+     * </p>
+     * <p>
+     * New in Python 2.5, it's also guaranteed that if <code>(i, j, n)</code> and <code>(i', j', n')</code> are adjacent triples in the list, and the second is
+     * not the last triple in the list, then <code>i+n !=
+     * i' or j+n != j'</code>. IOW, adjacent triples never describe adjacent equal blocks.
+     * </p>
+     * <p>
+     * The last triple is a dummy, <code>(len(a), len(b), 0)</code>, and is the only triple with <code>n==0</code>.
+     * </p>
+     *
+     * @return a list of matching blocks
+     */
+    public List<Match> getMatchingBlocks() {
+        if (matchingBlocks != null) {
+            return matchingBlocks;
+        }
+        int la = a.length();
+        int lb = b.length();
+
+        // This is most naturally expressed as a recursive algorithm, but
+        // at least one user bumped into extreme use cases that exceeded
+        // the recursion limit on their box. So, now we maintain a list
+        // ('queue') of blocks we still need to look at, and append partial
+        // results to `matching_blocks` in a loop; the matches are sorted
+        // at the end.
+
+        // Reuse queue and arrays to minimize object allocation
+        reusableQueue.clear();
+        reusableQueue.add(getOrCreateArray(0, la, 0, lb));
+        final List<Match> matchingBlocks = new ArrayList<>();
+
+        while (!reusableQueue.isEmpty()) {
+            int[] x = reusableQueue.remove(reusableQueue.size() - 1);
+            int alo = x[0];
+            int ahi = x[1];
+            int blo = x[2];
+            int bhi = x[3];
+            Match match = findLongestMatch(alo, ahi, blo, bhi);
+            int i = match.aOffset;
+            int j = match.bOffset;
+            int k = match.size;
+            if (k > 0) {
+                matchingBlocks.add(match);
+                if (alo < i && blo < j) {
+                    reusableQueue.add(getOrCreateArray(alo, i, blo, j));
+                }
+                if (i + k < ahi && j + k < bhi) {
+                    reusableQueue.add(getOrCreateArray(i + k, ahi, j + k, bhi));
+                }
+            }
+            // Return array to pool for reuse
+            recycleArray(x);
+        }
+
+        // It's possible that we have adjacent equal blocks in the
+        // matching_blocks list now. Starting with 2.5, this code was added
+        // to collapse them.
+        matchingBlocks.sort(Comparator.comparingInt((Match m) -> m.aOffset).thenComparingInt(m -> m.bOffset));
+        this.matchingBlocks = getNonAdjacentMatches(matchingBlocks, la, lb);
+        return this.matchingBlocks;
+    }
+
+    private static List<Match> getNonAdjacentMatches(List<Match> matchingBlocks, int la, int lb) {
+        final List<Match> nonAdjacent = new ArrayList<>();
+        int i1 = 0, j1 = 0, k1 = 0;
+        for (Match match : matchingBlocks) {
+            int i2 = match.aOffset;
+            int j2 = match.bOffset;
+            int k2 = match.size;
+            if (i1 + k1 == i2 && j1 + k1 == j2) {
+                k1 += k2;
+            } else {
+                if (k1 > 0) {
+                    nonAdjacent.add(new Match(i1, j1, k1));
+                }
+                i1 = i2;
+                j1 = j2;
+                k1 = k2;
+            }
+        }
+        if (k1 > 0) {
+            nonAdjacent.add(new Match(i1, j1, k1));
+        }
+        nonAdjacent.add(new Match(la, lb, 0));
+        return nonAdjacent;
+    }
+
+    /**
+     * Return list of 5-tuples describing how to turn <code>a</code> into <code>b</code>.
+     * <p>
+     * Each tuple is of the form <code>(tag, i1, i2, j1, j2)</code>. The first tuple has <code>i1 == j1 == 0</code>, and remaining tuples have
+     * <code>i1 == the i2</code> from the tuple preceding it, and likewise for <code>j1 ==</code> the previous <code>j2</code>.
+     * </p>
+     * <p>
+     * The tags are strings, with these meanings:
+     * </p>
+     * <dl>
+     * <dt>replace</dt>
+     * <dd><code>a[i1:i2]</code> should be replaced by <code>b[j1:j2]</code></dd>
+     * <dt>delete</dt>
+     * <dd><code>a[i1:i2]</code> should be deleted. Note that <code>j1==j2</code> in this case.</dd>
+     * <dt>insert</dt>
+     * <dd><code>b[j1:j2]</code> should be inserted at <code>a[i1:i1]</code>. Note that <code>i1==i2</code> in this case.</dd>
+     * <dt>equal</dt>
+     * <dd><code>a[i1:i2] == b[j1:j2]</code></dd>
+     * </dl>
+     *
+     * @return a list of opcodes
+     */
+    public List<Opcode> getOpcodes() {
+        if (opcodes != null) {
+            return opcodes;
+        }
+        int i = 0;
+        int j = 0;
+        List<Opcode> opcodes = new ArrayList<>();
+        for (Match match : getMatchingBlocks()) {
+            int ai = match.aOffset;
+            int bj = match.bOffset;
+            int size = match.size;
+            OpcodeTag tag = OpcodeTag.EMPTY;
+            if (i < ai && j < bj) {
+                tag = OpcodeTag.REPLACE;
+            } else if (i < ai) {
+                tag = OpcodeTag.DELETE;
+            } else if (j < bj) {
+                tag = OpcodeTag.INSERT;
+            }
+            if (!tag.equals(OpcodeTag.EMPTY)) {
+                opcodes.add(new Opcode(tag, i, ai, j, bj));
+            }
+            i = ai + size;
+            j = bj + size;
+            if (size > 0) {
+                opcodes.add(new Opcode(OpcodeTag.EQUAL, ai, i, bj, j));
+            }
+        }
+        this.opcodes = opcodes;
+        return opcodes;
+    }
+
+    /**
+     * Return a measure of the sequences' similarity (float in <code>[0,1]</code>).
+     * <p>
+     * Where <code>T</code> is the total number of elements in both sequences, and <code>M</code> is the number of matches, this is <code>2.0*M / T</code>. Note
+     * that this is 1 if the sequences are identical, and 0 if they have nothing in common.
+     * </p>
+     * <p>
+     * <code>ratio()</code> is expensive to compute if you haven't already computed {@link #getMatchingBlocks()} or {@link #getOpcodes()}, in which case you may
+     * want to try {@link #quickRatio()} or {@link #realQuickRatio()} first to get an upper bound.
+     * </p>
+     *
+     * @return a measure of the sequences' similarity, a float in <code>[0,1]</code>
+     */
+    public double ratio() {
+        int matches = getMatchingBlocks().stream().mapToInt(m -> m.size).sum();
+        return calculateRatio(matches, a.length() + b.length());
+    }
+
+    /**
+     * Return an upper bound on {@link #ratio()} relatively quickly.
+     * <p>
+     * This isn't defined beyond that it is an upper bound on {@link #ratio()}, and is faster to compute.
+     * </p>
+     *
+     * @return an upper bound on measure of the sequences' similarity, a float in <code>[0,1]</code>
+     */
+    public double quickRatio() {
+        if (fullBCount == null) {
+            fullBCount = new HashMap<>();
+            // Use charAt() instead of toCharArray() to avoid array creation
+            for (int i = 0; i < b.length(); i++) {
+                char elt = b.charAt(i);
+                fullBCount.put(elt, fullBCount.getOrDefault(elt, 0) + 1);
+            }
+        }
+        Map<Character,Integer> avail = new HashMap<>();
+        int matches = 0;
+        // Use charAt() instead of toCharArray() to avoid array creation
+        for (int i = 0; i < a.length(); i++) {
+            char elt = a.charAt(i);
+            int numb = avail.getOrDefault(elt, fullBCount.getOrDefault(elt, 0));
+            avail.put(elt, numb - 1);
+            if (numb > 0) {
+                matches++;
+            }
+        }
+        return calculateRatio(matches, a.length() + b.length());
+    }
+
+    /**
+     * Return an upper bound on {@link #ratio()} very quickly.
+     * <p>
+     * This isn't defined beyond that it is an upper bound on {@link #ratio()}, and is faster to compute than either {@link #ratio()} or {@link #quickRatio()}.
+     * </p>
+     *
+     * @return an upper bound on measure of the sequences' similarity, a float in <code>[0,1]</code>
+     */
+    public double realQuickRatio() {
+        int la = a.length();
+        int lb = b.length();
+        return calculateRatio(Math.min(la, lb), la + lb);
+    }
+
+    /**
+     * Get the set of junk characters in sequence b.
+     *
+     * @return the set of characters in b that are considered junk
+     */
+    public Set<Character> getBJunk() {
+        return new HashSet<>(bJunk);
+    }
+
+    private double calculateRatio(int matches, int length) {
+        if (length == 0) {
+            return 1.0;
+        }
+        return 2.0 * matches / length;
+    }
+
+    /**
+     * Get a reusable int array from the pool or create a new one.
+     *
+     * @param alo
+     *            start of a sequence
+     * @param ahi
+     *            end of a sequence
+     * @param blo
+     *            start of b sequence
+     * @param bhi
+     *            end of b sequence
+     * @return an array containing these offsets.
+     */
+    private int[] getOrCreateArray(int alo, int ahi, int blo, int bhi) {
+        int[] array;
+        if (!availableArrays.isEmpty()) {
+            array = availableArrays.remove(availableArrays.size() - 1);
+        } else {
+            array = new int[4];
+        }
+        array[0] = alo;
+        array[1] = ahi;
+        array[2] = blo;
+        array[3] = bhi;
+        return array;
+    }
+
+    /**
+     * Return an int array to the pool for reuse.
+     *
+     * @param array
+     *            the array to return to the pool.
+     */
+    private void recycleArray(int[] array) {
+        if (availableArrays.size() < 10) { // Limit pool size to avoid memory leaks
+            availableArrays.add(array);
+        }
+    }
+
+    /**
+     * Use SequenceMatcher to return list of the best "good enough" matches.
+     *
+     * @param word
+     *            is a sequence for which close matches are desired (typically a string).
+     * @param possibilities
+     *            is a list of sequences against which to match word (typically a list of strings).
+     * @param n
+     *            (default 3) is the maximum number of close matches to return. n must be &gt; 0.
+     * @param cutoff
+     *            (default 0.6) is a float in <code>[0, 1]</code>. Possibilities that don't score at least that similar to word are ignored.
+     *
+     * @return The best (no more than n) matches among the possibilities are returned in a list, sorted by similarity score, most similar first.
+     */
+    public static List<String> getCloseMatches(String word, List<String> possibilities, int n, double cutoff) {
+        if (n <= 0) {
+            throw new IllegalArgumentException("n must be > 0");
+        }
+        if (cutoff < 0.0 || cutoff > 1.0) {
+            throw new IllegalArgumentException("cutoff must be in [0.0, 1.0]");
+        }
+        List<MatchResult> result = new ArrayList<>();
+        SequenceMatcher s = new SequenceMatcher(null, "", word, true);
+        for (String x : possibilities) {
+            s.setSequenceA(x);
+            if (s.realQuickRatio() >= cutoff && s.quickRatio() >= cutoff && s.ratio() >= cutoff) {
+                result.add(new MatchResult(s.ratio(), x));
+            }
+        }
+        result.sort((a, b) -> Double.compare(b.score, a.score));
+        List<String> matches = new ArrayList<>();
+        for (int i = 0; i < Math.min(n, result.size()); i++) {
+            matches.add(result.get(i).word);
+        }
+        return matches;
+    }
+
+    /** Interface for junk filter operations */
+    public interface JunkFilter {
+        /**
+         * @param ch
+         *            the character to evaluate.
+         * @return true of the input character should be considered junk.
+         */
+        boolean isJunk(char ch);
+    }
+
+    public static final class Match {
+        public final int aOffset;
+        public final int bOffset;
+        public final int size;
+
+        public Match(int aOffset, int bOffset, int size) {
+            this.aOffset = aOffset;
+            this.bOffset = bOffset;
+            this.size = size;
+        }
+
+        @Override
+        public String toString() {
+            return "Match{" + "a=" + aOffset + ", b=" + bOffset + ", size=" + size + '}';
+        }
+    }
+
+    public static final class Opcode {
+        public final OpcodeTag tag;
+        public final int i1;
+        public final int i2;
+        public final int j1;
+        public final int j2;
+
+        public Opcode(OpcodeTag tag, int i1, int i2, int j1, int j2) {
+            this.tag = tag;
+            this.i1 = i1;
+            this.i2 = i2;
+            this.j1 = j1;
+            this.j2 = j2;
+        }
+    }
+
+    public enum OpcodeTag {
+        EMPTY, REPLACE, DELETE, INSERT, EQUAL
+    }
+
+    public static class MatchResult {
+        public final double score;
+        public final String word;
+
+        public MatchResult(double score, String word) {
+            this.score = score;
+            this.word = word;
+        }
+
+        @Override
+        public String toString() {
+            return "MatchResult{" + "score=" + score + ", word='" + word + '\'' + '}';
+        }
+    }
+}

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/SequenceMatcher.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/SequenceMatcher.java
@@ -1,6 +1,7 @@
 package datawave.util.keyword;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -52,16 +53,16 @@ import java.util.Set;
 public class SequenceMatcher {
 
     /** first sequence */
-    private String a;
+    private int[] a;
 
     /** second sequence; differences are computed as "what do we need to do to 'a' to change it into 'b'" */
-    private String b;
+    private int[] b;
 
     /** <code>for x in b, b2j[x]</code> is a list of the indices (into b) at which x appears; junk and popular elements do not appear */
-    private Map<Character,List<Integer>> b2j;
+    private Map<Integer,List<Integer>> b2j;
 
     /** the items in b for which {@link #junkFilter} is True. */
-    private Set<Character> bJunk;
+    private Set<Integer> bJunk;
 
     /** autoJunk should be set to <code>false</code> to disable the "automatic junk heuristic" that treats popular elements as junk. */
     private final boolean autoJunk;
@@ -102,7 +103,7 @@ public class SequenceMatcher {
      * <code>for x in b</code>, <code>fullBCount[x]</code> equals the number of times x appears in b; only materialized if really needed (used only for
      * computing {@link #quickRatio()})
      */
-    private Map<Character,Integer> fullBCount;
+    private Map<Integer,Integer> fullBCount;
 
     /**
      * a user-supplied function taking a sequence element and returning true iff the element is "junk". Only {@link #chainB()} uses this. Use
@@ -196,10 +197,11 @@ public class SequenceMatcher {
      */
 
     public void setSequenceA(String a) {
-        if (a.equals(this.a)) {
+        int[] codePoints = a.codePoints().toArray();
+        if (Arrays.equals(codePoints, this.a)) {
             return;
         }
-        this.a = a;
+        this.a = codePoints;
         this.matchingBlocks = null;
         this.opcodes = null;
         this.fullBCount = null;
@@ -215,10 +217,11 @@ public class SequenceMatcher {
      *            the second sequence to be compared
      */
     public void setSequenceB(String b) {
-        if (b.equals(this.b)) {
+        int[] codePoints = b.codePoints().toArray();
+        if (Arrays.equals(codePoints, this.b)) {
             return;
         }
-        this.b = b;
+        this.b = codePoints;
         this.matchingBlocks = null;
         this.opcodes = null;
         this.fullBCount = null;
@@ -251,34 +254,34 @@ public class SequenceMatcher {
     private void chainB() {
 
         this.b2j = new HashMap<>();
-        for (int i = 0; i < b.length(); i++) {
-            char elt = b.charAt(i);
+        for (int i = 0; i < b.length; i++) {
+            int elt = b[i];
             b2j.computeIfAbsent(elt, k -> new ArrayList<>()).add(i);
         }
 
         this.bJunk = new HashSet<>();
         if (junkFilter != null) {
-            for (char elt : b2j.keySet()) {
+            for (int elt : b2j.keySet()) {
                 if (junkFilter.isJunk(elt)) {
                     bJunk.add(elt);
                 }
             }
-            for (char elt : bJunk) {
+            for (int elt : bJunk) {
                 b2j.remove(elt);
             }
         }
 
         /* nonjunk items in b treated as junk by the heuristic (if used). */
-        Set<Character> bPopular = new HashSet<>();
-        int n = b.length();
+        Set<Integer> bPopular = new HashSet<>();
+        int n = b.length;
         if (autoJunk && n >= 200) {
             int nTest = n / 100 + 1;
-            for (Map.Entry<Character,List<Integer>> entry : b2j.entrySet()) {
+            for (Map.Entry<Integer,List<Integer>> entry : b2j.entrySet()) {
                 if (entry.getValue().size() > nTest) {
                     bPopular.add(entry.getKey());
                 }
             }
-            for (char elt : bPopular) {
+            for (int elt : bPopular) {
                 b2j.remove(elt);
             }
         }
@@ -346,7 +349,7 @@ public class SequenceMatcher {
 
         for (int i = alo; i < ahi; i++) {
             newj2len.clear();
-            for (int j : b2j.getOrDefault(a.charAt(i), EMPTY_INT_LIST)) {
+            for (int j : b2j.getOrDefault(a[i], EMPTY_INT_LIST)) {
                 if (j < blo)
                     continue;
                 if (j >= bhi)
@@ -365,23 +368,21 @@ public class SequenceMatcher {
             newj2len = temp;
         }
 
-        while (besti > alo && bestj > blo && !bJunk.contains(b.charAt(bestj - 1)) && a.charAt(besti - 1) == b.charAt(bestj - 1)) {
+        while (besti > alo && bestj > blo && !bJunk.contains(b[bestj - 1]) && a[besti - 1] == b[bestj - 1]) {
             besti--;
             bestj--;
             bestSize++;
         }
-        while (besti + bestSize < ahi && bestj + bestSize < bhi && !bJunk.contains(b.charAt(bestj + bestSize))
-                        && a.charAt(besti + bestSize) == b.charAt(bestj + bestSize)) {
+        while (besti + bestSize < ahi && bestj + bestSize < bhi && !bJunk.contains(b[bestj + bestSize]) && a[besti + bestSize] == b[bestj + bestSize]) {
             bestSize++;
         }
 
-        while (besti > alo && bestj > blo && bJunk.contains(b.charAt(bestj - 1)) && a.charAt(besti - 1) == b.charAt(bestj - 1)) {
+        while (besti > alo && bestj > blo && bJunk.contains(b[bestj - 1]) && a[besti - 1] == b[bestj - 1]) {
             besti--;
             bestj--;
             bestSize++;
         }
-        while (besti + bestSize < ahi && bestj + bestSize < bhi && bJunk.contains(b.charAt(bestj + bestSize))
-                        && a.charAt(besti + bestSize) == b.charAt(bestj + bestSize)) {
+        while (besti + bestSize < ahi && bestj + bestSize < bhi && bJunk.contains(b[bestj + bestSize]) && a[besti + bestSize] == b[bestj + bestSize]) {
             bestSize++;
         }
 
@@ -409,8 +410,8 @@ public class SequenceMatcher {
         if (matchingBlocks != null) {
             return matchingBlocks;
         }
-        int la = a.length();
-        int lb = b.length();
+        int la = a.length;
+        int lb = b.length;
 
         // This is most naturally expressed as a recursive algorithm, but
         // at least one user bumped into extreme use cases that exceeded
@@ -549,7 +550,7 @@ public class SequenceMatcher {
      */
     public double ratio() {
         int matches = getMatchingBlocks().stream().mapToInt(m -> m.size).sum();
-        return calculateRatio(matches, a.length() + b.length());
+        return calculateRatio(matches, a.length + b.length);
     }
 
     /**
@@ -563,24 +564,20 @@ public class SequenceMatcher {
     public double quickRatio() {
         if (fullBCount == null) {
             fullBCount = new HashMap<>();
-            // Use charAt() instead of toCharArray() to avoid array creation
-            for (int i = 0; i < b.length(); i++) {
-                char elt = b.charAt(i);
+            for (int elt : b) {
                 fullBCount.put(elt, fullBCount.getOrDefault(elt, 0) + 1);
             }
         }
-        Map<Character,Integer> avail = new HashMap<>();
+        Map<Integer,Integer> avail = new HashMap<>();
         int matches = 0;
-        // Use charAt() instead of toCharArray() to avoid array creation
-        for (int i = 0; i < a.length(); i++) {
-            char elt = a.charAt(i);
+        for (int elt : a) {
             int numb = avail.getOrDefault(elt, fullBCount.getOrDefault(elt, 0));
             avail.put(elt, numb - 1);
             if (numb > 0) {
                 matches++;
             }
         }
-        return calculateRatio(matches, a.length() + b.length());
+        return calculateRatio(matches, a.length + b.length);
     }
 
     /**
@@ -592,8 +589,8 @@ public class SequenceMatcher {
      * @return an upper bound on measure of the sequences' similarity, a float in <code>[0,1]</code>
      */
     public double realQuickRatio() {
-        int la = a.length();
-        int lb = b.length();
+        int la = a.length;
+        int lb = b.length;
         return calculateRatio(Math.min(la, lb), la + lb);
     }
 
@@ -602,7 +599,7 @@ public class SequenceMatcher {
      *
      * @return the set of characters in b that are considered junk
      */
-    public Set<Character> getBJunk() {
+    public Set<Integer> getBJunk() {
         return new HashSet<>(bJunk);
     }
 
@@ -696,7 +693,7 @@ public class SequenceMatcher {
          *            the character to evaluate.
          * @return true of the input character should be considered junk.
          */
-        boolean isJunk(char ch);
+        boolean isJunk(int codePoint);
     }
 
     public static final class Match {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -98,7 +98,12 @@ public class TagCloud {
 
         TagCloudUtils utils = new DefaultTagCloudUtils();
 
-        /** Add a set of keyword extraction results to the tag cloud to be built */
+        /**
+         * Add a set of keyword extraction results to the tag cloud to be built
+         *
+         * @param results
+         *            a results instance to add to the cloud.
+         */
         public void addResults(KeywordResults results) {
             final String source = results.getSource();
             final String language = results.getLanguage();
@@ -158,6 +163,10 @@ public class TagCloud {
 
         /**
          * Indicate that we should use a specific utilities instance.
+         *
+         * @param utils
+         *            the tag cloud utils implementation to sue for this builder.
+         * @return the builder.
          */
         public Builder withTagCloudUtilities(TagCloudUtils utils) {
             this.utils = utils;

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -177,6 +177,10 @@ public class TagCloud {
 
         /**
          * Indicate that we should use a specific utilities instance.
+         *
+         * @param utils
+         *            the tag cloud utils implementation to sue for this builder.
+         * @return the builder.
          */
         public Builder withTagCloudUtilities(TagCloudUtils utils) {
             this.utils = utils;

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/YakeKeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/YakeKeywordExtractor.java
@@ -54,6 +54,7 @@ public class YakeKeywordExtractor {
     public static final int DEFAULT_KEYWORD_COUNT = 10;
     public static final float DEFAULT_MAX_SCORE_THRESHOLD = 0.6f;
     public static final int DEFAULT_MAX_CONTENT_LENGTH = 32768;
+    public static final double DEFAULT_MAX_SIMILARITY_THRESHOLD = 0.9;
 
     private static final Logger log = LoggerFactory.getLogger(YakeKeywordExtractor.class);
 
@@ -78,6 +79,11 @@ public class YakeKeywordExtractor {
     /** the maximum number of characters to process as input for keyword extraction */
     private final int maxContentLength;
 
+    /**
+     * the similarity threshold for new candidate keywords. If the candidate similarity is higher than this, it won't be added to the final list
+     */
+    private final double maxSimilarityThreshold;
+
     /** a set of words to ignore, language dependent */
     private final Set<String> stopwords;
 
@@ -85,12 +91,14 @@ public class YakeKeywordExtractor {
     private final BreakIterator sentenceBreakIterator;
 
     // use the builder to construct.
-    private YakeKeywordExtractor(int minNGrams, int maxNGrams, int keywordCount, float maxScoreThreshold, int maxContentLength, YakeLanguage language) {
+    private YakeKeywordExtractor(int minNGrams, int maxNGrams, int keywordCount, float maxScoreThreshold, int maxContentLength, double similarityThreshold,
+                    YakeLanguage language) {
         this.minNGrams = minNGrams;
         this.maxNGrams = maxNGrams;
         this.keywordCount = keywordCount;
         this.maxScoreThreshold = maxScoreThreshold;
         this.maxContentLength = maxContentLength;
+        this.maxSimilarityThreshold = similarityThreshold;
         this.stopwords = language.getStopwords();
         this.sentenceBreakIterator = language.getSentenceBreakIterator();
     }
@@ -121,6 +129,10 @@ public class YakeKeywordExtractor {
 
     public Set<String> getStopwords() {
         return stopwords;
+    }
+
+    public double getMaxSimilarityThreshold() {
+        return maxSimilarityThreshold;
     }
 
     /**
@@ -676,13 +688,61 @@ public class YakeKeywordExtractor {
 
         final Stream<TokenScore> sortedByScoreAscending = filteredStream.sorted(Comparator.comparing(TokenScore::getScore));
 
-        // todo: implement similarity-based deduplication here
+        final Stream<TokenScore> deduplicated = deduplicateCandidateTokens(sortedByScoreAscending, maxSimilarityThreshold);
 
         // limit the number of keywords if a limit is set.
-        final Stream<TokenScore> limitedStream = this.getKeywordCount() > 0 ? sortedByScoreAscending.limit(this.getKeywordCount()) : sortedByScoreAscending;
+        final Stream<TokenScore> limitedStream = this.getKeywordCount() > 0 ? deduplicated.limit(this.getKeywordCount()) : deduplicated;
 
         return limitedStream.sorted(Comparator.comparing(TokenScore::getToken)) // by keyword ascending
                         .collect(Collectors.toMap(TokenScore::getToken, TokenScore::getScore, Double::sum, LinkedHashMap::new));
+    }
+
+    /**
+     * Given a stream of scored keywords, identify similar keywords and filter them.
+     *
+     * @param kwStream
+     *            a stream of candidate keywords ordered by score ascending.
+     * @param similarityThreshold
+     *            items that have a larger similarity than this to an existing item in the collection will be dropped
+     * @return a filtered stream of keywords.
+     */
+    protected static Stream<TokenScore> deduplicateCandidateTokens(Stream<TokenScore> kwStream, double similarityThreshold) {
+        if (similarityThreshold <= 0.0) {
+            return kwStream;
+        }
+
+        final List<TokenScore> kwList = kwStream.collect(Collectors.toList());
+        if (kwList.size() <= 1) {
+            return kwList.stream();
+        }
+
+        final SequenceMatcher sequenceMatcher = new SequenceMatcher();
+        final List<TokenScore> keywords = new ArrayList<>();
+        keywords.add(kwList.get(0));
+
+        boolean skip;
+        TokenScore candidate;
+        double ratio;
+        for (int i = 1; i < kwList.size(); i++) {
+            skip = false;
+            candidate = kwList.get(i);
+            sequenceMatcher.setSequenceA(candidate.getToken());
+
+            for (TokenScore keyword : keywords) {
+                sequenceMatcher.setSequenceB(keyword.getToken());
+                ratio = sequenceMatcher.ratio();
+                if (ratio >= similarityThreshold) {
+                    skip = true;
+                    break;
+                }
+            }
+
+            if (!skip) {
+                keywords.add(candidate);
+            }
+        }
+
+        return keywords.stream();
     }
 
     /**
@@ -763,6 +823,11 @@ public class YakeKeywordExtractor {
         /** the maximum number of characters to process as input for keyword extraction */
         private int maxContentLength = DEFAULT_MAX_CONTENT_LENGTH;
 
+        /**
+         * the similarity threshold for new candidate keywords. If the candidate similarity is higher than this, it won't be added to the final list
+         */
+        private double maxSimilarityThreshold = DEFAULT_MAX_SIMILARITY_THRESHOLD;
+
         private YakeLanguage language = BaseYakeLanguage.ENGLISH;
 
         public Builder() {}
@@ -792,13 +857,18 @@ public class YakeKeywordExtractor {
             return this;
         }
 
+        public Builder withMaxSimilarityThreshold(double similarityThreshold) {
+            this.maxSimilarityThreshold = similarityThreshold;
+            return this;
+        }
+
         public Builder withLanguage(YakeLanguage language) {
             this.language = language;
             return this;
         }
 
         public YakeKeywordExtractor build() {
-            return new YakeKeywordExtractor(minNGrams, maxNGrams, keywordCount, maxScoreThreshold, maxContentLength, language);
+            return new YakeKeywordExtractor(minNGrams, maxNGrams, keywordCount, maxScoreThreshold, maxContentLength, maxSimilarityThreshold, language);
         }
     }
 }

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/YakeKeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/YakeKeywordExtractor.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -688,12 +689,9 @@ public class YakeKeywordExtractor {
 
         final Stream<TokenScore> sortedByScoreAscending = filteredStream.sorted(Comparator.comparing(TokenScore::getScore));
 
-        final Stream<TokenScore> deduplicated = deduplicateCandidateTokens(sortedByScoreAscending, maxSimilarityThreshold);
+        final Stream<TokenScore> selected = deduplicateCandidateTokens(sortedByScoreAscending, maxSimilarityThreshold, this.getKeywordCount());
 
-        // limit the number of keywords if a limit is set.
-        final Stream<TokenScore> limitedStream = this.getKeywordCount() > 0 ? deduplicated.limit(this.getKeywordCount()) : deduplicated;
-
-        return limitedStream.sorted(Comparator.comparing(TokenScore::getToken)) // by keyword ascending
+        return selected.sorted(Comparator.comparing(TokenScore::getToken)) // by keyword ascending
                         .collect(Collectors.toMap(TokenScore::getToken, TokenScore::getScore, Double::sum, LinkedHashMap::new));
     }
 
@@ -704,28 +702,25 @@ public class YakeKeywordExtractor {
      *            a stream of candidate keywords ordered by score ascending.
      * @param similarityThreshold
      *            items that have a larger similarity than this to an existing item in the collection will be dropped
+     * @param keywordCount
+     *            the maximum number of keywords to return. A value less than or equal to zero means unlimited.
      * @return a filtered stream of keywords.
      */
-    protected static Stream<TokenScore> deduplicateCandidateTokens(Stream<TokenScore> kwStream, double similarityThreshold) {
+    protected static Stream<TokenScore> deduplicateCandidateTokens(Stream<TokenScore> kwStream, double similarityThreshold, int keywordCount) {
         if (similarityThreshold <= 0.0) {
-            return kwStream;
-        }
-
-        final List<TokenScore> kwList = kwStream.collect(Collectors.toList());
-        if (kwList.size() <= 1) {
-            return kwList.stream();
+            return keywordCount > 0 ? kwStream.limit(keywordCount) : kwStream;
         }
 
         final SequenceMatcher sequenceMatcher = new SequenceMatcher();
         final List<TokenScore> keywords = new ArrayList<>();
-        keywords.add(kwList.get(0));
+        final Iterator<TokenScore> candidates = kwStream.iterator();
 
         boolean skip;
         TokenScore candidate;
         double ratio;
-        for (int i = 1; i < kwList.size(); i++) {
+        while ((keywordCount <= 0 || keywords.size() < keywordCount) && candidates.hasNext()) {
             skip = false;
-            candidate = kwList.get(i);
+            candidate = candidates.next();
             sequenceMatcher.setSequenceA(candidate.getToken());
 
             for (TokenScore keyword : keywords) {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/YakeKeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/YakeKeywordExtractor.java
@@ -136,6 +136,12 @@ public class YakeKeywordExtractor {
         return maxSimilarityThreshold;
     }
 
+    public static void validateMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        if (!Double.isFinite(maxSimilarityThreshold) || maxSimilarityThreshold < 0.0 || maxSimilarityThreshold > 1.0) {
+            throw new IllegalArgumentException("Maximum similarity threshold must be finite and in the range [0.0, 1.0]: " + maxSimilarityThreshold);
+        }
+    }
+
     /**
      * Main entrypoint. Extract keywords from the string provided.
      *
@@ -853,6 +859,7 @@ public class YakeKeywordExtractor {
         }
 
         public Builder withMaxSimilarityThreshold(double similarityThreshold) {
+            validateMaxSimilarityThreshold(similarityThreshold);
             this.maxSimilarityThreshold = similarityThreshold;
             return this;
         }

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/SequenceMatcherTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/SequenceMatcherTest.java
@@ -1,0 +1,325 @@
+package datawave.util.keyword;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JUnit 5 tests for SequenceMatcher, ported from Python difflib test_difflib.py.
+ * <p/>
+ * This test suite covers the core functionality of the SequenceMatcher class including: - Basic sequence matching and difference detection - Junk filtering
+ * functionality - AutoJunk heuristic for popular characters - Various ratio calculations (ratio, quickRatio, realQuickRatio) - Edge cases and bug regression
+ * tests - Static utility methods like getCloseMatches
+ * <p/>
+ * Comments and test structure preserved from the original Python test suite where appropriate.
+ */
+public class SequenceMatcherTest {
+
+    /**
+     * Tests with ASCII characters - ported from TestWithAscii
+     */
+    @Nested
+    class TestWithAscii {
+
+        @Test
+        public void testOneInsert() {
+            // Test one insert at beginning
+            SequenceMatcher sm = new SequenceMatcher(null, "b".repeat(100), "a" + "b".repeat(100), true);
+            assertEquals(0.995, sm.ratio(), 0.001);
+
+            List<SequenceMatcher.Opcode> opcodes = sm.getOpcodes();
+            assertEquals(2, opcodes.size());
+            assertEquals(SequenceMatcher.OpcodeTag.INSERT, opcodes.get(0).tag);
+            assertEquals(0, opcodes.get(0).i1);
+            assertEquals(0, opcodes.get(0).i2);
+            assertEquals(0, opcodes.get(0).j1);
+            assertEquals(1, opcodes.get(0).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(1).tag);
+            assertEquals(0, opcodes.get(1).i1);
+            assertEquals(100, opcodes.get(1).i2);
+            assertEquals(1, opcodes.get(1).j1);
+            assertEquals(101, opcodes.get(1).j2);
+
+            // Test one insert in middle
+            sm = new SequenceMatcher(null, "b".repeat(100), "b".repeat(50) + "a" + "b".repeat(50), true);
+            assertEquals(0.995, sm.ratio(), 0.001);
+
+            opcodes = sm.getOpcodes();
+            assertEquals(3, opcodes.size());
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(0).tag);
+            assertEquals(0, opcodes.get(0).i1);
+            assertEquals(50, opcodes.get(0).i2);
+            assertEquals(0, opcodes.get(0).j1);
+            assertEquals(50, opcodes.get(0).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.INSERT, opcodes.get(1).tag);
+            assertEquals(50, opcodes.get(1).i1);
+            assertEquals(50, opcodes.get(1).i2);
+            assertEquals(50, opcodes.get(1).j1);
+            assertEquals(51, opcodes.get(1).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(2).tag);
+            assertEquals(50, opcodes.get(2).i1);
+            assertEquals(100, opcodes.get(2).i2);
+            assertEquals(51, opcodes.get(2).j1);
+            assertEquals(101, opcodes.get(2).j2);
+        }
+
+        @Test
+        public void testOneDelete() {
+            SequenceMatcher sm = new SequenceMatcher(null, "a".repeat(40) + "c" + "b".repeat(40), "a".repeat(40) + "b".repeat(40), true);
+            assertEquals(0.994, sm.ratio(), 0.001);
+
+            List<SequenceMatcher.Opcode> opcodes = sm.getOpcodes();
+            assertEquals(3, opcodes.size());
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(0).tag);
+            assertEquals(0, opcodes.get(0).i1);
+            assertEquals(40, opcodes.get(0).i2);
+            assertEquals(0, opcodes.get(0).j1);
+            assertEquals(40, opcodes.get(0).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.DELETE, opcodes.get(1).tag);
+            assertEquals(40, opcodes.get(1).i1);
+            assertEquals(41, opcodes.get(1).i2);
+            assertEquals(40, opcodes.get(1).j1);
+            assertEquals(40, opcodes.get(1).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(2).tag);
+            assertEquals(41, opcodes.get(2).i1);
+            assertEquals(81, opcodes.get(2).i2);
+            assertEquals(40, opcodes.get(2).j1);
+            assertEquals(80, opcodes.get(2).j2);
+        }
+
+        @Test
+        public void testBJunk() {
+            // Test with no junk
+            SequenceMatcher sm = new SequenceMatcher(ch -> ch == ' ', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40), true);
+            Assertions.assertTrue(sm.getBJunk().isEmpty());
+
+            // Test with junk characters
+            sm = new SequenceMatcher(ch -> ch == ' ', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40) + " ".repeat(20), true);
+            Set<Character> expectedJunk = new HashSet<>();
+            expectedJunk.add(' ');
+            assertEquals(expectedJunk, sm.getBJunk());
+
+            // Test with multiple junk characters
+            sm = new SequenceMatcher(ch -> ch == ' ' || ch == 'b', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40) + " ".repeat(20), true);
+            expectedJunk = new HashSet<>();
+            expectedJunk.add(' ');
+            expectedJunk.add('b');
+            assertEquals(expectedJunk, sm.getBJunk());
+        }
+    }
+
+    /**
+     * Tests for the autoJunk parameter - ported from TestAutoJunk
+     */
+    @Nested
+    public class TestAutoJunk {
+
+        @Test
+        public void testOneInsertHomogenousSequence() {
+            // By default, autoJunk = True and the heuristic kicks in for a sequence of length 200+
+            String seq1 = "b".repeat(200);
+            String seq2 = "a" + "b".repeat(200);
+
+            SequenceMatcher sm = new SequenceMatcher(null, seq1, seq2, true);
+            assertEquals(0.0, sm.ratio(), 0.001);
+
+            // Now turn the heuristic off
+            sm = new SequenceMatcher(null, seq1, seq2, false);
+            assertEquals(0.9975, sm.ratio(), 0.001);
+        }
+    }
+
+    /**
+     * Tests for various bug fixes - ported from TestSFBugs
+     */
+    @Nested
+    class TestSFBugs {
+
+        @Test
+        public void testRatioForNullSequence() {
+            // Check clearing of SF bug 763023
+            SequenceMatcher s = new SequenceMatcher(null, "", "", true);
+            assertEquals(1.0, s.ratio());
+            assertEquals(1.0, s.quickRatio());
+            assertEquals(1.0, s.realQuickRatio());
+        }
+
+        @Test
+        public void testMatchingBlocksCache() {
+            // Issue #21635 - test that matching blocks are cached properly
+            SequenceMatcher s = new SequenceMatcher(null, "abxcd", "abcd", true);
+            List<SequenceMatcher.Match> first = s.getMatchingBlocks();
+            List<SequenceMatcher.Match> second = s.getMatchingBlocks();
+            assertEquals(2, second.get(0).size);
+            assertEquals(2, second.get(1).size);
+            assertEquals(0, second.get(2).size);
+        }
+    }
+
+    /**
+     * Tests for find_longest_match functionality - ported from TestFindLongest
+     */
+    @Nested
+    class TestFindLongest {
+
+        private boolean longerMatchExists(String a, String b, int n) {
+            // Check if there's a longer match than n
+            for (int i = 0; i <= b.length() - n - 1; i++) {
+                String bPart = b.substring(i, i + n + 1);
+                if (a.contains(bPart)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Test
+        public void testDefaultArgs() {
+            String a = "foo bar";
+            String b = "foo baz bar";
+            SequenceMatcher sm = new SequenceMatcher(null, a, b, true);
+            SequenceMatcher.Match match = sm.findLongestMatch(0, a.length(), 0, b.length());
+            assertEquals(0, match.aOffset);
+            assertEquals(0, match.bOffset);
+            assertEquals(6, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            Assertions.assertFalse(longerMatchExists(a, b, match.size));
+
+            match = sm.findLongestMatch(2, a.length(), 4, b.length());
+            assertEquals(3, match.aOffset);
+            assertEquals(7, match.bOffset);
+            assertEquals(4, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            Assertions.assertFalse(longerMatchExists(a.substring(2), b.substring(4), match.size));
+
+            match = sm.findLongestMatch(0, a.length(), 1, 5);
+            assertEquals(1, match.aOffset);
+            assertEquals(1, match.bOffset);
+            assertEquals(4, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            Assertions.assertFalse(longerMatchExists(a, b.substring(1, 5), match.size));
+        }
+
+        @Test
+        public void testLongestMatchWithPopularChars() {
+            String a = "dabcd";
+            String b = "d".repeat(100) + "abc" + "d".repeat(100); // length over 200 so popular used
+            SequenceMatcher sm = new SequenceMatcher(null, a, b, true);
+            SequenceMatcher.Match match = sm.findLongestMatch(0, a.length(), 0, b.length());
+            assertEquals(0, match.aOffset);
+            assertEquals(99, match.bOffset);
+            assertEquals(5, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            Assertions.assertFalse(longerMatchExists(a, b, match.size));
+        }
+    }
+
+    /**
+     * Test get_close_matches static method
+     */
+    @Test
+    public void testGetCloseMatches() {
+        List<String> possibilities = Arrays.asList("apple", "peach", "orange", "grape", "apricot", "pineapple");
+
+        // Test basic functionality - exact match should be included
+        List<String> matches = SequenceMatcher.getCloseMatches("apple", possibilities, 3, 0.6);
+        Assertions.assertFalse(matches.isEmpty()); // should have at least the exact match
+        Assertions.assertTrue(matches.contains("apple")); // exact match should be included
+
+        // Test with lower cutoff to get more matches
+        matches = SequenceMatcher.getCloseMatches("apple", possibilities, 6, 0.1);
+        Assertions.assertTrue(matches.contains("apple")); // exact match should be included
+        Assertions.assertTrue(matches.contains("pineapple")); // partial match should be included with lower cutoff
+
+        // Test with different word
+        matches = SequenceMatcher.getCloseMatches("app", possibilities, 3, 0.1);
+        Assertions.assertTrue(matches.contains("apple"));
+
+        // Test with n=1
+        matches = SequenceMatcher.getCloseMatches("apple", possibilities, 1, 0.6);
+        assertEquals(1, matches.size());
+        Assertions.assertTrue(matches.contains("apple"));
+    }
+
+    /**
+     * Test exception handling for getCloseMatches
+     */
+    @Test
+    public void testGetCloseMatchesExceptions() {
+        List<String> possibilities = Arrays.asList("apple", "peach");
+
+        // Test n <= 0
+        Assertions.assertThrows(IllegalArgumentException.class, () -> SequenceMatcher.getCloseMatches("apple", possibilities, 0, 0.6));
+
+        // Test invalid cutoff
+        Assertions.assertThrows(IllegalArgumentException.class, () -> SequenceMatcher.getCloseMatches("apple", possibilities, 3, -0.1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> SequenceMatcher.getCloseMatches("apple", possibilities, 3, 1.1));
+    }
+
+    @Test
+    public void testRatioCalculationsIdentical() {
+        // Test identical strings should have ratio of 1.0
+        SequenceMatcher sm = new SequenceMatcher(null, "hello", "hello", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+
+        // Test with different identical strings
+        sm = new SequenceMatcher(null, "abc", "abc", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+
+        // Test with empty strings
+        sm = new SequenceMatcher(null, "", "", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+
+        // Test with single character
+        sm = new SequenceMatcher(null, "a", "a", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+    }
+
+    /**
+     * Test various ratio calculations
+     */
+    @Test
+    public void testRatioCalculations() {
+        // Test that all ratio methods return values between 0 and 1
+        SequenceMatcher sm = new SequenceMatcher(null, "abcd", "bcda", true);
+
+        double ratio = sm.ratio();
+        double quickRatio = sm.quickRatio();
+        double realQuickRatio = sm.realQuickRatio();
+
+        Assertions.assertTrue(ratio >= 0.0 && ratio <= 1.0);
+        Assertions.assertTrue(quickRatio >= 0.0 && quickRatio <= 1.0);
+        Assertions.assertTrue(realQuickRatio >= 0.0 && realQuickRatio <= 1.0);
+
+        // Quick ratios should be upper bounds on ratio
+        Assertions.assertTrue(quickRatio >= ratio);
+        Assertions.assertTrue(realQuickRatio >= ratio);
+    }
+
+    /**
+     * Test sequence setting methods
+     */
+    @Test
+    public void testSequenceSetting() {
+        SequenceMatcher sm = new SequenceMatcher(null, "abc", "def", true);
+
+        // Test setSeqs
+        sm.setSequences("hello", "world");
+        Assertions.assertNotEquals(1.0, sm.ratio()); // Should not be identical
+
+        // Test setSeqA
+        sm.setSequenceA("world");
+        assertEquals(1.0, sm.ratio()); // Should be identical now
+
+        // Test setSeqB
+        sm.setSequenceB("hello");
+        Assertions.assertNotEquals(1.0, sm.ratio()); // Should not be identical again
+    }
+}

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/SequenceMatcherTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/SequenceMatcherTest.java
@@ -1,0 +1,328 @@
+package datawave.util.keyword;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JUnit 5 tests for SequenceMatcher, ported from Python difflib test_difflib.py.
+ * <p/>
+ * This test suite covers the core functionality of the SequenceMatcher class including: - Basic sequence matching and difference detection - Junk filtering
+ * functionality - AutoJunk heuristic for popular characters - Various ratio calculations (ratio, quickRatio, realQuickRatio) - Edge cases and bug regression
+ * tests - Static utility methods like getCloseMatches
+ * <p/>
+ * Comments and test structure preserved from the original Python test suite where appropriate.
+ */
+public class SequenceMatcherTest {
+
+    /**
+     * Tests with ASCII characters - ported from TestWithAscii
+     */
+    @Nested
+    class TestWithAscii {
+
+        @Test
+        public void testOneInsert() {
+            // Test one insert at beginning
+            SequenceMatcher sm = new SequenceMatcher(null, "b".repeat(100), "a" + "b".repeat(100), true);
+            assertEquals(0.995, sm.ratio(), 0.001);
+
+            List<SequenceMatcher.Opcode> opcodes = sm.getOpcodes();
+            assertEquals(2, opcodes.size());
+            assertEquals(SequenceMatcher.OpcodeTag.INSERT, opcodes.get(0).tag);
+            assertEquals(0, opcodes.get(0).i1);
+            assertEquals(0, opcodes.get(0).i2);
+            assertEquals(0, opcodes.get(0).j1);
+            assertEquals(1, opcodes.get(0).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(1).tag);
+            assertEquals(0, opcodes.get(1).i1);
+            assertEquals(100, opcodes.get(1).i2);
+            assertEquals(1, opcodes.get(1).j1);
+            assertEquals(101, opcodes.get(1).j2);
+
+            // Test one insert in middle
+            sm = new SequenceMatcher(null, "b".repeat(100), "b".repeat(50) + "a" + "b".repeat(50), true);
+            assertEquals(0.995, sm.ratio(), 0.001);
+
+            opcodes = sm.getOpcodes();
+            assertEquals(3, opcodes.size());
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(0).tag);
+            assertEquals(0, opcodes.get(0).i1);
+            assertEquals(50, opcodes.get(0).i2);
+            assertEquals(0, opcodes.get(0).j1);
+            assertEquals(50, opcodes.get(0).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.INSERT, opcodes.get(1).tag);
+            assertEquals(50, opcodes.get(1).i1);
+            assertEquals(50, opcodes.get(1).i2);
+            assertEquals(50, opcodes.get(1).j1);
+            assertEquals(51, opcodes.get(1).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(2).tag);
+            assertEquals(50, opcodes.get(2).i1);
+            assertEquals(100, opcodes.get(2).i2);
+            assertEquals(51, opcodes.get(2).j1);
+            assertEquals(101, opcodes.get(2).j2);
+        }
+
+        @Test
+        public void testOneDelete() {
+            SequenceMatcher sm = new SequenceMatcher(null, "a".repeat(40) + "c" + "b".repeat(40), "a".repeat(40) + "b".repeat(40), true);
+            assertEquals(0.994, sm.ratio(), 0.001);
+
+            List<SequenceMatcher.Opcode> opcodes = sm.getOpcodes();
+            assertEquals(3, opcodes.size());
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(0).tag);
+            assertEquals(0, opcodes.get(0).i1);
+            assertEquals(40, opcodes.get(0).i2);
+            assertEquals(0, opcodes.get(0).j1);
+            assertEquals(40, opcodes.get(0).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.DELETE, opcodes.get(1).tag);
+            assertEquals(40, opcodes.get(1).i1);
+            assertEquals(41, opcodes.get(1).i2);
+            assertEquals(40, opcodes.get(1).j1);
+            assertEquals(40, opcodes.get(1).j2);
+            assertEquals(SequenceMatcher.OpcodeTag.EQUAL, opcodes.get(2).tag);
+            assertEquals(41, opcodes.get(2).i1);
+            assertEquals(81, opcodes.get(2).i2);
+            assertEquals(40, opcodes.get(2).j1);
+            assertEquals(80, opcodes.get(2).j2);
+        }
+
+        @Test
+        public void testBJunk() {
+            // Test with no junk
+            SequenceMatcher sm = new SequenceMatcher(ch -> ch == ' ', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40), true);
+            assertTrue(sm.getBJunk().isEmpty());
+
+            // Test with junk characters
+            sm = new SequenceMatcher(ch -> ch == ' ', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40) + " ".repeat(20), true);
+            Set<Character> expectedJunk = new HashSet<>();
+            expectedJunk.add(' ');
+            assertEquals(expectedJunk, sm.getBJunk());
+
+            // Test with multiple junk characters
+            sm = new SequenceMatcher(ch -> ch == ' ' || ch == 'b', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40) + " ".repeat(20), true);
+            expectedJunk = new HashSet<>();
+            expectedJunk.add(' ');
+            expectedJunk.add('b');
+            assertEquals(expectedJunk, sm.getBJunk());
+        }
+    }
+
+    /**
+     * Tests for the autoJunk parameter - ported from TestAutoJunk
+     */
+    @Nested
+    public class TestAutoJunk {
+
+        @Test
+        public void testOneInsertHomogenousSequence() {
+            // By default, autoJunk = True and the heuristic kicks in for a sequence of length 200+
+            String seq1 = "b".repeat(200);
+            String seq2 = "a" + "b".repeat(200);
+
+            SequenceMatcher sm = new SequenceMatcher(null, seq1, seq2, true);
+            assertEquals(0.0, sm.ratio(), 0.001);
+
+            // Now turn the heuristic off
+            sm = new SequenceMatcher(null, seq1, seq2, false);
+            assertEquals(0.9975, sm.ratio(), 0.001);
+        }
+    }
+
+    /**
+     * Tests for various bug fixes - ported from TestSFBugs
+     */
+    @Nested
+    class TestSFBugs {
+
+        @Test
+        public void testRatioForNullSequence() {
+            // Check clearing of SF bug 763023
+            SequenceMatcher s = new SequenceMatcher(null, "", "", true);
+            assertEquals(1.0, s.ratio());
+            assertEquals(1.0, s.quickRatio());
+            assertEquals(1.0, s.realQuickRatio());
+        }
+
+        @Test
+        public void testMatchingBlocksCache() {
+            // Issue #21635 - test that matching blocks are cached properly
+            SequenceMatcher s = new SequenceMatcher(null, "abxcd", "abcd", true);
+            List<SequenceMatcher.Match> first = s.getMatchingBlocks();
+            List<SequenceMatcher.Match> second = s.getMatchingBlocks();
+            assertEquals(2, second.get(0).size);
+            assertEquals(2, second.get(1).size);
+            assertEquals(0, second.get(2).size);
+        }
+    }
+
+    /**
+     * Tests for find_longest_match functionality - ported from TestFindLongest
+     */
+    @Nested
+    class TestFindLongest {
+
+        private boolean longerMatchExists(String a, String b, int n) {
+            // Check if there's a longer match than n
+            for (int i = 0; i <= b.length() - n - 1; i++) {
+                String bPart = b.substring(i, i + n + 1);
+                if (a.contains(bPart)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Test
+        public void testDefaultArgs() {
+            String a = "foo bar";
+            String b = "foo baz bar";
+            SequenceMatcher sm = new SequenceMatcher(null, a, b, true);
+            SequenceMatcher.Match match = sm.findLongestMatch(0, a.length(), 0, b.length());
+            assertEquals(0, match.aOffset);
+            assertEquals(0, match.bOffset);
+            assertEquals(6, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            assertFalse(longerMatchExists(a, b, match.size));
+
+            match = sm.findLongestMatch(2, a.length(), 4, b.length());
+            assertEquals(3, match.aOffset);
+            assertEquals(7, match.bOffset);
+            assertEquals(4, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            assertFalse(longerMatchExists(a.substring(2), b.substring(4), match.size));
+
+            match = sm.findLongestMatch(0, a.length(), 1, 5);
+            assertEquals(1, match.aOffset);
+            assertEquals(1, match.bOffset);
+            assertEquals(4, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            assertFalse(longerMatchExists(a, b.substring(1, 5), match.size));
+        }
+
+        @Test
+        public void testLongestMatchWithPopularChars() {
+            String a = "dabcd";
+            String b = "d".repeat(100) + "abc" + "d".repeat(100); // length over 200 so popular used
+            SequenceMatcher sm = new SequenceMatcher(null, a, b, true);
+            SequenceMatcher.Match match = sm.findLongestMatch(0, a.length(), 0, b.length());
+            assertEquals(0, match.aOffset);
+            assertEquals(99, match.bOffset);
+            assertEquals(5, match.size);
+            assertEquals(a.substring(match.aOffset, match.aOffset + match.size), b.substring(match.bOffset, match.bOffset + match.size));
+            assertFalse(longerMatchExists(a, b, match.size));
+        }
+    }
+
+    /**
+     * Test get_close_matches static method
+     */
+    @Test
+    public void testGetCloseMatches() {
+        List<String> possibilities = Arrays.asList("apple", "peach", "orange", "grape", "apricot", "pineapple");
+
+        // Test basic functionality - exact match should be included
+        List<String> matches = SequenceMatcher.getCloseMatches("apple", possibilities, 3, 0.6);
+        assertFalse(matches.isEmpty()); // should have at least the exact match
+        assertTrue(matches.contains("apple")); // exact match should be included
+
+        // Test with lower cutoff to get more matches
+        matches = SequenceMatcher.getCloseMatches("apple", possibilities, 6, 0.1);
+        assertTrue(matches.contains("apple")); // exact match should be included
+        assertTrue(matches.contains("pineapple")); // partial match should be included with lower cutoff
+
+        // Test with different word
+        matches = SequenceMatcher.getCloseMatches("app", possibilities, 3, 0.1);
+        assertTrue(matches.contains("apple"));
+
+        // Test with n=1
+        matches = SequenceMatcher.getCloseMatches("apple", possibilities, 1, 0.6);
+        assertEquals(1, matches.size());
+        assertTrue(matches.contains("apple"));
+    }
+
+    /**
+     * Test exception handling for getCloseMatches
+     */
+    @Test
+    public void testGetCloseMatchesExceptions() {
+        List<String> possibilities = Arrays.asList("apple", "peach");
+
+        // Test n <= 0
+        assertThrows(IllegalArgumentException.class, () -> SequenceMatcher.getCloseMatches("apple", possibilities, 0, 0.6));
+
+        // Test invalid cutoff
+        assertThrows(IllegalArgumentException.class, () -> SequenceMatcher.getCloseMatches("apple", possibilities, 3, -0.1));
+        assertThrows(IllegalArgumentException.class, () -> SequenceMatcher.getCloseMatches("apple", possibilities, 3, 1.1));
+    }
+
+    @Test
+    public void testRatioCalculationsIdentical() {
+        // Test identical strings should have ratio of 1.0
+        SequenceMatcher sm = new SequenceMatcher(null, "hello", "hello", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+
+        // Test with different identical strings
+        sm = new SequenceMatcher(null, "abc", "abc", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+
+        // Test with empty strings
+        sm = new SequenceMatcher(null, "", "", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+
+        // Test with single character
+        sm = new SequenceMatcher(null, "a", "a", true);
+        assertEquals(1.0, sm.ratio(), 0.001);
+    }
+
+    /**
+     * Test various ratio calculations
+     */
+    @Test
+    public void testRatioCalculations() {
+        // Test that all ratio methods return values between 0 and 1
+        SequenceMatcher sm = new SequenceMatcher(null, "abcd", "bcda", true);
+
+        double ratio = sm.ratio();
+        double quickRatio = sm.quickRatio();
+        double realQuickRatio = sm.realQuickRatio();
+
+        assertTrue(ratio >= 0.0 && ratio <= 1.0);
+        assertTrue(quickRatio >= 0.0 && quickRatio <= 1.0);
+        assertTrue(realQuickRatio >= 0.0 && realQuickRatio <= 1.0);
+
+        // Quick ratios should be upper bounds on ratio
+        assertTrue(quickRatio >= ratio);
+        assertTrue(realQuickRatio >= ratio);
+    }
+
+    /**
+     * Test sequence setting methods
+     */
+    @Test
+    public void testSequenceSetting() {
+        SequenceMatcher sm = new SequenceMatcher(null, "abc", "def", true);
+
+        // Test setSeqs
+        sm.setSequences("hello", "world");
+        assertNotEquals(1.0, sm.ratio()); // Should not be identical
+
+        // Test setSeqA
+        sm.setSequenceA("world");
+        assertEquals(1.0, sm.ratio()); // Should be identical now
+
+        // Test setSeqB
+        sm.setSequenceB("hello");
+        assertNotEquals(1.0, sm.ratio()); // Should not be identical again
+    }
+}

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/SequenceMatcherTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/SequenceMatcherTest.java
@@ -105,15 +105,15 @@ public class SequenceMatcherTest {
 
             // Test with junk characters
             sm = new SequenceMatcher(ch -> ch == ' ', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40) + " ".repeat(20), true);
-            Set<Character> expectedJunk = new HashSet<>();
-            expectedJunk.add(' ');
+            Set<Integer> expectedJunk = new HashSet<>();
+            expectedJunk.add((int) ' ');
             assertEquals(expectedJunk, sm.getBJunk());
 
             // Test with multiple junk characters
             sm = new SequenceMatcher(ch -> ch == ' ' || ch == 'b', "a".repeat(40) + "b".repeat(40), "a".repeat(44) + "b".repeat(40) + " ".repeat(20), true);
             expectedJunk = new HashSet<>();
-            expectedJunk.add(' ');
-            expectedJunk.add('b');
+            expectedJunk.add((int) ' ');
+            expectedJunk.add((int) 'b');
             assertEquals(expectedJunk, sm.getBJunk());
         }
     }
@@ -283,6 +283,23 @@ public class SequenceMatcherTest {
         // Test with single character
         sm = new SequenceMatcher(null, "a", "a", true);
         assertEquals(1.0, sm.ratio(), 0.001);
+    }
+
+    @Test
+    public void testSupplementaryUnicodeCharactersAreComparedAsCodePoints() {
+        SequenceMatcher sm = new SequenceMatcher("😀", "😁");
+        assertEquals(0.0, sm.ratio());
+        assertEquals(0.0, sm.quickRatio());
+
+        sm.setSequences("a😀b", "x😀y");
+        SequenceMatcher.Match match = sm.findLongestMatch(0, 3, 0, 3);
+        assertEquals(1, match.aOffset);
+        assertEquals(1, match.bOffset);
+        assertEquals(1, match.size);
+
+        int grinningFace = "😀".codePointAt(0);
+        sm = new SequenceMatcher(codePoint -> codePoint == grinningFace, "a😀b", "a😀b", true);
+        assertEquals(Set.of(grinningFace), sm.getBJunk());
     }
 
     /**

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
@@ -31,6 +31,14 @@ public class YakeKeywordExtractorTest {
                     + "given that Google is hosting its Cloud Next conference in San Francisco this week the official "
                     + "announcement could come as early as tomorrow.";
 
+    static final LinkedHashMap<String,Double> EXPECTED_DEDUPED_NEWS_OUTPUT = new LinkedHashMap<>();
+    static {
+        LinkedHashMap<String,Double> m = EXPECTED_DEDUPED_NEWS_OUTPUT;
+        m.put("acquiring kaggle", 0.4602);
+        m.put("cloud next", 0.3884);
+        m.put("san francisco", 0.3884);
+    }
+
     static final LinkedHashMap<String,Double> EXPECTED_NEWS_OUTPUT = new LinkedHashMap<>();
     static {
         LinkedHashMap<String,Double> m = EXPECTED_NEWS_OUTPUT;
@@ -106,6 +114,7 @@ public class YakeKeywordExtractorTest {
                 .withMinNGrams(2)
                 .withMaxNGrams(3)
                 .withKeywordCount(10)
+                .withMaxSimilarityThreshold(0.9)
                 .withLanguage(BaseYakeLanguage.ENGLISH)
                 .build();
         //@formatter:on
@@ -114,6 +123,25 @@ public class YakeKeywordExtractorTest {
         keywords.entrySet().forEach(i -> log.info(i.toString()));
         assertEquals(4, keywords.size());
         assertEquals(EXPECTED_NEWS_OUTPUT, keywords);
+    }
+
+    @Test
+    public void testInputWithStrictDeduplication() {
+        //@formatter:off
+        YakeKeywordExtractor keywordExtractor = new YakeKeywordExtractor.Builder()
+                .withMaxScoreThreshold(0.6f)
+                .withMinNGrams(2)
+                .withMaxNGrams(3)
+                .withKeywordCount(10)
+                .withMaxSimilarityThreshold(0.6)
+                .withLanguage(BaseYakeLanguage.ENGLISH)
+                .build();
+        //@formatter:on
+
+        Map<String,Double> keywords = keywordExtractor.extractKeywords(TEST_NEWS_INPUT_INPUT);
+        keywords.entrySet().forEach(i -> log.info(i.toString()));
+        assertEquals(3, keywords.size());
+        assertEquals(EXPECTED_DEDUPED_NEWS_OUTPUT, keywords);
     }
 
     @Test

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -142,6 +145,46 @@ public class YakeKeywordExtractorTest {
         keywords.entrySet().forEach(i -> log.info(i.toString()));
         assertEquals(3, keywords.size());
         assertEquals(EXPECTED_DEDUPED_NEWS_OUTPUT, keywords);
+    }
+
+    @Test
+    public void testDeduplicationStopsAtKeywordCount() {
+        AtomicInteger visited = new AtomicInteger();
+        Stream<TokenScore> candidates = Stream
+                        .of(new TokenScore("first keyword", 0.1), new TokenScore("second keyword", 0.2), new TokenScore("unexpected keyword", 0.3))
+                        .peek(candidate -> {
+                            if (visited.incrementAndGet() > 2) {
+                                throw new AssertionError("Consumed a candidate after reaching the keyword count");
+                            }
+                        });
+
+        List<TokenScore> selected = YakeKeywordExtractor.deduplicateCandidateTokens(candidates, 0.9, 2).collect(Collectors.toList());
+
+        assertEquals(2, selected.size());
+        assertEquals(2, visited.get());
+    }
+
+    @Test
+    public void testDeduplicationProcessesAllCandidatesWhenUnlimited() {
+        AtomicInteger visited = new AtomicInteger();
+        Stream<TokenScore> candidates = Stream
+                        .of(new TokenScore("first keyword", 0.1), new TokenScore("second keyword", 0.2), new TokenScore("third keyword", 0.3))
+                        .peek(candidate -> visited.incrementAndGet());
+
+        List<TokenScore> selected = YakeKeywordExtractor.deduplicateCandidateTokens(candidates, 0.9, 0).collect(Collectors.toList());
+
+        assertEquals(3, selected.size());
+        assertEquals(3, visited.get());
+    }
+
+    @Test
+    public void testDisabledDeduplicationStillHonorsKeywordCount() {
+        Stream<TokenScore> candidates = Stream.of(new TokenScore("first keyword", 0.1), new TokenScore("second keyword", 0.2),
+                        new TokenScore("third keyword", 0.3));
+
+        List<TokenScore> selected = YakeKeywordExtractor.deduplicateCandidateTokens(candidates, 0.0, 2).collect(Collectors.toList());
+
+        assertEquals(2, selected.size());
     }
 
     @Test

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordExtractorTest.java
@@ -1,6 +1,7 @@
 package datawave.util.keyword;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -185,6 +186,18 @@ public class YakeKeywordExtractorTest {
         List<TokenScore> selected = YakeKeywordExtractor.deduplicateCandidateTokens(candidates, 0.0, 2).collect(Collectors.toList());
 
         assertEquals(2, selected.size());
+    }
+
+    @Test
+    public void testSimilarityThresholdValidation() {
+        assertEquals(0.0, new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(0.0).build().getMaxSimilarityThreshold());
+        assertEquals(1.0, new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(1.0).build().getMaxSimilarityThreshold());
+
+        assertThrows(IllegalArgumentException.class, () -> new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(-0.1));
+        assertThrows(IllegalArgumentException.class, () -> new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(1.1));
+        assertThrows(IllegalArgumentException.class, () -> new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(Double.NaN));
+        assertThrows(IllegalArgumentException.class, () -> new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(Double.POSITIVE_INFINITY));
+        assertThrows(IllegalArgumentException.class, () -> new YakeKeywordExtractor.Builder().withMaxSimilarityThreshold(Double.NEGATIVE_INFINITY));
     }
 
     @Test

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordRegressionTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/YakeKeywordRegressionTest.java
@@ -52,6 +52,7 @@ public class YakeKeywordRegressionTest {
                 .withMaxNGrams(3)
                 .withKeywordCount(10)
                 .withMaxContentLength(32768)
+                .withMaxSimilarityThreshold(0.9)
                 .withLanguage(language)
                 .build();
         //@formatter:on

--- a/warehouse/query-core/src/main/java/datawave/query/config/KeywordQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/KeywordQueryConfiguration.java
@@ -28,6 +28,7 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
     private int maxKeywords = YakeKeywordExtractor.DEFAULT_KEYWORD_COUNT;
     private float maxScore = YakeKeywordExtractor.DEFAULT_MAX_SCORE_THRESHOLD;
     private int maxContentChars = YakeKeywordExtractor.DEFAULT_MAX_CONTENT_LENGTH;
+    private double maxSimilarityThreshold = YakeKeywordExtractor.DEFAULT_MAX_SIMILARITY_THRESHOLD;
     private int maxCloudTags = 0; // no limit by default
 
     private TagCloudUtils tagCloudUtils = new DefaultTagCloudUtils();
@@ -57,6 +58,7 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
         this.setMaxKeywords(other.maxKeywords);
         this.setMaxScore(other.maxScore);
         this.setMaxContentChars(other.maxContentChars);
+        this.setMaxSimilarityThreshold(other.maxSimilarityThreshold);
         this.setState(other.getState());
         this.setTagCloudUtils(other.getTagCloudUtils());
         this.setPreferredViews(other.getPreferredViews());
@@ -135,6 +137,14 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
         this.maxCloudTags = maxCloudTags;
     }
 
+    public double getMaxSimilarityThreshold() {
+        return maxSimilarityThreshold;
+    }
+
+    public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        this.maxSimilarityThreshold = maxSimilarityThreshold;
+    }
+
     /**
      * Factory method that instantiates a fresh KeywordQueryConfiguration
      *
@@ -152,12 +162,12 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
             return false;
         KeywordQueryConfiguration that = (KeywordQueryConfiguration) o;
         return minNgrams == that.minNgrams && maxNgrams == that.maxNgrams && maxKeywords == that.maxKeywords && Float.compare(maxScore, that.maxScore) == 0
-                        && maxContentChars == that.maxContentChars && Objects.equal(state, that.state);
+                        && maxContentChars == that.maxContentChars && maxSimilarityThreshold == that.maxSimilarityThreshold && Objects.equal(state, that.state);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(super.hashCode(), minNgrams, maxNgrams, maxKeywords, maxScore, maxContentChars, state);
+        return Objects.hashCode(super.hashCode(), minNgrams, maxNgrams, maxKeywords, maxScore, maxContentChars, maxSimilarityThreshold, state);
     }
 
     // todo: implement serialization methods?

--- a/warehouse/query-core/src/main/java/datawave/query/config/KeywordQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/KeywordQueryConfiguration.java
@@ -143,6 +143,7 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
     }
 
     public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        YakeKeywordExtractor.validateMaxSimilarityThreshold(maxSimilarityThreshold);
         this.maxSimilarityThreshold = maxSimilarityThreshold;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/config/KeywordQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/KeywordQueryConfiguration.java
@@ -28,6 +28,7 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
     private int maxKeywords = YakeKeywordExtractor.DEFAULT_KEYWORD_COUNT;
     private float maxScore = YakeKeywordExtractor.DEFAULT_MAX_SCORE_THRESHOLD;
     private int maxContentChars = YakeKeywordExtractor.DEFAULT_MAX_CONTENT_LENGTH;
+    private double maxSimilarityThreshold = YakeKeywordExtractor.DEFAULT_MAX_SIMILARITY_THRESHOLD;
     private int maxCloudTags = 0; // no limit by default
 
     private TagCloudUtils tagCloudUtils = new DefaultTagCloudUtils();
@@ -58,6 +59,7 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
         this.setMaxKeywords(other.maxKeywords);
         this.setMaxScore(other.maxScore);
         this.setMaxContentChars(other.maxContentChars);
+        this.setMaxSimilarityThreshold(other.maxSimilarityThreshold);
         this.setState(other.getState());
         this.setTagCloudUtils(other.getTagCloudUtils());
         this.setPreferredViews(other.getPreferredViews());
@@ -136,6 +138,14 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
         this.maxCloudTags = maxCloudTags;
     }
 
+    public double getMaxSimilarityThreshold() {
+        return maxSimilarityThreshold;
+    }
+
+    public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        this.maxSimilarityThreshold = maxSimilarityThreshold;
+    }
+
     /**
      * Factory method that instantiates a fresh KeywordQueryConfiguration
      *
@@ -153,12 +163,12 @@ public class KeywordQueryConfiguration extends GenericQueryConfiguration impleme
             return false;
         KeywordQueryConfiguration that = (KeywordQueryConfiguration) o;
         return minNgrams == that.minNgrams && maxNgrams == that.maxNgrams && maxKeywords == that.maxKeywords && Float.compare(maxScore, that.maxScore) == 0
-                        && maxContentChars == that.maxContentChars && Objects.equal(state, that.state);
+                        && maxContentChars == that.maxContentChars && maxSimilarityThreshold == that.maxSimilarityThreshold && Objects.equal(state, that.state);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(super.hashCode(), minNgrams, maxNgrams, maxKeywords, maxScore, maxContentChars, state);
+        return Objects.hashCode(super.hashCode(), minNgrams, maxNgrams, maxKeywords, maxScore, maxContentChars, maxSimilarityThreshold, state);
     }
 
     // todo: implement serialization methods?

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/KeywordExtractingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/KeywordExtractingIterator.java
@@ -58,6 +58,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
         defaultMapOptions.put(KeywordExtractor.MAX_KEYWORDS, "maximum number of keywords to extract");
         defaultMapOptions.put(KeywordExtractor.MAX_SCORE, "max keyword score allowed (smaller scores are better)");
         defaultMapOptions.put(KeywordExtractor.MAX_CONTENT_CHARS, "max number of input characters to process");
+        defaultMapOptions.put(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, "max similarity threshold");
         defaultMapOptions.put(VIEW_NAMES, "a comma separated list of views to extract keywords from, in priority order");
     }
 
@@ -367,6 +368,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
                 validateIntOption(KeywordExtractor.MAX_KEYWORDS, options);
                 validateFloatOption(KeywordExtractor.MAX_SCORE, options);
                 validateIntOption(KeywordExtractor.MAX_CONTENT_CHARS, options);
+                validateDoubleOption(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, options);
                 valid = true;
             } catch (Exception e) {
                 if (log.isDebugEnabled()) {
@@ -378,7 +380,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
     }
 
     public static void setOptions(IteratorSetting si, int minNgrams, int maxNgrams, int maxKeywords, float maxScore, int maxContentChars,
-                    List<String> viewNames, Map<String,String> documentLanguageMap) {
+                    double maxSimilarityThreshold, List<String> viewNames, Map<String,String> documentLanguageMap) {
 
         if (minNgrams > 0) {
             si.addOption(KeywordExtractor.MIN_NGRAMS, String.valueOf(minNgrams));
@@ -398,6 +400,10 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
 
         if (maxContentChars > 0) {
             si.addOption(KeywordExtractor.MAX_CONTENT_CHARS, String.valueOf(maxContentChars));
+        }
+
+        if (maxSimilarityThreshold > -1) {
+            si.addOption(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, String.valueOf(maxSimilarityThreshold));
         }
 
         si.addOption(VIEW_NAMES, String.join(",", viewNames));
@@ -426,6 +432,13 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
     private static void validateFloatOption(String name, Map<String,String> options) {
         if (options.containsKey(name)) {
             float f = Float.parseFloat(options.get(name));
+        }
+    }
+
+    @SuppressWarnings({"unused", "SameParameterValue"})
+    private static void validateDoubleOption(String name, Map<String,String> options) {
+        if (options.containsKey(name)) {
+            double d = Double.parseDouble(options.get(name));
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/KeywordExtractingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/KeywordExtractingIterator.java
@@ -38,6 +38,7 @@ import datawave.query.table.parser.ContentKeyValueFactory;
 import datawave.util.keyword.KeywordExtractor;
 import datawave.util.keyword.KeywordResults;
 import datawave.util.keyword.VisibleContent;
+import datawave.util.keyword.YakeKeywordExtractor;
 
 /** An iterator that will execute the keyword extractor when given 'd' column ranges to scan for specific documents */
 public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Value>, OptionDescriber {
@@ -404,6 +405,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
 
     public static void setOptions(IteratorSetting si, int minNgrams, int maxNgrams, int maxKeywords, float maxScore, int maxContentChars,
                     double maxSimilarityThreshold, List<String> viewNames, Map<String,String> documentLanguageMap) {
+        YakeKeywordExtractor.validateMaxSimilarityThreshold(maxSimilarityThreshold);
 
         if (minNgrams > 0) {
             si.addOption(KeywordExtractor.MIN_NGRAMS, String.valueOf(minNgrams));
@@ -425,9 +427,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
             si.addOption(KeywordExtractor.MAX_CONTENT_CHARS, String.valueOf(maxContentChars));
         }
 
-        if (maxSimilarityThreshold > -1) {
-            si.addOption(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, String.valueOf(maxSimilarityThreshold));
-        }
+        si.addOption(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, String.valueOf(maxSimilarityThreshold));
 
         si.addOption(VIEW_NAMES, String.join(",", viewNames));
         si.addOption(DOCUMENT_LANGUAGES, serializeMap(documentLanguageMap));
@@ -462,6 +462,9 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
     private static void validateDoubleOption(String name, Map<String,String> options) {
         if (options.containsKey(name)) {
             double d = Double.parseDouble(options.get(name));
+            if (KeywordExtractor.MAX_SIMILARITY_THRESHOLD.equals(name)) {
+                YakeKeywordExtractor.validateMaxSimilarityThreshold(d);
+            }
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/KeywordExtractingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/KeywordExtractingIterator.java
@@ -60,6 +60,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
         defaultMapOptions.put(KeywordExtractor.MAX_KEYWORDS, "maximum number of keywords to extract");
         defaultMapOptions.put(KeywordExtractor.MAX_SCORE, "max keyword score allowed (smaller scores are better)");
         defaultMapOptions.put(KeywordExtractor.MAX_CONTENT_CHARS, "max number of input characters to process");
+        defaultMapOptions.put(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, "max similarity threshold");
         defaultMapOptions.put(VIEW_NAMES, "a comma separated list of views to extract keywords from, in priority order");
     }
 
@@ -390,6 +391,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
                 validateIntOption(KeywordExtractor.MAX_KEYWORDS, options);
                 validateFloatOption(KeywordExtractor.MAX_SCORE, options);
                 validateIntOption(KeywordExtractor.MAX_CONTENT_CHARS, options);
+                validateDoubleOption(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, options);
                 valid = true;
             } catch (Exception e) {
                 if (log.isDebugEnabled()) {
@@ -401,7 +403,7 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
     }
 
     public static void setOptions(IteratorSetting si, int minNgrams, int maxNgrams, int maxKeywords, float maxScore, int maxContentChars,
-                    List<String> viewNames, Map<String,String> documentLanguageMap) {
+                    double maxSimilarityThreshold, List<String> viewNames, Map<String,String> documentLanguageMap) {
 
         if (minNgrams > 0) {
             si.addOption(KeywordExtractor.MIN_NGRAMS, String.valueOf(minNgrams));
@@ -421,6 +423,10 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
 
         if (maxContentChars > 0) {
             si.addOption(KeywordExtractor.MAX_CONTENT_CHARS, String.valueOf(maxContentChars));
+        }
+
+        if (maxSimilarityThreshold > -1) {
+            si.addOption(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, String.valueOf(maxSimilarityThreshold));
         }
 
         si.addOption(VIEW_NAMES, String.join(",", viewNames));
@@ -449,6 +455,13 @@ public class KeywordExtractingIterator implements SortedKeyValueIterator<Key,Val
     private static void validateFloatOption(String name, Map<String,String> options) {
         if (options.containsKey(name)) {
             float f = Float.parseFloat(options.get(name));
+        }
+    }
+
+    @SuppressWarnings({"unused", "SameParameterValue"})
+    private static void validateDoubleOption(String name, Map<String,String> options) {
+        if (options.containsKey(name)) {
+            double d = Double.parseDouble(options.get(name));
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -82,6 +82,11 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
     public static final String TAG_CLOUD_MAX = "tag.cloud.max";
 
     /**
+     * Used to specify that a tag cloud should remove tags that have a higher than this similarity with existing tags.
+     */
+    public static final String TAG_CLOUD_SIM_MAX = "tag.cloud.sim.max";
+
+    /**
      * Used to specify that the tag clouds should be grouped by language.
      */
     public static final String TAG_CLOUD_LANGUAGE = "tag.cloud.language";
@@ -207,6 +212,15 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
             log.warn("Could not parse parameter " + TAG_CLOUD_MAX + " (value: " + maxCloudTagsString + " as integer, ignoring.");
         }
 
+        // tag cloud similarity max is set from configuration and then overridden by the query param, no limit is 0.
+        String maxCloudTagSimString = settings.findParameter(TAG_CLOUD_SIM_MAX).getParameterValue().trim();
+        try {
+            double tagCloudSimMax = maxCloudTagSimString.isEmpty() ? config.getMaxSimilarityThreshold() : Double.parseDouble(maxCloudTagSimString);
+            state.setMaxSimilarityThreshold(tagCloudSimMax);
+        } catch (NumberFormatException e) {
+            log.warn("Could not parse parameter " + TAG_CLOUD_SIM_MAX + " (value: " + maxCloudTagSimString + " as double, ignoring.");
+        }
+
         // Execute the query logic.
         final Collection<String> queryTerms = extractQueryTerms(settings);
 
@@ -237,9 +251,11 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
                             config.getQuery());
             scanner.setRanges(config.getState().getRanges());
 
+            // use config.getState() for items that can be overridden with a query parameter.
             final IteratorSetting cfg = new IteratorSetting(60, "keyword-extractor", KeywordExtractingIterator.class);
             KeywordExtractingIterator.setOptions(cfg, config.getMinNgrams(), config.getMaxNgrams(), config.getMaxKeywords(), config.getMaxScore(),
-                            config.getMaxContentChars(), config.getState().getPreferredViews(), config.getState().getLanguageMap());
+                            config.getMaxContentChars(), config.getState().getMaxSimilarityThreshold(), config.getState().getPreferredViews(),
+                            config.getState().getLanguageMap());
             scanner.addScanIterator(cfg);
 
             this.iterator = scanner.iterator();
@@ -412,6 +428,14 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     public void setMaxKeywords(int maxKeywords) {
         getConfig().setMaxNgrams(maxKeywords);
+    }
+
+    public double getMaxSimilarityThreshold() {
+        return getConfig().getMaxSimilarityThreshold();
+    }
+
+    public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        getConfig().setMaxSimilarityThreshold(maxSimilarityThreshold);
     }
 
     public int getMaxNgrams() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -235,12 +235,15 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         setResponseVersion(responseVersion);
 
         // tag cloud similarity max is set from configuration and then overridden by the query param, no limit is 0.
+        state.setMaxSimilarityThreshold(config.getMaxSimilarityThreshold());
         String maxCloudTagSimString = settings.findParameter(TAG_CLOUD_SIM_MAX).getParameterValue().trim();
-        try {
-            double tagCloudSimMax = maxCloudTagSimString.isEmpty() ? config.getMaxSimilarityThreshold() : Double.parseDouble(maxCloudTagSimString);
-            state.setMaxSimilarityThreshold(tagCloudSimMax);
-        } catch (NumberFormatException e) {
-            log.warn("Could not parse parameter " + TAG_CLOUD_SIM_MAX + " (value: " + maxCloudTagSimString + " as double, ignoring.");
+        if (!maxCloudTagSimString.isEmpty()) {
+            try {
+                state.setMaxSimilarityThreshold(Double.parseDouble(maxCloudTagSimString));
+            } catch (IllegalArgumentException e) {
+                log.warn("Invalid parameter " + TAG_CLOUD_SIM_MAX + " (value: " + maxCloudTagSimString + "), using configured value "
+                                + config.getMaxSimilarityThreshold() + '.', e);
+            }
         }
 
         if (settings.getQuery() != null && !settings.getQuery().isEmpty()) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -93,6 +93,11 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
     public static final String TAG_CLOUD_MAX = "tag.cloud.max";
 
     /**
+     * Used to specify that a tag cloud should remove tags that have a higher than this similarity with existing tags.
+     */
+    public static final String TAG_CLOUD_SIM_MAX = "tag.cloud.sim.max";
+
+    /**
      * Used to specify that the tag clouds should be grouped by language.
      */
     public static final String TAG_CLOUD_LANGUAGE = "tag.cloud.language";
@@ -229,6 +234,15 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         String responseVersion = settings.findParameter(TAG_CLOUD_VERSION).getParameterValue().trim();
         setResponseVersion(responseVersion);
 
+        // tag cloud similarity max is set from configuration and then overridden by the query param, no limit is 0.
+        String maxCloudTagSimString = settings.findParameter(TAG_CLOUD_SIM_MAX).getParameterValue().trim();
+        try {
+            double tagCloudSimMax = maxCloudTagSimString.isEmpty() ? config.getMaxSimilarityThreshold() : Double.parseDouble(maxCloudTagSimString);
+            state.setMaxSimilarityThreshold(tagCloudSimMax);
+        } catch (NumberFormatException e) {
+            log.warn("Could not parse parameter " + TAG_CLOUD_SIM_MAX + " (value: " + maxCloudTagSimString + " as double, ignoring.");
+        }
+
         if (settings.getQuery() != null && !settings.getQuery().isEmpty()) {
             // Execute the query logic.
             final Collection<String> queryTerms = extractQueryTerms(settings);
@@ -273,7 +287,8 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
                 final IteratorSetting cfg = new IteratorSetting(60, "keyword-extractor", KeywordExtractingIterator.class);
                 KeywordExtractingIterator.setOptions(cfg, config.getMinNgrams(), config.getMaxNgrams(), config.getMaxKeywords(), config.getMaxScore(),
-                                config.getMaxContentChars(), config.getState().getPreferredViews(), config.getState().getLanguageMap());
+                                config.getMaxContentChars(), config.getState().getMaxSimilarityThreshold(), config.getState().getPreferredViews(),
+                                config.getState().getLanguageMap());
                 scanner.addScanIterator(cfg);
 
                 // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
@@ -453,6 +468,14 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     public void setMaxKeywords(int maxKeywords) {
         getConfig().setMaxNgrams(maxKeywords);
+    }
+
+    public double getMaxSimilarityThreshold() {
+        return getConfig().getMaxSimilarityThreshold();
+    }
+
+    public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        getConfig().setMaxSimilarityThreshold(maxSimilarityThreshold);
     }
 
     public int getMaxNgrams() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryState.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryState.java
@@ -50,6 +50,8 @@ public class KeywordQueryState {
      */
     private TagCloudUtils utils;
 
+    private double maxSimilarityThreshold;
+
     /** the ranges to scan based on the query terms */
     private final Collection<Range> ranges = new TreeSet<>();
 
@@ -108,5 +110,13 @@ public class KeywordQueryState {
 
     public TagCloudUtils getTagCloudUtils() {
         return utils;
+    }
+
+    public double getMaxSimilarityThreshold() {
+        return maxSimilarityThreshold;
+    }
+
+    public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        this.maxSimilarityThreshold = maxSimilarityThreshold;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryState.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryState.java
@@ -10,6 +10,7 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.data.Range;
 
 import datawave.util.keyword.TagCloudUtils;
+import datawave.util.keyword.YakeKeywordExtractor;
 
 /** Captures the internal state of a single keyword query */
 public class KeywordQueryState {
@@ -117,6 +118,7 @@ public class KeywordQueryState {
     }
 
     public void setMaxSimilarityThreshold(double maxSimilarityThreshold) {
+        YakeKeywordExtractor.validateMaxSimilarityThreshold(maxSimilarityThreshold);
         this.maxSimilarityThreshold = maxSimilarityThreshold;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
@@ -70,6 +70,7 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
         q.addParameter(KeywordQueryLogic.TAG_CLOUD_CREATE, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_CREATE).getParameterValue());
         q.addParameter(KeywordQueryLogic.PREFERRED_VIEW_NAMES, initialQuery.findParameter(KeywordQueryLogic.PREFERRED_VIEW_NAMES).getParameterValue());
         q.addParameter(KeywordQueryLogic.TAG_CLOUD_MAX, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_MAX).getParameterValue());
+        q.addParameter(KeywordQueryLogic.TAG_CLOUD_SIM_MAX, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_SIM_MAX).getParameterValue());
         q.addParameter(KeywordQueryLogic.TAG_CLOUD_LANGUAGE, initialQuery.findParameter(KeywordQueryLogic.TAG_CLOUD_LANGUAGE).getParameterValue());
 
         return q;

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/KeywordExtractingIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/KeywordExtractingIteratorTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -111,6 +112,25 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
      */
     private void initIterator() throws IOException {
         iterator.init(new SortedListKeyValueIterator(source), options, env);
+    }
+
+    @Test
+    public void testSimilarityThresholdOptionValidation() {
+        options.put(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, "0.75");
+        assertTrue(iterator.validateOptions(options));
+
+        for (String invalid : List.of("-0.1", "1.1", "NaN", "Infinity", "-Infinity", "not-a-number")) {
+            options.put(KeywordExtractor.MAX_SIMILARITY_THRESHOLD, invalid);
+            assertFalse(invalid, iterator.validateOptions(options));
+        }
+    }
+
+    @Test
+    public void testSimilarityThresholdOptionPropagation() {
+        IteratorSetting setting = new IteratorSetting(60, "keyword-extractor", KeywordExtractingIterator.class);
+        KeywordExtractingIterator.setOptions(setting, 1, 3, 10, 0.6f, 32768, 0.75, List.of("CONTENT"), Map.of());
+
+        assertEquals("0.75", setting.getOptions().get(KeywordExtractor.MAX_SIMILARITY_THRESHOLD));
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
@@ -1,5 +1,6 @@
 package datawave.query.tables.keyword;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -219,6 +220,50 @@ public class KeywordQueryLogicTest {
         assertEquals("ENGLISH", threeLanguage);
         assertEquals("UNKNOWN", fourLanguage);
         assertNull(fiveLanguage);
+    }
+
+    @Test
+    public void testSimilarityThresholdUsesConfiguredValueWithoutOverride() throws Exception {
+        KeywordQueryLogic logic = initializeWithSimilarityThreshold(0.75, null);
+        assertEquals(0.75, logic.getConfig().getState().getMaxSimilarityThreshold());
+    }
+
+    @Test
+    public void testSimilarityThresholdConfigurationRejectsInvalidValues() {
+        for (double invalid : List.of(-0.1, 1.1, Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+            assertThrows(IllegalArgumentException.class, () -> keywordQueryLogic.setMaxSimilarityThreshold(invalid), String.valueOf(invalid));
+        }
+    }
+
+    @Test
+    public void testSimilarityThresholdUsesValidQueryOverride() throws Exception {
+        KeywordQueryLogic logic = initializeWithSimilarityThreshold(0.75, "0.5");
+        assertEquals(0.5, logic.getConfig().getState().getMaxSimilarityThreshold());
+    }
+
+    @Test
+    public void testInvalidSimilarityThresholdOverridesRetainConfiguredValue() {
+        for (String invalid : List.of("-0.1", "1.1", "NaN", "Infinity", "-Infinity", "not-a-number")) {
+            assertEquals(0.75, assertDoesNotThrow(() -> initializeWithSimilarityThreshold(0.75, invalid)).getConfig().getState().getMaxSimilarityThreshold(),
+                            invalid);
+        }
+    }
+
+    private KeywordQueryLogic initializeWithSimilarityThreshold(double configuredThreshold, String queryOverride) throws Exception {
+        KeywordQueryLogic logic = new KeywordQueryLogic();
+        logic.setMarkingFunctions(markingFunctions);
+        logic.setResponseObjectFactory(new DefaultResponseObjectFactory());
+        logic.setMaxSimilarityThreshold(configuredThreshold);
+
+        Query settings = new QueryImpl();
+        settings.setQuery("event:20241218_0/sampleCsv/1.2.3");
+        settings.setQueryAuthorizations("A");
+        if (queryOverride != null) {
+            settings.addParameter(KeywordQueryLogic.TAG_CLOUD_SIM_MAX, queryOverride);
+        }
+
+        logic.initialize(mock(AccumuloClient.class), settings, Set.of(new Authorizations("A")));
+        return logic;
     }
 
     @Test


### PR DESCRIPTION
Recreating #2973 because its target branch wasn't updated before merge.

Deduplicate keywords using SequenceMatcher algorithm and a configurable similarity threshold

Port SequenceMatcher from Python
Integrate duplicate threshold in keyword selection
Add configuration items to specify similarity threshold per-request / disable deduplication.
(SequenceMathcer was used in the original paper and produced the most ideal results)