### PR TITLE
Remove unfielded numeric regex normalization

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -332,6 +332,7 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
             if (fieldName.equals(Constants.ANY_FIELD)) {
                 try {
                     dataTypes.addAll(helper.getAllDatatypes());
+                    dataTypes.remove(new datawave.data.type.NumberType());
                 } catch (InstantiationException | IllegalAccessException | TableNotFoundException e) {
                     log.error("Could not fetch all DataTypes while expanding unfielded term");
                     throw new RuntimeException(e);

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -6,6 +6,7 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -439,14 +440,14 @@ public abstract class ExecutableExpansionVisitorTest {
             log.debug("testAnyfieldNumericExpansion");
         }
         String[] queryStrings = {"_ANYFIELD_ =~'12340.*?'"};
-        @SuppressWarnings("unchecked")
-        // SOPRANO is the only one with a 0 after the 1234
-        List<String>[] expectedLists = new List[] {Arrays.asList("SOPRANO")};
+        // ANYFIELD numeric regex normalization is no longer used, so expect no results for this query
+        List<String> expectedLists = new ArrayList<>();
         for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
+            runTestQuery(expectedLists, queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
 
-        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Eval_ = true) && (_ANYFIELD_ =~ '12340.*?'))";
+        // No longer expect normalized numeric regexes for ANYFIELD
+        String expectedQueryStr = "_NOFIELD_ =~ '12340.*?'";
         String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
         Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
                         TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -708,42 +708,42 @@ public class ExpandMultiNormalizedTermsTest {
         // EQ
         expandTerms("_ANYFIELD_ == 'anywhere'", "_ANYFIELD_ == 'anywhere'");
         expandTerms("_ANYFIELD_ == 'oHIo'", "_ANYFIELD_ == 'ohio' || _ANYFIELD_ == 'oHIo'");
-        expandTerms("_ANYFIELD_ == '123'", "_ANYFIELD_ == '+cE1.23' || _ANYFIELD_ == '123'");
+        expandTerms("_ANYFIELD_ == '123'", "_ANYFIELD_ == '123'");
 
         // NE
         expandTerms("_ANYFIELD_ != 'anywhere'", "_ANYFIELD_ != 'anywhere'");
         expandTerms("_ANYFIELD_ != 'oHIo'", "_ANYFIELD_ != 'ohio' && _ANYFIELD_ != 'oHIo'");
-        expandTerms("_ANYFIELD_ != '123'", "_ANYFIELD_ != '+cE1.23' && _ANYFIELD_ != '123'");
+        expandTerms("_ANYFIELD_ != '123'", "_ANYFIELD_ != '123'");
 
         // ER
         expandTerms("_ANYFIELD_ =~ 'anywhere'", "_ANYFIELD_ =~ 'anywhere'");
         expandTerms("_ANYFIELD_ =~ 'oHIo'", "_ANYFIELD_ =~ 'ohio' || _ANYFIELD_ =~ 'oHIo'");
-        expandTerms("_ANYFIELD_ =~ '123'", "_ANYFIELD_ =~ '\\+cE1\\.23' || _ANYFIELD_ =~ '123'");
+        expandTerms("_ANYFIELD_ =~ '123'", "_ANYFIELD_ =~ '123'");
 
         // NR
         expandTerms("_ANYFIELD_ !~ 'anywhere'", "_ANYFIELD_ !~ 'anywhere'");
         expandTerms("_ANYFIELD_ !~ 'oHIo'", "_ANYFIELD_ !~ 'ohio' && _ANYFIELD_ !~ 'oHIo'");
-        expandTerms("_ANYFIELD_ !~ '123'", "_ANYFIELD_ !~ '\\+cE1\\.23' && _ANYFIELD_ !~ '123'");
+        expandTerms("_ANYFIELD_ !~ '123'", "_ANYFIELD_ !~ '123'");
 
         // LT
         expandTerms("_ANYFIELD_ < 'anywhere'", "_ANYFIELD_ < 'anywhere'");
         expandTerms("_ANYFIELD_ < 'oHIo'", "_ANYFIELD_ < 'ohio' || _ANYFIELD_ < 'oHIo'");
-        expandTerms("_ANYFIELD_ < '123'", "_ANYFIELD_ < '+cE1.23' || _ANYFIELD_ < '123'");
+        expandTerms("_ANYFIELD_ < '123'", "_ANYFIELD_ < '123'");
 
         // LE
         expandTerms("_ANYFIELD_ <= 'anywhere'", "_ANYFIELD_ <= 'anywhere'");
         expandTerms("_ANYFIELD_ <= 'oHIo'", "_ANYFIELD_ <= 'ohio' || _ANYFIELD_ <= 'oHIo'");
-        expandTerms("_ANYFIELD_ <= '123'", "_ANYFIELD_ <= '+cE1.23' || _ANYFIELD_ <= '123'");
+        expandTerms("_ANYFIELD_ <= '123'", "_ANYFIELD_ <= '123'");
 
         // GT
         expandTerms("_ANYFIELD_ > 'anywhere'", "_ANYFIELD_ > 'anywhere'");
         expandTerms("_ANYFIELD_ > 'oHIo'", "_ANYFIELD_ > 'ohio' || _ANYFIELD_ > 'oHIo'");
-        expandTerms("_ANYFIELD_ > '123'", "_ANYFIELD_ > '+cE1.23' || _ANYFIELD_ > '123'");
+        expandTerms("_ANYFIELD_ > '123'", "_ANYFIELD_ > '123'");
 
         // GE
         expandTerms("_ANYFIELD_ >= 'anywhere'", "_ANYFIELD_ >= 'anywhere'");
         expandTerms("_ANYFIELD_ >= 'oHIo'", "_ANYFIELD_ >= 'ohio' || _ANYFIELD_ >= 'oHIo'");
-        expandTerms("_ANYFIELD_ >= '123'", "_ANYFIELD_ >= '+cE1.23' || _ANYFIELD_ >= '123'");
+        expandTerms("_ANYFIELD_ >= '123'", "_ANYFIELD_ >= '123'");
     }
 
     private void expandTerms(String original, String expected) throws ParseException {


### PR DESCRIPTION
Removes use of numeric regex normalizer for unfielded terms. Also updates unit tests to reflect this change.