### PR TITLE
DRAFT: Correct Unfielded Index Expansion

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
@@ -1,0 +1,233 @@
+package datawave.core.iterators;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.user.SeekingFilter;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Splitter;
+
+import datawave.query.Constants;
+import datawave.query.data.parsers.ShardIndexKey;
+
+/**
+ * Attempts to expand a fielded regex into discrete values
+ * <p>
+ * Supports date and datatype filtering by default
+ */
+public class FieldedRegexExpansionIterator extends SeekingFilter implements OptionDescriber {
+
+    public static final Logger log = LoggerFactory.getLogger(FieldedRegexExpansionIterator.class);
+
+    public static final String START_DATE = "start.date";
+    public static final String END_DATE = "end.date";
+    public static final String DATATYPES = "dts";
+    public static final String FIELD = "field";
+    public static final String PATTERN = "pattern";
+    public static final String REVERSE = "reverse";
+
+    // TODO: max value threshold, max keys seen threshold?
+
+    private String startDate;
+    private String endDate;
+    private String field;
+    private Pattern pattern;
+    private Matcher matcher;
+    private Set<String> datatypes;
+
+    private boolean reverse = false;
+    private final StringBuilder sb = new StringBuilder();
+
+    private Text columnQualifierDate;
+    private Text columnQualifierDateAndDatatype;
+
+    private final ShardIndexKey parser = new ShardIndexKey();
+
+    enum HINT_TYPE {
+        NONE, FIELD, DATE
+    }
+
+    private HINT_TYPE hint = HINT_TYPE.NONE;
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+
+        if (!validateOptions(options)) {
+            throw new IllegalArgumentException("Iterator was not configured correctly");
+        }
+
+        super.init(source, options, env);
+
+        if (options.containsKey(START_DATE)) {
+            this.startDate = options.get(START_DATE);
+            this.columnQualifierDate = new Text(startDate + "_0");
+        } else {
+            throw new IllegalArgumentException("Iterator requires START_DATE option");
+        }
+
+        if (options.containsKey(END_DATE)) {
+            this.endDate = options.get(END_DATE) + Constants.MAX_UNICODE_STRING;
+        } else {
+            throw new IllegalArgumentException("Iterator requires END_DATE option");
+        }
+
+        if (options.containsKey(FIELD)) {
+            this.field = options.get(FIELD);
+        } else {
+            throw new IllegalArgumentException("Iterator requires FIELD option");
+        }
+
+        if (options.containsKey(PATTERN)) {
+            String option = options.get(PATTERN);
+            this.pattern = Pattern.compile(option);
+        } else {
+            throw new IllegalArgumentException("Iterator requires PATTERN option");
+        }
+
+        if (options.containsKey(DATATYPES)) {
+            String option = options.get(DATATYPES);
+            this.datatypes = new HashSet<>(Splitter.on(',').splitToList(option));
+
+            List<String> tmp = new ArrayList<>(datatypes);
+            Collections.sort(tmp);
+            this.columnQualifierDateAndDatatype = new Text(startDate + "_0\u0000" + tmp.get(0));
+        }
+
+        if (options.containsKey(REVERSE)) {
+            this.reverse = Boolean.parseBoolean(options.get(REVERSE));
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        if (!range.isStartKeyInclusive()) {
+            // need to skip to next row
+            Key skip = new Key(range.getStartKey().getRow().toString() + '\u0000');
+            if (skip.compareTo(range.getEndKey()) > 0) {
+                // handles case of bounded range against single value
+                // filter key: +cE1 NUM:20150808_0%00;generic [NA]
+                // skip key would be +cE1<null> but then the start key is greater than the end key. so we cheat accumulo.
+                Range skipRange = new Range(range.getEndKey(), true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            } else {
+                Range skipRange = new Range(skip, true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            }
+        } else {
+            super.seek(range, columnFamilies, inclusive);
+        }
+    }
+
+    @Override
+    public FilterResult filter(Key k, Value v) {
+        if (log.isInfoEnabled()) {
+            log.info("tk: {}", k.toStringNoTime());
+        }
+
+        // parse key and reset hint
+        parser.parse(k);
+        hint = HINT_TYPE.NONE;
+
+        if (reverse) {
+            sb.setLength(0);
+            sb.append(parser.getValue());
+            sb.reverse();
+            matcher = pattern.matcher(sb);
+        } else {
+            matcher = pattern.matcher(parser.getValue());
+        }
+
+        if (!matcher.matches()) {
+            // advance to next row
+            log.info("pattern does not match, advance to next row");
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        int result = parser.getField().compareTo(field);
+        if (result < 0) {
+            // advance to field
+            log.info("field {} sorts before target {}, advance to {}", parser.getField(), field, field);
+            hint = HINT_TYPE.FIELD;
+            return new FilterResult(false, AdvanceResult.USE_HINT);
+        } else if (result > 0) {
+            // advance to next row
+            log.info("field {} sorts after target {}, advance to next row", parser.getField(), field);
+            return new FilterResult(true, AdvanceResult.NEXT_ROW);
+        }
+
+        String date = parser.getShard();
+        if (date.compareTo(startDate) < 0) {
+            // advance to start date
+            log.info("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
+            hint = HINT_TYPE.DATE;
+            return new FilterResult(false, AdvanceResult.USE_HINT);
+        } else if (date.compareTo(endDate) > 0) {
+            // advance to next row
+            log.info("date {} sorts after end date {}, advance to next row", date, endDate);
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        if (datatypes != null && !datatypes.contains(parser.getDatatype())) {
+            log.info("datatype {} does not match, advance to next key", parser.getDatatype());
+            return new FilterResult(false, AdvanceResult.NEXT);
+        }
+
+        log.info("key accepted, advancing to next row");
+        return new FilterResult(true, AdvanceResult.NEXT_ROW);
+    }
+
+    @Override
+    public Key getNextKeyHint(Key k, Value v) {
+        switch (hint) {
+            case FIELD:
+            case DATE:
+                if (columnQualifierDateAndDatatype != null) {
+                    return new Key(k.getRow(), new Text(field), columnQualifierDateAndDatatype);
+                } else {
+                    return new Key(k.getRow(), new Text(field), columnQualifierDate);
+                }
+            case NONE:
+            default:
+                throw new IllegalStateException("Unhandled hint type: " + hint);
+        }
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions options = new IteratorOptions(getClass().getSimpleName(), "Iterator that expands a fielded regex into discrete values", null, null);
+        options.addNamedOption(START_DATE, "The start date");
+        options.addNamedOption(END_DATE, "The end date");
+        options.addNamedOption(FIELD, "The field");
+        options.addNamedOption(PATTERN, "The pattern");
+        options.addNamedOption(DATATYPES, "(optional) A comma-delimited set of datatypes used to restrict the search space");
+        return options;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        //  @formatter:off
+        return options.containsKey(START_DATE) &&
+                options.containsKey(END_DATE) &&
+                options.containsKey(FIELD) &&
+                options.containsKey(PATTERN);
+        //  @formatter:on
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/TimeoutExceptionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/TimeoutExceptionIterator.java
@@ -40,9 +40,7 @@ public class TimeoutExceptionIterator extends WrappingIterator {
 
     @Override
     public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
-
         super.init(source, options, env);
-
     }
 
     /**
@@ -56,10 +54,7 @@ public class TimeoutExceptionIterator extends WrappingIterator {
     @Override
     public boolean hasTop() {
         if (exceededTime) {
-            if (null != lastKey)
-                return true;
-            else
-                return false;
+            return null != lastKey;
         }
         return super.hasTop();
     }
@@ -97,7 +92,6 @@ public class TimeoutExceptionIterator extends WrappingIterator {
 
     @Override
     public void next() throws IOException {
-
         if (exceededTime) {
             return;
         }
@@ -107,10 +101,11 @@ public class TimeoutExceptionIterator extends WrappingIterator {
         } catch (IteratorTimeoutException e) {
             setReturnKey();
         } catch (RuntimeException e) {
-            if (e.getCause() instanceof IteratorTimeoutException)
+            if (e.getCause() instanceof IteratorTimeoutException) {
                 setReturnKey();
-            else
+            } else {
                 throw e;
+            }
         }
     }
 
@@ -118,10 +113,11 @@ public class TimeoutExceptionIterator extends WrappingIterator {
     public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
 
         if (!range.isInfiniteStartKey()) {
-            if (range.isStartKeyInclusive())
+            if (range.isStartKeyInclusive()) {
                 lastKey = range.getStartKey();
-            else
+            } else {
                 lastKey = range.getStartKey().followingKey(PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME);
+            }
         } else {
             lastKey = new Key();
         }
@@ -134,14 +130,13 @@ public class TimeoutExceptionIterator extends WrappingIterator {
         try {
             super.seek(range, columnFamilies, inclusive);
         } catch (IteratorTimeoutException e) {
-
             setReturnKey();
-
         } catch (RuntimeException e) {
-            if (e.getCause() instanceof IteratorTimeoutException)
+            if (e.getCause() instanceof IteratorTimeoutException) {
                 setReturnKey();
-            else
+            } else {
                 throw e;
+            }
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/TimeoutIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/TimeoutIterator.java
@@ -15,9 +15,9 @@ import org.apache.log4j.Logger;
 
 /**
  * Purpose: Enforces a timeout within this scan session
- *
+ * <p>
  * Design: Upon calls to next, seek, and even init ( in the case where we have filters ) we will check if we have reached an unfair execution event in which we
- * have exceed our timeout
+ * have exceeded our timeout
  */
 public class TimeoutIterator extends WrappingIterator {
 
@@ -57,21 +57,15 @@ public class TimeoutIterator extends WrappingIterator {
                 }
             }
         }
-
         currentSession = System.currentTimeMillis();
-
     }
 
     @Override
     public void next() throws IOException {
-
         if (isUnfairExecution()) {
-
             throw new IteratorTimeoutException("Exception next()");
         }
-
         super.next();
-
     }
 
     /**
@@ -85,13 +79,9 @@ public class TimeoutIterator extends WrappingIterator {
 
     @Override
     public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
-
         if (isUnfairExecution()) {
             throw new IteratorTimeoutException("Exception seek()");
         }
-
         super.seek(range, columnFamilies, inclusive);
-
     }
-
 }

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
@@ -1,0 +1,227 @@
+package datawave.core.iterators;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.user.SeekingFilter;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Splitter;
+
+import datawave.query.Constants;
+import datawave.query.data.parsers.ShardIndexKey;
+
+/**
+ * Attempts to expand an unfielded regex into discrete fields and values
+ * <p>
+ * Supports date and datatype filtering by default
+ */
+public class UnfieldedRegexExpansionIterator extends SeekingFilter implements OptionDescriber {
+
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedRegexExpansionIterator.class);
+
+    public static final String START_DATE = "start.date";
+    public static final String END_DATE = "end.date";
+    public static final String DATATYPES = "dts";
+    public static final String PATTERN = "pattern";
+    public static final String REVERSE = "reverse";
+
+    private String startDate;
+    private String endDate;
+    private Pattern pattern;
+    private boolean reverse;
+    private final StringBuilder sb = new StringBuilder();
+
+    private Matcher matcher;
+    private Set<String> datatypes;
+
+    private Text columnQualifierDate;
+    private Text columnQualifierDateAndDatatype;
+
+    // used to track the unique field value pairs
+    private final Set<String> foundPairs = new HashSet<>();
+
+    private final ShardIndexKey parser = new ShardIndexKey();
+
+    enum HINT_TYPE {
+        NONE, FIELD, DATE
+    }
+
+    private HINT_TYPE hint = HINT_TYPE.NONE;
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+
+        if (!validateOptions(options)) {
+            throw new IllegalArgumentException("Iterator was not configured correctly");
+        }
+
+        super.init(source, options, env);
+
+        if (options.containsKey(START_DATE)) {
+            this.startDate = options.get(START_DATE);
+            this.columnQualifierDate = new Text(startDate + "_0");
+        } else {
+            throw new IllegalArgumentException("Iterator requires START_DATE option");
+        }
+
+        if (options.containsKey(END_DATE)) {
+            this.endDate = options.get(END_DATE) + Constants.MAX_UNICODE_STRING;
+        } else {
+            throw new IllegalArgumentException("Iterator requires END_DATE option");
+        }
+
+        if (options.containsKey(PATTERN)) {
+            String option = options.get(PATTERN);
+            this.pattern = Pattern.compile(option);
+        } else {
+            throw new IllegalArgumentException("Iterator requires PATTERN option");
+        }
+
+        if (options.containsKey(DATATYPES)) {
+            String option = options.get(DATATYPES);
+            this.datatypes = new HashSet<>(Splitter.on(',').splitToList(option));
+
+            List<String> tmp = new ArrayList<>(datatypes);
+            Collections.sort(tmp);
+            this.columnQualifierDateAndDatatype = new Text(startDate + "_0\u0000" + tmp.get(0));
+        }
+
+        if (options.containsKey(REVERSE)) {
+            this.reverse = Boolean.parseBoolean(options.get(REVERSE));
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        if (!range.isStartKeyInclusive()) {
+            // need to skip to next row
+            // TODO: for the unfielded case this might need to be next column family
+            Key skip = new Key(range.getStartKey().getRow().toString() + '\u0000');
+            if (skip.compareTo(range.getEndKey()) > 0) {
+                // handles case of bounded range against single value
+                // filter key: +cE1 NUM:20150808_0%00;generic [NA]
+                // skip key would be +cE1<null> but then the start key is greater than the end key. so we cheat accumulo.
+                Range skipRange = new Range(range.getEndKey(), true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            } else {
+                Range skipRange = new Range(skip, true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            }
+        } else {
+            super.seek(range, columnFamilies, inclusive);
+        }
+    }
+
+    @Override
+    public FilterResult filter(Key k, Value v) {
+        if (log.isInfoEnabled()) {
+            log.info("tk: {}", k.toStringNoTime());
+        }
+
+        // parse key and reset hint
+        parser.parse(k);
+        hint = HINT_TYPE.NONE;
+
+        if (reverse) {
+            sb.setLength(0);
+            sb.append(parser.getValue());
+            sb.reverse();
+            matcher = pattern.matcher(sb);
+        } else {
+            matcher = pattern.matcher(parser.getValue());
+        }
+
+        if (!matcher.matches()) {
+            // advance to next row
+            log.info("pattern does not match, advance to next row");
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        String candidate = parser.getValue() + parser.getField();
+        boolean firstSeen = foundPairs.add(candidate);
+        if (!firstSeen) {
+            // advance to next field
+            foundPairs.clear();
+            log.info("Found duplicate field, advance to next field");
+            return new FilterResult(false, AdvanceResult.NEXT_CF);
+        }
+
+        String date = parser.getShard();
+        if (date.compareTo(startDate) < 0) {
+            // advance to start date
+            log.info("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
+            hint = HINT_TYPE.DATE;
+            return new FilterResult(false, AdvanceResult.USE_HINT);
+        } else if (date.compareTo(endDate) > 0) {
+            // advance to next row
+            log.info("date {} sorts after end date {}, advance to next row", date, endDate);
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        if (datatypes != null && !datatypes.contains(parser.getDatatype())) {
+            log.info("datatype {} does not match, advance to next key", parser.getDatatype());
+            return new FilterResult(false, AdvanceResult.NEXT);
+        }
+
+        log.info("key accepted, advancing to next column family");
+        return new FilterResult(true, AdvanceResult.NEXT_CF);
+    }
+
+    @Override
+    public Key getNextKeyHint(Key k, Value v) {
+        switch (hint) {
+            case FIELD:
+                // advance to next field
+                return k.followingKey(PartialKey.ROW_COLFAM);
+            case DATE:
+                if (columnQualifierDateAndDatatype != null) {
+                    return new Key(k.getRow(), k.getColumnFamily(), columnQualifierDateAndDatatype);
+                } else {
+                    return new Key(k.getRow(), k.getColumnFamily(), columnQualifierDate);
+                }
+            case NONE:
+            default:
+                throw new IllegalStateException("Unhandled hint type: " + hint);
+        }
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions options = new IteratorOptions(getClass().getSimpleName(), "Iterator that expands an unfielded regex into discrete fields and values",
+                        null, null);
+        options.addNamedOption(START_DATE, "The start date");
+        options.addNamedOption(END_DATE, "The end date");
+        options.addNamedOption(PATTERN, "The pattern");
+        options.addNamedOption(DATATYPES, "(optional) A comma-delimited set of datatypes used to restrict the search space");
+        options.addNamedOption(REVERSE, "(optional) true if this scan is for the shard reverse index");
+        return options;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        //  @formatter:off
+        return options.containsKey(START_DATE) &&
+                options.containsKey(END_DATE) &&
+                options.containsKey(PATTERN);
+        //  @formatter:on
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/AsyncIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/AsyncIndexLookup.java
@@ -27,10 +27,16 @@ public abstract class AsyncIndexLookup extends IndexLookup {
 
     protected ExecutorService execService;
 
+    protected final int maxUnfieldedExpansionThreshold;
+    protected final int maxValueExpansionThreshold;
+
     public AsyncIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, boolean unfieldedLookup, ExecutorService execService) {
         super(config, scannerFactory);
         this.unfieldedLookup = unfieldedLookup;
         this.execService = execService;
+
+        this.maxUnfieldedExpansionThreshold = config.getMaxUnfieldedExpansionThreshold();
+        this.maxValueExpansionThreshold = config.getMaxValueExpansionThreshold();
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
@@ -1,0 +1,145 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+
+import datawave.core.iterators.FieldedRegexExpansionIterator;
+import datawave.core.iterators.TimeoutExceptionIterator;
+import datawave.core.iterators.TimeoutIterator;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+import datawave.util.time.DateHelper;
+
+/**
+ * An asynchronous index lookup which expands a fielded regex into discrete values
+ */
+public class FieldedRegexIndexLookup extends AsyncIndexLookup {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldedRegexIndexLookup.class);
+
+    private final String field;
+    private final String pattern;
+    private final Range range;
+    private final boolean reverse;
+    private final StringBuilder sb = new StringBuilder();
+
+    private final Set<String> values = new HashSet<>();
+
+    private final CountDownLatch latch;
+
+    public FieldedRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, ExecutorService execService, String field, String pattern,
+                    Range range, boolean reverse) {
+        super(config, scannerFactory, false, execService);
+        this.field = field;
+        this.pattern = pattern;
+        this.range = range;
+        this.reverse = reverse;
+        this.latch = new CountDownLatch(1);
+        log.info("Created FieldedRegexIndexLookup with field {} and pattern {}", field, pattern);
+    }
+
+    @Override
+    public void submit() {
+        if (indexLookupMap == null) {
+            indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
+
+            execService.submit(() -> {
+                String tableName = reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
+                try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
+                    String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+                    scanner.setExecutionHints(Map.of(tableName, hintKey));
+
+                    IteratorSetting timeoutIterator = new IteratorSetting(1, TimeoutIterator.class);
+                    long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
+                    timeoutIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+                    scanner.addScanIterator(timeoutIterator);
+
+                    IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "fielded regex expansion",
+                                    FieldedRegexExpansionIterator.class.getName());
+                    setting.addOption(FieldedRegexExpansionIterator.FIELD, field);
+                    setting.addOption(FieldedRegexExpansionIterator.PATTERN, pattern);
+                    setting.addOption(FieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+                    setting.addOption(FieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+                    if (!config.getDatatypeFilter().isEmpty()) {
+                        setting.addOption(FieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
+                    }
+                    setting.addOption(FieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+
+                    scanner.addScanIterator(setting);
+
+                    IteratorSetting timeoutExceptionIterator = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+                    scanner.addScanIterator(timeoutExceptionIterator);
+
+                    scanner.setRange(range);
+
+                    scanner.fetchColumnFamily(new Text(field));
+
+                    for (Map.Entry<Key,Value> entry : scanner) {
+                        Key key = entry.getKey();
+
+                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
+                            // set state and break instead of throwing an exception
+                            throw new RuntimeException("Timeout exceeded for fielded regex lookup");
+                        }
+
+                        String value = key.getRow().toString();
+                        if (reverse) {
+                            value = reverse(value);
+                        }
+                        values.add(value);
+                    }
+
+                } catch (Exception e) {
+                    log.error(e.getMessage(), e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+    }
+
+    @Override
+    public IndexLookupMap lookup() {
+
+        synchronized (latch) {
+            if (latch.getCount() == 1) {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    log.error(e.getMessage(), e);
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        ValueSet set = new ValueSet(Integer.MAX_VALUE);
+        set.addAll(values);
+
+        IndexLookupMap map = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
+        map.put(field, set);
+        return map;
+    }
+
+    private String reverse(String value) {
+        sb.setLength(0);
+        sb.append(value);
+        sb.reverse();
+        return sb.toString();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/RegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/RegexIndexLookup.java
@@ -1,5 +1,7 @@
 package datawave.query.jexl.lookups;
 
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,12 +23,14 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.hadoop.io.Text;
 import org.apache.log4j.Logger;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
 import datawave.core.common.logging.ThreadConfigurableLogger;
+import datawave.core.iterators.FieldedRegexExpansionIterator;
 import datawave.core.iterators.TimeoutExceptionIterator;
 import datawave.core.iterators.TimeoutIterator;
 import datawave.core.query.configuration.Result;
@@ -40,12 +44,14 @@ import datawave.query.tables.ScannerFactory;
 import datawave.query.tables.ScannerSession;
 import datawave.query.tables.SessionOptions;
 import datawave.query.util.MetadataHelper;
+import datawave.util.time.DateHelper;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.PreConditionFailedQueryException;
 
 /**
  * An asynchronous index lookup which looks up concrete values for the specified regex term.
  */
+@Deprecated
 public class RegexIndexLookup extends AsyncIndexLookup {
 
     private static final Object LOCK = new Object();
@@ -163,8 +169,29 @@ public class RegexIndexLookup extends AsyncIndexLookup {
                 for (String key : forwardMap.keySet()) {
                     Collection<Range> ranges = forwardMap.get(key);
                     try {
-                        bs = ShardIndexQueryTableStaticMethods.configureLimitedDiscovery(config, scannerFactory, config.getIndexTableName(), ranges,
-                                        Collections.emptySet(), Collections.singleton(key), false, true);
+                        boolean next = false;
+                        if (next) {
+                            String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : config.getIndexTableName();
+                            bs = scannerFactory.newLimitedScanner(ScannerSession.class, config.getIndexTableName(), config.getAuthorizations(),
+                                            config.getQuery(), hintKey);
+
+                            bs.setRanges(ranges);
+
+                            Preconditions.checkArgument(fields.size() == 1);
+
+                            IteratorSetting setting = new IteratorSetting(50, "fielded regex expansion", FieldedRegexExpansionIterator.class.getName());
+                            setting.addOption(FieldedRegexExpansionIterator.FIELD, fields.iterator().next());
+                            setting.addOption(FieldedRegexExpansionIterator.PATTERN, key);
+                            setting.addOption(FieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+                            setting.addOption(FieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+
+                            SessionOptions options = new SessionOptions();
+                            options.addScanIterator(setting);
+                            bs.setOptions(options);
+                        } else {
+                            bs = ShardIndexQueryTableStaticMethods.configureLimitedDiscovery(config, scannerFactory, config.getIndexTableName(), ranges,
+                                            Collections.emptySet(), Collections.singleton(key), false, true);
+                        }
 
                         bs.setResourceClass(BatchResource.class);
                     } catch (Exception e) {
@@ -184,6 +211,7 @@ public class RegexIndexLookup extends AsyncIndexLookup {
                     }
 
                     forwardLookupData.getSessions().add(bs);
+                    // creating multiple batch scanners but not actually running them in parallel?
                     iter = Iterators.concat(iter, Result.keyValueIterator(bs));
                 }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ShardIndexQueryTableStaticMethods.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ShardIndexQueryTableStaticMethods.java
@@ -665,7 +665,7 @@ public class ShardIndexQueryTableStaticMethods {
                 Key endKey = new Key(reversedQueryTerm + Constants.MAX_UNICODE_STRING);
 
                 // set the upper and lower bounds
-                rangeDesc.range = new Range(startKey, false, endKey, false);
+                rangeDesc.range = new Range(startKey, true, endKey, false);
             }
 
         } else {
@@ -702,7 +702,7 @@ public class ShardIndexQueryTableStaticMethods {
 
                 // either middle or trailing wildcard, truncate the field value at the wildcard location
                 // for upper bound, tack on the upper bound UTF character
-                rangeDesc.range = new Range(startKey, false, endKey, false);
+                rangeDesc.range = new Range(startKey, true, endKey, false);
             }
         }
 
@@ -753,12 +753,12 @@ public class ShardIndexQueryTableStaticMethods {
         Set<String> datatypeFilter = config.getDatatypeFilter();
 
         // TODO Magical handling of a "null" fieldName
-        boolean isForwardIndexed = (null != fieldName) ? indexedInDatatype(fieldName, datatypeFilter, metadataHelper) : true;
-        boolean isReverseIndexed = (null != fieldName) ? reverseIndexedInDatatype(fieldName, datatypeFilter, metadataHelper) : true;
+        boolean isForwardIndexed = null == fieldName || indexedInDatatype(fieldName, datatypeFilter, metadataHelper);
+        boolean isReverseIndexed = null == fieldName || reverseIndexedInDatatype(fieldName, datatypeFilter, metadataHelper);
 
         // if not indexed at all, then error
         if (!isForwardIndexed && !isReverseIndexed) {
-            throw new DatawaveFatalQueryException("Cannot lookup a non-indexed term");
+            throw new DatawaveFatalQueryException("Cannot lookup a non-indexed term: " + fieldName);
         }
 
         // if only indexed one way, then choose that one

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
@@ -1,0 +1,161 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import datawave.core.iterators.TimeoutExceptionIterator;
+import datawave.core.iterators.TimeoutIterator;
+import datawave.core.iterators.UnfieldedRegexExpansionIterator;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+import datawave.util.time.DateHelper;
+
+/**
+ * An asynchronous index lookup which expands a fielded regex into discrete values
+ */
+public class UnfieldedRegexIndexLookup extends AsyncIndexLookup {
+
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedRegexIndexLookup.class);
+
+    private final String pattern;
+    private final Range range;
+    private final boolean reverse;
+    private final Set<String> fields;
+
+    private final Multimap<String,String> fieldValues = ArrayListMultimap.create();
+
+    private final CountDownLatch latch;
+    private final AtomicBoolean exceptionSeen = new AtomicBoolean(false);
+
+    public UnfieldedRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, ExecutorService execService, String pattern, Range range,
+                    boolean reverse, Set<String> fields) {
+        super(config, scannerFactory, true, execService);
+        this.pattern = pattern;
+        this.range = range;
+        this.reverse = reverse;
+        this.fields = Objects.requireNonNullElse(fields, Collections.emptySet());
+        this.latch = new CountDownLatch(1);
+        log.info("Created UnfieldedRegexIndexLookup with pattern {}", pattern);
+    }
+
+    @Override
+    public void submit() {
+        if (indexLookupMap == null) {
+            indexLookupMap = new IndexLookupMap(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+            execService.submit(() -> {
+                String tableName = reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
+                try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
+                    String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+                    scanner.setExecutionHints(Map.of(tableName, hintKey));
+
+                    IteratorSetting timeoutIterator = new IteratorSetting(1, TimeoutIterator.class);
+                    long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
+                    timeoutIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+                    scanner.addScanIterator(timeoutIterator);
+
+                    IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "unfielded regex expansion",
+                                    UnfieldedRegexExpansionIterator.class.getName());
+                    setting.addOption(UnfieldedRegexExpansionIterator.PATTERN, pattern);
+                    setting.addOption(UnfieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+                    setting.addOption(UnfieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+                    setting.addOption(UnfieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+                    if (!config.getDatatypeFilter().isEmpty()) {
+                        setting.addOption(UnfieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
+                    }
+                    scanner.addScanIterator(setting);
+
+                    IteratorSetting timeoutExceptionIterator = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+                    scanner.addScanIterator(timeoutExceptionIterator);
+
+                    scanner.setRange(range);
+
+                    for (String field : fields) {
+                        scanner.fetchColumnFamily(new Text(field));
+                    }
+
+                    for (Map.Entry<Key,Value> entry : scanner) {
+                        Key key = entry.getKey();
+
+                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
+                            // set state and break instead of throwing an exception
+                            throw new RuntimeException("Timeout exceeded for unfielded regex lookup");
+                        }
+
+                        String value = key.getRow().toString();
+                        String field = key.getColumnFamily().toString();
+                        if (reverse) {
+                            value = reverse(value);
+                        }
+                        fieldValues.put(field, value);
+                    }
+
+                } catch (Exception e) {
+                    exceptionSeen.set(true);
+                    log.error(e.getMessage(), e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+    }
+
+    @Override
+    public IndexLookupMap lookup() {
+
+        synchronized (latch) {
+            if (latch.getCount() == 1) {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    log.error(e.getMessage(), e);
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        if (exceptionSeen.get()) {
+            // the presence of any exception during unfielded index expansion means the
+            // query is potentially not satisfied due to a missing field. Treat this
+            // expansion as a total failure.
+            return new IndexLookupMap(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        }
+
+        IndexLookupMap map = new IndexLookupMap(Integer.MAX_VALUE, Integer.MAX_VALUE);
+        for (String key : fieldValues.keySet()) {
+            ValueSet set = new ValueSet(Integer.MAX_VALUE);
+            set.addAll(fieldValues.get(key));
+            map.put(key, set);
+        }
+        return map;
+    }
+
+    private final StringBuilder sb = new StringBuilder();
+
+    private String reverse(String value) {
+        sb.setLength(0);
+        sb.append(value);
+        sb.reverse();
+        return sb.toString();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -333,7 +333,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
         @Override
         public Thread newThread(Runnable r) {
             Thread thread = dtf.newThread(r);
-            thread.setName(name + " Session " + threadIdentifier + " -" + threadNum++);
+            thread.setName(name + " " + threadIdentifier + " -" + threadNum++);
             thread.setDaemon(true);
             thread.setUncaughtExceptionHandler(config.getQuery().getUncaughtExceptionHandler());
             return thread;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
@@ -9,11 +9,12 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_VALUE;
 import static org.apache.commons.jexl3.parser.JexlNodes.id;
 
-import java.util.Collection;
+import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -36,18 +37,25 @@ import com.google.common.collect.Maps;
 import datawave.query.Constants;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.exceptions.DoNotPerformOptimizedQueryException;
 import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.lookups.EmptyIndexLookup;
+import datawave.query.jexl.lookups.FieldedRegexIndexLookup;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.jexl.lookups.IndexLookupMap;
 import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods;
+import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.RefactoredRangeDescription;
+import datawave.query.jexl.lookups.UnfieldedRegexIndexLookup;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.model.QueryModel;
 import datawave.query.parser.JavaRegexAnalyzer;
 import datawave.query.planner.pushdown.Cost;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.MetadataHelper;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+import datawave.webservice.query.exception.PreConditionFailedQueryException;
 
 /**
  * Visits a Jexl tree, looks for regex terms, and replaces them with concrete values from the index
@@ -57,7 +65,10 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
 
     protected boolean expandUnfieldedNegations;
 
-    protected Collection<String> onlyUseThese;
+    protected Set<String> onlyUseThese;
+    protected Set<String> expansionFields;
+    protected Set<String> forwardIndexedFields;
+    protected Set<String> reverseIndexedFields;
 
     // This flag keeps track of whether we are in a negated portion of the tree.
     protected boolean negated = false;
@@ -84,10 +95,19 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
 
         if (config.isLimitTermExpansionToModel()) {
             QueryModel queryModel = helper.getQueryModel(config.getModelTableName(), config.getModelName());
-            this.onlyUseThese = queryModel.getForwardQueryMapping().values();
+            this.onlyUseThese = new HashSet<>(queryModel.getForwardQueryMapping().values());
         } else {
             this.onlyUseThese = null;
         }
+
+        this.expansionFields = helper.getExpansionFields(config.getDatatypeFilter());
+        if (this.expansionFields == null) {
+            this.expansionFields = new HashSet<>();
+        }
+
+        forwardIndexedFields = ShardIndexQueryTableStaticMethods.getIndexedExpansionFields(expansionFields, false, config.getDatatypeFilter(), helper);
+        reverseIndexedFields = ShardIndexQueryTableStaticMethods.getIndexedExpansionFields(expansionFields, true, config.getDatatypeFilter(), helper);
+
         this.stage = "regex";
     }
 
@@ -476,8 +496,42 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
     }
 
     protected IndexLookup createLookup(JexlNode node) {
-        String fieldName = JexlASTHelper.getIdentifier(node);
-        return ShardIndexQueryTableStaticMethods.expandRegexTerms((ASTERNode) node, config, scannerFactory, fieldName, helper, executor);
+        String field = JexlASTHelper.getIdentifier(node);
+        String pattern = String.valueOf(JexlASTHelper.getLiteralValue(node));
+        validatePattern(pattern);
+
+        if (field.equals(Constants.ANY_FIELD)) {
+            field = null; // need to pass null to 'getRegexRange' to avoid checking the indexed status of 'ANYFIELD'
+        }
+
+        RefactoredRangeDescription description;
+        try {
+            description = ShardIndexQueryTableStaticMethods.getRegexRange(field, pattern, config.getFullTableScanEnabled(), helper, config);
+        } catch (JavaRegexAnalyzer.JavaRegexParseException | TableNotFoundException | ExecutionException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+
+        if (field == null) {
+
+            Set<String> expansionFields = onlyUseThese;
+            if (expansionFields == null) {
+                if (description.isForReverseIndex) {
+                    expansionFields = reverseIndexedFields;
+                } else {
+                    expansionFields = forwardIndexedFields;
+                }
+            }
+
+            if (expansionFields.isEmpty()) {
+                // unfielded expansions must be scoped to a set of preconfigured expansion fields or the set of indexed fields
+                return new EmptyIndexLookup(config);
+            }
+
+            return new UnfieldedRegexIndexLookup(config, scannerFactory, executor, pattern, description.range, description.isForReverseIndex, expansionFields);
+        } else {
+            return new FieldedRegexIndexLookup(config, scannerFactory, executor, field, pattern, description.range, description.isForReverseIndex);
+        }
     }
 
     /**
@@ -705,5 +759,14 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         }
 
         futureJexlNode.setRebuiltNode(newNode);
+    }
+
+    protected void validatePattern(String pattern) {
+        if (config.getDisallowedRegexPatterns().contains(pattern)) {
+            PreConditionFailedQueryException qe = new PreConditionFailedQueryException(DatawaveErrorCode.IGNORE_PATTERN_FOR_INDEX_LOOKUP,
+                            MessageFormat.format("Pattern: {0}", pattern));
+            log.error(qe.getMessage(), qe);
+            throw new DoNotPerformOptimizedQueryException(qe);
+        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
@@ -1,7 +1,6 @@
 package datawave.query.jexl.visitors;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -22,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
@@ -43,18 +41,10 @@ import jline.internal.Preconditions;
 public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
     private static final Logger log = LoggerFactory.getLogger(UnfieldedIndexExpansionVisitor.class);
 
-    protected Set<String> expansionFields;
-
     // The constructor should not be made public so that we can ensure that the executor is setup and shutdown correctly
     protected UnfieldedIndexExpansionVisitor(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelper helper)
                     throws TableNotFoundException, IllegalAccessException, InstantiationException {
         super(config, scannerFactory, helper, null, "FieldNameIndexExpansion");
-
-        this.expansionFields = helper.getExpansionFields(config.getDatatypeFilter());
-        if (this.expansionFields == null) {
-            this.expansionFields = new HashSet<>();
-        }
-
         this.stage = "field";
     }
 
@@ -219,17 +209,6 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
     @Override
     protected boolean shouldExpand(JexlNode node) {
         return (!negated || expandUnfieldedNegations) && hasUnfieldedIdentifier(node);
-    }
-
-    @Override
-    protected IndexLookup createLookup(JexlNode node) {
-        try {
-            // Using the datatype filter when expanding this term isn't really
-            // necessary
-            return ShardIndexQueryTableStaticMethods.expandQueryTerms(node, config, scannerFactory, expansionFields, helper, executor);
-        } catch (TableNotFoundException e) {
-            throw new DatawaveFatalQueryException(e);
-        }
     }
 
     protected IndexLookup createFieldNameIndexLookup(JexlNode node) {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1202,6 +1202,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         // If the max regex expansion is reached for a term, then it will be
         // left as a regex
         if (!disableAnyFieldLookup) {
+            // should this be expanding into discrete values as well or no?
+            // seems like we should stick to doing one thing well, and do it fast
+            // allow the later stage to handle expanding values
             config.setQueryTree(timedExpandAnyFieldRegexNodes(timers, config.getQueryTree(), config, metadataHelper, scannerFactory, settings.getQuery()));
         }
 

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/FieldedRegexExpansionIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/FieldedRegexExpansionIteratorTest.java
@@ -1,0 +1,262 @@
+package datawave.core.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Unit tests for the {@link FieldedRegexExpansionIterator}
+ * <p>
+ * Each test will exercise the forward and reverse index so care should be taken when constructing regexes
+ */
+public class FieldedRegexExpansionIteratorTest {
+
+    private final SortedMap<Key,Value> forwardData = new TreeMap<>();
+    private final SortedMap<Key,Value> reverseData = new TreeMap<>();
+    private final Map<String,String> options = new HashMap<>();
+    private final Set<String> expected = new HashSet<>();
+    private final Set<String> results = new HashSet<>();
+
+    private String pattern;
+    private final StringBuilder sb = new StringBuilder();
+
+    private static final Value EMPTY_VALUE = new Value();
+
+    @BeforeEach
+    public void setup() {
+        forwardData.clear();
+        reverseData.clear();
+        options.clear();
+        expected.clear();
+        results.clear();
+    }
+
+    public void withData(String value, String field, String shard, String datatype) {
+        // don't need to worry about visibility for this test
+        Key key = new Key(value, field, shard + "\0" + datatype);
+        forwardData.put(key, EMPTY_VALUE);
+
+        String reversedValue = new StringBuilder(value).reverse().toString();
+        Key reversedKey = new Key(reversedValue, field, shard + "\0" + datatype);
+        reverseData.put(reversedKey, EMPTY_VALUE);
+    }
+
+    public void withDates(String startDate, String endDate) {
+        options.put(FieldedRegexExpansionIterator.START_DATE, startDate);
+        options.put(FieldedRegexExpansionIterator.END_DATE, endDate);
+    }
+
+    public void withDatatypeFilter(Set<String> datatypes) {
+        options.put(FieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(datatypes));
+    }
+
+    public void withFieldPattern(String field, String pattern) {
+        options.put(FieldedRegexExpansionIterator.FIELD, field);
+        this.pattern = pattern;
+    }
+
+    public void withExpected(String... values) {
+        expected.addAll(List.of(values));
+    }
+
+    @Test
+    public void testOptionsMissingField() {
+        withFieldPattern(null, "val");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingPattern() {
+        withFieldPattern("FIELD", null);
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingDate() {
+        withFieldPattern("FIELD", "val");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testSingleValueExpansion() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "aa");
+        withDates("20250804", "20250804");
+        withExpected("aaa");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionWithDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "aa");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aaa");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionExcludedByDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "aa");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-b"));
+        drive();
+    }
+
+    @Test
+    public void testMultiValueExpansion() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "a");
+        withDates("20250804", "20250804");
+        withExpected("aa", "ab", "ac");
+        drive();
+    }
+
+    @Test
+    public void testSkipField() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_B", "a");
+        withDates("20250804", "20250804");
+        withExpected("aa", "ac");
+        drive();
+    }
+
+    @Test
+    public void testSkipDate() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250805_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_B", "a");
+        withDates("20250804", "20250804");
+        withExpected("aa", "ac");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDatatypeFilter() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-b");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-c");
+        withFieldPattern("FIELD_A", "a");
+        withDates("20250804", "20250804");
+
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aa");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b"));
+        withExpected("ab");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-c"));
+        withExpected("ac");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b"));
+        withExpected("aa", "ab");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-c"));
+        withExpected("aa", "ac");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b", "datatype-c"));
+        withExpected("ab", "ac");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b", "datatype-c"));
+        withExpected("aa", "ab", "ac");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDateBounds() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250805_0", "datatype-a");
+        withFieldPattern("FIELD_A", "a");
+        withDates("20250804", "20250804");
+        withExpected("ab");
+        drive();
+    }
+
+    private void drive() throws Exception {
+        exerciseForwardIndex();
+        exerciseReverseIndex();
+    }
+
+    private void exerciseForwardIndex() throws Exception {
+        String trailingRegex = pattern + ".*";
+        options.put(FieldedRegexExpansionIterator.PATTERN, trailingRegex);
+        driveIterator(forwardData, false);
+    }
+
+    private void exerciseReverseIndex() throws Exception {
+        String leadingRegex = ".*" + pattern;
+        options.put(FieldedRegexExpansionIterator.PATTERN, leadingRegex);
+        driveIterator(reverseData, true);
+    }
+
+    private void driveIterator(SortedMap<Key,Value> data, boolean reverse) throws Exception {
+        FieldedRegexExpansionIterator iterator = new FieldedRegexExpansionIterator();
+        iterator.init(new SortedMapIterator(data), options, null);
+        iterator.seek(new Range(), Collections.emptySet(), false);
+
+        results.clear();
+        while (iterator.hasTop()) {
+            Key tk = iterator.getTopKey();
+            String value = tk.getRow().toString();
+            results.add(handleValue(value, reverse));
+            iterator.next();
+        }
+
+        assertEquals(expected, results);
+    }
+
+    private String handleValue(String value, boolean reverse) {
+        if (reverse) {
+            sb.setLength(0);
+            sb.append(value);
+            sb.reverse();
+            return sb.toString();
+        }
+        return value;
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/UnfieldedRegexExpansionIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/UnfieldedRegexExpansionIteratorTest.java
@@ -1,0 +1,267 @@
+package datawave.core.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+import datawave.query.data.parsers.ShardIndexKey;
+
+/**
+ * Unit tests for the {@link UnfieldedRegexExpansionIterator}
+ * <p>
+ * The UnfieldedRegexExpansionIterator should handle any test case that the FieldedRegexExpansionIterator can. It won't be as efficient, but the results should
+ * be the same.
+ */
+public class UnfieldedRegexExpansionIteratorTest {
+
+    private final SortedMap<Key,Value> data = new TreeMap<>();
+    private final Map<String,String> options = new HashMap<>();
+    private final List<String> expected = new ArrayList<>();
+    private final List<String> results = new ArrayList<>();
+
+    private final ShardIndexKey parser = new ShardIndexKey();
+
+    private static final Value EMPTY_VALUE = new Value();
+
+    @BeforeEach
+    public void setup() {
+        data.clear();
+        options.clear();
+        expected.clear();
+        results.clear();
+    }
+
+    public void withData(String value, String field, String shard, String datatype) {
+        // don't need to worry about visibility for this test
+        Key key = new Key(value, field, shard + "\0" + datatype);
+        data.put(key, EMPTY_VALUE);
+    }
+
+    public void withDates(String startDate, String endDate) {
+        options.put(UnfieldedRegexExpansionIterator.START_DATE, startDate);
+        options.put(UnfieldedRegexExpansionIterator.END_DATE, endDate);
+    }
+
+    public void withDatatypeFilter(Set<String> datatypes) {
+        options.put(UnfieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(datatypes));
+    }
+
+    public void withPattern(String pattern) {
+        options.put(UnfieldedRegexExpansionIterator.PATTERN, pattern);
+    }
+
+    public void withExpected(String... values) {
+        expected.addAll(List.of(values));
+    }
+
+    @Test
+    public void testOptionsMissingField() {
+        withPattern("val.*");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingPattern() {
+        withPattern(null);
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingDate() {
+        withPattern("val.*");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testSingleValueExpansion() throws Exception {
+        withData("aaa", "FIELD_A", "20250804", "datatype-a");
+        withPattern("aa.*");
+        withDates("20250804", "20250804");
+        withExpected("aaa FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionWithDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withPattern("aa.*");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aaa FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionExcludedByDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withPattern("aa.*");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-b"));
+        drive();
+    }
+
+    @Test
+    public void testMultiValueExpansion() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("aa FIELD_A", "ab FIELD_A", "ac FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testSkipField() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("aa FIELD_B", "ab FIELD_A", "ac FIELD_B");
+        drive();
+    }
+
+    @Test
+    public void testSkipDate() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("aa FIELD_B", "ac FIELD_B");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDatatypeFilter() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-b");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-c");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aa FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b"));
+        withExpected("ab FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-c"));
+        withExpected("ac FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b"));
+        withExpected("aa FIELD_A", "ab FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-c"));
+        withExpected("aa FIELD_A", "ac FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b", "datatype-c"));
+        withExpected("ab FIELD_A", "ac FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b", "datatype-c"));
+        withExpected("aa FIELD_A", "ab FIELD_A", "ac FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDateBounds() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250805_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("ab FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testUnfieldedExpansionReturnsUniqueValues() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("aa", "FIELD_A", "20250805_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250803", "20250805");
+        withExpected("aa FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testValueExpansionThreshold() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250803_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250803", "20250804");
+        withExpected("aa FIELD_A");
+        withExpected("ab FIELD_A");
+        withExpected("ac FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testFieldExpansionThreshold() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("aa", "FIELD_B", "20250803_0", "datatype-a");
+        withData("aa", "FIELD_C", "20250803_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250803", "20250804");
+        withExpected("aa FIELD_A");
+        withExpected("aa FIELD_B");
+        withExpected("aa FIELD_C");
+        drive();
+    }
+
+    private void drive() throws Exception {
+        UnfieldedRegexExpansionIterator iterator = new UnfieldedRegexExpansionIterator();
+        iterator.init(new SortedMapIterator(data), options, null);
+        iterator.seek(new Range(), Collections.emptySet(), false);
+
+        while (iterator.hasTop()) {
+            Key tk = iterator.getTopKey();
+            parser.parse(tk);
+            String result = parser.getValue() + " " + parser.getField();
+            results.add(result);
+            iterator.next();
+        }
+
+        assertEquals(expected, results);
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/AnyFieldQueryTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -161,11 +162,13 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
             Multimap<String,KeyValue> metadata = removeMetadataEntries(JexlASTHelper.getIdentifierNames(JexlASTHelper.parseJexlQuery(anyCity)),
                             ColumnFamilyConstants.COLF_I);
 
-            // expect no results
-            runTest(query, Collections.emptyList());
-
-            // add the metadata back in
-            addMetadataEntries(metadata);
+            try {
+                // expect no results
+                runTest(query, Collections.emptyList());
+            } finally {
+                // add the metadata back in
+                addMetadataEntries(metadata);
+            }
         }
     }
 
@@ -548,21 +551,24 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         // Test the plan with all expansions
         // test running the query
         String expect = this.dataManager.convertAnyField(phrase);
-        runTest(query, expect);
-
-        // remove the metadata entries
-        Multimap<String,KeyValue> metadata = removeMetadataEntries(JexlASTHelper.getIdentifierNames(JexlASTHelper.parseJexlQuery(expect)),
-                        ColumnFamilyConstants.COLF_RI);
+        // runTest(query, expect);
 
         // expect no results
+        Multimap<String,KeyValue> metadata = null;
         try {
+            // remove the metadata entries
+            Set<String> fieldsToRemove = JexlASTHelper.getIdentifierNames(JexlASTHelper.parseJexlQuery(expect));
+            metadata = removeMetadataEntries(fieldsToRemove, ColumnFamilyConstants.COLF_RI);
+
             runTest(query, Collections.emptyList());
         } catch (FullTableScansDisallowedException e) {
-            // ok, essential no matches in index
+            // ok, essentially no matches in index
+        } finally {
+            // add the metadata back in
+            if (metadata != null) {
+                addMetadataEntries(metadata);
+            }
         }
-
-        // add the metadata back in
-        addMetadataEntries(metadata);
     }
 
     @Test
@@ -688,10 +694,10 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
             runTest(query, Collections.emptyList());
         } catch (FullTableScansDisallowedException e) {
             // ok
+        } finally {
+            // add the metadata back in
+            addMetadataEntries(metadata);
         }
-
-        // add the metadata back in
-        addMetadataEntries(metadata);
     }
 
     @Test
@@ -777,7 +783,7 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         assertPlanEquals(expect, plan);
 
         // Test the plan sans value expansion
-        expect = CityField.CITY.name() + roPhrase + JEXL_OR_OP + CityField.STATE.name() + oPhrase;
+        expect = "CITY =~ 'ro.*' || STATE =~ '.*o'";
         plan = getPlan(query, true, false);
         assertPlanEquals(expect, plan);
 
@@ -833,20 +839,17 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         String query = Constants.ANY_FIELD + roPhrase + AND_OP + Constants.ANY_FIELD + oPhrase;
 
         // Test the plan with all expansions
-        String compositeField = CityField.CITY.name() + '_' + CityField.STATE.name();
-        String expect = "(" + compositeField + EQ_OP + "'rome" + CompositeIngest.DEFAULT_SEPARATOR + "lazio'" + JEXL_OR_OP + compositeField + EQ_OP + "'rome"
-                        + CompositeIngest.DEFAULT_SEPARATOR + "ohio')";
+        String expect = "CITY_STATE == 'rome\uDBFF\uDFFFlazio' || CITY_STATE == 'rome\uDBFF\uDFFFohio'";
         String plan = getPlan(query, true, true);
         assertPlanEquals(expect, plan);
 
         // Test the plan sans value expansion
-        expect = CityField.CITY.name() + roPhrase + JEXL_AND_OP + CityField.STATE.name() + oPhrase;
+        expect = "CITY =~ 'ro.*' && STATE =~ '.*o'";
         plan = getPlan(query, true, false);
         assertPlanEquals(expect, plan);
 
         // Test the plan sans field expansion
-        expect = Constants.ANY_FIELD + EQ_OP + "'rome'" + JEXL_AND_OP + "(" + Constants.ANY_FIELD + EQ_OP + "'lazio'" + JEXL_OR_OP + Constants.ANY_FIELD + EQ_OP
-                        + "'ohio')";
+        expect = "_ANYFIELD_ == 'rome' && (_ANYFIELD_ == 'lazio' || _ANYFIELD_ == 'ohio')";
         plan = getPlan(query, false, true);
         assertPlanEquals(expect, plan);
 
@@ -1032,7 +1035,7 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         this.logic.setQueryPlanner(new DefaultQueryPlanner());
 
         String regPhrase = RN_OP + "'.*ica'";
-        String query = Constants.ANY_FIELD + regPhrase;
+        String query = "_ANYFIELD_ !~ '.*ica'";
 
         // Test the plan with all expansions
         try {
@@ -1045,8 +1048,7 @@ public class AnyFieldQueryTest extends AbstractFunctionalQuery {
         }
 
         // Test the plan sans value expansion
-        String expect = "(((!(((_Delayed_ = true)" + JEXL_AND_OP + "(" + Constants.ANY_FIELD + RE_OP + "'.*ica')))" + JEXL_AND_OP + "!("
-                        + CityField.CONTINENT.name() + RE_OP + "'.*ica'))))";
+        String expect = "!((_Delayed_ = true) && (_ANYFIELD_ =~ '.*ica')) && !(CONTINENT =~ '.*ica')";
         String plan = getPlan(query, true, false);
         assertPlanEquals(expect, plan);
 

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionIndexOnlyQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionIndexOnlyQueryTest.java
@@ -4,18 +4,16 @@ import static datawave.query.testframework.RawDataManager.AND_OP;
 import static datawave.query.testframework.RawDataManager.EQ_OP;
 import static datawave.query.testframework.RawDataManager.NOT_OP;
 import static datawave.query.testframework.RawDataManager.RE_OP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import datawave.query.exceptions.DatawaveFatalQueryException;
-import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.planner.DatePartitionedQueryPlanner;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.testframework.AbstractFunctionalQuery;
@@ -66,22 +64,24 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         String code = RE_OP + "'b.*'";
 
         String query = CitiesDataType.CityField.CITY.name() + city + AND_OP + CitiesDataType.CityField.STATE.name() + code;
+        String expectedPlan = "CITY == 'a-1' && (STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2')";
 
         this.logic.setMaxValueExpansionThreshold(20);
         runTest(query, query);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // value threshold does not affect the final plan
         this.logic.setMaxValueExpansionThreshold(2);
-        try {
-            runTest(query, query);
-            Assert.fail("exception expected");
-        } catch (DatawaveFatalQueryException e) {
-            // expected
-        }
+        runTest(query, query);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // configuring ivarators does not affect the final plan
         ivaratorConfig();
         runTest(query, query);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -95,22 +95,24 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         String code = RE_OP + "'b.*'";
 
         String query = CitiesDataType.CityField.CITY.name() + city + AND_OP + CitiesDataType.CityField.STATE.name() + code;
+        String expectedPlan = "CITY == 'a-1' && (STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2')";
 
         this.logic.setMaxValueExpansionThreshold(20);
         runTest(query, query);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // value threshold does not affect final query plan
         this.logic.setMaxValueExpansionThreshold(2);
-        try {
-            runTest(query, query);
-            Assert.fail("exception expected");
-        } catch (DatawaveFatalQueryException e) {
-            // expected
-        }
+        runTest(query, query);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // ivarator config does not affect final query plan
         ivaratorConfig();
         runTest(query, query);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -126,21 +128,25 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         String anyA = this.dataManager.convertAnyField(regexA);
         String expect = anyT + AND_OP + anyA;
 
+        String expectedPlan = "(CODE == 'b-code' || CITY == 'b-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b-state') && (CODE == 'a-code' || CITY == 'a-1' || STATE == 'a-state' || STATE == 'a-s2')";
+
+        // value threshold does not affect final plan
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // value threshold does not affect final plan
         this.logic.setMaxValueExpansionThreshold(2);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception expected");
-        } catch (RuntimeException re) {
-            // expected
-        }
+        runTest(query, expect);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // ivarator config does not affect final plan
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
         // hit exists in shard 20151010_0
         // range is 20150404_0 to 20150404 + MAX_VALUE
@@ -148,7 +154,8 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         this.logic.setUseDocumentScheduler(false);
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 2);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -164,26 +171,31 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         String anyA = this.dataManager.convertAnyField(regexA);
         String expect = anyT + AND_OP + anyA;
 
+        String expectedPlan = "(CODE == 'b-code' || CITY == 'b-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b-state') && (CODE == 'a-code' || CITY == 'a-1' || STATE == 'a-state' || STATE == 'a-s2')";
+
+        // value threshold does not affect the final plan
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // value threshold does not affect the final plan
         this.logic.setMaxValueExpansionThreshold(2);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception expected");
-        } catch (RuntimeException re) {
-            // expected
-        }
+        runTest(query, expect);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // ivarator config does not affect the final plan
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
         this.logic.setMaxValueExpansionThreshold(1);
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 2);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -197,21 +209,25 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         String query = Constants.ANY_FIELD + EQ_OP + country + AND_OP + NOT_OP + "(" + Constants.ANY_FIELD + regexPhrase + ")";
         String expect = CitiesDataType.CityField.STATE.name() + EQ_OP + "'bi-s'";
 
+        String expectedPlan = "STATE == 'b-state' && !(((_Delayed_ = true) && (_ANYFIELD_ =~ 'a.*')) || CODE == 'a-code' || CITY == 'a-1' || STATE == 'a-state' || STATE == 'a-s2')";
+
+        // value threshold has no effect on final plan
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // value threshold has no effect on final plan
         this.logic.setMaxValueExpansionThreshold(1);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception expected");
-        } catch (FullTableScansDisallowedException e) {
-            // expected
-        }
+        runTest(query, expect);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // ivarator config has no effect on final plan
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -225,21 +241,25 @@ public class MaxExpansionIndexOnlyQueryTest extends AbstractFunctionalQuery {
         String query = Constants.ANY_FIELD + EQ_OP + country + AND_OP + NOT_OP + "(" + Constants.ANY_FIELD + regexPhrase + ")";
         String expect = CitiesDataType.CityField.STATE.name() + EQ_OP + "'bi-s'";
 
+        String expectedPlan = "STATE == 'b-state' && !(((_Delayed_ = true) && (_ANYFIELD_ =~ 'a.*')) || CODE == 'a-code' || CITY == 'a-1' || STATE == 'a-state' || STATE == 'a-s2')";
+
+        // value expansion does not affect final plan
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // value expansion does not affect final plan
         this.logic.setMaxValueExpansionThreshold(1);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception expected");
-        } catch (FullTableScansDisallowedException e) {
-            // expected
-        }
+        runTest(query, expect);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // ivarator config does not affect final plan
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     // ============================================

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionQueryTest.java
@@ -83,7 +83,7 @@ public class MaxExpansionQueryTest extends AbstractFunctionalQuery {
         super(CitiesDataType.getManager());
     }
 
-    @Test(expected = DatawaveFatalQueryException.class)
+    @Test
     public void testMaxUnfielded() throws Exception {
         log.info("------  testMaxUnfielded  ------");
 
@@ -96,13 +96,10 @@ public class MaxExpansionQueryTest extends AbstractFunctionalQuery {
         runTest(query, expect);
         parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
 
+        // unfielded regex expansion cannot under any circumstance have a value or field threshold imposed
+        // any threshold exception could leave a field undiscovered and thus reduce the accuracy of a query
         this.logic.setMaxUnfieldedExpansionThreshold(1);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception condition expected");
-        } catch (FullTableScansDisallowedException e) {
-            // expected
-        }
+        runTest(query, expect);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MaxExpansionRegexQueryTest.java
@@ -8,22 +8,15 @@ import static datawave.query.testframework.RawDataManager.OR_OP;
 import static datawave.query.testframework.RawDataManager.RE_OP;
 import static datawave.query.testframework.RawDataManager.RN_OP;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
-import java.io.File;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 import org.apache.log4j.Logger;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import datawave.query.exceptions.DatawaveIvaratorMaxResultsException;
-import datawave.query.exceptions.FullTableScansDisallowedException;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
 import datawave.query.testframework.CitiesDataType;
@@ -75,19 +68,16 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
 
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        String expectedPlan = "CODE == 'b-code' || CITY == 'b-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b-state'";
+        assertEquals(expectedPlan, plan);
 
+        // a failure to fully expand a value means a field could be missed, that term is no longer executable
         this.logic.setMaxValueExpansionThreshold(1);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception condition expected");
-        } catch (FullTableScansDisallowedException e) {
-            // expected
-        }
-
-        ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        expectedPlan = "CODE == 'b-code' || CITY == 'b-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b-state'";
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -100,29 +90,19 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
 
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
+        String plan = getPlan(query, true, true);
+        String expectedPlan = "CODE == 'a-code' || CITY == 'a-1' || STATE == 'a-state' || STATE == 'a-s2'";
+        assertEquals(expectedPlan, plan);
         parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
 
+        // value expansion threshold should not affect an unfielded regex
         this.logic.setMaxValueExpansionThreshold(1);
-        // set regex to match more fields than are specified for the unified expansion
-        try {
-            runTest(query, expect);
-            Assert.fail("exception condition expected");
-        } catch (FullTableScansDisallowedException e) {
-            // expected
-        }
-
-        ivaratorConfig();
-        runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 1);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     /**
-     * This test case consists of three phases.
-     * <ul>
-     * <li>In phase one, the query should NOT exceed any thresholds.</li>
-     * <li>In phase two, the query should exceed one threshold.</li>
-     * <li>In phase three, the query should exceed the threshold for each index.</li>
-     * </ul>
+     * At no point should any value expansion threshold affect the final plan for an unfielded regex
      *
      * @throws Exception
      *             if there is an issue
@@ -139,20 +119,23 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         String expect = anyRegex + AND_OP + anyCity;
 
         ivaratorConfig();
+        String expectedPlan = "(CODE == 'b2-code' || CODE == 'b-code' || CODE == 'b3-code' || CITY == 'b-city' || CITY == 'b2-city' || CITY == 'b3-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2') && CITY == 'b-city'";
 
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
         this.logic.setMaxValueExpansionThreshold(4);
         runTest(query, expect);
-        // threshold should exist for each index
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 2);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
+        ;
 
         this.logic.setMaxValueExpansionThreshold(1);
         runTest(query, expect);
-        // threshold should exist for each index
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 3);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -164,31 +147,11 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         String anyState = this.dataManager.convertAnyField(regexPhrase);
         String expect = anyState + AND_OP + CityField.CODE.name() + RN_OP + exclude;
 
+        String expectedPlan = "(CODE == 'b2-code' || CODE == 'b-code' || CODE == 'b3-code' || CITY == 'b-city' || CITY == 'b2-city' || CITY == 'b3-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2') && filter:excludeRegex(CODE, '.*de-a')";
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
-        parsePlan(FILTER_EXCLUDE_REGEX, 1);
-
-        this.logic.setMaxValueExpansionThreshold(4);
-        try {
-            runTest(query, expect);
-            Assert.fail("exception expected");
-        } catch (FullTableScansDisallowedException e) {
-            // expected
-        }
-
-        ivaratorConfig();
-        runTest(query, expect);
-        // city should have a threshold
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 2);
-        parsePlan(FILTER_EXCLUDE_REGEX, 1);
-
-        this.logic.setMaxValueExpansionThreshold(2);
-        ivaratorConfig();
-        runTest(query, expect);
-        // city,state, code should have all exceed threshold
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 3);
-        parsePlan(FILTER_EXCLUDE_REGEX, 1);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -199,20 +162,26 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         String query = Constants.ANY_FIELD + regexPhrase + AND_OP + Constants.ANY_FIELD + fieldVal;
 
         ivaratorConfig();
+        String expectedPlan = "!(((_Delayed_ = true) && (_ANYFIELD_ =~ 'b.*')) || CODE == 'b2-code' || CODE == 'b-code' || CODE == 'b3-code' || CITY == 'b-city' || CITY == 'b2-city' || CITY == 'b3-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2') && CITY == 'a-1'";
 
         // '!~' operation is not processed correctly - see QueryJexl docs
         // this is a hack for the expected results
         String expect = CityField.CITY.name() + EQ_OP + "'city-a'";
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // changing the value expansion threshold should not affect the final query plan
         this.logic.setMaxValueExpansionThreshold(4);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 2);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
+        // changing the value expansion threshold should not affect the final query plan
         this.logic.setMaxValueExpansionThreshold(1);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 3);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     @Test
@@ -233,23 +202,28 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
                 CityField.CITY.name() + EQ_OP + "'b3-city'" + ")";
         // @formatter:on
 
+        String expectedPlan = "(CODE == 'b2-code' || CODE == 'b-code' || CODE == 'b3-code' || CITY == 'b-city' || CITY == 'b2-city' || CITY == 'b3-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2') && !((((_Delayed_ = true) && (_ANYFIELD_ =~ 'a-.*')) || CODE == 'a-code' || CITY == 'a-1' || STATE == 'a-state' || STATE == 'a-s2') && CITY == 'a-1')";
+
         this.logic.setMaxValueExpansionThreshold(10);
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 0);
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
         this.logic.setMaxValueExpansionThreshold(4);
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 2);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
 
         this.logic.setMaxValueExpansionThreshold(1);
         ivaratorConfig();
         runTest(query, expect);
-        parsePlan(VALUE_THRESHOLD_JEXL_NODE, 4);
+        plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     /**
-     * This tests a query without an intersection such that when we force the ivarators to fail with a maxResults setting of 1, the query will fail.
+     * Demonstrate that an unfielded regex fully expands into fields and values, regardless of thresholds
      *
      * @throws Exception
      *             if there is an issue
@@ -259,49 +233,14 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         log.info("------  testMaxIvaratorResultsFailsQuery  ------");
         String regex = RE_OP + "'b.*'";
         String query = Constants.ANY_FIELD + regex;
-
-        String anyRegex = this.dataManager.convertAnyField(regex);
-        String expect = anyRegex;
-
-        List<String> dirs = ivaratorConfig();
-        // set collapseUids to ensure we have shard ranges such that ivarators will actually execute
-        this.logic.setCollapseUids(true);
         // force the regex lookup into an ivarator
         this.logic.setMaxValueExpansionThreshold(1);
         // set a small buffer size to ensure we actually persist the buffers so that we can detect this below
         this.logic.setIvaratorCacheBufferSize(2);
 
-        runTest(query, expect);
-        // verify that the ivarators ran and completed
-        if (this.logic.isCheckpointable()) {
-            assertEquals(8, countComplete(dirs));
-        } else {
-            assertEquals(3, countComplete(dirs));
-        }
-
-        // clear list before new set is added
-        dirs.clear();
-        // now get a new set of ivarator directories
-        dirs = ivaratorConfig();
-        // set the max ivarator results to 1
-        this.logic.setMaxIvaratorResults(1);
-        try {
-            // verify the query actually fails
-            runTest(query, expect);
-            fail("Expected the query to fail with the ivarators fail");
-        } catch (Exception e) {
-            if (!hasCause(e, DatawaveIvaratorMaxResultsException.class)) {
-                log.error("Unexpected exception", e);
-                fail("Unexpected exception: " + e.getMessage());
-            }
-        }
-    }
-
-    private boolean hasCause(Throwable e, Class<? extends Exception> causeClass) {
-        while (e != null && !causeClass.isInstance(e)) {
-            e = e.getCause();
-        }
-        return e != null;
+        String expectedPlan = "CODE == 'b2-code' || CODE == 'b-code' || CODE == 'b3-code' || CITY == 'b-city' || CITY == 'b2-city' || CITY == 'b3-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2'";
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     /**
@@ -322,7 +261,6 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         String anyCity = this.dataManager.convertAnyField(city);
         String expect = anyRegex + AND_OP + anyCity;
 
-        List<String> dirs = ivaratorConfig();
         // set collapseUids to ensure we have shard ranges such that ivarators will actually execute
         this.logic.setCollapseUids(true);
         // force the regex lookup into an ivarator
@@ -330,51 +268,12 @@ public class MaxExpansionRegexQueryTest extends AbstractFunctionalQuery {
         // set a small buffer size to ensure we actually persist the buffers so that we can detect this below
         this.logic.setIvaratorCacheBufferSize(2);
 
+        // verify query gets all expected results
         runTest(query, expect);
 
-        // verify that the ivarators ran and completed
-        if (this.logic.isCheckpointable()) {
-            assertEquals(8, countComplete(dirs));
-        } else {
-            assertEquals(3, countComplete(dirs));
-        }
-
-        // clear list before new set is added
-        dirs.clear();
-
-        // now get a new set of ivarator directories
-        dirs = ivaratorConfig();
-        // set the max ivarator results to 1
-        this.logic.setMaxIvaratorResults(1);
-        // verify we still get our expected results
-        runTest(query, expect);
-        // and verify that the ivarators indeed persisted
-        assertEquals(3, countComplete(dirs));
-    }
-
-    private int countComplete(List<String> dirs) throws Exception {
-        int count = 0;
-        for (String dir : dirs) {
-            File file = new File(new URI(dir));
-            for (File leaf : getLeaves(file)) {
-                if (leaf.getName().equals("complete")) {
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    private Collection<File> getLeaves(File file) {
-        List<File> children = new ArrayList<>();
-        for (File child : file.listFiles()) {
-            if (child.isDirectory()) {
-                children.addAll(getLeaves(child));
-            } else {
-                children.add(child);
-            }
-        }
-        return children;
+        String expectedPlan = "(CODE == 'b2-code' || CODE == 'b-code' || CODE == 'b3-code' || CITY == 'b-city' || CITY == 'b2-city' || CITY == 'b3-city' || CITY == 'b-2' || CITY == 'b-1' || STATE == 'b3-state' || STATE == 'b-state' || STATE == 'bi-s' || STATE == 'b2-state' || STATE == 'ba-s2') && CITY == 'b-city'";
+        String plan = getPlan(query, true, true);
+        assertEquals(expectedPlan, plan);
     }
 
     // ============================================

--- a/warehouse/query-core/src/test/java/datawave/query/RebuildingScannerTestHelper.java
+++ b/warehouse/query-core/src/test/java/datawave/query/RebuildingScannerTestHelper.java
@@ -41,6 +41,7 @@ import datawave.accumulo.inmemory.ScannerRebuilder;
 import datawave.query.attributes.Document;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.iterator.profile.FinalDocumentTrackingIterator;
+import datawave.util.TableName;
 
 /**
  * This helper provides support for testing the teardown of iterators at randomly. Simply use the getConnector methods and all scanners created will contain an
@@ -629,31 +630,50 @@ public class RebuildingScannerTestHelper {
 
         @Override
         public BatchScanner createBatchScanner(String s, Authorizations authorizations, int i) throws TableNotFoundException {
+            if (s.equals(TableName.SHARD_INDEX)) {
+                return super.createBatchScanner(s, authorizations, i);
+            }
             return new RebuildingBatchScanner((InMemoryBatchScanner) (super.createBatchScanner(s, authorizations, i)), teardown, interrupt);
         }
 
         @Override
         public BatchScanner createBatchScanner(String s, Authorizations authorizations) throws TableNotFoundException {
+            if (s.equals(TableName.SHARD_INDEX)) {
+                return super.createBatchScanner(s, authorizations);
+            }
             return new RebuildingBatchScanner((InMemoryBatchScanner) (super.createBatchScanner(s, authorizations)), teardown, interrupt);
         }
 
         @Override
         public BatchScanner createBatchScanner(String s) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
+            if (s.equals(TableName.SHARD_INDEX)) {
+                return super.createBatchScanner(s);
+            }
             return new RebuildingBatchScanner((InMemoryBatchScanner) (super.createBatchScanner(s)), teardown, interrupt);
         }
 
         @Override
         public Scanner createScanner(String s, Authorizations authorizations) throws TableNotFoundException {
+            Scanner scanner = super.createScanner(s, authorizations);
+            if (s.equals(TableName.SHARD_INDEX)) {
+                return scanner;
+            }
+            if (scanner instanceof RebuildingScanner) {
+                return scanner;
+            }
             return new RebuildingScanner((InMemoryScanner) (super.createScanner(s, authorizations)), teardown, interrupt);
         }
 
         @Override
         public Scanner createScanner(String s) throws TableNotFoundException, AccumuloSecurityException, AccumuloException {
             Scanner scanner = super.createScanner(s);
+            if (s.equals(TableName.SHARD_INDEX)) {
+                return scanner;
+            }
             if (scanner instanceof RebuildingScanner) {
                 return scanner;
             }
-            return new RebuildingScanner((InMemoryScanner) (super.createScanner(s)), teardown, interrupt);
+            return new RebuildingScanner((InMemoryScanner) scanner, teardown, interrupt);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -419,7 +419,7 @@ public abstract class ExecutableExpansionVisitorTest {
         String[] queryStrings = {"SENTENCE_DAYS=~'4015\\.0*'"};
         @SuppressWarnings("unchecked")
         // SOPRANO is the only one with a 0 after the 1234
-        List<String>[] expectedLists = new List[] {Arrays.asList("CAPONE")};
+        List<String>[] expectedLists = new List[] {List.of("CAPONE")};
         for (int i = 0; i < queryStrings.length; i++) {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
@@ -431,7 +431,7 @@ public abstract class ExecutableExpansionVisitorTest {
     }
 
     @Test
-    public void testAnyfieldNumericExpansion() throws Exception {
+    public void testAnyFieldNumericExpansion() throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitorTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Sets;
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.DoNotPerformOptimizedQueryException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.model.QueryModel;
@@ -292,27 +291,26 @@ public class UnfieldedIndexExpansionVisitorTest {
         test(query, expected, config, helper);
     }
 
-    // regex term fails to expand fields, marked with an exceeded term threshold marker
-    @Test(expected = DatawaveFatalQueryException.class)
+    @Test
     public void testExceededTermThreshold() throws Exception {
         ShardQueryConfiguration config = createConfig();
+        // verify the unfielded expansion threshold is not applied
         config.setMaxUnfieldedExpansionThreshold(2);
 
         String query = "_ANYFIELD_ =~ 'dog.*'";
-        String expected = "((_Term_ = true) && (_ANYFIELD_ =~ 'dog.*'))";
+        String expected = "FIELD7 == 'dogfish' || FIELD7 == 'dog' || FIELD7 == 'doghouse' || FIELD8 == 'dogfish' || FIELD8 == 'dog' || FIELD8 == 'doghouse' || FIELD9 == 'dogfish' || FIELD9 == 'dog' || FIELD9 == 'doghouse'";
         test(query, expected, config);
     }
 
-    // regex term expands into fields, but values expansion fails by exceeding a threshold.
-    // a conjunction of fielded exceeded value markers is created.
     @Test
     public void testExceededValueThreshold() throws Exception {
         ShardQueryConfiguration config = createConfig();
-        config.setMaxUnfieldedExpansionThreshold(3); // 3 fields <= max threshold
-        config.setMaxValueExpansionThreshold(1); // values per field exceed threshold, preserving regex
+        // verify that neither threshold affects the final query plan
+        config.setMaxUnfieldedExpansionThreshold(3);
+        config.setMaxValueExpansionThreshold(1);
 
         String query = "_ANYFIELD_ =~ 'dog.*'";
-        String expected = "((_Value_ = true) && (FIELD7 =~ 'dog.*')) || ((_Value_ = true) && (FIELD8 =~ 'dog.*')) || ((_Value_ = true) && (FIELD9 =~ 'dog.*'))";
+        String expected = "FIELD7 == 'dogfish' || FIELD7 == 'dog' || FIELD7 == 'doghouse' || FIELD8 == 'dogfish' || FIELD8 == 'dog' || FIELD8 == 'doghouse' || FIELD9 == 'dogfish' || FIELD9 == 'dog' || FIELD9 == 'doghouse'";
         test(query, expected, config);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -641,7 +641,11 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         q.setPagesize(Integer.MAX_VALUE);
         q.setQueryAuthorizations(auths.toString());
 
-        return this.logic.getPlan(client, q, this.authSet, expandFields, expandValues);
+        String plan = this.logic.getPlan(client, q, this.authSet, expandFields, expandValues);
+        // if this method is called multiple times the index expansion executor is still active
+        // calling close ensures consistent state
+        logic.close();
+        return plan;
     }
 
     /**


### PR DESCRIPTION
Add iterators for fielded and unfielded regex expansion. These iterators provide field, date and datatype filtering in a single layer of the iterator stack.

Discovered issue where the UnfieldedRegexExpansionVisitor would delegate lookups to the RegexIndexExpansionVisitor, thus setting field and value thresholds. If either threshold is exceeded during an unfielded lookup there is the potential for missed results.

Updated the index expansion visitors to avoid this error condition and corrected test assertions throughout.

It should be more clear precisely what kind of lookup is created.

Breakout of tasks
- add regex iterators https://github.com/NationalSecurityAgency/datawave/pull/3154
- cleanup timeout iterator https://github.com/NationalSecurityAgency/datawave/pull/3155
- add index expansion unit tests https://github.com/NationalSecurityAgency/datawave/pull/3157
- add new IndexLookups https://github.com/NationalSecurityAgency/datawave/pull/3161
- integrate new IndexLookups https://github.com/NationalSecurityAgency/datawave/pull/3191