### PR TITLE
Enforce concurrent query limits

### DIFF
--- a/core/base-rest-responses/src/main/java/datawave/webservice/query/exception/DatawaveErrorCode.java
+++ b/core/base-rest-responses/src/main/java/datawave/webservice/query/exception/DatawaveErrorCode.java
@@ -169,6 +169,7 @@ public enum DatawaveErrorCode {
     QUERY_PLAN_ERROR(500, 161, "Error retrieving plan for query."),
     QUERY_PREDICTIONS_ERROR(500, 162, "Error retrieving predictions for query."),
     QUERY_VALIDATION_ERROR(500, 163, "Error validating query."),
+    CONCURRENT_QUERY_LIMIT_ERROR(500, 164, "Error checking concurrent query limits."),
     // 204 No Content
     NO_QUERIES_FOUND(204, 1, "No queries found for user."),
     RESULTS_NOT_SENT(204, 2, "Results not sent."),
@@ -275,7 +276,8 @@ public enum DatawaveErrorCode {
     CURRENT_AND_PREVIOUS_EVENT_ORDER_INVALID(412, 16, "Current event and previous event are not in chronological order"),
     CURRENT_AND_NEXT_EVENT_ORDER_INVALID(412, 17, "Current event and next event are not in chronological order"),
     FIELD_PHRASE_QUERY_NOT_INDEXED(412, 18, "Field cannot be queried as a phrase since it was not indexed as such."),
-    NO_QUERY_VALIDATION_RULES_CONFIGURED(412, 19, "No query validation rules configured for the query logic.");
+    NO_QUERY_VALIDATION_RULES_CONFIGURED(412, 19, "No query validation rules configured for the query logic."),
+    CONCURRENT_QUERY_LIMIT_EXCEEDED(412, 20, "Concurrent query limit exceeded.");
 
     private String message;
     private int httpCode;

--- a/core/utils/type-utils/src/main/java/datawave/query/parser/JavaRegexAnalyzer.java
+++ b/core/utils/type-utils/src/main/java/datawave/query/parser/JavaRegexAnalyzer.java
@@ -23,7 +23,7 @@ public class JavaRegexAnalyzer {
 
     // Types as applied to portions of the regex. We are interested in portions that
     // are literals and those that contain regex constructs.
-    private enum RegexType {
+    public enum RegexType {
         LITERAL(true), // a literal value
         ESCAPED_LITERAL(true), // an escaped literal (e.g. \[ or \.)
         REGEX(false), // a regex
@@ -42,7 +42,7 @@ public class JavaRegexAnalyzer {
         }
     }
 
-    private static class RegexPart {
+    public static class RegexPart {
         // the regex is not-final to allow applyRegexCaseSensitivity
         public String regex;
         public RegexType type;
@@ -57,7 +57,19 @@ public class JavaRegexAnalyzer {
         public RegexPart(String reg, RegexType typ, int nonCapt) {
             this(reg, typ, (nonCapt > 0));
         }
-
+        
+        public String getRegex() {
+            return regex;
+        }
+        
+        public RegexType getType() {
+            return type;
+        }
+        
+        public boolean isNonCapturing() {
+            return nonCapturing;
+        }
+        
         @Override
         public boolean equals(Object o) {
             if (!(o instanceof RegexPart)) {
@@ -151,6 +163,10 @@ public class JavaRegexAnalyzer {
 
     public String getRegex() {
         return getRegex(regexParts);
+    }
+    
+    public RegexPart[] getRegexParts() {
+        return regexParts;
     }
 
     public static String getRegex(RegexPart[] regexParts) {

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
         <version.commons-pool>1.6</version.commons-pool>
         <version.commons-pool2>2.6.1</version.commons-pool2>
         <version.commons-text>1.11.0</version.commons-text>
-        <version.curator>5.7.1</version.curator>
-        <version.curator.test>5.7.1</version.curator.test>
+        <version.curator>5.9.0</version.curator>
+        <version.curator.test>5.9.0</version.curator.test>
         <version.datawave.accumulo-api>4.0.0</version.datawave.accumulo-api>
         <version.datawave.audit-api>4.0.0</version.datawave.audit-api>
         <version.datawave.authorization-api>4.0.0</version.datawave.authorization-api>

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/querylock/CombinedQueryLock.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/querylock/CombinedQueryLock.java
@@ -7,7 +7,6 @@ import java.util.List;
  */
 public class CombinedQueryLock implements QueryLock {
     private QueryLock[] locks;
-
     public CombinedQueryLock(List<QueryLock> locks) {
         this.locks = locks.toArray(new QueryLock[locks.size()]);
     }

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/querylock/HdfsQueryLock.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/querylock/HdfsQueryLock.java
@@ -16,10 +16,12 @@ import datawave.core.iterators.filesystem.FileSystemCache;
  * found, the query will be considered not running.
  */
 public class HdfsQueryLock implements QueryLock {
-    private static Logger log = Logger.getLogger(HdfsQueryLock.class);
-    private String queryId;
-    private String[] hdfsBaseURIs;
-    private FileSystemCache fsCache;
+    private static final Logger log = Logger.getLogger(HdfsQueryLock.class);
+    
+    private final String queryId;
+    private final String[] hdfsBaseURIs;
+    private final FileSystemCache fsCache;
+    
     private boolean privateCache = false;
 
     public HdfsQueryLock(String hdfsSiteConfigs, String hdfsBaseURIs, String queryId) throws MalformedURLException {
@@ -27,7 +29,7 @@ public class HdfsQueryLock implements QueryLock {
         this.privateCache = true;
     }
 
-    public HdfsQueryLock(FileSystemCache fsCache, String hdfsBaseURIs, String queryId) throws MalformedURLException {
+    public HdfsQueryLock(FileSystemCache fsCache, String hdfsBaseURIs, String queryId) {
         this.queryId = queryId;
         this.hdfsBaseURIs = filterHdfsOnly(hdfsBaseURIs.split(","));
         this.fsCache = fsCache;

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/querylock/ZookeeperQueryLock.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/querylock/ZookeeperQueryLock.java
@@ -26,13 +26,16 @@ import org.apache.zookeeper.server.quorum.QuorumPeerConfig.ConfigException;
  * zookeeper client after the specified interval of non-use.
  */
 public class ZookeeperQueryLock implements QueryLock {
-    private static Logger log = Logger.getLogger(ZookeeperQueryLock.class);
-    private String queryId;
-    private String zookeeperConfig;
+    
+    private static final Logger log = Logger.getLogger(ZookeeperQueryLock.class);
+    
+    private final String queryId;
+    private final String zookeeperConfig;
+    private final long clientCleanupInterval;
+    private final Lock clientLock = new ReentrantLock();
+    
     private Timer timer = null;
-    private long clientCleanupInterval;
     private long lastClientAccess;
-    private Lock clientLock = new ReentrantLock();
     private CuratorFramework client = null;
     private DistributedAtomicLong atomicLong = null;
 
@@ -40,7 +43,7 @@ public class ZookeeperQueryLock implements QueryLock {
         this.queryId = queryId;
         this.clientCleanupInterval = clientCleanupInterval;
 
-        URI zookeeperConfigFile = null;
+        URI zookeeperConfigFile;
         try {
             zookeeperConfigFile = new Path(zookeeperConfig).toUri();
             if (new File(zookeeperConfigFile).exists()) {
@@ -64,7 +67,7 @@ public class ZookeeperQueryLock implements QueryLock {
         this.zookeeperConfig = zookeeperConfig;
     }
 
-    private CuratorFramework getClient() {
+    private void initClient() {
         if (client == null) {
             clientLock.lock();
             try {
@@ -87,11 +90,10 @@ public class ZookeeperQueryLock implements QueryLock {
                 clientLock.unlock();
             }
         }
-        return client;
     }
 
     private DistributedAtomicLong getLong() {
-        getClient();
+        initClient();
         return atomicLong;
     }
 

--- a/warehouse/query-core/src/test/java/datawave/core/iterators/querylock/ZookeeperQueryLockTest.java
+++ b/warehouse/query-core/src/test/java/datawave/core/iterators/querylock/ZookeeperQueryLockTest.java
@@ -1,0 +1,43 @@
+package datawave.core.iterators.querylock;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class ZookeeperQueryLockTest {
+
+    private TestingServer server;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new TestingServer();
+    }
+    
+    @AfterEach
+    void tearDown() throws IOException {
+        if(server != null) {
+            server.close();
+        }
+    }
+    
+    /**
+     * Verify that a query is correctly evaluated as running/not running before and after starting/stopping the query.
+     */
+    @Test
+    void testQueryLifecycle() throws Exception {
+        String queryId = "1";
+        ZookeeperQueryLock queryLock = new ZookeeperQueryLock(server.getConnectString(), 120000, queryId);
+        Assertions.assertFalse(queryLock.isQueryRunning(), "Query should not be running before query is started");
+        
+        queryLock.startQuery();
+        Assertions.assertTrue(queryLock.isQueryRunning(), "Query should be running after query is started");
+        
+        queryLock.stopQuery();
+        Assertions.assertFalse(queryLock.isQueryRunning(), "Query should not be running after query is stopped");
+        
+    }
+}

--- a/web-services/query/pom.xml
+++ b/web-services/query/pom.xml
@@ -255,6 +255,15 @@
             <artifactId>javassist</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/ActiveQueryException.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/ActiveQueryException.java
@@ -1,0 +1,27 @@
+package datawave.webservice.query.limit;
+
+/**
+ * Represents an exception that occurred when interacting with the {@link ActiveQueryTracker}.
+ */
+public class ActiveQueryException extends RuntimeException {
+    
+    public ActiveQueryException() {
+        super();
+    }
+    
+    public ActiveQueryException(String message) {
+        super(message);
+    }
+    
+    public ActiveQueryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    public ActiveQueryException(Throwable cause) {
+        super(cause);
+    }
+    
+    protected ActiveQueryException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/ActiveQuerySnapshot.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/ActiveQuerySnapshot.java
@@ -1,0 +1,183 @@
+package datawave.webservice.query.limit;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Represents a snapshots of active queries that can be used to determine if a user will exceed any query limits when attempting to submit a new query.
+ */
+public class ActiveQuerySnapshot {
+    
+    // The user submitting the query.
+    private final String userDn;
+    
+    // The system name the query was submitted on.
+    private final String systemName;
+    
+    // The query logic the query is based on.
+    private final String queryLogic;
+    
+    // The total number of active queries for the user across all systems based on the query logic.
+    private final int totalUserQueriesForQueryLogic;
+    
+    // The total queries the user has running per system.
+    private final Map<String,Integer> totalUserQueriesPerSystem;
+    
+    // The total active queries on the system.
+    private final int totalSystemQueries;
+    
+    // The total queries the system has based on the query logic.
+    private final int totalSystemQueriesForQueryLogic;
+    
+    // The total queries across all systems based on the query logic.
+    private final int totalQueriesForQueryLogic;
+    
+    // The timestamp when this snapshot was captured.
+    private final long timestamp;
+    
+    public static Builder builder(String userDn, String systemName, String queryLogic) {
+        return new Builder(userDn, systemName, queryLogic);
+    }
+    
+    protected ActiveQuerySnapshot(Builder builder) {
+        this.userDn = builder.userDn;
+        this.systemName = builder.systemName;
+        this.queryLogic = builder.queryLogic;
+        this.totalUserQueriesForQueryLogic = builder.userQueriesForQueryLogic;
+        this.totalUserQueriesPerSystem = Map.copyOf(builder.userQueriesPerSystem);
+        this.totalSystemQueries = builder.systemQueries;
+        this.totalSystemQueriesForQueryLogic = builder.systemQueriesForQueryLogic;
+        this.totalQueriesForQueryLogic = builder.queriesForQueryLogic;
+        this.timestamp = builder.timestamp;
+    }
+    
+    public String getUserDn() {
+        return userDn;
+    }
+    
+    public String getSystemName() {
+        return systemName;
+    }
+    
+    public String getQueryLogic() {
+        return queryLogic;
+    }
+    
+    public int getTotalUserQueriesOnSystem() {
+        return totalUserQueriesPerSystem.getOrDefault(systemName, 0);
+    }
+    
+    public int getTotalUserQueriesForQueryLogic() {
+        return totalUserQueriesForQueryLogic;
+    }
+    
+    public Map<String,Integer> getTotalUserQueriesPerSystem() {
+        return totalUserQueriesPerSystem;
+    }
+    
+    public int getTotalSystemQueries() {
+        return totalSystemQueries;
+    }
+    
+    public int getTotalSystemQueriesForQueryLogic() {
+        return totalSystemQueriesForQueryLogic;
+    }
+    
+    public int getTotalQueriesForQueryLogic() {
+        return totalQueriesForQueryLogic;
+    }
+    
+    public long getTimestamp() {
+        return timestamp;
+    }
+    
+    public static class Builder {
+        private final String userDn;
+        private final String systemName;
+        private final String queryLogic;
+        private final Set<String> alreadyCapturedQueryIds = new HashSet<>();
+        
+        private final Map<String, Integer> userQueriesPerSystem = new HashMap<>();
+        
+        private int userQueriesForQueryLogic;
+        private int systemQueries;
+        private int systemQueriesForQueryLogic;
+        private int queriesForQueryLogic;
+        
+        private long timestamp = System.currentTimeMillis();
+        
+        public Builder(String userDn, String systemName, String queryLogic) {
+            this.userDn = userDn;
+            this.systemName = systemName;
+            this.queryLogic = queryLogic;
+        }
+        
+        public Builder withTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+        
+        public Builder capture(String queryId, String userDn, String systemName, String queryLogic) {
+            boolean notYetCaptured = alreadyCapturedQueryIds.add(queryId);
+            if(notYetCaptured) {
+                boolean userMatch = this.userDn.equals(userDn);
+                boolean systemMatch = this.systemName.equals(systemName);
+                boolean queryLogicMatch = this.queryLogic.equals(queryLogic);
+                
+                if(userMatch) {
+                    userQueriesPerSystem.compute(systemName, (key, value) -> value == null ? 1 : value + 1);
+                    
+                    if(queryLogicMatch) {
+                        userQueriesForQueryLogic++;
+                    }
+                }
+                if(systemMatch) {
+                    systemQueries++;
+                    if(queryLogicMatch) {
+                        systemQueriesForQueryLogic++;
+                    }
+                }
+                if(queryLogicMatch) {
+                    queriesForQueryLogic++;
+                }
+            }
+            return this;
+        }
+        
+        public ActiveQuerySnapshot build() {
+            return new ActiveQuerySnapshot(this);
+        }
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ActiveQuerySnapshot snapshot = (ActiveQuerySnapshot) o;
+        return totalUserQueriesForQueryLogic == snapshot.totalUserQueriesForQueryLogic && totalSystemQueries == snapshot.totalSystemQueries
+                        && totalSystemQueriesForQueryLogic == snapshot.totalSystemQueriesForQueryLogic
+                        && totalQueriesForQueryLogic == snapshot.totalQueriesForQueryLogic && timestamp == snapshot.timestamp && Objects.equals(userDn,
+                        snapshot.userDn) && Objects.equals(systemName, snapshot.systemName) && Objects.equals(queryLogic, snapshot.queryLogic)
+                        && Objects.equals(totalUserQueriesPerSystem, snapshot.totalUserQueriesPerSystem);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(userDn, systemName, queryLogic, totalUserQueriesForQueryLogic, totalUserQueriesPerSystem, totalSystemQueries,
+                        totalSystemQueriesForQueryLogic, totalQueriesForQueryLogic, timestamp);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ActiveQuerySnapshot.class.getSimpleName() + "[", "]").add("userDn='" + userDn + "'")
+                        .add("systemName='" + systemName + "'").add("queryLogic='" + queryLogic + "'")
+                        .add("totalUserQueriesForQueryLogic=" + totalUserQueriesForQueryLogic).add("totalUserQueriesPerSystem=" + totalUserQueriesPerSystem)
+                        .add("totalSystemQueries=" + totalSystemQueries).add("totalSystemQueriesForQueryLogic=" + totalSystemQueriesForQueryLogic)
+                        .add("totalQueriesForQueryLogic=" + totalQueriesForQueryLogic).add("timestamp=" + timestamp).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/ActiveQueryTracker.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/ActiveQueryTracker.java
@@ -1,0 +1,423 @@
+package datawave.webservice.query.limit;
+
+import org.apache.curator.framework.api.transaction.CuratorOp;
+import org.apache.curator.framework.recipes.nodes.PersistentNode;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.hadoop.fs.Path;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.log4j.Logger;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.quorum.QuorumPeer;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+
+import java.io.File;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This class provides methods for leveraging Zookeeper to track queries and their active status.
+ */
+public class ActiveQueryTracker implements AutoCloseable {
+    
+    public static final String ZOOKEEPER_NAMESPACE = "ActiveQueries";
+    
+    private static final Logger log = Logger.getLogger(ActiveQueryTracker.class);
+    
+    private final String zookeeperConfig;
+    private final long cleanUpClientInterval;
+    private final Lock clientLock = new ReentrantLock();
+    
+    private CuratorFramework client;
+    private long lastClientAccess;
+    private Timer clientCleanupTimer;
+    
+    /**
+     * Create and return a new {@link ActiveQueryTracker} instance
+     * @param zookeeperConfig the zookeeper config
+     * @param clientCleanupInterval the interval in milliseconds after which the zookeeper client should be cleaned up since its last access\
+     * @throws QuorumPeerConfig.ConfigException if an error occurs when verifying the zookeeper configuration
+     */
+    public ActiveQueryTracker(String zookeeperConfig, long clientCleanupInterval) throws QuorumPeerConfig.ConfigException {
+        this.zookeeperConfig = getQuorumPeerConfig(zookeeperConfig);
+        this.cleanUpClientInterval = clientCleanupInterval;
+    }
+    
+    private static String getQuorumPeerConfig(String zookeeperConfig) throws QuorumPeerConfig.ConfigException {
+        URI zookeeperConfigFile;
+        try {
+            zookeeperConfigFile = new Path(zookeeperConfig).toUri();
+            if (new File(zookeeperConfigFile).exists()) {
+                QuorumPeerConfig zooConfig = new QuorumPeerConfig();
+                zooConfig.parse(zookeeperConfigFile.getPath());
+                StringBuilder sb = new StringBuilder();
+                for (QuorumPeer.QuorumServer server : zooConfig.getServers().values()) {
+                    if (sb.length() > 0) {
+                        sb.append(',');
+                    }
+                    sb.append(server.addr.getReachableOrOne().getHostName()).append(':').append(zooConfig.getClientPortAddress().getPort());
+                }
+                if (sb.length() == 0) {
+                    sb.append(zooConfig.getClientPortAddress().getHostName()).append(':').append(zooConfig.getClientPortAddress().getPort());
+                }
+                return sb.toString();
+            }
+        } catch (IllegalArgumentException e) {
+            // Try the zookeeper config as is.
+        }
+        return zookeeperConfig;
+    }
+    
+    /**
+     * Return a snapshot of all queries considered to be active that either:
+     * <ul>
+     *     <li>Were submitted by the user associated with the given userDn.</li>
+     *     <li>Were submitted on the given system.</li>
+     *     <li>Were submitted as the given query logic.</li>
+     * </ul>
+     * @param userDn the user dn
+     * @param system the system name
+     * @param queryLogic the query logic
+     * @return the snapshot
+     * @throws Exception if an error occurs
+     */
+    public ActiveQuerySnapshot getSnapshot(String userDn, String system, String queryLogic) throws Exception {
+        if(log.isTraceEnabled()) {
+            log.trace("Fetching snapshot for userDn=" + userDn + ", system=" + system + ", queryLogic=" + queryLogic + ")");
+        }
+        clientLock.lock();
+        try {
+            long currentTimeMillis = System.currentTimeMillis();
+            initClient();
+            Set<String> queryIds = new HashSet<>();
+            
+            // Fetch the ids of all queries submitted by the user.
+            queryIds.addAll(getQueryIds(client, "/users/" + userDn));
+            // Fetch the ids of all queries submitted on the system.
+            queryIds.addAll(getQueryIds(client, "/systems/" + system));
+            // Fetch the ids of all queries that have the query logic.
+            queryIds.addAll(getQueryIds(client, "/queryLogics/" + queryLogic));
+            
+            if(log.isTraceEnabled()) {
+                log.trace("Found " + queryIds.size() + " potentially active related queries");
+            }
+            
+            ActiveQuerySnapshot.Builder builder = ActiveQuerySnapshot.builder(userDn, system, queryLogic).withTimestamp(currentTimeMillis);
+            // Fetch the metadata of each query and capture them if considered to be active.
+            for(String queryId : queryIds) {
+                String queryIdPath = "/queries/" + queryId;
+                try {
+                    // Only capture the current query ID as an active query if there is at least one heartbeat.
+                    if(!client.getChildren().forPath(queryIdPath + "/heartbeats").isEmpty()) {
+                        String userData = new String(client.getData().forPath(queryIdPath + "/user"));
+                        String systemData = new String(client.getData().forPath(queryIdPath + "/system"));
+                        String queryLogicData = new String(client.getData().forPath(queryIdPath + "/queryLogic"));
+                        builder.capture(queryId, userData, systemData, queryLogicData);
+                    }
+                } catch (KeeperException.NoNodeException e) {
+                    // If a NoNodeException occurred when fetching the metadata for a particular query ID, it is likely that the query was untracked by another
+                    // ActiveQueryTracker instance in the time between obtaining the query and now. Simply skip over it.
+                    if(log.isTraceEnabled()) {
+                        log.trace("Skipping capturing queryId=" + queryId + " in snapshot, nodes potentially deleted during scan");
+                    }
+                }
+            }
+            return builder.build();
+        } finally {
+            clientLock.unlock();
+        }
+    }
+    
+    /**
+     * Return the list of children for the given container, or an empty list if the container does not exist.
+     * @param client the client
+     * @param container the path to the container
+     * @return the list of query ids
+     * @throws Exception if an error occurs
+     */
+    private List<String> getQueryIds(CuratorFramework client, String container) throws Exception {
+        try {
+            return client.getChildren().forPath(container);
+        } catch (KeeperException.NoNodeException e) {
+            // If a NoNodeException was thrown here, it occurred because there are no queries being tracked anymore, and the container node was automatically
+            // cleaned up as a result of having no children. Simply return an empty list.
+            return List.of();
+        }
+    }
+    
+    /**
+     * Begin tracking an active query. The following ZNodes will be created in Zookeeper under the namespace {@value ZOOKEEPER_NAMESPACE}:
+     * <pre>
+     * /users/&lt;userDn&gt;/&lt;queryId&gt;
+     * /systems/&lt;systemName&gt;/&lt;queryId&gt;
+     * /queryLogics/&lt;queryLogic&gt;/&lt;queryId&gt;
+     * /queries/&lt;queryId&gt;
+     * /queries/&lt;queryId&gt;/user           [data = byte[] value of userDn]
+     * /queries/&lt;queryId&gt;/system         [data = byte[] value of systemName]
+     * /queries/&lt;queryId&gt;/queryLogic     [data = byte[] value of queryLogic]
+     * /queries/&lt;queryId&gt;/heartbeats
+     * </pre>
+     * The paths
+     * <pre>
+     * /users/&lt;userDn&gt;/&lt;queryId&gt;
+     * /systems/&lt;systemName&gt;/&lt;queryId&gt;
+     * /queryLogics/&lt;queryLogic&gt;/&lt;queryId&gt;
+     * /queries/&lt;queryId&gt;
+     * </pre>
+     * will be created as containers, and thus will become eligible for cleanup when they have no children.
+     * @param queryId the query's id
+     * @param userDn the user who submitted the query
+     * @param systemName the system the query was submitted on
+     * @param queryLogic the query logic of the query
+     */
+    public void trackQuery(String queryId, String userDn, String systemName, String queryLogic) {
+        if (log.isTraceEnabled()) {
+            log.trace("Tracking query: queryId=" + queryId + ", user=" + userDn + " " + systemName + " " + queryLogic + " " + queryId);
+        }
+        
+        clientLock.lock();
+        try {
+            // Initialize the client if needed.
+            initClient();
+            try {
+                String queryIdPath = "/queries/" + queryId;
+                Stat stat = client.checkExists().forPath(queryIdPath);
+                if (stat == null) {
+                    // Ensure that we create following container nodes.
+                    client.createContainers(queryIdPath);
+                    client.createContainers("/systems/" + systemName);
+                    client.createContainers("/users/" + userDn);
+                    client.createContainers("/queryLogics/" + queryLogic);
+                    
+                    // Populate the information for the specific query ID atomically as a single transaction.
+                    CuratorOp addQueryIdToUsers = client.transactionOp().create().forPath("/users/" + userDn + "/" + queryId);
+                    CuratorOp addQueryIdToSystems = client.transactionOp().create().forPath("/systems/" + systemName + "/" + queryId);
+                    CuratorOp addQueryIdToQueryLogics = client.transactionOp().create().forPath("/queryLogics/" + queryLogic + "/" + queryId);
+                    CuratorOp addUserData = client.transactionOp().create().forPath(queryIdPath + "/user", userDn.getBytes());
+                    CuratorOp addSystemData = client.transactionOp().create().forPath(queryIdPath + "/system", systemName.getBytes());
+                    CuratorOp addQueryLogicData = client.transactionOp().create().forPath(queryIdPath + "/queryLogic", queryLogic.getBytes());
+                    CuratorOp addHeartbeatsNode = client.transactionOp().create().forPath(queryIdPath + "/heartbeats");
+                    client.transaction().forOperations(addQueryIdToUsers, addQueryIdToSystems, addQueryIdToQueryLogics, addUserData, addSystemData,
+                                    addQueryLogicData, addHeartbeatsNode);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to track query " + queryId, e);
+            }
+        } finally {
+            clientLock.unlock();
+        }
+    }
+    
+    /**
+     * Stop tracking a query that is no longer considered to be active. The following ZNodes will be deleted in Zookeeper under the namespace
+     * {@value ZOOKEEPER_NAMESPACE}:
+     * <pre>
+     * /queries/&lt;queryId&gt;
+     * /queries/&lt;queryId&gt;/user
+     * /queries/&lt;queryId&gt;/system
+     * /queries/&lt;queryId&gt;/queryLogic
+     * /queries/&lt;queryId&gt;/heartbeats
+     * /users/&lt;userDn&gt;/&lt;queryId&gt;
+     * /systems/&lt;systemName&gt;/&lt;queryId&gt;
+     * /queryLogics/&lt;queryLogic&gt;/&lt;queryId&gt;
+     * </pre>
+     * @param queryId the query's id
+     * @throws ActiveQueryException if the node {@code /queries/<queryId>/heartbeats} has any children indicating that the query is considered to be active
+     */
+    public void stopTrackingQuery(String queryId) {
+        if(log.isTraceEnabled()) {
+            log.trace("Stopping tracking of query: queryId=" + queryId);
+        }
+        
+        clientLock.lock();
+        try {
+            initClient();
+            String queryIdPath = "/queries/" + queryId;
+            Stat stat = client.checkExists().forPath(queryIdPath);
+            // If the query id node exists, delete all information for the relevant
+            if (stat != null) {
+                // Do not allow the query to be untracked if any heartbeat nodes current exist.
+                String heartbeatsPath = queryIdPath + "/heartbeats";
+                Stat heartbeatsStat = client.checkExists().forPath(heartbeatsPath);
+                if(heartbeatsStat != null && heartbeatsStat.getNumChildren() > 0) {
+                    throw new ActiveQueryException("Cannot stop tracking query " + queryId + ", " + heartbeatsStat.getNumChildren() + " heartbeat(s) exist");
+                }
+                
+                // Delete the information for the specific query ID atomically as a single transaction.
+                String userDn = new String(client.getData().forPath(queryIdPath + "/user"));
+                String system = new String(client.getData().forPath(queryIdPath + "/system"));
+                String queryLogic = new String(client.getData().forPath(queryIdPath + "/queryLogic"));
+                
+                CuratorOp deleteQueryInUsers = client.transactionOp().delete().forPath("/users/" + userDn + "/" + queryId);
+                CuratorOp deleteQueryInSystems = client.transactionOp().delete().forPath("/systems/" + system + "/" + queryId);
+                CuratorOp deleteQueryInQueryLogics = client.transactionOp().delete().forPath("/queryLogics/" + queryLogic + "/" + queryId);
+                CuratorOp deleteQueryHeartbeats = client.transactionOp().delete().forPath(heartbeatsPath);
+                CuratorOp deleteQueryUser = client.transactionOp().delete().forPath(queryIdPath + "/user");
+                CuratorOp deleteQuerySystem = client.transactionOp().delete().forPath(queryIdPath + "/system");
+                CuratorOp deleteQueryQueryLogic = client.transactionOp().delete().forPath(queryIdPath + "/queryLogic");
+                CuratorOp deleteQueryIdNode = client.transactionOp().delete().forPath(queryIdPath);
+                client.transaction().forOperations(deleteQueryInUsers, deleteQueryInSystems, deleteQueryInQueryLogics, deleteQueryHeartbeats, deleteQueryUser,
+                                deleteQuerySystem, deleteQueryQueryLogic, deleteQueryIdNode);
+            }
+        } catch (ActiveQueryException e) {
+            log.error("Failed to stop tracking query " + queryId, e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to stop tracking of query: queryId=" + queryId, e);
+            throw new ActiveQueryException("Failed to clean up nodes for query " + queryId, e);
+        } finally {
+            clientLock.unlock();
+        }
+    }
+    
+    
+    /**
+     * Return a new {@link QueryHeartbeat} for the given queryId. This will result in the creation of a new sequential, ephemeral node as a child of the node
+     * {@code /queries/<queryId>/heartbeats} under the namespace {@value ZOOKEEPER_NAMESPACE}.
+     * @param queryId the queryId
+     * @return the heartbeat
+     * @throws ActiveQueryException if the query is not being tracked
+     */
+    public QueryHeartbeat createHeartbeat(String queryId) {
+        if(log.isTraceEnabled()) {
+            log.trace("Obtaining heartbeat for queryId=" + queryId);
+        }
+        clientLock.lock();
+        try {
+            initClient();
+            
+            // Make sure the query is being tracked.
+            String queryIdPath = "/queries/" + queryId;
+            Stat stat = client.checkExists().forPath(queryIdPath);
+            if(stat == null) {
+                throw new ActiveQueryException("Query " + queryId + " is not being tracked");
+            }
+            
+            // Prepare the heartbeat node.
+            String heartbeatPath = queryIdPath + "/heartbeats/heartbeat_";
+            CuratorFramework client = createClient();
+            PersistentNode node = new PersistentNode(client, CreateMode.EPHEMERAL_SEQUENTIAL, true, heartbeatPath, "".getBytes(), false);
+            if(log.isTraceEnabled()) {
+                log.trace("Created heartbeat " + node.getActualPath() + " for queryId=" + queryId);
+            }
+            
+            // Create the actual node, with the given wait for creation if needed. This will block until the node creation from start() exceeds, or until the
+            // wait time elapses, whichever comes first.
+            node.start();
+            node.waitForInitialCreate(5, TimeUnit.SECONDS);
+            return new QueryHeartbeat(queryId, node);
+        } catch (ActiveQueryException e) {
+            log.error("Failed to create heartbeat for queryId=" + queryId, e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to create heartbeat for queryId=" + queryId, e);
+            throw new ActiveQueryException("Unable to obtain heartbeat for queryId=" + queryId, e);
+        } finally {
+            clientLock.unlock();
+        }
+    }
+    
+    /**
+     * Initialize the zookeeper client and cleanup timer if not already initialize. Calling this method will update the last time the client was accessed to the
+     * current time.
+     */
+    private void initClient() {
+        if(client == null) {
+            clientLock.lock();
+            try {
+                // @formatter:off
+                client = createClient();
+                if (cleanUpClientInterval > 0) {
+                    createCleanupTimer();
+                }
+            } finally {
+                clientLock.unlock();
+            }
+        }
+        // Update the last time the client was accessed.
+        lastClientAccess = System.currentTimeMillis();
+    }
+    
+    /**
+     * Return a new zookeeper client targeting the namespace {@value #ZOOKEEPER_NAMESPACE}.
+     * @return the client
+     */
+    private CuratorFramework createClient() {
+        CuratorFramework client = CuratorFrameworkFactory.builder()
+                        .namespace(ZOOKEEPER_NAMESPACE)
+                        .connectString(zookeeperConfig)
+                        .sessionTimeoutMs(60000)
+                        .connectionTimeoutMs(60000)
+                        .retryPolicy(new RetryNTimes(10, 1000))
+                        .build();
+        
+        // @formatter:on
+        client.start();
+        return client;
+    }
+    
+    /**
+     * Create the cleanup timer.
+     */
+    private void createCleanupTimer() {
+        if (clientCleanupTimer == null) {
+            clientCleanupTimer = new Timer("Zookeeper Client Cleanup");
+        }
+        
+        clientCleanupTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                if (lastClientAccess + cleanUpClientInterval <= System.currentTimeMillis()) {
+                    cancel();
+                } else if (client == null) {
+                    cancel();
+                }
+            }
+        }, cleanUpClientInterval, cleanUpClientInterval);
+    }
+    
+    /**
+     * Clean up the underlying resources used by this {@link ActiveQueryTracker}.
+     */
+    public void cleanup() {
+        closeClientAndTimer();
+    }
+    
+    /**
+     * Close the client and clean up timer, and nullify them.
+     */
+    private void closeClientAndTimer() {
+        if (client != null) {
+            clientLock.lock();
+            try {
+                if (clientCleanupTimer != null) {
+                    clientCleanupTimer.cancel();
+                    clientCleanupTimer = null;
+                }
+                if (client != null) {
+                    try {
+                        client.close();
+                    } finally {
+                        client = null;
+                    }
+                }
+            } finally {
+                clientLock.unlock();
+            }
+        }
+    }
+    
+    @Override
+    public void close() {
+        cleanup();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/LimitSource.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/LimitSource.java
@@ -1,0 +1,11 @@
+package datawave.webservice.query.limit;
+
+/**
+ * Indicates the source of a query limit.
+ */
+public enum LimitSource {
+    // Came from default limits.
+    DEFAULTS,
+    // Came from a configured limit.
+    CONFIG
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/Matcher.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/Matcher.java
@@ -1,0 +1,18 @@
+package datawave.webservice.query.limit;
+
+/**
+ * A matcher is intended to determine if it matches against a string.
+ */
+public interface Matcher {
+    
+    enum Type {
+        // Do not reorder these. The ordinal value is important for use when sorting query limits.
+        EXACT,
+        PARTIAL,
+        ALL
+    }
+    
+    Type getType();
+    
+    boolean matches(String fieldValue);
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/PatternMatcher.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/PatternMatcher.java
@@ -1,0 +1,41 @@
+package datawave.webservice.query.limit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * {@link Matcher} implementation that matches a string against a pattern that was determined to neither be an exact-matching pattern, nor a wildcard-only
+ * pattern. The matching type for this {@link Matcher} will always be {@link Matcher.Type#PARTIAL}.
+ */
+public class PatternMatcher implements Matcher {
+    
+    private final Cache<String, Boolean> cache = Caffeine.newBuilder().build();
+    private final Pattern pattern;
+    
+    public PatternMatcher(Pattern pattern) {
+        Objects.requireNonNull(pattern, "pattern must not be null");
+        this.pattern = pattern;
+    }
+    
+    @Override
+    public Type getType() {
+        return Type.PARTIAL;
+    }
+    
+    @Override
+    public boolean matches(String value) {
+        Objects.requireNonNull(value, "value must not be null");
+        // Check if we have cached the match for this before.
+        Boolean matches = cache.getIfPresent(value);
+        // If not, check if the value matches.
+        if(matches == null) {
+            matches = pattern.matcher(value).matches();
+            // Cache the result.
+            cache.put(value, matches);
+        }
+        return matches;
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryHeartbeat.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryHeartbeat.java
@@ -1,0 +1,45 @@
+package datawave.webservice.query.limit;
+
+import org.apache.curator.framework.recipes.nodes.PersistentNode;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Represents a heartbeat for an active query. As long as the connection to Zookeeper is not disrupted, the heartbeat will persist and indicate that a query is
+ * currently running. Multiple heartbeats can be obtained for the same query.
+ */
+public class QueryHeartbeat {
+    
+    private final String queryId;
+    private final PersistentNode node;
+    
+    public QueryHeartbeat(String queryId, PersistentNode node) {
+        Objects.requireNonNull(queryId, "Parameter queryId must not be null");
+        Objects.requireNonNull(node, "Parameter node must not be null");
+        this.queryId = queryId;
+        this.node = node;
+    }
+    
+    /**
+     * Return the ID of the query this heartbeat is associated with.
+     * @return the query ID
+     */
+    public String getQueryId() {
+        return queryId;
+    }
+    
+    /**
+     * Return the path to the heartbeat node. Possibly null if the node no longer exists.
+     * @return the path
+     */
+    public String getPath() {
+        return node.getActualPath();
+    }
+    
+    /**
+     * Stop and delete the heartbeat.
+     */
+    public void stop() throws IOException {
+        node.close();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimitProvider.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimitProvider.java
@@ -1,0 +1,783 @@
+package datawave.webservice.query.limit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.Sets;
+import datawave.query.parser.JavaRegexAnalyzer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * This class provides method for identifying the query limits to enforce for individual users, systems, and query logic groups. This should be instantiated as
+ * a singleton bean.
+ */
+@Component("queryLimitProvider")
+public class QueryLimitProvider {
+    
+    private static final Logger log = Logger.getLogger(QueryLimitProvider.class);
+    private static final String ASTERISK = "*";
+    
+    // Matches against regex patterns that consist of '*' or any combination that results in a wildcard pattern.
+    private static final Pattern wildcardOnlyPattern = Pattern.compile("^\\*$|^(\\.\\*)+$");
+    
+    private final QueryLimitProviderConfiguration config;
+    
+    private QueryLogicGroupLimitProvider queryLogicGroupLimitProvider;
+    private UserLimitProvider userLimitProvider;
+    private SystemLimitProvider systemLimitProvider;
+    
+    @Autowired
+    public QueryLimitProvider(QueryLimitProviderConfiguration config) {
+        this.config = config;
+    }
+    
+    /**
+     * Validate the configuration and extract the query limits.
+     */
+    @PostConstruct
+    protected void postConstruct() {
+        if (config == null) {
+            throw new NullPointerException("Configuration must not be null");
+        }
+        
+        if(log.isTraceEnabled()) {
+            log.trace("Initializing with config: " + config);
+        }
+        
+        if (config.getDefaultUserQueryLimit() < 1) {
+            throw new IllegalArgumentException("Default user query limit must be greater than 0");
+        }
+        
+        if(config.getDefaultSystemQueryLimit() < 1) {
+            throw new IllegalArgumentException("Default system query limit must be greater than 0");
+        }
+        
+        this.queryLogicGroupLimitProvider = new QueryLogicGroupLimitProvider(config.getQueryLogicGroupConfigs());
+        this.userLimitProvider = new UserLimitProvider(config.getUserConfigs(), queryLogicGroupLimitProvider.getGroupNames());
+        this.systemLimitProvider = new SystemLimitProvider(config.getSystemConfigs(), queryLogicGroupLimitProvider.getGroupNames());
+    }
+    
+    /**
+     * Construct and return a {@link Matcher} based off the given pattern.
+     * @param pattern the pattern
+     * @return the matcher
+     * @throws JavaRegexAnalyzer.JavaRegexParseException if the pattern could not be analyzed
+     */
+    private static Matcher getMatcher(String pattern) throws JavaRegexAnalyzer.JavaRegexParseException {
+        if(wildcardOnlyPattern.matcher(pattern).matches()) {
+            return new WildcardMatcher();
+        } else {
+            // Analyze the regex to determine what, if any, regex constructs are present.
+            JavaRegexAnalyzer analyzer = new JavaRegexAnalyzer(pattern);
+            JavaRegexAnalyzer.RegexPart[] regexParts = analyzer.getRegexParts();
+            boolean escapedLiteralsSeen = false;
+            boolean regexSeen = false;
+            // Determine if the regex contains any escaped literals or non-literal regex constructs.
+            for(JavaRegexAnalyzer.RegexPart regexPart : regexParts) {
+                JavaRegexAnalyzer.RegexType type = regexPart.getType();
+                if(type == JavaRegexAnalyzer.RegexType.ESCAPED_LITERAL) {
+                    escapedLiteralsSeen = true;
+                } else if(type != JavaRegexAnalyzer.RegexType.LITERAL) {
+                    // We have seen a non-literal, and can stop early.
+                    regexSeen = true;
+                    break;
+                }
+            }
+            // If a non-literal regex construct was seen, use a Pattern matcher that falls into the 'partial-match' bucket.
+            if(regexSeen) {
+                return new PatternMatcher(Pattern.compile(pattern));
+            } else if(escapedLiteralsSeen) {
+                // If the pattern consists solely of literals and escaped literals, remove the escaping backslashes and use a string matcher that falls into the
+                // 'exact-match' bucket.
+                String literal = toUnescapedLiteralString(regexParts);
+                return new StringMatcher(literal);
+            } else {
+                // If the pattern consists only of literals, use a string matcher that falls into the 'exact-match' bucket.
+                return new StringMatcher(pattern);
+            }
+        }
+    }
+    
+    /**
+     * Return the given parts from a regex pattern as a simple, non-escaped string.
+     * @param regexParts the regex parts
+     * @return the simplified string
+     */
+    private static String toUnescapedLiteralString(JavaRegexAnalyzer.RegexPart[] regexParts) {
+        StringBuilder sb = new StringBuilder();
+        for(JavaRegexAnalyzer.RegexPart part : regexParts) {
+            if(part.getType() == JavaRegexAnalyzer.RegexType.LITERAL) {
+                sb.append(part.regex);
+            } else if(part.getType() == JavaRegexAnalyzer.RegexType.ESCAPED_LITERAL) {
+                sb.append(part.getRegex().charAt(1));
+            } else {
+                throw new IllegalArgumentException("Regex parts must be of type " + JavaRegexAnalyzer.RegexType.LITERAL + " or " +
+                                JavaRegexAnalyzer.RegexType.ESCAPED_LITERAL);
+            }
+        }
+        return sb.toString();
+    }
+    
+    /**
+     * Return the default user query limit.
+     * @return the default user query limit
+     */
+    public int getDefaultUserQueryLimit() {
+        return config.getDefaultUserQueryLimit();
+    }
+    
+    /**
+     * Return the default system query limit.
+     * @return the default system query limit
+     */
+    public int getDefaultSystemQueryLimit() {
+        return config.getDefaultSystemQueryLimit();
+    }
+    
+    /**
+     * Return the query limits for the given user.
+     * @param userDn the user DN
+     * @return the user's query limits
+     */
+    public UserQueryLimit getUserLimit(String userDn) {
+        return userLimitProvider.getLimit(userDn);
+    }
+    
+    /**
+     * Return the query limits for the given system.
+     * @param system the system name
+     * @return the system's query limits
+     */
+    public SystemQueryLimit getSystemLimit(String system) {
+        return systemLimitProvider.getLimit(system);
+    }
+    
+    /**
+     * Return whether queries count against a user's query limit when submitted to the given system
+     * @param system the system name
+     * @return true if queries count against a user's query limit on the given system, or false otherwise
+     */
+    public boolean systemCountsAgainstUserLimit(String system) {
+        return systemLimitProvider.countsAgainstUserLimit(system);
+    }
+    
+    /**
+     * Return the query limits for the given query logic if one was configured within a matching query logic group.
+     * @param queryLogic the query logic
+     * @return a populated {@link Optional} if a matching group was found, or an empty one otherwise
+     */
+    public Optional<QueryLogicGroupLimit> getQueryLogicGroupLimit(String queryLogic) {
+        return queryLogicGroupLimitProvider.getLimit(queryLogic);
+    }
+    
+    /**
+     * Return the query limits for the given query logic based on the given map of overridden group limits.
+     * @param sourceId a user DN or system name
+     * @param queryLogic the query logic
+     * @param overriddenLimits the map of group names to their overriding limit
+     * @return a populated {@link Optional} if a matching overriding group was found, or an empty one otherwise
+     */
+    public Optional<QueryLogicGroupLimit> getOverriddenQueryLogicGroupLimit(String sourceId, String queryLogic, Map<String, Integer> overriddenLimits) {
+        return queryLogicGroupLimitProvider.getOverriddenLimit(sourceId, queryLogic, overriddenLimits);
+    }
+    
+    /**
+     * This class is responsible for extracting the limits from {@link QueryLogicGroupConfiguration} instances and then identifying the query limits to enforce
+     * for individual query logics, overridden or otherwise.
+     */
+    private static class QueryLogicGroupLimitProvider {
+        
+        // Cache of query logic keys to either their best configured limits or empty optionals when they have no matching limit.
+        private final Cache<String, Optional<QueryLogicGroupLimit>> limitCache = Caffeine.newBuilder().build();
+        
+        // Cache of (userDn|systemName) + query logic keys to their best overriding limit, or empty optionals when they have no match.
+        private final Cache<String, Optional<QueryLogicGroupLimit>> overiddenLimitCache = Caffeine.newBuilder().build();
+        
+        // The set of unique query logic group names.
+        private Set<String> groupNames;
+        // Map of group names to their corresponding query logic matcher.
+        private Map<String, Matcher> groupMatchers;
+        // The set of query limits in sorted order of best match to worst.
+        private SortedSet<MatchableLimit> configuredLimits;
+    
+        private QueryLogicGroupLimitProvider(Collection<QueryLogicGroupConfiguration> configs) {
+            if(configs != null && !configs.isEmpty()) {
+                validateConfigs(configs);
+                populateLimits(configs);
+            } else {
+                groupNames = Set.of();
+                configuredLimits = Collections.emptySortedSet();
+            }
+        }
+        
+        /**
+         * Validate the given configurations.
+         * @param configs the configurations to validate
+         */
+        private void validateConfigs(Collection<QueryLogicGroupConfiguration> configs) {
+            Set<String> groupNames = new HashSet<>();
+            for(QueryLogicGroupConfiguration config : configs) {
+                
+                // Verify that a group name was given.
+                String groupName = config.getGroupName();
+                if(StringUtils.isBlank(groupName)) {
+                    throw new IllegalArgumentException("Query logic group limit configuration given with blank group name");
+                }
+                
+                // Verify that we have not seen a configuration with the group name before.
+                if(groupNames.contains(groupName)) {
+                    throw new IllegalArgumentException("Multiple query logic group configurations given with group name '" + groupName + "'");
+                } else {
+                    groupNames.add(groupName);
+                }
+                
+                // Verify that the query limit is not negative.
+                if (config.getQueryLimit() < 0) {
+                    throw new IllegalArgumentException("Negative limit given for query logic group '" + groupName + "'");
+                }
+                
+                // Verify that a query logic pattern was given.
+                String queryLogicPattern = config.getQueryLogicPattern();
+                if (StringUtils.isBlank(queryLogicPattern)) {
+                    throw new IllegalArgumentException("Blank query logic pattern given for query logic group '" + groupName + "'");
+                }
+                
+                // Verify that the pattern compiles if it is not simply a * as is occasionally used as a wildcard in configurations.
+                try {
+                    if (!queryLogicPattern.equals(ASTERISK)) {
+                        Pattern.compile(queryLogicPattern);
+                    }
+                } catch (PatternSyntaxException e) {
+                    throw new IllegalArgumentException("Invalid regex in query logic pattern '" + queryLogicPattern + "' for query logic group '" + groupName + "'", e);
+                }
+            }
+            this.groupNames = Set.copyOf(groupNames);
+        }
+        
+        /**
+         * Populate the limits to enforce for query logic groups.
+         * @param configs the configs to populate the limits from
+         */
+        private void populateLimits(Collection<QueryLogicGroupConfiguration> configs) {
+            Map<String,Matcher> groupMatchers = new HashMap<>();
+            SortedSet<MatchableLimit> groupLimits = new TreeSet<>();
+            // Create a matchable limit for each configuration.
+            for(QueryLogicGroupConfiguration config : configs) {
+                
+                // Identify the best matching strategy to use when matching query logics.
+                String queryLogicPattern = config.getQueryLogicPattern();
+                Matcher matcher;
+                try {
+                    matcher = getMatcher(queryLogicPattern);
+                } catch (JavaRegexAnalyzer.JavaRegexParseException e) {
+                    throw new IllegalArgumentException("Failed to analyze regex for query logic pattern '" + queryLogicPattern + "' for query logic group '" + config.getGroupName() + "': " + e.getMessage(), e);
+                }
+                
+                // Add a new matchable limit. The sorted set will be sorted in the following priority:
+                // 1. First by matching type: EXACT, then PARTIAL, then ALL
+                // 2. Then by query limit, from lowest to highest.
+                // 3. Then by group name.
+                groupLimits.add(new MatchableLimit(config.getGroupName(), matcher, config.getQueryLimit()));
+                groupMatchers.put(config.getGroupName(), matcher);
+            }
+            
+            this.configuredLimits = Collections.unmodifiableSortedSet(groupLimits);
+            this.groupMatchers = Map.copyOf(groupMatchers);
+        }
+        
+        /**
+         * Return the set of all query logic groups that this provider was configured with.
+         * @return the query logic group names
+         */
+        private Set<String> getGroupNames() {
+            return groupNames;
+        }
+        
+        /**
+         * Return the best matching {@link QueryLogicGroupLimit} to use when enforcing limits for the given query logic. If no match was found, an empty
+         * {@link Optional} will be returned
+         * @param queryLogic the query logic
+         * @return the {@link QueryLogicGroupLimit} if found
+         */
+        private Optional<QueryLogicGroupLimit> getLimit(String queryLogic) {
+            // Fetch the best match from the cache, if present.
+            Optional<QueryLogicGroupLimit> limit = limitCache.getIfPresent(queryLogic);
+            // Otherwise, identify the best match and update the cache.
+            if(limit == null) {
+                // Look for a query logic group limit originating from a configuration that matches the query logic. The first matching limit will be the best
+                // match due to how the limits are sorted, which is:
+                // 1. First by matching type: EXACT, then PARTIAL, then ALL
+                // 2. Then by query limit, from lowest to highest.
+                // 3. Then by group name.
+                for (MatchableLimit matchableLimit : configuredLimits) {
+                    if(matchableLimit.matcher.matches(queryLogic)) {
+                        limit = Optional.of(QueryLogicGroupLimit.fromConfig(matchableLimit.groupName, matchableLimit.queryLimit));
+                        break;
+                    }
+                }
+                
+                // If no matching limit was found, then cache an empty optional.
+                if(limit == null) {
+                    limit = Optional.empty();
+                }
+                
+                // Cache it.
+                if(log.isTraceEnabled()) {
+                    log.trace("Caching query logic group limit for '" + queryLogic + "': " + limit);
+                }
+                limitCache.put(queryLogic, limit);
+            }
+            return limit;
+        }
+        
+        /**
+         * Return the best matching overridden limit to use when enforcing limits for the given query logic. If no match was for the query logic against any of
+         * the groups present in the map of overridden limits, an empty optional will be returned.
+         * @param sourceId either a user dn or a system name
+         * @param queryLogic the query logic
+         * @param overriddenLimits a map of query logic group names to their corresponding overriding limit
+         * @return the {@link QueryLogicGroupLimit} if found
+         */
+        public Optional<QueryLogicGroupLimit> getOverriddenLimit(String sourceId, String queryLogic, Map<String,Integer> overriddenLimits) {
+            // The cache key consists of the source id and the query logic.
+            String key = sourceId + queryLogic;
+            Optional<QueryLogicGroupLimit> optional = overiddenLimitCache.getIfPresent(key);
+            // If we do not already have the best match cached, attempt to find it.
+            if (optional == null) {
+                // Construct a new sorted set of matchable limits that will be sorted in the following manner:
+                // 1. First by matching type: EXACT, then PARTIAL, then ALL
+                // 2. Then by the overridden query limit, from lowest to highest.
+                // 3. Then by the group name.
+                // This set will only consist of groups present in the map of overridden limits.
+                SortedSet<MatchableLimit> limits = new TreeSet<>();
+                for (Map.Entry<String,Integer> entry : overriddenLimits.entrySet()) {
+                    String groupName = entry.getKey();
+                    Matcher matcher = groupMatchers.get(groupName);
+                    if (matcher.matches(queryLogic)) {
+                        limits.add(new MatchableLimit(groupName, matcher, entry.getValue()));
+                    }
+                }
+                
+                // It's possible for the set to be empty if the query logic did not match against any of the query logic groups that were overridden. In this
+                // case, return an empty optional.
+                if (limits.isEmpty()) {
+                    optional = Optional.empty();
+                } else {
+                    // Otherwise the best match is the first one.
+                    MatchableLimit bestLimit = limits.first();
+                    QueryLogicGroupLimit limit = QueryLogicGroupLimit.fromConfig(bestLimit.groupName, bestLimit.queryLimit);
+                    optional = Optional.of(limit);
+                }
+                
+                // Cache it.
+                if(log.isTraceEnabled()) {
+                    log.trace("Caching overridden query logic group limit for '" + key + "': " + optional);
+                }
+                overiddenLimitCache.put(key, optional);
+            }
+            return optional;
+        }
+        
+        /**
+         * This class represents a sortable query logic group and its limit.
+         */
+        private static class MatchableLimit implements Comparable<MatchableLimit> {
+            
+            private final String groupName;
+            private final Matcher matcher;
+            private final int queryLimit;
+            
+            public MatchableLimit(String groupName, Matcher matcher, int queryLimit) {
+                this.groupName = groupName;
+                this.matcher = matcher;
+                this.queryLimit = queryLimit;
+            }
+            
+            @Override
+            public int compareTo(MatchableLimit o) {
+                // First sort by the matcher type, sorting in order EXACT, PARTIAL, then ALL.
+                int comparison = matcher.getType().compareTo(o.matcher.getType());
+                
+                // Then sort by the query limit from lowest to highest.
+                if (comparison == 0) {
+                    comparison = Integer.compare(queryLimit, o.queryLimit);
+                }
+                
+                // Then sort by the group name. In practice, this should always be unique.
+                if (comparison == 0) {
+                    comparison = groupName.compareTo(o.groupName);
+                }
+                return comparison;
+            }
+        }
+    }
+    
+    /**
+     * This class is responsible for extracting the limits from {@link UserConfiguration} instances and then identifying the query limits to enforce for
+     * individual users, overridden or otherwise.
+     */
+    private class UserLimitProvider {
+        
+        // Cache of user dns to their query limits.
+        private final Cache<String, UserQueryLimit> cache = Caffeine.newBuilder().build();
+        
+        // Map of user dns to configured query limits.
+        private Map<String, UserQueryLimit> configuredLimits;
+        
+        private UserLimitProvider(Collection<UserConfiguration> configs, Set<String> queryLogicGroups) {
+            if(configs != null && !configs.isEmpty()) {
+                validateConfigs(configs, queryLogicGroups);
+                populateLimits(configs);
+            } else {
+                this.configuredLimits = Map.of();
+            }
+        }
+        
+        /**
+         * Validate the given configurations.
+         * @param configs the configurations to validate
+         */
+        private void validateConfigs(Collection<UserConfiguration> configs, Set<String> queryLogicGroups) {
+            Set<String> userDns = new HashSet<>();
+            for(UserConfiguration config : configs) {
+                // Verify that a user dn was given.
+                String userDn = config.getUserDn();
+                if(StringUtils.isBlank(userDn)) {
+                    throw new IllegalArgumentException("User query limit configuration given with blank user DN");
+                }
+                
+                // Verify we have not seen a configuration with the user dn before.
+                if (userDns.contains(userDn)) {
+                    throw new IllegalArgumentException("Multiple query limit configurations specified for user '" + userDn + "'");
+                } else {
+                    userDns.add(userDn);
+                }
+                
+                // Verify that if the user query limit was overridden, it is not negative.
+                if(config.getQueryLimit() != null && config.getQueryLimit() < 0) {
+                    throw new IllegalArgumentException("Negative user query limit given for user '" + userDn + "'");
+                }
+                
+                // Verify that no non-existent query logic groups were specified.
+                Map<String,Integer> groupLimits = config.getQueryLogicGroupLimits();
+                if(groupLimits != null && !groupLimits.isEmpty()) {
+                    Set<String> groups = groupLimits.keySet();
+                    Sets.SetView<String> nonExistentGroups = Sets.difference(groups, queryLogicGroups);
+                    if(!nonExistentGroups.isEmpty()) {
+                        throw new IllegalArgumentException("Non-existent query logic groups specified for query limit configuration for user '" + userDn + "': " + nonExistentGroups);
+                    }
+                }
+            }
+        }
+        
+        /**
+         * Populate the limits to enforce for users.
+         * @param configs the configs to populate the limits from
+         */
+        private void populateLimits(Collection<UserConfiguration> configs) {
+            Map<String, UserQueryLimit> configuredLimits = new HashMap<>();
+            for(UserConfiguration config : configs) {
+                // If the query limit given for the user was null or less than zero, use the default user query limit.
+                Integer queryLimit = config.getQueryLimit();
+                if(queryLimit == null || queryLimit < 0) {
+                    queryLimit = QueryLimitProvider.this.config.getDefaultUserQueryLimit();
+                }
+                configuredLimits.put(config.getUserDn(), UserQueryLimit.fromConfig(config.getUserDn(), queryLimit, config.getQueryLogicGroupLimits()));
+            }
+            this.configuredLimits = Map.copyOf(configuredLimits);
+        }
+        
+        /**
+         * Return the best matching {@link UserQueryLimit} to use when enforcing limits for the given user. If no match was found to a configured limit, then
+         * default limits will be returned.
+         * @param userDn the user DN
+         * @return the {@link QueryLogicGroupLimit} if found
+         */
+        private UserQueryLimit getLimit(String userDn) {
+            // Fetch the limits from the cache if present.
+            UserQueryLimit limit = cache.getIfPresent(userDn);
+            if(limit == null) {
+                // Otherwise attempt to get it from the map of configured limits.
+                limit = configuredLimits.get(userDn);
+                // If no match was found, use the default user query limit.
+                if(limit == null) {
+                    limit = UserQueryLimit.fromDefaults(userDn, config.getDefaultUserQueryLimit());
+                }
+                
+                // Put it in the cache.
+                if(log.isTraceEnabled()) {
+                    log.trace("Caching user query limit for '" + userDn + "': " + limit);
+                }
+                cache.put(userDn, limit);
+            }
+            return limit;
+        }
+    }
+    
+    /**
+     * This class is responsible for extracting the limits from {@link SystemConfiguration} instances and then identifying the query limits to enforce for
+     * individual systems, overridden or otherwise.
+     */
+    private class SystemLimitProvider {
+        
+        // Cache of systems to their best limit.
+        private final Cache<String, SystemQueryLimit> limitCache = Caffeine.newBuilder().build();
+        // Cache of systems to whether queries submitted on them should count against user query limits.
+        private final Cache<String, Boolean> countsAgainstUserLimitCache = Caffeine.newBuilder().build();
+        // The set of query limits in sorted order of best match to worst.
+        private SortedSet<MatchableLimit> configuredLimits;
+        
+        private SystemLimitProvider(Collection<SystemConfiguration> configs, Set<String> queryLogicGroups) {
+            if(configs != null && !configs.isEmpty()) {
+                validateConfigs(configs, queryLogicGroups);
+                populateLimits(configs);
+            } else {
+                this.configuredLimits = Collections.emptySortedSet();
+            }
+        }
+        
+        /**
+         * Validate the given configurations.
+         * @param configs the configurations to validate
+         */
+        private void validateConfigs(Collection<SystemConfiguration> configs, Set<String> queryLogicGroups) {
+            Set<String> systemPatterns = new HashSet<>();
+            Map<String, String> matcherPatterns = new HashMap<>();
+            for(SystemConfiguration config : configs) {
+                // Verify that a system pattern was given.
+                String systemPattern = config.getSystemPattern();
+                if(StringUtils.isBlank(systemPattern)) {
+                    throw new IllegalArgumentException("System query limit configuration specified with blank system pattern");
+                }
+                
+                // Verify that the pattern compiles if it is not simply a * as is occasionally used as a wildcard in configurations.
+                try {
+                    if (!systemPattern.equals(ASTERISK)) {
+                        Pattern.compile(systemPattern);
+                    }
+                } catch (PatternSyntaxException e) {
+                    throw new IllegalArgumentException("Invalid regex in system pattern '" + systemPattern + "'", e);
+                }
+                
+                // Verify that we have not seen a configuration with the system pattern before.
+                if(systemPatterns.contains(systemPattern)) {
+                    throw new IllegalArgumentException("Multiple query limit configurations specified with system pattern '" + systemPattern + "'");
+                } else {
+                    systemPatterns.add(systemPattern);
+                }
+                
+                // Fetch the matcher that would be used for the system pattern.
+                Matcher matcher;
+                try {
+                    matcher = getMatcher(systemPattern);
+                } catch (JavaRegexAnalyzer.JavaRegexParseException e) {
+                    throw new IllegalArgumentException("Failed to analyze regex for system pattern '" + systemPattern + "': " + e.getMessage(), e);
+                }
+                
+                // Verify that we do not have an exact-matching pattern that is equivalent to a previously seen exact-matching pattern, such as 'SYSTEM-01' vs.
+                // 'SYSTEM\\-01'.
+                if(matcher instanceof StringMatcher) {
+                    String matcherPattern = ((StringMatcher) matcher).getValue();
+                    String equivalentSystemPattern = matcherPatterns.get(matcherPattern);
+                    if(equivalentSystemPattern != null) {
+                        throw new IllegalArgumentException("System pattern '" + systemPattern +
+                                        "' will resolve to an exact match that is equivalent to system pattern '" + equivalentSystemPattern +
+                                        "' from another system configuration.");
+                    } else {
+                        matcherPatterns.put(matcherPattern, systemPattern);
+                    }
+                }
+                
+                // Verify that we do not have a negative query limit.
+                if(config.getQueryLimit() != null && config.getQueryLimit() < 0) {
+                    throw new IllegalArgumentException("Negative query limit specified for system pattern '" + systemPattern + "'");
+                }
+                
+                // Safeguard against allowing a configuration to potentially set whether queries on a system counts against user limits to false for all
+                // systems. Only allow this to be done for exact system names, or non-wildcard-only patterns.
+                if (wildcardOnlyPattern.matcher(systemPattern).matches() && !config.getCountsAgainstsUserLimit()) {
+                    throw new IllegalArgumentException("System pattern '" + systemPattern +
+                                    "' is wildcard-only and may not be used to override whether queries count against user limits to false");
+                }
+                
+                // Verify that no non-existent query logic groups were specified.
+                Map<String,Integer> groupLimits = config.getQueryLogicGroupLimits();
+                if(groupLimits != null && !groupLimits.isEmpty()) {
+                    Set<String> groups = groupLimits.keySet();
+                    Sets.SetView<String> nonExistentGroups = Sets.difference(groups, queryLogicGroups);
+                    if(!nonExistentGroups.isEmpty()) {
+                        throw new IllegalArgumentException("Non-existent query logic groups given for system pattern '" + systemPattern + "': " + nonExistentGroups);
+                    }
+                }
+            }
+        }
+        
+        /**
+         * Populate the limits to enforce for systems.
+         * @param configs the configs to populate the limits from
+         */
+        private void populateLimits(Collection<SystemConfiguration> configs) {
+            SortedSet<MatchableLimit> configuredLimits = new TreeSet<>();
+            for(SystemConfiguration systemConfig : configs) {
+                
+                // Identify the best matching strategy to use for matching system names.
+                String systemPattern = systemConfig.getSystemPattern();
+                Matcher matcher;
+                try {
+                    matcher = getMatcher(systemPattern);
+                } catch (JavaRegexAnalyzer.JavaRegexParseException e) {
+                    throw new IllegalArgumentException("Failed to analyze regex for system pattern '" + systemPattern + "': " + e.getMessage(), e);
+                }
+                
+                // If the query limit given for the system was null or less than zero, use the default system query limit.
+                Integer queryLimit = systemConfig.getQueryLimit();
+                if(queryLimit == null || queryLimit < 0) {
+                    queryLimit = config.getDefaultSystemQueryLimit();
+                }
+                
+                // If countsAgainstUserLimit is null, use the default.
+                Boolean countsAgainstUserLimit = systemConfig.getCountsAgainstsUserLimit();
+                if(countsAgainstUserLimit == null) {
+                    countsAgainstUserLimit = true;
+                }
+                
+                configuredLimits.add(new MatchableLimit(matcher, systemPattern, queryLimit, countsAgainstUserLimit, systemConfig.getQueryLogicGroupLimits()));
+            }
+            this.configuredLimits = Collections.unmodifiableSortedSet(configuredLimits);
+        }
+        
+        /**
+         * Return the best matching {@link SystemQueryLimit} to use for the given system. If no match was found to a configured limit, then default limits will
+         * be returned.
+         * @param system the system name
+         * @return the {@link SystemQueryLimit}
+         */
+        private SystemQueryLimit getLimit(String system) {
+            // Check if we have the best match already cached.
+            SystemQueryLimit limit = limitCache.getIfPresent(system);
+            if(limit == null) {
+                // If not, attempt to find one from configured limits. The first matching limit will be the best one due to how the limits are sorted, which is:
+                // 1. First by matching type: EXACT, then PARTIAL, then ALL
+                // 2. Then by query limit, from lowest to highest.
+                // 3. Then by whether queries should apply to the user query limit, from true to false.
+                // 4. Then by system pattern.
+                for (MatchableLimit matchableLimit : configuredLimits) {
+                    if(matchableLimit.matcher.matches(system)) {
+                        limit = SystemQueryLimit.fromConfig(matchableLimit.systemPattern, matchableLimit.queryLimit, matchableLimit.countsAgainstUserLimit, matchableLimit.queryLogicGroupLimits);
+                        break;
+                    }
+                }
+                
+                // If a matching configured limit was not found, construct one from the default limits.
+                if(limit == null) {
+                    limit = SystemQueryLimit.fromDefaults(system, config.getDefaultSystemQueryLimit());
+                }
+                
+                // Cache it.
+                if(log.isTraceEnabled()) {
+                    log.trace("Caching system query limit for '" + system + "': " + limit);
+                }
+                limitCache.put(system, limit);
+            }
+            return limit;
+        }
+        
+        /**
+         * Return whether queries count against the user query limit when submitted on the given system.
+         * @param system the system name
+         * @return true if queries count against the user query limit, or false otherwise
+         */
+        private boolean countsAgainstUserLimit(String system) {
+            // Check if we already have an evaluation for this cached.
+            Boolean countsAgainstUserLimit = countsAgainstUserLimitCache.getIfPresent(system);
+            if(countsAgainstUserLimit == null) {
+                // If not, attempt to determine whether query limits apply based on the configured limits.
+                for(MatchableLimit matchableLimit : configuredLimits) {
+                    // Wildcard system patterns are not allowed to override countsAgainstUserLimit to false. If we encounter match type ALL, all remaining
+                    // limits have wildcard system patterns and can be skipped.
+                    if (matchableLimit.matcher.getType() == Matcher.Type.ALL) {
+                        break;
+                    }
+                    
+                    // If we found a match, update the counts against user limit. If countsAgainstUserLimit is true or this is an exact match, we do not need
+                    // to evaluate any other matches.
+                    if(matchableLimit.matcher.matches(system)) {
+                        countsAgainstUserLimit = matchableLimit.countsAgainstUserLimit;
+                        if(countsAgainstUserLimit || matchableLimit.matcher.getType() == Matcher.Type.EXACT) {
+                            break;
+                        }
+                    }
+                }
+                
+                // If we did not find any configured limit for the system, use the default value.
+                if(countsAgainstUserLimit == null) {
+                    countsAgainstUserLimit = true;
+                }
+                
+                // Cache it.
+                if(log.isTraceEnabled()) {
+                    log.trace("Caching countsAgainstUserLimitCache for '" + system + "': " + countsAgainstUserLimitCache);
+                }
+                countsAgainstUserLimitCache.put(system, countsAgainstUserLimit);
+            }
+            return countsAgainstUserLimit;
+        }
+        
+        /**
+         * This class represents a sortable system pattern and its limit configuration.
+         */
+        private class MatchableLimit implements Comparable<MatchableLimit> {
+            private final Matcher matcher;
+            private final String systemPattern;
+            private final int queryLimit;
+            private final boolean countsAgainstUserLimit;
+            private final Map<String, Integer> queryLogicGroupLimits;
+            
+            public MatchableLimit(Matcher matcher, String systemPattern, int queryLimit, boolean countsAgainstUserLimit, Map<String,Integer> queryLogicGroupLimits) {
+                this.matcher = matcher;
+                this.systemPattern = systemPattern;
+                this.queryLimit = queryLimit;
+                this.countsAgainstUserLimit = countsAgainstUserLimit;
+                this.queryLogicGroupLimits = queryLogicGroupLimits == null ? Map.of() : Map.copyOf(queryLogicGroupLimits);
+            }
+            
+            @Override
+            public int compareTo(MatchableLimit o) {
+                // First sort by the type, sorting in order EXACT, PARTIAL, then ALL.
+                int comparison = matcher.getType().compareTo(o.matcher.getType());
+                
+                // Then sort by the query limit from lowest to highest.
+                if(comparison == 0) {
+                    comparison = Integer.compare(queryLimit, o.queryLimit);
+                }
+                
+                // Then sort by whether queries count against the user limit, true to false.
+                if (comparison == 0) {
+                    comparison = Boolean.compare(o.countsAgainstUserLimit, countsAgainstUserLimit);
+                }
+                
+                // Then sort by the system pattern. In practice, this should always be unique.
+                if(comparison == 0) {
+                    comparison = systemPattern.compareTo(o.systemPattern);
+                }
+                
+                return comparison;
+            }
+        }
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimitProviderConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimitProviderConfiguration.java
@@ -1,0 +1,84 @@
+package datawave.webservice.query.limit;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Configuration bean for {@link QueryLimitProviderConfiguration}. In practice, this should be a singleton.
+ */
+@Component("queryLimitProviderConfig")
+public class QueryLimitProviderConfiguration {
+    
+    private int defaultUserQueryLimit;
+    private int defaultSystemQueryLimit;
+    
+    private List<UserConfiguration> userConfigs;
+    private List<SystemConfiguration> systemConfigs;
+    private List<QueryLogicGroupConfiguration> queryLogicGroupConfigs;
+    
+    public int getDefaultUserQueryLimit() {
+        return defaultUserQueryLimit;
+    }
+    
+    public void setDefaultUserQueryLimit(int defaultUserQueryLimit) {
+        this.defaultUserQueryLimit = defaultUserQueryLimit;
+    }
+    
+    public int getDefaultSystemQueryLimit() {
+        return defaultSystemQueryLimit;
+    }
+    
+    public void setDefaultSystemQueryLimit(int defaultSystemQueryLimit) {
+        this.defaultSystemQueryLimit = defaultSystemQueryLimit;
+    }
+    
+    public List<UserConfiguration> getUserConfigs() {
+        return userConfigs;
+    }
+    
+    public void setUserConfigs(List<UserConfiguration> userConfigs) {
+        this.userConfigs = userConfigs;
+    }
+    
+    public List<SystemConfiguration> getSystemConfigs() {
+        return systemConfigs;
+    }
+    
+    public void setSystemConfigs(List<SystemConfiguration> systemConfigs) {
+        this.systemConfigs = systemConfigs;
+    }
+    
+    public List<QueryLogicGroupConfiguration> getQueryLogicGroupConfigs() {
+        return queryLogicGroupConfigs;
+    }
+    
+    public void setQueryLogicGroupConfigs(List<QueryLogicGroupConfiguration> queryLogicGroupConfigs) {
+        this.queryLogicGroupConfigs = queryLogicGroupConfigs;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryLimitProviderConfiguration that = (QueryLimitProviderConfiguration) o;
+        return defaultUserQueryLimit == that.defaultUserQueryLimit && defaultSystemQueryLimit == that.defaultSystemQueryLimit && Objects.equals(userConfigs,
+                        that.userConfigs) && Objects.equals(systemConfigs, that.systemConfigs) && Objects.equals(queryLogicGroupConfigs,
+                        that.queryLogicGroupConfigs);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultUserQueryLimit, defaultSystemQueryLimit, userConfigs, systemConfigs, queryLogicGroupConfigs);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", QueryLimitProviderConfiguration.class.getSimpleName() + "[", "]").add("defaultUserQueryLimit=" + defaultUserQueryLimit)
+                        .add("defaultSystemQueryLimit=" + defaultSystemQueryLimit).add("userConfigs=" + userConfigs).add("systemConfigs=" + systemConfigs)
+                        .add("queryLogicGroupConfigs=" + queryLogicGroupConfigs).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimiter.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimiter.java
@@ -1,0 +1,148 @@
+package datawave.webservice.query.limit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This class is responsible for determining if any concurrent query limits are going to be exceeded for a user, system, or query logic when a new query is
+ * submitted.
+ */
+@Component("queryLimiter")
+public class QueryLimiter {
+    
+    private String zookeeperConfig;
+    private QueryLimitProvider queryLimitProvider;
+    private SnapshotProvider snapshotProvider;
+    
+    public String getZookeeperConfig() {
+        return zookeeperConfig;
+    }
+    
+    public void setZookeeperConfig(String zookeeperConfig) {
+        this.zookeeperConfig = zookeeperConfig;
+    }
+    
+    public QueryLimitProvider getQueryLimitProvider() {
+        return queryLimitProvider;
+    }
+    
+    @Autowired
+    public void setQueryLimitProvider(QueryLimitProvider queryLimitProvider) {
+        this.queryLimitProvider = queryLimitProvider;
+    }
+    
+    public SnapshotProvider getSnapshotProvider() {
+        // If the snapshot provider is null, create an implementation that will return a snapshot from the ActiveQueryTracker.
+        if(snapshotProvider == null) {
+            snapshotProvider = (userDn, system, queryLogic) -> {
+                try (ActiveQueryTracker tracker = new ActiveQueryTracker(zookeeperConfig, 120000)) {
+                    return tracker.getSnapshot(userDn, system, queryLogic);
+                }
+            };
+        }
+        return snapshotProvider;
+    }
+    
+    /**
+     * Return whether submitting a new query for the given user, on the given system, based on the given query logic, would exceed a configured concurrent query
+     * limit.
+     * @param userDn the user DN
+     * @param system the system name
+     * @param queryLogic the query logic
+     * @return the response
+     */
+    public QueryLimiterResponse checkForLimits(String userDn, String system, String queryLogic) throws Exception {
+        ActiveQuerySnapshot snapshot = getSnapshotProvider().getSnapshot(userDn, system, queryLogic);
+        
+        int totalQueriesForUser = getTotalQueriesThatCountAgainstLimit(snapshot);
+        boolean userOverrodeQueryLogicLimit = false;
+        
+        // Check if the user has reached their max concurrent query limit across all systems.
+        UserQueryLimit userLimit = queryLimitProvider.getUserLimit(userDn);
+        if (totalQueriesForUser >= userLimit.getQueryLimit()) {
+            String message = "User '" + userDn + "' has reached max " + (userLimit.getSource() == LimitSource.DEFAULTS ? "default " : "") + "user query limit of " + userLimit.getQueryLimit();
+            return QueryLimiterResponse.exceedsLimit(message);
+        }
+        
+        // Check if the user has reached their max concurrent query limit for any overridden query logic groups.
+        if (userLimit.overridesAnyQueryLogicLimits()) {
+            Optional<QueryLogicGroupLimit> optionalGroupLimit = queryLimitProvider.getOverriddenQueryLogicGroupLimit(userDn, queryLogic,
+                            userLimit.getQueryLogicGroupLimits());
+            if (optionalGroupLimit.isPresent()) {
+                userOverrodeQueryLogicLimit = true;
+                QueryLogicGroupLimit groupLimit = optionalGroupLimit.get();
+                if (snapshot.getTotalUserQueriesForQueryLogic() >= groupLimit.getQueryLimit()) {
+                    String message = "User '" + userDn + "' has reached max user query limit of " + groupLimit.getQueryLimit() + " for query logic " + queryLogic;
+                    return QueryLimiterResponse.exceedsLimit(message);
+                }
+            }
+        }
+        
+        // Check if the system has reached its max concurrent query limit.
+        SystemQueryLimit systemLimit = queryLimitProvider.getSystemLimit(system);
+        if (snapshot.getTotalSystemQueries() >= systemLimit.getQueryLimit()) {
+            String message = "System '" + system + "' has reached max " + (systemLimit.getSource() ==  LimitSource.DEFAULTS ? "default " : "") + "system query limit of " + systemLimit.getQueryLimit();
+            return QueryLimiterResponse.exceedsLimit(message);
+        }
+        
+        // Check if the system has reached its max concurrent query limit for any overridden query logic groups.
+        if (systemLimit.overridesAnyQueryLogicLimits()) {
+            Optional<QueryLogicGroupLimit> optionalGroupLimit = queryLimitProvider.getOverriddenQueryLogicGroupLimit(system, queryLogic,
+                            systemLimit.getQueryLogicGroupLimits());
+            if (optionalGroupLimit.isPresent()) {
+                QueryLogicGroupLimit groupLimit = optionalGroupLimit.get();
+                if (snapshot.getTotalSystemQueriesForQueryLogic() >= groupLimit.getQueryLimit()) {
+                    String message = "System '" + system + "' has reached max query limit of " + groupLimit.getQueryLimit() + " for query logic " + queryLogic;
+                    return QueryLimiterResponse.exceedsLimit(message);
+                }
+            }
+        }
+        
+        // If the user did not have any overridden query logic groups that matched the query logic, check if the user has reached the max concurrent query limit
+        // for a query logic group's default limit.
+        if(!userOverrodeQueryLogicLimit) {
+            Optional<QueryLogicGroupLimit> optionalGroupLimit = queryLimitProvider.getQueryLogicGroupLimit(queryLogic);
+            if (optionalGroupLimit.isPresent()) {
+                QueryLogicGroupLimit groupLimit = optionalGroupLimit.get();
+                if(snapshot.getTotalUserQueriesForQueryLogic() >= groupLimit.getQueryLimit()) {
+                    String message = "User '" + userDn + "' has reached max default query limit of " + groupLimit.getQueryLimit() + " for query logic " + queryLogic;
+                    return QueryLimiterResponse.exceedsLimit(message);
+                }
+            }
+        }
+        
+        // The query can be submitted.
+        return QueryLimiterResponse.doesNotExceedLimit();
+    }
+    
+    /**
+     * Return the total queries the user has running that count towards their query limit.
+     * @param snapshot the snapshot to extract query metrics from
+     * @return the total queries
+     */
+    private int getTotalQueriesThatCountAgainstLimit(ActiveQuerySnapshot snapshot) {
+        // The total number of queries a user has running, and the total number of those queries that count towards the user's query limit may differ. It
+        // depends on the systems the queries were submitted on, and whether queries on the systems count towards the user's query limit. Evaluate each system
+        // that the user has queries on, and only sum up the queries on systems that count towards the user's query limit.
+        int totalQueries = 0;
+        Map<String,Integer> totalUserQueriesPerSystem = snapshot.getTotalUserQueriesPerSystem();
+        for(Map.Entry<String,Integer> entry : totalUserQueriesPerSystem.entrySet()) {
+            String system = entry.getKey();
+            if (queryLimitProvider.systemCountsAgainstUserLimit(system)) {
+                totalQueries += entry.getValue();
+            }
+        }
+        return totalQueries;
+    }
+    
+    /**
+     * A simple interface for providing an {@link ActiveQueryTracker}. Used to allow ease of mock injection for testing purposes.
+     */
+    public interface SnapshotProvider {
+        ActiveQuerySnapshot getSnapshot(String userDn, String system, String queryLogic) throws Exception;
+    }
+}
+

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimiterResponse.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimiterResponse.java
@@ -1,0 +1,31 @@
+package datawave.webservice.query.limit;
+
+/**
+ * Response originating from {@link QueryLimiter}.
+ */
+public class QueryLimiterResponse {
+    
+    public static QueryLimiterResponse doesNotExceedLimit() {
+        return new QueryLimiterResponse(false, null);
+    }
+    
+    public static QueryLimiterResponse exceedsLimit(String message) {
+        return new QueryLimiterResponse(true, message);
+    }
+    
+    private final boolean exceedsLimit;
+    private final String message;
+    
+    public QueryLimiterResponse(boolean exceedsLimit, String message) {
+        this.exceedsLimit = exceedsLimit;
+        this.message = message;
+    }
+    
+    public boolean exceedsLimit() {
+        return exceedsLimit;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLogicGroupConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLogicGroupConfiguration.java
@@ -1,0 +1,64 @@
+package datawave.webservice.query.limit;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Represents a custom query limit configuration that can be configured for query logics.
+ */
+public class QueryLogicGroupConfiguration {
+    
+    // The name of the query logic group.
+    private String groupName;
+    
+    // The query logic regex pattern.
+    private String queryLogicPattern;
+    
+    // The default concurrency limit for users. This applies to the total concurrent queries a user may run that originate from a query logic in the group
+    // across all systems.
+    private int queryLimit;
+    
+    public String getGroupName() {
+        return groupName;
+    }
+    
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+    
+    public String getQueryLogicPattern() {
+        return queryLogicPattern;
+    }
+    
+    public void setQueryLogicPattern(String queryLogicPattern) {
+        this.queryLogicPattern = queryLogicPattern;
+    }
+    
+    public int getQueryLimit() {
+        return queryLimit;
+    }
+    
+    public void setQueryLimit(int queryLimit) {
+        this.queryLimit = queryLimit;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryLogicGroupConfiguration that = (QueryLogicGroupConfiguration) o;
+        return queryLimit == that.queryLimit && Objects.equals(groupName, that.groupName) && Objects.equals(queryLogicPattern, that.queryLogicPattern);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupName, queryLogicPattern, queryLimit);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", QueryLogicGroupConfiguration.class.getSimpleName() + "[", "]").add("groupName='" + groupName + "'")
+                        .add("queryLogicPattern='" + queryLogicPattern + "'").add("queryLimit=" + queryLimit).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLogicGroupLimit.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLogicGroupLimit.java
@@ -1,0 +1,67 @@
+package datawave.webservice.query.limit;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * This class represents the query limits to be enforced for query logic groups.
+ */
+public class QueryLogicGroupLimit {
+    
+    // The query logic group name.
+    private final String groupName;
+    
+    // The default concurrency limit for users.
+    private final int queryLimit;
+    
+    // The source of the limits (configuration vs. default limits).
+    private final LimitSource source;
+    
+    /**
+     * Return a new {@link QueryLogicGroupLimit} from a configuration.
+     * @param groupName  the group name
+     * @param queryLimit the query limit
+     * @return the new {@link QueryLogicGroupLimit}
+     */
+    public static QueryLogicGroupLimit fromConfig(String groupName, int queryLimit) {
+        return new QueryLogicGroupLimit(groupName, queryLimit, LimitSource.CONFIG);
+    }
+    
+    private QueryLogicGroupLimit(String groupName, int queryLimit, LimitSource source) {
+        this.queryLimit = queryLimit;
+        this.source = source;
+        this.groupName = groupName;
+    }
+    
+    public String getGroupName() {
+        return groupName;
+    }
+    
+    public int getQueryLimit() {
+        return queryLimit;
+    }
+    
+    public LimitSource getSource() {
+        return source;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryLogicGroupLimit that = (QueryLogicGroupLimit) o;
+        return queryLimit == that.queryLimit && Objects.equals(groupName, that.groupName) && source == that.source;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupName, queryLimit, source);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", QueryLogicGroupLimit.class.getSimpleName() + "[", "]").add("groupName='" + groupName + "'")
+                        .add("queryLimit=" + queryLimit).add("source=" + source).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/StringMatcher.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/StringMatcher.java
@@ -1,0 +1,50 @@
+package datawave.webservice.query.limit;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * {@link Matcher} implementation that exactly matches a string. The matching type for this {@link Matcher} will always be {@link Matcher.Type#EXACT}.
+ */
+public class StringMatcher implements Matcher {
+    
+    private final String value;
+    
+    public StringMatcher(String value) {
+        Objects.requireNonNull(value, "value must not be null");
+        this.value = value;
+    }
+    
+    public String getValue() {
+        return value;
+    }
+    
+    @Override
+    public Type getType() {
+        return Type.EXACT;
+    }
+    
+    @Override
+    public boolean matches(String value) {
+        return Objects.equals(this.value, value);
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StringMatcher that = (StringMatcher) o;
+        return Objects.equals(value, that.value);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", StringMatcher.class.getSimpleName() + "[", "]").add("value='" + value + "'").toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/SystemConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/SystemConfiguration.java
@@ -1,0 +1,78 @@
+package datawave.webservice.query.limit;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Represents a custom query limit configuration that can be configured for matching systems.
+ */
+public class SystemConfiguration {
+    
+    // The system name regex pattern.
+    private String systemPattern;
+    
+    // Whether queries submitted on matching systems should count against a user's query limit.
+    private Boolean countsAgainstsUserLimit = true;
+    
+    // The maximum number of queries that can run concurrently on matching systems.
+    private Integer queryLimit;
+    
+    // Map of query logic group names to the maximum number of queries that can run concurrently on the system when originating from query logics that fall
+    // within the query logic group.
+    private Map<String, Integer> queryLogicGroupLimits;
+    
+    public String getSystemPattern() {
+        return systemPattern;
+    }
+    
+    public void setSystemPattern(String systemPattern) {
+        this.systemPattern = systemPattern;
+    }
+    
+    public Boolean getCountsAgainstsUserLimit() {
+        return countsAgainstsUserLimit;
+    }
+    
+    public void setCountsAgainstsUserLimit(Boolean countsAgainstsUserLimit) {
+        this.countsAgainstsUserLimit = countsAgainstsUserLimit;
+    }
+    
+    public Integer getQueryLimit() {
+        return queryLimit;
+    }
+    
+    public void setQueryLimit(Integer queryLimit) {
+        this.queryLimit = queryLimit;
+    }
+    
+    public Map<String,Integer> getQueryLogicGroupLimits() {
+        return queryLogicGroupLimits;
+    }
+    
+    public void setQueryLogicGroupLimits(Map<String,Integer> queryLogicGroupLimits) {
+        this.queryLogicGroupLimits = queryLogicGroupLimits;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SystemConfiguration that = (SystemConfiguration) o;
+        return Objects.equals(systemPattern, that.systemPattern) && Objects.equals(countsAgainstsUserLimit, that.countsAgainstsUserLimit) && Objects.equals(
+                        queryLimit, that.queryLimit) && Objects.equals(queryLogicGroupLimits, that.queryLogicGroupLimits);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(systemPattern, countsAgainstsUserLimit, queryLimit, queryLogicGroupLimits);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SystemConfiguration.class.getSimpleName() + "[", "]").add("systemPattern='" + systemPattern + "'")
+                        .add("countsAgainstsUserLimit=" + countsAgainstsUserLimit).add("queryLimit=" + queryLimit)
+                        .add("queryLogicGroupLimits=" + queryLogicGroupLimits).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/SystemQueryLimit.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/SystemQueryLimit.java
@@ -1,0 +1,104 @@
+package datawave.webservice.query.limit;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * This class represents the query limits to be enforced for matching systems. Default limits will be configured, and custom limits can be specified for
+ * individual users, systems, and query logics.
+ */
+public class SystemQueryLimit {
+    
+    // The system name regex pattern.
+    private final String systemPattern;
+    
+    // The maximum number of queries that can run concurrently on matching systems.
+    private final int queryLimit;
+    
+    // Whether queries submitted on matching systems should count against a user's query limit.
+    private final boolean countsAgainstUserLimit;
+    
+    // Map of query logic group names to the maximum number of queries that can run concurrently on the system when originating from query logics that fall
+    // within the query logic group.
+    private final Map<String, Integer> queryLogicGroupLimits;
+    
+    // The source of the limits (configuration vs. default limits).
+    private final LimitSource source;
+    
+    /**
+     * Returns a new {@link SystemQueryLimit} with limits that originated from a matching system query limit configuration.
+     * @param systemPattern the system name regex pattern
+     * @param queryLimit the query limit
+     * @param countsAgainstUserLimit whether queries submitted on matching systems should count against the user's query limit
+     * @param queryLogicGroupLimits the overridden query logic group limits
+     * @return the new {@link SystemQueryLimit}
+     */
+    public static SystemQueryLimit fromConfig(String systemPattern, int queryLimit, boolean countsAgainstUserLimit, Map<String, Integer> queryLogicGroupLimits) {
+        return new SystemQueryLimit(systemPattern, queryLimit, countsAgainstUserLimit, queryLogicGroupLimits, LimitSource.CONFIG);
+    }
+    
+    /**
+     * Returns a new {@link SystemQueryLimit} with limits that originated from default limits
+     * @param systemPattern the system name pattern
+     * @param queryLimit the query limit
+     * @return the new {@link SystemQueryLimit}
+     */
+    public static SystemQueryLimit fromDefaults(String systemPattern, int queryLimit) {
+        return new SystemQueryLimit(systemPattern, queryLimit, true, null, LimitSource.DEFAULTS);
+    }
+    
+    private SystemQueryLimit(String systemPattern, int queryLimit, boolean countsAgainstUserLimit, Map<String, Integer> queryLogicGroupLimits, LimitSource source) {
+        this.systemPattern = systemPattern;
+        this.queryLimit = queryLimit;
+        this.countsAgainstUserLimit = countsAgainstUserLimit;
+        this.queryLogicGroupLimits = queryLogicGroupLimits == null ? Map.of() : Map.copyOf(queryLogicGroupLimits);
+        this.source = source;
+    }
+    
+    public String getSystemPattern() {
+        return systemPattern;
+    }
+    
+    public int getQueryLimit() {
+        return queryLimit;
+    }
+    
+    public boolean countsAgainstUserLimit() {
+        return countsAgainstUserLimit;
+    }
+    
+    public Map<String,Integer> getQueryLogicGroupLimits() {
+        return queryLogicGroupLimits;
+    }
+    
+    public boolean overridesAnyQueryLogicLimits() {
+        return !queryLogicGroupLimits.isEmpty();
+    }
+    
+    public LimitSource getSource() {
+        return source;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SystemQueryLimit that = (SystemQueryLimit) o;
+        return queryLimit == that.queryLimit && countsAgainstUserLimit == that.countsAgainstUserLimit && Objects.equals(systemPattern, that.systemPattern)
+                        && Objects.equals(queryLogicGroupLimits, that.queryLogicGroupLimits) && source == that.source;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(systemPattern, queryLimit, countsAgainstUserLimit, queryLogicGroupLimits, source);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SystemQueryLimit.class.getSimpleName() + "[", "]").add("systemPattern='" + systemPattern + "'")
+                        .add("queryLimit=" + queryLimit).add("countsAgainstUserLimit=" + countsAgainstUserLimit)
+                        .add("queryLogicGroupLimits=" + queryLogicGroupLimits).add("source=" + source).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/UserConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/UserConfiguration.java
@@ -1,0 +1,65 @@
+package datawave.webservice.query.limit;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Represents a custom query limit configuration that can be configured for a single user.
+ */
+public class UserConfiguration {
+    
+    // The user DN.
+    private String userDn;
+    
+    // The user's concurrent query limit. This applies to the total number of queries the user may run across all systems.
+    private Integer queryLimit;
+    
+    // Map of query logic group names to the user's concurrent query limit for the group.
+    private Map<String, Integer> queryLogicGroupLimits;
+    
+    public String getUserDn() {
+        return userDn;
+    }
+    
+    public void setUserDn(String userDn) {
+        this.userDn = userDn;
+    }
+    
+    public Integer getQueryLimit() {
+        return queryLimit;
+    }
+    
+    public void setQueryLimit(Integer queryLimit) {
+        this.queryLimit = queryLimit;
+    }
+    
+    public Map<String,Integer> getQueryLogicGroupLimits() {
+        return queryLogicGroupLimits;
+    }
+    
+    public void setQueryLogicGroupLimits(Map<String,Integer> queryLogicGroupLimits) {
+        this.queryLogicGroupLimits = queryLogicGroupLimits;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserConfiguration that = (UserConfiguration) o;
+        return Objects.equals(userDn, that.userDn) && Objects.equals(queryLimit, that.queryLimit) && Objects.equals(queryLogicGroupLimits,
+                        that.queryLogicGroupLimits);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(userDn, queryLimit, queryLogicGroupLimits);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", UserConfiguration.class.getSimpleName() + "[", "]").add("userDn='" + userDn + "'").add("queryLimit=" + queryLimit)
+                        .add("queryLogicGroupLimits=" + queryLogicGroupLimits).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/UserQueryLimit.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/UserQueryLimit.java
@@ -1,0 +1,92 @@
+package datawave.webservice.query.limit;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * This class represents the query limits to be enforced for an individual user.
+ */
+public class UserQueryLimit {
+    
+    // The user DN.
+    private final String userDn;
+    
+    // The user's concurrent query limit. This applies to the total number of queries the user may run across all systems.
+    private final int queryLimit;
+    
+    // Map of query logic group names to the user's concurrent query limit for the group.
+    private final Map<String, Integer> queryLogicGroupLimits;
+    
+    // The source of the limits (configuration vs. default limits).
+    private final LimitSource source;
+    
+    /**
+     * Returns a new {@link UserQueryLimit} with limits that originated from a matching user query limit configuration.
+     * @param userDn the user DN
+     * @param queryLimit the query limit
+     * @param queryLogicGroupLimits the overridden query logic group limits
+     * @return the new {@link UserQueryLimit}
+     */
+    public static UserQueryLimit fromConfig(String userDn, int queryLimit, Map<String, Integer> queryLogicGroupLimits) {
+        return new UserQueryLimit(userDn, queryLimit, queryLogicGroupLimits, LimitSource.CONFIG);
+    }
+    
+    /**
+     * Returns a new {@link UserQueryLimit} with limits that originated from the default limits.
+     * @param userDn the user DN
+     * @param queryLimit the query limit
+     * @return the new {@link UserQueryLimit}
+     */
+    public static UserQueryLimit fromDefaults(String userDn, int queryLimit) {
+        return new UserQueryLimit(userDn, queryLimit, null, LimitSource.DEFAULTS);
+    }
+    
+    private UserQueryLimit(String userDn, int queryLimit, Map<String,Integer> queryLogicGroupLimits, LimitSource source) {
+        this.userDn = userDn;
+        this.queryLimit = queryLimit;
+        this.queryLogicGroupLimits = queryLogicGroupLimits == null ? Map.of() : Map.copyOf(queryLogicGroupLimits);
+        this.source = source;
+    }
+    
+    public String getUserDn() {
+        return userDn;
+    }
+    
+    public int getQueryLimit() {
+        return queryLimit;
+    }
+    
+    public Map<String,Integer> getQueryLogicGroupLimits() {
+        return queryLogicGroupLimits;
+    }
+    
+    public boolean overridesAnyQueryLogicLimits() {
+        return !queryLogicGroupLimits.isEmpty();
+    }
+    
+    public LimitSource getSource() {
+        return source;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserQueryLimit that = (UserQueryLimit) o;
+        return queryLimit == that.queryLimit && Objects.equals(userDn, that.userDn) && Objects.equals(queryLogicGroupLimits, that.queryLogicGroupLimits)
+                        && source == that.source;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(userDn, queryLimit, queryLogicGroupLimits, source);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", UserQueryLimit.class.getSimpleName() + "[", "]").add("userDn='" + userDn + "'").add("queryLimit=" + queryLimit)
+                        .add("queryLogicGroupLimits=" + queryLogicGroupLimits).add("source=" + source).toString();
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/WildcardMatcher.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/WildcardMatcher.java
@@ -1,0 +1,18 @@
+package datawave.webservice.query.limit;
+
+/**
+ * {@link Matcher} implementation that represents a pattern that was determined to be wildcard-only. The matching type for this {@link Matcher} will always be
+ * {@link Matcher.Type#ALL}.
+ */
+public class WildcardMatcher implements Matcher {
+    
+    @Override
+    public Type getType() {
+        return Type.ALL;
+    }
+    
+    @Override
+    public boolean matches(String fieldValue) {
+        return true;
+    }
+}

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -69,6 +69,8 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 
+import datawave.webservice.query.limit.QueryLimiter;
+import datawave.webservice.query.limit.QueryLimiterResponse;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.Transformer;
@@ -265,6 +267,9 @@ public class QueryExecutorBean implements QueryExecutor {
     @Inject
     private ClosedQueryCache closedQueryCache;
 
+    @Inject
+    private QueryLimiter queryLimiter;
+    
     private static final int PAGE_TIMEOUT_MIN = 1;
     private static final int PAGE_TIMEOUT_MAX = 60;
     private static final String UUID_REGEX_RULE = "[a-fA-F\\d-]+";
@@ -646,7 +651,23 @@ public class QueryExecutorBean implements QueryExecutor {
         QueryData qd = validateQueryParameters(queryLogicName, uriInfo, queryParameters, httpHeaders);
 
         GenericResponse<String> response = new GenericResponse<>();
-
+        
+        try {
+            // Check if submitting a new query would exceed any configured concurrent query limits.
+            QueryLimiterResponse limiterResponse = queryLimiter.checkForLimits(qd.userDn, queryParameters.getFirst(QueryParameters.QUERY_SYSTEM_FROM),
+                            queryLogicName);
+            if (limiterResponse.exceedsLimit()) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_EXCEEDED, limiterResponse.getMessage());
+                response.addException(qe);
+                throw new BadRequestException(qe, response);
+            }
+        } catch (Exception e) {
+            log.error("Error checking concurrent query limits");
+            QueryException qe = new QueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_ERROR, e);
+            response.addException(qe);
+            throw new DatawaveWebApplicationException(qe, response, qe.getStatusCode());
+        }
+        
         // We need to put a disconnected RunningQuery instance into the cache. Otherwise TRANSIENT queries
         // will not exist when reset is called.
         RunningQuery rq;
@@ -722,7 +743,24 @@ public class QueryExecutorBean implements QueryExecutor {
             // then their value will overwrite this one. Otherwise, we return true so that
             // callers know they have to call next (even though next may not return results).
             response.setHasResults(true);
-
+            
+            try {
+                // Check if submitting a new query would exceed any configured concurrent query limits.
+                QueryLimiterResponse limiterResponse = queryLimiter.checkForLimits(qd.userDn, queryParameters.getFirst(QueryParameters.QUERY_SYSTEM_FROM),
+                                queryLogicName);
+                if (limiterResponse.exceedsLimit()) {
+                    BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_EXCEEDED, limiterResponse.getMessage());
+                    response.addException(qe);
+                    throw new BadRequestException(qe, response);
+                }
+            } catch (Exception e) {
+                log.error("Error checking concurrent query limits");
+                QueryException qe = new QueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_ERROR, e);
+                response.addException(qe);
+                throw qe;
+            }
+        
+            
             AuditType auditType = qd.logic.getAuditType(null);
             try {
                 Map<String,List<String>> optionalQueryParameters = qp.getUnknownParameters(MapUtils.toMultiValueMap(queryParameters));
@@ -877,7 +915,23 @@ public class QueryExecutorBean implements QueryExecutor {
         QueryData qd = validateQueryParameters(queryLogicName, uriInfo, queryParameters, null);
 
         GenericResponse<String> response = new GenericResponse<>();
-
+        
+        try {
+            // Check if submitting a new query would exceed any configured concurrent query limits.
+            QueryLimiterResponse limiterResponse = queryLimiter.checkForLimits(qd.userDn, queryParameters.getFirst(QueryParameters.QUERY_SYSTEM_FROM),
+                            queryLogicName);
+            if (limiterResponse.exceedsLimit()) {
+                BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_EXCEEDED, limiterResponse.getMessage());
+                response.addException(qe);
+                throw new BadRequestException(qe, response);
+            }
+        } catch (Exception e) {
+            log.error("Error checking concurrent query limits");
+            QueryException qe = new QueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_ERROR, e);
+            response.addException(qe);
+            throw new DatawaveWebApplicationException(qe, response, qe.getStatusCode());
+        }
+        
         Query q = null;
         AccumuloClient client = null;
         AccumuloConnectionFactory.Priority priority;
@@ -1264,7 +1318,24 @@ public class QueryExecutorBean implements QueryExecutor {
             // The lock should be released at the end of the method call.
             if (!queryCache.lock(id))
                 throw new QueryException(DatawaveErrorCode.QUERY_LOCKED_ERROR);
-
+            
+            try {
+                Query settings = query.getSettings();
+                // Check if submitting a new query would exceed any configured concurrent query limits.
+                QueryLimiterResponse limiterResponse = queryLimiter.checkForLimits(settings.getOwner(), settings.getSystemFrom(), settings.getQueryLogicName());
+                if (limiterResponse.exceedsLimit()) {
+                    BadRequestQueryException qe = new BadRequestQueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_EXCEEDED, limiterResponse.getMessage());
+                    response.addException(qe);
+                    throw new BadRequestException(qe, response);
+                }
+            } catch (Exception e) {
+                log.error("Error checking concurrent query limits");
+                QueryException qe = new QueryException(DatawaveErrorCode.CONCURRENT_QUERY_LIMIT_ERROR, e);
+                response.addException(qe);
+                throw qe;
+            }
+            
+            
             // We did not allocate a connection when we looked up the query. If
             // there's a connection when we get here, then we know it can only be
             // because the query was alive and in use, so we need to close that

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/ActiveQuerySnapshotTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/ActiveQuerySnapshotTest.java
@@ -1,0 +1,106 @@
+package datawave.webservice.query.limit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActiveQuerySnapshotTest {
+    
+    /**
+     * Verify that when a timestamp is not provided, that it is set to the current time.
+     */
+    @Test
+    void testDefaultTimestamp() {
+        long before = System.currentTimeMillis();
+        ActiveQuerySnapshot snapshot = ActiveQuerySnapshot.builder("cn=testuser, c=us", "SYSTEM-01", "TLDQueryLogic").build();
+        long after = System.currentTimeMillis();
+        
+        assertThat(before).isLessThanOrEqualTo(snapshot.getTimestamp());
+        assertThat(after).isGreaterThanOrEqualTo(snapshot.getTimestamp());
+    }
+    
+    /**
+     * Verify that when a timestamp is provided, it is kept.
+     */
+    @Test
+    void testOverriddenTimestamp() {
+        long timestamp = System.currentTimeMillis() - 5000L;
+        
+        ActiveQuerySnapshot snapshot = ActiveQuerySnapshot.builder("cn=testuser, c=us", "SYSTEM-01", "TLDQueryLogic").withTimestamp(timestamp).build();
+        
+        assertThat(snapshot.getTimestamp()).isEqualTo(timestamp);
+    }
+    
+    /**
+     * Verify that an empty snapshot is structured correctly.
+     */
+    @Test
+    void testSnapshotWithNoQueries() {
+        ActiveQuerySnapshot snapshot = ActiveQuerySnapshot.builder("cn=testuser, c=us", "SYSTEM-01", "TLDQueryLogic").build();
+        
+        assertThat(snapshot.getUserDn()).isEqualTo("cn=testuser, c=us");
+        assertThat(snapshot.getSystemName()).isEqualTo("SYSTEM-01");
+        assertThat(snapshot.getQueryLogic()).isEqualTo("TLDQueryLogic");
+        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEmpty();
+        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+    }
+    
+    /**
+     * Verify that query totals after consuming a variety of entries results in correct counts.
+     */
+    @Test
+    void testSnapshotWithConsumedQueries() {
+        ActiveQuerySnapshot.Builder builder = ActiveQuerySnapshot.builder("cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+        // Counts towards totals for user, system, and query logic.
+        builder.capture("query-1", "cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+        builder.capture("query-2", "cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+        builder.capture("query-3", "cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+        builder.capture("query-4", "cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+        
+        // Counts towards totals for system and query logic.
+        builder.capture("query-5", "cn=userB, c=us", "SYSTEM-01", "TLDQueryLogic");
+        builder.capture("query-6", "cn=userB, c=us", "SYSTEM-01", "TLDQueryLogic");
+        builder.capture("query-7", "cn=userB, c=us", "SYSTEM-01", "TLDQueryLogic");
+        
+        // Counts towards totals for user and system.
+        builder.capture("query-8", "cn=userA, c=us", "SYSTEM-01", "OtherQueryLogic");
+        builder.capture("query-9", "cn=userA, c=us", "SYSTEM-01", "OtherQueryLogic");
+        
+        // Counts towards totals for system.
+        builder.capture("query-10", "cn=userB, c=us", "SYSTEM-01", "OtherQueryLogic");
+        builder.capture("query-11", "cn=userB, c=us", "SYSTEM-01", "OtherQueryLogic");
+        
+        // Counts towards totals for user and query logic.
+        builder.capture("query-12", "cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+        builder.capture("query-13", "cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+        builder.capture("query-14", "cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+        builder.capture("query-15", "cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+        
+        // Counts towards totals for query logic.
+        builder.capture("query-16", "cn=userB, c=us", "SYSTEM-02", "TLDQueryLogic");
+        builder.capture("query-17", "cn=userB, c=us", "SYSTEM-02", "TLDQueryLogic");
+        builder.capture("query-18", "cn=userB, c=us", "SYSTEM-02", "TLDQueryLogic");
+        
+        // Counts towards totals for user.
+        builder.capture("query-19", "cn=userA, c=us", "SYSTEM-02", "OtherQueryLogic");
+        builder.capture("query-20", "cn=userA, c=us", "SYSTEM-02", "OtherQueryLogic");
+        
+        ActiveQuerySnapshot snapshot = builder.build();
+        
+        assertThat(snapshot.getUserDn()).isEqualTo("cn=userA, c=us");
+        assertThat(snapshot.getSystemName()).isEqualTo("SYSTEM-01");
+        assertThat(snapshot.getQueryLogic()).isEqualTo("TLDQueryLogic");
+        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(6);
+        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(8);
+        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("SYSTEM-01", 6, "SYSTEM-02", 6));
+        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(11);
+        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(7);
+        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(14);
+    }
+}

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/ActiveQueryTrackerTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/ActiveQueryTrackerTest.java
@@ -1,0 +1,522 @@
+package datawave.webservice.query.limit;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.data.Stat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ActiveQueryTrackerTest {
+    
+    private static final Pattern heartbeatNodeNamePattern = Pattern.compile(
+                    "_c_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-heartbeat_\\d{10}");
+    
+    TestingServer server;
+    ActiveQueryTracker tracker;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new TestingServer();
+        tracker = new ActiveQueryTracker(server.getConnectString(), 120000);
+    }
+    
+    @AfterEach
+    void tearDown() throws IOException {
+        if(server != null) {
+            server.close();
+        }
+    }
+    
+    @Nested @DisplayName("Given a single query")
+    class SingleQuery {
+        
+        String queryId = UUID.randomUUID().toString();
+        String user = "cn=test a. user, ou=example developers, o=example corp, c=us";
+        String system = "server-01";
+        String queryLogic = "ShardQueryLogic";
+        
+        @Nested @DisplayName("After tracking")
+        class AfterTracking {
+            
+            @BeforeEach
+            void setUp() {
+                tracker.trackQuery(queryId, user, system, queryLogic);
+            }
+            
+            @Test @DisplayName("it is tracked in Zookeeper")
+            void createsZNodes() throws Exception {
+                CuratorFramework client = getClient();
+                client.start();
+                
+                // Verify that the nodes were created as expected in Zookeeper.
+                assertThat(client.checkExists().forPath("/users/" + user + "/" + queryId)).isNotNull();
+                assertThat(client.checkExists().forPath("/systems/server-01/" + queryId)).isNotNull();
+                assertThat(client.checkExists().forPath("/queryLogics/ShardQueryLogic/" + queryId)).isNotNull();
+                assertThat(client.checkExists().forPath("/queries/" + queryId)).isNotNull();
+                assertThat(new String(client.getData().forPath("/queries/" + queryId + "/user"))).isEqualTo(user);
+                assertThat(new String(client.getData().forPath("/queries/" + queryId + "/system"))).isEqualTo(system);
+                assertThat(new String(client.getData().forPath("/queries/" + queryId + "/queryLogic"))).isEqualTo(queryLogic);
+                Stat stat = client.checkExists().forPath("/queries/" + queryId + "/heartbeats");
+                assertThat(stat).isNotNull();
+                assertThat(stat.getNumChildren()).isEqualTo(0);
+            }
+            
+            @Test @DisplayName("A failure will not occur if tracked again")
+            void allowsTrackingAgain() {
+                assertThatNoException().isThrownBy(() -> tracker.trackQuery(queryId, user, system, queryLogic));
+            }
+            
+            @Nested @DisplayName("After untracking")
+            class AfterUntracking {
+                
+                @BeforeEach
+                void setUp() {
+                    tracker.stopTrackingQuery(queryId);
+                }
+                
+                @Test @DisplayName("It is not tracked in Zookeeper")
+                void deletesZNodes() throws Exception {
+                    CuratorFramework client = getClient();
+                    client.start();
+                    
+                    // Verify that the nodes were deleted as expected in Zookeeper.
+                    assertThat(client.checkExists().forPath("/users/" + user + "/" + queryId)).isNull();
+                    assertThat(client.checkExists().forPath("/systems/server-01/" + queryId)).isNull();
+                    assertThat(client.checkExists().forPath("/queryLogics/ShardQueryLogic/" + queryId)).isNull();
+                    assertThat(client.checkExists().forPath("/queries/" + queryId)).isNull();
+                }
+                
+                @Test @DisplayName("A failure will not occur if untracked again")
+                void allowsUntrackingAgain() {
+                    assertThatNoException().isThrownBy(() -> tracker.stopTrackingQuery(queryId));
+                }
+                
+                @Test @DisplayName("A heartbeat cannot be created")
+                void cannotObtainHeartbeat() {
+                    assertThatThrownBy(() -> tracker.createHeartbeat(queryId)).isInstanceOf(ActiveQueryException.class)
+                                    .hasMessage("Query " + queryId + " is not being tracked");
+                }
+            }
+            
+            @Nested @DisplayName("When a single heartbeat is created")
+            class WhenSingleHeartBeatCreated {
+                
+                QueryHeartbeat heartbeat;
+                
+                @BeforeEach
+                void setUp() {
+                    heartbeat = tracker.createHeartbeat(queryId);
+                }
+                
+                @Test @DisplayName("The path is not blank")
+                void hasNonBlankPath() {
+                    assertThat(heartbeat.getPath().isBlank()).isFalse();
+                }
+                
+                @Test @DisplayName("It has the correct query ID")
+                void hasMatchingQueryId() {
+                    assertThat(heartbeat.getQueryId()).isEqualTo(queryId);
+                }
+                
+                @Test @DisplayName("It has the correct parent")
+                void wasCreatedInCorrectPath() {
+                    String path = heartbeat.getPath();
+                    String parentPath = path.substring(0, path.lastIndexOf('/'));
+                    assertThat(parentPath).isEqualTo("/queries/" + queryId + "/heartbeats");
+                }
+                
+                @Test @DisplayName("It has the expected name format")
+                void wasCreatedWithProtection() {
+                    String path = heartbeat.getPath();
+                    String nodeName = path.substring(path.lastIndexOf('/') + 1);
+                    assertThat(heartbeatNodeNamePattern.matcher(nodeName).matches()).isTrue();
+                }
+                
+                @Test @DisplayName("It has sequence 0")
+                void wasCreatedWithSequenceOfZeroes() {
+                    String path = heartbeat.getPath();
+                    String sequence = path.substring(path.lastIndexOf('_') + 1);
+                    assertThat(sequence).isEqualTo("0000000000");
+                }
+                
+                @Test @DisplayName("The query cannot be untracked")
+                void cannotBeUntracked() {
+                    assertThatThrownBy(() -> tracker.stopTrackingQuery(queryId)).isInstanceOf(ActiveQueryException.class)
+                                    .hasMessage("Cannot stop tracking query " + queryId + ", 1 heartbeat(s) exist");
+                }
+                
+                @Nested @DisplayName("When fetching snapshot")
+                class WhenFetchingSnapshot {
+                    
+                    @Test @DisplayName("It is captured for a matching userDn")
+                    void isCapturedForMatchingUser() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, "otherSystem", "otherQueryLogic");
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo(user);
+                        assertThat(snapshot.getSystemName()).isEqualTo("otherSystem");
+                        assertThat(snapshot.getQueryLogic()).isEqualTo("otherQueryLogic");
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("server-01", 1));
+                    }
+                    
+                    @Test @DisplayName("It is captured for a matching system")
+                    void isCapturedForMatchingSystem() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot("otherUser", system, "otherQueryLogic");
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo("otherUser");
+                        assertThat(snapshot.getSystemName()).isEqualTo(system);
+                        assertThat(snapshot.getQueryLogic()).isEqualTo("otherQueryLogic");
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(1);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of());
+                    }
+                    
+                    @Test @DisplayName("It is captured for a matching query logic")
+                    void isCapturedForMatchingQueryLogic() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot("otherUser", "otherSystem", queryLogic);
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo("otherUser");
+                        assertThat(snapshot.getSystemName()).isEqualTo("otherSystem");
+                        assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of());
+                    }
+                    
+                    @Test @DisplayName("It is captured for a matching userDn and system")
+                    void isCapturedForMatchingUserAndSystem() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, system, "otherQueryLogic");
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo(user);
+                        assertThat(snapshot.getSystemName()).isEqualTo(system);
+                        assertThat(snapshot.getQueryLogic()).isEqualTo("otherQueryLogic");
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(1);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(1);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("server-01", 1));
+                    }
+                    
+                    @Test @DisplayName("It is captured for a matching userDn and queryLogic")
+                    void isCapturedForMatchingUserAndQueryLogic() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, "otherSystem", queryLogic);
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo(user);
+                        assertThat(snapshot.getSystemName()).isEqualTo("otherSystem");
+                        assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("server-01", 1));
+                    }
+                    
+                    @Test @DisplayName("It is captured for a matching system and queryLogic")
+                    void isCapturedForMatchingSystemAndQueryLogic() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot("otherUser", system, queryLogic);
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo("otherUser");
+                        assertThat(snapshot.getSystemName()).isEqualTo(system);
+                        assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(1);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of());
+                    }
+                    
+                    @Test @DisplayName("It is captured for a matching userDn, system, and queryLogic")
+                    void isCapturedForMatchingUserAndSystemAndQueryLogic() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, system, queryLogic);
+                        
+                        assertThat(snapshot.getUserDn()).isEqualTo(user);
+                        assertThat(snapshot.getSystemName()).isEqualTo(system);
+                        assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(1);
+                        assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(1);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(1);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("server-01", 1));
+                    }
+                }
+                
+                @Test @DisplayName("Is is captured in a snapshot")
+                void isCapturedInSnapshot() {
+                }
+                
+                @Nested @DisplayName("After stopping the heartbeat")
+                class AfterStopping {
+                    
+                    @BeforeEach
+                    void setUp() throws IOException {
+                        heartbeat.stop();
+                    }
+                    
+                    @Test @DisplayName("It is deleted in Zookeeper")
+                    void deletesZNode() throws Exception {
+                        CuratorFramework client = getClient();
+                        client.start();
+                        
+                        Stat stat = client.checkExists().forPath("/queries/" + queryId + "/heartbeats");
+                        assertThat(stat.getNumChildren()).isEqualTo(0);
+                    }
+                    
+                    @Test @DisplayName("The path is null")
+                    void hasNullPath() {
+                        assertThat(heartbeat.getPath()).isNull();
+                    }
+                    
+                    @Test @DisplayName("A failure will not occur if stopped again")
+                    void allowsMultipleStops() throws IOException {
+                        heartbeat.stop();
+                    }
+                    
+                    @Test @DisplayName("The next heartbeat is still sequential")
+                    void doesNotAffectSequencingOfFutureHeartbeats() {
+                        QueryHeartbeat heartbeat = tracker.createHeartbeat(queryId);
+                        String path = heartbeat.getPath();
+                        String sequence = path.substring(path.lastIndexOf('_') + 1);
+                        assertThat(sequence).isEqualTo("0000000001");
+                    }
+                    
+                    @Test @DisplayName("It is not captured in snapshot")
+                    void isNotCapturedInSnapshot() throws Exception {
+                        ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, system, queryLogic);
+                        
+                        assertThat(snapshot).isNotNull();
+                        assertThat(snapshot.getUserDn()).isEqualTo(user);
+                        assertThat(snapshot.getSystemName()).isEqualTo(system);
+                        assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                        assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+                        assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                        assertThat(snapshot.getTotalUserQueriesPerSystem()).isEmpty();
+                    }
+                    
+                    @Test @DisplayName("The query can be untracked")
+                    void canBeUntracked() throws Exception {
+                        tracker.stopTrackingQuery(queryId);
+                        
+                        CuratorFramework client = getClient();
+                        client.start();
+                        
+                        // Verify that the nodes were deleted as expected in Zookeeper.
+                        assertThat(client.checkExists().forPath("/users/" + user + "/" + queryId)).isNull();
+                        assertThat(client.checkExists().forPath("/systems/server-01/" + queryId)).isNull();
+                        assertThat(client.checkExists().forPath("/queryLogics/ShardQueryLogic/" + queryId)).isNull();
+                        assertThat(client.checkExists().forPath("/queries/" + queryId)).isNull();
+                    }
+                }
+            }
+            @Nested @DisplayName("When multiple heartbeat are created")
+            class WhenMultipleHeartbeatsCreated {
+                
+                private final List<QueryHeartbeat> heartbeats = new ArrayList<>();
+                
+                @BeforeEach
+                void setUp() {
+                    CuratorFramework client = getClient();
+                    client.start();
+                    heartbeats.add(tracker.createHeartbeat(queryId));
+                    heartbeats.add(tracker.createHeartbeat(queryId));
+                    heartbeats.add(tracker.createHeartbeat(queryId));
+                }
+                
+                @AfterEach
+                void tearDown() {
+                    heartbeats.clear();
+                }
+                
+                @Test @DisplayName("It is captured in a snapshot when one heartbeat is not stopped")
+                void isCapturedInSnapshotWhenOneHeartbeatRemains() throws Exception {
+                    heartbeats.get(0).stop();
+                    heartbeats.get(1).stop();
+                    
+                    ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, system, queryLogic);
+                    
+                    assertThat(snapshot.getUserDn()).isEqualTo(user);
+                    assertThat(snapshot.getSystemName()).isEqualTo(system);
+                    assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                    assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(1);
+                    assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(1);
+                    assertThat(snapshot.getTotalSystemQueries()).isEqualTo(1);
+                    assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(1);
+                    assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(1);
+                    assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("server-01", 1));
+                }
+                
+                @Test @DisplayName("It is not captured in a snapshot when all heartbeats are stopped")
+                void isNotCapturedInSnapshotWhenNoHeartbeatsRemain() throws Exception {
+                    heartbeats.get(0).stop();
+                    heartbeats.get(1).stop();
+                    heartbeats.get(2).stop();
+                    
+                    ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, system, queryLogic);
+                    
+                    assertThat(snapshot.getUserDn()).isEqualTo(user);
+                    assertThat(snapshot.getSystemName()).isEqualTo(system);
+                    assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                    assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                    assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(0);
+                    assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+                    assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                    assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                    assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of());
+                }
+            }
+        }
+        
+        @Nested @DisplayName("When a query has never been tracked")
+        public class WhenNeverTracked {
+            
+            @Test @DisplayName("A heartbeat cannot be created")
+            void cannotCreateHeartbeat() {
+                assertThatThrownBy(() -> tracker.createHeartbeat(queryId)).isInstanceOf(ActiveQueryException.class).hasMessage("Query " + queryId + " is not being tracked");
+            }
+            
+            @Test @DisplayName("It is not captured in snapshot")
+            void isNotCapturedInSnapshot() throws Exception {
+                ActiveQuerySnapshot snapshot = tracker.getSnapshot(user, system, queryLogic);
+                
+                assertThat(snapshot.getUserDn()).isEqualTo(user);
+                assertThat(snapshot.getSystemName()).isEqualTo(system);
+                assertThat(snapshot.getQueryLogic()).isEqualTo(queryLogic);
+                assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(0);
+                assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                assertThat(snapshot.getTotalSystemQueries()).isEqualTo(0);
+                assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(0);
+                assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(0);
+                assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of());
+            }
+            
+            @Test @DisplayName("A failure will not occur if explicitly untracked")
+            void allowsUntrackingAgain() {
+                assertThatNoException().isThrownBy(() -> tracker.stopTrackingQuery(queryId));
+            }
+        }
+    }
+    
+    @Nested @DisplayName("Given multiple queries")
+    class MultipleQueries {
+        
+        private final Map<String, QueryHeartbeat> heartbeats = new HashMap<>();
+        
+        @BeforeEach
+        void setUp() {
+            // The following data assumes that we will be fetching a snapshot for user userA, on system SYSTEM-01, for query logic TLDQueryLogic.
+            
+            // Counts towards totals for user, system, and query logic.
+            createActiveQuery("cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+            
+            // Counts towards totals for system and query logic.
+            createActiveQuery("cn=userB, c=us", "SYSTEM-01", "TLDQueryLogic");
+            createActiveQuery("cn=userB, c=us", "SYSTEM-01", "TLDQueryLogic");
+            createActiveQuery("cn=userB, c=us", "SYSTEM-01", "TLDQueryLogic");
+            
+            // Counts towards totals for user and system.
+            createActiveQuery("cn=userA, c=us", "SYSTEM-01", "OtherQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-01", "OtherQueryLogic");
+            
+            // Counts towards totals for system.
+            createActiveQuery("cn=userB, c=us", "SYSTEM-01", "OtherQueryLogic");
+            createActiveQuery("cn=userB, c=us", "SYSTEM-01", "OtherQueryLogic");
+            
+            // Counts towards totals for user and query logic.
+            createActiveQuery("cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-02", "TLDQueryLogic");
+            
+            // Counts towards totals for query logic.
+            createActiveQuery("cn=userB, c=us", "SYSTEM-02", "TLDQueryLogic");
+            createActiveQuery("cn=userB, c=us", "SYSTEM-02", "TLDQueryLogic");
+            createActiveQuery("cn=userB, c=us", "SYSTEM-02", "TLDQueryLogic");
+            
+            // Counts towards totals for user.
+            createActiveQuery("cn=userA, c=us", "SYSTEM-02", "OtherQueryLogic");
+            createActiveQuery("cn=userA, c=us", "SYSTEM-02", "OtherQueryLogic");
+            
+            // These entries should not count towards any totals.
+            createActiveQuery("cn=userB, c=us", "SYSTEM-02", "OtherQueryLogic");
+            createActiveQuery("cn=userB, c=us", "SYSTEM-02", "OtherQueryLogic");
+            createActiveQuery("cn=userC, c=us", "SYSTEM-03", "OtherQueryLogic");
+            createActiveQuery("cn=userC, c=us", "SYSTEM-03", "OtherQueryLogic");
+            createActiveQuery("cn=userC, c=us", "SYSTEM-03", "OtherQueryLogic");
+        }
+        
+        private void createActiveQuery(String userDn, String system, String queryLogic) {
+            String queryId = UUID.randomUUID().toString();
+            tracker.trackQuery(queryId, userDn, system, queryLogic);
+            QueryHeartbeat heartbeat = tracker.createHeartbeat(queryId);
+            heartbeats.put(queryId, heartbeat);
+        }
+        
+        @Test @DisplayName("All relevant queries are captured in snapshot")
+        void isCapturedInSnapshot() throws Exception {
+            ActiveQuerySnapshot snapshot = tracker.getSnapshot("cn=userA, c=us", "SYSTEM-01", "TLDQueryLogic");
+            
+            assertThat(snapshot.getUserDn()).isEqualTo("cn=userA, c=us");
+            assertThat(snapshot.getSystemName()).isEqualTo("SYSTEM-01");
+            assertThat(snapshot.getQueryLogic()).isEqualTo("TLDQueryLogic");
+            assertThat(snapshot.getTotalUserQueriesPerSystem()).isEqualTo(Map.of("SYSTEM-01", 6, "SYSTEM-02", 6));
+            assertThat(snapshot.getTotalUserQueriesOnSystem()).isEqualTo(6);
+            assertThat(snapshot.getTotalUserQueriesForQueryLogic()).isEqualTo(8);
+            assertThat(snapshot.getTotalSystemQueries()).isEqualTo(11);
+            assertThat(snapshot.getTotalSystemQueriesForQueryLogic()).isEqualTo(7);
+            assertThat(snapshot.getTotalQueriesForQueryLogic()).isEqualTo(14);
+        }
+        
+        @AfterEach
+        void tearDown() {
+            heartbeats.clear();
+        }
+    }
+    
+    private CuratorFramework getClient() {
+        // @formatter:off
+        return CuratorFrameworkFactory.builder()
+                        .connectString(server.getConnectString())
+                        .namespace("ActiveQueries")
+                        .sessionTimeoutMs(60000)
+                        .connectionTimeoutMs(60000)
+                        .retryPolicy(new RetryNTimes(10, 1000))
+                        .build();
+        // @formatter:on
+    }
+}

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/PatternMatcherTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/PatternMatcherTest.java
@@ -1,0 +1,37 @@
+package datawave.webservice.query.limit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PatternMatcherTest {
+    
+    /**
+     * Verify that null patterns are not allowed.
+     */
+    @Test
+    void testNullPattern() {
+        assertThatThrownBy(() -> new PatternMatcher(null)).isInstanceOf(NullPointerException.class).hasMessageContaining("pattern must not be null");
+    }
+    
+    /**
+     * Verify that a matching string returns true.
+     */
+    @Test
+    void testMatchingString() {
+        PatternMatcher patternMatcher = new PatternMatcher(Pattern.compile("TLD.*"));
+        assertThat(patternMatcher.matches("TLDQueryLogic")).isTrue();
+    }
+    
+    /**
+     * Verify that a non-matching string returns false.
+     */
+    @Test
+    void testNonMatchingString() {
+        PatternMatcher patternMatcher = new PatternMatcher(Pattern.compile("TLD.*"));
+        assertThat(patternMatcher.matches("OtherQueryLogic")).isFalse();
+    }
+}

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimitProviderTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimitProviderTest.java
@@ -1,0 +1,702 @@
+package datawave.webservice.query.limit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class QueryLimitProviderTest {
+    
+    /**
+     * Contains tests focused on validation of behavior when retrieving limits for systems.
+     */
+    private abstract static class BaseQueryLimitProviderTest {
+        protected final List<UserConfiguration> userConfigs = new ArrayList<>();
+        protected final List<SystemConfiguration> systemConfigs = new ArrayList<>();
+        protected final List<QueryLogicGroupConfiguration> queryLogicGroupConfigs = new ArrayList<>();
+        
+        protected int defaultUserQueryLimit = 100;
+        protected int defaultSystemQueryLimit = 5000;
+        
+        protected QueryLimitProvider provider;
+        
+        @AfterEach
+        void tearDown() {
+            userConfigs.clear();
+            systemConfigs.clear();
+            queryLogicGroupConfigs.clear();
+            provider = null;
+        }
+        
+        protected void initProvider() {
+            QueryLimitProviderConfiguration config = new QueryLimitProviderConfiguration();
+            config.setDefaultUserQueryLimit(defaultUserQueryLimit);
+            config.setDefaultSystemQueryLimit(defaultSystemQueryLimit);
+            config.setUserConfigs(userConfigs);
+            config.setSystemConfigs(systemConfigs);
+            config.setQueryLogicGroupConfigs(queryLogicGroupConfigs);
+            provider = new QueryLimitProvider(config);
+            provider.postConstruct();
+        }
+        
+        protected void givenDefaultUserQueryLimit(int defaultSystemQueryLimit) {
+            this.defaultUserQueryLimit = defaultSystemQueryLimit;
+        }
+        
+        protected void givenDefaultSystemQueryLimit(int defaultSystemQueryLimit) {
+            this.defaultSystemQueryLimit = defaultSystemQueryLimit;
+        }
+        
+        protected void givenUserConfig(String userDn, Integer queryLimit, Map<String, Integer> queryLogicGroupLimits) {
+            UserConfiguration config = new UserConfiguration();
+            config.setUserDn(userDn);
+            config.setQueryLimit(queryLimit);
+            config.setQueryLogicGroupLimits(queryLogicGroupLimits);
+            this.userConfigs.add(config);
+        }
+        
+        protected void givenSystemConfig(String systemPattern, Integer queryLimit, Boolean countsAgainstUserLimit, Map<String, Integer> queryLogicGroupLimits) {
+            SystemConfiguration config = new SystemConfiguration();
+            config.setSystemPattern(systemPattern);
+            config.setCountsAgainstsUserLimit(countsAgainstUserLimit);
+            config.setQueryLimit(queryLimit);
+            config.setQueryLogicGroupLimits(queryLogicGroupLimits);
+            this.systemConfigs.add(config);
+        }
+        
+        protected void givenQueryLogicGroupConfig(String groupName, String queryLogicPattern, int queryLimit) {
+            QueryLogicGroupConfiguration config = new QueryLogicGroupConfiguration();
+            config.setGroupName(groupName);
+            config.setQueryLogicPattern(queryLogicPattern);
+            config.setQueryLimit(queryLimit);
+            queryLogicGroupConfigs.add(config);
+        }
+    }
+    
+    @Nested
+    class DefaultLimitTests extends BaseQueryLimitProviderTest {
+        
+        /**
+         * Verify that a null configuration results in an exception.
+         */
+        @Test
+        void testNullConfig() {
+            QueryLimitProvider provider = new QueryLimitProvider(null);
+            assertThatThrownBy(provider::postConstruct).isInstanceOf(NullPointerException.class).hasMessageContaining("Configuration must not be null");
+        }
+        
+        /**
+         * Verify that when only the defaults are configured, that all limits returned adhere to them.
+         */
+        @Test
+        void testDefaultsOnly() {
+            initProvider();
+            
+            assertThat(provider.getDefaultUserQueryLimit()).isEqualTo(defaultUserQueryLimit);
+            assertThat(provider.getDefaultSystemQueryLimit()).isEqualTo(defaultSystemQueryLimit);
+            
+            UserQueryLimit actualUserLimit = provider.getUserLimit("cn=testuser, ou=my department, o=my company, st=some-state, c=us");
+            UserQueryLimit expectedUserLimit = UserQueryLimit.fromDefaults("cn=testuser, ou=my department, o=my company, st=some-state, c=us", 100);
+            assertThat(actualUserLimit).isEqualTo(expectedUserLimit);
+            
+            SystemQueryLimit actualSystemLimit = provider.getSystemLimit("SYSTEM-01");
+            SystemQueryLimit expectedSystemLimit = SystemQueryLimit.fromDefaults("SYSTEM-01", 5000);
+            assertThat(actualSystemLimit).isEqualTo(expectedSystemLimit);
+            
+            Optional<QueryLogicGroupLimit> actualQueryLogicGroupLimit = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actualQueryLogicGroupLimit.isPresent()).isFalse();
+        }
+        
+        /**
+         * Verify that we do not allow a default user query limit that is 0 or less.
+         */
+        @Test
+        void testInvalidDefaultUserQueryLimit() {
+            givenDefaultUserQueryLimit(0);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Default user query limit must be greater than 0");
+        }
+        /**
+         * Verify that we do not allow a default system query limit that is 0 or less.
+         */
+        @Test
+        void testInvalidDefaultSystemQueryLimit() {
+            givenDefaultSystemQueryLimit(0);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Default system query limit must be greater than 0");
+        }
+    
+    }
+    
+    /**
+     * Contains tests focused on validating behavior when retrieving limits for query logics.
+     */
+    @Nested
+    class QueryLogicGroupLimitTests extends BaseQueryLimitProviderTest {
+        
+        /**
+         * Verify that configurations with blank group names are forbidden.
+         */
+        @Test
+        void testConfigWithBlankGroupName() {
+            givenQueryLogicGroupConfig(" ", "TLDQueryLogic", 50);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Query logic group limit configuration given with blank group name");
+        }
+        
+        /**
+         * Verify that multiple configurations with the same group name are forbidden.
+         */
+        @Test
+        void testMultipleConfigsWithSameGroupName() {
+            givenQueryLogicGroupConfig("TLD", "TLDQueryLogic", 50);
+            givenQueryLogicGroupConfig("TLD", "TLD*", 25);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Multiple query logic group configurations given with group name 'TLD'");
+        }
+        /**
+         * Verify that configurations with negative limits are forbidden.
+         */
+        @Test
+        void testConfigWithNegativeLimit() {
+            givenQueryLogicGroupConfig("TLD", "TLDQueryLogic", -1);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("Negative limit given for query logic group 'TLD'");
+        }
+        
+        /**
+         * Verify that configurations with blank query logic patterns are forbidden.
+         */
+        @Test
+        void testConfigWithBlankQueryLogicPattern() {
+            givenQueryLogicGroupConfig("TLD", " ", 50);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("Blank query logic pattern given for query logic group 'TLD'");
+        }
+        
+        /**
+         * Verify that query logic patterns that cannot be compiled are forbidden.
+         */
+        @Test
+        void testConfigWithUncompilableQueryLogicPattern() {
+            givenQueryLogicGroupConfig("TLD", "TLD[", 50);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("Invalid regex in query logic pattern 'TLD[' for query logic group 'TLD'");
+        }
+        
+        /**
+         * Verify that we support {@code *} as a wildcard pattern.
+         */
+        @Test
+        void testImpliedWildcardQueryLogicPattern() {
+            givenQueryLogicGroupConfig("ImpliedWildcard", "*", 25);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> actual = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actual.isPresent()).isTrue();
+            assertThat(actual.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("ImpliedWildcard", 25));
+        }
+        
+        /**
+         * Verify that an explicit wildcard pattern returns a limit for any query logic.
+         */
+        @Test
+        void testExplicitWildcardQueryLogicPattern() {
+            givenQueryLogicGroupConfig("ExplicitWildcard", ".*", 25);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> actual = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actual.isPresent()).isTrue();
+            assertThat(actual.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("ExplicitWildcard", 25));
+        }
+        
+        /**
+         * Verify that when we have a partial match and a wildcard match, that the partial match is returned.
+         */
+        @Test
+        void testPartialMatchOverridesWildcardMatch() {
+            givenQueryLogicGroupConfig("Wildcard", ".*", 25);
+            givenQueryLogicGroupConfig("PartialMatch", "TLD.*", 40);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> actual = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actual.isPresent()).isTrue();
+            assertThat(actual.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("PartialMatch", 40));
+        }
+        
+        /**
+         * Verify that when we have multiple partial matches, that the one with the lowest limit is returned.
+         */
+        @Test
+        void testMultiplePartialMatchesReturnsLowestLimit() {
+            givenQueryLogicGroupConfig("PartialMatch1", "TLD.*", 25);
+            givenQueryLogicGroupConfig("PartialMatch2", ".*TLD.*", 40);
+            givenQueryLogicGroupConfig("PartialMatch3", ".*LD.*", 15);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> actual = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actual.isPresent()).isTrue();
+            assertThat(actual.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("PartialMatch3", 15));
+        }
+        
+        /**
+         * Verify that when we have an exact match, partial match and a wildcard match, that the exact match is returned.
+         */
+        @Test
+        void testExactMatchOverridesPartialAndWildcardMatch() {
+            givenQueryLogicGroupConfig("Wildcard", ".*", 25);
+            givenQueryLogicGroupConfig("PartialMatch", "TLD.*", 40);
+            givenQueryLogicGroupConfig("ExactMatch", "TLDQueryLogic", 55);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> actual = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actual.isPresent()).isTrue();
+            assertThat(actual.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("ExactMatch", 55));
+        }
+        
+        /**
+         * Verify that when we have multiple exact matches, that the one with the lowest limit is returned.
+         */
+        @Test
+        void testMultipleExactMatchesReturnsLowestLimit() {
+            givenQueryLogicGroupConfig("ExactMatch1", "TLDQueryLogic", 25);
+            givenQueryLogicGroupConfig("ExactMatch2", "TLDQueryLogic", 40);
+            givenQueryLogicGroupConfig("ExactMatch3", "TLDQueryLogic", 55);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> actual = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(actual.isPresent()).isTrue();
+            assertThat(actual.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("ExactMatch1", 25));
+        }
+        
+        /**
+         * Verify that when there is no match against a query logic group, that an empty optional is returned.
+         */
+        @Test
+        void testNoMatch() {
+            givenQueryLogicGroupConfig("PartialMatch", "TLD.*", 40);
+            givenQueryLogicGroupConfig("ExactMatch", "TLDQueryLogic", 55);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> optional = provider.getQueryLogicGroupLimit("TLDQueryLogic");
+            assertThat(optional.isPresent()).isTrue();
+        }
+        
+        /**
+         * Verify that when attempting to fetch the best overridden limit, that if there is no match, then an empty optional is returned.
+         */
+        @Test
+        void testOverriddenLimitWithNoMatch() {
+            givenQueryLogicGroupConfig("PartialMatch", "TLD.*", 40);
+            givenQueryLogicGroupConfig("ExactMatch", "TLDQueryLogic", 55);
+         
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> optional = provider.getOverriddenQueryLogicGroupLimit("SYSTEM_01", "OtherQueryLogic", Map.of("ExactMatch", 100));
+            assertThat(optional.isPresent()).isFalse();
+        }
+        
+        /**
+         * Verify that when there are multiple matches for overridden limits, that the best match (that was present in the map of overridden limits) with the
+         * lowest limit is returned.
+         */
+        @Test
+        void testOverriddenPartialMatchesWithNonOverriddenExactMatch() {
+            givenQueryLogicGroupConfig("PartialMatch01", "TLD.*", 200);
+            givenQueryLogicGroupConfig("PartialMatch02", "TL.*", 75);
+            givenQueryLogicGroupConfig("PartialMatch03", "TLDQuery[Ll]ogic", 300);
+            givenQueryLogicGroupConfig("ExactMatch", "TLDQueryLogic", 5);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> optional = provider.getOverriddenQueryLogicGroupLimit("SYSTEM_01", "TLDQueryLogic", Map.of("PartialMatch01", 50, "PartialMatch03", 20));
+            assertThat(optional.isPresent()).isTrue();
+            
+            // We should not receive the group ExactMatch, since we are filtering our results by the groups present in the map of overridden limits.
+            assertThat(optional.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("PartialMatch03", 20));
+        }
+        
+        /**
+         * Verify that when there are multiple matches for overridden limits, that the best match (that was present in the map of overridden limits) with the
+         * lowest limit is returned.
+         */
+        @Test
+        void testOverriddenPartialMatchesWithOverriddenExactMatch() {
+            givenQueryLogicGroupConfig("PartialMatch01", "TLD.*", 200);
+            givenQueryLogicGroupConfig("PartialMatch02", "TL.*", 75);
+            givenQueryLogicGroupConfig("PartialMatch03", "TLDQuery[Ll]ogic", 300);
+            givenQueryLogicGroupConfig("ExactMatch", "TLDQueryLogic", 5);
+            
+            initProvider();
+            
+            Optional<QueryLogicGroupLimit> optional = provider.getOverriddenQueryLogicGroupLimit("SYSTEM_01", "TLDQueryLogic", Map.of("PartialMatch01", 50, "PartialMatch03", 20, "ExactMatch", 200));
+            assertThat(optional.isPresent()).isTrue();
+            
+            // We should receive ExactMatch this time, since it was present in the map of overridden limits.
+            assertThat(optional.get()).isEqualTo(QueryLogicGroupLimit.fromConfig("ExactMatch", 200));
+        }
+    }
+    
+    /**
+     * Contains tests focused on validation of behavior when retrieving limits for users.
+     */
+    @Nested
+    class UserLimitTests extends BaseQueryLimitProviderTest {
+        
+        /**
+         * Verify that blank user DNs are forbidden.
+         */
+        @Test
+        void testConfigWithBlankDn() {
+            givenUserConfig("  ", null, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("User query limit configuration given with blank user DN");
+        }
+        
+        /**
+         * Verify that multiple configurations with the same user DN are forbidden.
+         */
+        @Test
+        void testMultipleConfigsWithSameUserDn() {
+            givenUserConfig("cn=test user, c=us", 100, null);
+            givenUserConfig("cn=test user, c=us", 200, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("Multiple query limit configurations specified for user 'cn=test user, c=us'");
+        }
+        
+        /**
+         * Verify that negative query limits are forbidden.
+         */
+        @Test
+        void testConfigWithNegativeLimit() {
+            givenUserConfig("cn=test user, c=us", -1, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("Negative user query limit given for user 'cn=test user, c=us'");
+        }
+        
+        /**
+         * Verify that user configurations with query logic group names that do not match any existing query logic group configuration are forbidden.
+         */
+        @Test
+        void testUserConfigurationWithNonExistentQueryLogicGroupName() {
+            givenUserConfig("cn=test user, c=us", null, Map.of("TLD", 200));
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class).hasMessage("Non-existent query logic groups specified for query limit configuration for user 'cn=test user, c=us': [TLD]");
+        }
+        
+        /**
+         * Verify that user configurations that override various aspects of query limits are extracted correctly.
+         */
+        @Test
+        void testUserConfigurations() {
+            // Provide some query logic groups.
+            givenQueryLogicGroupConfig("TLDLogics", "TLDQueryLogic", 50);
+            givenQueryLogicGroupConfig("ExpensiveLogics", "Expensive*", 10);
+            
+            // A user configuration that overrides the user query limit, but does not override any query logic group limits.
+            givenUserConfig("cn=userA, c=us", 200, null);
+            
+            // A user configuration that does not override the user query limit, but does override the TLDLogics group limit.
+            givenUserConfig("cn=userB, c=us", null, Map.of("TLDLogics", 200));
+            
+            // A user configuration that overrides both the user query limit, and the TLDLogics group limit.
+            givenUserConfig("cn=userC, c=us", 50, Map.of("TLDLogics", 10));
+            
+            initProvider();
+            
+            // Assert that a user with no configuration has the default limits.
+            assertThat(provider.getUserLimit("cn=userD, c=us")).isEqualTo(UserQueryLimit.fromDefaults("cn=userD, c=us", defaultUserQueryLimit));
+            
+            // Assert userA.
+            assertThat(provider.getUserLimit("cn=userA, c=us")).isEqualTo(UserQueryLimit.fromConfig("cn=userA, c=us", 200, Map.of()));
+            
+            // Assert userB.
+            assertThat(provider.getUserLimit("cn=userB, c=us")).isEqualTo(UserQueryLimit.fromConfig("cn=userB, c=us", defaultUserQueryLimit, Map.of("TLDLogics", 200)));
+            
+            // Assert userC.
+            assertThat(provider.getUserLimit("cn=userC, c=us")).isEqualTo(UserQueryLimit.fromConfig("cn=userC, c=us", 50, Map.of("TLDLogics", 10)));
+        }
+    
+    }
+    
+    @Nested
+    class SystemLimitTests extends BaseQueryLimitProviderTest {
+        
+        /**
+         * Verify that configurations with blank system patterns are forbidden.
+         */
+        @Test
+        void testConfigWithBlankSystemPattern() {
+            givenSystemConfig(" ", 10, true, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("System query limit configuration specified with blank system pattern");
+        }
+        
+        /**
+         * Verify that configurations with regex system patterns that cannot be compiled are forbidden.
+         */
+        @Test
+        void testConfigWithUncompilableSystemPattern() {
+            givenSystemConfig("SYS[", 10, true, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Invalid regex in system pattern 'SYS['");
+        }
+        
+        /**
+         * Verify that multiple configurations using the same system patterns are forbidden.
+         */
+        @Test
+        void testMultipleConfigsWithSameSystemPattern() {
+            givenSystemConfig("SYSTEM_01*", 10, true, null);
+            givenSystemConfig("SYSTEM_01*", 10, true, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Multiple query limit configurations specified with system pattern 'SYSTEM_01*'");
+        }
+        
+        /**
+         * Verify that configurations with conflicting system patterns that are equivalent exact matches are forbidden.
+         */
+        @Test
+        void testEquivalentExactMatchPatterns() {
+            givenSystemConfig("SYSTEM_01", 10, true, null); // Literals only.
+            givenSystemConfig("SYSTEM\\_01", 10, true, null); // Literals and escaped literals.
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("System pattern 'SYSTEM\\_01' will resolve to an exact match that is equivalent to system pattern 'SYSTEM_01' from "
+                                            + "another system configuration.");
+        }
+        
+        /**
+         * Verify that configurations with negative query limits are forbidden.
+         */
+        @Test
+        void testNegativeQueryLimit() {
+            givenSystemConfig("SYSTEM_01*", -1, true, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Negative query limit specified for system pattern 'SYSTEM_01*'");
+        }
+        
+        /**
+         * Verify that configurations with an implied wildcard system pattern {@code *} that are configured to not apply to user limits are forbidden.
+         */
+        @Test
+        void testImpliedWildcardSystemPatternThatDoesNotApplyToUserLimit() {
+            givenSystemConfig("*", 10, false, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("System pattern '*' is wildcard-only and may not be used to override whether queries count against user limits to false");
+        }
+        
+        /**
+         * Verify that configurations with an explicit wildcard system pattern that are configured to not apply to user limits are forbidden.
+         */
+        @Test
+        void testExplicitWildcardSystemPatternThatDoesNotApplyToUserLimit() {
+            givenSystemConfig(".*", 10, false, null);
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("System pattern '.*' is wildcard-only and may not be used to override whether queries count against user limits to false");
+        }
+        
+        /**
+         * Verify that configurations with non-existent query logic groups are forbidden.
+         */
+        @Test
+        void testConfigurationWithNonExistentQueryLogicGroup() {
+            givenSystemConfig("SYSTEM-01", 100, true, Map.of("TLD", 200));
+            
+            assertThatThrownBy(this::initProvider).isInstanceOf(IllegalArgumentException.class)
+                            .hasMessage("Non-existent query logic groups given for system pattern 'SYSTEM-01': [TLD]");
+        }
+        
+        /**
+         * Verify that we support {@code *} as a wildcard pattern.
+         */
+        @Test
+        void testImpliedWildcardQueryLogicPattern() {
+            givenSystemConfig("*", 100, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-01")).isEqualTo(SystemQueryLimit.fromConfig("*", 100, true, null));
+        }
+        
+        /**
+         * Verify that an explicit wildcard pattern returns a limit for any system.
+         */
+        @Test
+        void testExplicitWildcardQueryLogicPattern() {
+            givenSystemConfig(".*", 100, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-01")).isEqualTo(SystemQueryLimit.fromConfig(".*", 100, true, null));
+        }
+        
+        /**
+         * Verify that when we have a partial match and a wildcard match, that the partial match is returned.
+         */
+        @Test
+        void testPartialMatchOverridesWildcardMatch() {
+            givenSystemConfig("SYSTEM-.*", 75, false, null);
+            givenSystemConfig(".*", 100, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-.*")).isEqualTo(SystemQueryLimit.fromConfig("SYSTEM-.*", 75, false, null));
+        }
+        
+        /**
+         * Verify that when we have multiple partial matches, that the one with the lowest limit is returned.
+         */
+        @Test
+        void testMultiplePartialMatchesReturnsLowestLimit() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-AB.*", 40, true, null);
+            givenSystemConfig("SYSTEM-ABC.*", 30, true, null);
+            givenSystemConfig(".*", 100, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-ABC")).isEqualTo(SystemQueryLimit.fromConfig("SYSTEM-ABC.*", 30, true, null));
+        }
+        
+        /**
+         * Verify that when we have an exact match, partial match and a wildcard match, that the exact match is returned.
+         */
+        @Test
+        void testExactMatchOverridesPartialAndWildcardMatch() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-AB.*", 40, true, null);
+            givenSystemConfig("SYSTEM-ABC.*", 30, true, null);
+            givenSystemConfig("SYSTEM-ABC", 400, true, null);
+            givenSystemConfig(".*", 100, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-ABC")).isEqualTo(SystemQueryLimit.fromConfig("SYSTEM-ABC", 400, true, null));
+        }
+        
+        /**
+         * Verify that a system pattern that consists only of literals and escaped literals is treated as an exact match.
+         */
+        @Test
+        void testExactMatchThatHasEscapedLiterals() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-AB.*", 40, true, null);
+            givenSystemConfig("SYSTEM-ABC.*", 30, true, null);
+            givenSystemConfig("SYSTEM\\-ABC", 400, true, null);
+            givenSystemConfig(".*", 100, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-ABC")).isEqualTo(SystemQueryLimit.fromConfig("SYSTEM\\-ABC", 400, true, null));
+        }
+        
+        /**
+         * Verify that when there is no match, that default limits are returned.
+         */
+        @Test
+        void testNoMatch() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-AB.*", 40, true, null);
+            givenSystemConfig("SYSTEM-ABC.*", 30, true, null);
+            givenSystemConfig("SYSTEM-ABC", 400, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.getSystemLimit("SYSTEM-ECHO")).isEqualTo(SystemQueryLimit.fromDefaults("SYSTEM-ECHO", defaultSystemQueryLimit));
+        }
+        
+        /**
+         * Verify that when there is no configured match for a system, that queries count against the user limit for the system.
+         */
+        @Test
+        void testCountsAgainstUserLimitNoMatch() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-ABC", 400, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.systemCountsAgainstUserLimit("SYSTEM-ECHO")).isTrue();
+        }
+        
+        /**
+         * Verify that an exact match where queries count against the user limits returns true.
+         */
+        @Test
+        void testCountsAgainstUserLimitWithExactMatchWithTrue() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-ABC", 400, true, null);
+            
+            initProvider();
+            
+            assertThat(provider.systemCountsAgainstUserLimit("SYSTEM-ABC")).isTrue();
+        }
+        
+        /**
+         * Verify that an exact match where queries count against the user limits returns false.
+         */
+        @Test
+        void testCountsAgainstUserLimitWithExactMatchWithFalse() {
+            givenSystemConfig("SYSTEM-A.*", 75, true, null);
+            givenSystemConfig("SYSTEM-ABC", 400, false, null);
+            
+            initProvider();
+            
+            assertThat(provider.systemCountsAgainstUserLimit("SYSTEM-ABC")).isFalse();
+        }
+        
+        /**
+         * Verify that when there is no exact match and there are multiple partial matches where at least one counts queries against the user limit, true is
+         * returned.
+         */
+        @Test
+        void testCountsAgainstUserLimitWithPartialMatchWithTrue() {
+            givenSystemConfig("SYSTEM-A.*", 75, true, null);
+            givenSystemConfig("SYSTEM-AB.*", 400, false, null);
+            givenSystemConfig("SYSTEM-ABC*", 400, false, null);
+            
+            initProvider();
+            
+            assertThat(provider.systemCountsAgainstUserLimit("SYSTEM-ABC")).isTrue();
+        }
+        
+        /**
+         * Verify that when there is no exact match and there are multiple partial matches where all do not count queries against the user limit, false is
+         * returned.
+         */
+        @Test
+        void testCountsAgainstUserLimitWithAllPartialMatchWithFalse() {
+            givenSystemConfig("SYSTEM-A.*", 75, false, null);
+            givenSystemConfig("SYSTEM-AB.*", 400, false, null);
+            givenSystemConfig("SYSTEM-ABC.*", 400, false, null);
+            
+            initProvider();
+            
+            assertThat(provider.systemCountsAgainstUserLimit("SYSTEM-ABC")).isFalse();
+        }
+    }
+}

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterTest.java
@@ -1,0 +1,247 @@
+package datawave.webservice.query.limit;
+
+import org.easymock.EasyMockExtension;
+import org.easymock.Mock;
+import org.easymock.TestSubject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+@ExtendWith(EasyMockExtension.class)
+class QueryLimiterTest {
+    
+    private static final String userDn = "cn=testuser, c=us";
+    private static final String system = "SYSTEM-01";
+    private static final String queryLogic = "TLDQueryLogic";
+    
+    @TestSubject
+    private final QueryLimiter limiter = new QueryLimiter();
+    
+    @Mock
+    private QueryLimiter.SnapshotProvider snapshotProvider;
+    
+    @Mock
+    private QueryLimitProvider limitProvider;
+    
+    @Mock
+    private ActiveQuerySnapshot snapshot;
+    
+    @BeforeEach
+    void setUp() throws Exception {
+        expect(snapshotProvider.getSnapshot(userDn, system, queryLogic)).andReturn(snapshot);
+    }
+    
+    /**
+     * Verify that a user that meets their configured max user query limit results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsConfiguredUserQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        expectUserQueryLimit(UserQueryLimit.fromConfig(userDn, 100, Map.of()));
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("User 'cn=testuser, c=us' has reached max user query limit of 100");
+    }
+    
+    /**
+     * Verify that a user that meets their default max user query limit results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsDefaultUserQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        expectUserQueryLimit(UserQueryLimit.fromDefaults(userDn, 100));
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("User 'cn=testuser, c=us' has reached max default user query limit of 100");
+    }
+    
+    /**
+     * Verify that a user that meets their max user query limit for an overridden query logic group limit results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsUserQueryLogicGroupQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of("TLD", 25));
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 25), 25);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("User 'cn=testuser, c=us' has reached max user query limit of 25 for query logic TLDQueryLogic");
+    }
+    
+    /**
+     * Verify that a system that meets their configured max query limit results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsConfiguredSystemQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of("TLD", 25));
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 25), 20);
+        expectTotalSystemQueries(SystemQueryLimit.fromConfig("SYSTEM-01", 100, true, Map.of()), 100);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("System 'SYSTEM-01' has reached max system query limit of 100");
+    }
+    
+    /**
+     * Verify that a system that meets their default max query limit results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsDefaultSystemQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of("TLD", 25));
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 25), 20);
+        expectTotalSystemQueries(SystemQueryLimit.fromDefaults("SYSTEM-01", 1000), 1000);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("System 'SYSTEM-01' has reached max default system query limit of 1000");
+    }
+    
+    /**
+     * Verify that a system that meets their max query limit for an overridden query logic group limit results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsSystemQueryLogicGroupQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of("TLD", 25));
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 25), 20);
+        SystemQueryLimit systemQueryLimit = SystemQueryLimit.fromConfig("SYSTEM-01", 1000, true, Map.of("TLD", 200));
+        expectTotalSystemQueries(systemQueryLimit, 500);
+        expectOverriddenQueryLogicLimit(systemQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 200), 200);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("System 'SYSTEM-01' has reached max query limit of 200 for query logic TLDQueryLogic");
+    }
+    
+    /**
+     * Verify that meets the default user query limit for a query logic group that they do not override results in an exceeds limit response.
+     */
+    @Test
+    void testExceedsDefaultQueryLogicGroupQueryLimit() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of());
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, null, 25);
+        SystemQueryLimit systemQueryLimit = SystemQueryLimit.fromConfig("SYSTEM-01", 1000, true, Map.of("TLD", 200));
+        expectTotalSystemQueries(systemQueryLimit, 500);
+        expectOverriddenQueryLogicLimit(systemQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 200), 150);
+        expectQueryLogicLimit(QueryLogicGroupLimit.fromConfig("TLD", 25), 25);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isTrue();
+        assertThat(response.getMessage()).isEqualTo("User 'cn=testuser, c=us' has reached max default query limit of 25 for query logic TLDQueryLogic");
+    }
+    
+    /**
+     * Verify that when no limits are exceeded, the response reflects that.
+     */
+    @Test
+    void testNoLimitsExceeded() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of());
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, null, 25);
+        SystemQueryLimit systemQueryLimit = SystemQueryLimit.fromConfig("SYSTEM-01", 1000, true, Map.of("TLD", 200));
+        expectTotalSystemQueries(systemQueryLimit, 500);
+        expectOverriddenQueryLogicLimit(systemQueryLimit, QueryLogicGroupLimit.fromConfig("TLD", 200), 150);
+        expectQueryLogicLimit(QueryLogicGroupLimit.fromConfig("TLD", 25), 15);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isFalse();
+        assertThat(response.getMessage()).isNull();
+    }
+    
+    /**
+     * Verify that when no matching query logic group limits are found, no issues occur.
+     */
+    @Test
+    void testNoQueryLogicGroupLimitsFound() throws Exception {
+        expectTotalUserQueries(Map.of(system, 100), Set.of());
+        UserQueryLimit userQueryLimit = UserQueryLimit.fromConfig(userDn, 200, Map.of());
+        expectUserQueryLimit(userQueryLimit);
+        expectOverriddenQueryLogicLimit(userQueryLimit, null, 25);
+        SystemQueryLimit systemQueryLimit = SystemQueryLimit.fromConfig("SYSTEM-01", 1000, true, Map.of("TLD", 200));
+        expectTotalSystemQueries(systemQueryLimit, 500);
+        expectOverriddenQueryLogicLimit(systemQueryLimit, null, 150);
+        expectQueryLogicLimit(null, 15);
+        
+        replay(snapshotProvider, limitProvider, snapshot);
+        
+        QueryLimiterResponse response = limiter.checkForLimits(userDn, system, queryLogic);
+        assertThat(response.exceedsLimit()).isFalse();
+        assertThat(response.getMessage()).isNull();
+    }
+    
+    private void expectTotalUserQueries(Map<String,Integer> userQueriesPerSystem, Set<String> systemsNotCountingTowardsUserLimits) {
+        expect(snapshot.getTotalUserQueriesPerSystem()).andReturn(userQueriesPerSystem);
+        for(String system : userQueriesPerSystem.keySet()) {
+            expect(limitProvider.systemCountsAgainstUserLimit(system)).andReturn(!systemsNotCountingTowardsUserLimits.contains(system));
+        }
+    }
+    
+    private void expectUserQueryLimit(UserQueryLimit userQueryLimit) {
+        expect(limitProvider.getUserLimit(userDn)).andReturn(userQueryLimit);
+    }
+    
+    private void expectOverriddenQueryLogicLimit(UserQueryLimit userQueryLimit, QueryLogicGroupLimit groupLimit, int totalUserQueriesForQueryLogic) {
+        Optional<QueryLogicGroupLimit> optional = Optional.ofNullable(groupLimit);
+        expect(limitProvider.getOverriddenQueryLogicGroupLimit(userDn, queryLogic, userQueryLimit.getQueryLogicGroupLimits())).andReturn(optional);
+        if(optional.isPresent()) {
+            expect(snapshot.getTotalUserQueriesForQueryLogic()).andReturn(totalUserQueriesForQueryLogic);
+        }
+    }
+    
+    private void expectTotalSystemQueries(SystemQueryLimit systemQueryLimit, int totalSystemQueries) {
+        expect(limitProvider.getSystemLimit(system)).andReturn(systemQueryLimit);
+        expect(snapshot.getTotalSystemQueries()).andReturn(totalSystemQueries);
+    }
+    
+    private void expectOverriddenQueryLogicLimit(SystemQueryLimit userQueryLimit, QueryLogicGroupLimit groupLimit, int totalSystemQueriesForQueryLogic) {
+        Optional<QueryLogicGroupLimit> optional = Optional.ofNullable(groupLimit);
+        expect(limitProvider.getOverriddenQueryLogicGroupLimit(system, queryLogic, userQueryLimit.getQueryLogicGroupLimits())).andReturn(optional);
+        if(optional.isPresent()) {
+            expect(snapshot.getTotalSystemQueriesForQueryLogic()).andReturn(totalSystemQueriesForQueryLogic);
+        }
+    }
+    
+    private void expectQueryLogicLimit(QueryLogicGroupLimit groupLimit, int totalUserQueriesForQueryLogic) {
+        Optional<QueryLogicGroupLimit> optional = Optional.ofNullable(groupLimit);
+        expect(limitProvider.getQueryLogicGroupLimit(queryLogic)).andReturn(optional);
+        if(optional.isPresent()) {
+            expect(snapshot.getTotalUserQueriesForQueryLogic()).andReturn(totalUserQueriesForQueryLogic);
+        }
+    }
+}

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/StringMatcherTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/StringMatcherTest.java
@@ -1,0 +1,29 @@
+package datawave.webservice.query.limit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StringMatcherTest {
+    
+    /**
+     * Verify that a null string is forbidden.
+     */
+    @Test
+    void testNullValue() {
+        assertThatThrownBy(() -> new StringMatcher(null)).isInstanceOf(NullPointerException.class).hasMessageContaining("value must not be null");
+    }
+    
+    @Test
+    void testNonMatch() {
+        StringMatcher matcher = new StringMatcher("abc");
+        assertThat(matcher.matches("abcdef")).isFalse();
+    }
+    
+    @Test
+    void testMatch() {
+        StringMatcher matcher = new StringMatcher("abc");
+        assertThat(matcher.matches("abc")).isTrue();
+    }
+}

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/WildcardMatcherTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/WildcardMatcherTest.java
@@ -1,0 +1,17 @@
+package datawave.webservice.query.limit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WildcardMatcherTest {
+    
+    /**
+     * Verify that the wildcard matcher always returns true.
+     */
+    @Test
+    void testMatchingBehavior() {
+        WildcardMatcher matcher = new WildcardMatcher();
+        assertThat(matcher.matches("anything")).isTrue();
+    }
+}


### PR DESCRIPTION
Initial work for supporting enforcing concurrent query limits. Currently working on integration testing and identifying logical points for starting/stopping query 'heartbeats'.

Resolves #3100 