### PR TITLE
Create LazyLoadingRangesIterator for use with SSDeep

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/SSDeepSimilarityQueryConfiguration.java
@@ -14,6 +14,9 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     int queryThreads = 100;
 
+    /** The number of ranges generated at a time by {@link datawave.query.tables.chained.iterators.LazyLoadingRangesIterator} */
+    int numRangesPerScanner = 50000;
+
     int ngramSize = NGramGenerator.DEFAULT_NGRAM_SIZE;
     int maxRepeatedCharacters = SSDeepHash.DEFAULT_MAX_REPEATED_CHARACTERS;
     int minHashSize = NGramGenerator.DEFAULT_MIN_HASH_SIZE;
@@ -73,6 +76,7 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
         setMaxRepeatedCharacters(other.getMaxRepeatedCharacters());
         setMinHashSize(other.getMinHashSize());
         setNGramSize(other.getNGramSize());
+        setNumRangesPerScanner(other.getNumRangesPerScanner());
         setQueryThreads(other.getQueryThreads());
         setDedupeSimilarityHashes(other.isDedupeSimilarityHashes());
         setMaxHashes(other.getMaxHashes());
@@ -94,6 +98,14 @@ public class SSDeepSimilarityQueryConfiguration extends GenericQueryConfiguratio
 
     public void setQueryThreads(int queryThreads) {
         this.queryThreads = queryThreads;
+    }
+
+    public int getNumRangesPerScanner() {
+        return numRangesPerScanner;
+    }
+
+    public void setNumRangesPerScanner(int numRangesPerScanner) {
+        this.numRangesPerScanner = numRangesPerScanner;
     }
 
     public int getNGramSize() {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/chained/iterators/LazyLoadingRangesIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/chained/iterators/LazyLoadingRangesIterator.java
@@ -1,0 +1,179 @@
+package datawave.query.tables.chained.iterators;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.query.config.SSDeepSimilarityQueryConfiguration;
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.tables.ScannerFactory;
+import datawave.query.tables.ssdeep.SSDeepMaxHashPerNGramFilter;
+import datawave.query.tables.ssdeep.SSDeepParsingFunction;
+import datawave.query.tables.ssdeep.SSDeepScoringFunction;
+import datawave.query.tables.ssdeep.SSDeepSeenFunction;
+import datawave.query.tables.ssdeep.ScoredSSDeepPair;
+import datawave.util.ssdeep.ChunkSizeEncoding;
+import datawave.util.ssdeep.IntegerEncoding;
+import datawave.util.ssdeep.NGramTuple;
+import datawave.util.ssdeep.SSDeepHash;
+
+/**
+ * Iterator that lazily calculates ranges. The amount of ranges to be calculated at a time is configurable. This approach avoids creating all the ranges at the
+ * same time and storing them all in memory for the life of the query.
+ */
+public class LazyLoadingRangesIterator implements Iterator<ScoredSSDeepPair> {
+    private static final Logger log = LoggerFactory.getLogger(LazyLoadingRangesIterator.class);
+
+    private final Iterator<NGramTuple> queryMapKeysIterator;
+    private final ScannerFactory scannerFactory;
+    private BatchScanner scanner;
+    private Iterator<Map.Entry<Key,Value>> scannerIterator;
+    private final int numRangesPerScanner;
+
+    private final ChunkSizeEncoding chunkSizeEncoder = new ChunkSizeEncoding();
+    private final IntegerEncoding bucketEncoder;
+    private final int indexBuckets;
+
+    private final SSDeepSimilarityQueryConfiguration config;
+
+    private final SSDeepParsingFunction parsingFunction;
+    private final SSDeepSeenFunction ssDeepDedupeFunction;
+    private final SSDeepMaxHashPerNGramFilter maxHashPerNGramLimiter;
+    private final AtomicLong count = new AtomicLong(0);
+    private final long maxResults;
+    private final SSDeepScoringFunction scoringFunction;
+
+    private Iterator<ScoredSSDeepPair> currentScoredSSDeepPairsIterator;
+
+    private ScoredSSDeepPair next;
+
+    public LazyLoadingRangesIterator(SSDeepSimilarityQueryConfiguration ssDeepSimilarityQueryConfiguration, ScannerFactory scannerFactory, long maxResults)
+                    throws TableNotFoundException {
+        config = ssDeepSimilarityQueryConfiguration;
+        this.maxResults = maxResults;
+        queryMapKeysIterator = config.getState().getQueryMap().keys().iterator();
+        bucketEncoder = new IntegerEncoding(config.getBucketEncodingBase(), config.getBucketEncodingLength());
+        indexBuckets = config.getIndexBuckets();
+        numRangesPerScanner = config.getNumRangesPerScanner();
+
+        this.scannerFactory = scannerFactory;
+
+        parsingFunction = new SSDeepParsingFunction(config);
+        ssDeepDedupeFunction = new SSDeepSeenFunction();
+        maxHashPerNGramLimiter = new SSDeepMaxHashPerNGramFilter(config);
+        scoringFunction = new SSDeepScoringFunction(config);
+    }
+
+    /**
+     * Continue creating new iterators using a new calculated set of ranges until a next result can be found
+     *
+     * @return true if a result has been found, false if not
+     */
+    @Override
+    public boolean hasNext() {
+        if (next != null) {
+            return true;
+        }
+
+        boolean foundNext = false;
+        while (!foundNext) {
+            if (currentScoredSSDeepPairsIterator == null || !currentScoredSSDeepPairsIterator.hasNext()) {
+                while (scannerIterator == null || !scannerIterator.hasNext()) {
+                    if (queryMapKeysIterator.hasNext()) {
+                        try {
+                            scannerIterator = createIteratorWithNewRanges();
+                        } catch (TableNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+
+                Map.Entry<Key,Value> entry = scannerIterator.next();
+
+                Map.Entry<NGramTuple,SSDeepHash> simplifiedEntry = parsingFunction.apply(entry);
+
+                if (config.isDedupeSimilarityHashes() && !ssDeepDedupeFunction.test(simplifiedEntry)) {
+                    continue;
+                }
+
+                if (config.getMaxHashesPerNGram() > -1 && !maxHashPerNGramLimiter.test(simplifiedEntry)) {
+                    continue;
+                }
+
+                if (maxResults > -1 && count.incrementAndGet() > maxResults) {
+                    throw new DatawaveFatalQueryException("Exceeded max work");
+                }
+
+                if (currentScoredSSDeepPairsIterator == null || !currentScoredSSDeepPairsIterator.hasNext()) {
+                    currentScoredSSDeepPairsIterator = scoringFunction.apply(simplifiedEntry).iterator();
+                }
+
+                if (currentScoredSSDeepPairsIterator.hasNext()) {
+                    foundNext = true;
+                    next = currentScoredSSDeepPairsIterator.next();
+                }
+            } else {
+                foundNext = true;
+                next = currentScoredSSDeepPairsIterator.next();
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Return next and reset
+     *
+     * @return the next item
+     */
+    @Override
+    public ScoredSSDeepPair next() {
+        ScoredSSDeepPair scoredPair = next;
+        next = null;
+        return scoredPair;
+    }
+
+    /**
+     * Process the query map keys to create ranges to scan in Accumulo. The number of ranges generated at a time is determined by {@code numRangesPerScanner}.
+     * The number of ranges may go over numRangesPerScanner slightly due to processing all index buckets per NGramTuple
+     *
+     * @return an iterator based on the next set of calculated ranges
+     */
+    private Iterator<Map.Entry<Key,Value>> createIteratorWithNewRanges() throws TableNotFoundException {
+        final Collection<Range> ranges = new HashSet<>();
+
+        while (queryMapKeysIterator.hasNext() && ranges.size() <= numRangesPerScanner) {
+            NGramTuple ct = queryMapKeysIterator.next();
+            final String sizeAndChunk = chunkSizeEncoder.encode(ct.getChunkSize()) + ct.getChunk();
+            for (int i = 0; i < indexBuckets; i++) {
+                final String bucketedSizeAndChunk = bucketEncoder.encode(i) + sizeAndChunk;
+                ranges.add(Range.exact(new Text(bucketedSizeAndChunk)));
+            }
+        }
+
+        if (scanner != null) {
+            scanner.close();
+        }
+        scanner = scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), config.getQueryThreads(), config.getQuery());
+
+        scanner.setRanges(ranges);
+
+        log.debug("Lazy loaded {} ranges.", ranges.size());
+        log.trace("Ranges are: {}", ranges);
+
+        return scanner.stream().iterator();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepChainedDiscoveryQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepChainedDiscoveryQueryLogic.java
@@ -34,7 +34,11 @@ public class SSDeepChainedDiscoveryQueryLogic extends ChainedQueryTable<ScoredSS
 
     @Override
     public void close() {
+        this.logic2.close();
+        this.logic1.close();
         super.close();
+        this.logic2 = null;
+        this.logic1 = null;
     }
 
     public GenericQueryConfiguration initialize(AccumuloClient client, Query settings, Set<Authorizations> auths) throws Exception {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepDiscoveryQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepDiscoveryQueryLogic.java
@@ -229,6 +229,12 @@ public class SSDeepDiscoveryQueryLogic extends BaseQueryLogic<DiscoveredSSDeep> 
     }
 
     @Override
+    public void close() {
+        super.close();
+        discoveryDelegate.close();
+    }
+
+    @Override
     public AccumuloConnectionFactory.Priority getConnectionPriority() {
         return discoveryDelegate.getConnectionPriority();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepScoringFunction.java
@@ -1,10 +1,10 @@
 package datawave.query.tables.ssdeep;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import org.apache.log4j.Logger;
 
@@ -18,7 +18,7 @@ import datawave.util.ssdeep.SSDeepHashScorer;
 import datawave.util.ssdeep.SSDeepNGramOverlapScorer;
 
 /** A function that transforms entries retrieved from Accumulo into Scored SSDeep hash matches */
-public class SSDeepScoringFunction implements Function<Map.Entry<NGramTuple,SSDeepHash>,Stream<ScoredSSDeepPair>> {
+public class SSDeepScoringFunction implements Function<Map.Entry<NGramTuple,SSDeepHash>,Collection<ScoredSSDeepPair>> {
 
     public static final String MIN_SSDEEP_SCORE_PARAMETER = "minScore";
     private static final Logger log = Logger.getLogger(SSDeepScoringFunction.class);
@@ -55,7 +55,7 @@ public class SSDeepScoringFunction implements Function<Map.Entry<NGramTuple,SSDe
      */
     private int readOptionalMinScoreThreshold(Query query) {
         QueryImpl.Parameter minScoreParameter = query.findParameter(MIN_SSDEEP_SCORE_PARAMETER);
-        if (minScoreParameter != null) {
+        if (minScoreParameter != null && !minScoreParameter.getParameterValue().isBlank()) {
             String minScoreString = minScoreParameter.getParameterValue();
             try {
                 int minScore = Integer.parseInt(minScoreString);
@@ -79,27 +79,29 @@ public class SSDeepScoringFunction implements Function<Map.Entry<NGramTuple,SSDe
      *
      * @param entry
      *            the function argument
-     * @return A Stream of scored SSDeep pairs related to the row returned by Accumulo.
+     * @return A Collection of scored SSDeep pairs related to the row returned by Accumulo.
      */
     @Override
-    public Stream<ScoredSSDeepPair> apply(Map.Entry<NGramTuple,SSDeepHash> entry) {
+    public Collection<ScoredSSDeepPair> apply(Map.Entry<NGramTuple,SSDeepHash> entry) {
         NGramTuple ngram = entry.getKey();
         SSDeepHash matchingHash = entry.getValue();
 
         // extract the query ssdeeps that contained this ngram from the query map.
         Collection<SSDeepHash> queryHashes = queryState.getQueryMap().get(ngram);
 
+        Collection<ScoredSSDeepPair> scoredSSDeepPairs = new HashSet<>();
+
         // score the match between each query ssdeep and matching hash, keep those that exceed the match
         // threshold.
-        return queryHashes.stream().flatMap(queryHash -> {
+        for (SSDeepHash queryHash : queryHashes) {
             Set<NGramTuple> overlappingNGrams = ngramOverlapScorer.apply(queryHash, matchingHash);
             int weightedScore = editDistanceScorer.apply(queryHash, matchingHash);
             if (minScoreThreshold <= 0 || weightedScore > minScoreThreshold) {
-                return Stream.of(new ScoredSSDeepPair(queryHash, matchingHash, overlappingNGrams, weightedScore));
-            } else {
-                return Stream.empty();
+                scoredSSDeepPairs.add(new ScoredSSDeepPair(queryHash, matchingHash, overlappingNGrams, weightedScore));
             }
-        });
+        }
+
+        return scoredSSDeepPairs;
     }
 
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryLogic.java
@@ -2,21 +2,15 @@ package datawave.query.tables.ssdeep;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.ScannerBase;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Multimap;
 
@@ -28,8 +22,7 @@ import datawave.microservice.query.Query;
 import datawave.query.config.SSDeepSimilarityQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.ScannerFactory;
-import datawave.util.ssdeep.ChunkSizeEncoding;
-import datawave.util.ssdeep.IntegerEncoding;
+import datawave.query.tables.chained.iterators.LazyLoadingRangesIterator;
 import datawave.util.ssdeep.NGramGenerator;
 import datawave.util.ssdeep.NGramTuple;
 import datawave.util.ssdeep.SSDeepHash;
@@ -37,11 +30,13 @@ import datawave.webservice.query.exception.QueryException;
 
 public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair> {
 
-    private static final Logger log = Logger.getLogger(SSDeepSimilarityQueryLogic.class);
+    private static final Logger log = LoggerFactory.getLogger(SSDeepSimilarityQueryLogic.class);
 
     private SSDeepSimilarityQueryConfiguration config;
 
-    ScannerFactory scannerFactory;
+    private ScannerFactory scannerFactory;
+
+    private LazyLoadingRangesIterator lazyLoadingRangesIterator;
 
     public SSDeepSimilarityQueryLogic() {
         super();
@@ -69,7 +64,7 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
         config.setClient(accumuloClient);
         config.setAuthorizations(auths);
         this.scannerFactory = new ScannerFactory(config);
-        setupRanges(settings, config);
+        setupQueryMap(settings, config);
         return config;
     }
 
@@ -82,62 +77,31 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
         final SSDeepSimilarityQueryConfiguration config = (SSDeepSimilarityQueryConfiguration) genericConfig;
 
         try {
-            final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), config.getQueryThreads(),
-                            config.getQuery());
+            lazyLoadingRangesIterator = new LazyLoadingRangesIterator(config, scannerFactory, this.getMaxResults());
 
-            scanner.setRanges(config.getState().getRanges());
-
-            final SSDeepParsingFunction parsingFunction = new SSDeepParsingFunction(config);
-            Stream<Map.Entry<NGramTuple,SSDeepHash>> parsedStream = scanner.stream().map(parsingFunction);
-
-            if (config.isDedupeSimilarityHashes()) {
-                final SSDeepSeenFunction ssDeepDedupeFunction = new SSDeepSeenFunction();
-                parsedStream = parsedStream.filter(ssDeepDedupeFunction);
-            }
-
-            if (config.getMaxHashesPerNGram() > -1) {
-                final SSDeepMaxHashPerNGramFilter maxHashPerNGramLimiter = new SSDeepMaxHashPerNGramFilter(config);
-                parsedStream = parsedStream.filter(maxHashPerNGramLimiter);
-            }
-
-            if (getMaxResults() > -1) {
-                final AtomicLong count = new AtomicLong();
-                parsedStream = parsedStream.peek(entry -> {
-                    if (count.incrementAndGet() > getMaxResults()) {
-                        throw new DatawaveFatalQueryException("Exceeded max work");
-                    }
-                });
-            }
-
-            // must be called after setRanges so that we get the query map from the config.
-            final SSDeepScoringFunction scoringFunction = new SSDeepScoringFunction(config);
-            Stream<ScoredSSDeepPair> scoredStream = parsedStream.flatMap(scoringFunction);
-
-            this.iterator = scoredStream.iterator();
-            this.scanner = scanner;
-
+            this.iterator = lazyLoadingRangesIterator;
         } catch (TableNotFoundException e) {
             throw new RuntimeException("Table not found: " + this.getTableName(), e);
         }
     }
 
     /**
-     * Process the query to create the ngrams for the ranges to scan in accumulo. Store these in the configs along with a map that can be used to identify which
-     * SSDeepHash each query ngram originated from.
+     * Process the query to create the map of ngrams that will be used by {@link datawave.query.tables.chained.iterators.LazyLoadingRangesIterator} to generate
+     * the ranges to scan in accumulo. Store this ngrams map in the config. The map can be used to identify which SSDeepHash each query ngram originated from.
      *
      * @param settings
      *            the query we will be running.
      * @param config
-     *            write ranges and query map to this object.
+     *            write query map to this object.
      */
-    public void setupRanges(Query settings, SSDeepSimilarityQueryConfiguration config) {
+    public void setupQueryMap(Query settings, SSDeepSimilarityQueryConfiguration config) {
         final String query = settings.getQuery().trim();
         Set<SSDeepHash> queries = Arrays.stream(query.split(" OR ")).map(k -> {
             final int pos = k.indexOf(':');
             return pos > 0 ? k.substring(pos + 1) : k;
         }).map(SSDeepHash::parse).collect(Collectors.toSet());
 
-        log.info("Pre-processing " + queries.size() + " SSDeepHash queries");
+        log.info("Pre-processing {} SSDeepHash queries", queries.size());
         final int maxRepeatedCharacters = config.getMaxRepeatedCharacters();
         final NGramGenerator nGramEngine = new NGramGenerator(config.getNGramSize(), maxRepeatedCharacters, config.getMinHashSize());
         if (maxRepeatedCharacters > 0) {
@@ -146,17 +110,11 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
         }
 
         if (config.getMaxHashes() != -1 && config.getMaxHashes() < queries.size()) {
-            log.error("Query exceeds max hash limit of " + config.getMaxHashes() + " count: " + queries.size());
+            log.error("Query exceeds max hash limit of {} count: {}", config.getMaxHashes(), queries.size());
             throw new DatawaveFatalQueryException("Query exceeds max hash limit of " + config.getMaxHashes() + " count: " + queries.size());
         }
 
         final Multimap<NGramTuple,SSDeepHash> queryMap = nGramEngine.preprocessQueries(queries);
-        final Set<Range> ranges = new TreeSet<>();
-
-        final IntegerEncoding bucketEncoder = new IntegerEncoding(config.getBucketEncodingBase(), config.getBucketEncodingLength());
-        final ChunkSizeEncoding chunkSizeEncoder = new ChunkSizeEncoding();
-
-        final int indexBuckets = config.getIndexBuckets();
 
         if (queryMap.isEmpty()) {
             String message = "Unable to generate SSDeepHash ngrams for query: " + settings.getQuery() + ", possibly due to invalid SSDeep hash(es)?";
@@ -164,21 +122,8 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
             throw new SSDeepRuntimeQueryException(message);
         }
 
-        // TODO: stream?
-        for (NGramTuple ct : queryMap.keys()) {
-            final String sizeAndChunk = chunkSizeEncoder.encode(ct.getChunkSize()) + ct.getChunk();
-            for (int i = 0; i < indexBuckets; i++) {
-                final String bucketedSizeAndChunk = bucketEncoder.encode(i) + sizeAndChunk;
-                ranges.add(Range.exact(new Text(bucketedSizeAndChunk)));
-            }
-        }
-
-        log.info("Generated " + queryMap.size() + " SSDeepHash ngrams of size " + nGramEngine.getNgramSize() + " and " + ranges.size() + " ranges. ");
-        if (log.isDebugEnabled()) {
-            log.debug("Query map is: " + queryMap);
-            log.debug("Ranges are: " + ranges);
-        }
-        config.getState().setRanges(ranges);
+        log.debug("Generated {} SSDeepHash ngrams of size {}.", queryMap.size(), nGramEngine.getNgramSize());
+        log.trace("Query map is: {}", queryMap);
         config.getState().setQueryMap(queryMap);
     }
 
@@ -201,8 +146,10 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
                 ++nClosed;
             }
             if (log.isDebugEnabled())
-                log.debug("Cleaned up " + nClosed + " batch scanners associated with this query logic.");
+                log.debug("Cleaned up {} batch scanners associated with this query logic.", nClosed);
         }
+        lazyLoadingRangesIterator = null;
+        config = null;
     }
 
     @Override
@@ -238,6 +185,10 @@ public class SSDeepSimilarityQueryLogic extends BaseQueryLogic<ScoredSSDeepPair>
 
     public void setQueryThreads(int queryThreads) {
         getConfig().setQueryThreads(queryThreads);
+    }
+
+    public void setNumRangesPerScanner(int numRangesPerScanner) {
+        getConfig().setNumRangesPerScanner(numRangesPerScanner);
     }
 
     public void setMaxRepeatedCharacters(int maxRepeatedCharacters) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryState.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryState.java
@@ -1,12 +1,9 @@
 package datawave.query.tables.ssdeep;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.accumulo.core.data.Range;
 
 import com.google.common.collect.Multimap;
 
@@ -14,8 +11,6 @@ import datawave.util.ssdeep.NGramTuple;
 import datawave.util.ssdeep.SSDeepHash;
 
 public class SSDeepSimilarityQueryState {
-    private Collection<Range> ranges;
-
     /**
      * The query map, which relates SSDeep hash ngrams with the original query hashes, so that the SSDeep hashes from Accumulo can be married up with the
      * original queries that caused them to be retrieved.
@@ -25,14 +20,6 @@ public class SSDeepSimilarityQueryState {
     private Set<Integer> seenHashes = new HashSet<>();
 
     private Map<String,Long> ngramCountMap = new HashMap<>();
-
-    public Collection<Range> getRanges() {
-        return ranges;
-    }
-
-    public void setRanges(Collection<Range> ranges) {
-        this.ranges = ranges;
-    }
 
     public Multimap<NGramTuple,SSDeepHash> getQueryMap() {
         return queryMap;

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIndexQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIndexQueryTest.java
@@ -144,6 +144,7 @@ public class SSDeepIndexQueryTest {
         logic.setBucketEncodingBase(BUCKET_ENCODING_BASE);
         logic.setBucketEncodingLength(BUCKET_ENCODING_LENGTH);
         logic.setIndexBuckets(BUCKET_COUNT);
+        logic.setNumRangesPerScanner(10);
 
         SubjectIssuerDNPair dn = SubjectIssuerDNPair.of("userDn", "issuerDn");
         DatawaveUser user = new DatawaveUser(dn, DatawaveUser.UserType.USER, Sets.newHashSet(auths.toString().split(",")), null, null, -1L);

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepIngestQueryTest.java
@@ -98,6 +98,7 @@ public class SSDeepIngestQueryTest extends AbstractFunctionalQuery {
         similarityQueryLogic.setBucketEncodingBase(BUCKET_ENCODING_BASE);
         similarityQueryLogic.setBucketEncodingLength(BUCKET_ENCODING_LENGTH);
         similarityQueryLogic.setIndexBuckets(BUCKET_COUNT);
+        similarityQueryLogic.setNumRangesPerScanner(10);
 
         discoveryQueryLogic = new SSDeepDiscoveryQueryLogic();
         discoveryQueryLogic.setTableName("shardIndex");

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ssdeep/SSDeepSimilarityQueryTest.java
@@ -10,6 +10,7 @@ import static datawave.query.tables.ssdeep.util.SSDeepTestUtil.TEST_SSDEEPS;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -93,6 +94,7 @@ public class SSDeepSimilarityQueryTest {
         logic.setBucketEncodingBase(BUCKET_ENCODING_BASE);
         logic.setBucketEncodingLength(BUCKET_ENCODING_LENGTH);
         logic.setIndexBuckets(BUCKET_COUNT);
+        logic.setNumRangesPerScanner(10);
 
         SubjectIssuerDNPair dn = SubjectIssuerDNPair.of("userDn", "issuerDn");
         DatawaveUser user = new DatawaveUser(dn, DatawaveUser.UserType.USER, Sets.newHashSet(auths.toString().split(",")), null, null, -1L);
@@ -150,6 +152,23 @@ public class SSDeepSimilarityQueryTest {
             log.debug(entry);
         }
         scanner.close();
+    }
+
+    @Test
+    public void testVariousNumRangesPerScanner() throws Exception {
+        String query = "CHECKSUM_SSDEEP:" + TEST_SSDEEPS[0] + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[1] + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[2]
+                        + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[3] + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[4] + " OR CHECKSUM_SSDEEP:" + TEST_SSDEEPS[5];
+
+        final int expectedEventCount = 9;
+
+        for (int numRangesPerScanner : Arrays.asList(1, 10, 100, 1000, 10000, 100000)) {
+            logic.setNumRangesPerScanner(numRangesPerScanner);
+            EventQueryResponseBase response = runSSDeepQuery(query, 0);
+            List<EventBase> events = response.getEvents();
+            int eventCount = events.size();
+
+            Assert.assertEquals(expectedEventCount, eventCount);
+        }
     }
 
     @SuppressWarnings("rawtypes")

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/SSDeepQueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/SSDeepQueryLogicFactory.xml
@@ -13,6 +13,7 @@
         <property name="auditType" value="NONE" />
         <property name="indexBuckets" value="32" />
         <property name="queryThreads" value="100" />
+        <property name="numRangesPerScanner" value="50000" />
         <property name="maxRepeatedCharacters" value="3" />
         <property name="bucketEncodingBase" value="32" />
         <property name="bucketEncodingLength" value="2" />
@@ -34,13 +35,15 @@
         <property name="logicDescription" value="Discovery query that returns information from the index about the supplied term(s)" />
     </bean>
 
-    <bean id="SSDeepSimilarityDiscoveryQuery" parent="baseQueryLogic" class="datawave.query.tables.ssdeep.SSDeepChainedDiscoveryQueryLogic">
+    <bean id="SSDeepSimilarityDiscoveryQuery" parent="baseQueryLogic" scope="prototype" class="datawave.query.tables.ssdeep.SSDeepChainedDiscoveryQueryLogic">
         <property name="tableName" value="ssdeepIndex" />
         <property name="logic1" ref="SSDeepSimilarityQuery"/>
         <property name="logic2" ref="SSDeepDiscoveryQuery"/>
         <property name="auditType" value="NONE"/>
         <property name="chainStrategy">
-            <bean class="datawave.query.tables.ssdeep.FullSSDeepDiscoveryChainStrategy"/>
+            <bean class="datawave.query.tables.ssdeep.FullSSDeepDiscoveryChainStrategy">
+                <property name="batchSize" value="100" />
+            </bean>
         </property>
     </bean>
 </beans>


### PR DESCRIPTION
This adds a LazyLoadingRangesIterator, which calculates a certain number of ranges at a time. The amount of ranges calculated at a time is configurable. This avoids calculating all ranges at the same time and storing them all in memory.