### PR TITLE
Add query validation configuration for quickstart

### DIFF
--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:util="http://www.springframework.org/schema/util"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans-4.0.xsd 
+    http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
     http://www.springframework.org/schema/context
     http://www.springframework.org/schema/context/spring-context-4.0.xsd
     http://www.springframework.org/schema/util
@@ -84,12 +84,12 @@
         <bean class="datawave.query.language.functions.jexl.Count"/>
     </util:list>
 
-    <!-- Fields we should not tokenize in a tokenized query. In non-tokenized 
+    <!-- Fields we should not tokenize in a tokenized query. In non-tokenized
          the field name is simply removed -->
     <util:set id="skipTokenizeFields" value-type="java.lang.String">
         <value>DOMETA</value>
     </util:set>
-    
+
     <!-- Fields we should tokenize in a tokenized query -->
     <util:set id="tokenizeFields" value-type="java.lang.String">
         <value>CONTENT</value>
@@ -205,6 +205,81 @@
         <property name="remoteQueryService" ref="RemoteQueryService" />
         <property name="remoteQueryLogic" value="EventQuery" />
         <property name="userOperations" ref="MyRemoteUserOps" />
+    </bean>
+
+    <bean id="AmbiguousNotRule" scope="prototype" class="datawave.query.rules.AmbiguousNotRule">
+        <property name="name" value="Check for Ambiguous Usage of NOT"/>
+    </bean>
+
+    <bean id="AmbiguousOrPhrasesRule" scope="prototype" class="datawave.query.rules.AmbiguousOrPhrasesRule">
+        <property name="name" value="Check for Unfielded Terms That Could Be Wrapped"/>
+    </bean>
+
+    <bean id="AmbiguousUnquotedPhrasesRule" scope="prototype" class="datawave.query.rules.AmbiguousUnquotedPhrasesRule">
+        <property name="name" value="Check for Unfielded Terms That Could Be Quoted"/>
+    </bean>
+
+    <bean id="IncludeExcludeArgsRule" scope="prototype" class="datawave.query.rules.IncludeExcludeArgsRule">
+        <property name="name" value="Validate Args of #INCLUDE and #EXCLUDE"/>
+    </bean>
+
+    <bean id="IncludeExcludeIndexFieldsRule" scope="prototype" class="datawave.query.rules.IncludeExcludeIndexFieldsRule">
+        <property name="name" value="Check #INCLUDE and #EXCLUDE for Indexed Fields"/>
+    </bean>
+
+    <bean id="InvalidQuoteRule" scope="prototype" class="datawave.query.rules.InvalidQuoteRule">
+        <property name="name" value="Check for Invalid Quote"/>
+    </bean>
+
+    <bean id="MinimumSlopProximityRule" scope="prototype" class="datawave.query.rules.MinimumSlopProximityRule">
+        <property name="name" value="Validate Slop Proximity"/>
+    </bean>
+
+    <bean id="NumericValueRule" scope="prototype" class="datawave.query.rules.NumericValueRule">
+        <property name="name" value="Validate Numeric Values Only Given for Numeric Fields"/>
+    </bean>
+
+    <bean id="TimeFunctionRule" scope="prototype" class="datawave.query.rules.TimeFunctionRule">
+        <property name="name" value="Validate #TIME_FUNCTION has Date Fields"/>
+    </bean>
+
+    <bean id="UnescapedWildcardsInPhrasesRule" scope="prototype" class="datawave.query.rules.UnescapedWildcardsInPhrasesRule">
+        <property name="name" value="Check Quoted Phrases for Unescaped Wildcard"/>
+    </bean>
+
+    <bean id="UnfieldedTermsRule" scope="prototype" class="datawave.query.rules.UnfieldedTermsRule">
+        <property name="name" value="Check for Unfielded Terms"/>
+    </bean>
+
+
+    <bean id="FieldExistenceRule" scope="prototype" class="datawave.query.rules.FieldExistenceRule">
+        <property name="name" value="Check Field Existence"/>
+        <property name="specialFields">
+            <list value-type="java.lang.String">
+                <value>_ANYFIELD_</value>
+                <value>_NOFIELD_</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="FieldPatternPresenceRule" scope="prototype" class="datawave.query.rules.FieldPatternPresenceRule">
+        <property name="name" value="Check Presence of Field or Pattern"/>
+        <property name="fieldMessages">
+            <map key-type="java.lang.String" value-type="java.lang.String">
+                <entry key="_ANYFIELD_" value="Detected presence of _ANYFIELD_"/>
+            </map>
+        </property>
+        <property name="patternMessages">
+            <map key-type="java.lang.String" value-type="java.lang.String">
+                <entry key=".*" value="Detected pattern '.*' that will match everything"/>
+            </map>
+        </property>
+    </bean>
+
+    <bean id="UnescapedSpecialCharsRule" scope="prototype" class="datawave.query.rules.UnescapedSpecialCharsRule">
+        <property name="name" value="Check for Unescaped Special Characters"/>
+        <property name="escapedWhitespaceRequiredForLiterals" value="false"/>
+        <property name="escapedWhitespaceRequiredForPatterns" value="false"/>
     </bean>
 
     <bean id="BaseEventQuery" parent="baseQueryLogic" class="datawave.query.tables.ShardQueryLogic" abstract="true">
@@ -330,6 +405,24 @@
         <property name="docAggregationThresholdMs" value="-1" />
         <property name="tfAggregationThresholdMs" value="-1" />
         <property name="summaryFieldName" value="SUMMARY" />
+        <property name="validationRules">
+            <list value-type="datawave.query.rules.QueryRule">
+                <ref bean="InvalidQuoteRule"/>
+                <ref bean="UnfieldedTermsRule"/>
+                <ref bean="UnescapedWildcardsInPhrasesRule"/>
+                <ref bean="AmbiguousNotRule"/>
+                <ref bean="AmbiguousOrPhrasesRule"/>
+                <ref bean="AmbiguousUnquotedPhrasesRule"/>
+                <ref bean="MinimumSlopProximityRule"/>
+                <ref bean="IncludeExcludeArgsRule"/>
+                <ref bean="FieldExistenceRule"/>
+                <ref bean="UnescapedSpecialCharsRule"/>
+                <ref bean="FieldPatternPresenceRule"/>
+                <ref bean="IncludeExcludeIndexFieldsRule"/>
+                <ref bean="NumericValueRule"/>
+                <ref bean="TimeFunctionRule"/>
+            </list>
+        </property>
     </bean>
 
     <util:list id="LocalIvaratorCacheDirConfigs">
@@ -378,7 +471,7 @@
         <property name="columnVisibility" value="" />
         <property name="beginDate" value="${lookup.uuid.beginDate}" />
     </bean>
-    
+
     <bean id="IdTranslatorConfiguration" class="datawave.webservice.query.configuration.IdTranslatorConfiguration">
         <property name="uuidTypes" ref="UUIDTypeList" />
         <property name="columnVisibility" value="" />
@@ -395,7 +488,7 @@
         <property name="pageByteTrigger" value="${query.page.byte.trigger}" />
 
     </bean>
-    
+
     <!-- Query Logic which performs a count on fieldIndex keys -->
     <bean id="FieldIndexCountQuery" parent="baseQueryLogic" scope="prototype"  class="datawave.query.tables.shard.FieldIndexCountQueryLogic">
         <property name="tableName" value="${shard.table.name}" />
@@ -692,8 +785,8 @@
         <property name="queryLogicFactoryConfiguration" ref="QueryLogicFactoryConfiguration" />
     </bean>
 
-    <!-- 
-        Factory method config for creating whatever model we want for the default. 
+    <!--
+        Factory method config for creating whatever model we want for the default.
         Provides a fall-back model in the event that the named query model 'modelName'
         isn't defined in Accumulo for whatever reason...
     -->


### PR DESCRIPTION
Currently all attempts to use the `Query/{logicName}/validate` endpoint to validate queries in the Quickstart will result in a 'Query validation not implemented' error due to the lack of configured rules for the baseline ShardQueryLogic bean.

Add default query validation rule definitions to the quickstart QueryLogicFactory.xml to fix this.