### PR TITLE
ValueSerializer buffer overflow fix for Kryo types

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/ValueSerializer.java
@@ -175,15 +175,19 @@ public interface ValueSerializer<T> {
     }
 
     class KryoValueSerializer implements ValueSerializer<KryoSerializable> {
-        private final static int DEFAULT_BUFFER_SIZE = 4096;
+        // Reference Kryo source (maximum length)
+        // See https://stackoverflow.com/questions/3038392/do-java-arrays-have-a-maximum-size
+        private final static int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+
+        final static int DEFAULT_BUFFER_SIZE = 4096;
 
         private final Kryo kryo = new Kryo();
         private final byte[] bufferInput = new byte[DEFAULT_BUFFER_SIZE];
         private final byte[] bufferOutput = new byte[DEFAULT_BUFFER_SIZE];
 
         @Override
-        public Value serialize(KryoSerializable item) {
-            try (Output output = new Output(bufferOutput)) {
+        public Value serialize(KryoSerializable item) throws IOException {
+            try (Output output = new Output(bufferOutput, MAX_BUFFER_SIZE)) {
                 item.write(kryo, output);
                 output.flush();
                 return new Value(output.toBytes());

--- a/warehouse/query-core/src/test/java/datawave/query/util/ValueSerializerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/ValueSerializerTest.java
@@ -1,5 +1,6 @@
 package datawave.query.util;
 
+import static datawave.query.util.ValueSerializer.KryoValueSerializer.DEFAULT_BUFFER_SIZE;
 import static datawave.query.util.ValueSerializerType.KRYO;
 import static datawave.query.util.ValueSerializerType.WRITABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,6 +11,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.accumulo.core.data.Value;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.io.Writable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,6 +44,18 @@ public class ValueSerializerTest {
         TestType actual = serializer.deserialize(v1, TestType::new);
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testKryoSerializerWithLargeBuffer() throws Exception {
+        String r1 = RandomStringUtils.randomAlphabetic(DEFAULT_BUFFER_SIZE);
+        String r2 = RandomStringUtils.randomAlphabetic(DEFAULT_BUFFER_SIZE);
+        ValueSerializer<TestType> serializer = ValueSerializer.newSerializer(TestType.class, null, KRYO);
+        TestType typeIn = new TestType(r1, r2);
+        Value valOut = serializer.serializeUnchecked(typeIn);
+        TestType typeOut = serializer.deserializeUnchecked(valOut, TestType::new);
+
+        assertEquals(typeIn, typeOut);
     }
 
     static class TestType implements KryoSerializable, Writable {


### PR DESCRIPTION
The `KyroValueSerializer` contains a bug where it does not properly handle buffer capacity condition. 

Implemented fix by specifying a large max capacity. Kyro internally resizes the buffer and then the caller obtain the copy when calling `output.toBytes()`.