### PR TITLE
Update TypeAttribute.sizeInBytes() to check for Long.MIN_VALUE

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -51,7 +51,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     @Override
     public long sizeInBytes() {
-        if (sizeInBytes == Long.MAX_VALUE) {
+        if (sizeInBytes == Long.MIN_VALUE) {
             // 4 for datawaveType reference
             sizeInBytes = ObjectSizeOf.Sizer.getObjectSize(datawaveType) + super.sizeInBytes(4);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/DocumentTest.java
@@ -84,42 +84,42 @@ public class DocumentTest {
     public void testDocumentWithLcType() {
         Attribute<?> attr = createAttribute("LC", "value");
         d.put("LC", attr);
-        roundTrip(MAX_ITERATIONS, 39);
+        roundTrip(MAX_ITERATIONS, 32);
     }
 
     @Test
     public void testDocumentWithLcNoDiacriticsType() {
         Attribute<?> attr = createAttribute("LC_ND", "value");
         d.put("LC_ND", attr);
-        roundTrip(MAX_ITERATIONS, 42);
+        roundTrip(MAX_ITERATIONS, 35);
     }
 
     @Test
     public void testDocumentWithHexType() {
         Attribute<?> attr = createAttribute("HEX", "a1b2c3");
         d.put("HEX", attr);
-        roundTrip(MAX_ITERATIONS, 47);
+        roundTrip(MAX_ITERATIONS, 40);
     }
 
     @Test
     public void testDocumentWithNumberType() {
         Attribute<?> attr = createAttribute("NUM", "12");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 43);
+        roundTrip(MAX_ITERATIONS, 36);
     }
 
     @Test
     public void testDocumentWithNumberTypeNormalizedValue() {
         Attribute<?> attr = createAttribute("NUM", "+bE1.2");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 43);
+        roundTrip(MAX_ITERATIONS, 36);
     }
 
     @Test
     public void testDocumentWithNumberTypeLargeValue() {
         Attribute<?> attr = createAttribute("NUM", "12456789.987654321");
         d.put("NUM", attr);
-        roundTrip(MAX_ITERATIONS, 74);
+        roundTrip(MAX_ITERATIONS, 67);
     }
 
     @Test


### PR DESCRIPTION
After working on https://github.com/NationalSecurityAgency/datawave/pull/2569, I found that sizeInBytes seemed to always be reported as a value close to Long.MIN_VALUE. This was due to TypeAttribute.sizeInBytes() checking against Long.MAX_VALUE instead of Long.MIN_VALUE.

For more context, see #2986

An example of the issue when testing #2569:
<img width="578" height="126" alt="docSize" src="https://github.com/user-attachments/assets/6e2c019e-e840-4b17-afa6-1a779134b5cf" />
