### PR TITLE
Add regex expansion iterators

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
@@ -44,8 +44,6 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
     public static final String PATTERN = "pattern";
     public static final String REVERSE = "reverse";
 
-    // TODO: max value threshold, max keys seen threshold?
-
     private String startDate;
     private String endDate;
     private String field;
@@ -54,6 +52,8 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
 
     private boolean reverse = false;
     private final StringBuilder sb = new StringBuilder();
+
+    private String previousMatch = null;
 
     private Text columnQualifierDate;
     private Text columnQualifierDateAndDatatype;
@@ -145,20 +145,23 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
         parser.parse(k);
         hint = HINT_TYPE.NONE;
 
-        Matcher matcher;
-        if (reverse) {
-            sb.setLength(0);
-            sb.append(parser.getValue());
-            sb.reverse();
-            matcher = pattern.matcher(sb);
-        } else {
-            matcher = pattern.matcher(parser.getValue());
-        }
+        if (previousMatch == null || !previousMatch.equals(parser.getValue())) {
+            Matcher matcher;
+            if (reverse) {
+                sb.setLength(0);
+                sb.append(parser.getValue());
+                sb.reverse();
+                matcher = pattern.matcher(sb);
+            } else {
+                matcher = pattern.matcher(parser.getValue());
+            }
 
-        if (!matcher.matches()) {
-            // advance to next row
-            log.info("pattern does not match, advance to next row");
-            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+            if (!matcher.matches()) {
+                // advance to next row
+                log.info("pattern does not match, advance to next row");
+                return new FilterResult(false, AdvanceResult.NEXT_ROW);
+            }
+            previousMatch = parser.getValue();
         }
 
         int result = parser.getField().compareTo(field);

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
@@ -50,7 +50,6 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
     private String endDate;
     private String field;
     private Pattern pattern;
-    private Matcher matcher;
     private Set<String> datatypes;
 
     private boolean reverse = false;
@@ -146,6 +145,7 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
         parser.parse(k);
         hint = HINT_TYPE.NONE;
 
+        Matcher matcher;
         if (reverse) {
             sb.setLength(0);
             sb.append(parser.getValue());

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
@@ -137,8 +137,8 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
 
     @Override
     public FilterResult filter(Key k, Value v) {
-        if (log.isInfoEnabled()) {
-            log.info("tk: {}", k.toStringNoTime());
+        if (log.isDebugEnabled()) {
+            log.debug("tk: {}", k.toStringNoTime());
         }
 
         // parse key and reset hint
@@ -158,7 +158,7 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
 
             if (!matcher.matches()) {
                 // advance to next row
-                log.info("pattern does not match, advance to next row");
+                log.debug("pattern does not match, advance to next row");
                 return new FilterResult(false, AdvanceResult.NEXT_ROW);
             }
             previousMatch = parser.getValue();
@@ -167,33 +167,33 @@ public class FieldedRegexExpansionIterator extends SeekingFilter implements Opti
         int result = parser.getField().compareTo(field);
         if (result < 0) {
             // advance to field
-            log.info("field {} sorts before target {}, advance to {}", parser.getField(), field, field);
+            log.debug("field {} sorts before target {}, advance to {}", parser.getField(), field, field);
             hint = HINT_TYPE.FIELD;
             return new FilterResult(false, AdvanceResult.USE_HINT);
         } else if (result > 0) {
             // advance to next row
-            log.info("field {} sorts after target {}, advance to next row", parser.getField(), field);
+            log.debug("field {} sorts after target {}, advance to next row", parser.getField(), field);
             return new FilterResult(true, AdvanceResult.NEXT_ROW);
         }
 
         String date = parser.getShard();
         if (date.compareTo(startDate) < 0) {
             // advance to start date
-            log.info("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
+            log.debug("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
             hint = HINT_TYPE.DATE;
             return new FilterResult(false, AdvanceResult.USE_HINT);
         } else if (date.compareTo(endDate) > 0) {
             // advance to next row
-            log.info("date {} sorts after end date {}, advance to next row", date, endDate);
+            log.debug("date {} sorts after end date {}, advance to next row", date, endDate);
             return new FilterResult(false, AdvanceResult.NEXT_ROW);
         }
 
         if (datatypes != null && !datatypes.contains(parser.getDatatype())) {
-            log.info("datatype {} does not match, advance to next key", parser.getDatatype());
+            log.debug("datatype {} does not match, advance to next key", parser.getDatatype());
             return new FilterResult(false, AdvanceResult.NEXT);
         }
 
-        log.info("key accepted, advancing to next row");
+        log.debug("key accepted, advancing to next row");
         return new FilterResult(true, AdvanceResult.NEXT_ROW);
     }
 

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/FieldedRegexExpansionIterator.java
@@ -1,0 +1,234 @@
+package datawave.core.iterators;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.user.SeekingFilter;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Splitter;
+
+import datawave.query.Constants;
+import datawave.query.data.parsers.ShardIndexKey;
+
+/**
+ * Attempts to expand a fielded regex into discrete values
+ * <p>
+ * Supports date and datatype filtering by default
+ */
+public class FieldedRegexExpansionIterator extends SeekingFilter implements OptionDescriber {
+
+    public static final Logger log = LoggerFactory.getLogger(FieldedRegexExpansionIterator.class);
+
+    public static final String START_DATE = "start.date";
+    public static final String END_DATE = "end.date";
+    public static final String DATATYPES = "dts";
+    public static final String FIELD = "field";
+    public static final String PATTERN = "pattern";
+    public static final String REVERSE = "reverse";
+
+    // TODO: max value threshold, max keys seen threshold?
+
+    private String startDate;
+    private String endDate;
+    private String field;
+    private Pattern pattern;
+    private Matcher matcher;
+    private Set<String> datatypes;
+
+    private boolean reverse = false;
+    private final StringBuilder sb = new StringBuilder();
+
+    private Text columnQualifierDate;
+    private Text columnQualifierDateAndDatatype;
+
+    private final ShardIndexKey parser = new ShardIndexKey();
+
+    enum HINT_TYPE {
+        NONE, FIELD, DATE
+    }
+
+    private HINT_TYPE hint = HINT_TYPE.NONE;
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+
+        if (!validateOptions(options)) {
+            throw new IllegalArgumentException("Iterator was not configured correctly");
+        }
+
+        super.init(source, options, env);
+
+        if (options.containsKey(START_DATE)) {
+            this.startDate = options.get(START_DATE);
+            this.columnQualifierDate = new Text(startDate + "_0");
+        } else {
+            throw new IllegalArgumentException("Iterator requires START_DATE option");
+        }
+
+        if (options.containsKey(END_DATE)) {
+            this.endDate = options.get(END_DATE) + Constants.MAX_UNICODE_STRING;
+        } else {
+            throw new IllegalArgumentException("Iterator requires END_DATE option");
+        }
+
+        if (options.containsKey(FIELD)) {
+            this.field = options.get(FIELD);
+        } else {
+            throw new IllegalArgumentException("Iterator requires FIELD option");
+        }
+
+        if (options.containsKey(PATTERN)) {
+            String option = options.get(PATTERN);
+            this.pattern = Pattern.compile(option);
+        } else {
+            throw new IllegalArgumentException("Iterator requires PATTERN option");
+        }
+
+        if (options.containsKey(DATATYPES)) {
+            String option = options.get(DATATYPES);
+            this.datatypes = new HashSet<>(Splitter.on(',').splitToList(option));
+
+            List<String> tmp = new ArrayList<>(datatypes);
+            Collections.sort(tmp);
+            this.columnQualifierDateAndDatatype = new Text(startDate + "_0\u0000" + tmp.get(0));
+        }
+
+        if (options.containsKey(REVERSE)) {
+            this.reverse = Boolean.parseBoolean(options.get(REVERSE));
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        if (!range.isStartKeyInclusive()) {
+            // need to skip to next row
+            Key skip = new Key(range.getStartKey().getRow().toString() + '\u0000');
+            if (skip.compareTo(range.getEndKey()) > 0) {
+                // handles case of bounded range against single value
+                // filter key: +cE1 NUM:20150808_0%00;generic [NA]
+                // skip key would be +cE1<null> but then the start key is greater than the end key. so we cheat accumulo.
+                Range skipRange = new Range(range.getEndKey(), true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            } else {
+                Range skipRange = new Range(skip, true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            }
+        } else {
+            super.seek(range, columnFamilies, inclusive);
+        }
+    }
+
+    @Override
+    public FilterResult filter(Key k, Value v) {
+        if (log.isInfoEnabled()) {
+            log.info("tk: {}", k.toStringNoTime());
+        }
+
+        // parse key and reset hint
+        parser.parse(k);
+        hint = HINT_TYPE.NONE;
+
+        if (reverse) {
+            sb.setLength(0);
+            sb.append(parser.getValue());
+            sb.reverse();
+            matcher = pattern.matcher(sb);
+        } else {
+            matcher = pattern.matcher(parser.getValue());
+        }
+
+        if (!matcher.matches()) {
+            // advance to next row
+            log.info("pattern does not match, advance to next row");
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        int result = parser.getField().compareTo(field);
+        if (result < 0) {
+            // advance to field
+            log.info("field {} sorts before target {}, advance to {}", parser.getField(), field, field);
+            hint = HINT_TYPE.FIELD;
+            return new FilterResult(false, AdvanceResult.USE_HINT);
+        } else if (result > 0) {
+            // advance to next row
+            log.info("field {} sorts after target {}, advance to next row", parser.getField(), field);
+            return new FilterResult(true, AdvanceResult.NEXT_ROW);
+        }
+
+        String date = parser.getShard();
+        if (date.compareTo(startDate) < 0) {
+            // advance to start date
+            log.info("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
+            hint = HINT_TYPE.DATE;
+            return new FilterResult(false, AdvanceResult.USE_HINT);
+        } else if (date.compareTo(endDate) > 0) {
+            // advance to next row
+            log.info("date {} sorts after end date {}, advance to next row", date, endDate);
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        if (datatypes != null && !datatypes.contains(parser.getDatatype())) {
+            log.info("datatype {} does not match, advance to next key", parser.getDatatype());
+            return new FilterResult(false, AdvanceResult.NEXT);
+        }
+
+        log.info("key accepted, advancing to next row");
+        return new FilterResult(true, AdvanceResult.NEXT_ROW);
+    }
+
+    @Override
+    public Key getNextKeyHint(Key k, Value v) {
+        switch (hint) {
+            case FIELD:
+            case DATE:
+                if (columnQualifierDateAndDatatype != null) {
+                    return new Key(k.getRow(), new Text(field), columnQualifierDateAndDatatype);
+                } else {
+                    return new Key(k.getRow(), new Text(field), columnQualifierDate);
+                }
+            case NONE:
+            default:
+                throw new IllegalStateException("Unhandled hint type: " + hint);
+        }
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions options = new IteratorOptions(getClass().getSimpleName(), "Iterator that expands a fielded regex into discrete values", null, null);
+        options.addNamedOption(START_DATE, "The start date");
+        options.addNamedOption(END_DATE, "The end date");
+        options.addNamedOption(FIELD, "The field");
+        options.addNamedOption(PATTERN, "The pattern");
+        options.addNamedOption(DATATYPES, "(optional) A comma-delimited set of datatypes used to restrict the search space");
+        options.addNamedOption(REVERSE, "(optional) A boolean that denotes if this scan is for the shard reverse index");
+        return options;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        //  @formatter:off
+        return options.containsKey(START_DATE) &&
+                options.containsKey(END_DATE) &&
+                options.containsKey(FIELD) &&
+                options.containsKey(PATTERN);
+        //  @formatter:on
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
@@ -1,0 +1,227 @@
+package datawave.core.iterators;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iterators.user.SeekingFilter;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Splitter;
+
+import datawave.query.Constants;
+import datawave.query.data.parsers.ShardIndexKey;
+
+/**
+ * Attempts to expand an unfielded regex into discrete fields and values
+ * <p>
+ * Supports date and datatype filtering by default
+ */
+public class UnfieldedRegexExpansionIterator extends SeekingFilter implements OptionDescriber {
+
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedRegexExpansionIterator.class);
+
+    public static final String START_DATE = "start.date";
+    public static final String END_DATE = "end.date";
+    public static final String DATATYPES = "dts";
+    public static final String PATTERN = "pattern";
+    public static final String REVERSE = "reverse";
+
+    private String startDate;
+    private String endDate;
+    private Pattern pattern;
+    private boolean reverse;
+    private final StringBuilder sb = new StringBuilder();
+
+    private Matcher matcher;
+    private Set<String> datatypes;
+
+    private Text columnQualifierDate;
+    private Text columnQualifierDateAndDatatype;
+
+    // used to track the unique field value pairs
+    private final Set<String> foundPairs = new HashSet<>();
+
+    private final ShardIndexKey parser = new ShardIndexKey();
+
+    enum HINT_TYPE {
+        NONE, FIELD, DATE
+    }
+
+    private HINT_TYPE hint = HINT_TYPE.NONE;
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+
+        if (!validateOptions(options)) {
+            throw new IllegalArgumentException("Iterator was not configured correctly");
+        }
+
+        super.init(source, options, env);
+
+        if (options.containsKey(START_DATE)) {
+            this.startDate = options.get(START_DATE);
+            this.columnQualifierDate = new Text(startDate + "_0");
+        } else {
+            throw new IllegalArgumentException("Iterator requires START_DATE option");
+        }
+
+        if (options.containsKey(END_DATE)) {
+            this.endDate = options.get(END_DATE) + Constants.MAX_UNICODE_STRING;
+        } else {
+            throw new IllegalArgumentException("Iterator requires END_DATE option");
+        }
+
+        if (options.containsKey(PATTERN)) {
+            String option = options.get(PATTERN);
+            this.pattern = Pattern.compile(option);
+        } else {
+            throw new IllegalArgumentException("Iterator requires PATTERN option");
+        }
+
+        if (options.containsKey(DATATYPES)) {
+            String option = options.get(DATATYPES);
+            this.datatypes = new HashSet<>(Splitter.on(',').splitToList(option));
+
+            List<String> tmp = new ArrayList<>(datatypes);
+            Collections.sort(tmp);
+            this.columnQualifierDateAndDatatype = new Text(startDate + "_0\u0000" + tmp.get(0));
+        }
+
+        if (options.containsKey(REVERSE)) {
+            this.reverse = Boolean.parseBoolean(options.get(REVERSE));
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        if (!range.isStartKeyInclusive()) {
+            // need to skip to next row
+            // TODO: for the unfielded case this might need to be next column family
+            Key skip = new Key(range.getStartKey().getRow().toString() + '\u0000');
+            if (skip.compareTo(range.getEndKey()) > 0) {
+                // handles case of bounded range against single value
+                // filter key: +cE1 NUM:20150808_0%00;generic [NA]
+                // skip key would be +cE1<null> but then the start key is greater than the end key. so we cheat accumulo.
+                Range skipRange = new Range(range.getEndKey(), true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            } else {
+                Range skipRange = new Range(skip, true, range.getEndKey(), range.isEndKeyInclusive());
+                super.seek(skipRange, columnFamilies, inclusive);
+            }
+        } else {
+            super.seek(range, columnFamilies, inclusive);
+        }
+    }
+
+    @Override
+    public FilterResult filter(Key k, Value v) {
+        if (log.isInfoEnabled()) {
+            log.info("tk: {}", k.toStringNoTime());
+        }
+
+        // parse key and reset hint
+        parser.parse(k);
+        hint = HINT_TYPE.NONE;
+
+        if (reverse) {
+            sb.setLength(0);
+            sb.append(parser.getValue());
+            sb.reverse();
+            matcher = pattern.matcher(sb);
+        } else {
+            matcher = pattern.matcher(parser.getValue());
+        }
+
+        if (!matcher.matches()) {
+            // advance to next row
+            log.info("pattern does not match, advance to next row");
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        String candidate = parser.getValue() + parser.getField();
+        boolean firstSeen = foundPairs.add(candidate);
+        if (!firstSeen) {
+            // advance to next field
+            foundPairs.clear();
+            log.info("Found duplicate field, advance to next field");
+            return new FilterResult(false, AdvanceResult.NEXT_CF);
+        }
+
+        String date = parser.getShard();
+        if (date.compareTo(startDate) < 0) {
+            // advance to start date
+            log.info("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
+            hint = HINT_TYPE.DATE;
+            return new FilterResult(false, AdvanceResult.USE_HINT);
+        } else if (date.compareTo(endDate) > 0) {
+            // advance to next row
+            log.info("date {} sorts after end date {}, advance to next row", date, endDate);
+            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+        }
+
+        if (datatypes != null && !datatypes.contains(parser.getDatatype())) {
+            log.info("datatype {} does not match, advance to next key", parser.getDatatype());
+            return new FilterResult(false, AdvanceResult.NEXT);
+        }
+
+        log.info("key accepted, advancing to next column family");
+        return new FilterResult(true, AdvanceResult.NEXT_CF);
+    }
+
+    @Override
+    public Key getNextKeyHint(Key k, Value v) {
+        switch (hint) {
+            case FIELD:
+                // advance to next field
+                return k.followingKey(PartialKey.ROW_COLFAM);
+            case DATE:
+                if (columnQualifierDateAndDatatype != null) {
+                    return new Key(k.getRow(), k.getColumnFamily(), columnQualifierDateAndDatatype);
+                } else {
+                    return new Key(k.getRow(), k.getColumnFamily(), columnQualifierDate);
+                }
+            case NONE:
+            default:
+                throw new IllegalStateException("Unhandled hint type: " + hint);
+        }
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions options = new IteratorOptions(getClass().getSimpleName(), "Iterator that expands an unfielded regex into discrete fields and values",
+                        null, null);
+        options.addNamedOption(START_DATE, "The start date");
+        options.addNamedOption(END_DATE, "The end date");
+        options.addNamedOption(PATTERN, "The pattern");
+        options.addNamedOption(DATATYPES, "(optional) A comma-delimited set of datatypes used to restrict the search space");
+        options.addNamedOption(REVERSE, "(optional) true if this scan is for the shard reverse index");
+        return options;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        //  @formatter:off
+        return options.containsKey(START_DATE) &&
+                options.containsKey(END_DATE) &&
+                options.containsKey(PATTERN);
+        //  @formatter:on
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
@@ -133,8 +133,8 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
 
     @Override
     public FilterResult filter(Key k, Value v) {
-        if (log.isInfoEnabled()) {
-            log.info("tk: {}", k.toStringNoTime());
+        if (log.isDebugEnabled()) {
+            log.debug("tk: {}", k.toStringNoTime());
         }
 
         // parse key and reset hint
@@ -154,7 +154,7 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
 
             if (!matcher.matches()) {
                 // advance to next row
-                log.info("pattern does not match, advance to next row");
+                log.debug("pattern does not match, advance to next row");
                 return new FilterResult(false, AdvanceResult.NEXT_ROW);
             }
             previousMatch = parser.getValue();
@@ -165,28 +165,28 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
         if (!firstSeen) {
             // advance to next field
             foundPairs.clear();
-            log.info("Found duplicate field, advance to next field");
+            log.debug("Found duplicate field, advance to next field");
             return new FilterResult(false, AdvanceResult.NEXT_CF);
         }
 
         String date = parser.getShard();
         if (date.compareTo(startDate) < 0) {
             // advance to start date
-            log.info("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
+            log.debug("start date {} is before start date {}, advance to date {}", parser.getShard(), startDate, startDate);
             hint = HINT_TYPE.DATE;
             return new FilterResult(false, AdvanceResult.USE_HINT);
         } else if (date.compareTo(endDate) > 0) {
             // advance to next row
-            log.info("date {} sorts after end date {}, advance to next row", date, endDate);
+            log.debug("date {} sorts after end date {}, advance to next row", date, endDate);
             return new FilterResult(false, AdvanceResult.NEXT_ROW);
         }
 
         if (datatypes != null && !datatypes.contains(parser.getDatatype())) {
-            log.info("datatype {} does not match, advance to next key", parser.getDatatype());
+            log.debug("datatype {} does not match, advance to next key", parser.getDatatype());
             return new FilterResult(false, AdvanceResult.NEXT);
         }
 
-        log.info("key accepted, advancing to next column family");
+        log.debug("key accepted, advancing to next column family");
         return new FilterResult(true, AdvanceResult.NEXT_CF);
     }
 

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
@@ -52,6 +52,8 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
 
     private Set<String> datatypes;
 
+    private String previousMatch = null;
+
     private Text columnQualifierDate;
     private Text columnQualifierDateAndDatatype;
 
@@ -113,7 +115,6 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
     public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
         if (!range.isStartKeyInclusive()) {
             // need to skip to next row
-            // TODO: for the unfielded case this might need to be next column family
             Key skip = new Key(range.getStartKey().getRow().toString() + '\u0000');
             if (skip.compareTo(range.getEndKey()) > 0) {
                 // handles case of bounded range against single value
@@ -140,20 +141,23 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
         parser.parse(k);
         hint = HINT_TYPE.NONE;
 
-        Matcher matcher;
-        if (reverse) {
-            sb.setLength(0);
-            sb.append(parser.getValue());
-            sb.reverse();
-            matcher = pattern.matcher(sb);
-        } else {
-            matcher = pattern.matcher(parser.getValue());
-        }
+        if (previousMatch == null || !previousMatch.equals(parser.getValue())) {
+            Matcher matcher;
+            if (reverse) {
+                sb.setLength(0);
+                sb.append(parser.getValue());
+                sb.reverse();
+                matcher = pattern.matcher(sb);
+            } else {
+                matcher = pattern.matcher(parser.getValue());
+            }
 
-        if (!matcher.matches()) {
-            // advance to next row
-            log.info("pattern does not match, advance to next row");
-            return new FilterResult(false, AdvanceResult.NEXT_ROW);
+            if (!matcher.matches()) {
+                // advance to next row
+                log.info("pattern does not match, advance to next row");
+                return new FilterResult(false, AdvanceResult.NEXT_ROW);
+            }
+            previousMatch = parser.getValue();
         }
 
         String candidate = parser.getValue() + parser.getField();

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/UnfieldedRegexExpansionIterator.java
@@ -50,7 +50,6 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
     private boolean reverse;
     private final StringBuilder sb = new StringBuilder();
 
-    private Matcher matcher;
     private Set<String> datatypes;
 
     private Text columnQualifierDate;
@@ -141,6 +140,7 @@ public class UnfieldedRegexExpansionIterator extends SeekingFilter implements Op
         parser.parse(k);
         hint = HINT_TYPE.NONE;
 
+        Matcher matcher;
         if (reverse) {
             sb.setLength(0);
             sb.append(parser.getValue());

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/FieldedRegexExpansionIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/FieldedRegexExpansionIteratorTest.java
@@ -1,0 +1,262 @@
+package datawave.core.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+/**
+ * Unit tests for the {@link FieldedRegexExpansionIterator}
+ * <p>
+ * Each test will exercise the forward and reverse index so care should be taken when constructing regexes
+ */
+public class FieldedRegexExpansionIteratorTest {
+
+    private final SortedMap<Key,Value> forwardData = new TreeMap<>();
+    private final SortedMap<Key,Value> reverseData = new TreeMap<>();
+    private final Map<String,String> options = new HashMap<>();
+    private final Set<String> expected = new HashSet<>();
+    private final Set<String> results = new HashSet<>();
+
+    private String pattern;
+    private final StringBuilder sb = new StringBuilder();
+
+    private static final Value EMPTY_VALUE = new Value();
+
+    @BeforeEach
+    public void setup() {
+        forwardData.clear();
+        reverseData.clear();
+        options.clear();
+        expected.clear();
+        results.clear();
+    }
+
+    public void withData(String value, String field, String shard, String datatype) {
+        // don't need to worry about visibility for this test
+        Key key = new Key(value, field, shard + "\0" + datatype);
+        forwardData.put(key, EMPTY_VALUE);
+
+        String reversedValue = new StringBuilder(value).reverse().toString();
+        Key reversedKey = new Key(reversedValue, field, shard + "\0" + datatype);
+        reverseData.put(reversedKey, EMPTY_VALUE);
+    }
+
+    public void withDates(String startDate, String endDate) {
+        options.put(FieldedRegexExpansionIterator.START_DATE, startDate);
+        options.put(FieldedRegexExpansionIterator.END_DATE, endDate);
+    }
+
+    public void withDatatypeFilter(Set<String> datatypes) {
+        options.put(FieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(datatypes));
+    }
+
+    public void withFieldPattern(String field, String pattern) {
+        options.put(FieldedRegexExpansionIterator.FIELD, field);
+        this.pattern = pattern;
+    }
+
+    public void withExpected(String... values) {
+        expected.addAll(List.of(values));
+    }
+
+    @Test
+    public void testOptionsMissingField() {
+        withFieldPattern(null, "val");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingPattern() {
+        withFieldPattern("FIELD", null);
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingDate() {
+        withFieldPattern("FIELD", "val");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testSingleValueExpansion() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "aa");
+        withDates("20250804", "20250804");
+        withExpected("aaa");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionWithDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "aa");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aaa");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionExcludedByDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "aa");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-b"));
+        drive();
+    }
+
+    @Test
+    public void testMultiValueExpansion() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_A", "a");
+        withDates("20250804", "20250804");
+        withExpected("aa", "ab", "ac");
+        drive();
+    }
+
+    @Test
+    public void testSkipField() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_B", "a");
+        withDates("20250804", "20250804");
+        withExpected("aa", "ac");
+        drive();
+    }
+
+    @Test
+    public void testSkipDate() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250805_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withFieldPattern("FIELD_B", "a");
+        withDates("20250804", "20250804");
+        withExpected("aa", "ac");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDatatypeFilter() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-b");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-c");
+        withFieldPattern("FIELD_A", "a");
+        withDates("20250804", "20250804");
+
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aa");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b"));
+        withExpected("ab");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-c"));
+        withExpected("ac");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b"));
+        withExpected("aa", "ab");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-c"));
+        withExpected("aa", "ac");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b", "datatype-c"));
+        withExpected("ab", "ac");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b", "datatype-c"));
+        withExpected("aa", "ab", "ac");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDateBounds() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250805_0", "datatype-a");
+        withFieldPattern("FIELD_A", "a");
+        withDates("20250804", "20250804");
+        withExpected("ab");
+        drive();
+    }
+
+    private void drive() throws Exception {
+        exerciseForwardIndex();
+        exerciseReverseIndex();
+    }
+
+    private void exerciseForwardIndex() throws Exception {
+        String trailingRegex = pattern + ".*";
+        options.put(FieldedRegexExpansionIterator.PATTERN, trailingRegex);
+        driveIterator(forwardData, false);
+    }
+
+    private void exerciseReverseIndex() throws Exception {
+        String leadingRegex = ".*" + pattern;
+        options.put(FieldedRegexExpansionIterator.PATTERN, leadingRegex);
+        driveIterator(reverseData, true);
+    }
+
+    private void driveIterator(SortedMap<Key,Value> data, boolean reverse) throws Exception {
+        FieldedRegexExpansionIterator iterator = new FieldedRegexExpansionIterator();
+        iterator.init(new SortedMapIterator(data), options, null);
+        iterator.seek(new Range(), Collections.emptySet(), false);
+
+        results.clear();
+        while (iterator.hasTop()) {
+            Key tk = iterator.getTopKey();
+            String value = tk.getRow().toString();
+            results.add(handleValue(value, reverse));
+            iterator.next();
+        }
+
+        assertEquals(expected, results);
+    }
+
+    private String handleValue(String value, boolean reverse) {
+        if (reverse) {
+            sb.setLength(0);
+            sb.append(value);
+            sb.reverse();
+            return sb.toString();
+        }
+        return value;
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/UnfieldedRegexExpansionIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/UnfieldedRegexExpansionIteratorTest.java
@@ -1,0 +1,267 @@
+package datawave.core.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+import datawave.query.data.parsers.ShardIndexKey;
+
+/**
+ * Unit tests for the {@link UnfieldedRegexExpansionIterator}
+ * <p>
+ * The UnfieldedRegexExpansionIterator should handle any test case that the FieldedRegexExpansionIterator can. It won't be as efficient, but the results should
+ * be the same.
+ */
+public class UnfieldedRegexExpansionIteratorTest {
+
+    private final SortedMap<Key,Value> data = new TreeMap<>();
+    private final Map<String,String> options = new HashMap<>();
+    private final List<String> expected = new ArrayList<>();
+    private final List<String> results = new ArrayList<>();
+
+    private final ShardIndexKey parser = new ShardIndexKey();
+
+    private static final Value EMPTY_VALUE = new Value();
+
+    @BeforeEach
+    public void setup() {
+        data.clear();
+        options.clear();
+        expected.clear();
+        results.clear();
+    }
+
+    public void withData(String value, String field, String shard, String datatype) {
+        // don't need to worry about visibility for this test
+        Key key = new Key(value, field, shard + "\0" + datatype);
+        data.put(key, EMPTY_VALUE);
+    }
+
+    public void withDates(String startDate, String endDate) {
+        options.put(UnfieldedRegexExpansionIterator.START_DATE, startDate);
+        options.put(UnfieldedRegexExpansionIterator.END_DATE, endDate);
+    }
+
+    public void withDatatypeFilter(Set<String> datatypes) {
+        options.put(UnfieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(datatypes));
+    }
+
+    public void withPattern(String pattern) {
+        options.put(UnfieldedRegexExpansionIterator.PATTERN, pattern);
+    }
+
+    public void withExpected(String... values) {
+        expected.addAll(List.of(values));
+    }
+
+    @Test
+    public void testOptionsMissingField() {
+        withPattern("val.*");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingPattern() {
+        withPattern(null);
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testOptionsMissingDate() {
+        withPattern("val.*");
+        assertThrows(IllegalArgumentException.class, this::drive);
+    }
+
+    @Test
+    public void testSingleValueExpansion() throws Exception {
+        withData("aaa", "FIELD_A", "20250804", "datatype-a");
+        withPattern("aa.*");
+        withDates("20250804", "20250804");
+        withExpected("aaa FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionWithDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withPattern("aa.*");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aaa FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testSingleValueExpansionExcludedByDatatypeFilter() throws Exception {
+        withData("aaa", "FIELD_A", "20250804_0", "datatype-a");
+        withPattern("aa.*");
+        withDates("20250804", "20250804");
+        withDatatypeFilter(Set.of("datatype-b"));
+        drive();
+    }
+
+    @Test
+    public void testMultiValueExpansion() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("aa FIELD_A", "ab FIELD_A", "ac FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testSkipField() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("aa FIELD_B", "ab FIELD_A", "ac FIELD_B");
+        drive();
+    }
+
+    @Test
+    public void testSkipDate() throws Exception {
+        withData("aa", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_B", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_B", "20250804_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("aa FIELD_B", "ac FIELD_B");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDatatypeFilter() throws Exception {
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-b");
+        withData("ac", "FIELD_A", "20250804_0", "datatype-c");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+
+        withDatatypeFilter(Set.of("datatype-a"));
+        withExpected("aa FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b"));
+        withExpected("ab FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-c"));
+        withExpected("ac FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b"));
+        withExpected("aa FIELD_A", "ab FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-c"));
+        withExpected("aa FIELD_A", "ac FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-b", "datatype-c"));
+        withExpected("ab FIELD_A", "ac FIELD_A");
+        drive();
+
+        expected.clear();
+        results.clear();
+        withDatatypeFilter(Set.of("datatype-a", "datatype-b", "datatype-c"));
+        withExpected("aa FIELD_A", "ab FIELD_A", "ac FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testVerifyDateBounds() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250804_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250805_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250804", "20250804");
+        withExpected("ab FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testUnfieldedExpansionReturnsUniqueValues() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("aa", "FIELD_A", "20250804_0", "datatype-a");
+        withData("aa", "FIELD_A", "20250805_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250803", "20250805");
+        withExpected("aa FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testValueExpansionThreshold() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ab", "FIELD_A", "20250803_0", "datatype-a");
+        withData("ac", "FIELD_A", "20250803_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250803", "20250804");
+        withExpected("aa FIELD_A");
+        withExpected("ab FIELD_A");
+        withExpected("ac FIELD_A");
+        drive();
+    }
+
+    @Test
+    public void testFieldExpansionThreshold() throws Exception {
+        withData("aa", "FIELD_A", "20250803_0", "datatype-a");
+        withData("aa", "FIELD_B", "20250803_0", "datatype-a");
+        withData("aa", "FIELD_C", "20250803_0", "datatype-a");
+        withPattern("a.*");
+        withDates("20250803", "20250804");
+        withExpected("aa FIELD_A");
+        withExpected("aa FIELD_B");
+        withExpected("aa FIELD_C");
+        drive();
+    }
+
+    private void drive() throws Exception {
+        UnfieldedRegexExpansionIterator iterator = new UnfieldedRegexExpansionIterator();
+        iterator.init(new SortedMapIterator(data), options, null);
+        iterator.seek(new Range(), Collections.emptySet(), false);
+
+        while (iterator.hasTop()) {
+            Key tk = iterator.getTopKey();
+            parser.parse(tk);
+            String result = parser.getValue() + " " + parser.getField();
+            results.add(result);
+            iterator.next();
+        }
+
+        assertEquals(expected, results);
+    }
+
+}


### PR DESCRIPTION
Breaking https://github.com/NationalSecurityAgency/datawave/pull/3144 into more manageable chunks

- add regex expansion iterators and tests
- migrate matchers to local variables
- record previous matching value to avoid excessive regex matching