### PR TITLE
Allows JSON POSTs in Datawave Query API

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/KeywordExtraction.test
+++ b/contrib/datawave-quickstart/bin/services/datawave/test-web/tests/KeywordExtraction.test
@@ -10,6 +10,7 @@
 # unique-ish key for its related documents may be registered in QLF.xml
 # for this purpose
 
+###############################################################
 # First, Extract wikipedia keywords by PAGE_ID
 
 TEST_UID_TYPE="PAGE_ID"
@@ -22,6 +23,20 @@ configureTest \
       ExtractKeywordsByPageId \
       "Performs keyword extraction based on the PAGE_ID field in our wiki data" \
       "--header 'Content-Type: application/x-www-form-urlencoded' ${DW_CURL_DATA} -X POST ${URI_ROOT}/Query/generateTagCloud" \
+      "application/xml;charset=UTF-8" \
+      200
+
+runTest
+
+###############################################################
+# Next, Extract wikipedia keywords by PAGE_ID but use a json POST body
+
+JSON_DATA='{ "uuidPairs": "PAGE_ID:12", "content.view.names": "REVISION_TEXT" }'
+
+configureTest \
+      ExtractKeywordsByPageIdJSON \
+      "Performs keyword extraction based on the PAGE_ID field in our wiki data with json post data" \
+      "--header 'Content-Type: application/json' --data '${JSON_DATA}' -X POST ${URI_ROOT}/Query/generateTagCloud" \
       "application/xml;charset=UTF-8" \
       200
 

--- a/web-services/common/src/main/java/datawave/webservice/common/json/JacksonContextResolver.java
+++ b/web-services/common/src/main/java/datawave/webservice/common/json/JacksonContextResolver.java
@@ -2,6 +2,7 @@ package datawave.webservice.common.json;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 /**
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
 public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
-    private ObjectMapper mapper;
+    private final ObjectMapper mapper;
 
     public JacksonContextResolver() {
         mapper = new ObjectMapper();
@@ -28,6 +30,10 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
         mapper.setAnnotationIntrospector(
                         AnnotationIntrospector.pair(new JacksonAnnotationIntrospector(), new JaxbAnnotationIntrospector(mapper.getTypeFactory())));
         mapper.setSerializationInclusion(Include.NON_NULL);
+
+        final SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(MultivaluedMap.class, new MultivaluedMapDeserializer());
+        mapper.registerModule(simpleModule);
     }
 
     @Override

--- a/web-services/common/src/main/java/datawave/webservice/common/json/MultivaluedMapDeserializer.java
+++ b/web-services/common/src/main/java/datawave/webservice/common/json/MultivaluedMapDeserializer.java
@@ -1,0 +1,44 @@
+package datawave.webservice.common.json;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Deserializes JSON received in a POST parameter into a MultivaluedMap&lt;String, String&gt; */
+public class MultivaluedMapDeserializer extends JsonDeserializer<MultivaluedMap<String,String>> {
+    @Override
+    public MultivaluedMap<String,String> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                    throws IOException, JsonProcessingException {
+        final MultivaluedMap<String,String> result = new MultivaluedHashMap<>();
+        ObjectMapper mapper = (ObjectMapper) jsonParser.getCodec();
+        JsonNode node = mapper.readTree(jsonParser);
+
+        if (!node.isObject()) {
+            throw new JsonParseException(jsonParser, "Expected an object, but received a " + node.getNodeType());
+        }
+
+        final Iterator<Map.Entry<String,JsonNode>> it = node.fields();
+
+        while (it.hasNext()) {
+            final Map.Entry<String,JsonNode> entry = it.next();
+            final JsonNode value = entry.getValue();
+            if (!value.isTextual()) {
+                throw new JsonParseException(jsonParser, "Expected a textual value, but received a " + value.getNodeType());
+            }
+            result.add(entry.getKey(), value.asText());
+        }
+
+        return result;
+    }
+}

--- a/web-services/common/src/test/java/datawave/webservice/common/json/MultivaluedMapDeserializerTest.java
+++ b/web-services/common/src/test/java/datawave/webservice/common/json/MultivaluedMapDeserializerTest.java
@@ -1,0 +1,85 @@
+package datawave.webservice.common.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class MultivaluedMapDeserializerTest {
+
+    private static final TypeReference<MultivaluedMap<String,String>> deserializationType = new TypeReference<>() {};
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setUp() {
+        objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(MultivaluedMap.class, new MultivaluedMapDeserializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void testDeserializeSimple() throws IOException {
+        final String jsonInput = "{ \"key\": \"value\", \"foo\": \"bar\" }";
+        MultivaluedMap<String,String> result = objectMapper.readValue(jsonInput, deserializationType);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("value", result.getFirst("key"));
+        assertEquals("bar", result.getFirst("foo"));
+    }
+
+    @Test
+    public void testDeserializeEmpty() throws IOException {
+        final String jsonInput = "{}";
+        MultivaluedMap<String,String> result = objectMapper.readValue(jsonInput, deserializationType);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testDeserializeBadJson() {
+        assertThrows(JsonParseException.class, () -> {
+            final String jsonInput = "{ \"key\": \"value\", \"foo\", \"bar\" }";
+            objectMapper.readValue(jsonInput, deserializationType);
+        });
+    }
+
+    @Test
+    public void testDeserializeList() {
+        assertThrows(JsonParseException.class, () -> {
+            final String jsonInput = "[\"bar\", \"baz\"]";
+            objectMapper.readValue(jsonInput, deserializationType);
+        });
+    }
+
+    @Test
+    public void testDeserializeListValue() {
+        assertThrows(JsonParseException.class, () -> {
+            final String jsonInput = "{ \"key\": \"value\", \"foo\": [\"bar\", \"baz\"] }";
+            objectMapper.readValue(jsonInput, deserializationType);
+        });
+    }
+
+    @Test
+    public void testDeserializeNumeric() throws IOException {
+        assertThrows(JsonParseException.class, () -> {
+            final String jsonInput = "{ \"789\": 123, \"foo\": 456 }";
+            MultivaluedMap<String,String> result = objectMapper.readValue(jsonInput, deserializationType);
+        });
+    }
+}


### PR DESCRIPTION
Currently HTTP POST requests to endpoints exposed by the `QueryExecutorBean` can not be transmitted using `Content-type: application/json`, and there are some circumstances where it is more straightforward to use this format over `application/x-www-form-urlencoded`. This demonstrates one way to support an `application/json` POST payload for the batch lookupUUID, lookupContentUUID and generateTagCloud endpoints 