### PR TITLE
Mitigate build failures by increasing lock timeout

### DIFF
--- a/.github/workflows/datawave-tests.yml
+++ b/.github/workflows/datawave-tests.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   JAVA_VERSION: '11'
   JAVA_DISTRIBUTION: 'zulu' #This is the default on v1 of the action for 1.8
-  MAVEN_OPTS: "-Djansi.force=true -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true -XX:ThreadStackSize=1m"
+  MAVEN_OPTS: "-Djansi.force=true -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Djava.awt.headless=true -XX:ThreadStackSize=1m -Daether.syncContext.named.time=480"
   REGISTRY: ghcr.io
   USER_NAME: ${{ secrets.GHCR_WRITE_USER_NAME }}
   ACCESS_TOKEN: ${{ secrets.GHCR_WRITE_ACCESS_TOKEN }}


### PR DESCRIPTION
The builds have periodically been failing due to a lock timeout. The following increases a lock timeout so we will wait for longer if it happens.