### PR TITLE
Improve Bounded Range Normalization

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -258,12 +258,18 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
             // create a marked bounded range node
             JexlNode boundedRange = QueryPropertyMarker.create(rangeNode, BOUNDED_RANGE);
 
+            LiteralRange<?> normalizedRange = JexlASTHelper.findRange().getRange(boundedRange);
             String rangeString = JexlStringBuildingVisitor.buildQueryWithoutParse(boundedRange);
-            aliasedBounds.putIfAbsent(rangeString, boundedRange);
+            if (normalizedRange.isLowerBoundGreaterThanUpperBound()) {
+                log.warn("after normalization range lower bound was greater than upper bound " + normalizedRange);
+            } else {
+                aliasedBounds.putIfAbsent(rangeString, boundedRange);
+            }
         }
 
         if (aliasedBounds.isEmpty()) {
-            return node;
+            // we do not return the original term because the range might not actually be a valid bounded range
+            throw new IllegalStateException("After applying normalizers to bounded range, no valid range was found");
         } else {
             this.expandedNodes.addAll(aliasedBounds.values());
 

--- a/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
@@ -82,7 +82,6 @@ import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
 import datawave.policy.IngestPolicyEnforcer;
 import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.exceptions.InvalidQueryException;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.model.QueryModel;
 import datawave.query.planner.DefaultQueryPlanner;
@@ -682,7 +681,7 @@ public class MixedGeoAndGeoWaveTest {
     }
 
     // Note: Trying to ingest non-point WKT as PointType will not work. PointType can only be used for POINT wkt
-    @Test(expected = InvalidQueryException.class)
+    @Test(expected = IllegalStateException.class)
     public void polyPointTest() throws Exception {
         String query = "geo:within_bounding_box(" + POLY_POINT_FIELD + ", '-1_-1', '1_1')";
         getQueryResults(query);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -214,6 +214,22 @@ public class ExpandMultiNormalizedTermsTest {
         expandTerms(original, expected);
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testBoundedNormalizedBoundsCaseWithTextNormalizer() throws ParseException {
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new LcNoDiacriticsType()));
+
+        helper.setIndexedFields(dataTypes.keySet());
+        helper.setIndexOnlyFields(dataTypes.keySet());
+        helper.addTermFrequencyFields(dataTypes.keySet());
+
+        config.setQueryFieldsDatatypes(dataTypes);
+
+        String original = "((_Bounded_ = true) && (FOO > '4' && FOO < '10'))";
+        String expected = "((_Bounded_ = true) && (FOO > '4' && FOO < '10'))";
+        expandTerms(original, expected);
+    }
+
     @Test
     public void testMultiNormalizedBounds() throws ParseException {
         Multimap<String,Type<?>> dataTypes = HashMultimap.create();
@@ -243,6 +259,22 @@ public class ExpandMultiNormalizedTermsTest {
 
         String original = "((_Bounded_ = true) && (FOO > 1 && FOO < 10))";
         String expected = "((((_Bounded_ = true) && (FOO > '+aE1' && FOO < '+bE1'))) || (((_Bounded_ = true) && (FOO > '1' && FOO < '10'))))";
+        expandTerms(original, expected);
+    }
+
+    @Test
+    public void testBoundedMultiNormalizedBoundsWithInvalidTextRange() throws ParseException {
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new NumberType(), new LcNoDiacriticsType()));
+
+        helper.setIndexedFields(dataTypes.keySet());
+        helper.setIndexOnlyFields(dataTypes.keySet());
+        helper.addTermFrequencyFields(dataTypes.keySet());
+
+        config.setQueryFieldsDatatypes(dataTypes);
+
+        String original = "((_Bounded_ = true) && (FOO > 4 && FOO < 10))";
+        String expected = "((_Bounded_ = true) && (FOO > '+aE4' && FOO < '+bE1'))";
         expandTerms(original, expected);
     }
 
@@ -316,7 +348,7 @@ public class ExpandMultiNormalizedTermsTest {
         expandTerms(original, expected);
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void testBoundedNormalizedAndUnNormalizedBoundsCase() throws ParseException {
         Multimap<String,Type<?>> dataTypes = HashMultimap.create();
         dataTypes.put("NEW", new LcNoDiacriticsType());


### PR DESCRIPTION
ExpandMultiNormalizedTerms will drop invalid ranges and throw an exception if no valid range exists after applying normalizers