### PR TITLE
Mixed bag of annotation web framework updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
         <version.infinispan>9.4.21.Final</version.infinispan>
         <version.jackson>2.10.0.pr1</version.jackson>
         <version.jackson-mapper-asl>1.9.13</version.jackson-mapper-asl>
-        <version.jackson.protobuf>0.9.12</version.jackson.protobuf>
         <version.jakarta>2.3.3</version.jakarta>
         <version.javassist>3.24.0-GA</version.javassist>
         <version.javastatsd>3.1.0</version.javastatsd>
@@ -268,11 +267,6 @@
                 <groupId>com.googlecode.json-simple</groupId>
                 <artifactId>json-simple</artifactId>
                 <version>${version.googlecode-json-simple}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.hubspot.jackson</groupId>
-                <artifactId>jackson-datatype-protobuf</artifactId>
-                <version>${version.jackson.protobuf}</version>
             </dependency>
             <dependency>
                 <groupId>com.mysql</groupId>

--- a/warehouse/annotation-core/src/main/java/datawave/annotation/util/Validator.java
+++ b/warehouse/annotation-core/src/main/java/datawave/annotation/util/Validator.java
@@ -91,7 +91,7 @@ public class Validator<T> {
      * @param target
      *            the target to check
      * @param failFast
-     *            wetheer to fail fast.
+     *            whether to fail fast.
      * @return the validation state.
      */
     public ValidationState<T> check(T target, boolean failFast) {

--- a/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/AnnotationUtils.java
+++ b/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/AnnotationUtils.java
@@ -16,7 +16,7 @@ import datawave.annotation.protobuf.v1.SegmentValue;
 
 public class AnnotationUtils {
     private static final JsonFormat.Printer PRINTER = JsonFormat.printer().preservingProtoFieldNames();
-    private static final JsonFormat.Parser PARSER = JsonFormat.parser().ignoringUnknownFields();
+    private static final JsonFormat.Parser PARSER = JsonFormat.parser();
 
     public static Annotation addSegmentBoundaryTypes(Annotation a) {
         Annotation.Builder b = a.toBuilder().clearSegments();

--- a/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonAnnotationDeserializer.java
+++ b/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonAnnotationDeserializer.java
@@ -1,0 +1,33 @@
+package datawave.annotation.util.v1;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Annotation;
+
+/** Implements a custom Jackson Annotation deserializer that simply uses the native Protobuf JsonFormat.Parser */
+public class JacksonAnnotationDeserializer extends JsonDeserializer<Annotation> {
+    private static final JsonFormat.Parser protobufJsonParser = JsonFormat.parser();
+
+    private final Annotation defaultInstance;
+
+    public JacksonAnnotationDeserializer() {
+        this(Annotation.newBuilder().build());
+    }
+
+    public JacksonAnnotationDeserializer(Annotation defaultInstance) {
+        this.defaultInstance = defaultInstance;
+    }
+
+    @Override
+    public Annotation deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        Annotation.Builder builder = defaultInstance.newBuilderForType();
+        protobufJsonParser.merge(p.readValueAsTree().toString(), builder);
+        return builder.build();
+    }
+}

--- a/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonAnnotationSerializer.java
+++ b/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonAnnotationSerializer.java
@@ -1,0 +1,22 @@
+package datawave.annotation.util.v1;
+
+import static datawave.annotation.util.v1.AnnotationUtils.addSegmentBoundaryTypes;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Annotation;
+
+/** Implements a custom Jackson Annotation serializer that simply uses the native Protobuf JsonFormat.Printer */
+public class JacksonAnnotationSerializer extends JsonSerializer<Annotation> {
+    private static final JsonFormat.Printer protobufJsonPrinter = JsonFormat.printer();
+
+    @Override
+    public void serialize(Annotation annotation, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeRawValue(protobufJsonPrinter.print(addSegmentBoundaryTypes(annotation)));
+    }
+}

--- a/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonSegmentDeserializer.java
+++ b/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonSegmentDeserializer.java
@@ -1,0 +1,33 @@
+package datawave.annotation.util.v1;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Segment;
+
+/** Implements a custom Jackson Segment deserializer that simply uses the native Protobuf JsonFormat.Parser */
+public class JacksonSegmentDeserializer extends JsonDeserializer<Segment> {
+    private static final JsonFormat.Parser protobufJsonParser = JsonFormat.parser();
+
+    private final Segment defaultInstance;
+
+    public JacksonSegmentDeserializer() {
+        this(Segment.newBuilder().build());
+    }
+
+    public JacksonSegmentDeserializer(Segment defaultInstance) {
+        this.defaultInstance = defaultInstance;
+    }
+
+    @Override
+    public Segment deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        Segment.Builder builder = defaultInstance.newBuilderForType();
+        protobufJsonParser.merge(p.readValueAsTree().toString(), builder);
+        return builder.build();
+    }
+}

--- a/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonSegmentSerializer.java
+++ b/warehouse/annotation-core/src/main/java/datawave/annotation/util/v1/JacksonSegmentSerializer.java
@@ -1,0 +1,20 @@
+package datawave.annotation.util.v1;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Segment;
+
+/** Implements a custom Jackson Segment serializer that simply uses the native Protobuf JsonFormat.Printer */
+public class JacksonSegmentSerializer extends JsonSerializer<Segment> {
+    private static final JsonFormat.Printer protobufJsonPrinter = JsonFormat.printer();
+
+    @Override
+    public void serialize(Segment segment, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeRawValue(protobufJsonPrinter.print(AnnotationUtils.injectBoundaryType(segment)));
+    }
+}

--- a/warehouse/annotation-core/src/test/java/datawave/annotation/util/v1/JacksonJsonSerializationTest.java
+++ b/warehouse/annotation-core/src/test/java/datawave/annotation/util/v1/JacksonJsonSerializationTest.java
@@ -1,0 +1,66 @@
+package datawave.annotation.util.v1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.test.v1.AnnotationAssertions;
+import datawave.annotation.test.v1.AnnotationTestDataUtil;
+
+/**
+ * Ensures that the Jackson Datatype Protobuf serialization is compatible with canonical Protobuf based JSON serialization for Annotations and Segments
+ */
+public class JacksonJsonSerializationTest {
+
+    private static final JsonFormat.Printer protobufPrinter = JsonFormat.printer();
+    private static final JsonFormat.Parser protobufParser = JsonFormat.parser();
+
+    static ObjectMapper objectMapper;
+
+    @BeforeAll
+    public static void configureObjectMapper() {
+        objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Annotation.class, new JacksonAnnotationDeserializer());
+        module.addSerializer(Annotation.class, new JacksonAnnotationSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void testJacksonCanSerialize() {
+        assertTrue(objectMapper.canSerialize(Annotation.class));
+    }
+
+    @Test
+    public void testEqualSerialization() throws Exception {
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+        String jacksonString = objectMapper.writeValueAsString(a);
+        String protobufString = protobufPrinter.print(a);
+        assertEquals(protobufString, jacksonString);
+    }
+
+    @Test
+    public void testJacksonDeserialization() throws Exception {
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+        String protobufString = protobufPrinter.print(a);
+        Annotation b = objectMapper.readValue(protobufString, Annotation.class);
+        AnnotationAssertions.assertAnnotationsEqual(a, b);
+    }
+
+    @Test
+    public void testProtobufDeserialization() throws Exception {
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+        String jacksonString = objectMapper.writeValueAsString(a);
+        Annotation.Builder bb = Annotation.newBuilder();
+        protobufParser.merge(jacksonString, bb);
+        Annotation b = bb.build();
+        AnnotationAssertions.assertAnnotationsEqual(a, b);
+    }
+}

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
@@ -84,11 +84,11 @@ public class AnnotationManagerBean implements AnnotationManager {
     @SpringBean(name = "AnnotationManagerConfig")
     private AnnotationManagerConfig config;
 
-    // Stateful variables, managed locally.
-    Set<Authorizations> authorizations;
-    AccumuloClient client;
-    LookupUUIDService lookupUUIDService;
-    AnnotationDataAccess annotationDataAccess;
+    // Per-request stateful variables, managed internally.
+    private Set<Authorizations> authorizations;
+    private AccumuloClient client;
+    private LookupUUIDService lookupUUIDService;
+    private AnnotationDataAccess annotationDataAccess;
 
     @VisibleForTesting
     public void setEJBContext(EJBContext ctx) {
@@ -276,7 +276,7 @@ public class AnnotationManagerBean implements AnnotationManager {
     @POST
     @Path("/{idType}/{id}/annotation")
     @Produces("application/json")
-    // TODO: @RolesAllowed({"AnnotationWriter"})
+    @RolesAllowed({"AnnotationWriter"})
     @Override
     public Response addAnnotation(@PathParam("idType") String idType, @PathParam("id") String id, String body) {
         try {
@@ -331,7 +331,7 @@ public class AnnotationManagerBean implements AnnotationManager {
     @PUT
     @Path("/{idType}/{id}/annotation/{annotationId}")
     @Produces("application/json")
-    // TODO: @RolesAllowed({"AnnotationWriter"})
+    @RolesAllowed({"AnnotationWriter"})
     @Override
     public Response updateAnnotation(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId,
                     String body) {
@@ -491,15 +491,25 @@ public class AnnotationManagerBean implements AnnotationManager {
      *             if the id is malformed.
      */
     private Metadata lookupDocumentIdentifier(String idType, String id) throws QueryException {
-        // TODO: if the idType is CONTENT or DOCUMENT, assume that the id provided is an internal id, otherwise
-        if (idType.equals("DOCUMENT")) {
+        if (idType.equals("DOCUMENT") || idType.equals("RECORD_ID")) {
+            // If the idType is RECORD_ID or DOCUMENT treat the id provided is an internal id.
             return parseDocumentIdentifier(id);
         } else {
+            // Otherwise, perform a lookup to find the internal id.
             final LookupUUIDService lookup = initializeLookupUUIDService();
             return lookup.executeLookupUUIDQuery(idType, id);
         }
     }
 
+    /**
+     * Parse an identifier that is expected to be in the shardId/datatype/eventUID format into a Metadata object
+     *
+     * @param identifier
+     *            the identifier to parse
+     * @return the corresponding Metadata object
+     * @throws IllegalArgumentException
+     *             if the identifier is not in the expected shardId/datatype/eventUID format.
+     */
     private Metadata parseDocumentIdentifier(String identifier) {
         final String[] parts = identifier.split("/");
         if (parts.length != 3) {

--- a/web-services/annotations/src/test/java/datawave/webservice/annotation/JacksonContextAnnotationJsonTest.java
+++ b/web-services/annotations/src/test/java/datawave/webservice/annotation/JacksonContextAnnotationJsonTest.java
@@ -1,0 +1,58 @@
+package datawave.webservice.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.test.v1.AnnotationAssertions;
+import datawave.annotation.test.v1.AnnotationTestDataUtil;
+import datawave.webservice.common.json.JacksonContextResolver;
+
+/**
+ * Ensures that the Jackson annotation serialization configured for the webservice is compatible with canonical Protobuf based JSON serialization for
+ * Annotations and Segments
+ */
+public class JacksonContextAnnotationJsonTest {
+
+    private static final JacksonContextResolver jacksonResolver = new JacksonContextResolver();
+    private static final ObjectMapper objectMapper = jacksonResolver.getContext(null);
+
+    private static final JsonFormat.Printer protobufPrinter = JsonFormat.printer();
+    private static final JsonFormat.Parser protobufParser = JsonFormat.parser();
+
+    @Test
+    public void testJacksonCanSerialize() {
+        assertTrue(objectMapper.canSerialize(Annotation.class));
+    }
+
+    @Test
+    public void testEqualSerialization() throws Exception {
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+        String jacksonString = objectMapper.writeValueAsString(a);
+        String protobufString = protobufPrinter.print(a);
+        assertEquals(protobufString, jacksonString);
+    }
+
+    @Test
+    public void testJacksonDeserialization() throws Exception {
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+        String protobufString = protobufPrinter.print(a);
+        Annotation b = objectMapper.readValue(protobufString, Annotation.class);
+        AnnotationAssertions.assertAnnotationsEqual(a, b);
+    }
+
+    @Test
+    public void testProtobufDeserialization() throws Exception {
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+        String jacksonString = objectMapper.writeValueAsString(a);
+        Annotation.Builder bb = Annotation.newBuilder();
+        protobufParser.merge(jacksonString, bb);
+        Annotation b = bb.build();
+        AnnotationAssertions.assertAnnotationsEqual(a, b);
+    }
+}

--- a/web-services/common/pom.xml
+++ b/web-services/common/pom.xml
@@ -32,16 +32,16 @@
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.hubspot.jackson</groupId>
-            <artifactId>jackson-datatype-protobuf</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>dns</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>gov.nsa.datawave</groupId>
+            <artifactId>datawave-annotation-core</artifactId>
         </dependency>
         <dependency>
             <groupId>gov.nsa.datawave</groupId>

--- a/web-services/common/src/main/java/datawave/webservice/common/json/JacksonContextResolver.java
+++ b/web-services/common/src/main/java/datawave/webservice/common/json/JacksonContextResolver.java
@@ -8,13 +8,18 @@ import javax.ws.rs.ext.Provider;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
-import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.Segment;
+import datawave.annotation.util.v1.JacksonAnnotationDeserializer;
+import datawave.annotation.util.v1.JacksonAnnotationSerializer;
+import datawave.annotation.util.v1.JacksonSegmentDeserializer;
+import datawave.annotation.util.v1.JacksonSegmentSerializer;
 
 /**
  * Configures JSON serialization via Jackson to honor JAXB annotations. This provider must be listed in the value of a {@code resteasy.providers} servlet
@@ -35,10 +40,14 @@ public class JacksonContextResolver implements ContextResolver<ObjectMapper> {
 
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addDeserializer(MultivaluedMap.class, new MultivaluedMapDeserializer());
-        mapper.registerModule(simpleModule);
 
-        mapper.registerModule(new ProtobufModule());
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // Added for Annotation and Segment serialization and deserialization.
+        simpleModule.addDeserializer(Annotation.class, new JacksonAnnotationDeserializer());
+        simpleModule.addSerializer(Annotation.class, new JacksonAnnotationSerializer());
+        simpleModule.addDeserializer(Segment.class, new JacksonSegmentDeserializer());
+        simpleModule.addSerializer(Segment.class, new JacksonSegmentSerializer());
+
+        mapper.registerModule(simpleModule);
     }
 
     @Override


### PR DESCRIPTION
* Addressed some late comments to the PR
* Enforce the AnnotationWriter role for annotation adds and updates
* Trim the webservices/annotations pom of unused or unnecessary dependencies
* Replaced `jackson-databind-protobuf` because its response serialization was inconsistent with request deserialization. The result is simpler.