### PR TITLE
Add new IndexLookups

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BaseRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BaseRegexIndexLookup.java
@@ -1,0 +1,99 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Range;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.core.iterators.TimeoutExceptionIterator;
+import datawave.core.iterators.TimeoutIterator;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+
+/**
+ * Holds common variables to reduce duplicate code in {@link FieldedRegexIndexLookup} and {@link UnfieldedRegexIndexLookup}.
+ */
+public abstract class BaseRegexIndexLookup extends AsyncIndexLookup {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseRegexIndexLookup.class);
+
+    protected final String pattern;
+    protected final Range range;
+    protected final boolean reverse;
+
+    protected final CountDownLatch latch;
+
+    // used when scanning the shard reverse index
+    private final StringBuilder sb = new StringBuilder();
+
+    public BaseRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, boolean unfieldedLookup, ExecutorService execService,
+                    String pattern, Range range, boolean reverse) {
+        super(config, scannerFactory, unfieldedLookup, execService);
+        this.pattern = pattern;
+        this.range = range;
+        this.reverse = reverse;
+        this.latch = new CountDownLatch(1);
+    }
+
+    protected String getTableName() {
+        return reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
+    }
+
+    protected String getHintKey(String tableName) {
+        return config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+    }
+
+    protected IteratorSetting createTimeoutIterator() {
+        long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
+        IteratorSetting iterator = new IteratorSetting(1, TimeoutIterator.class);
+        iterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+        return iterator;
+    }
+
+    /**
+     * Extending classes decide how to build a regex iterator depending on if the regex is fielded or not
+     *
+     * @return an {@link IteratorSetting}
+     */
+    protected abstract IteratorSetting createRegexIterator();
+
+    protected IteratorSetting createTimeoutExceptionIterator() {
+        return new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+    }
+
+    /**
+     * Waits for the future to complete before returning the index lookup map
+     */
+    protected void await() {
+        synchronized (latch) {
+            if (latch.getCount() == 1) {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    log.error(e.getMessage(), e);
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverses the value coming off the shard reverse index
+     *
+     * @param value
+     *            the value
+     * @return the reversed value
+     */
+    protected String reverse(String value) {
+        sb.setLength(0);
+        sb.append(value);
+        sb.reverse();
+        return sb.toString();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -43,6 +43,8 @@ import datawave.webservice.query.exception.QueryException;
 
 /**
  * An asynchronous index lookup which looks up concrete values for the specified bounded range.
+ * <p>
+ * A fielded bounded range is already executable so this lookup is allowed to hit timeout or value thresholds.
  */
 public class BoundedRangeIndexLookup extends AsyncIndexLookup {
     private static final Logger log = ThreadConfigurableLogger.getLogger(BoundedRangeIndexLookup.class);

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
@@ -1,0 +1,164 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+
+import datawave.core.iterators.FieldedRegexExpansionIterator;
+import datawave.core.iterators.TimeoutExceptionIterator;
+import datawave.core.iterators.TimeoutIterator;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+import datawave.util.time.DateHelper;
+
+/**
+ * An asynchronous index lookup which expands a fielded regex into discrete values.
+ * <p>
+ * A fielded regex is already executable so this lookup is allowed to hit timeout and value thresholds.
+ */
+public class FieldedRegexIndexLookup extends AsyncIndexLookup {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldedRegexIndexLookup.class);
+
+    private final String field;
+    private final String pattern;
+    private final Range range;
+    private final boolean reverse;
+    private final StringBuilder sb = new StringBuilder();
+
+    private final Set<String> values = new HashSet<>();
+
+    private final CountDownLatch latch;
+
+    public FieldedRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, ExecutorService execService, String field, String pattern,
+                    Range range, boolean reverse) {
+        super(config, scannerFactory, false, execService);
+        this.field = field;
+        this.pattern = pattern;
+        this.range = range;
+        this.reverse = reverse;
+        this.latch = new CountDownLatch(1);
+        log.info("Created FieldedRegexIndexLookup with field {} and pattern {}", field, pattern);
+    }
+
+    @Override
+    public void submit() {
+        if (indexLookupMap == null) {
+            indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
+
+            execService.submit(() -> {
+                String tableName = reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
+                try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
+                    String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+                    scanner.setExecutionHints(Map.of(tableName, hintKey));
+
+                    IteratorSetting timeoutIterator = new IteratorSetting(1, TimeoutIterator.class);
+                    long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
+                    timeoutIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+                    scanner.addScanIterator(timeoutIterator);
+
+                    IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "fielded regex expansion",
+                                    FieldedRegexExpansionIterator.class.getName());
+                    setting.addOption(FieldedRegexExpansionIterator.FIELD, field);
+                    setting.addOption(FieldedRegexExpansionIterator.PATTERN, pattern);
+                    setting.addOption(FieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+                    setting.addOption(FieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+                    if (!config.getDatatypeFilter().isEmpty()) {
+                        setting.addOption(FieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
+                    }
+                    setting.addOption(FieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+
+                    scanner.addScanIterator(setting);
+
+                    IteratorSetting timeoutExceptionIterator = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+                    scanner.addScanIterator(timeoutExceptionIterator);
+
+                    scanner.setRange(range);
+
+                    scanner.fetchColumnFamily(new Text(field));
+
+                    for (Map.Entry<Key,Value> entry : scanner) {
+                        Key key = entry.getKey();
+
+                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
+                            exceededTimeoutThreshold.set(true);
+                            break;
+                        }
+
+                        String value = key.getRow().toString();
+                        if (reverse) {
+                            value = reverse(value);
+                        }
+                        values.add(value);
+
+                        if (values.size() > maxValueExpansionThreshold) {
+                            values.remove(value); // remove operation so test results make logical sense
+                            exceededValueThreshold.set(true);
+                            break;
+                        }
+                    }
+
+                } catch (Exception e) {
+                    exceptionSeen.set(true);
+                    log.error(e.getMessage(), e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+    }
+
+    @Override
+    public IndexLookupMap lookup() {
+
+        synchronized (latch) {
+            if (latch.getCount() == 1) {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    log.error(e.getMessage(), e);
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        IndexLookupMap map = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
+        if (!values.isEmpty()) {
+            ValueSet set = new ValueSet(Integer.MAX_VALUE);
+            set.addAll(values);
+            map.put(field, set);
+        }
+
+        if (exceededValueThreshold.get()) {
+            map.setKeyThresholdExceeded();
+        }
+
+        if (exceededTimeoutThreshold.get()) {
+            map.setTimeoutExceeded(true);
+        }
+
+        return map;
+    }
+
+    private String reverse(String value) {
+        sb.setLength(0);
+        sb.append(value);
+        sb.reverse();
+        return sb.toString();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
@@ -1,11 +1,8 @@
 package datawave.query.jexl.lookups;
 
-import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -20,7 +17,6 @@ import com.google.common.base.Joiner;
 
 import datawave.core.iterators.FieldedRegexExpansionIterator;
 import datawave.core.iterators.TimeoutExceptionIterator;
-import datawave.core.iterators.TimeoutIterator;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.time.DateHelper;
@@ -30,28 +26,17 @@ import datawave.util.time.DateHelper;
  * <p>
  * A fielded regex is already executable so this lookup is allowed to hit timeout and value thresholds.
  */
-public class FieldedRegexIndexLookup extends AsyncIndexLookup {
+public class FieldedRegexIndexLookup extends BaseRegexIndexLookup {
 
     private static final Logger log = LoggerFactory.getLogger(FieldedRegexIndexLookup.class);
 
     private final String field;
-    private final String pattern;
-    private final Range range;
-    private final boolean reverse;
-    private final StringBuilder sb = new StringBuilder();
-
     private final Set<String> values = new HashSet<>();
-
-    private final CountDownLatch latch;
 
     public FieldedRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, ExecutorService execService, String field, String pattern,
                     Range range, boolean reverse) {
-        super(config, scannerFactory, false, execService);
+        super(config, scannerFactory, false, execService, pattern, range, reverse);
         this.field = field;
-        this.pattern = pattern;
-        this.range = range;
-        this.reverse = reverse;
-        this.latch = new CountDownLatch(1);
         log.info("Created FieldedRegexIndexLookup with field {} and pattern {}", field, pattern);
     }
 
@@ -61,30 +46,18 @@ public class FieldedRegexIndexLookup extends AsyncIndexLookup {
             indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
 
             execService.submit(() -> {
-                String tableName = reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
+                String tableName = getTableName();
                 try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
-                    String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+                    String hintKey = getHintKey(tableName);
                     scanner.setExecutionHints(Map.of(tableName, hintKey));
 
-                    IteratorSetting timeoutIterator = new IteratorSetting(1, TimeoutIterator.class);
-                    long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
-                    timeoutIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+                    IteratorSetting timeoutIterator = createTimeoutIterator();
                     scanner.addScanIterator(timeoutIterator);
 
-                    IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "fielded regex expansion",
-                                    FieldedRegexExpansionIterator.class.getName());
-                    setting.addOption(FieldedRegexExpansionIterator.FIELD, field);
-                    setting.addOption(FieldedRegexExpansionIterator.PATTERN, pattern);
-                    setting.addOption(FieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
-                    setting.addOption(FieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
-                    if (!config.getDatatypeFilter().isEmpty()) {
-                        setting.addOption(FieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
-                    }
-                    setting.addOption(FieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+                    IteratorSetting regexIterator = createRegexIterator();
+                    scanner.addScanIterator(regexIterator);
 
-                    scanner.addScanIterator(setting);
-
-                    IteratorSetting timeoutExceptionIterator = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+                    IteratorSetting timeoutExceptionIterator = createTimeoutExceptionIterator();
                     scanner.addScanIterator(timeoutExceptionIterator);
 
                     scanner.setRange(range);
@@ -123,19 +96,24 @@ public class FieldedRegexIndexLookup extends AsyncIndexLookup {
     }
 
     @Override
+    protected IteratorSetting createRegexIterator() {
+        IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "fielded regex expansion",
+                        FieldedRegexExpansionIterator.class.getName());
+        setting.addOption(FieldedRegexExpansionIterator.FIELD, field);
+        setting.addOption(FieldedRegexExpansionIterator.PATTERN, pattern);
+        setting.addOption(FieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+        setting.addOption(FieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+        if (!config.getDatatypeFilter().isEmpty()) {
+            setting.addOption(FieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
+        }
+        setting.addOption(FieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+        return setting;
+    }
+
+    @Override
     public IndexLookupMap lookup() {
 
-        synchronized (latch) {
-            if (latch.getCount() == 1) {
-                try {
-                    latch.await();
-                } catch (InterruptedException e) {
-                    log.error(e.getMessage(), e);
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
-            }
-        }
+        await();
 
         IndexLookupMap map = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
         if (!values.isEmpty()) {
@@ -153,12 +131,5 @@ public class FieldedRegexIndexLookup extends AsyncIndexLookup {
         }
 
         return map;
-    }
-
-    private String reverse(String value) {
-        sb.setLength(0);
-        sb.append(value);
-        sb.reverse();
-        return sb.toString();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/IndexLookupMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/IndexLookupMap.java
@@ -19,6 +19,10 @@ public class IndexLookupMap implements Map<String,ValueSet>, Serializable {
     private int keyThreshold = -1;
     private int valueThreshold = -1;
 
+    // recorded state about the index lookup operation
+    private boolean exceptionSeen = false;
+    private boolean timeoutExceeded = false;
+
     public IndexLookupMap(int keyThreshold, int valueThreshold) {
         this.keyThreshold = keyThreshold;
         this.valueThreshold = valueThreshold;
@@ -194,5 +198,21 @@ public class IndexLookupMap implements Map<String,ValueSet>, Serializable {
 
     public Set<String> getPatterns() {
         return this.patterns;
+    }
+
+    public boolean isExceptionSeen() {
+        return exceptionSeen;
+    }
+
+    public void setExceptionSeen(boolean exceptionSeen) {
+        this.exceptionSeen = exceptionSeen;
+    }
+
+    public boolean isTimeoutExceeded() {
+        return timeoutExceeded;
+    }
+
+    public void setTimeoutExceeded(boolean timeoutExceeded) {
+        this.timeoutExceeded = timeoutExceeded;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
@@ -1,12 +1,9 @@
 package datawave.query.jexl.lookups;
 
-import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -20,7 +17,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Joiner;
 
 import datawave.core.iterators.TimeoutExceptionIterator;
-import datawave.core.iterators.TimeoutIterator;
 import datawave.core.iterators.UnfieldedRegexExpansionIterator;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
@@ -31,27 +27,16 @@ import datawave.util.time.DateHelper;
  * <p>
  * Because an unfielded term is not executable it is best if this index lookup runs without a time or field threshold.
  */
-public class UnfieldedRegexIndexLookup extends AsyncIndexLookup {
+public class UnfieldedRegexIndexLookup extends BaseRegexIndexLookup {
 
     private static final Logger log = LoggerFactory.getLogger(UnfieldedRegexIndexLookup.class);
 
-    private final String pattern;
-    private final Range range;
-    private final boolean reverse;
     private final Set<String> fields;
-
-    private final StringBuilder sb = new StringBuilder();
-
-    private final CountDownLatch latch;
 
     public UnfieldedRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, ExecutorService execService, String pattern, Range range,
                     boolean reverse, Set<String> fields) {
-        super(config, scannerFactory, true, execService);
-        this.pattern = pattern;
-        this.range = range;
-        this.reverse = reverse;
+        super(config, scannerFactory, true, execService, pattern, range, reverse);
         this.fields = Objects.requireNonNullElse(fields, Collections.emptySet());
-        this.latch = new CountDownLatch(1);
         log.info("Created UnfieldedRegexIndexLookup with pattern {}", pattern);
     }
 
@@ -63,27 +48,17 @@ public class UnfieldedRegexIndexLookup extends AsyncIndexLookup {
             execService.submit(() -> {
                 String tableName = reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
                 try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
-                    String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+                    String hintKey = getHintKey(tableName);
                     scanner.setExecutionHints(Map.of(tableName, hintKey));
 
                     // use a different timeout threshold for unfielded expansions
-                    IteratorSetting timeoutIterator = new IteratorSetting(1, TimeoutIterator.class);
-                    long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
-                    timeoutIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+                    IteratorSetting timeoutIterator = createTimeoutIterator();
                     scanner.addScanIterator(timeoutIterator);
 
-                    IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "unfielded regex expansion",
-                                    UnfieldedRegexExpansionIterator.class.getName());
-                    setting.addOption(UnfieldedRegexExpansionIterator.PATTERN, pattern);
-                    setting.addOption(UnfieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
-                    setting.addOption(UnfieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
-                    setting.addOption(UnfieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
-                    if (!config.getDatatypeFilter().isEmpty()) {
-                        setting.addOption(UnfieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
-                    }
-                    scanner.addScanIterator(setting);
+                    IteratorSetting regexIterator = createRegexIterator();
+                    scanner.addScanIterator(regexIterator);
 
-                    IteratorSetting timeoutExceptionIterator = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+                    IteratorSetting timeoutExceptionIterator = createTimeoutExceptionIterator();
                     scanner.addScanIterator(timeoutExceptionIterator);
 
                     scanner.setRange(range);
@@ -119,27 +94,22 @@ public class UnfieldedRegexIndexLookup extends AsyncIndexLookup {
     }
 
     @Override
-    public IndexLookupMap lookup() {
-
-        synchronized (latch) {
-            if (latch.getCount() == 1) {
-                try {
-                    latch.await();
-                } catch (InterruptedException e) {
-                    log.error(e.getMessage(), e);
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
-            }
+    protected IteratorSetting createRegexIterator() {
+        IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "unfielded regex expansion",
+                        UnfieldedRegexExpansionIterator.class.getName());
+        setting.addOption(UnfieldedRegexExpansionIterator.PATTERN, pattern);
+        setting.addOption(UnfieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+        setting.addOption(UnfieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+        setting.addOption(UnfieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+        if (!config.getDatatypeFilter().isEmpty()) {
+            setting.addOption(UnfieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
         }
-
-        return indexLookupMap;
+        return setting;
     }
 
-    private String reverse(String value) {
-        sb.setLength(0);
-        sb.append(value);
-        sb.reverse();
-        return sb.toString();
+    @Override
+    public IndexLookupMap lookup() {
+        await();
+        return indexLookupMap;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
@@ -1,0 +1,145 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+
+import datawave.core.iterators.TimeoutExceptionIterator;
+import datawave.core.iterators.TimeoutIterator;
+import datawave.core.iterators.UnfieldedRegexExpansionIterator;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.tables.ScannerFactory;
+import datawave.util.time.DateHelper;
+
+/**
+ * An asynchronous index lookup which expands a fielded regex into discrete fields and values.
+ * <p>
+ * Because an unfielded term is not executable it is best if this index lookup runs without a time or field threshold.
+ */
+public class UnfieldedRegexIndexLookup extends AsyncIndexLookup {
+
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedRegexIndexLookup.class);
+
+    private final String pattern;
+    private final Range range;
+    private final boolean reverse;
+    private final Set<String> fields;
+
+    private final StringBuilder sb = new StringBuilder();
+
+    private final CountDownLatch latch;
+
+    public UnfieldedRegexIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, ExecutorService execService, String pattern, Range range,
+                    boolean reverse, Set<String> fields) {
+        super(config, scannerFactory, true, execService);
+        this.pattern = pattern;
+        this.range = range;
+        this.reverse = reverse;
+        this.fields = Objects.requireNonNullElse(fields, Collections.emptySet());
+        this.latch = new CountDownLatch(1);
+        log.info("Created UnfieldedRegexIndexLookup with pattern {}", pattern);
+    }
+
+    @Override
+    public void submit() {
+        if (indexLookupMap == null) {
+            indexLookupMap = new IndexLookupMap(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+            execService.submit(() -> {
+                String tableName = reverse ? config.getReverseIndexTableName() : config.getIndexTableName();
+                try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
+                    String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
+                    scanner.setExecutionHints(Map.of(tableName, hintKey));
+
+                    // use a different timeout threshold for unfielded expansions
+                    IteratorSetting timeoutIterator = new IteratorSetting(1, TimeoutIterator.class);
+                    long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
+                    timeoutIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
+                    scanner.addScanIterator(timeoutIterator);
+
+                    IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 50, "unfielded regex expansion",
+                                    UnfieldedRegexExpansionIterator.class.getName());
+                    setting.addOption(UnfieldedRegexExpansionIterator.PATTERN, pattern);
+                    setting.addOption(UnfieldedRegexExpansionIterator.START_DATE, DateHelper.format(config.getBeginDate()));
+                    setting.addOption(UnfieldedRegexExpansionIterator.END_DATE, DateHelper.format(config.getEndDate()));
+                    setting.addOption(UnfieldedRegexExpansionIterator.REVERSE, Boolean.toString(reverse));
+                    if (!config.getDatatypeFilter().isEmpty()) {
+                        setting.addOption(UnfieldedRegexExpansionIterator.DATATYPES, Joiner.on(',').join(config.getDatatypeFilter()));
+                    }
+                    scanner.addScanIterator(setting);
+
+                    IteratorSetting timeoutExceptionIterator = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
+                    scanner.addScanIterator(timeoutExceptionIterator);
+
+                    scanner.setRange(range);
+
+                    for (String field : fields) {
+                        scanner.fetchColumnFamily(new Text(field));
+                    }
+
+                    for (Map.Entry<Key,Value> entry : scanner) {
+                        Key key = entry.getKey();
+
+                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
+                            indexLookupMap.setTimeoutExceeded(true);
+                            break;
+                        }
+
+                        String value = key.getRow().toString();
+                        String field = key.getColumnFamily().toString();
+                        if (reverse) {
+                            value = reverse(value);
+                        }
+                        indexLookupMap.put(field, value);
+                    }
+
+                } catch (Exception e) {
+                    indexLookupMap.setExceptionSeen(true);
+                    log.error(e.getMessage(), e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+    }
+
+    @Override
+    public IndexLookupMap lookup() {
+
+        synchronized (latch) {
+            if (latch.getCount() == 1) {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    log.error(e.getMessage(), e);
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        return indexLookupMap;
+    }
+
+    private String reverse(String value) {
+        sb.setLength(0);
+        sb.append(value);
+        sb.reverse();
+        return sb.toString();
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BaseIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BaseIndexLookupTest.java
@@ -1,0 +1,200 @@
+package datawave.query.jexl.lookups;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.util.MockMetadataHelper;
+import datawave.util.TableName;
+import datawave.util.time.DateHelper;
+
+/**
+ * Collection of helpful methods for testing {@link IndexLookup}s.
+ * <p>
+ * Note: these tests use an {@link InMemoryInstance} and in some cases it is better to test with {@link MiniAccumuloCluster}
+ */
+public abstract class BaseIndexLookupTest {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseIndexLookupTest.class);
+
+    private static final String DEFAULT_DATE = "20250606";
+    private static final String DEFAULT_DATATYPE = "datatype";
+    private static final Value EMPTY_VALUE = new Value();
+    protected ExecutorService executor;
+
+    protected static AccumuloClient client;
+    protected static TableOperations tops;
+
+    protected final Set<String> indexedFields = Set.of("_ANYFIELD_", "FIELD_A", "FIELD_B", "FIELD_C");
+
+    protected final ShardQueryConfiguration config = new ShardQueryConfiguration();
+    protected final MockMetadataHelper metadataHelper = new MockMetadataHelper();
+
+    protected String query = null;
+    private IndexLookupMap result;
+
+    private final StringBuilder sb = new StringBuilder();
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        InMemoryInstance instance = new InMemoryInstance();
+        client = new InMemoryAccumuloClient("root", instance);
+        tops = client.tableOperations();
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        if (tops.exists(TableName.SHARD_INDEX)) {
+            tops.delete(TableName.SHARD_INDEX);
+        }
+        tops.create(TableName.SHARD_INDEX);
+
+        if (tops.exists(TableName.SHARD_RINDEX)) {
+            tops.delete(TableName.SHARD_RINDEX);
+        }
+        tops.create(TableName.SHARD_RINDEX);
+
+        config.setClient(client);
+        config.setBeginDate(DateHelper.parse("20250606"));
+        config.setEndDate(DateHelper.parse("20250606"));
+
+        metadataHelper.setIndexedFields(indexedFields);
+        metadataHelper.setReverseIndexFields(indexedFields);
+
+        query = null;
+        result = null;
+        executor = Executors.newFixedThreadPool(5);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        executor.shutdownNow();
+    }
+
+    public void write(String value, String field) {
+        write(value, field, DEFAULT_DATE, DEFAULT_DATATYPE, EMPTY_VALUE);
+    }
+
+    public void write(String value, String field, Value v) {
+        write(value, field, DEFAULT_DATE, DEFAULT_DATATYPE, v);
+    }
+
+    public void write(String value, String field, String date, String datatype) {
+        write(value, field, date, datatype, EMPTY_VALUE);
+    }
+
+    public void write(String value, String field, String date, String datatype, Value v) {
+        try (var writer = client.createBatchWriter(TableName.SHARD_INDEX)) {
+            Mutation m = new Mutation(value);
+            m.put(field, date + "\0" + datatype, v);
+            writer.addMutation(m);
+        } catch (TableNotFoundException | MutationsRejectedException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    public void writeReverse(String value, String field) {
+        writeReverse(value, field, DEFAULT_DATE, DEFAULT_DATATYPE, EMPTY_VALUE);
+    }
+
+    public void writeReverse(String value, String field, Value v) {
+        writeReverse(value, field, DEFAULT_DATE, DEFAULT_DATATYPE, v);
+    }
+
+    public void writeReverse(String value, String field, String date, String datatype) {
+        writeReverse(value, field, date, datatype, EMPTY_VALUE);
+    }
+
+    public void writeReverse(String value, String field, String date, String datatype, Value v) {
+        try (var writer = client.createBatchWriter(TableName.SHARD_RINDEX)) {
+            Mutation m = new Mutation(reverse(value));
+            m.put(field, date + "\0" + datatype, v);
+            writer.addMutation(m);
+        } catch (TableNotFoundException | MutationsRejectedException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    private String reverse(String value) {
+        sb.setLength(0);
+        sb.append(value);
+        return sb.reverse().toString();
+    }
+
+    public void withQuery(String query) {
+        this.query = query;
+    }
+
+    /**
+     * Extending classes must implement this method with all setup logic. Once the {@link AsyncIndexLookup} is configured, the method should call
+     * {@link #executeLookup(AsyncIndexLookup)}.
+     */
+    protected abstract void executeLookup();
+
+    protected void executeLookup(AsyncIndexLookup lookup) {
+        lookup.submit();
+        this.result = lookup.lookup();
+    }
+
+    protected JexlNode parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query).jjtGetChild(0);
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query);
+        }
+        return null;
+    }
+
+    protected void assertNoResults() {
+        Preconditions.checkNotNull(result, "result cannot be null");
+        assertTrue(result.isEmpty());
+    }
+
+    protected void assertResultFields(Set<String> expected) {
+        Preconditions.checkNotNull(result, "result cannot be null");
+        assertEquals(expected, result.keySet());
+    }
+
+    protected void assertResultValues(String field, Set<String> values) {
+        Preconditions.checkNotNull(result, "result cannot be null");
+        assertTrue(result.containsKey(field), "result did not contain field: " + field);
+        Set<String> resultValues = new HashSet<>(result.get(field));
+        assertEquals(values, resultValues);
+    }
+
+    protected void assertExceptionSeen() {
+        Preconditions.checkNotNull(result, "result cannot be null");
+        assertTrue(result.isExceptionSeen());
+    }
+
+    protected void assertTimeoutExceeded() {
+        Preconditions.checkNotNull(result, "result cannot be null");
+        assertTrue(result.isTimeoutExceeded());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldExpansionIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldExpansionIndexLookupTest.java
@@ -1,0 +1,122 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Set;
+
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.tables.ScannerFactory;
+
+/**
+ * Tests for the {@link FieldExpansionIndexLookup}
+ */
+public class FieldExpansionIndexLookupTest extends BaseIndexLookupTest {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldExpansionIndexLookupTest.class);
+
+    @Test
+    public void testValueDoesNotExpand() {
+        // no data
+        withQuery("_ANYFIELD_ == 'bar'");
+        executeLookup();
+        assertNoResults();
+    }
+
+    @Test
+    public void testValueExpandsIntoSingleField() {
+        write("bar", "FIELD_A");
+        withQuery("_ANYFIELD_ == 'bar'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+    }
+
+    @Test
+    public void testValueExpandsIntoMultipleFields() {
+        write("bar", "FIELD_A");
+        write("bar", "FIELD_B");
+        withQuery("_ANYFIELD_ == 'bar'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+        assertResultValues("FIELD_B", Set.of("bar"));
+    }
+
+    @Test
+    public void testValueExpandsIntoMultipleFieldsSkippingPreviouslyIndexedFields() {
+        write("bar", "FIELD_A");
+        write("bar", "FIELD_B");
+        write("bar", "FIELD_C");
+        write("bar", "FIELD_X");
+        withQuery("_ANYFIELD_ == 'bar'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B", "FIELD_C"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+        assertResultValues("FIELD_B", Set.of("bar"));
+        assertResultValues("FIELD_C", Set.of("bar"));
+    }
+
+    @Test
+    public void testExpansionHitsTimeoutThreshold() {
+        write("bar", "FIELD_A");
+        write("bar", "FIELD_B", EXCEPTEDVALUE);
+        write("bar", "FIELD_C");
+        withQuery("_ANYFIELD_ == 'bar'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B", "FIELD_C"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+        // field expansion iterator does not (currently) honor timeout exceptions
+    }
+
+    @Test
+    public void testExpansionHitsValueThreshold_singleValueMultiField() {
+        int valueExpansionThreshold = config.getMaxValueExpansionThreshold();
+        try {
+            write("bar", "FIELD_A");
+            write("bar", "FIELD_B");
+            write("bar", "FIELD_C");
+            withQuery("_ANYFIELD_ == 'bar'");
+            config.setMaxValueExpansionThreshold(1);
+            executeLookup();
+            assertResultFields(Set.of("FIELD_A", "FIELD_B", "FIELD_C"));
+            assertResultValues("FIELD_A", Set.of("bar"));
+            assertResultValues("FIELD_B", Set.of("bar"));
+            assertResultValues("FIELD_C", Set.of("bar"));
+        } finally {
+            config.setMaxValueExpansionThreshold(valueExpansionThreshold);
+        }
+    }
+
+    @Override
+    protected void executeLookup() {
+        try {
+            Preconditions.checkNotNull(query, "query cannot be null");
+            JexlNode node = parse(query);
+            String field = JexlASTHelper.getIdentifier(node);
+            assertEquals("_ANYFIELD_", field);
+
+            Object literal = JexlASTHelper.getLiteralValueSafely(node);
+            String value = String.valueOf(literal);
+
+            AsyncIndexLookup lookup = createLookup(value);
+            executeLookup(lookup);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            fail("Lookup failed: " + e.getMessage());
+        }
+    }
+
+    private AsyncIndexLookup createLookup(String value) {
+        ScannerFactory scannerFactory = new ScannerFactory(client);
+        return new FieldExpansionIndexLookup(config, scannerFactory, value, indexedFields, executor);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldedRegexIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldedRegexIndexLookupTest.java
@@ -1,0 +1,137 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Range;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.RefactoredRangeDescription;
+import datawave.query.tables.ScannerFactory;
+
+public class FieldedRegexIndexLookupTest extends BaseIndexLookupTest {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldedRegexIndexLookupTest.class);
+
+    @Test
+    public void testExpansionWithNodata() {
+        // no data
+        withQuery("FIELD_A =~ 'ba.*'");
+        executeLookup();
+        assertNoResults();
+    }
+
+    @Test
+    public void testExpandsIntoSingleValue() {
+        write("bar", "FIELD_A");
+        withQuery("FIELD_A =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+    }
+
+    @Test
+    public void testExpandsIntoMultipleValues() {
+        write("bar", "FIELD_A");
+        write("baz", "FIELD_A");
+        withQuery("FIELD_A =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar", "baz"));
+    }
+
+    @Test
+    public void testExpandsIntoMultipleValuesSkipsDifferentField() {
+        write("bar", "FIELD_A");
+        write("bar", "FIELD_B");
+        write("baz", "FIELD_A");
+        withQuery("FIELD_A =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar", "baz"));
+    }
+
+    @Test
+    public void testExpansionSkipsPreviouslyIndexedFields() {
+        write("bar", "FIELD_A");
+        write("bar", "FIELD_X");
+        write("baz", "FIELD_A");
+        withQuery("FIELD_A =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar", "baz"));
+    }
+
+    @Test
+    public void testExpansionTimeoutFailure() {
+        write("bar", "FIELD_A");
+        write("baz", "FIELD_A", EXCEPTEDVALUE);
+        withQuery("FIELD_A =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+        assertTimeoutExceeded();
+    }
+
+    @Test
+    public void testReverseExpansionNoData() {
+        // no data
+        withQuery("FIELD_A =~ '.*ab'");
+        executeLookup();
+        assertNoResults();
+    }
+
+    @Test
+    public void testReverseExpansionSingleValue() {
+        writeReverse("tim", "FIELD_A");
+        withQuery("FIELD_A =~ '.*m'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("tim"));
+    }
+
+    @Test
+    public void testReverseExpansionMultipleValues() {
+        writeReverse("tim", "FIELD_A");
+        writeReverse("tam", "FIELD_A");
+        withQuery("FIELD_A =~ '.*m'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("tim", "tam"));
+    }
+
+    @Override
+    protected void executeLookup() {
+        try {
+            Preconditions.checkNotNull(query, "query cannot be null");
+            JexlNode node = parse(query);
+            String field = JexlASTHelper.getIdentifier(node);
+
+            Object literal = JexlASTHelper.getLiteralValueSafely(node);
+            String value = String.valueOf(literal);
+
+            RefactoredRangeDescription desc = ShardIndexQueryTableStaticMethods.getRegexRange(field, value, false, metadataHelper, config);
+            Range range = desc.range;
+            boolean reverse = desc.isForReverseIndex;
+
+            AsyncIndexLookup lookup = createLookup(field, value, range, reverse);
+            executeLookup(lookup);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            fail("Lookup failed: " + e.getMessage());
+        }
+    }
+
+    private AsyncIndexLookup createLookup(String field, String value, Range range, boolean reverse) {
+        ScannerFactory scannerFactory = new ScannerFactory(client);
+        return new FieldedRegexIndexLookup(config, scannerFactory, executor, field, value, range, reverse);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookupTest.java
@@ -1,0 +1,187 @@
+package datawave.query.jexl.lookups;
+
+import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Range;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.query.Constants;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.RefactoredRangeDescription;
+import datawave.query.tables.ScannerFactory;
+import datawave.util.TableName;
+
+/**
+ * Some basic tests for the {@link UnfieldedRegexIndexLookup}
+ */
+public class UnfieldedRegexIndexLookupTest extends BaseIndexLookupTest {
+
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedRegexIndexLookupTest.class);
+
+    @Test
+    public void testExpansionZeroHits() {
+        // no data
+        withQuery("_ANYFIELD_ =~ 'ba.*'");
+        executeLookup();
+        assertNoResults();
+    }
+
+    @Test
+    public void testExpansionOneHit() {
+        write("bar", "FIELD");
+        withQuery("_ANYFIELD_ =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD"));
+        assertResultValues("FIELD", Set.of("bar"));
+    }
+
+    @Test
+    public void testExpandsIntoSingleFieldWithMultipleValues() {
+        write("bar", "FIELD");
+        write("baz", "FIELD");
+        withQuery("_ANYFIELD_ =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD"));
+        assertResultValues("FIELD", Set.of("bar", "baz"));
+    }
+
+    @Test
+    public void testExpandsIntoMultipleFieldsWithSingleValues() {
+        write("bar", "FIELD_A");
+        write("barstool", "FIELD_B");
+        withQuery("_ANYFIELD_ =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B"));
+        assertResultValues("FIELD_A", Set.of("bar"));
+        assertResultValues("FIELD_B", Set.of("barstool"));
+    }
+
+    @Test
+    public void testExpandsIntoMultipleFieldsWithMultipleValues() {
+        write("bar", "FIELD_A");
+        write("barstool", "FIELD_A");
+        write("baz", "FIELD_B");
+        write("bazaar", "FIELD_B");
+        withQuery("_ANYFIELD_ =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B"));
+        assertResultValues("FIELD_A", Set.of("bar", "barstool"));
+        assertResultValues("FIELD_B", Set.of("baz", "bazaar"));
+    }
+
+    @Test
+    public void testSimulatedTimeout() {
+        write("bar", "FIELD_A");
+        write("baz", "FIELD_A");
+        write("baz-kaboom", "FIELD_A", EXCEPTEDVALUE);
+        withQuery("_ANYFIELD_ =~ 'ba.*'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A"));
+        assertResultValues("FIELD_A", Set.of("bar", "baz"));
+        assertTimeoutExceeded();
+    }
+
+    @Test
+    public void testReverseExpansionZeroHits() {
+        // no data
+        withQuery("_ANYFIELD_ =~ '.*m'");
+        executeLookup();
+        assertNoResults();
+    }
+
+    @Test
+    public void testReverseExpansionOneHit() {
+        writeReverse("tim", "FIELD");
+        withQuery("_ANYFIELD_ =~ '.*m'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD"));
+        assertResultValues("FIELD", Set.of("tim"));
+    }
+
+    @Test
+    public void testReverseExpandsIntoSingleFieldWithMultipleValues() {
+        writeReverse("tim", "FIELD");
+        writeReverse("tom", "FIELD");
+        withQuery("_ANYFIELD_ =~ '.*m'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD"));
+        assertResultValues("FIELD", Set.of("tim", "tom"));
+    }
+
+    @Test
+    public void testReverseExpandsIntoMultipleFieldsWithSingleValues() {
+        writeReverse("tim", "FIELD_A");
+        writeReverse("tom", "FIELD_B");
+        withQuery("_ANYFIELD_ =~ '.*m'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B"));
+        assertResultValues("FIELD_A", Set.of("tim"));
+        assertResultValues("FIELD_B", Set.of("tom"));
+    }
+
+    @Test
+    public void testReverseExpandsIntoMultipleFieldsWithMultipleValues() {
+        writeReverse("tim", "FIELD_A");
+        writeReverse("tom", "FIELD_A");
+        writeReverse("tim", "FIELD_B");
+        writeReverse("tam", "FIELD_B");
+        withQuery("_ANYFIELD_ =~ '.*m'");
+        executeLookup();
+        assertResultFields(Set.of("FIELD_A", "FIELD_B"));
+        assertResultValues("FIELD_A", Set.of("tim", "tom"));
+        assertResultValues("FIELD_B", Set.of("tim", "tam"));
+    }
+
+    /**
+     * Build an index lookup from the query and store the results
+     */
+    @Override
+    protected void executeLookup() {
+        try {
+            Preconditions.checkNotNull(query, "query cannot be null");
+            JexlNode node = parse(query);
+            String field = JexlASTHelper.getIdentifier(node);
+            assertEquals(Constants.ANY_FIELD, field);
+
+            Object literal = JexlASTHelper.getLiteralValueSafely(node);
+            String value = String.valueOf(literal);
+
+            RefactoredRangeDescription desc = ShardIndexQueryTableStaticMethods.getRegexRange(field, value, false, metadataHelper, config);
+            Range range = desc.range;
+            boolean reverse = desc.isForReverseIndex;
+
+            AsyncIndexLookup lookup = createLookup(value, range, reverse, null);
+            executeLookup(lookup);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            fail("Lookup failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Create an {@link UnfieldedRegexIndexLookup}
+     *
+     * @param regex
+     *            the regex
+     * @param range
+     *            the range
+     * @param reverse
+     *            flag denoting use of the {@link TableName#SHARD_RINDEX}
+     * @param fields
+     *            an optional set of fields used to restrict the scan
+     * @return an UnfieldedRegexIndexLookup
+     */
+    private AsyncIndexLookup createLookup(String regex, Range range, boolean reverse, Set<String> fields) {
+        ScannerFactory scannerFactory = new ScannerFactory(client);
+        return new UnfieldedRegexIndexLookup(config, scannerFactory, executor, regex, range, reverse, fields);
+    }
+}


### PR DESCRIPTION
Add IndexLookups for fielded and unfielded regex expansion iterators, add test framework for IndexLookups

IndexLookupMap now has variables to track state. This lays the groundwork for migrating the control flow away from thrown exceptions