### PR TITLE
Fix IPv6 compression

### DIFF
--- a/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
@@ -126,10 +126,10 @@ public class IpV6Address extends IpAddress {
         int zeroHextetLength = -1;
         if (skipZeros) {
             for (int i = 0; i < hextets.size(); i++) {
-                if (isHextetAllZeroes(hextets.get(i))) {
+                if (hextets.get(i).equals("0")) {
                     int len = 1;
                     for (int j = i + 1; j < hextets.size(); j++) {
-                        if (isHextetAllZeroes(hextets.get(j))) {
+                        if (hextets.get(j).equals("0")) {
                             len++;
                         } else {
                             break;
@@ -140,6 +140,7 @@ public class IpV6Address extends IpAddress {
                         zeroHextetStart = i;
                         zeroHextetLength = len;
                         log.trace("found sequence at index: {} length: {}", zeroHextetStart, zeroHextetLength);
+                        i += (len - 1); // do not look at zero hextets that were already skipped
                     }
                 }
             }
@@ -147,15 +148,6 @@ public class IpV6Address extends IpAddress {
 
         // now build the final address, replacing the longest run of zeroes if necessary
         return buildAddress(hextets, zeroHextetStart, zeroHextetLength);
-    }
-
-    private static boolean isHextetAllZeroes(String hextet) {
-        for (int i = 0; i < hextet.length(); i++) {
-            if (hextet.charAt(i) != '0') {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**

--- a/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
@@ -7,6 +7,7 @@ import org.apache.datasketches.common.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 
@@ -106,6 +107,7 @@ public class IpV6Address extends IpAddress {
 
     public static String toString(short[] address, boolean zeroPadded, boolean skipZeros) {
 
+        Preconditions.checkArgument(zeroPadded != skipZeros, "cannot zero pad address and skip zeros");
         // first convert to list of strings
         List<String> hextets = new ArrayList<>();
         StringBuilder sb = new StringBuilder();

--- a/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
@@ -160,9 +160,13 @@ public class IpV6Address extends IpAddress {
 
     /**
      * Build the final IPv6 address. If a run of all-zero hextets was detected and skipping zeroes was requested then a compressed address will be built.
-     * @param hextets the list of address components
-     * @param zeroHextetStart the start index of the longest run of all-zero hextets
-     * @param zeroHextetLength the length of the longest run of all-zero hextets
+     *
+     * @param hextets
+     *            the list of address components
+     * @param zeroHextetStart
+     *            the start index of the longest run of all-zero hextets
+     * @param zeroHextetLength
+     *            the length of the longest run of all-zero hextets
      * @return an IPv6 address
      */
     private static String buildAddress(List<String> hextets, int zeroHextetStart, int zeroHextetLength) {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
@@ -1,7 +1,12 @@
 package datawave.data.type.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.datasketches.common.SuppressFBWarnings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -11,6 +16,9 @@ import com.google.common.collect.Iterables;
  *
  */
 public class IpV6Address extends IpAddress {
+
+    private static final Logger log = LoggerFactory.getLogger(IpV6Address.class);
+
     private static final long serialVersionUID = -1528748156190096213L;
     private final short[] ipaddress = new short[8];
 
@@ -98,10 +106,20 @@ public class IpV6Address extends IpAddress {
     }
 
     public static String toString(short[] address, boolean zeroPadded, boolean skipZeros) {
+        boolean orig = false;
+        if (orig) {
+            return origToString(address, zeroPadded, skipZeros);
+        } else {
+            return nextToString(address, zeroPadded, skipZeros);
+        }
+    }
+
+    public static String origToString(short[] address, boolean zeroPadded, boolean skipZeros) {
         StringBuilder builder = new StringBuilder(39);
         int startSkip = -1;
         int length = 0;
         if (skipZeros) {
+            // TODO: there must be multiple consecutive sequences of all zeroes in order to compress to '::'
             // find the longest sequence of zeros
             int count = 0;
             for (int i = 0; i < 8; i++) {
@@ -140,6 +158,71 @@ public class IpV6Address extends IpAddress {
             }
         }
         return builder.toString();
+    }
+
+    public static String nextToString(short[] address, boolean zeroPadded, boolean skipZeros) {
+
+        // first convert to list of strings
+        List<String> hextets = new ArrayList<>();
+        for (int i = 0; i < address.length; i++) {
+            StringBuilder sb = new StringBuilder();
+            String value = Integer.toString(0x00FFFF & address[i], 16);
+            if (zeroPadded) {
+                for (int j = value.length(); j < 4; j++) {
+                    sb.append('0');
+                }
+            }
+            sb.append(value);
+            hextets.add(sb.toString());
+        }
+
+        // now find the longest run of all-zero hextets, first find breaks ties
+        int zeroHextetStart = -1;
+        int zeroHextetLength = -1;
+        for (int i = 0; i < hextets.size(); i++) {
+            if (isHextetAllZeroes(hextets.get(i))) {
+                int len = 1;
+                for (int j = i + 1; j < hextets.size(); j++) {
+                    if (isHextetAllZeroes(hextets.get(j))) {
+                        len++;
+                    } else {
+                        break;
+                    }
+                }
+
+                if (len >= 2 && len > zeroHextetLength) {
+                    zeroHextetStart = i;
+                    zeroHextetLength = len;
+                    log.debug("found sequence at index: {} length: {}", zeroHextetStart, zeroHextetLength);
+                }
+            }
+        }
+
+        // now build the final address, replacing the longest run of zeroes if necessary
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < hextets.size(); i++) {
+            if (i == zeroHextetStart) {
+                sb.append("::");
+                i += (zeroHextetLength - 1);
+            } else {
+                sb.append(hextets.get(i));
+                if (i != hextets.size() - 1 && (i + 1 != zeroHextetStart)) {
+                    // append delimiter if not at start and not before an all zero start
+                    sb.append(":");
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    private static boolean isHextetAllZeroes(String hextet) {
+        for (int i = 0; i < hextet.length(); i++) {
+            if (hextet.charAt(i) != '0') {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/util/IpV6Address.java
@@ -3,7 +3,6 @@ package datawave.data.type.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.datasketches.common.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,66 +105,12 @@ public class IpV6Address extends IpAddress {
     }
 
     public static String toString(short[] address, boolean zeroPadded, boolean skipZeros) {
-        boolean orig = false;
-        if (orig) {
-            return origToString(address, zeroPadded, skipZeros);
-        } else {
-            return nextToString(address, zeroPadded, skipZeros);
-        }
-    }
-
-    public static String origToString(short[] address, boolean zeroPadded, boolean skipZeros) {
-        StringBuilder builder = new StringBuilder(39);
-        int startSkip = -1;
-        int length = 0;
-        if (skipZeros) {
-            // TODO: there must be multiple consecutive sequences of all zeroes in order to compress to '::'
-            // find the longest sequence of zeros
-            int count = 0;
-            for (int i = 0; i < 8; i++) {
-                if (address[i] == 0) {
-                    count++;
-                } else {
-                    if (count > length) {
-                        startSkip = i - count;
-                        length = count;
-                    }
-                    count = 0;
-                }
-            }
-            if (count > length) {
-                startSkip = 8 - count;
-                length = count;
-            }
-        }
-        for (int i = 0; i < address.length; i++) {
-            if (i == startSkip) {
-                builder.append(':');
-                i += length;
-            }
-            if (builder.length() > 0 && StringUtils.countMatches(builder.toString(), ":") < 7) {
-                // the countMatches test will prevent adding an extra : at the end and making it look like 9 tokens instead of the allowed max of 8
-                builder.append(':');
-            }
-            if (i < address.length) {
-                String value = Integer.toString(0x00FFFF & address[i], 16);
-                if (zeroPadded) {
-                    for (int j = value.length(); j < 4; j++) {
-                        builder.append('0');
-                    }
-                }
-                builder.append(value);
-            }
-        }
-        return builder.toString();
-    }
-
-    public static String nextToString(short[] address, boolean zeroPadded, boolean skipZeros) {
 
         // first convert to list of strings
         List<String> hextets = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < address.length; i++) {
-            StringBuilder sb = new StringBuilder();
+            sb.setLength(0);
             String value = Integer.toString(0x00FFFF & address[i], 16);
             if (zeroPadded) {
                 for (int j = value.length(); j < 4; j++) {
@@ -179,25 +124,48 @@ public class IpV6Address extends IpAddress {
         // now find the longest run of all-zero hextets, first find breaks ties
         int zeroHextetStart = -1;
         int zeroHextetLength = -1;
-        for (int i = 0; i < hextets.size(); i++) {
-            if (isHextetAllZeroes(hextets.get(i))) {
-                int len = 1;
-                for (int j = i + 1; j < hextets.size(); j++) {
-                    if (isHextetAllZeroes(hextets.get(j))) {
-                        len++;
-                    } else {
-                        break;
+        if (skipZeros) {
+            for (int i = 0; i < hextets.size(); i++) {
+                if (isHextetAllZeroes(hextets.get(i))) {
+                    int len = 1;
+                    for (int j = i + 1; j < hextets.size(); j++) {
+                        if (isHextetAllZeroes(hextets.get(j))) {
+                            len++;
+                        } else {
+                            break;
+                        }
                     }
-                }
 
-                if (len >= 2 && len > zeroHextetLength) {
-                    zeroHextetStart = i;
-                    zeroHextetLength = len;
-                    log.debug("found sequence at index: {} length: {}", zeroHextetStart, zeroHextetLength);
+                    if (len >= 2 && len > zeroHextetLength) {
+                        zeroHextetStart = i;
+                        zeroHextetLength = len;
+                        log.trace("found sequence at index: {} length: {}", zeroHextetStart, zeroHextetLength);
+                    }
                 }
             }
         }
 
+        // now build the final address, replacing the longest run of zeroes if necessary
+        return buildAddress(hextets, zeroHextetStart, zeroHextetLength);
+    }
+
+    private static boolean isHextetAllZeroes(String hextet) {
+        for (int i = 0; i < hextet.length(); i++) {
+            if (hextet.charAt(i) != '0') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Build the final IPv6 address. If a run of all-zero hextets was detected and skipping zeroes was requested then a compressed address will be built.
+     * @param hextets the list of address components
+     * @param zeroHextetStart the start index of the longest run of all-zero hextets
+     * @param zeroHextetLength the length of the longest run of all-zero hextets
+     * @return an IPv6 address
+     */
+    private static String buildAddress(List<String> hextets, int zeroHextetStart, int zeroHextetLength) {
         // now build the final address, replacing the longest run of zeroes if necessary
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < hextets.size(); i++) {
@@ -214,15 +182,6 @@ public class IpV6Address extends IpAddress {
         }
 
         return sb.toString();
-    }
-
-    private static boolean isHextetAllZeroes(String hextet) {
-        for (int i = 0; i < hextet.length(); i++) {
-            if (hextet.charAt(i) != '0') {
-                return false;
-            }
-        }
-        return true;
     }
 
     @Override

--- a/core/utils/type-utils/src/test/java/datawave/data/type/util/IpV6AddressTypeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/util/IpV6AddressTypeTest.java
@@ -1,6 +1,7 @@
 package datawave.data.type.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,9 @@ public class IpV6AddressTypeTest {
     //  @formatter:off
     private final String[] inputs = { //
             "2001:0db8:0000:0000:0000:ff00:0042:8329", //
-            "2003:DEAD:BEEF:4DAD:23:46:bb:101", //
-            "2000:FFFF:EEEE:DD:CC:0000:0000:0000", //
-            "AAAA:BBBB:CCCC:DDDD:EEEE:FFFF:2222:0", //
+            "2003:DEAD:BEEF:4DAD:0023:0046:00bb:0101", //
+            "2000:FFFF:EEEE:00DD:00CC:0000:0000:0000", //
+            "AAAA:BBBB:CCCC:DDDD:EEEE:FFFF:2222:0000", //
             "ff02:0b00:0000:0000:0001:0000:0000:000a", //
             "0000:0000:0000:0000:0000:0000:0000:0001", //
             "0001:0000:0000:0000:0000:0000:0000:0000", //
@@ -102,6 +103,15 @@ public class IpV6AddressTypeTest {
         assertRoundTrip(original, expected);
     }
 
+    @Test
+    public void testInvalidToStringCall() {
+        String zeroAddress = "0000:0000:0000:0000:0000:0000:0000:0000";
+        IpV6Address address = IpV6Address.parse(zeroAddress);
+        short[] shorts = address.toShorts();
+        assertThrows(IllegalArgumentException.class, () -> IpV6Address.toString(shorts, true, true));
+        assertThrows(IllegalArgumentException.class, () -> IpV6Address.toString(shorts, false, false));
+    }
+
     private void assertRoundTrip(String original, String expected) {
         assertEquals(7, StringUtils.countMatches(original, ":"));
 
@@ -111,5 +121,8 @@ public class IpV6AddressTypeTest {
 
         IpV6Address deserialized = IpV6Address.parse(serialized);
         assertEquals(expected, deserialized.toString());
+
+        String zeroPadded = deserialized.toZeroPaddedString();
+        assertEquals(original.toUpperCase(), zeroPadded.toUpperCase());
     }
 }

--- a/core/utils/type-utils/src/test/java/datawave/data/type/util/IpV6AddressTypeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/util/IpV6AddressTypeTest.java
@@ -1,42 +1,44 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package datawave.data.type.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.log4j.Logger;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- *
- */
 public class IpV6AddressTypeTest {
-    private static Logger log = Logger.getLogger(IpV6AddressTypeTest.class);
 
-    private final String[] in = { //
+    private static final Logger log = LoggerFactory.getLogger(IpV6AddressTypeTest.class);
+
+    //  @formatter:off
+    private final String[] inputs = { //
             "2001:0db8:0000:0000:0000:ff00:0042:8329", //
             "2003:DEAD:BEEF:4DAD:23:46:bb:101", //
             "2000:FFFF:EEEE:DD:CC:0000:0000:0000", //
             "AAAA:BBBB:CCCC:DDDD:EEEE:FFFF:2222:0", //
             "ff02:0b00:0000:0000:0001:0000:0000:000a", //
             "0000:0000:0000:0000:0000:0000:0000:0001", //
-            "0000:0000:0000:0000:0000:0000:0000:0000", //
             "0001:0000:0000:0000:0000:0000:0000:0000", //
+            "abcd:0000:0000:abcd:0000:0000:0000:abcd", //
+            "abcd:0000:abcd:0000:0000:0000:0000:abcd", //
+            "0000:0bcd:abcd:abcd:abcd:abcd:abcd:abcd",
+            "abcd:abcd:0000:0000:abcd:0000:0000:abcd", // replace first run of zero hextets when there is a tie
     };
-    private final String[] out = { //
+    private final String[] outputs = { //
             "2001:db8::ff00:42:8329", //
             "2003:dead:beef:4dad:23:46:bb:101", //
-            "2000:ffff:eeee:dd:cc:", //
-            "aaaa:bbbb:cccc:dddd:eeee:ffff:2222:", //
-            "ff02:b00::0001:0:0:a", //
+            "2000:ffff:eeee:dd:cc::", //
+            "aaaa:bbbb:cccc:dddd:eeee:ffff:2222:0", //
+            "ff02:b00::1:0:0:a", //
             "::1", //
-            "::", //
-            "1::"
-
+            "1::",
+            "abcd:0:0:abcd::abcd",
+            "abcd:0:abcd::abcd",
+            "0:bcd:abcd:abcd:abcd:abcd:abcd:abcd",
+            "abcd:abcd::abcd:0:0:abcd"
     };
+    //  @formatter:on
 
     /**
      * Take a valid IpV6Address string, parse it to an IpV6Address instance, take the toString value from the IpV6Address and parse that into another
@@ -44,13 +46,70 @@ public class IpV6AddressTypeTest {
      */
     @Test
     public void testIpNormalizer01() {
-
-        for (String address : in) {
-            IpV6Address addr = IpV6Address.parse(address);
-            log.debug(address + " parsed to: " + addr);
-            IpV6Address reparsed = IpV6Address.parse(addr.toString());
-            log.debug(address + " parsed to: " + addr + " and re-parsed to " + reparsed);
-            assertEquals(reparsed.toString(), addr.toString(), "Had a problem re-parsing " + address);
+        for (int i = 0; i < inputs.length; i++) {
+            String input = inputs[i];
+            String expected = outputs[i];
+            assertRoundTrip(input, expected);
         }
+    }
+
+    @Test
+    public void testRoundTripToString() {
+        String input = "0000:0bcd:abcd:abcd:abcd:abcd:abcd:abcd";
+        String expected = "0:bcd:abcd:abcd:abcd:abcd:abcd:abcd";
+        assertRoundTrip(input, expected);
+    }
+
+    @Test
+    public void testAllZeroAddress() {
+        String original = "0000:0000:0000:0000:0000:0000:0000:0000";
+        String expected = "::";
+        assertRoundTrip(original, expected);
+    }
+
+    @Test
+    public void testAllZeroHextetsReplacedAtStart() {
+        String original = "0000:0000:abcd:abcd:abcd:abcd:abcd:abcd";
+        String expected = "::abcd:abcd:abcd:abcd:abcd:abcd";
+        assertRoundTrip(original, expected);
+    }
+
+    @Test
+    public void testAllZeroHextetsReplacedAtEnd() {
+        String original = "abcd:abcd:abcd:abcd:abcd:abcd:0000:0000";
+        String expected = "abcd:abcd:abcd:abcd:abcd:abcd::";
+        assertRoundTrip(original, expected);
+    }
+
+    @Test
+    public void testAllZeroHextetsReplacedInMiddle() {
+        String original = "abcd:abcd:abcd:0000:0000:abcd:abcd:abcd";
+        String expected = "abcd:abcd:abcd::abcd:abcd:abcd";
+        assertRoundTrip(original, expected);
+    }
+
+    @Test
+    public void testTwoInstancesOfZeroHextetsOfEquivalentLengthsOnlyFirstIsReplaced() {
+        String original = "abcd:0000:0000:abcd:0000:0000:abcd:abcd";
+        String expected = "abcd::abcd:0:0:abcd:abcd";
+        assertRoundTrip(original, expected);
+    }
+
+    @Test
+    public void testLongerInstanceOfZeroHextetIsReplaced() {
+        String original = "abcd:0000:0000:abcd:0000:0000:0000:abcd";
+        String expected = "abcd:0:0:abcd::abcd";
+        assertRoundTrip(original, expected);
+    }
+
+    private void assertRoundTrip(String original, String expected) {
+        assertEquals(7, StringUtils.countMatches(original, ":"));
+
+        IpV6Address address = IpV6Address.parse(original);
+        String serialized = address.toString();
+        assertEquals(expected, serialized);
+
+        IpV6Address deserialized = IpV6Address.parse(serialized);
+        assertEquals(expected, deserialized.toString());
     }
 }


### PR DESCRIPTION
Previous algorithm was incorrectly replacing a single leading hextet of all zeroes with `::` which led to invalid IPv6 addresses that would throw an exception when attempting to parse.