### PR TITLE
Prevent Docker Quickstart from using incorrect MAVEN_HOME path

### DIFF
--- a/contrib/datawave-quickstart/docker/Dockerfile
+++ b/contrib/datawave-quickstart/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM maven:3-amazoncorretto-11 AS builder
 FROM rockylinux/rockylinux:8
 
 ENV MAVEN_HOME=/usr/share/maven
-COPY --from=builder ${MAVEN_HOME} ${MAVEN_HOME}
-RUN ln -s ${MAVEN_HOME}/bin/mvn /usr/bin/mvn
+COPY --from=builder /usr/share/maven /usr/share/maven
+RUN ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
 ARG DATAWAVE_COMMIT_ID
 ARG DATAWAVE_BRANCH_NAME


### PR DESCRIPTION
The MAVEN_HOME ENV variable set in the Dockerfile is not used in the COPY / ADD lines. Instead, the host's MAVEN_HOME path is used and will lead to a "file not found" error if it is anything other than `/usr/share/maven`.

This resolves this issue by hardcoding the paths instead.

Fixes #3064 