### PR TITLE
Update AnnotationManagerBean to properly handle documents with multiple internal ids

### DIFF
--- a/warehouse/annotation-core/src/test/java/datawave/annotation/test/v1/AnnotationAssertions.java
+++ b/warehouse/annotation-core/src/test/java/datawave/annotation/test/v1/AnnotationAssertions.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class AnnotationAssertions {
     }
 
     /** Assert that two lists of segment are equal. We start by ensuring that both of the segment id's */
-    public static void assertSegmentsEqual(List<Segment> expected, List<Segment> result) {
+    public static void assertSegmentsEqual(Collection<Segment> expected, Collection<Segment> result) {
         Map<String,Segment> expectedByUID = indexSegments(expected);
         Set<String> expectedUIDs = expectedByUID.keySet();
 
@@ -85,7 +86,7 @@ public class AnnotationAssertions {
      *            the list of segments we'll be comparing/
      * @return a map of segment id to segment.
      */
-    public static Map<String,Segment> indexSegments(List<Segment> input) {
+    public static Map<String,Segment> indexSegments(Collection<Segment> input) {
         final Map<String,Segment> index = new HashMap<>();
         for (Segment s : input) {
             index.put(s.getSegmentId(), s);

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
@@ -191,7 +191,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 }
             }
             if (results.isEmpty()) {
-                return jsonNotFound("annotation types", idType, id, Metadata.format(metadata), null, null, null);
+                return jsonNotFound("annotation types", idType, id, metadata.toString(), null, null, null);
             }
             return jsonOk(results);
         } catch (Exception e) {
@@ -222,7 +222,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 }
             }
             if (results.isEmpty()) {
-                return jsonNotFound("annotations", idType, id, Metadata.format(metadata), null, null, null);
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, null, null);
             }
             return jsonOk(results);
         } catch (Exception e) {
@@ -254,7 +254,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 }
             }
             if (results.isEmpty()) {
-                return jsonNotFound("annotations of type", idType, id, Metadata.format(metadata), annotationType, null, null);
+                return jsonNotFound("annotations of type", idType, id, metadata.toString(), annotationType, null, null);
             }
             return jsonOk(results);
         } catch (Exception e) {
@@ -282,7 +282,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 annotations.ifPresent(results::add);
             }
             if (results.isEmpty()) {
-                return jsonNotFound("annotations", idType, id, Metadata.format(metadata), null, annotationId, null);
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, annotationId, null);
             }
             return jsonOk(results);
         } catch (Exception e) {
@@ -315,7 +315,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonNotFound(message);
             } else if (metadataList.size() > 1) {
                 final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
-                                id, Metadata.format(metadataList));
+                                id, metadataList);
                 log.info(message);
                 return jsonError(message);
             }
@@ -378,7 +378,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonNotFound(message);
             } else if (metadataList.size() > 1) {
                 final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
-                                id, Metadata.format(metadataList));
+                                id, metadataList);
                 log.info(message);
                 return jsonError(message);
             }
@@ -436,12 +436,12 @@ public class AnnotationManagerBean implements AnnotationManager {
             }
 
             if (annotationResults.isEmpty()) {
-                return jsonNotFound("annotations", idType, id, Metadata.format(metadata), null, annotationId, segmentId);
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, annotationId, segmentId);
             }
 
             final Map<Metadata,Collection<Segment>> results = new HashMap<>();
             for (Map.Entry<Metadata,Annotation> entry : annotationResults.entrySet()) {
-                // now select only the segment that were requested.
+                // now select only the segments that were requested.
                 List<Segment> matchingSegments = new ArrayList<>();
                 for (Segment s : entry.getValue().getSegmentsList()) {
                     if (s.getSegmentId().equals(segmentId)) {
@@ -454,7 +454,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             }
 
             if (results.isEmpty()) {
-                return jsonNotFound("segments", idType, id, Metadata.format(metadata), null, annotationId, segmentId);
+                return jsonNotFound("segments", idType, id, metadata.toString(), null, annotationId, segmentId);
             }
             return jsonOk(results);
         } catch (QueryException e) {
@@ -481,7 +481,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonNotFound(message);
             } else if (metadataList.size() > 1) {
                 final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
-                                id, Metadata.format(metadataList));
+                                id, metadataList);
                 log.info(message);
                 return jsonError(message);
             }

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,7 +53,6 @@ import datawave.core.common.connection.AccumuloConnectionFactory;
 import datawave.microservice.authorization.util.AuthorizationsUtil;
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.webservice.query.exception.QueryException;
-import datawave.webservice.query.result.event.Metadata;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.query.runner.AccumuloConnectionRequestBean;
 
@@ -176,18 +176,24 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Produces("application/json")
     @Override
     public Response getAnnotationTypes(@PathParam("idType") String idType, @PathParam("id") String id) {
+        // TODO sanitize input to make sure it contains nothing weird like nulls.
         try {
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-
             final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
-            final Collection<String> types = annotationDataAccess.getAnnotationTypes(metadata.getRow(), metadata.getDataType(), metadata.getInternalId());
-            if (types.isEmpty()) {
-                return jsonNotFound("annotation types", idType, id, mdFmt(metadata), null, null);
+            final Map<Metadata,Collection<String>> results = new HashMap<>();
+            for (Metadata md : metadata) {
+                final Collection<String> types = annotationDataAccess.getAnnotationTypes(md.getRow(), md.getDataType(), md.getInternalId());
+                if (!types.isEmpty()) {
+                    results.put(md, types);
+                }
             }
-            return jsonOk(types);
+            if (results.isEmpty()) {
+                return jsonNotFound("annotation types", idType, id, Metadata.format(metadata), null, null, null);
+            }
+            return jsonOk(results);
         } catch (Exception e) {
             final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
             log.error(message, e);
@@ -201,19 +207,24 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotationsFor(@PathParam("idType") String idType, @PathParam("id") String id) {
         // TODO sanitize input to make sure it contains nothing weird like nulls.
-
         try {
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-
             final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
-            final List<Annotation> annotations = annotationDataAccess.getAnnotations(metadata.getRow(), metadata.getDataType(), metadata.getInternalId());
-            if (annotations.isEmpty()) {
-                return jsonNotFound("annotations", idType, id, mdFmt(metadata), null, null);
+
+            final List<Annotation> results = new ArrayList<>();
+            for (Metadata md : metadata) {
+                final List<Annotation> annotations = annotationDataAccess.getAnnotations(md.getRow(), md.getDataType(), md.getInternalId());
+                if (!annotations.isEmpty()) {
+                    results.addAll(annotations);
+                }
             }
-            return jsonOk(annotations);
+            if (results.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, Metadata.format(metadata), null, null, null);
+            }
+            return jsonOk(results);
         } catch (Exception e) {
             final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
             log.error(message, e);
@@ -227,20 +238,25 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotationsByType(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationType") String annotationType) {
         // TODO sanitize input to make sure it contains nothing weird like nulls.
-
         try {
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-
             final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
-            final List<Annotation> annotations = annotationDataAccess.getAnnotationsForType(metadata.getRow(), metadata.getDataType(), metadata.getInternalId(),
-                            annotationType);
-            if (annotations.isEmpty()) {
-                return jsonNotFound("annotations of type", idType, id, mdFmt(metadata), annotationType, null);
+
+            final List<Annotation> results = new ArrayList<>();
+            for (Metadata md : metadata) {
+                final List<Annotation> annotations = annotationDataAccess.getAnnotationsForType(md.getRow(), md.getDataType(), md.getInternalId(),
+                                annotationType);
+                if (!annotations.isEmpty()) {
+                    results.addAll(annotations);
+                }
             }
-            return jsonOk(annotations);
+            if (results.isEmpty()) {
+                return jsonNotFound("annotations of type", idType, id, Metadata.format(metadata), annotationType, null, null);
+            }
+            return jsonOk(results);
         } catch (Exception e) {
             final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
             log.error(message, e);
@@ -254,18 +270,21 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotation(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId) {
         try {
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-
             final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
-            final Optional<Annotation> annotations = annotationDataAccess.getAnnotation(metadata.getRow(), metadata.getDataType(), metadata.getInternalId(),
-                            annotationId);
-            if (annotations.isEmpty()) {
-                return jsonNotFound("annotations", idType, id, mdFmt(metadata), null, annotationId);
+
+            final List<Annotation> results = new ArrayList<>();
+            for (Metadata md : metadata) {
+                final Optional<Annotation> annotations = annotationDataAccess.getAnnotation(md.getRow(), md.getDataType(), md.getInternalId(), annotationId);
+                annotations.ifPresent(results::add);
             }
-            return jsonOk(annotations);
+            if (results.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, Metadata.format(metadata), null, annotationId, null);
+            }
+            return jsonOk(results);
         } catch (Exception e) {
             final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
             log.error(message, e);
@@ -289,12 +308,19 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonError(message);
             }
 
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
+            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id);
+            if (metadataList.isEmpty()) {
                 final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
                 log.info(message);
                 return jsonNotFound(message);
+            } else if (metadataList.size() > 1) {
+                final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
+                                id, Metadata.format(metadataList));
+                log.info(message);
+                return jsonError(message);
             }
+
+            final Metadata metadata = metadataList.get(0);
 
             //@formatter:off
             final Annotation localizedAnnotation = rawAnnotation.toBuilder()
@@ -345,12 +371,19 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonError(message);
             }
 
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
+            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id);
+            if (metadataList.isEmpty()) {
                 final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
                 log.info(message);
                 return jsonNotFound(message);
+            } else if (metadataList.size() > 1) {
+                final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
+                                id, Metadata.format(metadataList));
+                log.info(message);
+                return jsonError(message);
             }
+
+            final Metadata metadata = metadataList.get(0);
 
             //@formatter:off
             final Annotation localizedAnnotation = rawAnnotation.toBuilder()
@@ -390,50 +423,42 @@ public class AnnotationManagerBean implements AnnotationManager {
     public Response getAnnotationSegment(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId,
                     @PathParam("segmentId") String segmentId) {
         try {
-
-            // TODO: validate that we still need to retrieve individual segments. This is sorta brute force for now, we
-            // retrieve the entire annotation and return the segment with the matching id. Optimize later if this is a
-            // heavily used case.
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
-                final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
-                log.info(message);
-                return jsonNotFound(message);
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            if (metadata.isEmpty()) {
+                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-
             final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
-            final Optional<Annotation> annotation = annotationDataAccess.getAnnotation(metadata.getRow(), metadata.getDataType(), metadata.getInternalId(),
-                            annotationId);
-            if (annotation.isEmpty()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("No annotation found for idType: {}, id: {}, internalId: {}", idType, id, mdFmt(metadata));
+
+            final Map<Metadata,Annotation> annotationResults = new HashMap<>();
+            for (Metadata md : metadata) {
+                final Optional<Annotation> annotation = annotationDataAccess.getAnnotation(md.getRow(), md.getDataType(), md.getInternalId(), annotationId);
+                annotation.ifPresent(value -> annotationResults.put(md, value));
+            }
+
+            if (annotationResults.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, Metadata.format(metadata), null, annotationId, segmentId);
+            }
+
+            final Map<Metadata,Collection<Segment>> results = new HashMap<>();
+            for (Map.Entry<Metadata,Annotation> entry : annotationResults.entrySet()) {
+                // now select only the segment that were requested.
+                List<Segment> matchingSegments = new ArrayList<>();
+                for (Segment s : entry.getValue().getSegmentsList()) {
+                    if (s.getSegmentId().equals(segmentId)) {
+                        matchingSegments.add(s);
+                    }
                 }
-                return jsonNotFound("annotations", idType, id, mdFmt(metadata), null, annotationId);
-            }
-
-            // now filter out the segment that was requested
-            Annotation a = annotation.get();
-            List<Segment> matchingSegments = new ArrayList<>();
-            for (Segment s : a.getSegmentsList()) {
-                if (s.getSegmentId().equals(segmentId)) {
-                    matchingSegments.add(s);
+                if (!matchingSegments.isEmpty()) {
+                    results.put(entry.getKey(), matchingSegments);
                 }
             }
 
-            if (matchingSegments.isEmpty()) {
-                final String message = String.format("No segments found for identifier '%s:%s', internalId: '%s', with annotation id '%s' and segment id '%s'",
-                                idType, id, mdFmt(metadata), annotationId, segmentId);
-                log.debug(message);
-                return jsonNotFound(message);
-            } else if (matchingSegments.size() > 1) {
-                throw new QueryException(
-                                String.format("Multiple segments found for identifier '%s:%s', internalId: '%s', with annotation id '%s' and segment id '%s'",
-                                                idType, id, mdFmt(metadata), annotationId, segmentId));
+            if (results.isEmpty()) {
+                return jsonNotFound("segments", idType, id, Metadata.format(metadata), null, annotationId, segmentId);
             }
-            return jsonOk(Optional.of(matchingSegments.get(0)));
-
+            return jsonOk(results);
         } catch (QueryException e) {
-            final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
+            final String message = String.format("Internal error fetching segment: %s", e.getMessage());
             log.error(message, e);
             return jsonError(message);
         }
@@ -448,10 +473,20 @@ public class AnnotationManagerBean implements AnnotationManager {
     public Response addSegment(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId, String body) {
         try {
             Segment segment = AnnotationUtils.segmentFromJson(body);
-            final Metadata metadata = lookupDocumentIdentifier(idType, id);
-            if (metadata == null) {
-                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
+
+            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id);
+            if (metadataList.isEmpty()) {
+                final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
+                log.info(message);
+                return jsonNotFound(message);
+            } else if (metadataList.size() > 1) {
+                final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
+                                id, Metadata.format(metadataList));
+                log.info(message);
+                return jsonError(message);
             }
+            final Metadata metadata = metadataList.get(0);
+
             final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
             annotationDataAccess.addSegment(metadata.getRow(), metadata.getDataType(), metadata.getInternalId(), annotationId, segment);
             return jsonOk(segment.getSegmentId());
@@ -475,8 +510,7 @@ public class AnnotationManagerBean implements AnnotationManager {
     public Response updateSegment(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId,
                     @PathParam("segmentId") String segmentId, String body) {
         // TODO: determine update semantics.
-
-        return Response.ok().build();
+        return jsonError("Not implemented");
     }
 
     /**
@@ -486,11 +520,12 @@ public class AnnotationManagerBean implements AnnotationManager {
      *            the type of id provided
      * @param id
      *            the id itself.
-     * @return a Metadata object containing the source table, row, datatype and internal document id (uid).
+     * @return a list of zero to many Metadata objects with the internal shard, datatype, uid and table name of the identifier(s) provided. The list will be
+     *         empty if no identifier could be found using the authorizations and query logic employed by this class.
      * @throws QueryException
      *             if the id is malformed.
      */
-    private Metadata lookupDocumentIdentifier(String idType, String id) throws QueryException {
+    private List<Metadata> lookupDocumentIdentifier(String idType, String id) throws QueryException {
         if (idType.equals("DOCUMENT") || idType.equals("RECORD_ID")) {
             // If the idType is RECORD_ID or DOCUMENT treat the id provided is an internal id.
             return parseDocumentIdentifier(id);
@@ -506,25 +541,22 @@ public class AnnotationManagerBean implements AnnotationManager {
      *
      * @param identifier
      *            the identifier to parse
-     * @return the corresponding Metadata object
+     * @return a singleton list the corresponding Metadata object
      * @throws IllegalArgumentException
      *             if the identifier is not in the expected shardId/datatype/eventUID format.
      */
-    private Metadata parseDocumentIdentifier(String identifier) {
+    private List<Metadata> parseDocumentIdentifier(String identifier) {
         final String[] parts = identifier.split("/");
         if (parts.length != 3) {
             throw new IllegalArgumentException("Identifier does not specify all needed 3 parts. Identifier must be in the form 'shardId/datatype/eventUID'.");
         }
 
-        final Metadata md = new Metadata();
-        md.setTable(config.getLookupUUIDQueryLogic().getTableName());
-        md.setRow(parts[0]);
-        md.setDataType(parts[1]);
-        md.setInternalId(parts[2]);
-        return md;
+        final Metadata md = new Metadata(config.getLookupUUIDQueryLogic().getTableName(), parts[0], parts[1], parts[2]);
+        return Collections.singletonList(md);
     }
 
-    private static Response jsonNotFound(String objectType, String idType, String id, String internalId, String annotationType, String annotationId) {
+    private static Response jsonNotFound(String objectType, String idType, String id, String internalId, String annotationType, String annotationId,
+                    String segmentId) {
         String message = id.contains(internalId) ? String.format("No %s found for identifier: '%s:%s'", objectType, idType, id)
                         : String.format("No %s found for identifier '%s:%s', internalId: '%s'", objectType, idType, id, internalId);
 
@@ -533,6 +565,9 @@ public class AnnotationManagerBean implements AnnotationManager {
         }
         if (!StringUtils.isEmpty(annotationId)) {
             message += String.format(", annotationId '%s'", annotationId);
+        }
+        if (!StringUtils.isEmpty(segmentId)) {
+            message += String.format(", segmentId '%s'", segmentId);
         }
 
         return jsonNotFound(message);
@@ -551,10 +586,5 @@ public class AnnotationManagerBean implements AnnotationManager {
     private static Response jsonOk(Object responseObject) {
         // TODO: do we want to return more? (e.g., include fields like internal id, etc..
         return Response.ok(responseObject, MediaType.APPLICATION_JSON_TYPE.withCharset("utf-8")).build();
-    }
-
-    /** Format metadata for error messages, since it doesn't have a reasonable {@code toString} method */
-    private static String mdFmt(Metadata metadata) {
-        return String.format("%s/%s/%s [%s]", metadata.getRow(), metadata.getDataType(), metadata.getInternalId(), metadata.getTable());
     }
 }

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/LookupUUIDService.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/LookupUUIDService.java
@@ -21,7 +21,6 @@ import datawave.query.tables.ShardQueryLogic;
 import datawave.query.transformer.DocumentTransformer;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.result.event.EventBase;
-import datawave.webservice.query.result.event.Metadata;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 
 /**
@@ -68,16 +67,16 @@ public class LookupUUIDService {
      *            the type of id to query.
      * @param id
      *            the id value to query.
-     * @return a Metadata object with the internal shard, datatype, uid and table name of the corresponding document or null if no identifier could be found
-     *         using the authorizations and query logic employed by this class.
+     * @return a list of zero to many Metadata objects with the internal shard, datatype, uid and table name of the identifier(s) provided. The list will be
+     *         empty if no identifier could be found using the authorizations and query logic employed by this class.
      * @throws QueryException
      *             if exceptions are encountered performing the lookup.
      */
-    public Metadata executeLookupUUIDQuery(String idType, String id) throws QueryException {
+    public List<Metadata> executeLookupUUIDQuery(String idType, String id) throws QueryException {
         final String query = String.format("%s:%s", idType, id);
         final Map<String,String> queryParameters = new HashMap<>();
         queryParameters.put(QueryParameters.QUERY_SYNTAX, "LUCENE-UUID");
-        // TODO: setup other parameters.
+        // TODO: setup other parameters?
 
         Query settings = responseObjectFactory.getQueryImpl();
         settings.setBeginDate(config.getBeginAsDate());
@@ -100,18 +99,16 @@ public class LookupUUIDService {
         List<Metadata> metadataList = new ArrayList<>();
         while (iter.hasNext()) {
             EventBase<?,?> e = iter.next();
-            metadataList.add(e.getMetadata());
-        }
+            datawave.webservice.query.result.event.Metadata eventMetadata = e.getMetadata();
+            if (log.isDebugEnabled()) {
 
-        if (metadataList.isEmpty()) {
-            return null;
-        } else if (metadataList.size() > 1) {
-            throw new QueryException("Multiple metadata items returned for idType: " + idType + " id: " + id + " metadata items: " + metadataList);
+                String metadataMessage = String.format("%s/%s/%s [%s]", eventMetadata.getRow(), eventMetadata.getDataType(), eventMetadata.getInternalId(),
+                                eventMetadata.getTable());
+                log.debug("Found metadata {} for idType {}, id {}", metadataMessage, idType, id);
+            }
+            metadataList.add(new Metadata(eventMetadata));
         }
-
-        final Metadata md = metadataList.get(0);
-        log.debug("Found metadata {} for idType {}, id {}", md, idType, id);
-        return md;
+        return metadataList;
     }
 
     private static String getAuthorizationString(Set<Authorizations> authorizations) {

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/Metadata.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/Metadata.java
@@ -1,6 +1,5 @@
 package datawave.webservice.annotation;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -52,21 +51,6 @@ public class Metadata {
         this.table = table;
     }
 
-    /** Format metadata for error messages, since it doesn't have a reasonable {@code toString} method */
-    static String format(Metadata metadata) {
-        return String.format("%s/%s/%s [%s]", metadata.getRow(), metadata.getDataType(), metadata.getInternalId(), metadata.getTable());
-    }
-
-    /** Format metadata for error messages, since it doesn't have a reasonable {@code toString} method */
-    static String format(List<Metadata> metadata) {
-        StringBuilder b = new StringBuilder().append("[");
-        for (Metadata md : metadata) {
-            b.append(format(md)).append("; ");
-        }
-        b.setLength(b.length() - 2);
-        return b.append("]").toString();
-    }
-
     public String getDataType() {
         return dataType;
     }
@@ -84,7 +68,7 @@ public class Metadata {
     }
 
     public String toString() {
-        return format(this);
+        return String.format("%s/%s/%s [%s]", row, dataType, internalId, table);
     }
 
     @Override

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/Metadata.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/Metadata.java
@@ -1,0 +1,103 @@
+package datawave.webservice.annotation;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An immutable object that captures the internal Metadata associated with a record. It also provides a {@code equals} and {@code hashCode} implementation so
+ * that it can be used as a {@code Map} key. Similar to the {@link datawave.webservice.query.result.event.Metadata} class, but adds features specific to working
+ * with {@link datawave.annotation.protobuf.v1.Annotation} and {@link datawave.annotation.protobuf.v1.Segment}.
+ */
+public class Metadata {
+    /** the table where the record is stored */
+    private final String table;
+    /** the accumulo row / shard associated with a record */
+    private final String row;
+    /** the datatype of a record */
+    private final String dataType;
+    /** the internal identifier for a record */
+    private final String internalId;
+
+    /**
+     * Create a Metadata object using the field values from a {@link datawave.webservice.query.result.event.Metadata} object.
+     *
+     * @param eventMetadata
+     *            the object whose fields to copy.
+     */
+    public Metadata(datawave.webservice.query.result.event.Metadata eventMetadata) {
+        this(eventMetadata.getTable(), eventMetadata.getRow(), eventMetadata.getDataType(), eventMetadata.getInternalId());
+    }
+
+    /**
+     * Create a Metatata object based on the specified field values
+     *
+     * @param table
+     *            the table where the record is stored
+     * @param row
+     *            accumulo row / shard associated with a record
+     * @param dataType
+     *            the datatype of a record
+     * @param internalId
+     *            the internal identifier for a record
+     */
+    public Metadata(String table, String row, String dataType, String internalId) {
+        if (table == null || row == null || dataType == null || internalId == null) {
+            final String message = String.format("Null value provided when creating metadata: %s/%s/%s [%s]", row, dataType, internalId, table);
+            throw new NullPointerException(message);
+        }
+
+        this.row = row;
+        this.dataType = dataType;
+        this.internalId = internalId;
+        this.table = table;
+    }
+
+    /** Format metadata for error messages, since it doesn't have a reasonable {@code toString} method */
+    static String format(Metadata metadata) {
+        return String.format("%s/%s/%s [%s]", metadata.getRow(), metadata.getDataType(), metadata.getInternalId(), metadata.getTable());
+    }
+
+    /** Format metadata for error messages, since it doesn't have a reasonable {@code toString} method */
+    static String format(List<Metadata> metadata) {
+        StringBuilder b = new StringBuilder().append("[");
+        for (Metadata md : metadata) {
+            b.append(format(md)).append("; ");
+        }
+        b.setLength(b.length() - 2);
+        return b.append("]").toString();
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    public String getInternalId() {
+        return internalId;
+    }
+
+    public String getRow() {
+        return row;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String toString() {
+        return format(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Metadata metadata = (Metadata) o;
+        return Objects.equals(row, metadata.row) && Objects.equals(dataType, metadata.dataType) && Objects.equals(internalId, metadata.internalId)
+                        && Objects.equals(table, metadata.table);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(row, dataType, internalId, table);
+    }
+}

--- a/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanFunctionalTest.java
+++ b/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanFunctionalTest.java
@@ -6,14 +6,15 @@ import static datawave.annotation.test.v1.AnnotationTestDataUtil.generateMultiTe
 import static datawave.annotation.test.v1.AnnotationTestDataUtil.generateTestAnnotation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -241,9 +242,13 @@ public class AnnotationManagerBeanFunctionalTest {
 
     @Test
     public void testGetAnnotationTypesInternalId() {
+        Metadata expectedMetadata = new Metadata("shard", "20250704_249", "testDataType", "abcde.fghij.klmno");
         Response response = annotationManager.getAnnotationTypes("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno");
         assertResponseStatus(200, response);
-        Set<String> annotationTypeList = assertExpectedEntity(Set.class, response);
+        Map<Metadata,Collection<String>> annotationTypeMap = assertExpectedEntity(HashMap.class, response);
+        assertEquals(1, annotationTypeMap.size());
+        Collection<String> annotationTypeList = annotationTypeMap.get(expectedMetadata);
+        assertNotNull(annotationTypeList);
         assertEquals(1, annotationTypeList.size());
         assertTrue(annotationTypeList.contains("testAnnotationType"));
     }
@@ -268,9 +273,13 @@ public class AnnotationManagerBeanFunctionalTest {
 
     @Test
     public void testGetAnnotationTypesExternalIdWithAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-d5uxna.msizfm.-oxy0iu");
         Response response = annotationManager.getAnnotationTypes("UUID", "CORLEONE");
         assertResponseStatus(200, response);
-        Set<String> annotationTypeList = assertExpectedEntity(Set.class, response);
+        HashMap<Metadata,Collection<String>> annotationTypeMap = assertExpectedEntity(HashMap.class, response);
+        assertEquals(1, annotationTypeMap.size());
+        Collection<String> annotationTypeList = annotationTypeMap.get(expectedMetadata);
+        assertNotNull(annotationTypeList);
         assertEquals(1, annotationTypeList.size());
         assertTrue(annotationTypeList.contains("corleoneAnnotationType"));
     }
@@ -382,9 +391,10 @@ public class AnnotationManagerBeanFunctionalTest {
         Annotation expectedAnnotation = AnnotationUtils.injectAnnotationAndSegmentIds(testAnnotation);
         Response response = annotationManager.getAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", "a75beb9e");
         assertResponseStatus(200, response);
-        Optional<Annotation> annotationOptional = assertExpectedEntity(Optional.class, response);
-        assertFalse(annotationOptional.isEmpty());
-        assertAnnotationsEqual(expectedAnnotation, annotationOptional.get());
+        List<Annotation> annotationList = assertExpectedEntity(List.class, response);
+        assertFalse(annotationList.isEmpty());
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.iterator().next());
     }
 
     @Test
@@ -416,9 +426,10 @@ public class AnnotationManagerBeanFunctionalTest {
         Annotation expectedAnnotation = AnnotationUtils.injectAnnotationAndSegmentIds(testAnnotation);
         Response response = annotationManager.getAnnotation("UUID", "CORLEONE", "2e8fbb3e");
         assertResponseStatus(200, response);
-        Optional<Annotation> annotationOptional = assertExpectedEntity(Optional.class, response);
-        assertFalse(annotationOptional.isEmpty());
-        assertAnnotationsEqual(expectedAnnotation, annotationOptional.get());
+        List<Annotation> annotationList = assertExpectedEntity(List.class, response);
+        assertFalse(annotationList.isEmpty());
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.iterator().next());
     }
 
     @Ignore
@@ -433,6 +444,7 @@ public class AnnotationManagerBeanFunctionalTest {
 
     @Test
     public void testGetAnnotationSegmentInternalId() {
+        Metadata expectedMetadata = new Metadata("shard", "20250704_249", "testDataType", "abcde.fghij.klmno");
         Annotation testAnnotation = generateTestAnnotation();
         Annotation expectedAnnotation = AnnotationUtils.injectAnnotationAndSegmentIds(testAnnotation);
         //@formatter:off
@@ -444,9 +456,14 @@ public class AnnotationManagerBeanFunctionalTest {
         );
         //@formatter:on
         assertResponseStatus(200, response);
-        Optional<Segment> result = assertExpectedEntity(Optional.class, response);
+        Map<Metadata,Collection<Segment>> result = assertExpectedEntity(Map.class, response);
         assertFalse(result.isEmpty());
-        assertSegmentsEqual(expectedAnnotation.getSegmentsList(), List.of(result.get()));
+        assertEquals(1, result.size());
+        Collection<Segment> segmentsList = result.get(expectedMetadata);
+        assertNotNull(segmentsList);
+        assertFalse(segmentsList.isEmpty());
+        assertEquals(1, segmentsList.size());
+        assertSegmentsEqual(expectedAnnotation.getSegmentsList(), segmentsList);
     }
 
     @Test


### PR DESCRIPTION
The major change here is that `lookupDocumentIdentifier` in AnnotationManagerBean now returns a `List<Metadata>` instead of a `Metadata` objects, so all bean methods had to be updated to work with more than one `Metadata` object.

Also implemented a separate annotation-sepecific `Metadata` different from the one in the event package because the two contexts has different needs and it made sense to decouple the two.