### PR TITLE
Replace usages of Collections.EMPTY_LIST with Collections.emptyList()

### DIFF
--- a/core/base-rest-responses/src/main/java/datawave/security/authorization/ConditionalRemoteUserOperations.java
+++ b/core/base-rest-responses/src/main/java/datawave/security/authorization/ConditionalRemoteUserOperations.java
@@ -51,7 +51,7 @@ public class ConditionalRemoteUserOperations implements UserOperations {
             return delegate.listEffectiveAuthorizations(callerObject);
         } else {
             AuthorizationsListBase response = authorizationsListBaseSupplier.get();
-            response.setUserAuths(callerObject.getPrimaryUser().getDn().subjectDN(), callerObject.getPrimaryUser().getDn().issuerDN(), Collections.EMPTY_LIST);
+            response.setUserAuths(callerObject.getPrimaryUser().getDn().subjectDN(), callerObject.getPrimaryUser().getDn().issuerDN(), Collections.emptyList());
             return response;
         }
     }

--- a/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/config/QueryMetricHandlerProperties.java
+++ b/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/config/QueryMetricHandlerProperties.java
@@ -119,7 +119,7 @@ public class QueryMetricHandlerProperties {
             "USER",
             "YIELD_COUNT");
 
-    protected List<String> additionalIndexFields = Collections.EMPTY_LIST;
+    protected List<String> additionalIndexFields = Collections.emptyList();
 
     protected List<String> reverseIndexFields = Arrays.asList(
             "ERROR_CODE",
@@ -137,7 +137,7 @@ public class QueryMetricHandlerProperties {
             "QUERY_TYPE",
             "USER");
 
-    protected List<String> additionalReverseIndexFields = Collections.EMPTY_LIST;
+    protected List<String> additionalReverseIndexFields = Collections.emptyList();
 
     protected List<String> numericFields = Arrays.asList(
             "CREATE_CALL_TIME",
@@ -155,7 +155,7 @@ public class QueryMetricHandlerProperties {
             "NUM_UPDATES",
             "YIELD_COUNT");
 
-    protected List<String> additionalNumericFields = Collections.EMPTY_LIST;
+    protected List<String> additionalNumericFields = Collections.emptyList();
     //@formatter:on
 
     public Map<String,String> getProperties() {

--- a/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/handler/ContentQueryMetricsIngestHelper.java
+++ b/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/handler/ContentQueryMetricsIngestHelper.java
@@ -21,7 +21,6 @@ import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.ingest.data.config.ingest.CSVIngestHelper;
 import datawave.ingest.data.config.ingest.TermFrequencyIngestHelperInterface;
-import datawave.microservice.query.QueryImpl;
 import datawave.microservice.querymetric.BaseQueryMetric;
 import datawave.microservice.querymetric.BaseQueryMetric.PageMetric;
 import datawave.microservice.querymetric.BaseQueryMetric.Prediction;
@@ -94,7 +93,7 @@ public class ContentQueryMetricsIngestHelper extends CSVIngestHelper implements 
     }
 
     public static class HelperDelegate<T extends BaseQueryMetric> {
-        private Collection<String> ignoredFields = Collections.EMPTY_LIST;
+        private Collection<String> ignoredFields = Collections.emptyList();
 
         public HelperDelegate() {}
 

--- a/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/handler/ShardTableQueryMetricHandler.java
+++ b/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/handler/ShardTableQueryMetricHandler.java
@@ -219,7 +219,7 @@ public abstract class ShardTableQueryMetricHandler<T extends BaseQueryMetric> ex
             AbstractColumnBasedHandler<Key> handler = new ContentIndexingColumnBasedHandler() {
                 @Override
                 public AbstractContentIngestHelper getContentIndexingDataTypeHelper() {
-                    return getQueryMetricsIngestHelper(false, Collections.EMPTY_LIST);
+                    return getQueryMetricsIngestHelper(false, Collections.emptyList());
                 }
             };
             Map<String,String> trackingMap = AccumuloClientTracking.getTrackingMap(Thread.currentThread().getStackTrace());
@@ -255,7 +255,7 @@ public abstract class ShardTableQueryMetricHandler<T extends BaseQueryMetric> ex
     }
 
     public void writeMetric(T updatedQueryMetric, List<T> storedQueryMetrics, long timestamp, boolean delete) throws Exception {
-        writeMetric(updatedQueryMetric, storedQueryMetrics, timestamp, delete, Collections.EMPTY_LIST);
+        writeMetric(updatedQueryMetric, storedQueryMetrics, timestamp, delete, Collections.emptyList());
     }
 
     public void writeMetadata(T metric) throws Exception {
@@ -341,7 +341,7 @@ public abstract class ShardTableQueryMetricHandler<T extends BaseQueryMetric> ex
     public Map<String,String> getEventFields(BaseQueryMetric queryMetric) {
         // ignore duplicates as none are expected
         Map<String,String> eventFields = new HashMap<>();
-        ContentQueryMetricsIngestHelper ingestHelper = getQueryMetricsIngestHelper(false, Collections.EMPTY_LIST);
+        ContentQueryMetricsIngestHelper ingestHelper = getQueryMetricsIngestHelper(false, Collections.emptyList());
         ingestHelper.setup(conf);
         Multimap<String,NormalizedContentInterface> fieldsToWrite = ingestHelper.getEventFieldsToWrite(queryMetric, null);
         for (Entry<String,NormalizedContentInterface> entry : fieldsToWrite.entries()) {

--- a/microservices/starters/query/src/main/java/datawave/microservice/query/storage/TaskCache.java
+++ b/microservices/starters/query/src/main/java/datawave/microservice/query/storage/TaskCache.java
@@ -108,7 +108,7 @@ public class TaskCache {
     public List<QueryTask> getTasks(String queryId) {
         List<QueryTask> tasks = (List<QueryTask>) cacheInspector.listMatching(CACHE_NAME, QueryTask.class, QueryKey.toUUIDKey(queryId));
         if (tasks == null) {
-            tasks = Collections.EMPTY_LIST;
+            tasks = Collections.emptyList();
         }
         if (log.isDebugEnabled()) {
             log.debug("Retrieved " + tasks.size() + " tasks for queryId " + queryId);
@@ -126,7 +126,7 @@ public class TaskCache {
     public List<QueryTask> getTasks(QueryKey queryKey) {
         List<QueryTask> tasks = (List<QueryTask>) cacheInspector.listMatching(CACHE_NAME, QueryTask.class, queryKey.toKey());
         if (tasks == null) {
-            tasks = Collections.EMPTY_LIST;
+            tasks = Collections.emptyList();
         }
         if (log.isDebugEnabled()) {
             log.debug("Retrieved " + tasks.size() + " tasks for queryId " + queryKey);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/DatawaveFieldIndexCachingIteratorJexl.java
@@ -272,7 +272,7 @@ public abstract class DatawaveFieldIndexCachingIteratorJexl extends WrappingIter
     // We do not want the underlying iterators to filter keys so that we can check the bounds in this iterator as quickly
     // as possible.
     @SuppressWarnings("unchecked")
-    protected static final Collection<ByteSequence> EMPTY_CFS = Collections.EMPTY_LIST;
+    protected static final Collection<ByteSequence> EMPTY_CFS = Collections.emptyList();
 
     // These are the ranges to scan in the field index
     private final List<Range> boundingFiRanges = new ArrayList<>();

--- a/warehouse/query-core/src/main/java/datawave/query/config/RemoteQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/RemoteQueryConfiguration.java
@@ -63,7 +63,7 @@ public class RemoteQueryConfiguration extends GenericQueryConfiguration implemen
 
     @Override
     public RemoteQueryConfiguration checkpoint() {
-        return new RemoteQueryConfiguration(this, Collections.EMPTY_LIST);
+        return new RemoteQueryConfiguration(this, Collections.emptyList());
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -1316,7 +1316,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     @SuppressWarnings("unchecked")
     public void setFilterClassNames(List<String> filterClassNames) {
-        this.filterClassNames = new ArrayList<>((filterClassNames != null ? filterClassNames : Collections.EMPTY_LIST));
+        this.filterClassNames = new ArrayList<>((filterClassNames != null ? filterClassNames : Collections.emptyList()));
     }
 
     public String getFieldRuleClassName() {
@@ -1348,7 +1348,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
      */
     @SuppressWarnings("unchecked")
     public void setIndexFilteringClassNames(List<String> classNames) {
-        this.indexFilteringClassNames = new ArrayList<>((classNames != null ? classNames : Collections.EMPTY_LIST));
+        this.indexFilteringClassNames = new ArrayList<>((classNames != null ? classNames : Collections.emptyList()));
     }
 
     public Class<? extends Type<?>> getDefaultType() {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/DocumentSpecificNestedIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/DocumentSpecificNestedIterator.java
@@ -44,12 +44,12 @@ public class DocumentSpecificNestedIterator extends NestedQueryIterator<Key> {
 
     @Override
     public Collection<NestedIterator<Key>> leaves() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
     public Collection<NestedIterator<Key>> children() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/EvaluationPhaseFilterFunctions.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -383,7 +382,8 @@ public class EvaluationPhaseFilterFunctions {
                 }
             }
         }
-        return Collections.EMPTY_LIST.stream();
+
+        return Stream.empty();
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -869,7 +869,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
                 this.setReducedResponse(false);
                 config.setReducedResponse(false);
                 // clear the content field names to prevent content field transformations (see DocumentTransformer)
-                this.setContentFieldNames(Collections.EMPTY_LIST);
+                this.setContentFieldNames(Collections.emptyList());
                 // clear the model name to avoid field name translations
                 this.setModelName(null);
                 config.setModelName(null);
@@ -950,7 +950,7 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
         String transformContentStr = settings.findParameter(QueryParameters.TRANSFORM_CONTENT_TO_UID).getParameterValue().trim();
         if (StringUtils.isNotBlank(transformContentStr)) {
             if (!Boolean.valueOf(transformContentStr)) {
-                setContentFieldNames(Collections.EMPTY_LIST);
+                setContentFieldNames(Collections.emptyList());
             }
         }
 

--- a/warehouse/query-core/src/test/java/datawave/query/ancestor/AncestorUidIntersectorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ancestor/AncestorUidIntersectorTest.java
@@ -68,7 +68,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c", node1));
         uids2.add(new IndexMatch("a.b.c.1.1", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -80,7 +80,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.1.1", node1));
         uids2.add(new IndexMatch("a.b.c", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -92,7 +92,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.10.1", node1));
         uids2.add(new IndexMatch("a.b.c.1", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertTrue("expected size 0, got " + result.size(), result.isEmpty());
@@ -104,7 +104,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.1", node1));
         uids2.add(new IndexMatch("a.b.c.10.1", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertTrue("expected size 0, got " + result.size(), result.isEmpty());
@@ -118,7 +118,7 @@ public class AncestorUidIntersectorTest {
         uids2.add(new IndexMatch("a.b.c.1.1.1", node2));
         uids2.add(new IndexMatch("a.b.c.1.1.2", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 2, got " + result.size(), 2, result.size());
@@ -131,7 +131,7 @@ public class AncestorUidIntersectorTest {
         uids2.add(new IndexMatch("a.b.c.1.1", node2));
         uids2.add(new IndexMatch("a.b.c.1.1.2", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -145,7 +145,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.1.1.1", node2));
         uids1.add(new IndexMatch("a.b.c.1.1.2", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 2, got " + result.size(), 2, result.size());
@@ -158,7 +158,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.1.1", node2));
         uids1.add(new IndexMatch("a.b.c.1.1.2", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -170,7 +170,7 @@ public class AncestorUidIntersectorTest {
         uids2.add(new IndexMatch("a.b.c.1", node1));
         uids1.add(new IndexMatch("a.b.c.1", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -185,7 +185,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.1", node2));
         uids1.add(new IndexMatch("a.b.c", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -199,7 +199,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.1", node2));
         uids1.add(new IndexMatch("a.b.c.2.1", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 2, got " + result.size(), 2, result.size());
@@ -236,7 +236,7 @@ public class AncestorUidIntersectorTest {
         uids1.add(new IndexMatch("a.b.c.2.1", node2));
         uids1.add(new IndexMatch("a.b.c", node2));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertEquals("expected size 1, got " + result.size(), 1, result.size());
@@ -247,7 +247,7 @@ public class AncestorUidIntersectorTest {
     public void testEmptyUids1() {
         uids2.add(new IndexMatch("a.b.c", node1));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertTrue("expected size 0, got " + result.size(), result.isEmpty());
@@ -258,7 +258,7 @@ public class AncestorUidIntersectorTest {
     public void testEmptyUids2() {
         uids1.add(new IndexMatch("a.b.c", node1));
 
-        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.EMPTY_LIST);
+        Set<IndexMatch> result = intersector.intersect(uids1, uids2, Collections.emptyList());
 
         assertNotNull(result);
         assertTrue("expected size 0, got " + result.size(), result.isEmpty());

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/TestLookupTask.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/TestLookupTask.java
@@ -70,7 +70,7 @@ public class TestLookupTask<T extends QueryIterator> {
             Range r = range;
             while (!rangeCompleted) {
                 log.trace("Seeking to range:" + r);
-                this.iterator.seek(r, Collections.EMPTY_LIST, false);
+                this.iterator.seek(r, Collections.emptyList(), false);
                 while (this.iterator.hasTop()) {
                     Document document = deserializeAndFilterDocument(this.iterator.getTopValue());
                     if (document.getDictionary().size() > 0) {

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/DocumentTransformerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/DocumentTransformerTest.java
@@ -119,7 +119,7 @@ public class DocumentTransformerTest { // extends EasyMockSupport {
         AbstractMap.SimpleEntry<Key,Value> entry = new AbstractMap.SimpleEntry<>(key, value);
 
         Map<String,List<String>> fieldMap = new HashMap<>();
-        List<String> fieldList = Collections.EMPTY_LIST;
+        List<String> fieldList = Collections.emptyList();
         fieldMap.put("field2", fieldList);
         Document d = new Document();
         basicExpects(d, key, entry);

--- a/web-services/map-reduce-embedded/src/main/java/datawave/webservice/common/connection/EmbeddedAccumuloConnectionFactory.java
+++ b/web-services/map-reduce-embedded/src/main/java/datawave/webservice/common/connection/EmbeddedAccumuloConnectionFactory.java
@@ -80,7 +80,7 @@ public class EmbeddedAccumuloConnectionFactory implements AccumuloConnectionFact
 
     @Override
     public List<ConnectionPool> getConnectionPools() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/web-services/security/src/test/java/datawave/security/user/ListEffectiveAuthorizationsTest.java
+++ b/web-services/security/src/test/java/datawave/security/user/ListEffectiveAuthorizationsTest.java
@@ -253,7 +253,7 @@ public class ListEffectiveAuthorizationsTest extends EasyMockSupport {
         SubjectIssuerDNPair filteredUserDN = SubjectIssuerDNPair.of("filteredUserDN", "filteredIssuerDN");
 
         DatawaveUser user = new DatawaveUser(userDN, DatawaveUser.UserType.USER, Sets.newHashSet("A", "C", "D"), null, null, System.currentTimeMillis());
-        DatawaveUser filteredUser = new DatawaveUser(filteredUserDN, DatawaveUser.UserType.USER, Collections.EMPTY_LIST, null, null,
+        DatawaveUser filteredUser = new DatawaveUser(filteredUserDN, DatawaveUser.UserType.USER, Collections.emptyList(), null, null,
                         System.currentTimeMillis());
         DatawavePrincipal proxiedUserPrincipal = new DatawavePrincipal(Lists.newArrayList(user));
         DatawavePrincipal remoteUserPrincipal = new DatawavePrincipal(Lists.newArrayList(filteredUser));


### PR DESCRIPTION
Replace all usages of `Collections.EMPTY_LIST` with `Collections.emptyList()` where we are returning/instantiating a list. This allows for inferred generic types.