### PR TITLE
Document avoid collection copies

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -238,7 +238,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         if (!(o instanceof Attribute)) {
             return false;
         }
-        Attribute other = (Attribute) o;
+        Attribute<?> other = (Attribute<?>) o;
         EqualsBuilder equals = new EqualsBuilder().append(this.isMetadataSet(), other.isMetadataSet());
         if (this.isMetadataSet()) {
             equals.append(this.getMetadata(), other.getMetadata());

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/AttributeBag.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/AttributeBag.java
@@ -48,6 +48,8 @@ public abstract class AttributeBag<T extends Comparable<T>> extends Attribute<T>
 
     public abstract Collection<Attribute<? extends Comparable<?>>> getAttributes();
 
+    protected abstract Collection<Attribute<? extends Comparable<?>>> getRawAttributes();
+
     @Override
     public long getTimestamp() {
         // calling isMetadataSet first to update the metadata as needed
@@ -67,7 +69,7 @@ public abstract class AttributeBag<T extends Comparable<T>> extends Attribute<T>
         long ts = updateTimestamps();
         ColumnVisibility vis = super.getColumnVisibility();
         try {
-            vis = this.combineAndSetColumnVisibilities(getAttributes());
+            vis = this.combineAndSetColumnVisibilities(getRawAttributes());
         } catch (Exception e) {
             log.error("got error combining visibilities", e);
         }
@@ -85,7 +87,7 @@ public abstract class AttributeBag<T extends Comparable<T>> extends Attribute<T>
 
     private long updateTimestamps() {
         MutableLong ts = new MutableLong(Long.MAX_VALUE);
-        for (Attribute<?> attribute : getAttributes()) {
+        for (Attribute<?> attribute : getRawAttributes()) {
             mergeTimestamps(attribute, ts);
         }
         return ts.longValue();
@@ -95,7 +97,7 @@ public abstract class AttributeBag<T extends Comparable<T>> extends Attribute<T>
         // if this is a set of attributes, then examine each one. Note not recursing on a Document as it should have already applied the shard time.
         if (other instanceof AttributeBag) {
             // recurse on the sub attributes
-            for (Attribute<?> attribute : ((AttributeBag<?>) other).getAttributes()) {
+            for (Attribute<?> attribute : ((AttributeBag<?>) other).getRawAttributes()) {
                 mergeTimestamps(attribute, ts);
             }
         } else if (other.isMetadataSet()) {

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
@@ -75,6 +75,16 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
         return Collections.unmodifiableSet(this.attributes);
     }
 
+    /**
+     * Access the raw values similar to {@link #getAttributes()} but without a collection copy
+     *
+     * @return the raw values
+     */
+    @Override
+    public Collection<Attribute<? extends Comparable<?>>> getRawAttributes() {
+        return attributes;
+    }
+
     private Set<Attribute<? extends Comparable<?>>> _getAttributes() {
         return this.attributes;
     }
@@ -224,7 +234,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
     @Override
     public int hashCode() {
         HashCodeBuilder hcb = new HashCodeBuilder(131, 127);
-        for (Attribute<?> a : getAttributes()) {
+        for (Attribute<?> a : _getAttributes()) {
             hcb.append(a);
         }
         return hcb.toHashCode();
@@ -233,7 +243,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
     @Override
     public Collection<ValueTuple> visit(Collection<String> fieldNames, DatawaveJexlContext context) {
         Set<ValueTuple> children = new FunctionalSet<>();
-        for (Attribute<?> attr : getAttributes()) {
+        for (Attribute<?> attr : _getAttributes()) {
             children.addAll(attr.visit(fieldNames, context));
         }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -69,9 +69,6 @@ public class Document extends AttributeBag<Document> implements Serializable {
 
     private int _count = 0;
     long _bytes = 0;
-    private static final long ONE_HUNDRED_M = 1024L * 1000 * 100;
-    private static final long ONE_M = 1024L * 1000;
-    private static final long FIVE_HUNDRED_K = 1024L * 500;
     TreeMap<String,Attribute<? extends Comparable<?>>> dict;
 
     /**
@@ -133,6 +130,16 @@ public class Document extends AttributeBag<Document> implements Serializable {
     @Override
     public Collection<Attribute<? extends Comparable<?>>> getAttributes() {
         return Collections.unmodifiableCollection(this.dict.values());
+    }
+
+    /**
+     * Access the raw values similar to {@link #getAttributes()} but without a collection copy
+     *
+     * @return the raw values
+     */
+    @Override
+    protected Collection<Attribute<? extends Comparable<?>>> getRawAttributes() {
+        return this.dict.values();
     }
 
     public Map<String,Attribute<? extends Comparable<?>>> getDictionary() {

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -160,6 +160,12 @@ public abstract class SizesTest extends AbstractQueryTest {
     }
 
     @Test
+    public void testAllSizesAndGroupByColorShapeSize() throws Exception {
+        withQuery("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large') && f:groupby(COLOR,SHAPE,SIZE)");
+        planAndExecuteQuery();
+    }
+
+    @Test
     public void testSizeMedium() throws Exception {
         withQuery("SIZE == 'medium'");
         planAndExecuteQuery();


### PR DESCRIPTION
There are several Document methods that are copying the underlying collection of attributes. Stop doing that.