### PR TITLE
Data Dictionary Help Menu

### DIFF
--- a/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
+++ b/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
@@ -56,14 +56,6 @@
   text-align: center;
 }
 
-.help-btn {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  z-index: 2000;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
-}
-
 ::-webkit-scrollbar {
     height: 12px;
     width: 14px;

--- a/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
+++ b/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
@@ -56,6 +56,14 @@
   text-align: center;
 }
 
+.help-btn {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 2000;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+}
+
 ::-webkit-scrollbar {
     height: 12px;
     width: 14px;

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
@@ -8,6 +8,16 @@ export interface Banner {
   styleBottom?: string;
 }
 
+export interface Menu {
+  enabled: boolean;
+  menuOne?: string;
+  menuTwo?: string;
+  menuThree?: string;
+  menuOneLink?: string;
+  menuTwoLink?: string;
+  menuThreeLink?: string;
+}
+
 export interface System {
   systemName: string;
 }

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -248,7 +248,7 @@
         </template>
       </q-table>
     </div>
-    <HelpMenu :menu?="helpMenu" />
+    <HelpMenu v-if="helpMenu" :menu="helpMenu" />
   </main>
   <div v-if="banner?.enabled" :style="banner?.styleTop" style="margin-top: 0.50vh;">
       {{ banner?.messageTop }}

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -20,7 +20,8 @@
       class="icon"
       :src="'icons/favicon-32x32.png'"
       spinner-color="white"
-    />
+      />
+      <HelpMenu v-if="helpMenu" :menu="helpMenu" />
     </div>
     <div class="row" style="width: 100%; height: 80%">
       <p class="information">
@@ -248,7 +249,6 @@
         </template>
       </q-table>
     </div>
-    <HelpMenu v-if="helpMenu" :menu="helpMenu" />
   </main>
   <div v-if="banner?.enabled" :style="banner?.styleTop" style="margin-top: 0.50vh;">
       {{ banner?.messageTop }}

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -248,6 +248,7 @@
         </template>
       </q-table>
     </div>
+    <HelpMenu :menu?="helpMenu" />
   </main>
   <div v-if="banner?.enabled" :style="banner?.styleTop" style="margin-top: 0.50vh;">
       {{ banner?.messageTop }}
@@ -263,10 +264,11 @@ import { useRoute, useRouter } from 'vue-router';
 import { QTable, QTableProps, exportFile, useQuasar, Notify } from 'quasar';
 import { useToggle, useDark } from '@vueuse/core';
 import { api } from '../boot/axios';
-import { Banner, columns, System } from '../functions/components';
+import { Banner, Menu, columns, System } from '../functions/components';
 import * as Formatters from '../functions/formatters';
 import * as Wrapper from '../functions/csvWrapper';
 import * as Feature from '../functions/features';
+import HelpMenu from './HelpMenu.vue';
 
 // Defines the Table References, loading for axios, search filter, and pagination to sort.
 const $q = useQuasar();
@@ -278,6 +280,7 @@ const router = useRouter();
 const changeFilter = ref<string>('');
 const banner = ref<Banner>();
 const system = ref<System>();
+const helpMenu = ref<Menu>();
 const search = ref('');
 let rows: QTableProps['rows'] = [];
 const paginationFront = ref({
@@ -291,10 +294,12 @@ onMounted(() => {
   let endpointData = '';
   let bannerData = 'banner';
   let systemData = 'system';
+  let helpMenuData = 'menu';
   if (process.env.DEV) {
     endpointData = 'data/v2/'
     bannerData = 'data/v2/banner/'
     systemData = 'data/v2/system/'
+    helpMenuData = 'data/v2/menu/'
   }
 
   api
@@ -304,6 +309,14 @@ onMounted(() => {
   })
   .catch((reason) => {
     console.error('Could not fetch banner: ' + reason);
+  });
+
+  api.get(helpMenuData)
+  .then((response) => {
+    helpMenu.value = response.data as Menu;
+  })
+  .catch((reason) => {
+    console.error('Could not fetch help menu: ' + reason);
   });
 
   api

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <q-btn
+      round
+      color="cyan-8"
+      icon="help"
+      class="help-btn"
+    >
+      <q-menu
+        anchor="top right"
+        self="bottom right"
+        :offset="[0, 10]"
+      >
+        <q-list style="min-width: 200px;">
+          <q-item clickable v-ripple @click="openSkill">
+            <q-item-section> {{ props.menu!.menuOne ?? "Menu One" }}</q-item-section>
+          </q-item>
+          <q-item clickable v-ripple @click="openTrain">
+            <q-item-section> {{ props.menu!.menuTwo ?? "Menu Two" }}</q-item-section>
+          </q-item>
+          <q-item clickable v-ripple @click="openHelp">
+            <q-item-section> {{ props.menu!.menuThree ?? "Menu Three" }}</q-item-section>
+          </q-item>
+        </q-list>
+      </q-menu>
+    </q-btn>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import { Menu } from '../functions/components';
+
+const props = defineProps<{ menu?: Menu }>();
+
+function openSkill() {
+  window.open(props.menu!.menuOneLink ?? '', '_blank');
+}
+function openTrain() {
+  window.open(props.menu!.menuTwoLink ?? '', '_blank');
+}
+function openHelp() {
+  window.open(props.menu!.menuThreeLink ?? '', '_blank');
+}
+</script>

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
@@ -5,7 +5,7 @@
       round
       color="cyan-8"
       icon="help"
-      style="position: fixed; top: 15px; right: 15px;"
+      :style="{ position: 'fixed', top: btnTop + 'px', right: '15px', transition: 'top 0.3s ease' }"
       aria-label="Help Menu"
     />
     <q-menu
@@ -30,12 +30,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted, onBeforeUnmount } from 'vue';
 import { defineProps } from 'vue';
 import { Menu } from '../functions/components';
 
 const props = defineProps<{ menu: Menu }>();
 const helpBtn = ref();
+const btnTop = ref(70); // Initial position of the button at 70px from the top.
+
+// Function to adjust button position based on scroll position of 50px. This is to account for the banner at the top of the page.
+function onScroll() { btnTop.value = window.scrollY > 50 ? 15 : 70;}
+
+// Reset button position on scroll, and removes event listener on unmount (garbage collection).
+onMounted(() => { window.addEventListener('scroll', onScroll); });
+onBeforeUnmount(() => { window.removeEventListener('scroll', onScroll); });
 
 function openSkill() { window.open(props.menu.menuOneLink ?? 'test', '_blank'); }
 function openTrain() { window.open(props.menu.menuTwoLink ?? 'test', '_blank'); }

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
@@ -13,13 +13,13 @@
       >
         <q-list style="min-width: 200px;">
           <q-item clickable v-ripple @click="openSkill">
-            <q-item-section> {{ props.menu!.menuOne ?? "Menu One" }}</q-item-section>
+            <q-item-section> {{ props.menu.menuOne ?? "Menu One" }}</q-item-section>
           </q-item>
           <q-item clickable v-ripple @click="openTrain">
-            <q-item-section> {{ props.menu!.menuTwo ?? "Menu Two" }}</q-item-section>
+            <q-item-section> {{ props.menu.menuTwo ?? "Menu Two" }}</q-item-section>
           </q-item>
           <q-item clickable v-ripple @click="openHelp">
-            <q-item-section> {{ props.menu!.menuThree ?? "Menu Three" }}</q-item-section>
+            <q-item-section> {{ props.menu.menuThree ?? "Menu Three" }}</q-item-section>
           </q-item>
         </q-list>
       </q-menu>
@@ -31,15 +31,15 @@
 import { defineProps } from 'vue';
 import { Menu } from '../functions/components';
 
-const props = defineProps<{ menu?: Menu }>();
+const props = defineProps<{ menu: Menu }>();
 
 function openSkill() {
-  window.open(props.menu!.menuOneLink ?? '', '_blank');
+  window.open(props.menu.menuOneLink ?? 'test', '_blank');
 }
 function openTrain() {
-  window.open(props.menu!.menuTwoLink ?? '', '_blank');
+  window.open(props.menu.menuTwoLink ?? 'test', '_blank');
 }
 function openHelp() {
-  window.open(props.menu!.menuThreeLink ?? '', '_blank');
+  window.open(props.menu.menuThreeLink ?? 'test', '_blank');
 }
 </script>

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/HelpMenu.vue
@@ -1,45 +1,43 @@
 <template>
   <div>
     <q-btn
+      ref="helpBtn"
       round
       color="cyan-8"
       icon="help"
-      class="help-btn"
+      style="position: fixed; top: 15px; right: 15px;"
+      aria-label="Help Menu"
+    />
+    <q-menu
+      :target="helpBtn?.$el"
+      anchor="bottom right"
+      self="top right"
+      :offset="[-8, 8]"
     >
-      <q-menu
-        anchor="top right"
-        self="bottom right"
-        :offset="[0, 10]"
-      >
-        <q-list style="min-width: 200px;">
-          <q-item clickable v-ripple @click="openSkill">
-            <q-item-section> {{ props.menu.menuOne ?? "Menu One" }}</q-item-section>
-          </q-item>
-          <q-item clickable v-ripple @click="openTrain">
-            <q-item-section> {{ props.menu.menuTwo ?? "Menu Two" }}</q-item-section>
-          </q-item>
-          <q-item clickable v-ripple @click="openHelp">
-            <q-item-section> {{ props.menu.menuThree ?? "Menu Three" }}</q-item-section>
-          </q-item>
-        </q-list>
-      </q-menu>
-    </q-btn>
+      <q-list style="min-width: 200px;">
+        <q-item clickable v-ripple @click="openSkill">
+          <q-item-section>{{ props.menu.menuOne ?? "Menu One" }}</q-item-section>
+        </q-item>
+        <q-item clickable v-ripple @click="openTrain">
+          <q-item-section>{{ props.menu.menuTwo ?? "Menu Two" }}</q-item-section>
+        </q-item>
+        <q-item clickable v-ripple @click="openHelp">
+          <q-item-section>{{ props.menu.menuThree ?? "Menu Three" }}</q-item-section>
+        </q-item>
+      </q-list>
+    </q-menu>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { defineProps } from 'vue';
 import { Menu } from '../functions/components';
 
 const props = defineProps<{ menu: Menu }>();
+const helpBtn = ref();
 
-function openSkill() {
-  window.open(props.menu.menuOneLink ?? 'test', '_blank');
-}
-function openTrain() {
-  window.open(props.menu.menuTwoLink ?? 'test', '_blank');
-}
-function openHelp() {
-  window.open(props.menu.menuThreeLink ?? 'test', '_blank');
-}
+function openSkill() { window.open(props.menu.menuOneLink ?? 'test', '_blank'); }
+function openTrain() { window.open(props.menu.menuTwoLink ?? 'test', '_blank'); }
+function openHelp()  { window.open(props.menu.menuThreeLink ?? 'test', '_blank'); }
 </script>

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerLogic.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerLogic.java
@@ -305,6 +305,20 @@ public class DataDictionaryControllerLogic<DESC extends DescriptionBase<DESC>,DI
         return dataDictionaryConfiguration.getBanner();
     }
 
+    /**
+     * Sets the Help menu Options for the Data Dictionary.
+     *
+     * @return the default Help Menu for Data Dictionary
+     */
+    public DataDictionaryProperties.HelpMenu retrieveMenu() {
+        return dataDictionaryConfiguration.getHelpMenu();
+    }
+
+    /**
+     * Sets the System for the Data Dictionary.
+     *
+     * @return the default system for Data Dictionary
+     */
     public DictionaryServiceProperties.System retrieveSystem() {
         return dictionaryServiceConfiguration.getSystem();
     }

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerV2.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/DataDictionaryControllerV2.java
@@ -112,6 +112,12 @@ public class DataDictionaryControllerV2<DESC extends DescriptionBase<DESC>,DICT 
         return dataDictionaryControllerLogic.retrieveBanner();
     }
 
+    @GetMapping(value = "/menu", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed(name = "dw.dictionary.data.menu", absolute = true)
+    public DataDictionaryProperties.HelpMenu menu() {
+        return dataDictionaryControllerLogic.retrieveMenu();
+    }
+
     @GetMapping(value = "/system", produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed(name = "dw.dictionary.system", absolute = true)
     public DictionaryServiceProperties.System system() {

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/config/DataDictionaryProperties.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/config/DataDictionaryProperties.java
@@ -44,8 +44,8 @@ public class DataDictionaryProperties {
 
     @Getter
     @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class HelpMenu {
-        private boolean enabled = false;
         private String menuOne;
         private String menuOneLink;
         private String menuTwo;

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/config/DataDictionaryProperties.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/dictionary/config/DataDictionaryProperties.java
@@ -26,6 +26,7 @@ public class DataDictionaryProperties {
     @NotBlank
     private String metadataTableName;
     private Banner banner = new Banner();
+    private HelpMenu helpMenu = new HelpMenu();
     @Positive
     private int numThreads;
     private Map<String,String> normalizerMap;
@@ -40,4 +41,17 @@ public class DataDictionaryProperties {
         private String styleTop;
         private String styleBottom;
     }
+
+    @Getter
+    @Setter
+    public static class HelpMenu {
+        private boolean enabled = false;
+        private String menuOne;
+        private String menuOneLink;
+        private String menuTwo;
+        private String menuTwoLink;
+        private String menuThree;
+        private String menuThreeLink;
+    }
+
 }


### PR DESCRIPTION
This creates a Data Dictionary Help Menu that allows users to click between 3 menu options. It does the following:
1. Question Help Menu in the Top right _(circular button)_. Follows the User's page when scrolling to account for the banner.
2. Opens to 3 menu options.
3. Opens a new tab for the user to these 3 links.