### PR TITLE
validation - index only fields found within filter function

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/rules/IncludeExcludeIndexFieldsRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/rules/IncludeExcludeIndexFieldsRule.java
@@ -15,10 +15,9 @@ import datawave.query.jexl.visitors.FetchFunctionFieldsVisitor;
 import datawave.query.util.MetadataHelper;
 
 /**
- * @deprecated use IncudeExcdludeIndexOnlyFieldsRule instead A {@link QueryRule} implementation that will check if any indexed fields are used within the
+ * @deprecated use IncludeExcludeIndexOnlyFieldsRule instead A {@link QueryRule} implementation that will check if any indexed fields are used within the
  *             functions {@code filter:includeRegex} or {@code filter:excludeRegex} in a query.
  */
-
 @Deprecated
 public class IncludeExcludeIndexFieldsRule extends ShardQueryRule {
 

--- a/warehouse/query-core/src/main/java/datawave/query/rules/IncludeExcludeIndexOnlyFieldsRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/rules/IncludeExcludeIndexOnlyFieldsRule.java
@@ -15,22 +15,20 @@ import datawave.query.jexl.visitors.FetchFunctionFieldsVisitor;
 import datawave.query.util.MetadataHelper;
 
 /**
- * @deprecated use IncudeExcdludeIndexOnlyFieldsRule instead A {@link QueryRule} implementation that will check if any indexed fields are used within the
- *             functions {@code filter:includeRegex} or {@code filter:excludeRegex} in a query.
+ * A {@link QueryRule} implementation that will check if any indexed only fields are used within the functions {@code filter:includeRegex} or
+ * {@code filter:excludeRegex} in a query.
  */
+public class IncludeExcludeIndexOnlyFieldsRule extends ShardQueryRule {
 
-@Deprecated
-public class IncludeExcludeIndexFieldsRule extends ShardQueryRule {
-
-    private static final Logger log = Logger.getLogger(IncludeExcludeIndexFieldsRule.class);
+    private static final Logger log = Logger.getLogger(IncludeExcludeIndexOnlyFieldsRule.class);
 
     private static final Set<Pair<String,String>> functions = Collections.unmodifiableSet(Sets.newHashSet(
                     Pair.of(EvaluationPhaseFilterFunctions.EVAL_PHASE_FUNCTION_NAMESPACE, EvaluationPhaseFilterFunctionsDescriptor.INCLUDE_REGEX),
                     Pair.of(EvaluationPhaseFilterFunctions.EVAL_PHASE_FUNCTION_NAMESPACE, EvaluationPhaseFilterFunctionsDescriptor.EXCLUDE_REGEX)));
 
-    public IncludeExcludeIndexFieldsRule() {}
+    public IncludeExcludeIndexOnlyFieldsRule() {}
 
-    public IncludeExcludeIndexFieldsRule(String name) {
+    public IncludeExcludeIndexOnlyFieldsRule(String name) {
         super(name);
     }
 
@@ -52,16 +50,16 @@ public class IncludeExcludeIndexFieldsRule extends ShardQueryRule {
             ASTJexlScript jexlScript = (ASTJexlScript) ruleConfig.getParsedQuery();
             // Fetch the set of fields given within any filter:includeRegex or filter:excludeRegex function calls in the query, if any.
             Set<FetchFunctionFieldsVisitor.FunctionFields> functions = FetchFunctionFieldsVisitor.fetchFields(jexlScript,
-                            IncludeExcludeIndexFieldsRule.functions, metadataHelper);
+                            IncludeExcludeIndexOnlyFieldsRule.functions, metadataHelper);
             if (!functions.isEmpty()) {
-                Set<String> indexedFields = metadataHelper.getIndexedFields(null);
+                Set<String> indexOnlyFields = metadataHelper.getIndexOnlyFields(null);
                 // Each FunctionField object represents the collection of all fields seen for either filter:includeRegex or filter:excludeRegex.
                 for (FetchFunctionFieldsVisitor.FunctionFields functionFields : functions) {
-                    Set<String> intersection = Sets.intersection(indexedFields, functionFields.getFields());
-                    // If the function contains any index fields, add a message to the result.
+                    Set<String> intersection = Sets.intersection(indexOnlyFields, functionFields.getFields());
+                    // If the function contains any index only fields, add a message to the result.
                     if (!intersection.isEmpty()) {
-                        result.addMessage("Indexed fields found within the function " + functionFields.getNamespace() + ":" + functionFields.getFunction()
-                                        + ": " + String.join(", ", intersection));
+                        result.addMessage("Index Only fields found within the filter function " + functionFields.getNamespace() + ":"
+                                        + functionFields.getFunction() + ": " + String.join(", ", intersection));
                     }
                 }
             }
@@ -75,6 +73,6 @@ public class IncludeExcludeIndexFieldsRule extends ShardQueryRule {
 
     @Override
     public QueryRule copy() {
-        return new IncludeExcludeIndexFieldsRule(name);
+        return new IncludeExcludeIndexOnlyFieldsRule(name);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/rules/IncludeExcludeIndexOnlyFieldsRuleTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/rules/IncludeExcludeIndexOnlyFieldsRuleTest.java
@@ -10,17 +10,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import datawave.query.util.MockMetadataHelper;
 
-/**
- * @deprecated use IncludeExcludeIndexOnlyFieldsRule/IncludeExcludeIndexOnlyFieldsRuleTest instead
- */
-@Deprecated
-class IncludeExcludeIndexFieldsRuleTest extends ShardQueryRuleTest {
+class IncludeExcludeIndexOnlyFieldsRuleTest extends ShardQueryRuleTest {
 
     private static final MockMetadataHelper metadataHelper = new MockMetadataHelper();
 
     @BeforeAll
     static void beforeAll() {
-        metadataHelper.setIndexedFields(Set.of("INDEXED1", "INDEXED2"));
+        metadataHelper.setIndexOnlyFields(Set.of("INDEXED1", "INDEXED2"));
     }
 
     @BeforeEach
@@ -42,14 +38,14 @@ class IncludeExcludeIndexFieldsRuleTest extends ShardQueryRuleTest {
     }
 
     /**
-     * Test versions of the includeRegex and excludeRegex functions without indexed fields.
+     * Test versions of the includeRegex and excludeRegex functions without index only fields.
      *
      * @param name
      *            the function name
      */
     @ParameterizedTest
     @ValueSource(strings = {"includeRegex", "excludeRegex"})
-    void testFunctionWithoutIndexedField(String name) throws Exception {
+    void testFunctionWithoutIndexedOnlyField(String name) throws Exception {
         givenQuery("filter:" + name + "(FOO,'value')");
 
         // Do not expect any messages.
@@ -57,16 +53,16 @@ class IncludeExcludeIndexFieldsRuleTest extends ShardQueryRuleTest {
     }
 
     /**
-     * Test versions of the includeRegex and excludeRegex functions with an indexed field.
+     * Test versions of the includeRegex and excludeRegex functions with an index only field.
      *
      * @param name
      *            the function name
      */
     @ParameterizedTest
     @ValueSource(strings = {"includeRegex", "excludeRegex"})
-    void testFunctionWithSingleIndexedField(String name) throws Exception {
+    void testFunctionWithSingleIndexOnlyField(String name) throws Exception {
         givenQuery("filter:" + name + "(INDEXED1,'value')");
-        expectMessage("Indexed fields found within the function filter:" + name + ": INDEXED1");
+        expectMessage("Index Only fields found within the filter function filter:" + name + ": INDEXED1");
 
         assertResult();
     }
@@ -75,10 +71,10 @@ class IncludeExcludeIndexFieldsRuleTest extends ShardQueryRuleTest {
      * Test a query with both the includeRegex and excludeRegex functions with indexed fields.
      */
     @Test
-    void testMultipleFunctionWithIndexedField() throws Exception {
+    void testMultipleFunctionWithIndexOnlyField() throws Exception {
         givenQuery("filter:includeRegex(INDEXED1,'value') && filter:excludeRegex(INDEXED2, 'value')");
-        expectMessage("Indexed fields found within the function filter:includeRegex: INDEXED1");
-        expectMessage("Indexed fields found within the function filter:excludeRegex: INDEXED2");
+        expectMessage("Index Only fields found within the filter function filter:includeRegex: INDEXED1");
+        expectMessage("Index Only fields found within the filter function filter:excludeRegex: INDEXED2");
 
         assertResult();
     }
@@ -87,7 +83,7 @@ class IncludeExcludeIndexFieldsRuleTest extends ShardQueryRuleTest {
      * Test a query with both the includeRegex and excludeRegex functions without indexed fields.
      */
     @Test
-    void testMultipleFunctionWithoutIndexedField() throws Exception {
+    void testMultipleFunctionWithoutIndexOnlyField() throws Exception {
         givenQuery("filter:includeRegex(FOO,'value') && filter:excludeRegex(BAR, 'value')");
 
         // Do not expect any messages.
@@ -101,6 +97,6 @@ class IncludeExcludeIndexFieldsRuleTest extends ShardQueryRuleTest {
 
     @Override
     protected ShardQueryRule getNewRule() {
-        return new IncludeExcludeIndexFieldsRule(ruleName);
+        return new IncludeExcludeIndexOnlyFieldsRule(ruleName);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicQueryValidationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicQueryValidationTest.java
@@ -50,7 +50,7 @@ import datawave.query.rules.FieldExistenceRule;
 import datawave.query.rules.FieldPatternPresenceRule;
 import datawave.query.rules.GroupedInterpretationRule;
 import datawave.query.rules.IncludeExcludeArgsRule;
-import datawave.query.rules.IncludeExcludeIndexFieldsRule;
+import datawave.query.rules.IncludeExcludeIndexOnlyFieldsRule;
 import datawave.query.rules.InvalidQuoteRule;
 import datawave.query.rules.MinimumSlopProximityRule;
 import datawave.query.rules.NumericValueRule;
@@ -174,7 +174,7 @@ public class ShardQueryLogicQueryValidationTest {
         expectedRules.add(new UnescapedSpecialCharsRule("Check for Unescaped Special Characters", Set.of('?'), Set.of('_'), false, false));
         expectedRules.add(new FieldPatternPresenceRule("Check Presence of Field or Pattern", Map.of("_ANYFIELD_", "Detected presence of _ANYFIELD_"),
                         Map.of(".*", "Detected pattern '.*' that will match everything")));
-        expectedRules.add(new IncludeExcludeIndexFieldsRule("Check #INCLUDE and #EXCLUDE for Indexed Fields"));
+        expectedRules.add(new IncludeExcludeIndexOnlyFieldsRule("Check #INCLUDE and #EXCLUDE for Index Only Fields"));
         expectedRules.add(new NumericValueRule("Validate Numeric Values Only Given for Numeric Fields"));
         expectedRules.add(new TimeFunctionRule("Validate #TIME_FUNCTION has Date Fields"));
 

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -200,8 +200,8 @@
         <property name="name" value="Validate Args of #INCLUDE and #EXCLUDE"/>
     </bean>
 
-    <bean id="IncludeExcludeIndexFieldsRule" scope="prototype" class="datawave.query.rules.IncludeExcludeIndexFieldsRule">
-        <property name="name" value="Check #INCLUDE and #EXCLUDE for Indexed Fields"/>
+    <bean id="IncludeExcludeIndexOnlyFieldsRule" scope="prototype" class="datawave.query.rules.IncludeExcludeIndexOnlyFieldsRule">
+        <property name="name" value="Check #INCLUDE and #EXCLUDE for Index Only Fields"/>
     </bean>
 
     <bean id="InvalidQuoteRule" scope="prototype" class="datawave.query.rules.InvalidQuoteRule">
@@ -426,7 +426,7 @@
                 <ref bean="FieldExistenceRule"/>
                 <ref bean="UnescapedSpecialCharsRule"/>
                 <ref bean="FieldPatternPresenceRule"/>
-                <ref bean="IncludeExcludeIndexFieldsRule"/>
+                <ref bean="IncludeExcludeIndexOnlyFieldsRule"/>
                 <ref bean="NumericValueRule"/>
                 <ref bean="TimeFunctionRule"/>
             </list>


### PR DESCRIPTION
fixes #2873 

adds `IncludeExcludeIndexOnlyFieldsRule` and deprecates previous `IncludeExcludeIndexFieldsRule` -- changes check for index fields to be index only fields

this is a cleaned-up version of #2969 