### PR TITLE
Adding URL Search Query Implementation

### DIFF
--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -1,4 +1,5 @@
-import { Ref, WritableComputedRef, computed, defineComponent, ref } from 'vue';
+import { Ref, ref } from 'vue';
+import { LocationQueryValue } from 'vue-router';
 
 const regexDataType = /^[1-9]\d*\s+types?$/;
 
@@ -164,4 +165,15 @@ export function setVisibility(rows: readonly any[]) {
 // Lets the DOM know what is visible and what is not based on setVisibility filters.
 export function isVisible(row: any) {
   return row.duplicate == 0 || row.isVisible.value;
+}
+
+// Filters the URL Search Bar to handle Edge Cases and only queries 1 item.
+export function filterSearch(searchVal: LocationQueryValue | LocationQueryValue[], searchValNew: string): string {
+  if (Array.isArray(searchVal)) {
+    searchValNew = searchVal[0] || '';
+  } else if (searchVal !== null && searchVal !== undefined) {
+    searchValNew = searchVal;
+  }
+
+  return searchValNew;
 }

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -268,54 +268,28 @@ onMounted(() => {
     console.log('Error fetching and formatting rows: ' + reason);
   });
 
-  // This block is similar to watch() methods below, but handles the search when initially set via the URL.
-  const q = route.query.search;
-
-  // Converts to valid string and then queries if filter is changed.
-  if (Array.isArray(q)) {
-    changeFilter.value = q[0] || '';
-  } else if (q !== null && q !== undefined) {
-    changeFilter.value = q;
-  }
+  // This line is similar to the one in the watch() method below, but handles the search when initially set via the URL.
+  changeFilter.value = Formatters.filterSearch(route.query.search, changeFilter.value);
 
   if (changeFilter.value) {
     queryTable();
   }
 });
 
-// This watch() handles initial changes (if a search query was added to loaded page).
-// Logic: Input -> URL (UI -> URL)
-watch(changeFilter, (val) => {
-  router.replace({
-    query: {
-      ...route.query,
-      search: val || undefined,
-    },
-  });
-});
-
 // This watch() handles a URL Change from a previous query.
 // Logic: Input + Table (reactive URL -> UI + Filters)
 watch(
   () => route.query.search,
-  (val) => {
-    let newVal = '';
-
+  (searchVal) => {
     // Converts the input into a valid string to be queried.
-    if (Array.isArray(val)) {
-      newVal = val[0] || '';
-    } else if (val !== null && val !== undefined) {
-      newVal = val;
-    }
+    let searchValNew = Formatters.filterSearch(searchVal, '');
 
-    if (newVal !== changeFilter.value) {
-      changeFilter.value = newVal;
-      if (newVal) {
-
+    if (searchValNew !== changeFilter.value) {
+      changeFilter.value = searchValNew;
+      if (searchValNew) {
         // Triggers a re-query if the user has changed to a new value.
         queryTable();
       } else {
-
         // This retriggers back to the original state if user clears.
         filter.value = '';
         const originalRows = rows;
@@ -362,6 +336,15 @@ function exportTable(this: any) {
 async function queryTable(this: any) {
   // Wait Until User Enters...
   await waitUp();
+
+  // Handles the URL change to reflect when the user searches.
+  // Logic: Input -> URL (UI -> URL)
+  router.replace({
+    query: {
+      ...route.query,
+      search: changeFilter.value || undefined,
+    },
+  });
 
   // 1 - Filter the Rows
   const rowsToExport = table.value?.filteredSortedRows.filter(() => true);

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -271,7 +271,7 @@ onMounted(() => {
   // This block is similar to watch() methods below, but handles the search when initially set not added.
   const q = route.query.search;
 
-  // Converts to valid string and ten queries if filter is changed.
+  // Converts to valid string and then queries if filter is changed.
   if (Array.isArray(q)) {
     changeFilter.value = q[0] || '';
   } else if (q !== null && q !== undefined) {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -186,7 +186,8 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import { QTable, QTableProps, exportFile, useQuasar, Notify } from 'quasar';
 import { useToggle, useDark } from '@vueuse/core';
 import { api } from '../boot/axios';
@@ -200,7 +201,9 @@ const $q = useQuasar();
 const table = ref();
 const loading = ref(true);
 const filter = ref('');
-const changeFilter = ref('');
+const route = useRoute();
+const router = useRouter();
+const changeFilter = ref<string>('');
 const banner = ref<Banner>();
 const system = ref<System>();
 let rows: QTableProps['rows'] = [];
@@ -264,7 +267,63 @@ onMounted(() => {
   .catch((reason) => {
     console.log('Error fetching and formatting rows: ' + reason);
   });
+
+  // This block is similar to watch() methods below, but handles the search when initially set not added.
+  const q = route.query.search;
+
+  // Converts to valid string and ten queries if filter is changed.
+  if (Array.isArray(q)) {
+    changeFilter.value = q[0] || '';
+  } else if (q !== null && q !== undefined) {
+    changeFilter.value = q;
+  }
+
+  if (changeFilter.value) {
+    queryTable();
+  }
 });
+
+// This watch() handles initial changes (if a search query was added to loaded page).
+// Logic: Input -> URL (UI -> URL)
+watch(changeFilter, (val) => {
+  router.replace({
+    query: {
+      ...route.query,
+      search: val || undefined,
+    },
+  });
+});
+
+// This watch() handles a URL Change from a previous query.
+// Logic: Input + Table (reactive URL -> UI + Filters)
+watch(
+  () => route.query.search,
+  (val) => {
+    let newVal = '';
+
+    // Converts the input into a valid string to be queried.
+    if (Array.isArray(val)) {
+      newVal = val[0] || '';
+    } else if (val !== null && val !== undefined) {
+      newVal = val;
+    }
+
+    if (newVal !== changeFilter.value) {
+      changeFilter.value = newVal;
+      if (newVal) {
+
+        // Triggers a re-query if the user has changed to a new value.
+        queryTable();
+      } else {
+
+        // This retriggers back to the original state if user clears.
+        filter.value = '';
+        const originalRows = rows;
+        rows = Formatters.setVisibility(originalRows);
+      }
+    }
+  }
+);
 
 // Export - Attempts to Wrap the CSV and Download.
 function exportTable(this: any) {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -268,7 +268,7 @@ onMounted(() => {
     console.log('Error fetching and formatting rows: ' + reason);
   });
 
-  // This block is similar to watch() methods below, but handles the search when initially set not added.
+  // This block is similar to watch() methods below, but handles the search when initially set via the URL.
   const q = route.query.search;
 
   // Converts to valid string and then queries if filter is changed.


### PR DESCRIPTION
**This PR adds a search query implementation that does the following:**
1. User can input '?search=<query>' to search anything in the table.
2. It is reactive, can be added/removed/changed to a different query, and changes the filter in the search bar as well.
3. Adds comments to help readability for the search functionality.