### PR TITLE
Adds warnings for when regex doesn't match

### DIFF
--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -147,7 +147,7 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
                 }
             }
 
-            Preconditions.checkState(tabletsLeft == 0);
+            Preconditions.checkState(tabletsLeft == 0, tabletsLeft + " tablets are unassigned. Ensure the tserver regex patterns are correct");
 
             return counts;
         }

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/RendezvousHostBalancer.java
@@ -110,6 +110,10 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
             return total;
         }
 
+        public boolean isEmpty() {
+            return tservers.isEmpty();
+        }
+
         /**
          * If there are 1000 tablets and there are 40 hosts with 5 tservers and 10 hosts with 4 tservers then this function will do the following
          *
@@ -183,13 +187,15 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
         tabletsToAssign.forEach((tabletGroup, tablets) -> {
             TServers tserversForGroup = computedTservers.computeIfAbsent(tabletGroup, g -> new TServers(tabletServerPartitioner.apply(tabletGroup)));
 
-            // Must pass the set of all tablets for the group to compute the desired location, not just the subset of tablets being assigned
-            var allTablets = allTabletsGrouped.get(tabletGroup);
-            Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, allTablets, tserversForGroup, allLocations);
+            if (!tserversForGroup.isEmpty()) {
+                // Must pass the set of all tablets for the group to compute the desired location, not just the subset of tablets being assigned
+                var allTablets = allTabletsGrouped.get(tabletGroup);
+                Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, allTablets, tserversForGroup, allLocations);
 
-            tablets.forEach(tabletId -> {
-                assignmentParameters.addAssignment(tabletId, desiredLocs.get(tabletId));
-            });
+                tablets.forEach(tabletId -> {
+                    assignmentParameters.addAssignment(tabletId, desiredLocs.get(tabletId));
+                });
+            } // else there are no tservers so can not assign
         });
 
     }
@@ -242,23 +248,25 @@ public abstract class RendezvousHostBalancer implements TabletBalancer {
             List<TabletId> tablets = tpgEntry.getValue();
             TServers tserversForGroup = computedTservers.computeIfAbsent(tabletGroup, g -> new TServers(tabletServerPartitioner.apply(tabletGroup)));
 
-            Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, tablets, tserversForGroup, allLocations);
+            if (!tserversForGroup.isEmpty()) {
+                Map<TabletId,TabletServerId> desiredLocs = getDesiredLocationsForTabletGroup(tabletGroup, tablets, tserversForGroup, allLocations);
 
-            for (var dlEntry : desiredLocs.entrySet()) {
-                TabletId tabletId = dlEntry.getKey();
-                TabletServerId tabletServerId = dlEntry.getValue();
-                // This code could handle assigning tablets w/o a location, however the balancer framework does not support this so ignore tablets w/o a
-                // location. Normally accumulo will only call the balancer when all tablets are assigned. However if a tablet becomes unassigned during
-                // balancing a null location may be seen.
-                var currTsever = allLocations.get(tabletId);
-                if (currTsever != null && !currTsever.equals(tabletServerId)) {
-                    balanceParameters.migrationsOut().add(new TabletMigration(tabletId, currTsever, tabletServerId));
-                    migrationsAdded++;
-                    if (migrationsAdded >= maxMigrations) {
-                        break outer;
+                for (var dlEntry : desiredLocs.entrySet()) {
+                    TabletId tabletId = dlEntry.getKey();
+                    TabletServerId tabletServerId = dlEntry.getValue();
+                    // This code could handle assigning tablets w/o a location, however the balancer framework does not support this so ignore tablets w/o a
+                    // location. Normally accumulo will only call the balancer when all tablets are assigned. However if a tablet becomes unassigned during
+                    // balancing a null location may be seen.
+                    var currTsever = allLocations.get(tabletId);
+                    if (currTsever != null && !currTsever.equals(tabletServerId)) {
+                        balanceParameters.migrationsOut().add(new TabletMigration(tabletId, currTsever, tabletServerId));
+                        migrationsAdded++;
+                        if (migrationsAdded >= maxMigrations) {
+                            break outer;
+                        }
                     }
                 }
-            }
+            } // else there are not tservers so can not balance
         }
 
         lastRunTime = System.currentTimeMillis();

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeParseException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -16,6 +17,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.TableId;
@@ -68,6 +70,7 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
     private static final String SHARDED_PROPERTY_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "sharded.balancer.";
     public static final String SHARDED_MAX_MIGRATIONS = SHARDED_PROPERTY_PREFIX + "max.migrations";
     public static final int MAX_MIGRATIONS_DEFAULT = 10000;
+    private static final HashSet<Pattern> UnMatchedPatterns = new HashSet<>();
 
     private Configuration tableConfig;
 
@@ -128,6 +131,9 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
             matcher.reset(tabletServerId.getHost() + ":" + tabletServerId.getPort());
             if (matcher.matches()) {
                 db.add(daysBack);
+                if (!UnMatchedPatterns.isEmpty()) {
+                    UnMatchedPatterns.remove(matcher.pattern());
+                }
             }
         }
         return db;
@@ -158,6 +164,7 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
         if (configuredTiers.isEmpty()) {
             throw new IllegalStateException("Tier configuration is not set");
         }
+        UnMatchedPatterns.addAll(configuredTiers.stream().map(Map.Entry::getValue).map(Matcher::pattern).collect(Collectors.toSet()));
 
         TreeMap<Long,List<TabletServerId>> serverPartitioningMap = new TreeMap<>();
 
@@ -172,6 +179,11 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
                 log.warn("Tserver {} did not match any tiers", tabletServerId);
             }
         });
+
+        UnMatchedPatterns.forEach(regex -> {
+            log.warn("Regex: {} did not match against any tservers", regex);
+        });
+        UnMatchedPatterns.clear();
 
         // grab this once outside the lambda so the lambda always makes consistent decisions.
         var today = today();

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
@@ -70,7 +70,6 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
     private static final String SHARDED_PROPERTY_PREFIX = Property.TABLE_ARBITRARY_PROP_PREFIX.getKey() + "sharded.balancer.";
     public static final String SHARDED_MAX_MIGRATIONS = SHARDED_PROPERTY_PREFIX + "max.migrations";
     public static final int MAX_MIGRATIONS_DEFAULT = 10000;
-    private static final HashSet<Pattern> UnMatchedPatterns = new HashSet<>();
 
     private Configuration tableConfig;
 
@@ -123,7 +122,7 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
         return configuredTiers;
     }
 
-    protected List<Long> getDaysBack(List<Map.Entry<Long,Matcher>> configuredTiers, TabletServerId tabletServerId) {
+    private List<Long> getDaysBack(List<Map.Entry<Long,Matcher>> configuredTiers, TabletServerId tabletServerId, HashSet<Pattern> unMatchedPatterns) {
         ArrayList<Long> db = new ArrayList<>();
         for (var entry : configuredTiers) {
             long daysBack = entry.getKey();
@@ -131,8 +130,8 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
             matcher.reset(tabletServerId.getHost() + ":" + tabletServerId.getPort());
             if (matcher.matches()) {
                 db.add(daysBack);
-                if (!UnMatchedPatterns.isEmpty()) {
-                    UnMatchedPatterns.remove(matcher.pattern());
+                if (!unMatchedPatterns.isEmpty()) {
+                    unMatchedPatterns.remove(matcher.pattern());
                 }
             }
         }
@@ -164,12 +163,16 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
         if (configuredTiers.isEmpty()) {
             throw new IllegalStateException("Tier configuration is not set");
         }
-        UnMatchedPatterns.addAll(configuredTiers.stream().map(Map.Entry::getValue).map(Matcher::pattern).collect(Collectors.toSet()));
+
+        final HashSet<Pattern> unMatchedPatterns = new HashSet<>();
+        unMatchedPatterns.addAll(configuredTiers.stream().map(Map.Entry::getValue).map(Matcher::pattern).collect(Collectors.toSet()));
 
         TreeMap<Long,List<TabletServerId>> serverPartitioningMap = new TreeMap<>();
 
+        configuredTiers.forEach(e -> serverPartitioningMap.put(e.getKey(), new ArrayList<>()));
+
         allTservers.forEach(tabletServerId -> {
-            var daysBack = getDaysBack(configuredTiers, tabletServerId);
+            var daysBack = getDaysBack(configuredTiers, tabletServerId, unMatchedPatterns);
             if (!daysBack.isEmpty()) {
                 for (var db : daysBack) {
                     log.trace(" daysBack:{} tserver:{}", db, tabletServerId);
@@ -180,10 +183,10 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
             }
         });
 
-        UnMatchedPatterns.forEach(regex -> {
+        unMatchedPatterns.forEach(regex -> {
             log.warn("Regex: {} did not match against any tservers", regex);
         });
-        UnMatchedPatterns.clear();
+        unMatchedPatterns.clear();
 
         // grab this once outside the lambda so the lambda always makes consistent decisions.
         var today = today();

--- a/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
+++ b/warehouse/accumulo-extensions/src/main/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancer.java
@@ -169,6 +169,8 @@ public class ShardRendezvousHostBalancer extends RendezvousHostBalancer {
 
         TreeMap<Long,List<TabletServerId>> serverPartitioningMap = new TreeMap<>();
 
+        // Ensure each tier has a list of tservers. This will ensure that when a tiers regex matches nothing that the tier has an empty list. This will cause
+        // its tablets to not be assigned anywhere.
         configuredTiers.forEach(e -> serverPartitioningMap.put(e.getKey(), new ArrayList<>()));
 
         allTservers.forEach(tabletServerId -> {

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
@@ -518,13 +518,19 @@ public class ShardRendezvousHostBalancerTest {
         tableProps.put("table.custom.volume.tier.names", "t1,t2");
         tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
         tableProps.put("table.custom.volume.tiered.t1.tservers", "host0000.*");
-        tableProps.put("table.custom.volume.tiered.t2.days.back", "30");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "20");
         tableProps.put("table.custom.volume.tiered.t2.tservers", "willNotMatch[12].*");
 
         generateTabletServers(0, 29, 3).forEach(testTServers::addTServer);
 
         balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
         testTServers.applyAssignments(aout);
+
+        var shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
+        // should only assign 20 of the 30 days because tier t2 has no tservers
+        shardStats.check(20, 31, 10, 3);
+        // should only see the first 10 of 29 host used, no regex matches the other 19 host
+        assertTrue(testTServers.getLocationProvider().values().stream().map(TabletServerId::getHost).allMatch(h -> h.matches("host0000.*")));
 
         assertEquals(1000, balancer.getMaxMigrations());
 

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
@@ -511,6 +511,28 @@ public class ShardRendezvousHostBalancerTest {
     }
 
     @Test
+    public void testNoTserversForRegex() throws Exception {
+        tablets.addAll(createShards(tableId, "20010101", 30, 31));
+        today.set(parseDay("20010130"));
+
+        tableProps.put("table.custom.volume.tier.names", "t1,t2");
+        tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
+        tableProps.put("table.custom.volume.tiered.t1.tservers", "host0000.*");
+        tableProps.put("table.custom.volume.tiered.t2.days.back", "30");
+        tableProps.put("table.custom.volume.tiered.t2.tservers", "willNotMatch[12].*");
+
+        generateTabletServers(0, 29, 3).forEach(testTServers::addTServer);
+
+        balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout));
+        testTServers.applyAssignments(aout);
+
+        assertEquals(1000, balancer.getMaxMigrations());
+
+        balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
+        assertTrue(migrations.isEmpty());
+    }
+
+    @Test
     public void testLast() throws Exception {
         tablets.addAll(createShards(tableId, "20010101", 30, 31));
         today.set(parseDay("20010130"));
@@ -828,7 +850,7 @@ public class ShardRendezvousHostBalancerTest {
         SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd");
         var date = fmt.parse(startDate);
         GregorianCalendar cal = new GregorianCalendar();
-        cal.set(date.getYear() + 1900, date.getMonth(), date.getDate());
+        cal.setTime(date);
 
         var shards = new ArrayList<TabletId>(days * shardsPerDay);
 


### PR DESCRIPTION
Adds warning log messages for when tier regex patterns do not match any tservers.

This covers the case where tservers match against one of the tier regexes, but not a second regex.

Removed usage of deprecated date methods.