### PR TITLE
Fix issues with visitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitor.java
@@ -1,12 +1,13 @@
 package datawave.query.jexl.visitors;
 
-import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl3.parser.ASTEQNode;
@@ -22,14 +23,13 @@ import org.apache.commons.jexl3.parser.ASTNENode;
 import org.apache.commons.jexl3.parser.ASTNRNode;
 import org.apache.commons.jexl3.parser.ASTOrNode;
 import org.apache.commons.jexl3.parser.JexlNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.hadoop.util.Sets;
 
-import datawave.microservice.query.Query;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.functions.JexlFunctionArgumentDescriptorFactory;
 import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
 import datawave.query.util.MetadataHelper;
+import datawave.util.time.DateHelper;
 
 /**
  * Class to check that each query node contains a field which exists in the schema for the given date range.
@@ -42,17 +42,11 @@ import datawave.query.util.MetadataHelper;
  */
 public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
-    private static final Logger log = LoggerFactory.getLogger(FieldMissingFromDateRangeVisitor.class);
-
     private final MetadataHelper helper;
     private final Set<String> datatypeFilter;
-    private final Query querySettings;
-    private final Set<String> specialFields;
 
-    public FieldMissingFromDateRangeVisitor(MetadataHelper helper, Set<String> datatypeFilter, Set<String> specialFields, Query querySettings) {
+    public FieldMissingFromDateRangeVisitor(MetadataHelper helper, Set<String> datatypeFilter) {
         this.helper = helper;
-        this.querySettings = querySettings;
-        this.specialFields = specialFields;
         // if given datatypeFilter is empty or null, assume that means ALL datatypes
         if (datatypeFilter == null) {
             datatypeFilter = Collections.emptySet();
@@ -61,74 +55,26 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
     }
 
     @SuppressWarnings("unchecked")
-    public static Set<String> getNonIngestedFields(MetadataHelper helper, ASTJexlScript script, Set<String> datatypes, Set<String> specialFields,
-                    Query querySettings) {
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd");
-        FieldMissingFromDateRangeVisitor visitor = new FieldMissingFromDateRangeVisitor(helper, datatypes, specialFields, querySettings);
+    public static List<ImmaterialNode> getNonIngestedFields(MetadataHelper helper, ASTJexlScript script, Set<String> datatypes, Set<String> specialFields,
+                    Date beginDate, Date endDate) {
+        if (datatypes == null) {
+            datatypes = Collections.emptySet();
+        }
+
         // Collect the fields
-        Set<String> collectedFields = (Set<String>) script.jjtAccept(visitor, new LinkedHashSet<>());
-        if (collectedFields != null && !collectedFields.isEmpty()) {
-            Set<String> missingFields = visitor.helper.getMissingFieldsInDateRange(collectedFields, visitor.datatypeFilter,
-                            formatter.format(visitor.querySettings.getBeginDate()), formatter.format(visitor.querySettings.getEndDate()),
-                            visitor.specialFields);
-            if (script.jjtGetChild(0) instanceof ASTOrNode) {
-                // If it is an OR node, check if all fields are missing.
-                if (missingFields.containsAll(collectedFields)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Found missing fields:  {}", missingFields);
-                    }
-                    return missingFields;
-                } else {
-                    // If only some are missing, we do not want to return any.
-                    return Collections.emptySet();
-                }
-            } else {
-                // Not an OR node, so return the missing fields we found.
-                return missingFields;
-            }
-        } else {
-            return Collections.emptySet();
+        FieldMissingFromDateRangeVisitor visitor = new FieldMissingFromDateRangeVisitor(helper, datatypes);
+        List<CandidateNode> nodeData = (List<CandidateNode>) script.jjtAccept(visitor, new ArrayList<>());
+
+        if (nodeData.isEmpty()) {
+            return Collections.emptyList();
         }
-    }
 
-    /**
-     * @param node
-     *            Jexl node
-     * @param data
-     *            The set of names which we have determined have not been ingested during the date range.
-     * @return the updated set of names which have not been ingested during the date range.
-     */
-    private Object collectFields(ASTOrNode node, Object data) throws TableNotFoundException {
-        @SuppressWarnings("unchecked")
-        Set<String> collectedFieldNames = (Set<String>) data;
-        List<ASTIdentifier> identifiers;
+        Set<String> allFields = nodeData.stream().map(CandidateNode::getFields).flatMap(Set::stream).collect(Collectors.toSet());
+        Set<String> missingFields = visitor.helper.getMissingFieldsInDateRange(allFields, datatypes, DateHelper.format(beginDate), DateHelper.format(endDate),
+                        specialFields);
 
-        int numChildren = node.jjtGetNumChildren();
-
-        for (int i = 0; i < numChildren; i++) {
-            JexlNode child = node.jjtGetChild(i);
-
-            // A node could be literal == literal in terms of an identityQuery
-            try {
-                identifiers = JexlASTHelper.getIdentifiers(child);
-            } catch (NoSuchElementException e) {
-                return collectedFieldNames;
-            }
-
-            if (identifiers.isEmpty()) {
-                // Catch cases where we have two literals
-                // essentially everything but identifier op literal
-                return collectedFieldNames;
-            }
-
-            for (ASTIdentifier identifier : identifiers) {
-                String fieldName = JexlASTHelper.deconstructIdentifier(identifier);
-                if (!specialFields.contains(fieldName)) {
-                    collectedFieldNames.add(fieldName);
-                }
-            }
-        }
-        return collectedFieldNames;
+        return nodeData.stream().filter((node) -> !node.fields.isEmpty()).filter((node) -> node.containsNoneOf(specialFields))
+                        .filter((node) -> node.allFieldsMissing(missingFields)).map(ImmaterialNode::new).collect(Collectors.toList());
     }
 
     /**
@@ -139,31 +85,41 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
      * @return the updated set of names which have not been ingested during the date range.
      */
     private Object collectFields(JexlNode node, Object data) throws TableNotFoundException {
-        @SuppressWarnings("unchecked")
-        Set<String> collectedFieldNames = (Set<String>) data;
+        // If data is a CandidateNode, the node is a descendent of an OR node.
+        if (data instanceof CandidateNode) {
+            addFields(node, (CandidateNode) data);
+        } else {
+            // Otherwise it is a top-level node.
+            @SuppressWarnings("unchecked")
+            List<CandidateNode> list = (List<CandidateNode>) data;
+            CandidateNode candidateNode = new CandidateNode(node);
+            collectFields(node, candidateNode);
+            list.add(candidateNode);
+        }
+        return data;
+    }
+
+    // All fields from the given node to the given candidate node.
+    private void addFields(JexlNode node, CandidateNode data) {
         List<ASTIdentifier> identifiers;
 
         // A node could be literal == literal in terms of an identityQuery
         try {
             identifiers = JexlASTHelper.getIdentifiers(node);
         } catch (NoSuchElementException e) {
-            return collectedFieldNames;
+            return;
         }
 
         if (identifiers.isEmpty()) {
             // Catch cases where we have two literals
             // essentially everything but identifier op literal
-            return collectedFieldNames;
+            return;
         }
 
         for (ASTIdentifier identifier : identifiers) {
             String fieldName = JexlASTHelper.deconstructIdentifier(identifier);
-            if (!specialFields.contains(fieldName)) {
-                collectedFieldNames.add(fieldName);
-            }
+            data.addField(fieldName);
         }
-        return collectedFieldNames;
-
     }
 
     @Override
@@ -240,19 +196,28 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
     @Override
     public Object visit(ASTFunctionNode node, Object data) {
-        JexlArgumentDescriptor desc = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(node);
-        @SuppressWarnings("unchecked")
-        Set<String> collectedFieldNames = (null == data) ? new HashSet<>() : (Set<String>) data;
-
-        for (String fieldName : desc.fields(this.helper, this.datatypeFilter)) {
-            // deconstruct the identifier
-            final String testFieldName = JexlASTHelper.deconstructIdentifier(fieldName);
-            // changed to allow _ANYFIELD_ in functions
-            if (!specialFields.contains(fieldName)) {
-                collectedFieldNames.add(fieldName);
-            }
+        // If data is a CandidateNode, this function node is a descendant of an OR node.
+        if (data instanceof CandidateNode) {
+            CandidateNode candidateNode = (CandidateNode) data;
+            addFields(node, candidateNode);
+        } else {
+            // Otherwise this is a top-level node. Create a new CandidateNode and collect all fields from the function node.
+            @SuppressWarnings("unchecked")
+            List<CandidateNode> list = (List<CandidateNode>) data;
+            CandidateNode candidateNode = new CandidateNode(node);
+            addFields(node, candidateNode);
+            list.add(candidateNode);
         }
-        return collectedFieldNames;
+        return data;
+    }
+
+    // Add all fields found within the given function node to the given candidate node.
+    private void addFields(ASTFunctionNode node, CandidateNode candidateNode) {
+        JexlArgumentDescriptor desc = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(node);
+        for (String fieldName : desc.fields(this.helper, this.datatypeFilter)) {
+            fieldName = JexlASTHelper.deconstructIdentifier(fieldName);
+            candidateNode.addField(fieldName);
+        }
     }
 
     // Descend through these nodes
@@ -264,10 +229,87 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
     @Override
     public Object visit(ASTOrNode node, Object data) {
-        try {
-            return collectFields(node, data);
-        } catch (TableNotFoundException e) {
-            throw new RuntimeException(e);
+        // If data is a CandidateNode, this OR node is nested within another OR node. Pass it along to its children.
+        if (data instanceof CandidateNode) {
+            node.childrenAccept(this, data);
+        } else {
+            // Otherwise this is a top-level OR node. Create a new CandidateNode and collect all fields from the node's children.
+            @SuppressWarnings("unchecked")
+            List<CandidateNode> list = (List<CandidateNode>) data;
+            CandidateNode candidateNode = new CandidateNode(node);
+            node.childrenAccept(this, candidateNode);
+            if (!candidateNode.fields.isEmpty()) {
+                list.add(candidateNode);
+            }
+        }
+        return data;
+    }
+
+    /**
+     * Represents a node that may be a candidate to be an immaterial node.
+     */
+    private static class CandidateNode {
+        private final JexlNode node;
+        private final Set<String> fields = new LinkedHashSet<>(); // Maintain insertion order.
+
+        public CandidateNode(JexlNode node) {
+            this.node = node;
+        }
+
+        public Set<String> getFields() {
+            return fields;
+        }
+
+        public void addField(String field) {
+            fields.add(field);
+        }
+
+        /**
+         * Return whether this candidate node contains none of the given fields.
+         *
+         * @param specialFields
+         *            the fields
+         * @return true if this candidate node has none of the given fields, or false otherwise
+         */
+        public boolean containsNoneOf(Set<String> specialFields) {
+            return Sets.intersection(specialFields, this.fields).isEmpty();
+        }
+
+        /**
+         * Return whether this candidate node's fields consist only of missing fields.
+         *
+         * @param missingFields
+         *            the missing fields
+         * @return true if this candidate node contains only missing fields, or false otherwise
+         */
+        public boolean allFieldsMissing(Set<String> missingFields) {
+            return missingFields.containsAll(this.fields);
+        }
+    }
+
+    /**
+     * Represents a node within a jexl query that is considered to be immaterial because it only contains fields that are missing within a query's date range.
+     */
+    public static class ImmaterialNode {
+
+        private final JexlNode node;
+        private final Set<String> fields;
+
+        public ImmaterialNode(JexlNode node, Set<String> fields) {
+            this.node = RebuildingVisitor.copy(node);
+            this.fields = fields == null ? Set.of() : Collections.unmodifiableSet(fields); // Maintain insertion order.
+        }
+
+        private ImmaterialNode(CandidateNode data) {
+            this(data.node, data.fields);
+        }
+
+        public JexlNode getNode() {
+            return node;
+        }
+
+        public Set<String> getFields() {
+            return fields;
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitor.java
@@ -37,7 +37,6 @@ import datawave.util.time.DateHelper;
  * <pre>
  * 1. If a datatype filter was specified, then the existence check is limited to only those datatypes
  * 2. If a datatype filter is NOT specified (null or empty), this implies ALL datatypes.
- * 3. If querySettings is NOT specified (null), it will not report any missing fields. This is due to no begin or end date being provided.
  * </pre>
  */
 public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
@@ -85,7 +84,7 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
      * @return the updated set of names which have not been ingested during the date range.
      */
     private Object collectFields(JexlNode node, Object data) throws TableNotFoundException {
-        // If data is a CandidateNode, the node is a descendent of an OR node.
+        // If data is a CandidateNode, the node is a descendant of an OR node.
         if (data instanceof CandidateNode) {
             addFields(node, (CandidateNode) data);
         } else {
@@ -246,7 +245,7 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
     }
 
     /**
-     * Represents a node that may be a candidate to be an immaterial node.
+     * Represents a node that may be a candidate to be an {@link ImmaterialNode}.
      */
     private static class CandidateNode {
         private final JexlNode node;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitor.java
@@ -54,7 +54,7 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
     }
 
     @SuppressWarnings("unchecked")
-    public static List<ImmaterialNode> getNonIngestedFields(MetadataHelper helper, ASTJexlScript script, Set<String> datatypes, Set<String> specialFields,
+    public static Set<String> getNonIngestedFields(MetadataHelper helper, ASTJexlScript script, Set<String> datatypes, Set<String> specialFields,
                     Date beginDate, Date endDate) {
         if (datatypes == null) {
             datatypes = Collections.emptySet();
@@ -62,44 +62,56 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
         // Collect the fields
         FieldMissingFromDateRangeVisitor visitor = new FieldMissingFromDateRangeVisitor(helper, datatypes);
-        List<CandidateNode> nodeData = (List<CandidateNode>) script.jjtAccept(visitor, new ArrayList<>());
+        List<Set<String>> fieldSets = (List<Set<String>>) script.jjtAccept(visitor, new ArrayList<>());
 
-        if (nodeData.isEmpty()) {
-            return Collections.emptyList();
+        if (fieldSets.isEmpty()) {
+            return Set.of();
         }
 
-        Set<String> allFields = nodeData.stream().map(CandidateNode::getFields).flatMap(Set::stream).collect(Collectors.toSet());
+        // @formatter:off
+        Set<String> allFields = fieldSets.stream()
+                        .flatMap(Set::stream)
+                        .collect(Collectors.toSet());
+        // @formatter:on
+
+        // If only special field were found, do not return any fields.
+        if (specialFields.containsAll(allFields)) {
+            return Set.of();
+        }
+
+        // Fetch all fields not found in the target date range.
         Set<String> missingFields = visitor.helper.getMissingFieldsInDateRange(allFields, datatypes, DateHelper.format(beginDate), DateHelper.format(endDate),
                         specialFields);
 
-        return nodeData.stream().filter((node) -> !node.fields.isEmpty()).filter((node) -> node.containsNoneOf(specialFields))
-                        .filter((node) -> node.allFieldsMissing(missingFields)).map(ImmaterialNode::new).collect(Collectors.toList());
+        // @formatter:off
+        return fieldSets.stream()
+                        .filter((set) -> !set.isEmpty())
+                        .filter((set) -> Sets.intersection(specialFields, set).isEmpty())
+                        .filter(missingFields::containsAll)
+                        .flatMap(Set::stream)
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+        // @formatter:on
     }
 
-    /**
-     * @param node
-     *            Jexl node
-     * @param data
-     *            The set of names which we have determined have not been ingested during the date range.
-     * @return the updated set of names which have not been ingested during the date range.
-     */
+    // Collect all field names in given node.
     private Object collectFields(JexlNode node, Object data) throws TableNotFoundException {
-        // If data is a CandidateNode, the node is a descendant of an OR node.
-        if (data instanceof CandidateNode) {
-            addFields(node, (CandidateNode) data);
+        // If data is a set, the node is a descendant of an OR node.
+        if (data instanceof Set) {
+            // noinspection unchecked
+            addFields(node, (Set<String>) data);
         } else {
-            // Otherwise it is a top-level node.
+            // Otherwise it is a top-level node. Create a new set and collect all fields into it.
             @SuppressWarnings("unchecked")
-            List<CandidateNode> list = (List<CandidateNode>) data;
-            CandidateNode candidateNode = new CandidateNode(node);
-            collectFields(node, candidateNode);
-            list.add(candidateNode);
+            List<Set<String>> fieldSets = (List<Set<String>>) data;
+            Set<String> fields = new LinkedHashSet<>();
+            collectFields(node, fields);
+            fieldSets.add(fields);
         }
         return data;
     }
 
     // All fields from the given node to the given candidate node.
-    private void addFields(JexlNode node, CandidateNode data) {
+    private void addFields(JexlNode node, Set<String> data) {
         List<ASTIdentifier> identifiers;
 
         // A node could be literal == literal in terms of an identityQuery
@@ -117,7 +129,7 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
         for (ASTIdentifier identifier : identifiers) {
             String fieldName = JexlASTHelper.deconstructIdentifier(identifier);
-            data.addField(fieldName);
+            data.add(fieldName);
         }
     }
 
@@ -195,27 +207,27 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
     @Override
     public Object visit(ASTFunctionNode node, Object data) {
-        // If data is a CandidateNode, this function node is a descendant of an OR node.
-        if (data instanceof CandidateNode) {
-            CandidateNode candidateNode = (CandidateNode) data;
-            addFields(node, candidateNode);
+        // If data is a set, this function node is a descendant of an OR node.
+        if (data instanceof Set) {
+            // noinspection unchecked
+            addFields(node, (Set<String>) data);
         } else {
-            // Otherwise this is a top-level node. Create a new CandidateNode and collect all fields from the function node.
+            // Otherwise this is a top-level node. Create a new set of fields and collect all fields from the function node.
             @SuppressWarnings("unchecked")
-            List<CandidateNode> list = (List<CandidateNode>) data;
-            CandidateNode candidateNode = new CandidateNode(node);
-            addFields(node, candidateNode);
-            list.add(candidateNode);
+            List<Set<String>> fieldSets = (List<Set<String>>) data;
+            Set<String> fields = new LinkedHashSet<>();
+            addFields(node, fields);
+            fieldSets.add(fields);
         }
         return data;
     }
 
-    // Add all fields found within the given function node to the given candidate node.
-    private void addFields(ASTFunctionNode node, CandidateNode candidateNode) {
+    // Add all fields found within the given function node to the given set.
+    private void addFields(ASTFunctionNode node, Set<String> fields) {
         JexlArgumentDescriptor desc = JexlFunctionArgumentDescriptorFactory.F.getArgumentDescriptor(node);
         for (String fieldName : desc.fields(this.helper, this.datatypeFilter)) {
             fieldName = JexlASTHelper.deconstructIdentifier(fieldName);
-            candidateNode.addField(fieldName);
+            fields.add(fieldName);
         }
     }
 
@@ -228,87 +240,20 @@ public class FieldMissingFromDateRangeVisitor extends ShortCircuitBaseVisitor {
 
     @Override
     public Object visit(ASTOrNode node, Object data) {
-        // If data is a CandidateNode, this OR node is nested within another OR node. Pass it along to its children.
-        if (data instanceof CandidateNode) {
+        // If data is a set, this OR node is nested within another OR node. Pass it along to its children.
+        if (data instanceof Set) {
             node.childrenAccept(this, data);
         } else {
-            // Otherwise this is a top-level OR node. Create a new CandidateNode and collect all fields from the node's children.
+            // Otherwise this is a top-level OR node. Create a new set and collect all fields from the node's children.
             @SuppressWarnings("unchecked")
-            List<CandidateNode> list = (List<CandidateNode>) data;
-            CandidateNode candidateNode = new CandidateNode(node);
-            node.childrenAccept(this, candidateNode);
-            if (!candidateNode.fields.isEmpty()) {
-                list.add(candidateNode);
+            List<Set<String>> fieldSets = (List<Set<String>>) data;
+            Set<String> fields = new LinkedHashSet<>();
+            node.childrenAccept(this, fields);
+            if (!fields.isEmpty()) {
+                fieldSets.add(fields);
             }
         }
         return data;
     }
 
-    /**
-     * Represents a node that may be a candidate to be an {@link ImmaterialNode}.
-     */
-    private static class CandidateNode {
-        private final JexlNode node;
-        private final Set<String> fields = new LinkedHashSet<>(); // Maintain insertion order.
-
-        public CandidateNode(JexlNode node) {
-            this.node = node;
-        }
-
-        public Set<String> getFields() {
-            return fields;
-        }
-
-        public void addField(String field) {
-            fields.add(field);
-        }
-
-        /**
-         * Return whether this candidate node contains none of the given fields.
-         *
-         * @param specialFields
-         *            the fields
-         * @return true if this candidate node has none of the given fields, or false otherwise
-         */
-        public boolean containsNoneOf(Set<String> specialFields) {
-            return Sets.intersection(specialFields, this.fields).isEmpty();
-        }
-
-        /**
-         * Return whether this candidate node's fields consist only of missing fields.
-         *
-         * @param missingFields
-         *            the missing fields
-         * @return true if this candidate node contains only missing fields, or false otherwise
-         */
-        public boolean allFieldsMissing(Set<String> missingFields) {
-            return missingFields.containsAll(this.fields);
-        }
-    }
-
-    /**
-     * Represents a node within a jexl query that is considered to be immaterial because it only contains fields that are missing within a query's date range.
-     */
-    public static class ImmaterialNode {
-
-        private final JexlNode node;
-        private final Set<String> fields;
-
-        public ImmaterialNode(JexlNode node, Set<String> fields) {
-            this.node = RebuildingVisitor.copy(node);
-            this.fields = fields == null ? Set.of() : Collections.unmodifiableSet(fields); // Maintain insertion order.
-        }
-
-        private ImmaterialNode(CandidateNode data) {
-            this(data.node, data.fields);
-        }
-
-        public JexlNode getNode() {
-            return node;
-        }
-
-        public Set<String> getFields() {
-            return fields;
-        }
-    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
@@ -104,7 +104,7 @@ public class FieldExistenceRule extends ShardQueryRule {
     private String formatMessage(FieldMissingFromDateRangeVisitor.ImmaterialNode irrelevantJunction) {
         // @formatter:off
         return new StringBuilder()
-                        .append("All fields ")
+                        .append("Fields ")
                         .append(irrelevantJunction.getFields())
                         .append(" found in the query subset '")
                         .append(JexlStringBuildingVisitor.buildQuery(irrelevantJunction.getNode()))

--- a/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
@@ -1,7 +1,6 @@
 package datawave.query.rules;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -13,7 +12,6 @@ import org.apache.log4j.Logger;
 import datawave.microservice.query.Query;
 import datawave.query.jexl.visitors.FieldMissingFromDateRangeVisitor;
 import datawave.query.jexl.visitors.FieldMissingFromSchemaVisitor;
-import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 
 /**
  * A {@link QueryRule} implementation that will check a query for any non-existent fields, i.e. not present in the data dictionary.
@@ -88,29 +86,17 @@ public class FieldExistenceRule extends ShardQueryRule {
 
             // Find all OR branches in the query that consist entirely of fields not present within the query's date range.
             Query settings = ruleConfig.getQuerySettings();
-            List<FieldMissingFromDateRangeVisitor.ImmaterialNode> irrelevantJunctions = FieldMissingFromDateRangeVisitor.getNonIngestedFields(
-                            ruleConfig.getMetadataHelper(), jexlQuery, Collections.emptySet(), getSpecialFields(), settings.getBeginDate(),
-                            settings.getEndDate());
-            // If any irrelevant branches were found, add a message for them.
-            irrelevantJunctions.stream().map(this::formatMessage).forEach(result::addMessage);
+            Set<String> missingFields = FieldMissingFromDateRangeVisitor.getNonIngestedFields(ruleConfig.getMetadataHelper(), jexlQuery, Collections.emptySet(),
+                            getSpecialFields(), settings.getBeginDate(), settings.getEndDate());
+            if (!missingFields.isEmpty()) {
+                result.addMessage("Fields not ingested in the provided date range: " + missingFields);
+            }
         } catch (Exception e) {
             // If an exception occurred, log and preserve it in the result.
             log.error("Error occurred when validating against instance '" + getName() + "' of " + getClass(), e);
             result.setException(e);
         }
         return result;
-    }
-
-    private String formatMessage(FieldMissingFromDateRangeVisitor.ImmaterialNode irrelevantJunction) {
-        // @formatter:off
-        return new StringBuilder()
-                        .append("Fields ")
-                        .append(irrelevantJunction.getFields())
-                        .append(" found in the query subset '")
-                        .append(JexlStringBuildingVisitor.buildQuery(irrelevantJunction.getNode()))
-                        .append("' were not ingested in the provided date range.")
-                        .toString();
-        // @formatter:on
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
@@ -1,6 +1,7 @@
 package datawave.query.rules;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -9,8 +10,10 @@ import java.util.stream.Collectors;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.log4j.Logger;
 
+import datawave.microservice.query.Query;
 import datawave.query.jexl.visitors.FieldMissingFromDateRangeVisitor;
 import datawave.query.jexl.visitors.FieldMissingFromSchemaVisitor;
+import datawave.query.jexl.visitors.JexlStringBuildingVisitor;
 
 /**
  * A {@link QueryRule} implementation that will check a query for any non-existent fields, i.e. not present in the data dictionary.
@@ -78,21 +81,36 @@ public class FieldExistenceRule extends ShardQueryRule {
             ASTJexlScript jexlQuery = (ASTJexlScript) ruleConfig.getParsedQuery();
             Set<String> nonExistentFields = FieldMissingFromSchemaVisitor.getNonExistentFields(ruleConfig.getMetadataHelper(), jexlQuery,
                             Collections.emptySet(), getSpecialFields());
-            Set<String> nonIngestedFieldsForDateRange = FieldMissingFromDateRangeVisitor.getNonIngestedFields(ruleConfig.getMetadataHelper(), jexlQuery,
-                            Collections.emptySet(), getSpecialFields(), ruleConfig.getQuerySettings());
             // If any non-existent fields were found, add them to the result.
             if (!nonExistentFields.isEmpty()) {
                 result.addMessage("Fields not found in data dictionary: " + String.join(", ", nonExistentFields));
             }
-            if (!nonIngestedFieldsForDateRange.isEmpty()) {
-                result.addMessage("Fields not ingested in provided date range: " + String.join(", ", nonIngestedFieldsForDateRange));
-            }
+
+            // Find all OR branches in the query that consist entirely of fields not present within the query's date range.
+            Query settings = ruleConfig.getQuerySettings();
+            List<FieldMissingFromDateRangeVisitor.ImmaterialNode> irrelevantJunctions = FieldMissingFromDateRangeVisitor.getNonIngestedFields(
+                            ruleConfig.getMetadataHelper(), jexlQuery, Collections.emptySet(), getSpecialFields(), settings.getBeginDate(),
+                            settings.getEndDate());
+            // If any irrelevant branches were found, add a message for them.
+            irrelevantJunctions.stream().map(this::formatMessage).forEach(result::addMessage);
         } catch (Exception e) {
             // If an exception occurred, log and preserve it in the result.
             log.error("Error occurred when validating against instance '" + getName() + "' of " + getClass(), e);
             result.setException(e);
         }
         return result;
+    }
+
+    private String formatMessage(FieldMissingFromDateRangeVisitor.ImmaterialNode irrelevantJunction) {
+        // @formatter:off
+        return new StringBuilder()
+                        .append("All fields ")
+                        .append(irrelevantJunction.getFields())
+                        .append(" found in the query subset '")
+                        .append(JexlStringBuildingVisitor.buildQuery(irrelevantJunction.getNode()))
+                        .append("' were not ingested in the provided date range.")
+                        .toString();
+        // @formatter:on
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/rules/FieldExistenceRule.java
@@ -12,6 +12,7 @@ import org.apache.log4j.Logger;
 import datawave.microservice.query.Query;
 import datawave.query.jexl.visitors.FieldMissingFromDateRangeVisitor;
 import datawave.query.jexl.visitors.FieldMissingFromSchemaVisitor;
+import datawave.util.time.DateHelper;
 
 /**
  * A {@link QueryRule} implementation that will check a query for any non-existent fields, i.e. not present in the data dictionary.
@@ -89,7 +90,8 @@ public class FieldExistenceRule extends ShardQueryRule {
             Set<String> missingFields = FieldMissingFromDateRangeVisitor.getNonIngestedFields(ruleConfig.getMetadataHelper(), jexlQuery, Collections.emptySet(),
                             getSpecialFields(), settings.getBeginDate(), settings.getEndDate());
             if (!missingFields.isEmpty()) {
-                result.addMessage("Fields not ingested in the provided date range: " + missingFields);
+                result.addMessage("There is no data in the following fields " + missingFields + " for the entire date range "
+                                + DateHelper.format(settings.getBeginDate()) + " to " + DateHelper.format(settings.getEndDate()) + ".");
             }
         } catch (Exception e) {
             // If an exception occurred, log and preserve it in the result.

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitorTest.java
@@ -1,518 +1,300 @@
 package datawave.query.jexl.visitors;
 
-import static datawave.data.ColumnFamilyConstants.COLF_F;
 import static datawave.query.Constants.ANY_FIELD;
 import static datawave.query.Constants.NO_FIELD;
-import static org.apache.accumulo.core.iterators.LongCombiner.VAR_LEN_ENCODER;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.BatchWriter;
-import org.apache.accumulo.core.client.BatchWriterConfig;
-import org.apache.accumulo.core.client.MutationsRejectedException;
-import org.apache.accumulo.core.client.TableExistsException;
-import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.ParseException;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableUtils;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockExtension;
+import org.easymock.Mock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.google.common.collect.Sets;
-
-import datawave.microservice.query.Query;
 import datawave.query.jexl.JexlASTHelper;
-import datawave.query.model.DateFrequencyMap;
-import datawave.query.util.MockMetadataHelper;
-import datawave.util.TableName;
+import datawave.query.util.MetadataHelper;
 import datawave.util.time.DateHelper;
 
+@ExtendWith(EasyMockExtension.class)
 public class FieldMissingFromDateRangeVisitorTest {
-    private static final String[] AUTHS = {"FOO", "BAR"};
-    private static final Set<Authorizations> AUTHS_SET = Collections.singleton(new Authorizations(AUTHS));
-    private static final String NULL_BYTE = "\0";
-    private static final String AGGREGATED = "AGG";
-    private final MockMetadataHelper helper = new MockMetadataHelper(AUTHS_SET, AUTHS_SET);
-    private final List<Mutation> mutations = new ArrayList<>();
-    private Query querySettings;
 
-    // Special fields required by visitor.
-    private final Set<String> specialFields = Sets.newHashSet(ANY_FIELD, NO_FIELD);
+    private static final String beginDate = "20201231";
+    private static final String endDate = "20251231";
+    private static final Set<String> specialFields = Set.of(ANY_FIELD, NO_FIELD);
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        querySettings = Mockito.mock(Query.class);
+    @Mock
+    private MetadataHelper helper;
+
+    private String query;
+
+    private final Set<String> dataTypes = new HashSet<>();
+    private final Set<String> foundFields = new HashSet<>();
+    private final Set<String> missingFields = new HashSet<>();
+    private final List<FieldMissingFromDateRangeVisitor.ImmaterialNode> expectedNodes = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        this.query = null;
+        this.dataTypes.clear();
+        this.foundFields.clear();
+        this.missingFields.clear();
     }
 
     /**
      * Test query with ANDed fields where all exist during the date range.
      */
     @Test
-    public void testWithAndFieldsThatAllExist()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' && GENDER == 'bar'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testWithAndFieldsThatAllExist() throws ParseException {
+        givenQuery("AGE == 'foo' && GENDER == 'bar'");
+        expectFieldsToBeFound("AGE", "GENDER");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num", "text"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "text"), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with multiple ORed fields that all exist during the date range.
      */
     @Test
-    public void testWithORFieldsThatAllExist()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testWithORFieldsThatAllExist() throws ParseException {
+        givenQuery("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'");
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet(), false);
-    }
-
-    /**
-     * Test query with ANDed fields where all exist during the date range and no DataType Filter is given.
-     */
-    @Test
-    public void testWithAndFieldsThatAllExistWithoutDataTypeFilter()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' && GENDER == 'bar'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), false);
-    }
-
-    /**
-     * Test query with ORed fields where all exist during the date range and no DataType Filter is given.
-     */
-    @Test
-    public void testWithORFieldsThatAllExistWithoutDataTypeFilter()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with ANDed fields but only some exist during the date range.
      */
     @Test
-    public void testWithAndFieldsThatSomeExist()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' && GENDER == 'bar' && JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testWithAndFieldsThatSomeExist() throws ParseException {
+        givenQuery("AGE == 'foo' && GENDER == 'bar' && JOB == 'foo'");
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("JOB");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1704153600000L); // 01/02/2024 00:00:00 GMT
+        expectIrrelevantNode("JOB == 'foo'", Set.of("JOB"));
 
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet("JOB"), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet("JOB"), false);
+        assertResult();
+    }
+
+    /**
+     * Test query with ANDed fields but only some exist during the date range with a datatype filter.
+     */
+    @Test
+    public void testWithAndFieldsThatSomeExistWithNonEmptyDataTypes() throws ParseException {
+        givenQuery("AGE == 'foo' && GENDER == 'bar' && JOB == 'foo'");
+        givenDataTypes("attr");
+
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("JOB");
+
+        expectIrrelevantNode("JOB == 'foo'", Set.of("JOB"));
+
+        assertResult();
     }
 
     /**
      * Test query with only special fields ANDed.
      */
     @Test
-    public void testAndWithOnlySpecialFields()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "_ANYFIELD_ == 'foo' && _NOFIELD_ == 'bar'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testAndWithOnlySpecialFields() throws ParseException {
+        givenQuery("_ANYFIELD_ == 'foo' && _NOFIELD_ == 'bar'");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1704153600000L); // 01/02/2024 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with only special fields ORd.
      */
     @Test
-    public void testOrWithOnlySpecialFields()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "_ANYFIELD_ == 'foo' || _NOFIELD_ == 'bar'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testOrWithOnlySpecialFields() throws ParseException {
+        givenQuery("_ANYFIELD_ == 'foo' || _NOFIELD_ == 'bar'");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1704153600000L); // 01/02/2024 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet(), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with ORed fields but only some exist during the date range. Fields will only be returned as NonIngested if ALL ORed fields are not found.
      */
     @Test
-    public void testWithOrFieldsThatSomeExist()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testWithOrFieldsThatSomeExist() throws ParseException {
+        givenQuery("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'");
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("AGE", "GENDER");
 
-        Date begin = new Date(1609459200000L); // 01/01/2021 00:00:00 GMT
-        Date end = new Date(1704153600000L); // 01/02/2024 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with ORed fields but ALL do not exist during the date range. Fields will only be returned as NonIngested if ALL ORed fields are not found.
      */
     @Test
-    public void testWithOrFieldsThatAllDoNotExist()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testWithOrFieldsThatAllDoNotExist() throws ParseException {
+        givenQuery("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'");
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("AGE", "GENDER", "JOB");
 
-        Date begin = new Date(1546214400000L); // 12/31/2018 00:00:00 GMT
-        Date end = new Date(1577923200000L); // 01/02/2020 00:00:00 GMT
+        expectIrrelevantNode("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'", Set.of("AGE", "GENDER", "JOB"));
 
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet("AGE", "GENDER", "JOB"), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "text", "attr"), Sets.newHashSet("AGE", "GENDER", "JOB"), false);
-    }
-
-    /**
-     * Test query with multiple ANDed fields where some will be missed due to the datatype filter.
-     */
-    @Test
-    public void testOneMissingAndFieldBecauseOfDatatypeFilter()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' && GENDER == 'bar' && JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num", "attr"), Sets.newHashSet("GENDER"), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "attr"), Sets.newHashSet("GENDER"), false);
-    }
-
-    /**
-     * Test query with multiple ANDed fields where some will be missed due to the datatype filter. The special field will be excluded.
-     */
-    @Test
-    public void testOneMissingAndFieldBecauseOfDatatypeFilterWithSpecialField()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' && GENDER == 'bar' && JOB == 'foo' && _ANYFIELD_ == 'test'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num", "attr"), Sets.newHashSet("GENDER"), true);
-        runCheck(script, begin, end, Sets.newHashSet("num", "attr"), Sets.newHashSet("GENDER"), false);
-    }
-
-    /**
-     * Test query with multiple ORed fields where some will be missed due to the datatype filter. Fields will only be returned as NonIngested if ALL ORed fields
-     * are not found.
-     */
-    @Test
-    public void testOneMissingORFieldBecauseOfDatatypeFilter()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet(), false);
-    }
-
-    /**
-     * Test query with multiple ORed fields where ALL will be missed due to the datatype filter. Fields will only be returned as NonIngested if ALL ORed fields
-     * are not found.
-     */
-    @Test
-    public void testAllMissingORFieldBecauseOfDatatypeFilter()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("foo"), Sets.newHashSet("AGE", "GENDER", "JOB"), true);
-        runCheck(script, begin, end, Sets.newHashSet("foo"), Sets.newHashSet("AGE", "GENDER", "JOB"), false);
-    }
-
-    /**
-     * Test query with multiple ORed fields where ALL will be missed due to the datatype filter. The special field will be excluded. Fields will only be
-     * returned as NonIngested if ALL ORed fields are not found.
-     */
-    @Test
-    public void testAllMissingORFieldBecauseOfDatatypeFilterWithSpecialField()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || GENDER == 'bar' || JOB == 'foo' || _ANYFIELD_ = 'abc'";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("foo"), Sets.newHashSet("AGE", "GENDER", "JOB"), true);
-        runCheck(script, begin, end, Sets.newHashSet("foo"), Sets.newHashSet("AGE", "GENDER", "JOB"), false);
+        assertResult();
     }
 
     /**
      * Test query with function for a field that exists in the date range.
      */
     @Test
-    public void testRegexFunctionWithFieldThatExists()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "filter:includeRegex(GENDER, 'bar.*')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testRegexFunctionWithFieldThatExists() throws ParseException {
+        givenQuery("filter:includeRegex(GENDER, 'bar.*')");
+        expectFieldsToBeFound("GENDER");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("text"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("text"), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with function for a special field.
      */
     @Test
-    public void testRegexFunctionWithSpecialField()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "filter:includeRegex(_ANYFIELD_, 'bar.*')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testRegexFunctionWithSpecialField() throws ParseException {
+        givenQuery("filter:includeRegex(_ANYFIELD_, 'bar.*')");
+        expectFieldsToBeFound("_ANYFIELD_");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("text"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("text"), Sets.newHashSet(), false);
+        assertResult();
     }
 
     /**
      * Test query with function for a field that does not exist in the date range.
      */
     @Test
-    public void testRegexFunctionWithFieldThatDoesNotExist()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "filter:includeRegex(JOB, 'bar.*')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testRegexFunctionWithFieldThatDoesNotExist() throws ParseException {
+        givenQuery("filter:includeRegex(JOB, 'bar.*')");
+        expectFieldsToBeFound("JOB");
+        givenMissingFields("JOB");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1704153600000L); // 01/02/2024 00:00:00 GMT
+        expectIrrelevantNode("filter:includeRegex(JOB, 'bar.*')", Set.of("JOB"));
 
-        runCheck(script, begin, end, Sets.newHashSet("attr"), Sets.newHashSet("JOB"), true);
-        runCheck(script, begin, end, Sets.newHashSet("attr"), Sets.newHashSet("JOB"), false);
+        assertResult();
     }
 
-    /**
-     * Test query with function for a field that does not exist in the date range under the provided datatype filter.
-     */
     @Test
-    public void testRegexFunctionWithUnknownFieldBecauseOfDatatypeFilter()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "filter:includeRegex(GENDER, 'bar.*')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    void testNestedFunction() throws ParseException {
+        givenQuery("AGE == 'foo' && (NAME == 'bar' || filter:includeRegex(JOB, 'bar.*'))");
+        expectFieldsToBeFound("AGE", "NAME", "JOB");
+        givenMissingFields("NAME", "JOB");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
+        expectIrrelevantNode("NAME == 'bar' || filter:includeRegex(JOB, 'bar.*')", Set.of("JOB", "NAME"));
 
-        runCheck(script, begin, end, Sets.newHashSet("foo"), Sets.newHashSet("GENDER"), true);
-        runCheck(script, begin, end, Sets.newHashSet("foo"), Sets.newHashSet("GENDER"), false);
+        assertResult();
     }
 
-    /**
-     * CHANGE.
-     */
     @Test
-    public void testNestedIntersection() throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' || (GENDER == 'bar' && JOB == 'foo')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testNestedIntersectionWithSomeMissingFields() throws ParseException {
+        givenQuery("AGE == 'foo' || (GENDER == 'bar' && JOB == 'foo')");
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("GENDER", "JOB");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
-
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet(), false);
+        assertResult();
     }
 
-    /**
-     * CHANGE.
-     */
     @Test
-    public void testNestedUnion() throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "AGE == 'foo' && (GENDER == 'bar' || JOB == 'foo')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testNestedUnion() throws ParseException {
+        givenQuery("AGE == 'foo' && (GENDER == 'bar' || JOB == 'foo')");
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("GENDER", "JOB");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
+        expectIrrelevantNode("GENDER == 'bar' || JOB == 'foo'", Set.of("GENDER", "JOB"));
 
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet("GENDER", "JOB"), true);
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet("GENDER", "JOB"), false);
+        assertResult();
     }
 
-    /**
-     * CHANGE.
-     */
     @Test
-    public void testDoubleNestedIntersection()
-                    throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+    public void testDoubleNestedIntersectionWhereSomeMissing() throws ParseException {
+        givenQuery("(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("AGE", "GENDER");
 
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("num"), Sets.newHashSet(), false);
+        assertResult();
     }
 
-    /**
-     * CHANGE.
-     */
     @Test
-    public void testDoubleNestedUnion() throws ParseException, AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        String query = "(AGE == 'foo' || GENDER == 'foo') && (NAME == 'bar' || JOB == 'foo')";
-        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-        System.out.println();
+    public void testDoubleNestedIntersectionWhereAllMissing() throws ParseException {
+        givenQuery("(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')");
 
-        Date begin = new Date(1609372800000L); // 12/31/2020 00:00:00 GMT
-        Date end = new Date(1735776000000L); // 01/02/2025 00:00:00 GMT
+        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+        givenMissingFields("AGE", "GENDER", "JOB");
 
-        runCheck(script, begin, end, Sets.newHashSet("attr"), Sets.newHashSet(), true);
-        runCheck(script, begin, end, Sets.newHashSet("attr"), Sets.newHashSet(), false);
+        expectIrrelevantNode("(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')", Set.of("AGE", "GENDER", "JOB"));
+
+        assertResult();
     }
 
-    private void runCheck(ASTJexlScript script, Date begin, Date end, Set<String> filter, Set<String> expected, boolean isAggregated)
-                    throws AccumuloException, TableExistsException, AccumuloSecurityException, TableNotFoundException {
-        if (helper.getAccumuloClient().tableOperations().exists(TableName.METADATA)) {
-            helper.getAccumuloClient().tableOperations().delete(TableName.METADATA);
-        }
-        helper.getAccumuloClient().tableOperations().create(TableName.METADATA);
+    @Test
+    public void testDoubleNestedUnionWithSomeORsMissingAllFields() throws ParseException {
+        givenQuery("(AGE == 'foo' || GENDER == 'foo') && (NAME == 'bar' || JOB == 'foo') && (ORG == 'hr' || NAME == 'hat')");
 
-        if (isAggregated) {
-            givenAggregatedRow("AGE", COLF_F, "num", "FOO", 1499999999L, createDateFrequencyMap("20210101", 40L, "20210102", 15L, "20210103", 20L));
-            givenAggregatedRow("AGE", COLF_F, "lifetime", "FOO", 1499999999L, createDateFrequencyMap("20220101", 40L, "20220102", 15L, "20220103", 20L));
-            givenAggregatedRow("AGE", COLF_F, "var", "BAR", 1499999999L, createDateFrequencyMap("20230101", 40L, "20230102", 15L, "20230103", 20L));
-            givenAggregatedRow("GENDER", COLF_F, "text", "FOO", 1499999999L, createDateFrequencyMap("20240101", 40L, "20240102", 15L, "20240103", 20L));
-            givenAggregatedRow("JOB", COLF_F, "attr", "FOO", 1499999999L, createDateFrequencyMap("20250101", 40L, "20250102", 15L, "20250103", 20L));
-            givenAggregatedRow("NAME", COLF_F, "attr", "FOO", 1499999999L, createDateFrequencyMap("20250101", 40L, "20250102", 15L, "20250103", 20L));
-        } else {
-            givenNonAggregatedFrequencyRows("AGE", COLF_F, "num", "20210101", "20210103", 1L);
-            givenNonAggregatedFrequencyRows("AGE", COLF_F, "lifetime", "20220101", "20220103", 1L);
-            givenNonAggregatedFrequencyRows("AGE", COLF_F, "var", "20230101", "20230103", 1L);
-            givenNonAggregatedFrequencyRows("GENDER", COLF_F, "text", "20240101", "20240103", 1L);
-            givenNonAggregatedFrequencyRows("JOB", COLF_F, "attr", "20250101", "20250103", 1L);
-            givenNonAggregatedFrequencyRows("NAME", COLF_F, "attr", "20250101", "20250103", 1L);
-        }
-        writeMutations(helper.getAccumuloClient(), this.mutations);
-        Mockito.doReturn(begin).when(querySettings).getBeginDate();
-        Mockito.doReturn(end).when(querySettings).getEndDate();
-        Set<String> actual = FieldMissingFromDateRangeVisitor.getNonIngestedFields(helper, script, filter, specialFields, querySettings);
-        Assertions.assertEquals(expected, actual);
+        expectFieldsToBeFound("AGE", "GENDER", "NAME", "JOB", "ORG");
+        givenMissingFields("AGE", "GENDER", "NAME", "JOB");
+
+        expectIrrelevantNode("AGE == 'foo' || GENDER == 'foo'", Set.of("AGE", "GENDER"));
+        expectIrrelevantNode("NAME == 'bar' || JOB == 'foo'", Set.of("NAME", "JOB"));
+
+        assertResult();
     }
 
-    public static DateFrequencyMap createDateFrequencyMap(Object... entries) {
-        DateFrequencyMap map = new DateFrequencyMap();
-        int lastEntry = entries.length - 1;
-        for (int i = 0; i < lastEntry; i++) {
-            String date = (String) entries[i];
-            i++;
-            long count = (Long) entries[i];
-            map.put(date, count);
-        }
-        return map;
-    }
+    private void assertResult() throws ParseException {
+        boolean helperMocked = false;
 
-    /**
-     * Return the set of dates contained within the start and end date
-     *
-     * @param startDateStr
-     * @param endDateStr
-     * @return
-     */
-    public static List<String> getDatesInRange(String startDateStr, String endDateStr) {
-        Date startDate = DateHelper.parse(startDateStr);
-        Date endDate = DateHelper.parse(endDateStr);
-
-        List<String> dates = new ArrayList<>();
-        dates.add(startDateStr);
-
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(startDate);
-        while (true) {
-            calendar.add(Calendar.DAY_OF_MONTH, 1);
-            Date date = calendar.getTime();
-            if (date.before(endDate) || date.equals(endDate)) {
-                dates.add(DateHelper.format(date));
-            } else {
-                break;
-            }
+        // If we expect any fields to be found, mock up a call to the helper function.
+        if (!foundFields.isEmpty()) {
+            EasyMock.expect(this.helper.getMissingFieldsInDateRange(foundFields, dataTypes, beginDate, endDate, specialFields)).andReturn(missingFields);
+            EasyMock.replay(this.helper);
+            helperMocked = true;
         }
 
-        return dates;
-    }
+        // Fetch the nodes considered to be irrelevant.
+        ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+        List<FieldMissingFromDateRangeVisitor.ImmaterialNode> immaterialNodes = FieldMissingFromDateRangeVisitor.getNonIngestedFields(this.helper, script,
+                        dataTypes, specialFields, DateHelper.parse(beginDate), DateHelper.parse(endDate));
 
-    private void givenAggregatedRow(String row, Text colf, String datatype, String colv, long timestamp, DateFrequencyMap map) {
-        givenMutation(row, colf, datatype + NULL_BYTE + AGGREGATED, colv, timestamp, new Value(WritableUtils.toByteArray(map)));
-    }
-
-    private void givenNonAggregatedFrequencyRows(String row, Text colf, String datatype, String startDate, String endDate, long count) {
-        Mutation mutation = new Mutation(row);
-        Value value = new Value(VAR_LEN_ENCODER.encode(count));
-        List<String> dates = getDatesInRange(startDate, endDate);
-        dates.forEach((date) -> mutation.put(colf, new Text(datatype + NULL_BYTE + date), value));
-        givenMutation(mutation);
-    }
-
-    private void givenMutation(Mutation mutation) {
-        this.mutations.add(mutation);
-    }
-
-    private void givenMutation(String row, Text colf, String colq, String colv, long timestamp, Value value) {
-        Mutation mutation = new Mutation(row);
-        mutation.put(colf, new Text(colq), new ColumnVisibility(colv), timestamp, value);
-        this.mutations.add(mutation);
-    }
-
-    private void writeMutations(AccumuloClient client, Collection<Mutation> mutations) {
-        BatchWriterConfig config = new BatchWriterConfig();
-        config.setMaxMemory(0);
-        try (BatchWriter writer = client.createBatchWriter(TableName.METADATA, config)) {
-            writer.addMutations(mutations);
-            writer.flush();
-        } catch (MutationsRejectedException | TableNotFoundException e) {
-            throw new RuntimeException(e);
+        if (helperMocked) {
+            // If the helper function was mocked, verify that the arguments to the function matched what we expected.
+            EasyMock.verify(this.helper);
         }
+
+        assertThat(immaterialNodes).hasSameSizeAs(expectedNodes);
+
+        for (int i = 0; i < immaterialNodes.size(); i++) {
+            FieldMissingFromDateRangeVisitor.ImmaterialNode actual = immaterialNodes.get(i);
+            FieldMissingFromDateRangeVisitor.ImmaterialNode expected = expectedNodes.get(i);
+            assertThat(JexlStringBuildingVisitor.buildQuery(actual.getNode())).isEqualTo(JexlStringBuildingVisitor.buildQuery(expected.getNode()));
+            assertThat(actual.getFields()).containsExactlyInAnyOrderElementsOf(expected.getFields());
+        }
+    }
+
+    private void givenQuery(String query) {
+        this.query = query;
+    }
+
+    private void expectFieldsToBeFound(String... fields) {
+        this.foundFields.addAll(Arrays.asList(fields));
+    }
+
+    private void givenDataTypes(String... dataTypes) {
+        this.dataTypes.addAll(Arrays.asList(dataTypes));
+    }
+
+    private void givenMissingFields(String... fields) {
+        this.missingFields.addAll(Arrays.asList(fields));
+    }
+
+    private void expectIrrelevantNode(String node, Set<String> fields) throws ParseException {
+        this.expectedNodes.add(new FieldMissingFromDateRangeVisitor.ImmaterialNode(JexlASTHelper.parseJexlQuery(node), fields));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldMissingFromDateRangeVisitorTest.java
@@ -4,10 +4,9 @@ import static datawave.query.Constants.ANY_FIELD;
 import static datawave.query.Constants.NO_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.apache.commons.jexl3.parser.ASTJexlScript;
@@ -36,16 +35,15 @@ public class FieldMissingFromDateRangeVisitorTest {
     private String query;
 
     private final Set<String> dataTypes = new HashSet<>();
-    private final Set<String> foundFields = new HashSet<>();
-    private final Set<String> missingFields = new HashSet<>();
-    private final List<FieldMissingFromDateRangeVisitor.ImmaterialNode> expectedNodes = new ArrayList<>();
+    private final Set<String> expectedImmaterialFields = new LinkedHashSet<>();
+
+    private boolean helperMocked = false;
 
     @AfterEach
     void tearDown() {
         this.query = null;
         this.dataTypes.clear();
-        this.foundFields.clear();
-        this.missingFields.clear();
+        this.expectedImmaterialFields.clear();
     }
 
     /**
@@ -54,7 +52,8 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testWithAndFieldsThatAllExist() throws ParseException {
         givenQuery("AGE == 'foo' && GENDER == 'bar'");
-        expectFieldsToBeFound("AGE", "GENDER");
+
+        expectHelperToBeCalled(Set.of("AGE", "GENDER"), Set.of());
 
         assertResult();
     }
@@ -65,7 +64,8 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testWithORFieldsThatAllExist() throws ParseException {
         givenQuery("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'");
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
+
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of());
 
         assertResult();
     }
@@ -76,10 +76,10 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testWithAndFieldsThatSomeExist() throws ParseException {
         givenQuery("AGE == 'foo' && GENDER == 'bar' && JOB == 'foo'");
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("JOB");
 
-        expectIrrelevantNode("JOB == 'foo'", Set.of("JOB"));
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("JOB"));
+
+        expectImmaterialFields("JOB");
 
         assertResult();
     }
@@ -92,10 +92,9 @@ public class FieldMissingFromDateRangeVisitorTest {
         givenQuery("AGE == 'foo' && GENDER == 'bar' && JOB == 'foo'");
         givenDataTypes("attr");
 
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("JOB");
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("JOB"));
 
-        expectIrrelevantNode("JOB == 'foo'", Set.of("JOB"));
+        expectImmaterialFields("JOB");
 
         assertResult();
     }
@@ -126,8 +125,8 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testWithOrFieldsThatSomeExist() throws ParseException {
         givenQuery("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'");
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("AGE", "GENDER");
+
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("AGE", "GENDER"));
 
         assertResult();
     }
@@ -138,10 +137,10 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testWithOrFieldsThatAllDoNotExist() throws ParseException {
         givenQuery("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'");
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("AGE", "GENDER", "JOB");
 
-        expectIrrelevantNode("AGE == 'foo' || GENDER == 'bar' || JOB == 'foo'", Set.of("AGE", "GENDER", "JOB"));
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("AGE", "GENDER", "JOB"));
+
+        expectImmaterialFields("AGE", "GENDER", "JOB");
 
         assertResult();
     }
@@ -152,7 +151,8 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testRegexFunctionWithFieldThatExists() throws ParseException {
         givenQuery("filter:includeRegex(GENDER, 'bar.*')");
-        expectFieldsToBeFound("GENDER");
+
+        expectHelperToBeCalled(Set.of("GENDER"), Set.of());
 
         assertResult();
     }
@@ -163,7 +163,6 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testRegexFunctionWithSpecialField() throws ParseException {
         givenQuery("filter:includeRegex(_ANYFIELD_, 'bar.*')");
-        expectFieldsToBeFound("_ANYFIELD_");
 
         assertResult();
     }
@@ -174,10 +173,10 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testRegexFunctionWithFieldThatDoesNotExist() throws ParseException {
         givenQuery("filter:includeRegex(JOB, 'bar.*')");
-        expectFieldsToBeFound("JOB");
-        givenMissingFields("JOB");
 
-        expectIrrelevantNode("filter:includeRegex(JOB, 'bar.*')", Set.of("JOB"));
+        expectHelperToBeCalled(Set.of("JOB"), Set.of("JOB"));
+
+        expectImmaterialFields("JOB");
 
         assertResult();
     }
@@ -185,10 +184,10 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     void testNestedFunction() throws ParseException {
         givenQuery("AGE == 'foo' && (NAME == 'bar' || filter:includeRegex(JOB, 'bar.*'))");
-        expectFieldsToBeFound("AGE", "NAME", "JOB");
-        givenMissingFields("NAME", "JOB");
 
-        expectIrrelevantNode("NAME == 'bar' || filter:includeRegex(JOB, 'bar.*')", Set.of("JOB", "NAME"));
+        expectHelperToBeCalled(Set.of("AGE", "NAME", "JOB"), Set.of("NAME", "JOB"));
+
+        expectImmaterialFields("JOB", "NAME");
 
         assertResult();
     }
@@ -196,8 +195,8 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testNestedIntersectionWithSomeMissingFields() throws ParseException {
         givenQuery("AGE == 'foo' || (GENDER == 'bar' && JOB == 'foo')");
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("GENDER", "JOB");
+
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("GENDER", "JOB"));
 
         assertResult();
     }
@@ -205,10 +204,10 @@ public class FieldMissingFromDateRangeVisitorTest {
     @Test
     public void testNestedUnion() throws ParseException {
         givenQuery("AGE == 'foo' && (GENDER == 'bar' || JOB == 'foo')");
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("GENDER", "JOB");
 
-        expectIrrelevantNode("GENDER == 'bar' || JOB == 'foo'", Set.of("GENDER", "JOB"));
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("GENDER", "JOB"));
+
+        expectImmaterialFields("GENDER", "JOB");
 
         assertResult();
     }
@@ -217,8 +216,7 @@ public class FieldMissingFromDateRangeVisitorTest {
     public void testDoubleNestedIntersectionWhereSomeMissing() throws ParseException {
         givenQuery("(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')");
 
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("AGE", "GENDER");
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("AGE", "GENDER"));
 
         assertResult();
     }
@@ -227,10 +225,9 @@ public class FieldMissingFromDateRangeVisitorTest {
     public void testDoubleNestedIntersectionWhereAllMissing() throws ParseException {
         givenQuery("(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')");
 
-        expectFieldsToBeFound("AGE", "GENDER", "JOB");
-        givenMissingFields("AGE", "GENDER", "JOB");
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "JOB"), Set.of("AGE", "GENDER", "JOB"));
 
-        expectIrrelevantNode("(AGE == 'foo' && GENDER == 'foo') || (GENDER == 'bar' && JOB == 'foo')", Set.of("AGE", "GENDER", "JOB"));
+        expectImmaterialFields("AGE", "GENDER", "JOB");
 
         assertResult();
     }
@@ -239,62 +236,42 @@ public class FieldMissingFromDateRangeVisitorTest {
     public void testDoubleNestedUnionWithSomeORsMissingAllFields() throws ParseException {
         givenQuery("(AGE == 'foo' || GENDER == 'foo') && (NAME == 'bar' || JOB == 'foo') && (ORG == 'hr' || NAME == 'hat')");
 
-        expectFieldsToBeFound("AGE", "GENDER", "NAME", "JOB", "ORG");
-        givenMissingFields("AGE", "GENDER", "NAME", "JOB");
+        expectHelperToBeCalled(Set.of("AGE", "GENDER", "NAME", "JOB", "ORG"), Set.of("AGE", "GENDER", "NAME", "JOB"));
 
-        expectIrrelevantNode("AGE == 'foo' || GENDER == 'foo'", Set.of("AGE", "GENDER"));
-        expectIrrelevantNode("NAME == 'bar' || JOB == 'foo'", Set.of("NAME", "JOB"));
+        expectImmaterialFields("AGE", "GENDER", "NAME", "JOB");
 
         assertResult();
     }
 
     private void assertResult() throws ParseException {
-        boolean helperMocked = false;
-
         // If we expect any fields to be found, mock up a call to the helper function.
-        if (!foundFields.isEmpty()) {
-            EasyMock.expect(this.helper.getMissingFieldsInDateRange(foundFields, dataTypes, beginDate, endDate, specialFields)).andReturn(missingFields);
-            EasyMock.replay(this.helper);
-            helperMocked = true;
-        }
-
-        // Fetch the nodes considered to be irrelevant.
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-        List<FieldMissingFromDateRangeVisitor.ImmaterialNode> immaterialNodes = FieldMissingFromDateRangeVisitor.getNonIngestedFields(this.helper, script,
-                        dataTypes, specialFields, DateHelper.parse(beginDate), DateHelper.parse(endDate));
+        Set<String> actualImmaterialFields = FieldMissingFromDateRangeVisitor.getNonIngestedFields(this.helper, script, dataTypes, specialFields,
+                        DateHelper.parse(beginDate), DateHelper.parse(endDate));
 
         if (helperMocked) {
             // If the helper function was mocked, verify that the arguments to the function matched what we expected.
             EasyMock.verify(this.helper);
         }
 
-        assertThat(immaterialNodes).hasSameSizeAs(expectedNodes);
-
-        for (int i = 0; i < immaterialNodes.size(); i++) {
-            FieldMissingFromDateRangeVisitor.ImmaterialNode actual = immaterialNodes.get(i);
-            FieldMissingFromDateRangeVisitor.ImmaterialNode expected = expectedNodes.get(i);
-            assertThat(JexlStringBuildingVisitor.buildQuery(actual.getNode())).isEqualTo(JexlStringBuildingVisitor.buildQuery(expected.getNode()));
-            assertThat(actual.getFields()).containsExactlyInAnyOrderElementsOf(expected.getFields());
-        }
+        assertThat(actualImmaterialFields).isEqualTo(expectedImmaterialFields);
     }
 
     private void givenQuery(String query) {
         this.query = query;
     }
 
-    private void expectFieldsToBeFound(String... fields) {
-        this.foundFields.addAll(Arrays.asList(fields));
+    private void expectHelperToBeCalled(Set<String> foundFields, Set<String> missingFields) {
+        EasyMock.expect(this.helper.getMissingFieldsInDateRange(foundFields, dataTypes, beginDate, endDate, specialFields)).andReturn(missingFields);
+        EasyMock.replay(this.helper);
+        helperMocked = true;
     }
 
     private void givenDataTypes(String... dataTypes) {
         this.dataTypes.addAll(Arrays.asList(dataTypes));
     }
 
-    private void givenMissingFields(String... fields) {
-        this.missingFields.addAll(Arrays.asList(fields));
-    }
-
-    private void expectIrrelevantNode(String node, Set<String> fields) throws ParseException {
-        this.expectedNodes.add(new FieldMissingFromDateRangeVisitor.ImmaterialNode(JexlASTHelper.parseJexlQuery(node), fields));
+    private void expectImmaterialFields(String... fields) {
+        this.expectedImmaterialFields.addAll(Arrays.asList(fields));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/rules/FieldExistenceRuleTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/rules/FieldExistenceRuleTest.java
@@ -1,102 +1,131 @@
 package datawave.query.rules;
 
+import static datawave.query.Constants.ANY_FIELD;
+import static datawave.query.Constants.NO_FIELD;
+
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.easymock.EasyMock;
+import org.easymock.EasyMockExtension;
+import org.easymock.Mock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import datawave.microservice.query.Query;
 import datawave.query.util.MetadataHelper;
-import datawave.query.util.MockMetadataHelper;
-import datawave.util.TableName;
+import datawave.util.time.DateHelper;
 
+@ExtendWith(EasyMockExtension.class)
 public class FieldExistenceRuleTest extends ShardQueryRuleTest {
 
-    private static final Set<String> ALL_FIELDS = Set.of("FOO", "BAR", "BAT");
-    private static final String[] AUTHS = {"FOO", "BAR", "BAT"};
-    private static final Set<Authorizations> AUTHS_SET = Collections.singleton(new Authorizations(AUTHS));
-    private static final String ANYFIELD = "_ANYFIELD_";
-    private static final MockMetadataHelper defaultMetadataHelper = new MockMetadataHelper(AUTHS_SET, AUTHS_SET);
+    private static final String beginDate = "20201231";
+    private static final String endDate = "20251231";
+    private static final Set<String> specialFields = Set.of(ANY_FIELD, NO_FIELD);
 
-    private final Set<String> fieldExceptions = new HashSet<>();
+    @Mock
+    private MetadataHelper helper;
+
+    @Mock
+    private Query settings;
+
+    private final Set<String> existingFields = new HashSet<>();
+    private final Set<String> foundFields = new HashSet<>();
+    private final Set<String> missingFields = new HashSet<>();
 
     @BeforeAll
-    public static void beforeClass() throws Exception {
-        defaultMetadataHelper.addFields(ALL_FIELDS);
-    }
+    public static void beforeClass() throws Exception {}
 
     @BeforeEach
     public void setUp() throws Exception {
-        givenQuerySettings(Mockito.mock(Query.class));
-        Mockito.doReturn(new Date(0L)).when(querySettings).getBeginDate();
-        Mockito.doReturn(new Date(4070908800L)).when(querySettings).getEndDate();
         givenRuleName(RULE_NAME);
-        givenMetadataHelper(defaultMetadataHelper);
+        givenMetadataHelper(helper);
         expectRuleName(RULE_NAME);
-        if (!defaultMetadataHelper.getAccumuloClient().tableOperations().exists(TableName.METADATA)) {
-            defaultMetadataHelper.getAccumuloClient().tableOperations().create(TableName.METADATA);
-        }
+    }
+
+    @AfterEach
+    @Override
+    void tearDown() {
+        query = null;
+        existingFields.clear();
+        foundFields.clear();
+        missingFields.clear();
     }
 
     /**
-     * Test a query where all fields exist.
+     * Test no non-existent fields or immaterial query subsets.
      */
     @Test
-    public void testAllFieldsExist() throws Exception {
-        givenQuery("FOO == 'abc' || BAR =~ 'abc' || filter:includeRegex(BAT, '45*')");
-        expectMessage("Fields not ingested in provided date range: BAR, BAT, FOO");
+    void testNoIssuesFound() throws Exception {
+        givenQuery("AGE == 'foo' || GENDER == 'bar'");
+
+        givenExistingFields("AGE", "GENDER");
+        expectFoundFields("AGE", "GENDER");
+
         assertResult();
+
+        EasyMock.verify(settings, helper);
     }
 
     /**
-     * Test a query where some fields do not exist.
+     * Test the presence of a non-existent field.
      */
     @Test
-    public void testNonExistentFields() throws Exception {
-        givenQuery("TOMFOOLERY == 'abc' || CHAOS =~ 'abc' || filter:includeRegex(SHENANIGANS, '45.8') || FOO == 'aa'");
-        expectMessage("Fields not found in data dictionary: TOMFOOLERY, CHAOS, SHENANIGANS");
-        expectMessage("Fields not ingested in provided date range: CHAOS, TOMFOOLERY, FOO, SHENANIGANS");
+    void testNonExistentFieldFound() throws Exception {
+        givenQuery("AGE == 'foo' || GENDER == 'bar'");
+
+        givenExistingFields("AGE");
+        expectFoundFields("AGE", "GENDER");
+        givenMissingFields("GENDER");
+
+        expectMessage("Fields not found in data dictionary: GENDER");
+
         assertResult();
+
+        EasyMock.verify(settings, helper);
     }
 
     /**
-     * Test a query that has a non-existent field that is a special field.
+     * Test the presence of an immaterial query subset.
      */
     @Test
-    public void testSpecialField() throws Exception {
-        givenQuery("FOO == 'abc' || TOMFOOLERY == 'abc' || _ANYFIELD_ = 'abc'");
-        givenFieldException(ANYFIELD);
-        expectMessage("Fields not found in data dictionary: TOMFOOLERY");
-        expectMessage("Fields not ingested in provided date range: TOMFOOLERY, FOO");
+    void testImmaterialFieldsFound() throws Exception {
+        givenQuery("AGE == 'foo' || GENDER == 'bar'");
+
+        givenExistingFields("AGE", "GENDER");
+        expectFoundFields("AGE", "GENDER");
+        givenMissingFields("AGE", "GENDER");
+
+        expectMessage("All fields [AGE, GENDER] found in the query subset 'AGE == 'foo' || GENDER == 'bar'' were not ingested in the provided date range.");
+
         assertResult();
+
+        EasyMock.verify(settings, helper);
     }
 
     /**
-     * Test a scenario where an exception gets thrown by the metadata helper.
+     * Test the presence of a non-existent field and an immaterial query subset.
      */
     @Test
-    public void testExceptionThrown() throws Exception {
-        MetadataHelper mockHelper = EasyMock.createMock(MetadataHelper.class);
-        Exception exception = new IllegalArgumentException("Failed to fetch all fields");
-        EasyMock.expect(mockHelper.getAllFields(Collections.emptySet())).andThrow(exception);
-        EasyMock.replay(mockHelper);
+    void testNonExistentFieldsAndImmaterialFieldsFound() throws Exception {
+        givenQuery("NAME == 'hat' && (AGE == 'foo' || GENDER == 'bar')");
 
-        givenQuery("FOO == 'abc'");
-        givenMetadataHelper(mockHelper);
+        givenExistingFields("AGE", "GENDER");
+        expectFoundFields("AGE", "GENDER", "NAME");
+        givenMissingFields("AGE", "GENDER");
 
-        expectException(exception);
+        expectMessage("Fields not found in data dictionary: NAME");
+        expectMessage("All fields [AGE, GENDER] found in the query subset 'AGE == 'foo' || GENDER == 'bar'' were not ingested in the provided date range.");
+
         assertResult();
-    }
 
-    private void givenFieldException(String exception) {
-        this.fieldExceptions.add(exception);
+        EasyMock.verify(settings, helper);
     }
 
     @Override
@@ -106,8 +135,37 @@ public class FieldExistenceRuleTest extends ShardQueryRuleTest {
 
     @Override
     protected ShardQueryRule getNewRule() {
+        EasyMock.expect(settings.getBeginDate()).andReturn(DateHelper.parse(beginDate));
+        EasyMock.expect(settings.getEndDate()).andReturn(DateHelper.parse(endDate));
+        givenQuerySettings(settings);
+
+        try {
+            EasyMock.expect(helper.getAllFields(Collections.emptySet())).andReturn(existingFields);
+        } catch (TableNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (!foundFields.isEmpty()) {
+            EasyMock.expect(helper.getMissingFieldsInDateRange(foundFields, Collections.emptySet(), beginDate, endDate, specialFields))
+                            .andReturn(missingFields);
+        }
+
+        EasyMock.replay(settings, helper);
+
         FieldExistenceRule rule = new FieldExistenceRule(ruleName);
-        rule.setSpecialFields(fieldExceptions);
+        rule.setSpecialFields(specialFields);
         return rule;
+    }
+
+    private void givenExistingFields(String... fields) {
+        this.existingFields.addAll(Arrays.asList(fields));
+    }
+
+    private void expectFoundFields(String... fields) {
+        this.foundFields.addAll(Arrays.asList(fields));
+    }
+
+    private void givenMissingFields(String... fields) {
+        this.missingFields.addAll(Arrays.asList(fields));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/rules/FieldExistenceRuleTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/rules/FieldExistenceRuleTest.java
@@ -135,8 +135,8 @@ public class FieldExistenceRuleTest extends ShardQueryRuleTest {
 
     @Override
     protected ShardQueryRule getNewRule() {
-        EasyMock.expect(settings.getBeginDate()).andReturn(DateHelper.parse(beginDate));
-        EasyMock.expect(settings.getEndDate()).andReturn(DateHelper.parse(endDate));
+        EasyMock.expect(settings.getBeginDate()).andReturn(DateHelper.parse(beginDate)).anyTimes();
+        EasyMock.expect(settings.getEndDate()).andReturn(DateHelper.parse(endDate)).anyTimes();
         givenQuerySettings(settings);
 
         try {

--- a/warehouse/query-core/src/test/java/datawave/query/rules/FieldExistenceRuleTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/rules/FieldExistenceRuleTest.java
@@ -102,7 +102,7 @@ public class FieldExistenceRuleTest extends ShardQueryRuleTest {
         expectFoundFields("AGE", "GENDER");
         givenMissingFields("AGE", "GENDER");
 
-        expectMessage("All fields [AGE, GENDER] found in the query subset 'AGE == 'foo' || GENDER == 'bar'' were not ingested in the provided date range.");
+        expectMessage("Fields not ingested in the provided date range: [AGE, GENDER]");
 
         assertResult();
 
@@ -121,7 +121,7 @@ public class FieldExistenceRuleTest extends ShardQueryRuleTest {
         givenMissingFields("AGE", "GENDER");
 
         expectMessage("Fields not found in data dictionary: NAME");
-        expectMessage("All fields [AGE, GENDER] found in the query subset 'AGE == 'foo' || GENDER == 'bar'' were not ingested in the provided date range.");
+        expectMessage("Fields not ingested in the provided date range: [AGE, GENDER]");
 
         assertResult();
 

--- a/warehouse/query-core/src/test/java/datawave/query/util/MockMetadataHelper.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MockMetadataHelper.java
@@ -73,10 +73,6 @@ public class MockMetadataHelper extends MetadataHelper {
                         Collections.emptySet());
     }
 
-    public MockMetadataHelper(Set<Authorizations> allMetadataAuths, Set<Authorizations> auths) {
-        super(createAllFieldMetadataHelper(getClient()), allMetadataAuths, getClient(), TableName.METADATA, auths, Collections.emptySet());
-    }
-
     private static AllFieldMetadataHelper createAllFieldMetadataHelper(AccumuloClient client) {
         final Set<Authorizations> allMetadataAuths = Collections.emptySet();
         final Set<Authorizations> auths = Collections.emptySet();
@@ -146,10 +142,6 @@ public class MockMetadataHelper extends MetadataHelper {
 
     public void addTermFrequencyFields(Collection<String> fields) {
         getMetadata().termFrequencyFields.addAll(fields);
-    }
-
-    public AccumuloClient getAccumuloClient() {
-        return this.accumuloClient;
     }
 
     @Override


### PR DESCRIPTION
- Simplify test setup and execution.
- Update visitor to collect fields from top-level nodes in separate subsets.
- Update rule to provide more information about which query subsets are considered immaterial.