### PR TITLE
Fix bug when matchesInGroup specifies an index

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/GroupingRequiredFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/GroupingRequiredFilterFunctions.java
@@ -184,11 +184,11 @@ public class GroupingRequiredFilterFunctions {
             for (int i = 2; i < args.length; i += 2) {
 
                 if (args[i] instanceof Iterable) {
-                    for (Object fv : (Iterable) args[i]) {
-                        manageMatchesInGroupRemainingArgs(fv, args[i + 1].toString(), context, allMatches, currentMatch);
+                    for (Object fv : (Iterable<?>) args[i]) {
+                        manageMatchesInGroupRemainingArgs(fv, args[i + 1].toString(), context, allMatches, currentMatch, positionFromRight);
                     }
                 } else if (args[i] instanceof ValueTuple) {
-                    manageMatchesInGroupRemainingArgs(args[i], args[i + 1].toString(), context, allMatches, currentMatch);
+                    manageMatchesInGroupRemainingArgs(args[i], args[i + 1].toString(), context, allMatches, currentMatch, positionFromRight);
                 }
             }
         });
@@ -219,11 +219,13 @@ public class GroupingRequiredFilterFunctions {
      *            group of matches
      * @param currentMatch
      *            a current match
+     * @param positionFromRight
+     *            the number of groups used to calculate context
      */
     private static void manageMatchesInGroupRemainingArgs(Object fieldValue, String regex, String context, Collection<ValueTuple> allMatches,
-                    ValueTuple currentMatch) {
+                    ValueTuple currentMatch, int positionFromRight) {
         String fieldName = ValueTuple.getFieldName(fieldValue);
-        String subgroup = getSubgroup(fieldName);
+        String subgroup = EvaluationPhaseFilterFunctions.getMatchToRightOfPeriod(fieldName, positionFromRight);
         if (subgroup != null && subgroup.equals(context)) {
             // includeRegex will return either an emptyCollection, or a SingletonCollection containing
             // the first match that was found
@@ -290,11 +292,14 @@ public class GroupingRequiredFilterFunctions {
                     // look for a match on FREDO
                     for (Object fieldValue : (Iterable<?>) args[i]) {
                         String fieldName = ValueTuple.getFieldName(fieldValue);
+                        String nextRegex = args[i + 1].toString();
+                        String matchToLeftOfPeriod = EvaluationPhaseFilterFunctions.getMatchToLeftOfPeriod(fieldName, positionFromLeft);
                         // @formatter:off
                         manageMatchesInGroupLeftRemainingArgs(fieldValue,
-                                args[i + 1].toString(), // regex
-                                allMatches, theFirstMatch,
-                                EvaluationPhaseFilterFunctions.getMatchToLeftOfPeriod(fieldName, positionFromLeft), // the next match
+                                nextRegex, // regex
+                                allMatches,
+                                theFirstMatch,
+                                matchToLeftOfPeriod, // the next match
                                 currentMatch);
                         // @formatter:on
                     }

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/TestLookupTask.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/TestLookupTask.java
@@ -29,6 +29,8 @@ public class TestLookupTask<T extends QueryIterator> {
     private Class<T> iteratorClass;
     private QueryIterator iterator;
 
+    private boolean includeGroupingContext = false;
+
     public TestLookupTask(Class<T> iteratorClass) {
         this.iteratorClass = iteratorClass;
     }
@@ -52,6 +54,14 @@ public class TestLookupTask<T extends QueryIterator> {
 
     public List<Map.Entry<Key,Document>> lookup(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env,
                     List<Range> ranges) throws IOException {
+
+        if (options.containsKey(QueryOptions.INCLUDE_GROUPING_CONTEXT)) {
+            String option = options.get(QueryOptions.INCLUDE_GROUPING_CONTEXT);
+            includeGroupingContext = Boolean.parseBoolean(option);
+        } else {
+            includeGroupingContext = false;
+        }
+
         List<Map.Entry<Key,Document>> results = new ArrayList<>();
         YieldCallback<Key> yield = new YieldCallback();
         this.iterator = init(source, options, env, yield);
@@ -100,7 +110,7 @@ public class TestLookupTask<T extends QueryIterator> {
         Document filteredDocument = new Document();
         d.getDictionary().entrySet().stream().forEach(e -> {
             if (!e.getKey().equals(TIMING_METADATA) && !e.getKey().equals(WAIT_WINDOW_OVERRUN)) {
-                filteredDocument.put(e.getKey(), e.getValue());
+                filteredDocument.put(e.getKey(), e.getValue(), includeGroupingContext);
             }
         });
         return filteredDocument;

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/functions/GroupingRequiredFilterFunctionsIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/functions/GroupingRequiredFilterFunctionsIT.java
@@ -1,0 +1,125 @@
+package datawave.query.jexl.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.data.type.LcType;
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.AttributeFactory;
+import datawave.query.attributes.Document;
+import datawave.query.function.JexlEvaluation;
+import datawave.query.jexl.DatawaveJexlContext;
+import datawave.query.util.Tuple3;
+import datawave.query.util.TypeMetadata;
+
+/**
+ * Integration style test that evaluates grouping functions against various data sets
+ */
+public class GroupingRequiredFilterFunctionsIT {
+
+    private final Key docKey = new Key("20250703", "datatype\0uid");
+    private final Set<String> fields = Set.of("FIELD");
+
+    private String query;
+    private Document document;
+    private AttributeFactory attributeFactory;
+
+    @BeforeEach
+    public void setup() {
+        this.query = null;
+        this.document = new Document();
+
+        TypeMetadata metadata = new TypeMetadata();
+        metadata.put("FIELD", "datatype", LcType.class.getTypeName());
+
+        attributeFactory = new AttributeFactory(metadata);
+    }
+
+    public void withQuery(String query) {
+        this.query = query;
+    }
+
+    public void withData(String field, String value) {
+        withData(field, value, "uid");
+    }
+
+    public void withData(String field, String value, String uid) {
+        Attribute<?> source = attributeFactory.create(field, value, createKey(uid), true);
+        document.put(field, source, true);
+    }
+
+    @Test
+    public void testMatchesInGroup() {
+        withQuery("grouping:matchesInGroup(FIELD, 'a', FIELD, 'b')");
+        withData("FIELD.1.2.3", "a");
+        withData("FIELD.1.2.3", "b");
+        evaluate(true);
+    }
+
+    @Test
+    public void testMatchesInGroupWithIndex() {
+        withQuery("grouping:matchesInGroup(FIELD, 'a', FIELD, 'b', 1)");
+        withData("FIELD.1.2.3", "a");
+        withData("FIELD.1.2.3", "b");
+        evaluate(true);
+    }
+
+    @Test
+    public void testMatchesInGroupWithIndex_noMatch() {
+        withQuery("grouping:matchesInGroup(FIELD, 'a', FIELD, 'b', 1)");
+        withData("FIELD.1.2.3", "a");
+        withData("FIELD.1.1.3", "b");
+        evaluate(false);
+    }
+
+    @Test
+    public void testMatchesInGroupWithIndex_indexHigherThanGroupsAvailable() {
+        withQuery("grouping:matchesInGroup(FIELD, 'a', FIELD, 'b', 7)");
+        withData("FIELD.1.2.3", "a");
+        withData("FIELD.1.2.3", "b");
+        evaluate(false);
+    }
+
+    @Test
+    public void testMatchesInGroupLeft() {
+        withQuery("grouping:matchesInGroupLeft(FIELD, 'a', FIELD, 'b')");
+        withData("FIELD.1.2.3", "a");
+        withData("FIELD.1.2.3", "b");
+        evaluate(true);
+    }
+
+    @Test
+    public void testMatchesInGroupLeft_withIndex() {
+        withQuery("grouping:matchesInGroupLeft(FIELD, 'a', FIELD, 'b', 1)");
+        withData("FIELD.1.2.4", "a");
+        withData("FIELD.1.2.7", "b");
+        evaluate(true);
+    }
+
+    @Test
+    public void testTLD_matchesInGroup() {
+        withQuery("grouping:matchesInGroup(FIELD, 'a', FIELD, 'b')");
+        withData("FIELD.1.2.3", "a", "uid.1");
+        withData("FIELD.1.2.3", "b", "uid.2");
+        // grouping should not match across different child documents
+        evaluate(true);
+    }
+
+    private void evaluate(boolean expected) {
+        DatawaveJexlContext context = new DatawaveJexlContext();
+        document.visit(fields, context);
+
+        JexlEvaluation evaluation = new JexlEvaluation(query);
+        boolean result = evaluation.apply(new Tuple3<>(docKey, document, context));
+        assertEquals(expected, result);
+    }
+
+    private Key createKey(String uid) {
+        return new Key("20250703", "datatype\0" + uid);
+    }
+}


### PR DESCRIPTION
Add grouping tests from branch to QueryIteratorIT

Fix bug in matchesInGroup that prevented matches when an index higher than zero was requested.

QueryIteratorIT pulled in from branch [feature/matchesInGroupTesting](https://github.com/NationalSecurityAgency/datawave/tree/feature/matchesInGroupTesting).