### PR TITLE
Add IndexKeyParsers and TruncatedIndexConversionIterator

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/BitSetCombiner.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/BitSetCombiner.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.Combiner;
 
 import datawave.util.TableName;
 
@@ -16,7 +15,7 @@ import datawave.util.TableName;
  * <p>
  * Deletes are not honored.
  */
-public class BitSetCombiner extends Combiner {
+public class BitSetCombiner extends PropogatingCombiner {
 
     @Override
     public Value reduce(Key key, Iterator<Value> iter) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/TruncatedIndexConversionIterator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/TruncatedIndexConversionIterator.java
@@ -1,0 +1,140 @@
+package datawave.ingest.table.aggregator;
+
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.ingest.table.aggregator.util.TruncatedIndexKeyParser;
+
+/**
+ * This iterator can transform a global index table to a truncated index where the shard number becomes an index in a bitset
+ * <p>
+ * Although the underlying {@link TruncatedIndexKeyParser} supports parsing sharded keys this iterator only assumes two key formats: standard and truncated.
+ */
+public class TruncatedIndexConversionIterator implements SortedKeyValueIterator<Key,Value> {
+
+    private static final Logger log = LoggerFactory.getLogger(TruncatedIndexConversionIterator.class);
+
+    protected SortedKeyValueIterator<Key,Value> delegate;
+    protected final TreeMap<Key,BitSet> buffer = new TreeMap<>();
+    protected Key tk = null;
+    protected Value tv = null;
+
+    // dedicated parser for the first key seen
+    private final TruncatedIndexKeyParser tkParser = new TruncatedIndexKeyParser();
+    // dedicated parser for all subsequent matching keys
+    private final TruncatedIndexKeyParser nextParser = new TruncatedIndexKeyParser();
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> option, IteratorEnvironment env) throws IOException {
+        this.delegate = source;
+    }
+
+    @Override
+    public boolean hasTop() {
+        if (tk == null && buffer.isEmpty() && delegate.hasTop()) {
+            try {
+                fillBuffer();
+                next();
+            } catch (IOException e) {
+                log.error("failed to fill buffer");
+                log.error(e.getMessage(), e);
+            }
+        }
+
+        return tk != null;
+    }
+
+    @Override
+    public void next() throws IOException {
+        if (!buffer.isEmpty()) {
+            Map.Entry<Key,BitSet> entry = buffer.pollFirstEntry();
+            tk = entry.getKey();
+            tv = new Value(entry.getValue().toByteArray());
+        } else {
+            tk = null;
+            tv = null;
+        }
+    }
+
+    protected void fillBuffer() throws IOException {
+        if (delegate.hasTop()) {
+            Key top = delegate.getTopKey();
+            tkParser.parse(top);
+
+            buffer.clear();
+            if (tkParser.isTruncatedKey()) {
+                addToBuffer(top, BitSet.valueOf(delegate.getTopValue().get()));
+            } else {
+                addToBuffer(tkParser.convert(), tkParser.getBitset());
+            }
+
+            delegate.next();
+
+            while (delegate.hasTop()) {
+                Key k = delegate.getTopKey();
+                nextParser.parse(k);
+
+                if (!tkParser.getDate().equals(nextParser.getDate())) {
+                    break; // dates don't match, stop aggregating keys
+                }
+
+                if (nextParser.isTruncatedKey()) {
+                    addToBuffer(k, BitSet.valueOf(delegate.getTopValue().get()));
+                } else {
+                    Key truncated = nextParser.convert();
+                    addToBuffer(truncated, nextParser.getBitset());
+                }
+
+                delegate.next();
+            }
+        }
+    }
+
+    protected void addToBuffer(Key key, BitSet bitset) {
+        if (buffer.containsKey(key)) {
+            BitSet original = buffer.get(key);
+            original.or(bitset);
+            buffer.put(key, original);
+        } else {
+            buffer.put(key, bitset);
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        delegate.seek(range, columnFamilies, inclusive);
+        hasTop();
+    }
+
+    @Override
+    public Key getTopKey() {
+        return tk;
+    }
+
+    @Override
+    public Value getTopValue() {
+        return tv;
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment iteratorEnvironment) {
+        TruncatedIndexConversionIterator copy = new TruncatedIndexConversionIterator();
+        copy.delegate = delegate.deepCopy(iteratorEnvironment);
+        copy.tk = tk;
+        copy.tv = tv;
+        copy.buffer.putAll(buffer);
+        return copy;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/AbstractIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/AbstractIndexKeyParser.java
@@ -42,21 +42,57 @@ public abstract class AbstractIndexKeyParser implements IndexKeyParser {
         this.bitset = null;
     }
 
+    /**
+     * Standard shard index keys take the form
+     *
+     * <pre>
+     *     value FIELD:yyyyMMdd_shard0x00datatype (uid list)
+     * </pre>
+     *
+     * @return true if the key is a standard shard index key
+     */
     @Override
     public boolean isStandardKey() {
         return cqUnderscoreIndex != -1 && cqNullIndex != -1;
     }
 
+    /**
+     * Truncated shard index keys take the form
+     *
+     * <pre>
+     *     value FIELD:yyyyMMdd0x00datatype (bitset of shard offsets)
+     * </pre>
+     *
+     * @return true if the key is a truncated shard index key
+     */
     @Override
     public boolean isTruncatedKey() {
         return cqUnderscoreIndex == -1 && cqNullIndex == 8;
     }
 
+    /**
+     * Sharded day index keys take the form
+     *
+     * <pre>
+     *     yyyyMMdd0x00value FIELD:datatype (bitset of shard offsets)
+     * </pre>
+     *
+     * @return true if the key is a sharded index key
+     */
     @Override
     public boolean isShardedDayKey() {
         return rowNullIndex == 8 && cqUnderscoreIndex == -1 && cqNullIndex == -1;
     }
 
+    /**
+     * Sharded year index keys take the form
+     *
+     * <pre>
+     *     yyyy0x00value FIELD:datatype (bitset of day offsets)
+     * </pre>
+     *
+     * @return true if the key is a sharded year index key
+     */
     @Override
     public boolean isShardedYearKey() {
         return rowNullIndex == 4 && cqUnderscoreIndex == -1 && cqNullIndex == -1;
@@ -117,6 +153,15 @@ public abstract class AbstractIndexKeyParser implements IndexKeyParser {
         }
     }
 
+    /**
+     * The column qualifier may or may not contain a null byte or underscore depending on the type of index key.
+     * <p>
+     * A standard index key's column qualifier will always contain a null byte and an underscore
+     * <p>
+     * A truncated index key's column qualifier will always contain a null byte and never contain an underscore
+     * <p>
+     * A sharded day or year index key's column qualifier will never contain a null byte or an underscore
+     */
     protected void parseColumnQualifier() {
         cq = key.getColumnQualifier().toString();
         char[] charArray = cq.toCharArray();

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/AbstractIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/AbstractIndexKeyParser.java
@@ -1,0 +1,136 @@
+package datawave.ingest.table.aggregator.util;
+
+import java.util.BitSet;
+
+import org.apache.accumulo.core.data.Key;
+
+/**
+ * Holds common methods for the implementations of {@link IndexKeyParser}
+ */
+public abstract class AbstractIndexKeyParser implements IndexKeyParser {
+
+    protected final char NULL_CHAR = '\u0000';
+    protected final char UNDERSCORE_CHAR = '_';
+
+    protected Key key;
+    protected String row;
+    protected String cf;
+    protected String cq;
+
+    // indices are used to determine what type of index key the parser is operating on
+    private int rowNullIndex = -1;
+    protected int cqNullIndex = -1;
+    protected int cqUnderscoreIndex = -1;
+
+    protected BitSet bitset;
+
+    public void parse(Key key) {
+        clearState();
+        this.key = key;
+        parseRow();
+        parseColumnQualifier();
+    }
+
+    private void clearState() {
+        this.key = null;
+        this.row = null;
+        this.cq = null;
+        this.cf = null;
+        this.rowNullIndex = -1;
+        this.cqNullIndex = -1;
+        this.cqUnderscoreIndex = -1;
+        this.bitset = null;
+    }
+
+    @Override
+    public boolean isStandardKey() {
+        return cqUnderscoreIndex != -1 && cqNullIndex != -1;
+    }
+
+    @Override
+    public boolean isTruncatedKey() {
+        return cqUnderscoreIndex == -1 && cqNullIndex == 8;
+    }
+
+    @Override
+    public boolean isShardedDayKey() {
+        return rowNullIndex == 8 && cqUnderscoreIndex == -1 && cqNullIndex == -1;
+    }
+
+    @Override
+    public boolean isShardedYearKey() {
+        return rowNullIndex == 4 && cqUnderscoreIndex == -1 && cqNullIndex == -1;
+    }
+
+    public String getValue() {
+        if (isStandardKey() || isTruncatedKey()) {
+            return row;
+        } else if (isShardedDayKey() || isShardedYearKey()) {
+            return row.substring(rowNullIndex + 1);
+        }
+        throw new IllegalStateException("unknown shard index key structure: " + key.toString());
+    }
+
+    public String getField() {
+        if (cf == null) {
+            cf = key.getColumnFamily().toString();
+        }
+        return cf;
+    }
+
+    public String getDate() {
+        if (isStandardKey()) {
+            return cq.substring(0, cqUnderscoreIndex);
+        } else if (isTruncatedKey()) {
+            return cq.substring(0, cqNullIndex);
+        } else if (isShardedDayKey() || isShardedYearKey()) {
+            return row.substring(0, rowNullIndex);
+        }
+        throw new IllegalStateException("unknown shard index key structure: " + key.toString());
+    }
+
+    public String getDateAndShard() {
+        if (isStandardKey() || isTruncatedKey()) {
+            return cq.substring(0, cqNullIndex);
+        } else if (isShardedDayKey() || isShardedYearKey()) {
+            return row.substring(0, rowNullIndex);
+        }
+        throw new IllegalStateException("unknown shard index key structure: " + key.toString());
+    }
+
+    public String getDatatype() {
+        return cq.substring(cqNullIndex + 1);
+    }
+
+    /**
+     * Parses the row and records the presence of the first null byte. This information is used in conjunction with the {@link #cqNullIndex} to determine the
+     * index key version.
+     */
+    protected void parseRow() {
+        row = key.getRow().toString();
+        char[] charArray = row.toCharArray();
+        for (int i = 0; i < charArray.length; i++) {
+            if (charArray[i] == NULL_CHAR) {
+                rowNullIndex = i;
+                break;
+            }
+        }
+    }
+
+    protected void parseColumnQualifier() {
+        cq = key.getColumnQualifier().toString();
+        char[] charArray = cq.toCharArray();
+        for (int i = 0; i < charArray.length; i++) {
+            switch (charArray[i]) {
+                case UNDERSCORE_CHAR:
+                    cqUnderscoreIndex = i;
+                    break;
+                case NULL_CHAR:
+                    cqNullIndex = i;
+                    break;
+                default:
+                    // keep going
+            }
+        }
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/IndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/IndexKeyParser.java
@@ -1,0 +1,25 @@
+package datawave.ingest.table.aggregator.util;
+
+import org.apache.accumulo.core.data.Key;
+
+/**
+ * A key parser for shard index keys that supports conversion between index key types, i.e.
+ * <ul>
+ * <li>standard shard index key</li>
+ * <li>truncated shard index key</li>
+ * <li>sharded day index key</li>
+ * <li>sharded year index key</li>
+ * </ul>
+ */
+public interface IndexKeyParser {
+
+    boolean isStandardKey();
+
+    boolean isTruncatedKey();
+
+    boolean isShardedDayKey();
+
+    boolean isShardedYearKey();
+
+    Key convert();
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParser.java
@@ -29,7 +29,7 @@ public class ShardedDayIndexKeyParser extends AbstractIndexKeyParser {
 
     @Override
     public Key convert() {
-        if (isShardedYearKey()) {
+        if (isShardedDayKey()) {
             return key; // pass-through
         }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParser.java
@@ -1,0 +1,54 @@
+package datawave.ingest.table.aggregator.util;
+
+import java.util.BitSet;
+
+import org.apache.accumulo.core.data.Key;
+
+/**
+ * A parser that handles a converting a standard shard index key or a truncated shard index key to a sharded day index key.
+ * <p>
+ * Converts either a standard shard index key in the form
+ *
+ * <pre>
+ * value FIELD:yyyyMMdd_shard0x00datatype (uid list)
+ * </pre>
+ *
+ * or a truncated shard index key in the form
+ *
+ * <pre>
+ * value FIELD:yyyyMMdd0x00datatype (bitset offset)
+ * </pre>
+ *
+ * to a sharded day index key
+ *
+ * <pre>
+ * yyyyMMdd0x00value FIELD:datatype (bitset offset)
+ * </pre>
+ */
+public class ShardedDayIndexKeyParser extends AbstractIndexKeyParser {
+
+    @Override
+    public Key convert() {
+        if (isShardedYearKey()) {
+            return key; // pass-through
+        }
+
+        String nextRow = getDate() + NULL_CHAR + getValue();
+        return new Key(nextRow, getField(), getDatatype(), key.getColumnVisibilityParsed(), key.getTimestamp());
+    }
+
+    public BitSet getBitset() {
+        if (isTruncatedKey() || isShardedDayKey() || isShardedYearKey()) {
+            // pass-through for truncated or sharded keys
+            return null;
+        }
+
+        if (bitset == null && isStandardKey()) {
+            String shardNumber = cq.substring(cqUnderscoreIndex + 1, cqNullIndex);
+            int num = Integer.parseInt(shardNumber);
+            bitset = new BitSet();
+            bitset.set(num);
+        }
+        return bitset;
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedYearIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedYearIndexKeyParser.java
@@ -1,0 +1,44 @@
+package datawave.ingest.table.aggregator.util;
+
+import java.util.BitSet;
+import java.util.Calendar;
+
+import org.apache.accumulo.core.data.Key;
+
+import datawave.util.time.DateHelper;
+
+public class ShardedYearIndexKeyParser extends AbstractIndexKeyParser {
+
+    @Override
+    public Key convert() {
+        if (isShardedYearKey()) {
+            return key; // pass-through
+        }
+
+        String year = getYear();
+        String nextRow = year + NULL_CHAR + getValue();
+        return new Key(nextRow, getField(), getDatatype(), key.getColumnVisibilityParsed(), key.getTimestamp());
+    }
+
+    public BitSet getBitset() {
+        if (isShardedYearKey()) {
+            return null;
+        }
+
+        if (bitset == null) {
+            String date = getDate();
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(DateHelper.parse(date));
+
+            int offset = calendar.get(Calendar.DAY_OF_YEAR);
+            bitset = new BitSet();
+            bitset.set(offset);
+        }
+        return bitset;
+    }
+
+    protected String getYear() {
+        String date = getDate();
+        return date.substring(0, 4);
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/TruncatedIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/TruncatedIndexKeyParser.java
@@ -1,0 +1,55 @@
+package datawave.ingest.table.aggregator.util;
+
+import java.util.BitSet;
+
+import org.apache.accumulo.core.data.Key;
+
+import datawave.ingest.table.aggregator.TruncatedIndexConversionIterator;
+
+/**
+ * A parser that can handle either a shard index key in either standard format or truncated format
+ * <p>
+ * Converts a standard shard index key in the form
+ *
+ * <pre>
+ * value FIELD:yyyyMMdd_shard0x00datatype (uid list)
+ * </pre>
+ *
+ * to
+ *
+ * <pre>
+ * value FIELD:yyyyMMdd0x00datatype (bitset offset)
+ * </pre>
+ *
+ * Can be used in a map reduce job or in conjunction with the {@link TruncatedIndexConversionIterator}.
+ */
+public class TruncatedIndexKeyParser extends AbstractIndexKeyParser {
+
+    @Override
+    public Key convert() {
+        if (isStandardKey()) {
+            // might want to snag the delete flag as well in the future
+            return new Key(getValue(), getField(), getDate() + NULL_CHAR + getDatatype(), key.getColumnVisibilityParsed(), key.getTimestamp());
+        } else {
+            // become a pass-through if the key is already truncated, or is a sharded key
+            return key;
+        }
+    }
+
+    public BitSet getBitset() {
+        if (isTruncatedKey() || isShardedDayKey() || isShardedYearKey()) {
+            // pass-though for truncated or sharded keys
+            return null;
+        }
+
+        if (bitset == null) {
+            String shardNumber = cq.substring(cqUnderscoreIndex + 1, cqNullIndex);
+            int num = Integer.parseInt(shardNumber);
+            bitset = new BitSet();
+            bitset.set(num);
+        }
+
+        return bitset;
+    }
+
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/IndexKeyConversionTests.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/IndexKeyConversionTests.java
@@ -1,0 +1,21 @@
+package datawave.ingest.table.aggregator.util;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Interface that ensures each index key conversion iterators can handle every shard index key format
+ */
+public interface IndexKeyConversionTests {
+
+    @Test
+    void testStandardShardIndexKey();
+
+    @Test
+    void testTruncatedShardIndexKey();
+
+    @Test
+    void testShardedDayIndexKey();
+
+    @Test
+    void testShardedYearIndexKey();
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParserTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParserTest.java
@@ -1,0 +1,79 @@
+package datawave.ingest.table.aggregator.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.BitSet;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.Test;
+
+public class ShardedDayIndexKeyParserTest implements IndexKeyConversionTests {
+
+    private final ShardedDayIndexKeyParser parser = new ShardedDayIndexKeyParser();
+
+    @Test
+    public void testStandardShardIndexKey() {
+        Key key = new Key("value", "FIELD", "20250606_123\u0000datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606_123", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        Key expected = new Key("20250606\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        assertEquals(expected, parser.convert());
+
+        BitSet expectedBits = new BitSet();
+        expectedBits.set(123);
+        assertEquals(expectedBits, parser.getBitset());
+    }
+
+    @Test
+    public void testTruncatedShardIndexKey() {
+        Key key = new Key("value", "FIELD", "20250606\u0000datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser will convert a truncated index key, but the bitset is a pass-through
+        Key expected = new Key("20250606\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        assertEquals(expected, parser.convert());
+        assertNull(parser.getBitset());
+    }
+
+    @Test
+    public void testShardedDayIndexKey() {
+        Key key = new Key("20250606\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser should be a pass-through. convert returns the original key, getBitSet returns null
+        assertEquals(key, parser.convert());
+        assertNull(parser.getBitset());
+    }
+
+    @Test
+    public void testShardedYearIndexKey() {
+        Key key = new Key("2025\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("2025", parser.getDateAndShard());
+        assertEquals("2025", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser should be a pass-through. convert returns the original key, getBitSet returns null
+        assertEquals(key, parser.convert());
+        assertNull(parser.getBitset());
+    }
+
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/ShardedYearIndexKeyParserTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/ShardedYearIndexKeyParserTest.java
@@ -1,0 +1,83 @@
+package datawave.ingest.table.aggregator.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.BitSet;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.Test;
+
+public class ShardedYearIndexKeyParserTest implements IndexKeyConversionTests {
+
+    private final ShardedYearIndexKeyParser parser = new ShardedYearIndexKeyParser();
+
+    @Test
+    public void testStandardShardIndexKey() {
+        Key key = new Key("value", "FIELD", "20250606_123\u0000datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606_123", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        Key expected = new Key("2025\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        assertEquals(expected, parser.convert());
+
+        BitSet expectedBits = new BitSet();
+        expectedBits.set(157);
+        assertEquals(expectedBits, parser.getBitset());
+    }
+
+    @Test
+    public void testTruncatedShardIndexKey() {
+        Key key = new Key("value", "FIELD", "20250606\u0000datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        Key expected = new Key("2025\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        assertEquals(expected, parser.convert());
+
+        BitSet expectedBits = new BitSet();
+        expectedBits.set(157);
+        assertEquals(expectedBits, parser.getBitset());
+    }
+
+    @Test
+    public void testShardedDayIndexKey() {
+        Key key = new Key("20250606\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        Key expected = new Key("2025\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        assertEquals(expected, parser.convert());
+
+        BitSet expectedBits = new BitSet();
+        expectedBits.set(157);
+        assertEquals(expectedBits, parser.getBitset());
+    }
+
+    @Test
+    public void testShardedYearIndexKey() {
+        Key key = new Key("2025\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("2025", parser.getDateAndShard());
+        assertEquals("2025", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser should be a pass-through. convert returns the original key, getBitSet returns null
+        assertEquals(key, parser.convert());
+        assertNull(parser.getBitset());
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/TruncatedIndexKeyParserTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/table/aggregator/util/TruncatedIndexKeyParserTest.java
@@ -1,0 +1,77 @@
+package datawave.ingest.table.aggregator.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.BitSet;
+
+import org.apache.accumulo.core.data.Key;
+import org.junit.jupiter.api.Test;
+
+public class TruncatedIndexKeyParserTest implements IndexKeyConversionTests {
+
+    private final TruncatedIndexKeyParser parser = new TruncatedIndexKeyParser();
+
+    @Test
+    public void testStandardShardIndexKey() {
+        Key key = new Key("value", "FIELD", "20250606_123\u0000datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606_123", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        Key expected = new Key("value", "FIELD", "20250606\u0000datatype-a", "VIZ-A");
+        assertEquals(expected, parser.convert());
+
+        BitSet expectedBits = new BitSet();
+        expectedBits.set(123);
+        assertEquals(expectedBits, parser.getBitset());
+    }
+
+    @Test
+    public void testTruncatedShardIndexKey() {
+        Key key = new Key("value", "FIELD", "20250606\u0000datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser should be a pass-through. convert returns the original key, getBitSet returns null
+        assertEquals(key, parser.convert());
+        assertNull(parser.getBitset());
+    }
+
+    @Test
+    public void testShardedDayIndexKey() {
+        Key key = new Key("20250606\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("20250606", parser.getDateAndShard());
+        assertEquals("20250606", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser should be a pass-through. convert returns the original key, getBitSet returns null
+        assertEquals(key, parser.convert());
+        assertNull(parser.getBitset());
+    }
+
+    @Test
+    public void testShardedYearIndexKey() {
+        Key key = new Key("2025\u0000value", "FIELD", "datatype-a", "VIZ-A");
+        parser.parse(key);
+        assertEquals("value", parser.getValue());
+        assertEquals("FIELD", parser.getField());
+        assertEquals("2025", parser.getDateAndShard());
+        assertEquals("2025", parser.getDate());
+        assertEquals("datatype-a", parser.getDatatype());
+
+        // parser should be a pass-through. convert returns the original key, getBitSet returns null
+        assertEquals(key, parser.convert());
+        assertNull(parser.getBitset());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionTests.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionTests.java
@@ -1,0 +1,77 @@
+package datawave.test.index;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class contains tests that should be implemented by each extending class
+ * <p>
+ * {@link IndexConversionUtils} contains all boilerplate code to support declarative style tests
+ */
+public interface IndexConversionTests {
+
+    /**
+     * A test case that verifies duplicate keys are correctly collapsed into a single key
+     */
+    @Test
+    void testDuplicateKeysCollapse();
+
+    /**
+     * A test case that verifies key order is preserved with variable values
+     */
+    @Test
+    void testVariableValues();
+
+    /**
+     * A test case that verifies key order is preserved with variable fields
+     */
+    @Test
+    void testVariableFields();
+
+    /**
+     * A test that verifies key order is preserved with variable days
+     */
+    @Test
+    void testVariableDays();
+
+    /**
+     * A test that verifies key order is preserved with variable shards
+     */
+    @Test
+    void testVariableShards();
+
+    /**
+     * A test that verifies key order is preserved with variable datatypes
+     */
+    @Test
+    void testVariableDatatypes();
+
+    /**
+     * A test that verifies key order is preserved with variable visibilities
+     */
+    @Test
+    void testVariableVisibilities();
+
+    /**
+     * A test that verifies key order is preserved with variable uids
+     */
+    @Test
+    void testVariableUids();
+
+    /**
+     * A test that verifies key order is preserved with variable values, fields, days, shards, visibilities and uids.
+     */
+    @Test
+    void testPermutationsAndCompareTables();
+
+    /**
+     * A test that verifies the iterator can handle both old and new key structures. This is a key requirement for a 'clone-and-compact' strategy.
+     */
+    @Test
+    void testMixOfKeyStructures();
+
+    /**
+     * A test that verifies proper handling of keys with the delete flag set to true.
+     */
+    @Test
+    void testDeletes();
+}

--- a/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionUtils.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionUtils.java
@@ -1,0 +1,421 @@
+package datawave.test.index;
+
+import static datawave.util.TableName.SHARD_INDEX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.CloneConfiguration;
+import org.apache.accumulo.core.client.admin.CompactionConfig;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.clientImpl.CloneConfigurationImpl;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.accumulo.minicluster.MiniAccumuloConfig;
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import datawave.accumulo.inmemory.InMemoryAccumulo;
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.ingest.protobuf.Uid;
+import datawave.util.TableName;
+
+/**
+ * This class contains all boilerplate code to support declarative style tests
+ */
+public abstract class IndexConversionUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(IndexConversionUtils.class);
+
+    @TempDir
+    public static Path macFolder;
+
+    private static final String PASS = "password";
+    private static MiniAccumuloCluster mac;
+
+    protected static AccumuloClient macClient;
+    protected static AccumuloClient imaClient;
+
+    protected static TableOperations macTops;
+    protected static TableOperations imaTops;
+
+    private final String DEFAULT_VISIBILITY = "VIZ-A";
+
+    private static final Authorizations auths = new Authorizations("VIZ-A", "VIZ-B", "VIZ-C");
+
+    protected final List<Map.Entry<Key,Value>> expected = new ArrayList<>();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        MiniAccumuloConfig config = new MiniAccumuloConfig(macFolder.toFile(), PASS);
+        config.setNumTservers(1);
+
+        mac = new MiniAccumuloCluster(config);
+        mac.start();
+
+        macClient = mac.createAccumuloClient("root", new PasswordToken(PASS));
+        macTops = macClient.tableOperations();
+
+        InMemoryInstance instance = new InMemoryInstance(IndexConversionUtils.class.getName());
+        imaClient = new InMemoryAccumuloClient("root", instance);
+        imaTops = imaClient.tableOperations();
+
+        macClient.securityOperations().changeUserAuthorizations("root", auths);
+        imaClient.securityOperations().changeUserAuthorizations("root", auths);
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        recreateTable(imaTops, SHARD_INDEX);
+        recreateTable(macTops, SHARD_INDEX);
+        configureShardIndex(imaTops);
+        configureShardIndex(macTops);
+        expected.clear();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        deleteTable(imaTops, getCloneTableName());
+        deleteTable(macTops, getCloneTableName());
+    }
+
+    protected void recreateTable(TableOperations tops, String tableName) {
+        if (tops.exists(tableName)) {
+            try {
+                tops.delete(tableName);
+            } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
+                fail("Failed to delete: " + tableName, e);
+            }
+        }
+        try {
+            tops.create(tableName);
+        } catch (AccumuloException | AccumuloSecurityException | TableExistsException e) {
+            fail("Failed to create: " + tableName, e);
+        }
+    }
+
+    protected void deleteTable(TableOperations tops, String tableName) {
+        if (tops.exists(tableName)) {
+            try {
+                tops.delete(tableName);
+            } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
+                fail("Failed to delete: " + tableName, e);
+            }
+        }
+    }
+
+    protected void configureShardIndex(TableOperations tops) {
+        try {
+            for (var scope : IteratorUtil.IteratorScope.values()) {
+                String name = "table.iterator." + scope.name() + ".agg";
+                String opt = "table.iterator." + scope.name() + ".agg.opt.*";
+
+                tops.setProperty(SHARD_INDEX, name, "19,datawave.iterators.TotalAggregatingIterator");
+                tops.setProperty(SHARD_INDEX, opt, "datawave.ingest.table.aggregator.KeepCountOnlyUidAggregator");
+            }
+        } catch (Exception e) {
+            fail("Failed to configure shard index", e);
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        mac.stop();
+    }
+
+    /**
+     * Write a key and value to the shard index for both the InMemoryAccumulo and MiniAccumuloCluster instances
+     *
+     * @param key
+     *            the key
+     * @param value
+     *            the value
+     */
+    protected void write(Key key, Value value) {
+        write(SHARD_INDEX, key, value);
+    }
+
+    /**
+     * Write a key and value to the specified table for both the InMemoryAccumulo and MiniAccumuloCluster instances
+     *
+     * @param tableName
+     *            the table name
+     * @param key
+     *            the key
+     * @param value
+     *            the value
+     */
+    protected void write(String tableName, Key key, Value value) {
+        try (var bw = macClient.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), value);
+            bw.addMutation(m);
+        } catch (TableNotFoundException | MutationsRejectedException e) {
+            fail(e.getMessage(), e);
+        }
+
+        try (var bw = imaClient.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), value);
+            bw.addMutation(m);
+        } catch (TableNotFoundException | MutationsRejectedException e) {
+            fail(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Add a key and value to the list of expected results
+     *
+     * @param key
+     *            the key
+     * @param value
+     *            the value
+     */
+    protected void expect(Key key, Value value) {
+        expected.add(new AbstractMap.SimpleEntry<>(key, value));
+    }
+
+    protected Key create(String row, String cf, String cq) {
+        return create(row, cf, cq, DEFAULT_VISIBILITY);
+    }
+
+    protected Key create(String row, String cf, String cq, String cv) {
+        return new Key(row, cf, cq, cv, 0L);
+    }
+
+    protected Key delete(String row, String cf, String cq) {
+        return new Key(row.getBytes(), cf.getBytes(), cq.getBytes(), DEFAULT_VISIBILITY.getBytes(), 1L, true);
+    }
+
+    /**
+     * Clone the {@link TableName#SHARD_INDEX} to the configured {@link #getCloneTableName()}, configure the cloned table, and compact it.
+     */
+    protected void cloneAndCompactMac() {
+        cloneAndCompactMac(macTops, getCloneTableName());
+    }
+
+    /**
+     * Clone the {@link TableName#SHARD_INDEX} to the configured {@link #getCloneTableName()}, configure the cloned table, and compact it.
+     * <p>
+     * TableOperations dictates usage of {@link MiniAccumuloCluster} or {@link InMemoryAccumulo}
+     *
+     * @param tops
+     *            the TableOperations
+     * @param tableName
+     *            the new table name
+     */
+    protected void cloneAndCompactMac(TableOperations tops, String tableName) {
+        try {
+            //  @formatter:off
+            CloneConfiguration cloneConfiguration = new CloneConfigurationImpl()
+                    .setFlush(true)
+                    .setKeepOffline(false)
+                    .build();
+            //  @formatter:on
+            tops.clone(SHARD_INDEX, tableName, cloneConfiguration);
+        } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException | TableExistsException e) {
+            fail("failed to clone table: " + tableName, e);
+        }
+
+        configureClonedTable(tops, tableName);
+
+        try {
+            CompactionConfig compactionConfig = new CompactionConfig();
+            compactionConfig.setFlush(true);
+            compactionConfig.setWait(true);
+            compactionConfig.setStartRow(new Text("\0"));
+            compactionConfig.setEndRow(new Text("~"));
+
+            tops.compact(tableName, compactionConfig);
+        } catch (AccumuloSecurityException | TableNotFoundException | AccumuloException e) {
+            fail("failed to compact table: " + tableName, e);
+        }
+    }
+
+    protected abstract void configureClonedTable(TableOperations tops, String tableName);
+
+    /**
+     * {@link InMemoryAccumulo} does not support a compact operation, so create a new table, configure it, and copy data in.
+     * <p>
+     * The configured iterator at scan time simulates a compaction and should match the output of {@link #cloneAndCompactMac()}
+     */
+    protected void cloneAndCopyIma() {
+        recreateTable(imaTops, getCloneTableName());
+        configureClonedTable(imaTops, getCloneTableName());
+
+        try (var scanner = imaClient.createScanner(SHARD_INDEX, auths); var writer = imaClient.createBatchWriter(getCloneTableName())) {
+
+            scanner.setRange(new Range());
+            for (var entry : scanner) {
+                Key k = entry.getKey();
+                Mutation m = new Mutation(k.getRow());
+                m.put(k.getColumnFamily(), k.getColumnQualifier(), k.getColumnVisibilityParsed(), k.getTimestamp(), entry.getValue());
+                writer.addMutation(m);
+            }
+        } catch (Exception e) {
+            fail("failed to clone and copy table: " + SHARD_INDEX + " to " + getCloneTableName(), e);
+        }
+    }
+
+    /**
+     * Scan the table hosted by the {@link MiniAccumuloCluster} instance
+     *
+     * @param tableName
+     *            the table name
+     * @return a {@link ScanResult}
+     */
+    protected ScanResult scanMac(String tableName) {
+        return scanTable(tableName, macClient);
+    }
+
+    /**
+     * Scan the table hosted by the {@link InMemoryAccumulo} instance
+     *
+     * @param tableName
+     *            the table name
+     * @return a {@link ScanResult}
+     */
+    protected ScanResult scanIma(String tableName) {
+        return scanTable(tableName, imaClient);
+    }
+
+    /**
+     * Scan the table and return a {@link ScanResult}
+     *
+     * @param tableName
+     *            the table name
+     * @param client
+     *            the client used to create the scanner
+     * @return a scan result
+     */
+    protected ScanResult scanTable(String tableName, AccumuloClient client) {
+        ScanResult scanResult = new ScanResult(tableName);
+        try (var scanner = client.createScanner(tableName, auths)) {
+            scanner.setRange(new Range());
+            for (var entry : scanner) {
+                scanResult.addResult(entry);
+            }
+            return scanResult;
+        } catch (TableNotFoundException e) {
+            log.error("failed to scan {}", tableName);
+            throw new RuntimeException(e);
+        } finally {
+            log.info("scan of {} has k: {} v: {} bytes", tableName, scanResult.keyBytes, scanResult.valueBytes);
+        }
+    }
+
+    protected void assertUidTable(String tableName) {
+        assertUidTable(macClient, tableName);
+        assertUidTable(imaClient, tableName);
+    }
+
+    protected void assertUidTable(AccumuloClient client, String tableName) {
+        ScanResult result = scanTable(tableName, client);
+        assertEquals(expected.size(), result.numKeys);
+        assertUidResults(result);
+    }
+
+    /**
+     * Method handles asserting uid results. The order of elements in the uid list is not guaranteed, so this method enforces order for better comparison.
+     *
+     * @param results
+     *            the {@link ScanResult}
+     */
+    protected void assertUidResults(ScanResult results) {
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i).getKey(), results.getResults().get(i).getKey(), "key mismatch");
+            try {
+                Uid.List expectedList = Uid.List.parseFrom(expected.get(i).getValue().get());
+                Uid.List resultList = Uid.List.parseFrom(results.getResults().get(i).getValue().get());
+
+                List<String> expectedUids = new ArrayList<>(expectedList.getUIDList());
+                List<String> resultUids = new ArrayList<>(resultList.getUIDList());
+
+                Collections.sort(expectedUids);
+                Collections.sort(resultUids);
+
+                assertEquals(expectedUids, resultUids, "uid list mismatch");
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    protected abstract String getCloneTableName();
+
+    protected abstract void assertClonedResults(ScanResult results);
+
+    protected void assertClonedResults() {
+        assertClonedResults(getCloneTableName(), imaClient);
+        assertClonedResults(getCloneTableName(), macClient);
+    }
+
+    protected void assertClonedResults(String tableName, AccumuloClient client) {
+        ScanResult result = scanTable(tableName, client);
+        assertEquals(expected.size(), result.numKeys);
+        assertClonedResults(result);
+    }
+
+    protected Value createNoUidValue(int count) {
+        Uid.List.Builder b = Uid.List.newBuilder();
+        b.setIGNORE(true);
+        b.setCOUNT(count);
+        return new Value(b.build().toByteArray());
+    }
+
+    protected Value createUidValue(String uid) {
+        Uid.List.Builder b = Uid.List.newBuilder();
+        b.setIGNORE(false);
+        b.addAllUID(List.of(uid));
+        b.setCOUNT(1);
+        return new Value(b.build().toByteArray());
+    }
+
+    protected Value createUidValue(String... uids) {
+        Uid.List.Builder b = Uid.List.newBuilder();
+        b.setIGNORE(false);
+        b.addAllUID(List.of(uids));
+        b.setCOUNT(uids.length);
+        return new Value(b.build().toByteArray());
+    }
+
+    protected Value createBitSetValue(int... bits) {
+        return new Value(createBitSet(bits).toByteArray());
+    }
+
+    protected BitSet createBitSet(int... bits) {
+        BitSet bitSet = new BitSet();
+        for (int bit : bits) {
+            bitSet.set(bit);
+        }
+        return bitSet;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/index/NoUidIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/NoUidIndexTest.java
@@ -1,0 +1,294 @@
+package datawave.test.index;
+
+import static datawave.util.TableName.SHARD_INDEX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.junit.jupiter.api.Test;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import datawave.ingest.protobuf.Uid;
+
+/**
+ * Prototypical example of how these tests operate. Typical flow is
+ * <ul>
+ * <li>write data to shard index</li>
+ * <li>declare and assert expected keys</li>
+ * <li>create new table via clone and compact</li>
+ * <li>declare and assert expected keys</li>
+ * </ul>
+ */
+public class NoUidIndexTest extends IndexConversionUtils implements IndexConversionTests {
+
+    @Test
+    public void testDuplicateKeysCollapse() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableValues() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-b", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-c", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-b", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-c", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-b", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-c", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableFields() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_B", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_C", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_B", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_C", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_B", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_C", "20250606_1\0datatype-a"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableDays() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250607_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250608_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250607_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250608_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250607_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250608_1\0datatype-a"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableShards() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_2\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_2\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250606_2\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableDatatypes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-b"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-b"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-b"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableVisibilities() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-A"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-B"), createUidValue("uid-b"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), createUidValue("uid-c"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-A"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-B"), createUidValue("uid-b"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), createUidValue("uid-c"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-A"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-B"), createNoUidValue(1));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableUids() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-b"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-c"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a", "uid-b", "uid-c"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(3));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testPermutationsAndCompareTables() {
+        List<String> values = List.of("value-a", "value-b", "value-c");
+        List<String> fields = List.of("FIELD_A", "FIELD_B", "FIELD_C");
+        List<String> dates = List.of("20250606", "20250607", "20250608");
+        List<String> shards = List.of("_1", "_2", "_3");
+        List<String> datatypes = List.of("datatype-a", "datatype-b", "datatype-c");
+        List<String> visibilities = List.of("VIZ-A", "VIZ-B", "VIZ-C");
+        List<String> uids = List.of("uid-a", "uid-b", "uid-c");
+        for (String value : values) {
+            for (String field : fields) {
+                for (String date : dates) {
+                    for (String num : shards) {
+                        for (String datatype : datatypes) {
+                            for (String visibility : visibilities) {
+                                for (String uid : uids) {
+                                    Key key = create(value, field, date + num + "\0" + datatype, visibility);
+                                    Value v = createUidValue(uid);
+                                    write(key, v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        // this test case only counts the results, perhaps sample a few keys to verify?
+        ScanResult macResult = scanMac(getCloneTableName());
+        assertEquals(729, macResult.numKeys);
+
+        ScanResult imaResult = scanIma(getCloneTableName());
+        assertEquals(729, imaResult.numKeys);
+    }
+
+    @Test
+    public void testMixOfKeyStructures() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(23));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(24));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(24));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testDeletes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(delete("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createNoUidValue(1));
+        assertClonedResults();
+    }
+
+    @Override
+    protected String getCloneTableName() {
+        return "shardIndexNoUids";
+    }
+
+    @Override
+    protected void configureClonedTable(TableOperations tops, String tableName) {
+        try {
+            for (var scope : IteratorUtil.IteratorScope.values()) {
+                String name = "table.iterator." + scope.name() + ".agg";
+                String opt = "table.iterator." + scope.name() + ".agg.opt.*";
+
+                tops.setProperty(getCloneTableName(), name, "19,datawave.iterators.TotalAggregatingIterator");
+                tops.setProperty(getCloneTableName(), opt, "datawave.ingest.table.aggregator.KeepCountOnlyNoUidAggregator");
+            }
+        } catch (Exception e) {
+            fail("Failed to configure shard index", e);
+        }
+    }
+
+    @Override
+    protected void assertClonedResults(ScanResult results) {
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i).getKey(), results.getResults().get(i).getKey(), "key mismatch");
+            try {
+                Uid.List expectedList = Uid.List.parseFrom(expected.get(i).getValue().get());
+                Uid.List resultList = Uid.List.parseFrom(results.getResults().get(i).getValue().get());
+
+                assertEquals(expectedList.getCOUNT(), resultList.getCOUNT());
+                assertEquals(expectedList.getIGNORE(), resultList.getIGNORE());
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/index/ScanResult.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/ScanResult.java
@@ -1,0 +1,50 @@
+package datawave.test.index;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class that provides additional stats beyond simple key value pairs returned
+ */
+public class ScanResult {
+
+    private static final Logger log = LoggerFactory.getLogger(ScanResult.class);
+
+    public final String tableName;
+    public int numKeys = 0;
+    public int keyBytes = 0;
+    public int valueBytes = 0;
+    private final List<Map.Entry<Key,Value>> results = new ArrayList<>();
+
+    public ScanResult(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public void addResult(Map.Entry<Key,Value> entry) {
+        numKeys++;
+        keyBytes += entry.getKey().getSize();
+        valueBytes += entry.getValue().getSize();
+        results.add(entry);
+    }
+
+    public List<Map.Entry<Key,Value>> getResults() {
+        return results;
+    }
+
+    public void printTable() {
+        for (Map.Entry<Key,Value> result : results) {
+            log.info("{} {}", result.getKey(), result.getValue().getSize());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return tableName + " keys:" + numKeys + ", k-size:" + keyBytes + ", v-size:" + valueBytes;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/index/TruncatedIndexConversionIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/TruncatedIndexConversionIteratorTest.java
@@ -1,0 +1,278 @@
+package datawave.test.index;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.ingest.protobuf.Uid;
+import datawave.ingest.table.aggregator.TruncatedIndexConversionIterator;
+import datawave.query.iterator.SourceManagerTest.MockIteratorEnvironment;
+
+class TruncatedIndexConversionIteratorTest implements IndexConversionTests {
+
+    private final String DEFAULT_VISIBILITY = "VIZ-A";
+    private final TreeMap<Key,Value> data = new TreeMap<>();
+    private final List<Entry<Key,Value>> expected = new ArrayList<>();
+
+    @BeforeEach
+    public void beforeEach() {
+        data.clear();
+        expected.clear();
+    }
+
+    @Test
+    public void testDuplicateKeysCollapse() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableValues() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-b", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-c", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        expect(create("value-b", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        expect(create("value-c", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableFields() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_B", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_C", "20250606_1\0datatype-a"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        expect(create("value-a", "FIELD_B", "20250606\0datatype-a"), bitSetValue(1));
+        expect(create("value-a", "FIELD_C", "20250606\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableDays() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250607_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250608_1\0datatype-a"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250607\0datatype-a"), bitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250608\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableShards() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_2\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1, 2, 3));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableDatatypes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-b"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-b"), bitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-c"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testInvertedDatatypes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_2\0datatype-b"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(3));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-b"), bitSetValue(2));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-c"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableVisibilities() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-A"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-B"), uidValue("uid-b"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), uidValue("uid-c"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-A"), bitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-B"), bitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-C"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testInvertedVisibilities() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_2\0datatype-a", "VIZ-B"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_3\0datatype-a", "VIZ-A"), uidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-A"), bitSetValue(3));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-B"), bitSetValue(2));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-C"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testVariableUids() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-b"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-c"));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testPermutationsAndCompareTables() {
+        List<String> values = List.of("value-a", "value-b", "value-c");
+        List<String> fields = List.of("FIELD_A", "FIELD_B", "FIELD_C");
+        List<String> dates = List.of("20250606", "20250607", "20250608");
+        List<String> shards = List.of("_1", "_2", "_3");
+        List<String> datatypes = List.of("datatype-a", "datatype-b", "datatype-c");
+        List<String> visibilities = List.of("VIZ-A", "VIZ-B", "VIZ-C");
+        List<String> uids = List.of("uid-a", "uid-b", "uid-c");
+        for (String value : values) {
+            for (String field : fields) {
+                for (String date : dates) {
+                    for (String num : shards) {
+                        for (String datatype : datatypes) {
+                            for (String visibility : visibilities) {
+                                for (String uid : uids) {
+                                    Key key = create(value, field, date + num + "\0" + datatype, visibility);
+                                    Value v = uidValue(uid);
+                                    write(key, v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(729, data.size());
+        assertCount(243);
+    }
+
+    @Test
+    public void testMixOfKeyStructures() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    @Test
+    public void testDeletes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), uidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), bitSetValue(1));
+        assertResults();
+    }
+
+    private Key create(String row, String cf, String cq) {
+        return create(row, cf, cq, DEFAULT_VISIBILITY);
+    }
+
+    private Key create(String row, String cf, String cq, String cv) {
+        return new Key(row, cf, cq, cv);
+    }
+
+    private Value uidValue(String uid) {
+        Uid.List.Builder b = Uid.List.newBuilder();
+        b.setIGNORE(false);
+        b.addAllUID(List.of(uid));
+        b.setCOUNT(1);
+        return new Value(b.build().toByteArray());
+    }
+
+    private Value bitSetValue(int... bits) {
+        BitSet bitSet = new BitSet();
+        for (int bit : bits) {
+            bitSet.set(bit);
+        }
+        return new Value(bitSet.toByteArray());
+    }
+
+    private void write(Key k, Value v) {
+        data.put(k, v);
+    }
+
+    public void expect(Key k, Value v) {
+        expected.add(new SimpleEntry<>(k, v));
+    }
+
+    private void assertResults() {
+        try {
+            TruncatedIndexConversionIterator iter = new TruncatedIndexConversionIterator();
+            iter.init(new SortedMapIterator(data), Collections.emptyMap(), new MockIteratorEnvironment());
+            iter.seek(new Range(), Collections.emptySet(), true);
+
+            List<Entry<Key,Value>> results = new ArrayList<>();
+
+            while (iter.hasTop()) {
+                Key k = iter.getTopKey();
+                Value v = iter.getTopValue();
+                results.add(new SimpleEntry<>(k, v));
+                iter.next();
+            }
+
+            for (int i = 0; i < expected.size(); i++) {
+                assertEquals(expected.get(i).getKey(), results.get(i).getKey(), "key mismatch");
+
+                BitSet expectedBits = BitSet.valueOf(expected.get(i).getValue().get());
+                BitSet resultBits = BitSet.valueOf(results.get(i).getValue().get());
+                assertEquals(expectedBits, resultBits, "bitset mismatch");
+            }
+        } catch (Exception e) {
+            fail("Test failure", e);
+        }
+    }
+
+    private void assertCount(int count) {
+        try {
+            TruncatedIndexConversionIterator iter = new TruncatedIndexConversionIterator();
+            iter.init(new SortedMapIterator(data), Collections.emptyMap(), new MockIteratorEnvironment());
+            iter.seek(new Range(), Collections.emptySet(), true);
+
+            List<Entry<Key,Value>> results = new ArrayList<>();
+
+            while (iter.hasTop()) {
+                Key k = iter.getTopKey();
+                Value v = iter.getTopValue();
+                results.add(new SimpleEntry<>(k, v));
+                iter.next();
+            }
+
+            assertEquals(count, results.size());
+        } catch (Exception e) {
+            fail("Test failure", e);
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/index/TruncatedIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/TruncatedIndexTest.java
@@ -1,0 +1,282 @@
+package datawave.test.index;
+
+import static datawave.util.TableName.SHARD_INDEX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.BitSet;
+import java.util.List;
+
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.junit.jupiter.api.Test;
+
+public class TruncatedIndexTest extends IndexConversionUtils implements IndexConversionTests {
+
+    @Test
+    public void testDuplicateKeysCollapse() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableValues() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-b", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-c", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-b", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-c", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        expect(create("value-b", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        expect(create("value-c", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableFields() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_B", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_C", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_B", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_C", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_B", "20250606\0datatype-a"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_C", "20250606\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableDays() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250607_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250608_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250607_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250608_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250607\0datatype-a"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250608\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableShards() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_2\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_2\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_3\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1, 2, 3));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableDatatypes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-b"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-b"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-c"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-b"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-c"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableVisibilities() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-A"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-B"), createUidValue("uid-b"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), createUidValue("uid-c"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-A"), createUidValue("uid-a"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-B"), createUidValue("uid-b"));
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a", "VIZ-C"), createUidValue("uid-c"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-A"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-B"), createBitSetValue(1));
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a", "VIZ-C"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testVariableUids() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-b"));
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-c"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a", "uid-b", "uid-c"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testPermutationsAndCompareTables() {
+        List<String> values = List.of("value-a", "value-b", "value-c");
+        List<String> fields = List.of("FIELD_A", "FIELD_B", "FIELD_C");
+        List<String> dates = List.of("20250606", "20250607", "20250608");
+        List<String> shards = List.of("_1", "_2", "_3");
+        List<String> datatypes = List.of("datatype-a", "datatype-b", "datatype-c");
+        List<String> visibilities = List.of("VIZ-A", "VIZ-B", "VIZ-C");
+        List<String> uids = List.of("uid-a", "uid-b", "uid-c");
+
+        int written = 0;
+        for (String value : values) {
+            for (String field : fields) {
+                for (String date : dates) {
+                    for (String num : shards) {
+                        for (String datatype : datatypes) {
+                            for (String visibility : visibilities) {
+                                for (String uid : uids) {
+                                    Key key = create(value, field, date + num + "\0" + datatype, visibility);
+                                    Value v = createUidValue(uid);
+                                    write(key, v);
+                                    written++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(2187, written);
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        // this test case only counts the results, perhaps sample a few keys to verify?
+        ScanResult macResult = scanMac(getCloneTableName());
+        assertEquals(243, macResult.numKeys);
+
+        ScanResult imaResult = scanIma(getCloneTableName());
+        assertEquals(243, imaResult.numKeys);
+    }
+
+    @Test
+    public void testMixOfKeyStructures() {
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        write(getCloneTableName(), create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(getCloneTableName(), create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Test
+    public void testDeletes() {
+        write(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        write(delete("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+
+        expect(create("value-a", "FIELD_A", "20250606_1\0datatype-a"), createUidValue("uid-a"));
+        assertUidTable(SHARD_INDEX);
+
+        cloneAndCompactMac();
+        cloneAndCopyIma();
+
+        expected.clear();
+        expect(create("value-a", "FIELD_A", "20250606\0datatype-a"), createBitSetValue(1));
+        assertClonedResults();
+    }
+
+    @Override
+    protected String getCloneTableName() {
+        return "truncatedIndex";
+    }
+
+    @Override
+    protected void configureClonedTable(TableOperations tops, String tableName) {
+        try {
+            for (var scope : IteratorUtil.IteratorScope.values()) {
+                String name = "table.iterator." + scope.name() + ".agg";
+                String opt = "table.iterator." + scope.name() + ".agg.opt.*";
+                tops.removeProperty(tableName, name);
+                tops.removeProperty(tableName, opt);
+
+                String truncatedName = "table.iterator." + scope.name() + ".truncate";
+                tops.setProperty(tableName, truncatedName, "18,datawave.ingest.table.aggregator.TruncatedIndexConversionIterator");
+
+                String combinerName = "table.iterator." + scope.name() + ".bits";
+                String combinerOpt = "table.iterator." + scope.name() + ".bits.opt.all";
+                tops.setProperty(tableName, combinerName, "19,datawave.ingest.table.aggregator.BitSetCombiner");
+                tops.setProperty(tableName, combinerOpt, "true");
+            }
+        } catch (Exception e) {
+            fail("Failed to configure shard index", e);
+        }
+    }
+
+    @Override
+    protected void assertClonedResults(ScanResult results) {
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i).getKey(), results.getResults().get(i).getKey(), "key mismatch");
+
+            BitSet expectedBits = BitSet.valueOf(expected.get(i).getValue().get());
+            BitSet resultBits = BitSet.valueOf(results.getResults().get(i).getValue().get());
+            assertEquals(expectedBits, resultBits, "bitset mismatch");
+        }
+    }
+}


### PR DESCRIPTION
Add index key parsers for converting between table formats

Add test framework for index table that supports both MiniAccumuloCluster and InMemoryAccumulo

Add test interface to ensure no missed test cases as additional cases are added.