### PR TITLE
Replace all usages of Accumulo Pair class

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,6 +11,14 @@
         <property name="file" value="${basedir}/import-control-accumulo.xml"/>
         <property name="severity" value="warning"/>
     </module>
+    <!-- Check that forbidden classes are not imported anywhere. -->
+    <module name="IllegalImport">
+        <property name="regexp" value="true"/>
+        <property name="illegalClasses"
+                  value="^org\.apache\.accumulo\.core\.util\.Pair"/>
+        <property name="severity" value="error"/>
+    </module>
+    <!-- Do not allow any unused imports. -->
     <module name="UnusedImports">
         <property name="severity" value="error"/>
     </module>

--- a/core/connection-pool/src/main/java/datawave/core/common/connection/AccumuloConnectionFactoryImpl.java
+++ b/core/connection-pool/src/main/java/datawave/core/common/connection/AccumuloConnectionFactoryImpl.java
@@ -15,9 +15,9 @@ import java.util.Set;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableInt;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,8 +125,8 @@ public class AccumuloConnectionFactoryImpl implements AccumuloConnectionFactory 
             Pair<String,PasswordToken> pair = instances.get(cache.getInstance().getInstanceID());
             String user = "root";
             PasswordToken password = new PasswordToken(new byte[0]);
-            if (pair != null && user.equals(pair.getFirst()))
-                password = pair.getSecond();
+            if (pair != null && user.equals(pair.getLeft()))
+                password = pair.getRight();
             SecurityOperations security = new InMemoryAccumuloClient(user, cache.getInstance()).securityOperations();
             Set<String> users = security.listLocalUsers();
             if (!users.contains(conf.getUsername())) {
@@ -137,10 +137,10 @@ public class AccumuloConnectionFactoryImpl implements AccumuloConnectionFactory 
                 // If we're changing root's password, and trying to change then keep track of that. If we have multiple instances
                 // that specify mismatching passwords, then throw an error.
                 if (user.equals(conf.getUsername())) {
-                    if (pair != null && !newPassword.equals(pair.getSecond()))
+                    if (pair != null && !newPassword.equals(pair.getRight()))
                         throw new IllegalStateException(
                                         "Invalid AccumuloConnectionFactoryBean configuration--multiple pools are configured with different root passwords!");
-                    instances.put(cache.getInstance().getInstanceID(), new Pair<>(conf.getUsername(), newPassword));
+                    instances.put(cache.getInstance().getInstanceID(), Pair.of(conf.getUsername(), newPassword));
                 }
                 // match root's password on mock to the password on the actual Accumulo instance
                 security.changeLocalUserPassword(conf.getUsername(), newPassword);

--- a/core/connection-pool/src/main/java/datawave/core/query/runner/AccumuloConnectionRequestMap.java
+++ b/core/connection-pool/src/main/java/datawave/core/query/runner/AccumuloConnectionRequestMap.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,11 +33,11 @@ public class AccumuloConnectionRequestMap {
             if (connectionRequestPairs != null) {
                 for (Pair<Map<String,String>,Thread> connectionRequestPair : connectionRequestPairs) {
                     try {
-                        if (connectionRequestPair != null && connectionRequestPair.getFirst() != null) {
-                            String connectionRequestPrincipalName = connectionRequestPair.getFirst().get(AccumuloConnectionFactory.USER_DN);
+                        if (connectionRequestPair != null && connectionRequestPair.getLeft() != null) {
+                            String connectionRequestPrincipalName = connectionRequestPair.getLeft().get(AccumuloConnectionFactory.USER_DN);
                             String connectionCancelPrincipalName = userDn;
                             if (connectionRequestPrincipalName.equals(connectionCancelPrincipalName)) {
-                                connectionRequestPair.getSecond().interrupt();
+                                connectionRequestPair.getRight().interrupt();
                                 connectionRequestCanceled = true;
                             }
                         }
@@ -58,8 +58,8 @@ public class AccumuloConnectionRequestMap {
         if (connectionRequestPairs != null) {
             for (Pair<Map<String,String>,Thread> connectionRequestPair : connectionRequestPairs) {
                 try {
-                    if (connectionRequestPair != null && connectionRequestPair.getFirst() != null) {
-                        connectionRequestPair.getSecond().interrupt();
+                    if (connectionRequestPair != null && connectionRequestPair.getLeft() != null) {
+                        connectionRequestPair.getRight().interrupt();
                         connectionRequestCanceled = true;
                     }
                 } catch (Exception e) {
@@ -78,7 +78,7 @@ public class AccumuloConnectionRequestMap {
                 connectionRequestPairs = new ArrayList<>();
                 connectionThreadMap.put(id, connectionRequestPairs);
             }
-            Pair<Map<String,String>,Thread> connectionRequestPair = new Pair<>(trackingMap, Thread.currentThread());
+            Pair<Map<String,String>,Thread> connectionRequestPair = Pair.of(trackingMap, Thread.currentThread());
             if (userDN != null && trackingMap != null)
                 trackingMap.put(AccumuloConnectionFactory.USER_DN, userDN);
             connectionRequestPairs.add(connectionRequestPair);
@@ -93,7 +93,7 @@ public class AccumuloConnectionRequestMap {
             boolean found = false;
             while (!found && it.hasNext()) {
                 Pair<Map<String,String>,Thread> connectionRequestPair = it.next();
-                if (connectionRequestPair.getSecond().equals(t)) {
+                if (connectionRequestPair.getRight().equals(t)) {
                     it.remove();
                     found = true;
                 }

--- a/core/modification/src/main/java/datawave/modification/MutableMetadataHandler.java
+++ b/core/modification/src/main/java/datawave/modification/MutableMetadataHandler.java
@@ -33,8 +33,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -361,7 +361,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
                                     new HashMap<>(), null);
 
                     for (Pair<Key,Value> p : fieldHistoryList) {
-                        if (p.getFirst().getColumnQualifier().find(mr.getFieldValue()) > -1) {
+                        if (p.getLeft().getColumnQualifier().find(mr.getFieldValue()) > -1) {
                             ++valHistoryCount;
                         }
                     }
@@ -690,18 +690,18 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
 
         for (Pair<Key,Value> currentEntry : currentEntryList) {
 
-            ColumnVisibility viz = currentEntry.getFirst().getColumnVisibilityParsed();
+            ColumnVisibility viz = currentEntry.getLeft().getColumnVisibilityParsed();
 
-            DatawaveKey key = new DatawaveKey(currentEntry.getFirst());
+            DatawaveKey key = new DatawaveKey(currentEntry.getLeft());
 
             String shardId = key.getRow().toString();
 
-            long currentEntryTimestamp = currentEntry.getFirst().getTimestamp();
+            long currentEntryTimestamp = currentEntry.getLeft().getTimestamp();
 
             if (key.getType().equals(KeyType.INDEX_EVENT)) {
                 // Only the delete the fi key
-                Mutation e = new Mutation(currentEntry.getFirst().getRow());
-                e.putDelete(currentEntry.getFirst().getColumnFamily(), currentEntry.getFirst().getColumnQualifier(), viz, currentEntryTimestamp);
+                Mutation e = new Mutation(currentEntry.getLeft().getRow());
+                e.putDelete(currentEntry.getLeft().getColumnFamily(), currentEntry.getLeft().getColumnQualifier(), viz, currentEntryTimestamp);
                 writer.getBatchWriter(this.getEventTableName()).addMutation(e);
             } else if (key.getType().equals(KeyType.EVENT)) {
                 Mutation m = new Mutation(key.getFieldName());
@@ -710,9 +710,9 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
                 m.put(ColumnFamilyConstants.COLF_F, new Text(key.getDataType() + NULL_BYTE + DateHelper.format(currentEntryTimestamp)),
                                 new Value(SummingCombiner.VAR_LEN_ENCODER.encode(-1L)));
                 // Remove the event field.
-                Mutation e = new Mutation(currentEntry.getFirst().getRow());
+                Mutation e = new Mutation(currentEntry.getLeft().getRow());
                 if (!isIndexOnlyField) {
-                    e.putDelete(currentEntry.getFirst().getColumnFamily(), currentEntry.getFirst().getColumnQualifier(), viz, currentEntryTimestamp);
+                    e.putDelete(currentEntry.getLeft().getColumnFamily(), currentEntry.getLeft().getColumnQualifier(), viz, currentEntryTimestamp);
                 }
 
                 // Remove the content column
@@ -857,7 +857,7 @@ public class MutableMetadataHandler extends ModificationServiceConfiguration {
                         continue;
                     }
                 }
-                results.add(new Pair<>(e.getKey(), e.getValue()));
+                results.add(Pair.of(e.getKey(), e.getValue()));
             }
         } finally {
             s.close();

--- a/import-control-accumulo.xml
+++ b/import-control-accumulo.xml
@@ -3,7 +3,7 @@
         "https://checkstyle.org/dtds/import_control_1_4.dtd">
 
 <!-- This checkstyle rule is configured to ensure only use of Accumulo API -->
-<import-control 
+<import-control
         pkg="(|
         |datawave.*|
         |datawave\.common\.test.*|

--- a/warehouse/core/src/main/java/datawave/mr/bulk/BulkInputFormat.java
+++ b/warehouse/core/src/main/java/datawave/mr/bulk/BulkInputFormat.java
@@ -57,10 +57,10 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.security.TablePermission;
 import org.apache.accumulo.core.singletons.SingletonManager;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.format.DateFormatSupplier;
 import org.apache.accumulo.core.util.threads.Threads;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -406,12 +406,12 @@ public class BulkInputFormat extends InputFormat<Key,Value> {
         ArgumentChecker.notNull(columnFamilyColumnQualifierPairs);
         ArrayList<String> columnStrings = new ArrayList<>(columnFamilyColumnQualifierPairs.size());
         for (Pair<Text,Text> column : columnFamilyColumnQualifierPairs) {
-            if (column.getFirst() == null)
+            if (column.getLeft() == null)
                 throw new IllegalArgumentException("Column family can not be null");
 
-            String col = new String(Base64.encodeBase64(TextUtil.getBytes(column.getFirst())));
-            if (column.getSecond() != null)
-                col += ":" + new String(Base64.encodeBase64(TextUtil.getBytes(column.getSecond())));
+            String col = new String(Base64.encodeBase64(TextUtil.getBytes(column.getLeft())));
+            if (column.getRight() != null)
+                col += ":" + new String(Base64.encodeBase64(TextUtil.getBytes(column.getRight())));
             columnStrings.add(col);
         }
         conf.setStrings(COLUMNS, columnStrings.toArray(new String[columnStrings.size()]));
@@ -576,7 +576,7 @@ public class BulkInputFormat extends InputFormat<Key,Value> {
             int idx = col.indexOf(':');
             Text cf = new Text(idx < 0 ? Base64.decodeBase64(col.getBytes()) : Base64.decodeBase64(col.substring(0, idx).getBytes()));
             Text cq = idx < 0 ? null : new Text(Base64.decodeBase64(col.substring(idx + 1).getBytes()));
-            columns.add(new Pair<>(cf, cq));
+            columns.add(Pair.of(cf, cq));
         }
         return columns;
     }
@@ -882,12 +882,12 @@ public class BulkInputFormat extends InputFormat<Key,Value> {
 
             // setup a scanner within the bounds of this split
             for (Pair<Text,Text> c : getFetchedColumns(conf)) {
-                if (c.getSecond() != null) {
-                    log.debug("Fetching column {}:{}", c.getFirst(), c.getSecond());
-                    scanner.fetchColumn(c.getFirst(), c.getSecond());
+                if (c.getRight() != null) {
+                    log.debug("Fetching column {}:{}", c.getLeft(), c.getRight());
+                    scanner.fetchColumn(c.getLeft(), c.getRight());
                 } else {
-                    log.debug("Fetching column family {}", c.getFirst());
-                    scanner.fetchColumnFamily(c.getFirst());
+                    log.debug("Fetching column family {}", c.getLeft());
+                    scanner.fetchColumnFamily(c.getLeft());
                 }
             }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reduce/AggregatingReducer.java
@@ -25,7 +25,7 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.accumulo.core.iteratorsImpl.conf.ColumnSet;
 import org.apache.accumulo.core.iteratorsImpl.conf.ColumnToClassMapping;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Reducer;
@@ -384,9 +384,10 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
 
                 Pair<Text,Text> pcic;
                 if (ALL_CF_STR.equals(column)) {
-                    pcic = new Pair<>(ALL_CF_KEY.getColumnFamily(), null);
+                    pcic = Pair.of(ALL_CF_KEY.getColumnFamily(), null);
                 } else {
-                    pcic = ColumnSet.decodeColumns(column);
+                    org.apache.accumulo.core.util.Pair<Text,Text> columnSetPair = ColumnSet.decodeColumns(column);
+                    pcic = Pair.of(columnSetPair.getFirst(), columnSetPair.getSecond());
                 }
 
                 Combiner agg = null;
@@ -401,10 +402,10 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                     throw new RuntimeException(e);
                 }
 
-                if (pcic.getSecond() == null) {
-                    addObject(pcic.getFirst(), agg);
+                if (pcic.getRight() == null) {
+                    addObject(pcic.getLeft(), agg);
                 } else {
-                    addObject(pcic.getFirst(), pcic.getSecond(), agg);
+                    addObject(pcic.getLeft(), pcic.getRight(), agg);
                 }
             }
 
@@ -424,9 +425,10 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
 
                 Pair<Text,Text> pcic;
                 if (ALL_CF_STR.equals(column)) {
-                    pcic = new Pair<>(ALL_CF_KEY.getColumnFamily(), null);
+                    pcic = Pair.of(ALL_CF_KEY.getColumnFamily(), null);
                 } else {
-                    pcic = ColumnSet.decodeColumns(column);
+                    org.apache.accumulo.core.util.Pair<Text,Text> columnSetPair = ColumnSet.decodeColumns(column);
+                    pcic = Pair.of(columnSetPair.getFirst(), columnSetPair.getSecond());
                 }
 
                 Combiner agg = null;
@@ -442,10 +444,10 @@ public abstract class AggregatingReducer<IK,IV,OK,OV> extends Reducer<IK,IV,OK,O
                     throw new RuntimeException(e);
                 }
 
-                if (pcic.getSecond() == null) {
-                    addObject(pcic.getFirst(), agg);
+                if (pcic.getRight() == null) {
+                    addObject(pcic.getLeft(), agg);
                 } else {
-                    addObject(pcic.getFirst(), pcic.getSecond(), agg);
+                    addObject(pcic.getLeft(), pcic.getRight(), agg);
                 }
             }
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/facet/FacetHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/facet/FacetHandlerTest.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -312,7 +312,7 @@ public class FacetHandlerTest {
             for (FacetResult pair : results) {
                 switch (tableName) {
                     case DATAWAVE_FACETS:
-                        String facet = pair.getFirst().getKey().toString() + " " + FacetHandler.extractCardinality(pair.getSecond());
+                        String facet = pair.getLeft().getKey().toString() + " " + FacetHandler.extractCardinality(pair.getRight());
                         log.debug(tableName + " " + facet);
                         if (!expectedFacets.remove(facet)) {
                             unexpectedFacets.add(facet);
@@ -320,7 +320,7 @@ public class FacetHandlerTest {
                         facetKeyCounts.compute(facet, (k, v) -> 1 + (v == null ? 0 : v));
                         break;
                     case DATAWAVE_FACET_METADATA:
-                        String facetMetadata = pair.getFirst().getKey().toString();
+                        String facetMetadata = pair.getLeft().getKey().toString();
                         log.debug(tableName + " " + facetMetadata);
                         if (!expectedFacetMetadata.remove(facetMetadata)) {
                             unexpectedFacetMetadata.add(facetMetadata);
@@ -328,14 +328,14 @@ public class FacetHandlerTest {
                         facetMetadataKeyCounts.compute(facetMetadata, (k, v) -> 1 + (v == null ? 0 : v));
                         break;
                     case DATAWAVE_FACET_HASHES:
-                        String facetHash = pair.getFirst().getKey().toString();
+                        String facetHash = pair.getLeft().getKey().toString();
                         log.debug(tableName + " " + facetHash);
                         if (!expectedFacetHashes.remove(facetHash)) {
                             unexpectedFacetHashes.add(facetHash);
                         }
                         break;
                     default:
-                        String item = tableName + " " + pair.getFirst().getKey().toString();
+                        String item = tableName + " " + pair.getLeft().getKey().toString();
                         log.warn("Unexpected table name/key: " + item);
                         totallyUnexpected.add(item);
                         break;
@@ -652,13 +652,33 @@ public class FacetHandlerTest {
     }
 
     private static class FacetResult extends Pair<BulkIngestKey,Value> implements Comparable<Pair<BulkIngestKey,Value>> {
+
+        private final BulkIngestKey key;
+        private final Value value;
+
         public FacetResult(BulkIngestKey f, Value s) {
-            super(f, s);
+            this.key = f;
+            this.value = s;
         }
 
         @Override
         public int compareTo(Pair<BulkIngestKey,Value> o) {
-            return getFirst().compareTo(o.getFirst());
+            return getLeft().compareTo(o.getLeft());
+        }
+
+        @Override
+        public BulkIngestKey getLeft() {
+            return key;
+        }
+
+        @Override
+        public Value getRight() {
+            return value;
+        }
+
+        @Override
+        public Value setValue(Value value) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/iterators/FirstAndLastSeenDate.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterators/FirstAndLastSeenDate.java
@@ -1,11 +1,16 @@
 package datawave.query.iterators;
 
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class FirstAndLastSeenDate extends Pair<String,String> {
-    public FirstAndLastSeenDate(String f, String s) {
-        super(f, s);
+
+    private final String first;
+    private final String last;
+
+    public FirstAndLastSeenDate(String first, String last) {
+        this.first = first;
+        this.last = last;
     }
 
     public FirstAndLastSeenDate(Value value) {
@@ -13,11 +18,26 @@ public class FirstAndLastSeenDate extends Pair<String,String> {
     }
 
     private FirstAndLastSeenDate(String[] split) {
-        super(split[0], split[1]);
+        this(split[0], split[1]);
+    }
+
+    @Override
+    public String getLeft() {
+        return first;
+    }
+
+    @Override
+    public String getRight() {
+        return last;
     }
 
     @Override
     public String toString() {
-        return getFirst() + "," + getSecond();
+        return getLeft() + "," + getRight();
+    }
+
+    @Override
+    public String setValue(String field) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/cache/QueryCacheBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/cache/QueryCacheBean.java
@@ -15,7 +15,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.deltaspike.core.api.exclude.Exclude;
 import org.apache.deltaspike.core.api.jmx.JmxManaged;
 import org.apache.deltaspike.core.api.jmx.MBean;
@@ -81,7 +81,7 @@ public class QueryCacheBean {
         }
         // Iterate over queries that are in the init phase
         for (Entry<String,Pair<QueryLogic<?>,AccumuloClient>> entry : qlCache.snapshot().entrySet()) {
-            result.getQueries().add("Identifier: " + entry.getKey() + " Query Logic: " + entry.getValue().getFirst().getClass().getName() + "\n");
+            result.getQueries().add("Identifier: " + entry.getKey() + " Query Logic: " + entry.getValue().getLeft().getClass().getName() + "\n");
         }
         return result;
     }

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -71,9 +71,9 @@ import javax.xml.bind.Marshaller;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.jexl3.parser.TokenMgrException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.deltaspike.core.api.exclude.Exclude;
 import org.apache.log4j.Logger;
 import org.jboss.resteasy.annotations.GZIP;
@@ -2274,13 +2274,13 @@ public class QueryExecutorBean implements QueryExecutor {
                 }
                 response.addMessage(id + " closed.");
             } else {
-                QueryLogic<?> logic = tuple.getFirst();
+                QueryLogic<?> logic = tuple.getLeft();
                 try {
                     logic.close();
                 } catch (Exception e) {
                     log.error("Exception occurred while closing query logic; may be innocuous if scanners were running.", e);
                 }
-                connectionFactory.returnClient(tuple.getSecond());
+                connectionFactory.returnClient(tuple.getRight());
                 response.addMessage(id + " closed before create completed.");
             }
 
@@ -2334,13 +2334,13 @@ public class QueryExecutorBean implements QueryExecutor {
                 }
                 response.addMessage(id + " closed.");
             } else {
-                QueryLogic<?> logic = tuple.getFirst();
+                QueryLogic<?> logic = tuple.getLeft();
                 try {
                     logic.close();
                 } catch (Exception e) {
                     log.error("Exception occurred while closing query logic; may be innocuous if scanners were running.", e);
                 }
-                connectionFactory.returnClient(tuple.getSecond());
+                connectionFactory.returnClient(tuple.getRight());
                 response.addMessage(id + " closed before create completed.");
             }
 
@@ -2428,13 +2428,13 @@ public class QueryExecutorBean implements QueryExecutor {
                 }
                 response.addMessage(id + " canceled.");
             } else {
-                QueryLogic<?> logic = tuple.getFirst();
+                QueryLogic<?> logic = tuple.getLeft();
                 try {
                     logic.close();
                 } catch (Exception e) {
                     log.error("Exception occurred while canceling query logic; may be innocuous if scanners were running.", e);
                 }
-                connectionFactory.returnClient(tuple.getSecond());
+                connectionFactory.returnClient(tuple.getRight());
                 response.addMessage(id + " closed before create completed due to cancel.");
             }
 
@@ -2489,13 +2489,13 @@ public class QueryExecutorBean implements QueryExecutor {
                 }
                 response.addMessage(id + " closed.");
             } else {
-                QueryLogic<?> logic = tuple.getFirst();
+                QueryLogic<?> logic = tuple.getLeft();
                 try {
                     logic.close();
                 } catch (Exception e) {
                     log.error("Exception occurred while canceling query logic; may be innocuous if scanners were running.", e);
                 }
-                connectionFactory.returnClient(tuple.getSecond());
+                connectionFactory.returnClient(tuple.getRight());
                 response.addMessage(id + " closed before create completed due to cancel.");
             }
 

--- a/web-services/query/src/test/java/datawave/webservice/query/cache/CreatedQueryLogicCacheBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/cache/CreatedQueryLogicCacheBeanTest.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;

--- a/web-services/query/src/test/java/datawave/webservice/query/cache/QueryCacheBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/cache/QueryCacheBeanTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.util.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
@@ -58,7 +58,7 @@ public class QueryCacheBeanTest {
         Map<String,Pair<QueryLogic<?>,AccumuloClient>> snapshot = new HashMap<>();
         snapshot.put("key", this.pair);
         expect(this.remoteCache.snapshot()).andReturn(snapshot);
-        expect(this.pair.getFirst()).andReturn((QueryLogic) this.logic);
+        expect(this.pair.getLeft()).andReturn((QueryLogic) this.logic);
 
         // Run the test
         PowerMock.replayAll();

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedQueryExecutorBeanTest.java
@@ -45,8 +45,8 @@ import javax.ws.rs.core.UriInfo;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.collections4.iterators.TransformIterator;
+import org.apache.commons.lang3.tuple.Pair;
 import org.easymock.EasyMock;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 import org.junit.Before;
@@ -253,9 +253,9 @@ public class ExtendedQueryExecutorBeanTest {
         // Set expectations of the create logic
         expect(this.connectionRequestBean.adminCancelConnectionRequest(queryId.toString())).andReturn(false);
         expect(this.qlCache.poll(queryId.toString())).andReturn(this.tuple);
-        expect(this.tuple.getFirst()).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.tuple.getLeft()).andReturn((QueryLogic) this.queryLogic1);
         this.queryLogic1.close();
-        expect(this.tuple.getSecond()).andReturn(this.client);
+        expect(this.tuple.getRight()).andReturn(this.client);
         this.connectionFactory.returnClient(this.client);
 
         // Run the test
@@ -417,9 +417,9 @@ public class ExtendedQueryExecutorBeanTest {
         // Set expectations
         expect(this.connectionRequestBean.adminCancelConnectionRequest(queryId.toString())).andReturn(false);
         expect(this.qlCache.poll(queryId.toString())).andReturn(this.tuple);
-        expect(this.tuple.getFirst()).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.tuple.getLeft()).andReturn((QueryLogic) this.queryLogic1);
         this.queryLogic1.close();
-        expect(this.tuple.getSecond()).andReturn(this.client);
+        expect(this.tuple.getRight()).andReturn(this.client);
         this.connectionFactory.returnClient(this.client);
 
         // Run the test
@@ -486,9 +486,9 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getProxyServers()).andReturn(new ArrayList<>(0)).anyTimes();
         expect(this.qlCache.pollIfOwnedBy(queryId.toString(), userSid)).andReturn(this.tuple);
         this.closedCache.remove(queryId.toString());
-        expect(this.tuple.getFirst()).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.tuple.getLeft()).andReturn((QueryLogic) this.queryLogic1);
         this.queryLogic1.close();
-        expect(this.tuple.getSecond()).andReturn(this.client);
+        expect(this.tuple.getRight()).andReturn(this.client);
         this.connectionFactory.returnClient(this.client);
 
         // Run the test
@@ -662,10 +662,10 @@ public class ExtendedQueryExecutorBeanTest {
         expect(this.principal.getProxyServers()).andReturn(new ArrayList<>(0)).anyTimes();
         expect(this.qlCache.pollIfOwnedBy(queryId.toString(), userSid)).andReturn(this.tuple);
         expect(this.principal.getUserDN()).andReturn(SubjectIssuerDNPair.of(userName));
-        expect(this.tuple.getFirst()).andReturn((QueryLogic) this.queryLogic1);
+        expect(this.tuple.getLeft()).andReturn((QueryLogic) this.queryLogic1);
         this.queryLogic1.close();
         PowerMock.expectLastCall().andThrow(ILLEGAL_STATE_EXCEPTION);
-        expect(this.tuple.getSecond()).andThrow(ILLEGAL_STATE_EXCEPTION);
+        expect(this.tuple.getRight()).andThrow(ILLEGAL_STATE_EXCEPTION);
 
         // Run the test
         PowerMock.replayAll();

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -34,10 +34,10 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.util.Pair;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -774,11 +774,11 @@ public class QueryExecutorBeanTest {
             Assert.assertNull(cachedRunningQuery);
             Pair<QueryLogic<?>,AccumuloClient> pair = qlCache.poll(q.getId().toString());
             Assert.assertNotNull(pair);
-            Assert.assertEquals(logic, pair.getFirst());
-            Assert.assertEquals(c, pair.getSecond());
+            Assert.assertEquals(logic, pair.getLeft());
+            Assert.assertEquals(c, pair.getRight());
 
             // Have to add these back because poll was destructive
-            qlCache.add(q.getId().toString(), principal.getShortName(), pair.getFirst(), pair.getSecond());
+            qlCache.add(q.getId().toString(), principal.getShortName(), pair.getLeft(), pair.getRight());
 
             // Call close
             bean.close(q.getId().toString());


### PR DESCRIPTION
Replace all usages of the class org.apache.accumulo.core.util.Pair class with org.apache.commons.lang3.tuple.Pair. Additionally, add an IllegalImport check to the maven checkstyle plugin configuration that will explicitly forbid the use of the accumulo Pair class.

Fixes #3031