### PR TITLE
Range and regex filter iterators should only seek the underlying sour…

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/RangeFilterIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/RangeFilterIterator.java
@@ -67,7 +67,7 @@ public class RangeFilterIterator implements NestedIterator<Key>, Comparable<Inde
 
     @Override
     public void seek(Range range, Collection<ByteSequence> collection, boolean b) throws IOException {
-        source.seek(range, collection, b);
+        // no-op
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/RegexFilterIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/RegexFilterIterator.java
@@ -68,7 +68,7 @@ public class RegexFilterIterator implements NestedIterator<Key>, Comparable<Inde
 
     @Override
     public void seek(Range range, Collection<ByteSequence> collection, boolean b) throws IOException {
-        source.seek(range, collection, b);
+        // no-op
     }
 
     @Override


### PR DESCRIPTION
…ce when a move() is called