### PR TITLE
Filter Button to Retrieve Prior 'X' Amount of Days

### DIFF
--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -129,6 +129,8 @@ export function setVisibility(rows: readonly any[], priorDays?: any) {
       row['duplicate'] = 1;
       row['button'] = true;
       row['dataTypeCount'] = countValues.get(row.internalFieldName) + ' types';
+
+      buttonValues.set(row.internalFieldName, -1); // This ensures only one button per internalFieldName (no duplicate buttons)
     }
     // Checks to Render Collapsible Row - Refreshes on Search
     else if (

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -91,6 +91,7 @@ export function toggleVisibility(row: any) {
 
 // Set the Visibility in DOM, sorts and filters by lastUpdated, and the respective row to render button.
 export function setVisibility(rows: readonly any[], priorDays?: number) {
+  //console.log(rows);
   const fieldVisibility: Map<string, Ref<boolean>> = new Map<
     string,
     Ref<boolean>

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -90,8 +90,7 @@ export function toggleVisibility(row: any) {
 }
 
 // Set the Visibility in DOM, sorts and filters by lastUpdated, and the respective row to render button.
-export function setVisibility(rows: readonly any[], priorDays?: number) {
-  //console.log(rows);
+export function setVisibility(rows: readonly any[], priorDays?: any) {
   const fieldVisibility: Map<string, Ref<boolean>> = new Map<
     string,
     Ref<boolean>
@@ -104,7 +103,10 @@ export function setVisibility(rows: readonly any[], priorDays?: number) {
     const currentRowInternalFieldName: any = row.internalFieldName;
     const currentRowDataType: any = row.dataType;
 
-    if (currentRowDataType) {
+    const meetsDateFilter = priorDays === undefined || row.lastUpdated >= getDateCode(priorDays);
+    row['priorDays'] = meetsDateFilter;
+
+    if (currentRowDataType && meetsDateFilter) {
       let currentValue = countValues.get(currentRowInternalFieldName) || 0;
       countValues.set(currentRowInternalFieldName, ++currentValue);
     }
@@ -121,18 +123,17 @@ export function setVisibility(rows: readonly any[], priorDays?: number) {
   for (const row of rows) {
     // Checks to Render button
     if (
-      buttonValues.has(row.internalFieldName) &&
-      row.lastUpdated == buttonValues.get(row.internalFieldName)
+      (buttonValues.has(row.internalFieldName) &&
+      row.lastUpdated == buttonValues.get(row.internalFieldName)) && (countValues.get(row.internalFieldName)! > 1)
     ) {
       row['duplicate'] = 1;
       row['button'] = true;
-
       row['dataTypeCount'] = countValues.get(row.internalFieldName) + ' types';
     }
     // Checks to Render Collapsible Row - Refreshes on Search
     else if (
-      buttonValues.has(row.internalFieldName) &&
-      row.lastUpdated != buttonValues.get(row.internalFieldName)
+      (buttonValues.has(row.internalFieldName) &&
+      row.lastUpdated != buttonValues.get(row.internalFieldName))
     ) {
       row['duplicate'] = 1;
       row['button'] = false;
@@ -153,18 +154,11 @@ export function setVisibility(rows: readonly any[], priorDays?: number) {
     }
 
     const visibility = fieldVisibility.get(internalFieldName);
-    let priorDaysFilter = true;
-
-    if (priorDays !== undefined && priorDays >= 0) {
-      const priorDateCode = getDateCode(priorDays);
-      priorDaysFilter = Number(row.lastUpdated) >= Number(priorDateCode);
-    }
 
     row['toggleVisibility'] = () => {
       visibility!.value = !visibility?.value;
     };
     row['isVisible'] = visibility;
-    row['priorDays'] = priorDaysFilter;
   }
 
   return rows;
@@ -172,10 +166,14 @@ export function setVisibility(rows: readonly any[], priorDays?: number) {
 
 // Lets the DOM know what is visible and what is not based on setVisibility filters.
 export function isVisible(row: any) {
-  return (row.duplicate == 0 || row.isVisible.value) && row.priorDays;
+ return (row.duplicate == 0 || row.isVisible.value) && row.priorDays;
 }
 
-export function getDateCode(daysPrior = 0): number {
+export function getDateCode(daysPrior = Infinity): number {
+  if (!isFinite(daysPrior)) {
+    return 0; // return earliest possible dateCode (match all)
+  }
+
   const date = new Date();
   date.setDate(date.getDate() - daysPrior);
   const y = date.getFullYear();

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -80,8 +80,8 @@ export function maxSubstring(str: any, colName: any): any {
 }
 
 // Defines how the expandability is parsed on the table.
-export function buttonParse(col: any, row: any): boolean {
-  return row.button == 1;
+export function buttonParse(row: any): boolean {
+  return row.button && row.priorDays;
 }
 
 // Toggles how the row collapses based on the DOM. Filters visible rows.
@@ -90,7 +90,7 @@ export function toggleVisibility(row: any) {
 }
 
 // Set the Visibility in DOM, sorts and filters by lastUpdated, and the respective row to render button.
-export function setVisibility(rows: readonly any[]) {
+export function setVisibility(rows: readonly any[], priorDays?: number) {
   const fieldVisibility: Map<string, Ref<boolean>> = new Map<
     string,
     Ref<boolean>
@@ -152,11 +152,18 @@ export function setVisibility(rows: readonly any[]) {
     }
 
     const visibility = fieldVisibility.get(internalFieldName);
+    let priorDaysFilter = true;
+
+    if (priorDays !== undefined && priorDays >= 0) {
+      const priorDateCode = getDateCode(priorDays);
+      priorDaysFilter = Number(row.lastUpdated) >= Number(priorDateCode);
+    }
 
     row['toggleVisibility'] = () => {
       visibility!.value = !visibility?.value;
     };
     row['isVisible'] = visibility;
+    row['priorDays'] = priorDaysFilter;
   }
 
   return rows;
@@ -164,7 +171,16 @@ export function setVisibility(rows: readonly any[]) {
 
 // Lets the DOM know what is visible and what is not based on setVisibility filters.
 export function isVisible(row: any) {
-  return row.duplicate == 0 || row.isVisible.value;
+  return (row.duplicate == 0 || row.isVisible.value) && row.priorDays;
+}
+
+export function getDateCode(daysPrior = 0): number {
+  const date = new Date();
+  date.setDate(date.getDate() - daysPrior);
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return Number(`${y}${m}${d}000000`);
 }
 
 // Filters the URL Search Bar to handle Edge Cases and only queries 1 item.

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -134,8 +134,8 @@ export function setVisibility(rows: readonly any[], priorDays?: any) {
     }
     // Checks to Render Collapsible Row - Refreshes on Search
     else if (
-      (buttonValues.has(row.internalFieldName) &&
-      row.lastUpdated != buttonValues.get(row.internalFieldName))
+      buttonValues.has(row.internalFieldName) &&
+      row.lastUpdated != buttonValues.get(row.internalFieldName)
     ) {
       row['duplicate'] = 1;
       row['button'] = false;

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -69,6 +69,63 @@
           />
         </template>
         <template v-slot:top-right>
+          <div>
+            <q-btn
+              size="10px"
+              color="cyan-8"
+              icon="bi-funnel-fill"
+              style="margin-right: 10px; padding: 2px;"
+              dense
+              ref="buttonRef"
+            >
+              <q-menu
+                anchor="bottom right"
+                self="top right"
+                :offset="[0, 5]"
+              >
+                <q-card style="max-width: 205px; padding: 5px; box-shadow: 0 0 12px rgba(0, 188, 212, 0.6);" class="q-pa-sm">
+                  <q-card-section class="text-center text-subtitle1" style="font-weight: 550;">
+                    FILTER DAYS
+                  </q-card-section>
+                  <q-separator />
+                  <q-card-section class="q-gutter-sm">
+                    <div class="row items-center q-col-gutter-sm">
+                      <q-input
+                        dense
+                        color="cyan-8"
+                        v-model="search"
+                        placeholder="30"
+                        @keyup.enter="applyFilter"
+                        style="width: 50px; margin-left: 15px;"
+                        input-class="text-center"
+                      />
+                      <q-item-label style="font-weight: 450;"> DAY(S) PRIOR</q-item-label>
+                    </div>
+                  </q-card-section>
+                  <q-separator />
+                  <q-card-section class="q-pt-none">
+                    <div class="row items-center q-gutter-sm" style="margin-top: 15px;">
+                      <q-btn
+                        dense
+                        style="padding: 5px;"
+                        size="12px"
+                        label="Apply"
+                        color="cyan-8"
+                        @click="applyFilter"
+                      />
+                      <q-btn
+                        dense
+                        style="padding: 5px;"
+                        size="12px"
+                        label="Show All Rows"
+                        color="cyan-8"
+                      />
+                    </div>
+                  </q-card-section>
+                </q-card>
+              </q-menu>
+            </q-btn>
+          </div>
           <q-input
             borderless
             dense
@@ -83,7 +140,6 @@
                 size="12px"
                 color="cyan-8"
                 icon="search"
-                round
                 dense
                 @click="queryTable"
               />
@@ -206,6 +262,7 @@ const router = useRouter();
 const changeFilter = ref<string>('');
 const banner = ref<Banner>();
 const system = ref<System>();
+const search = ref('');
 let rows: QTableProps['rows'] = [];
 const paginationFront = ref({
   rowsPerPage: 200,
@@ -262,6 +319,7 @@ onMounted(() => {
       }
     });
     rows = Formatters.setVisibility(rows);
+    // new formatter here
     loading.value = false;
   })
   .catch((reason) => {
@@ -276,28 +334,11 @@ onMounted(() => {
   }
 });
 
-// This watch() handles a URL Change from a previous query.
-// Logic: Input + Table (reactive URL -> UI + Filters)
-watch(
-  () => route.query.search,
-  (searchVal) => {
-    // Converts the input into a valid string to be queried.
-    let searchValNew = Formatters.filterSearch(searchVal, '');
-
-    if (searchValNew !== changeFilter.value) {
-      changeFilter.value = searchValNew;
-      if (searchValNew) {
-        // Triggers a re-query if the user has changed to a new value.
-        queryTable();
-      } else {
-        // This retriggers back to the original state if user clears.
-        filter.value = '';
-        const originalRows = rows;
-        rows = Formatters.setVisibility(originalRows);
-      }
-    }
+function applyFilter(): void {
+  if (Number.isInteger(+search.value) && +search.value >= 0) {
+    console.log('Applied filter:', search.value)
   }
-);
+}
 
 // Export - Attempts to Wrap the CSV and Download.
 function exportTable(this: any) {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -69,64 +69,6 @@
           />
         </template>
         <template v-slot:top-right>
-          <div>
-            <q-btn
-              size="10px"
-              color="cyan-8"
-              icon="bi-funnel-fill"
-              style="margin-right: 10px; padding: 2px;"
-              dense
-              ref="buttonRef"
-            >
-              <q-menu
-                anchor="bottom right"
-                self="top right"
-                :offset="[0, 5]"
-              >
-                <q-card style="max-width: 205px; padding: 5px; box-shadow: 0 0 12px rgba(0, 188, 212, 0.6);" class="q-pa-sm">
-                  <q-card-section class="text-center text-subtitle1" style="font-weight: 550;">
-                    FILTER DAYS
-                  </q-card-section>
-                  <q-separator />
-                  <q-card-section class="q-gutter-sm">
-                    <div class="row items-center q-col-gutter-sm">
-                      <q-input
-                        dense
-                        color="cyan-8"
-                        v-model="search"
-                        placeholder="30"
-                        @keyup.enter="queryTable(search)"
-                        style="width: 50px; margin-left: 15px;"
-                        input-class="text-center"
-                      />
-                      <q-item-label style="font-weight: 450;"> DAY(S) PRIOR</q-item-label>
-                    </div>
-                  </q-card-section>
-                  <q-separator />
-                  <q-card-section class="q-pt-none">
-                    <div class="row items-center q-gutter-sm" style="margin-top: 15px;">
-                      <q-btn
-                        dense
-                        style="padding: 5px;"
-                        size="12px"
-                        label="Apply"
-                        color="cyan-8"
-                        @click="queryTable(search)"
-                      />
-                      <q-btn
-                        dense
-                        style="padding: 5px;"
-                        size="12px"
-                        label="Show All Rows"
-                        color="cyan-8"
-                        @click="queryTable()"
-                      />
-                    </div>
-                  </q-card-section>
-                </q-card>
-              </q-menu>
-            </q-btn>
-          </div>
           <q-input
             borderless
             dense
@@ -147,12 +89,86 @@
         <template v-slot:header="props">
           <q-tr :props="props">
             <q-th />
-            <q-th v-for="col in props.cols" :key="col.name" :props="props">
-              <div class="tooltip-wrapper">
-                {{ col.label }}
-                <q-tooltip class="tooltip-text" anchor="bottom middle" self="top middle" :offset="[0, 5]">
-                  {{ Feature.toolTipGen(col.name) }}
-                </q-tooltip>
+            <q-th
+              v-for="col in props.cols"
+              :key="col.name"
+              :props="props"
+            >
+              <div class="tooltip-wrapper row items-center no-wrap">
+                <span class="q-mr-xs">
+                  <span class="cursor-pointer">
+                    {{ col.label }}
+                    <q-tooltip
+                      class="tooltip-text"
+                      anchor="bottom middle"
+                      self="top middle"
+                      :offset="[0, 5]"
+                    >
+                      {{ Feature.toolTipGen(col.name) }}
+                    </q-tooltip>
+                  </span>
+                </span>
+                <template v-if="col.name === 'lastUpdated'">
+                  <q-btn
+                    size="7px"
+                    color="cyan-8"
+                    icon="bi-funnel-fill"
+                    style="padding: 2.5px; margin-bottom: 1.5px;"
+                    dense
+                    ref="buttonRef"
+                  >
+                    <q-menu
+                      anchor="bottom right"
+                      self="top right"
+                      :offset="[0, 5]"
+                    >
+                      <q-card
+                        style="max-width: 205px; padding: 5px; box-shadow: 0 0 12px rgba(0, 188, 212, 0.6);"
+                        class="q-pa-sm"
+                      >
+                        <q-card-section class="text-center text-subtitle1" style="font-weight: 550;">
+                          FILTER DAYS
+                        </q-card-section>
+                        <q-separator />
+                        <q-card-section class="q-gutter-sm">
+                          <div class="row items-center q-col-gutter-sm">
+                            <q-input
+                              dense
+                              color="cyan-8"
+                              v-model="search"
+                              placeholder="30"
+                              @keyup.enter="queryTable(search)"
+                              style="width: 50px; margin-left: 15px;"
+                              input-class="text-center"
+                            />
+                            <q-item-label style="font-weight: 450;"> DAY(S) PRIOR</q-item-label>
+                          </div>
+                        </q-card-section>
+                        <q-separator />
+                        <q-card-section class="q-pt-none">
+                          <div class="row items-center q-gutter-sm" style="margin-top: 15px;">
+                            <q-btn
+                              dense
+                              style="padding: 5px;"
+                              size="12px"
+                              label="Apply"
+                              color="cyan-8"
+                              @click="queryTable(search)"
+                            />
+                            <q-btn
+                              dense
+                              style="padding: 5px;"
+                              size="12px"
+                              label="Clear Filter"
+                              color="cyan-8"
+                              @click="queryTable()"
+                            />
+                          </div>
+                        </q-card-section>
+                      </q-card>
+                    </q-menu>
+                  </q-btn>
+                </template>
               </div>
             </q-th>
           </q-tr>
@@ -318,7 +334,7 @@ onMounted(() => {
         return b.lastUpdated - a.lastUpdated;
       }
     });
-    rows = Formatters.setVisibility(rows);
+    rows = Formatters.setVisibility(rows, 30); // defualt at 30 days
     loading.value = false;
   })
   .catch((reason) => {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -334,7 +334,10 @@ onMounted(() => {
         return b.lastUpdated - a.lastUpdated;
       }
     });
-    rows = Formatters.setVisibility(rows, 30); // default at 30 days
+    rows = changeFilter.value
+      ? Formatters.setVisibility(rows) // if searched through URL bar, it removes 30 day filter.
+      : Formatters.setVisibility(rows, 30); // default at 30 days when loaded without '?search=<val>' query.
+
     loading.value = false;
   })
   .catch((reason) => {
@@ -348,6 +351,28 @@ onMounted(() => {
     queryTable();
   }
 });
+
+// This watch() handles a URL Change from a previous query.
+// Logic: Input + Table (reactive URL -> UI + Filters)
+watch(
+  () => route.query.search,
+  (searchVal) => {
+    // Converts the input into a valid string to be queried.
+    let searchValNew = Formatters.filterSearch(searchVal, '');
+    if (searchValNew !== changeFilter.value) {
+      changeFilter.value = searchValNew;
+      if (searchValNew) {
+        // Triggers a re-query if the user has changed to a new value.
+        queryTable();
+      } else {
+        // This retriggers back to the original state if user clears.
+        filter.value = '';
+        const originalRows = rows;
+        rows = Formatters.setVisibility(originalRows);
+      }
+    }
+  }
+);
 
 // Export - Attempts to Wrap the CSV and Download.
 function exportTable(this: any) {
@@ -385,6 +410,17 @@ function exportTable(this: any) {
 // Query - Runs through a Search Process as it waits for the user.
 async function queryTable(priorDays?: any) {
   await waitUp();
+
+  // Handles the URL change to reflect when the user searches.
+  // Logic: Input -> URL (UI -> URL)
+  const daysToUse = priorDays ?? (Number(search.value) || Infinity);
+  router.replace({
+    query: {
+      ...route.query,
+      search: changeFilter.value || undefined,
+    },
+  });
+
   // 1 - Filter the Rows
   const rowsToExport = table.value?.filteredSortedRows.filter(() => true);
 

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -119,6 +119,7 @@
                         size="12px"
                         label="Show All Rows"
                         color="cyan-8"
+                        @click="queryTable()"
                       />
                     </div>
                   </q-card-section>
@@ -318,7 +319,6 @@ onMounted(() => {
       }
     });
     rows = Formatters.setVisibility(rows);
-    // new formatter here
     loading.value = false;
   })
   .catch((reason) => {
@@ -368,40 +368,22 @@ function exportTable(this: any) {
 
 // Query - Runs through a Search Process as it waits for the user.
 async function queryTable(priorDays?: any) {
-  // Wait Until User Enters...
   await waitUp();
-
-  // Handles the URL change to reflect when the user searches.
-  // Logic: Input -> URL (UI -> URL)
-  router.replace({
-    query: {
-      ...route.query,
-      search: changeFilter.value || undefined,
-    },
-  });
-
   // 1 - Filter the Rows
   const rowsToExport = table.value?.filteredSortedRows.filter(() => true);
-  const filteredSubset = rowsToExport.filter((row: { lastUpdated: any; }) => {
-    if (priorDays === undefined || priorDays < 0) return true;
-    const priorDateCode = Formatters.getDateCode(priorDays);
-    return Number(row.lastUpdated) >= priorDateCode;
-  });
 
   // 2 - Define Refresh Trigger (By Pagination) and Orginial Rows Stored
   const originalRows = rows;
   const triggerRefresh = paginationFront.value.rowsPerPage;
 
-  console.log('before', rows);
-  // 3 - Set the Current Rows to Filtered Value
-  rows = Formatters.setVisibility(filteredSubset, priorDays);
-  console.log('after', rows)
+  // 3 - Set filtered rows with visibility flags updated
+  rows = Formatters.setVisibility(rowsToExport, priorDays);
 
-  // 4 - Trigger the Refresh
+  // 4 - Refresh pagination to trigger table update
   paginationFront.value.rowsPerPage = 100;
   paginationFront.value.rowsPerPage = triggerRefresh;
 
-  // 5 - Restore Original Rows for Next Query
+  // 5 - Restore original rows for next queries
   rows = originalRows;
 }
 

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -95,7 +95,7 @@
                         color="cyan-8"
                         v-model="search"
                         placeholder="30"
-                        @keyup.enter="applyFilter"
+                        @keyup.enter="queryTable(search)"
                         style="width: 50px; margin-left: 15px;"
                         input-class="text-center"
                       />
@@ -111,7 +111,7 @@
                         size="12px"
                         label="Apply"
                         color="cyan-8"
-                        @click="applyFilter"
+                        @click="queryTable(search)"
                       />
                       <q-btn
                         dense
@@ -160,7 +160,7 @@
         <template v-slot:body="props">
           <q-tr
             :props="props"
-            v-if="Formatters.buttonParse(props.cols, props.row)"
+            v-if="Formatters.buttonParse(props.row)"
           >
             <q-td class="cell-spacing">
               <q-btn
@@ -334,12 +334,6 @@ onMounted(() => {
   }
 });
 
-function applyFilter(): void {
-  if (Number.isInteger(+search.value) && +search.value >= 0) {
-    console.log('Applied filter:', search.value)
-  }
-}
-
 // Export - Attempts to Wrap the CSV and Download.
 function exportTable(this: any) {
   const rowsToExport = table.value?.filteredSortedRows.filter(
@@ -374,7 +368,7 @@ function exportTable(this: any) {
 }
 
 // Query - Runs through a Search Process as it waits for the user.
-async function queryTable(this: any) {
+async function queryTable(priorDays?: any) {
   // Wait Until User Enters...
   await waitUp();
 
@@ -395,7 +389,8 @@ async function queryTable(this: any) {
   const triggerRefresh = paginationFront.value.rowsPerPage;
 
   // 3 - Set the Current Rows to Filtered Value
-  rows = Formatters.setVisibility(rowsToExport);
+  rows = Formatters.setVisibility(rowsToExport, priorDays);
+  console.log(rows)
 
   // 4 - Trigger the Refresh
   paginationFront.value.rowsPerPage = 100;

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -129,7 +129,6 @@
           <q-input
             borderless
             dense
-            debounce="300"
             v-model="changeFilter"
             placeholder="Search"
             @keydown.enter.prevent="queryTable"
@@ -383,14 +382,20 @@ async function queryTable(priorDays?: any) {
 
   // 1 - Filter the Rows
   const rowsToExport = table.value?.filteredSortedRows.filter(() => true);
+  const filteredSubset = rowsToExport.filter((row: { lastUpdated: any; }) => {
+    if (priorDays === undefined || priorDays < 0) return true;
+    const priorDateCode = Formatters.getDateCode(priorDays);
+    return Number(row.lastUpdated) >= priorDateCode;
+  });
 
   // 2 - Define Refresh Trigger (By Pagination) and Orginial Rows Stored
   const originalRows = rows;
   const triggerRefresh = paginationFront.value.rowsPerPage;
 
+  console.log('before', rows);
   // 3 - Set the Current Rows to Filtered Value
-  rows = Formatters.setVisibility(rowsToExport, priorDays);
-  console.log(rows)
+  rows = Formatters.setVisibility(filteredSubset, priorDays);
+  console.log('after', rows)
 
   // 4 - Trigger the Refresh
   paginationFront.value.rowsPerPage = 100;

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -334,7 +334,7 @@ onMounted(() => {
         return b.lastUpdated - a.lastUpdated;
       }
     });
-    rows = Formatters.setVisibility(rows, 30); // defualt at 30 days
+    rows = Formatters.setVisibility(rows, 30); // default at 30 days
     loading.value = false;
   })
   .catch((reason) => {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -359,6 +359,7 @@ watch(
   (searchVal) => {
     // Converts the input into a valid string to be queried.
     let searchValNew = Formatters.filterSearch(searchVal, '');
+
     if (searchValNew !== changeFilter.value) {
       changeFilter.value = searchValNew;
       if (searchValNew) {
@@ -413,7 +414,6 @@ async function queryTable(priorDays?: any) {
 
   // Handles the URL change to reflect when the user searches.
   // Logic: Input -> URL (UI -> URL)
-  const daysToUse = priorDays ?? (Number(search.value) || Infinity);
   router.replace({
     query: {
       ...route.query,


### PR DESCRIPTION
This PR does the following:
1. Creates a filter icon near the search bar
2. Can filter 'X' days prior based on a full search _(by the search bar)_ by input and 'apply' button.
3. Can reset and show all rows by clicking the 'show all rows' button by showing all rows.
4. On loading, it will default to only 30 days prior.
5. _NEW 8/13/25:_ Fixed the Button Parse Bug (duplicate buttons appearing on same sections of data).

_Note: ~~Right now this has not been integration tested~~. ~~Probably needs a rebase as well.~~_