### PR TITLE
Better handle case where IvaratorRunnable gets stuck during yield / suspend

### DIFF
--- a/properties/default.properties
+++ b/properties/default.properties
@@ -277,6 +277,8 @@ query.tld.collapse.uids=false
 evaluation.only.fields=
 # Time to wait before yielding in the QueryIterator
 query.iterator.yield.threshold.ms=188400
+# Maximum number of times to yield at the same yieldKey
+query.iterator.max.yields=20
 ############################
 #
 # Accumulo Connection Pools

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -357,6 +357,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private int maxRangesPerRangeIvarator = 5;
     private int maxOrExpansionFstThreshold = 750;
     private long yieldThresholdMs = Long.MAX_VALUE;
+    private int maxYields = 20;
     private String hdfsSiteConfigURLs = null;
     private String hdfsFileCompressionCodec = null;
     private String zookeeperConfig = null;
@@ -741,6 +742,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setMaxRangesPerRangeIvarator(other.getMaxRangesPerRangeIvarator());
         this.setMaxOrExpansionFstThreshold(other.getMaxOrExpansionFstThreshold());
         this.setYieldThresholdMs(other.getYieldThresholdMs());
+        this.setMaxYields(other.getMaxYields());
         this.setHdfsSiteConfigURLs(other.getHdfsSiteConfigURLs());
         this.setHdfsFileCompressionCodec(other.getHdfsFileCompressionCodec());
         this.setZookeeperConfig(other.getZookeeperConfig());
@@ -2561,6 +2563,14 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.yieldThresholdMs = yieldThresholdMs;
     }
 
+    public int getMaxYields() {
+        return maxYields;
+    }
+
+    public void setMaxYields(int maxYields) {
+        this.maxYields = maxYields;
+    }
+
     public boolean isTrackSizes() {
         return trackSizes;
     }
@@ -3044,6 +3054,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 getMaxRangesPerRangeIvarator() == that.getMaxRangesPerRangeIvarator() &&
                 getMaxOrExpansionFstThreshold() == that.getMaxOrExpansionFstThreshold() &&
                 getYieldThresholdMs() == that.getYieldThresholdMs() &&
+                getMaxYields() == that.getMaxYields() &&
                 getIvaratorCacheBufferSize() == that.getIvaratorCacheBufferSize() &&
                 getIvaratorCacheScanPersistThreshold() == that.getIvaratorCacheScanPersistThreshold() &&
                 getIvaratorCacheScanTimeout() == that.getIvaratorCacheScanTimeout() &&
@@ -3313,6 +3324,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 getMaxRangesPerRangeIvarator(),
                 getMaxOrExpansionFstThreshold(),
                 getYieldThresholdMs(),
+                getMaxYields(),
                 getHdfsSiteConfigURLs(),
                 getHdfsFileCompressionCodec(),
                 getZookeeperConfig(),

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2535,6 +2535,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             if (config.getYieldThresholdMs() != Long.MAX_VALUE && config.getYieldThresholdMs() > 0) {
                 addOption(cfg, QueryOptions.YIELD_THRESHOLD_MS, Long.toString(config.getYieldThresholdMs()), false);
             }
+            addOption(cfg, QueryOptions.MAX_YIELDS, Integer.toString(config.getMaxYields()), false);
 
             addOption(cfg, QueryOptions.SORTED_UIDS, Boolean.toString(config.isSortedUIDs()), false);
 

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -2139,6 +2139,14 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
         getConfig().setYieldThresholdMs(yieldThresholdMs);
     }
 
+    public int getMaxYields() {
+        return getConfig().getMaxYields();
+    }
+
+    public void setMaxYields(int maxYields) {
+        getConfig().setMaxYields(maxYields);
+    }
+
     public boolean isCleanupShardsAndDaysQueryHints() {
         return getConfig().isCleanupShardsAndDaysQueryHints();
     }

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -394,6 +394,8 @@ public class ShardQueryConfigurationTest {
         updatedValues.put("maxOrExpansionFstThreshold", 500);
         defaultValues.put("yieldThresholdMs", Long.MAX_VALUE);
         updatedValues.put("yieldThresholdMs", 65535L);
+        defaultValues.put("maxYields", 20);
+        updatedValues.put("maxYields", 10);
         defaultValues.put("hdfsSiteConfigURLs", null);
         updatedValues.put("hdfsSiteConfigURLs", "file://etc/hadoop/hdfs_site.xml");
         defaultValues.put("hdfsFileCompressionCodec", null);

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLogicFactory.xml
@@ -299,6 +299,7 @@
         <property name="maxResults" value="${event.query.max.results}" />
         <property name="queryThreads" value="${shard.query.threads}" />
         <property name="yieldThresholdMs" value="${query.iterator.yield.threshold.ms}" />
+        <property name="maxYields" value="${query.iterator.max.yields}" />
         <property name="collectTimingDetails" value="${beq.collectTimingDetails}" />
         <property name="indexLookupThreads" value="${index.query.threads}" />
         <property name="dateIndexThreads" value="${date.index.threads}" />


### PR DESCRIPTION
Better handle case where IvaratorRunnable gets stuck during yield / suspend

If an IvaratorRunnable is being suspended on a yield and an Accumulo scan prevents it from checking suspendRequested for greater than 60 seconds, then the suspend request will return, the yield will be processed, and

the IvaratorRunnable will likely get an exception when using the Accumulo source and print an ERROR log
To limit unnecessary ERRORs in the log, we should log at INFO if the suspendRequested AtomicBoolean is set and ERROR otherwise

While some code is in place to make maxYields configurable, it is not coded throuth to the query logic configuration the same way that the yield threshold is. We should fix this and sen the maxYields to 20 which would then be > 60 minutes at which point the query will time out in the webservice.