### PR TITLE
Setting version of zk-jute, to match zk.

### DIFF
--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -155,6 +155,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper-jute</artifactId>
+                <version>${version.zookeeper}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>datatables</artifactId>
                 <version>${version.webjars.datatables}</version>


### PR DESCRIPTION
Fixing Data Dictionary by matching zk with zk-jute from the upgrade of Accumulo 2.1.1 to Accumulo 2.1.4.