### PR TITLE
IndexInfo serialization support for Kryo

### DIFF
--- a/warehouse/query-core/pom.xml
+++ b/warehouse/query-core/pom.xml
@@ -391,6 +391,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
@@ -1,6 +1,6 @@
 package datawave.query.index.lookup;
 
-import static datawave.query.util.ValueSerializerType.KRYO;
+import static datawave.query.util.ValueSerializerType.WRITABLE;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -71,7 +71,7 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
 
     private static final Logger log = Logger.getLogger(CreateUidsIterator.class);
 
-    public static final ValueSerializerType DEFAULT_VALUE_ENCODING_TYPE = KRYO;
+    public static final ValueSerializerType DEFAULT_VALUE_ENCODING_TYPE = WRITABLE;
 
     public static final String COLLAPSE_UIDS = "index.lookup.collapse";
     public static final String PARSE_TLD_UIDS = "index.lookup.parse.tld.uids";

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/CreateUidsIterator.java
@@ -1,5 +1,7 @@
 package datawave.query.index.lookup;
 
+import static datawave.query.util.ValueSerializerType.KRYO;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,7 +20,6 @@ import org.apache.accumulo.core.iterators.OptionDescriber;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableUtils;
 import org.apache.log4j.Logger;
 
 import com.google.common.collect.Lists;
@@ -27,6 +28,8 @@ import datawave.ingest.protobuf.Uid;
 import datawave.query.tld.TLD;
 import datawave.query.util.Tuple3;
 import datawave.query.util.Tuples;
+import datawave.query.util.ValueSerializer;
+import datawave.query.util.ValueSerializerType;
 import datawave.query.util.count.CountMap;
 
 /**
@@ -68,10 +71,13 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
 
     private static final Logger log = Logger.getLogger(CreateUidsIterator.class);
 
+    public static final ValueSerializerType DEFAULT_VALUE_ENCODING_TYPE = KRYO;
+
     public static final String COLLAPSE_UIDS = "index.lookup.collapse";
     public static final String PARSE_TLD_UIDS = "index.lookup.parse.tld.uids";
     public static final String FIELD_COUNTS = "field.counts";
     public static final String TERM_COUNTS = "term.counts";
+    public static final String VALUE_ENCODING = "value.encoding";
 
     protected boolean collapseUids = false;
     protected boolean parseTldUids = false;
@@ -81,6 +87,7 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
     protected SortedKeyValueIterator<Key,Value> src;
     protected Key tk;
     protected IndexInfo tv;
+    protected ValueSerializer<IndexInfo> valueSerializer;
 
     private String field;
     private String value;
@@ -109,6 +116,10 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
             if (null != termCountsOpt) {
                 termCounts = Boolean.parseBoolean(termCountsOpt);
             }
+            valueSerializer = ValueSerializer.newSerializer(IndexInfo.class, options.get(VALUE_ENCODING), DEFAULT_VALUE_ENCODING_TYPE);
+        }
+        if (valueSerializer == null) {
+            valueSerializer = ValueSerializer.newSerializer(IndexInfo.class, DEFAULT_VALUE_ENCODING_TYPE);
         }
     }
 
@@ -226,7 +237,7 @@ public class CreateUidsIterator implements SortedKeyValueIterator<Key,Value>, Op
 
     @Override
     public Value getTopValue() {
-        return new Value(WritableUtils.toByteArray(this.getValue()));
+        return valueSerializer.serializeUnchecked(this.getValue());
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
@@ -106,7 +106,9 @@ public class IndexInfo implements Writable, KryoSerializable, UidIntersector {
             output.writeLong(count, true);
         }
         output.writeInt(uids.size(), true);
-        uids.forEach(v -> v.write(kryo, output));
+        for (IndexMatch uid : uids) {
+            uid.write(kryo, output);
+        }
         fieldCounts.write(kryo, output);
         termCounts.write(kryo, output);
     }
@@ -150,15 +152,15 @@ public class IndexInfo implements Writable, KryoSerializable, UidIntersector {
         this.count = infinite ? -1 : input.readLong(true);
         final int nUids = input.readInt(true);
 
-        ImmutableSortedSet.Builder<IndexMatch> setBuilder = ImmutableSortedSet.naturalOrder();
+        IndexMatch[] uidsLocal = new IndexMatch[nUids];
 
-        for (int i = 0; i < nUids; ++i) {
+        for (int i = 0; i < nUids; i++) {
             IndexMatch index = new IndexMatch();
             index.read(kryo, input);
-            setBuilder.add(index);
+            uidsLocal[i] = index;
         }
 
-        this.uids = setBuilder.build();
+        this.uids = ImmutableSortedSet.copyOf(uidsLocal);
 
         this.fieldCounts = new CountMap();
         this.termCounts = new CountMap();

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexInfo.java
@@ -24,6 +24,10 @@ import org.apache.hadoop.io.VLongWritable;
 import org.apache.hadoop.io.Writable;
 import org.apache.log4j.Logger;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.base.Objects;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedSet;
@@ -45,7 +49,7 @@ import datawave.query.util.count.CountMap;
  * <p>
  * The IndexInfo object supports union and intersection operations with other IndexInfo objects.
  */
-public class IndexInfo implements Writable, UidIntersector {
+public class IndexInfo implements Writable, KryoSerializable, UidIntersector {
 
     private static final Logger log = Logger.getLogger(IndexInfo.class);
 
@@ -95,6 +99,19 @@ public class IndexInfo implements Writable, UidIntersector {
     }
 
     @Override
+    public void write(Kryo kryo, Output output) {
+        boolean infinite = isInfinite();
+        output.writeBoolean(infinite);
+        if (!infinite) {
+            output.writeLong(count, true);
+        }
+        output.writeInt(uids.size(), true);
+        uids.forEach(v -> v.write(kryo, output));
+        fieldCounts.write(kryo, output);
+        termCounts.write(kryo, output);
+    }
+
+    @Override
     public void write(DataOutput out) throws IOException {
         new VLongWritable(count).write(out);
         new VIntWritable(uids.size()).write(out);
@@ -125,6 +142,29 @@ public class IndexInfo implements Writable, UidIntersector {
 
     public JexlNode getNode() {
         return myNode;
+    }
+
+    @Override
+    public void read(Kryo kryo, Input input) {
+        final boolean infinite = input.readBoolean();
+        this.count = infinite ? -1 : input.readLong(true);
+        final int nUids = input.readInt(true);
+
+        ImmutableSortedSet.Builder<IndexMatch> setBuilder = ImmutableSortedSet.naturalOrder();
+
+        for (int i = 0; i < nUids; ++i) {
+            IndexMatch index = new IndexMatch();
+            index.read(kryo, input);
+            setBuilder.add(index);
+        }
+
+        this.uids = setBuilder.build();
+
+        this.fieldCounts = new CountMap();
+        this.termCounts = new CountMap();
+
+        this.fieldCounts.read(kryo, input);
+        this.termCounts.read(kryo, input);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexMatch.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/IndexMatch.java
@@ -8,13 +8,17 @@ import java.util.Set;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.hadoop.io.WritableComparable;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.language.parser.jexl.JexlNodeSet;
 
-public class IndexMatch implements WritableComparable<IndexMatch> {
+public class IndexMatch implements KryoSerializable, WritableComparable<IndexMatch> {
 
     protected String shard;
     protected String uid;
@@ -156,8 +160,18 @@ public class IndexMatch implements WritableComparable<IndexMatch> {
     }
 
     @Override
+    public void read(Kryo kryo, Input input) {
+        uid = input.readString();
+    }
+
+    @Override
     public void readFields(DataInput in) throws IOException {
         uid = in.readUTF();
+    }
+
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeString(uid);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -11,6 +11,7 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_TERM;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_VALUE;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.INDEX_HOLE;
+import static datawave.query.util.ValueSerializerType.KRYO;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -609,6 +610,8 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
                 uidSetting.addOption(CreateUidsIterator.TERM_COUNTS, Boolean.toString(false));
             }
 
+            uidSetting.addOption(CreateUidsIterator.VALUE_ENCODING, KRYO.name());
+
             /*
              * Create a scanner in the initialized state so that we can scan immediately
              */
@@ -632,7 +635,7 @@ public class RangeStream extends BaseVisitor implements CloseableIterable<QueryP
             scannerSession.setRanges(Collections.singleton(range));
 
             // Create the EntryParser prior to ScannerStream.
-            EntryParser entryParser = new EntryParser(node, fieldName, literal, indexOnlyFields);
+            EntryParser entryParser = new EntryParser(node, fieldName, literal, indexOnlyFields, KRYO);
 
             return ScannerStream.initialized(scannerSession, entryParser, node);
 

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
@@ -505,7 +505,7 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
 
     public IndexInfo readInfoFromValue(Value value) {
         try {
-            IndexInfo info = ValueSerializer.newSerializer(IndexInfo.class, KRYO).deserialize(value, IndexInfo::new);
+            IndexInfo info = valueSerializer.deserialize(value, IndexInfo::new);
             if (log.isTraceEnabled()) {
                 for (IndexMatch match : info.uids()) {
                     log.trace("match is " + StringUtils.split(match.getUid(), '\u0000')[1]);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
@@ -1,9 +1,7 @@
 package datawave.query.tables;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
+import static datawave.query.util.ValueSerializerType.KRYO;
+
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -46,6 +44,7 @@ import datawave.query.index.lookup.IndexInfo;
 import datawave.query.index.lookup.IndexMatch;
 import datawave.query.index.lookup.ShardEquality;
 import datawave.query.tables.stats.ScanSessionStats.TIMERS;
+import datawave.query.util.ValueSerializer;
 
 /**
  * Purpose: Extends Scanner session so that we can modify how we build our subsequent ranges. Breaking this out cleans up the code. May require implementation
@@ -90,6 +89,9 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
 
     protected ScannerFactory scannerFactory;
 
+    // Not thread-safe by default
+    protected ValueSerializer<IndexInfo> valueSerializer;
+
     @Override
     protected String serviceName() {
         String id = "NoQueryId";
@@ -97,17 +99,6 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
             id = settings.getId().toString();
         }
         return "RangeStreamScanner (" + id + ")";
-    }
-
-    public RangeStreamScanner(String tableName, Set<Authorizations> auths, ResourceQueue delegator, int maxResults, Query settings) {
-        super(tableName, auths, delegator, maxResults, settings);
-        delegatedResourceInitializer = BatchResource.class;
-        currentQueue = Queues.newArrayDeque();
-        readLock = queueLock.readLock();
-        writeLock = queueLock.writeLock();
-        myExecutor = MoreExecutors.newDirectExecutorService();
-        if (null != stats)
-            initializeTimers();
     }
 
     public RangeStreamScanner(String tableName, Set<Authorizations> auths, ResourceQueue delegator, int maxResults, Query settings, SessionOptions options,
@@ -118,8 +109,13 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
         readLock = queueLock.readLock();
         writeLock = queueLock.writeLock();
         myExecutor = MoreExecutors.newDirectExecutorService();
+        valueSerializer = ValueSerializer.newSerializer(IndexInfo.class, KRYO);
         if (null != stats)
             initializeTimers();
+    }
+
+    public RangeStreamScanner(String tableName, Set<Authorizations> auths, ResourceQueue delegator, int maxResults, Query settings) {
+        this(tableName, auths, delegator, maxResults, settings, new SessionOptions(), null);
     }
 
     public RangeStreamScanner(ScannerSession other) {
@@ -509,34 +505,13 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
 
     public IndexInfo readInfoFromValue(Value value) {
         try {
-            IndexInfo info = new IndexInfo();
-            info.readFields(new DataInputStream(new ByteArrayInputStream(value.get())));
+            IndexInfo info = ValueSerializer.newSerializer(IndexInfo.class, KRYO).deserialize(value, IndexInfo::new);
             if (log.isTraceEnabled()) {
                 for (IndexMatch match : info.uids()) {
                     log.trace("match is " + StringUtils.split(match.getUid(), '\u0000')[1]);
                 }
             }
             return info;
-        } catch (IOException e) {
-            log.error(e);
-            throw new DatawaveFatalQueryException(e);
-        }
-    }
-
-    public Value writeInfoToValue() {
-        return writeInfoToValue(new IndexInfo(-1));
-    }
-
-    public Value writeInfoToValue(IndexInfo info) {
-        try {
-            ByteArrayOutputStream outByteStream = new ByteArrayOutputStream();
-            DataOutputStream outDataStream = new DataOutputStream(outByteStream);
-            info.write(outDataStream);
-
-            outDataStream.close();
-            outByteStream.close();
-
-            return new Value(outByteStream.toByteArray());
         } catch (IOException e) {
             log.error(e);
             throw new DatawaveFatalQueryException(e);

--- a/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializer.java
@@ -1,0 +1,213 @@
+package datawave.query.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Supplier;
+
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableUtils;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Value serializer for {@link Value} objects.
+ * <p>
+ * A serializer may not be thread-safe.
+ * </p>
+ *
+ * @param <T>
+ */
+public interface ValueSerializer<T> {
+    /**
+     * Gets the type of serializer specification implemented
+     *
+     * @return the type of serializer
+     */
+    ValueSerializerType getType();
+
+    /**
+     * Serializes the item into {@link Value}
+     *
+     * @param item
+     *            serialize into the value
+     * @return a new value with the item serialized
+     * @throws IOException
+     */
+    Value serialize(T item) throws IOException;
+
+    /**
+     * Deserializes the value into an item.
+     *
+     * @param value
+     *            to deserialize
+     * @param fn
+     *            get or create an instance
+     * @return the item deserialized
+     * @throws IOException
+     */
+    T deserialize(Value value, Supplier<T> fn) throws IOException;
+
+    /**
+     * Validates that the class is supported by the serializer.
+     *
+     * @param clazz
+     *            the class to check support
+     * @return true if the class is supported, otherwise false
+     */
+    boolean isClassSupported(Class<T> clazz);
+
+    /**
+     * Serializes and catches any {@link IOException}, which will be rethrown as a {@link UncheckedIOException}
+     *
+     * @param item
+     * @return
+     */
+    default Value serializeUnchecked(T item) {
+        Value val;
+        try {
+            val = serialize(item);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return val;
+    }
+
+    /**
+     * Deserializes and catches any {@link IOException}, which will be rethrown as a {@link UncheckedIOException}
+     *
+     * @param value
+     * @param fn
+     * @return
+     */
+    default T deserializeUnchecked(Value value, Supplier<T> fn) {
+        T val;
+        try {
+            val = deserialize(value, fn);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return val;
+    }
+
+    /**
+     * Creates a new serializer instance.
+     * <p>
+     * Note: the type of class being serialized/deserialized must meet the requirements of the serializer.
+     * </p>
+     *
+     * @param clazz
+     *            class of type to serialize
+     * @param typeName
+     *            type of serializer (mapped to {@link ValueSerializerType})
+     * @param defaultType
+     *            default type if {@param typeName} is null.
+     * @return a new serializer
+     * @param <V>
+     */
+    static <V> ValueSerializer<V> newSerializer(Class<V> clazz, String typeName, ValueSerializerType defaultType) {
+        ValueSerializerType type = typeName != null ? ValueSerializerType.valueOf(typeName.toUpperCase()) : defaultType;
+        return newSerializer(clazz, type);
+    }
+
+    /**
+     * Creates a new serializer instance.
+     * <p>
+     * Note: the type of class being serialized/deserialized must meet the requirements of the serializer.
+     * </p>
+     *
+     * @param clazz
+     *            class of type to serialize
+     * @param type
+     *            type of serializer to create
+     * @return a new serializer
+     * @param <V>
+     */
+    static <V> ValueSerializer<V> newSerializer(Class<V> clazz, ValueSerializerType type) {
+        ValueSerializer<V> serializer;
+        switch (type) {
+            case WRITABLE:
+                // noinspection unchecked
+                serializer = (ValueSerializer<V>) new WritableValueSerializer();
+                break;
+            case KRYO:
+                // noinspection unchecked
+                serializer = (ValueSerializer<V>) new KryoValueSerializer();
+                break;
+            default:
+                throw new IllegalStateException("Unsupported serializer type: " + type);
+        }
+        if (!serializer.isClassSupported(clazz)) {
+            throw new IllegalStateException("Unsupported serializer type: " + type + " for " + clazz);
+        }
+        return serializer;
+    }
+
+    class WritableValueSerializer implements ValueSerializer<Writable> {
+        @Override
+        public Value serialize(Writable item) {
+            return new Value(WritableUtils.toByteArray(item));
+        }
+
+        @Override
+        public Writable deserialize(Value value, Supplier<Writable> fn) throws IOException {
+            Writable data = fn.get();
+            try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(value.get()))) {
+                data.readFields(dis);
+            }
+            return data;
+        }
+
+        @Override
+        public boolean isClassSupported(Class<Writable> clazz) {
+            return Writable.class.isAssignableFrom(clazz);
+        }
+
+        @Override
+        public ValueSerializerType getType() {
+            return ValueSerializerType.WRITABLE;
+        }
+    }
+
+    class KryoValueSerializer implements ValueSerializer<KryoSerializable> {
+        private final static int DEFAULT_BUFFER_SIZE = 4096;
+
+        private final Kryo kryo = new Kryo();
+        private final byte[] bufferInput = new byte[DEFAULT_BUFFER_SIZE];
+        private final byte[] bufferOutput = new byte[DEFAULT_BUFFER_SIZE];
+
+        @Override
+        public Value serialize(KryoSerializable item) {
+            try (Output output = new Output(bufferOutput)) {
+                item.write(kryo, output);
+                output.flush();
+                return new Value(output.toBytes());
+            }
+        }
+
+        @Override
+        public KryoSerializable deserialize(Value value, Supplier<KryoSerializable> fn) throws IOException {
+            KryoSerializable data = fn.get();
+            try (ByteArrayInputStream bin = new ByteArrayInputStream(value.get()); Input input = new Input(bufferInput)) {
+                input.setInputStream(bin);
+                data.read(kryo, input);
+            }
+            return data;
+        }
+
+        @Override
+        public boolean isClassSupported(Class<KryoSerializable> clazz) {
+            return KryoSerializable.class.isAssignableFrom(clazz);
+        }
+
+        @Override
+        public ValueSerializerType getType() {
+            return ValueSerializerType.KRYO;
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializer.java
@@ -106,7 +106,7 @@ public interface ValueSerializer<T> {
      * @param typeName
      *            type of serializer (mapped to {@link ValueSerializerType})
      * @param defaultType
-     *            default type if {@param typeName} is null.
+     *            default type if {@code typeName} is null.
      * @return a new serializer
      * @param <V>
      */

--- a/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializerType.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializerType.java
@@ -1,0 +1,5 @@
+package datawave.query.util;
+
+public enum ValueSerializerType {
+    WRITABLE, KRYO
+}

--- a/warehouse/query-core/src/main/java/datawave/query/util/count/CountMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/count/CountMap.java
@@ -14,11 +14,10 @@ import com.esotericsoftware.kryo.io.Output;
  * Wrapper around a HashMap that supports Kryo serialization
  */
 public class CountMap implements KryoSerializable {
-
     private final Map<String,Long> counts;
 
     public CountMap() {
-        counts = new HashMap<>();
+        this.counts = new HashMap<>();
     }
 
     public Long put(String key, Long value) {

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/EntryParserTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/EntryParserTest.java
@@ -12,7 +12,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeMap;
 
-import datawave.query.util.ValueSerializerType;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -25,6 +24,7 @@ import datawave.ingest.protobuf.Uid;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.util.Tuple2;
+import datawave.query.util.ValueSerializerType;
 
 public class EntryParserTest {
     private final static ValueSerializerType SERIALIZER_TYPE = ValueSerializerType.WRITABLE;

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/EntryParserTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/EntryParserTest.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeMap;
 
+import datawave.query.util.ValueSerializerType;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -26,6 +27,7 @@ import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 import datawave.query.util.Tuple2;
 
 public class EntryParserTest {
+    private final static ValueSerializerType SERIALIZER_TYPE = ValueSerializerType.WRITABLE;
 
     private static void addToExpected(Collection<IndexMatch> expected, String prefix, Iterable<String> docIds, JexlNode node) {
         for (String docId : docIds)
@@ -54,7 +56,7 @@ public class EntryParserTest {
         iterator.init(new SortedMapIterator(data), null, null);
         iterator.seek(new Range(new Key("row", "cf"), null), Collections.emptySet(), false);
 
-        EntryParser parser = new EntryParser("hello", "world", true);
+        EntryParser parser = new EntryParser("hello", "world", true, SERIALIZER_TYPE);
         Result top = new Result(iterator.getTopKey(), iterator.getTopValue());
         Tuple2<String,IndexInfo> tuple = parser.apply(top);
         assertTrue(iterator.hasTop());
@@ -89,7 +91,7 @@ public class EntryParserTest {
         iterator.seek(new Range(new Key("row", "cf"), null), Collections.emptySet(), false);
         assertTrue(iterator.hasTop());
 
-        EntryParser parser = new EntryParser("hello", "world", false);
+        EntryParser parser = new EntryParser("hello", "world", false, SERIALIZER_TYPE);
         Result top = new Result(iterator.getTopKey(), iterator.getTopValue());
         Tuple2<String,IndexInfo> tuple = parser.apply(top);
 
@@ -121,7 +123,7 @@ public class EntryParserTest {
         iterator.seek(new Range(new Key("row", "cf"), null), Collections.emptySet(), false);
         assertTrue(iterator.hasTop());
 
-        EntryParser parser = new EntryParser("hello", "world", false);
+        EntryParser parser = new EntryParser("hello", "world", false, SERIALIZER_TYPE);
         Result top = new Result(iterator.getTopKey(), iterator.getTopValue());
         Tuple2<String,IndexInfo> tuple = parser.apply(top);
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerTest.java
@@ -59,6 +59,7 @@ import datawave.query.index.lookup.ScannerStream;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.util.QueryScannerHelper;
 import datawave.query.util.Tuple2;
+import datawave.query.util.ValueSerializerType;
 import datawave.util.time.DateHelper;
 
 /**
@@ -220,6 +221,9 @@ public class RangeStreamScannerTest {
         // Set iterator option. Do not collapse uids into shard ranges, just pass results back.
         final IteratorSetting uidSetting = new IteratorSetting(priority++, CreateUidsIterator.class);
         uidSetting.addOption(CreateUidsIterator.COLLAPSE_UIDS, Boolean.valueOf(false).toString());
+
+        // Use Kryo serialization
+        uidSetting.addOption(CreateUidsIterator.VALUE_ENCODING, ValueSerializerType.KRYO.toString());
 
         options.addScanIterator(uidSetting);
         options.addScanIterator(QueryScannerHelper.getQueryInfoIterator(config.getQuery(), false, queryString));

--- a/warehouse/query-core/src/test/java/datawave/query/util/ValueSerializerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/ValueSerializerTest.java
@@ -1,0 +1,102 @@
+package datawave.query.util;
+
+import static datawave.query.util.ValueSerializerType.KRYO;
+import static datawave.query.util.ValueSerializerType.WRITABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Writable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+public class ValueSerializerTest {
+    @Test
+    public void testNewSerializerDefaultsWhenTypeNull() {
+        ValueSerializer<?> serializerWritable = ValueSerializer.newSerializer(TestType.class, null, WRITABLE);
+        assertEquals(WRITABLE, serializerWritable.getType());
+    }
+
+    @Test
+    public void testNewSerializerThrowsWithUnsupportedKryo() {
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> ValueSerializer.newSerializer(Object.class, null, KRYO));
+        assertEquals("Unsupported serializer type: KRYO for class java.lang.Object", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ValueSerializerType.class)
+    public void testSerializeAndDeserialize(ValueSerializerType serializerType) throws IOException {
+        TestType expected = new TestType("a", "b");
+        ValueSerializer<TestType> serializer = ValueSerializer.newSerializer(TestType.class, serializerType);
+        Value v1 = serializer.serialize(expected);
+        TestType actual = serializer.deserialize(v1, TestType::new);
+
+        assertEquals(expected, actual);
+    }
+
+    static class TestType implements KryoSerializable, Writable {
+        private String field1;
+        private String field2;
+
+        TestType() {
+            // no code
+        }
+
+        TestType(String field1, String field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (!(o instanceof TestType))
+                return false;
+
+            TestType that = (TestType) o;
+            return field1.equals(that.field1) && field2.equals(that.field2);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = field1.hashCode();
+            result = 31 * result + field2.hashCode();
+            return result;
+        }
+
+        @Override
+        public void write(Kryo kryo, Output output) {
+            output.writeString(field1);
+            output.writeString(field2);
+        }
+
+        @Override
+        public void read(Kryo kryo, Input input) {
+            this.field1 = input.readString();
+            this.field2 = input.readString();
+        }
+
+        @Override
+        public void write(DataOutput dataOutput) throws IOException {
+            dataOutput.writeUTF(field1);
+            dataOutput.writeUTF(field2);
+        }
+
+        @Override
+        public void readFields(DataInput dataInput) throws IOException {
+            this.field1 = dataInput.readUTF();
+            this.field2 = dataInput.readUTF();
+        }
+    }
+}


### PR DESCRIPTION
Implements Kryo serialization for IndexInfo instances.
- ValueSerializer class encapsulates Accumulo value serialization between Writable and Kyro formats.
- CreateUidsIterator supports multiple serialization formats for IndexInfo, defaults to Writable.