### PR TITLE
Replace Collections.EMPTY_MAP with Collections.emptyMap()

### DIFF
--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizationServiceV1Test.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizationServiceV1Test.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.UUID;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,7 +155,7 @@ public class AuthorizationServiceV1Test {
         @Bean
         public CachedDatawaveUserService cachedDatawaveUserService(CacheManager cacheManager,
                         @Qualifier("cacheInspectorFactory") Function<CacheManager,CacheInspector> cacheInspectorFactory) {
-            return new AuthorizationTestUserService(Collections.EMPTY_MAP, true);
+            return new AuthorizationTestUserService(Collections.emptyMap(), true);
         }
 
         @Bean

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizationServiceV2Test.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizationServiceV2Test.java
@@ -112,7 +112,7 @@ public class AuthorizationServiceV2Test {
         @Bean
         public CachedDatawaveUserService cachedDatawaveUserService(CacheManager cacheManager,
                         @Qualifier("cacheInspectorFactory") Function<CacheManager,CacheInspector> cacheInspectorFactory) {
-            return new AuthorizationTestUserService(Collections.EMPTY_MAP, true);
+            return new AuthorizationTestUserService(Collections.emptyMap(), true);
         }
 
         @Bean

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsAllowedCallerTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsAllowedCallerTest.java
@@ -78,7 +78,7 @@ public class AuthorizeHttpsAllowedCallerTest {
         @Bean
         public CachedDatawaveUserService cachedDatawaveUserService(CacheManager cacheManager,
                         @Qualifier("cacheInspectorFactory") Function<CacheManager,CacheInspector> cacheInspectorFactory) {
-            return new AuthorizationTestUserService(Collections.EMPTY_MAP, true);
+            return new AuthorizationTestUserService(Collections.emptyMap(), true);
         }
 
         @Bean

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsNotAllowedCallerTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsNotAllowedCallerTest.java
@@ -79,7 +79,7 @@ public class AuthorizeHttpsNotAllowedCallerTest {
         @Bean
         public CachedDatawaveUserService cachedDatawaveUserService(CacheManager cacheManager,
                         @Qualifier("cacheInspectorFactory") Function<CacheManager,CacheInspector> cacheInspectorFactory) {
-            return new AuthorizationTestUserService(Collections.EMPTY_MAP, true);
+            return new AuthorizationTestUserService(Collections.emptyMap(), true);
         }
 
         @Bean

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/ProxiedEntityUserDetailsServiceTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/ProxiedEntityUserDetailsServiceTest.java
@@ -101,7 +101,7 @@ public class ProxiedEntityUserDetailsServiceTest {
     public static class ProxiedEntityUserDetailsServiceTestConfiguration {
         @Bean
         public CachedDatawaveUserService cachedDatawaveUserService() {
-            return new AuthorizationTestUserService(Collections.EMPTY_MAP, true);
+            return new AuthorizationTestUserService(Collections.emptyMap(), true);
         }
 
         @Bean

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/config/CachingConfigurerTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/config/CachingConfigurerTest.java
@@ -125,7 +125,7 @@ public class CachingConfigurerTest {
         @Bean
         public CachedDatawaveUserService cachedDatawaveUserService(CacheManager cacheManager,
                         @Qualifier("cacheInspectorFactory") Function<CacheManager,CacheInspector> cacheInspectorFactory) {
-            return new AuthorizationTestUserService(Collections.EMPTY_MAP, true);
+            return new AuthorizationTestUserService(Collections.emptyMap(), true);
         }
 
         @Bean

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/DocumentTransformerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/DocumentTransformerTest.java
@@ -83,7 +83,7 @@ public class DocumentTransformerTest { // extends EasyMockSupport {
         EasyMock.expect(mockDeserializer.apply(entry)).andReturn(documentEntry);
         // EasyMock.expect(mockDocument.getDictionary()).andReturn(Collections.EMPTY_MAP);
         // mockDocument.debugDocumentSize(key);
-        EasyMock.expect(mockMarkingFunctions.translateFromColumnVisibility(key.getColumnVisibilityParsed())).andReturn(Collections.EMPTY_MAP);
+        EasyMock.expect(mockMarkingFunctions.translateFromColumnVisibility(key.getColumnVisibilityParsed())).andReturn(Collections.emptyMap());
         // EasyMock.expect(mockDocument.getDictionary()).andReturn(dictionary);
         // EasyMock.expect(mockNumeric.getData()).andReturn("5");
         EasyMock.expect(mockResponseFactory.getField()).andReturn(simpleField);


### PR DESCRIPTION
Replace all usages of Collections.EMPTY_MAP with Collections.emptyMap() where we are returning/instantiating a map. This allows for inferred generic types.