### PR TITLE
Add ColumnVisibility cache

### DIFF
--- a/core/common-util/src/main/java/datawave/core/cache/CVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/CVCache.java
@@ -13,6 +13,11 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 public interface CVCache {
 
     /**
+     * The default cache size
+     */
+    int DEFAULT_SIZE = 256;
+
+    /**
      * The name of the cache implementation
      *
      * @return the name

--- a/core/common-util/src/main/java/datawave/core/cache/CVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/CVCache.java
@@ -1,0 +1,30 @@
+package datawave.core.cache;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.security.ColumnVisibility;
+
+/**
+ * An interface that defines a {@link ColumnVisibility} cache.
+ * <p>
+ * All caches must support threadsafe operations.
+ * <p>
+ * No implementation should rely on static variables.
+ */
+public interface CVCache {
+
+    /**
+     * The name of the cache implementation
+     *
+     * @return the name
+     */
+    String name();
+
+    /**
+     * Get or create a ColumnVisibility for the provided ByteSequence
+     *
+     * @param bytes
+     *            a {@link ByteSequence}
+     * @return a {@link ColumnVisibility}
+     */
+    ColumnVisibility get(ByteSequence bytes);
+}

--- a/core/common-util/src/main/java/datawave/core/cache/CVCacheFactory.java
+++ b/core/common-util/src/main/java/datawave/core/cache/CVCacheFactory.java
@@ -1,0 +1,25 @@
+package datawave.core.cache;
+
+/**
+ * Factory for creating various implementations of a {@link CVCache}.
+ * <p>
+ * The default implementation is the {@link CaffeineCVCache}.
+ */
+public class CVCacheFactory {
+
+    public static CVCache create() {
+        return new CaffeineCVCache();
+    }
+
+    public static CVCache createCaffeineCVCache() {
+        return new CaffeineCVCache();
+    }
+
+    public static CVCache createLRUMapCVCache() {
+        return new LRUMapCVCache();
+    }
+
+    public static CVCache createGuavaCVCache() {
+        return new GuavaCVCache();
+    }
+}

--- a/core/common-util/src/main/java/datawave/core/cache/CaffeineCVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/CaffeineCVCache.java
@@ -13,12 +13,20 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
  */
 public class CaffeineCVCache implements CVCache {
 
-    //  @formatter:off
-    private final LoadingCache<ByteSequence,ColumnVisibility> cache = Caffeine.newBuilder()
-            .maximumSize(128)
-            .expireAfterAccess(1, TimeUnit.HOURS)
-            .build(bytes -> new ColumnVisibility(bytes.toArray()));
-    //  @formatter:on
+    private final LoadingCache<ByteSequence,ColumnVisibility> cache;
+
+    public CaffeineCVCache() {
+        this(DEFAULT_SIZE);
+    }
+
+    public CaffeineCVCache(int size) {
+        //  @formatter:off
+        cache = Caffeine.newBuilder()
+                .maximumSize(size)
+                .expireAfterAccess(1, TimeUnit.HOURS)
+                .build(bytes -> new ColumnVisibility(bytes.toArray()));
+        //  @formatter:on
+    }
 
     @Override
     public String name() {

--- a/core/common-util/src/main/java/datawave/core/cache/CaffeineCVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/CaffeineCVCache.java
@@ -1,0 +1,32 @@
+package datawave.core.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.security.ColumnVisibility;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+/**
+ * A {@link Caffeine} implementation of a {@link CVCache}
+ */
+public class CaffeineCVCache implements CVCache {
+
+    //  @formatter:off
+    private final LoadingCache<ByteSequence,ColumnVisibility> cache = Caffeine.newBuilder()
+            .maximumSize(128)
+            .expireAfterAccess(1, TimeUnit.HOURS)
+            .build(bytes -> new ColumnVisibility(bytes.toArray()));
+    //  @formatter:on
+
+    @Override
+    public String name() {
+        return "Caffeine";
+    }
+
+    @Override
+    public ColumnVisibility get(ByteSequence bytes) {
+        return cache.get(bytes);
+    }
+}

--- a/core/common-util/src/main/java/datawave/core/cache/GuavaCVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/GuavaCVCache.java
@@ -15,17 +15,25 @@ import com.google.common.cache.LoadingCache;
  */
 public class GuavaCVCache implements CVCache {
 
-    //  @formatter:off
-    private final LoadingCache<ByteSequence,ColumnVisibility> cache = CacheBuilder.newBuilder()
-            .maximumSize(128)
-            .expireAfterWrite(1, TimeUnit.HOURS)
-            .build(new CacheLoader<>() {
-                @Override
-                public ColumnVisibility load(ByteSequence bytes) {
-                    return new ColumnVisibility(bytes.toArray());
-                }
-            });
-    //  @formatter:on
+    private final LoadingCache<ByteSequence,ColumnVisibility> cache;
+
+    public GuavaCVCache() {
+        this(DEFAULT_SIZE);
+    }
+
+    public GuavaCVCache(int size) {
+        //  @formatter:off
+        cache = CacheBuilder.newBuilder()
+                .maximumSize(size)
+                .expireAfterWrite(1, TimeUnit.HOURS)
+                .build(new CacheLoader<>() {
+                    @Override
+                    public ColumnVisibility load(ByteSequence bytes) {
+                        return new ColumnVisibility(bytes.toArray());
+                    }
+                });
+        //  @formatter:on
+    }
 
     @Override
     public String name() {

--- a/core/common-util/src/main/java/datawave/core/cache/GuavaCVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/GuavaCVCache.java
@@ -1,0 +1,43 @@
+package datawave.core.cache;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.security.ColumnVisibility;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+/**
+ * A guava {@link LoadingCache} implementation of a {@link CVCache}
+ */
+public class GuavaCVCache implements CVCache {
+
+    //  @formatter:off
+    private final LoadingCache<ByteSequence,ColumnVisibility> cache = CacheBuilder.newBuilder()
+            .maximumSize(128)
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .build(new CacheLoader<>() {
+                @Override
+                public ColumnVisibility load(ByteSequence bytes) {
+                    return new ColumnVisibility(bytes.toArray());
+                }
+            });
+    //  @formatter:on
+
+    @Override
+    public String name() {
+        return "Guava";
+    }
+
+    @Override
+    public ColumnVisibility get(ByteSequence bytes) {
+        try {
+            return cache.get(bytes);
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Invalid ColumnVisibility", e);
+        }
+    }
+}

--- a/core/common-util/src/main/java/datawave/core/cache/LRUMapCVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/LRUMapCVCache.java
@@ -1,0 +1,31 @@
+package datawave.core.cache;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.collections4.map.LRUMap;
+
+/**
+ * A {@link LRUMap} implementation of a {@link CVCache}
+ */
+public class LRUMapCVCache implements CVCache {
+
+    private final Map<ByteSequence,ColumnVisibility> cache = Collections.synchronizedMap(new LRUMap<>(256));
+
+    @Override
+    public String name() {
+        return "LRUMap";
+    }
+
+    @Override
+    public ColumnVisibility get(ByteSequence bytes) {
+        ColumnVisibility vis = cache.get(bytes);
+        if (vis == null) {
+            vis = new ColumnVisibility(bytes.toArray());
+            cache.put(bytes, vis);
+        }
+        return vis;
+    }
+}

--- a/core/common-util/src/main/java/datawave/core/cache/LRUMapCVCache.java
+++ b/core/common-util/src/main/java/datawave/core/cache/LRUMapCVCache.java
@@ -12,7 +12,15 @@ import org.apache.commons.collections4.map.LRUMap;
  */
 public class LRUMapCVCache implements CVCache {
 
-    private final Map<ByteSequence,ColumnVisibility> cache = Collections.synchronizedMap(new LRUMap<>(256));
+    private final Map<ByteSequence,ColumnVisibility> cache;
+
+    public LRUMapCVCache() {
+        this(DEFAULT_SIZE);
+    }
+
+    public LRUMapCVCache(int size) {
+        cache = Collections.synchronizedMap(new LRUMap<>(size));
+    }
 
     @Override
     public String name() {

--- a/core/common-util/src/test/java/datawave/core/cache/CVCacheIT.java
+++ b/core/common-util/src/test/java/datawave/core/cache/CVCacheIT.java
@@ -1,0 +1,252 @@
+package datawave.core.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.core.util.BadArgumentException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+/**
+ * A suite of unit tests that compare the performance of different cache implementations in various configurations
+ */
+public class CVCacheIT {
+
+    private final boolean debug = false;
+    private final int maxIterations = 1_000;
+    private final int lowThreads = 5;
+    private final int highThreads = 15;
+
+    @Test
+    public void testSimpleVisibility() {
+        ByteSequence sequence = get("PUBLIC");
+        testSingleThread(List.of(sequence));
+    }
+
+    @Test
+    public void testComplexVisibility() {
+        ByteSequence sequence = get("PUBLIC&FOO&(BAR|BAZ)");
+        testSingleThread(List.of(sequence));
+    }
+
+    @Test
+    public void testVariableColumnVisibilities() {
+        List<ByteSequence> sequences = List.of(get("PUBLIC"), get("PRIVATE"), get("PUBLIC&FOO&(BAR|BAZ)"), get("FIZZ|BUZZ"));
+        testSingleThread(sequences);
+    }
+
+    @Test
+    public void testInvalidColumnVisibility() {
+        String visibility = "PUBLIC&)|";
+        int count = 0;
+        List<CVCache> caches = getCaches();
+        for (CVCache cache : caches) {
+            ByteSequence sequence = get(visibility);
+            try {
+                cache.get(sequence);
+            } catch (Exception e) {
+                boolean isBadArgumentException = e instanceof BadArgumentException;
+                boolean isUncheckedExecutionException = e instanceof UncheckedExecutionException;
+                assertTrue(isBadArgumentException || isUncheckedExecutionException);
+            }
+            count++;
+        }
+        assertEquals(count, caches.size());
+    }
+
+    /**
+     * Drive the input byte sequences against each cache implementation
+     *
+     * @param sequences
+     *            the list of input byte sequences
+     */
+    protected void testSingleThread(List<ByteSequence> sequences) {
+        List<CVCache> caches = getCaches();
+        List<Pair<Long,String>> outputs = new ArrayList<>();
+        for (CVCache cache : caches) {
+            Pair<Long,String> output = testSingleThread(cache, sequences);
+            outputs.add(output);
+        }
+
+        if (debug) {
+            Collections.sort(outputs);
+            for (Pair<Long,String> output : outputs) {
+                System.out.println(output.getRight());
+            }
+        }
+    }
+
+    /**
+     * Drive the input byte sequences against the provided {@link CVCache}
+     *
+     * @param cache
+     *            a specific {@link CVCache} implementation
+     * @param sequences
+     *            the list of input byte sequences
+     * @return the total time to access the cache with a stats line
+     */
+    protected Pair<Long,String> testSingleThread(CVCache cache, List<ByteSequence> sequences) {
+        long total = 0L;
+        List<ColumnVisibility> expected = new ArrayList<>();
+        List<ColumnVisibility> results = new ArrayList<>();
+        for (int i = 0; i < maxIterations; i++) {
+            for (ByteSequence sequence : sequences) {
+                long elapsed = System.nanoTime();
+                ColumnVisibility result = cache.get(sequence);
+                total += System.nanoTime() - elapsed;
+                ColumnVisibility expectation = new ColumnVisibility(sequence.toArray());
+                results.add(result);
+                expected.add(expectation);
+            }
+            assertEquals(expected, results);
+        }
+
+        String line = "T=1 " + maxIterations + " took " + total + " ns for " + cache.name();
+        return Pair.of(total, line);
+    }
+
+    @Test
+    public void testLowThreadsLowVariance() {
+        List<ByteSequence> sequences = getRandomSequences(10);
+        testThreads(lowThreads, sequences);
+    }
+
+    @Test
+    public void testHighThreadsLowVariance() {
+        List<ByteSequence> sequences = getRandomSequences(10);
+        testThreads(highThreads, sequences);
+    }
+
+    @Test
+    public void testLowThreadsHighVariance() {
+        List<ByteSequence> sequences = getRandomSequences(100);
+        testThreads(lowThreads, sequences);
+    }
+
+    @Test
+    public void testHighThreadsHighVariance() {
+        List<ByteSequence> sequences = getRandomSequences(100);
+        testThreads(highThreads, sequences);
+    }
+
+    /**
+     * Drive the input byte sequences against the provided {@link CVCache} with a number of threads
+     *
+     * @param threads
+     *            the number of threads to use
+     * @param sequences
+     *            the list of input byte sequences
+     */
+    protected void testThreads(int threads, List<ByteSequence> sequences) {
+        List<CVCache> caches = getCaches();
+        List<Pair<Long,String>> outputs = new ArrayList<>();
+        for (CVCache cache : caches) {
+            Pair<Long,String> output = testThreads(threads, cache, sequences);
+            outputs.add(output);
+        }
+
+        if (debug) {
+            Collections.sort(outputs);
+            for (Pair<Long,String> output : outputs) {
+                System.out.println(output.getRight());
+            }
+        }
+    }
+
+    /**
+     * Drive the input byte sequences against the provided {@link CVCache} with a number of threads
+     *
+     * @param threads
+     *            the number of threads to use
+     * @param cache
+     *            a specific {@link CVCache} implementation
+     * @param sequences
+     *            the list of input byte sequences
+     * @return the total time to access the cache across all threads with a stats line
+     */
+    protected Pair<Long,String> testThreads(int threads, CVCache cache, List<ByteSequence> sequences) {
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+        List<Callable<Long>> callables = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            final List<ByteSequence> copy = new ArrayList<>(sequences);
+            Collections.shuffle(copy);
+            callables.add(() -> {
+                long total = 0L;
+                List<ColumnVisibility> expected = new ArrayList<>();
+                List<ColumnVisibility> results = new ArrayList<>();
+                for (int k = 0; k < maxIterations; k++) {
+                    for (ByteSequence sequence : copy) {
+                        long elapsed = System.nanoTime();
+                        ColumnVisibility result = cache.get(sequence);
+                        total += System.nanoTime() - elapsed;
+
+                        results.add(result);
+                        expected.add(new ColumnVisibility(sequence.toArray()));
+                    }
+                    assertEquals(expected, results);
+                }
+                return total;
+            });
+        }
+
+        try {
+            List<Future<Long>> futures = executor.invokeAll(callables);
+
+            long total = 0L;
+            for (Future<Long> future : futures) {
+                long time = future.get();
+                total += time;
+            }
+            String line = "T=" + threads + " " + maxIterations + " took " + total + " ns for " + cache.name();
+            return Pair.of(total, line);
+
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected List<ByteSequence> getRandomSequences(int n) {
+        List<ByteSequence> sequences = new ArrayList<>();
+        while (sequences.size() < n) {
+            String data = RandomStringUtils.secure().nextAlphabetic(10);
+            sequences.add(get(data));
+        }
+        return sequences;
+    }
+
+    protected ArrayByteSequence get(String s) {
+        return new ArrayByteSequence(s);
+    }
+
+    /**
+     * Get a list of each unique cache implementation in random order
+     *
+     * @return the list of caches
+     */
+    protected List<CVCache> getCaches() {
+        List<CVCache> caches = new ArrayList<>();
+        caches.add(new GuavaCVCache());
+        caches.add(new CaffeineCVCache());
+        caches.add(new LRUMapCVCache());
+
+        Collections.shuffle(caches);
+        return caches;
+    }
+
+}


### PR DESCRIPTION
Add several column visibility cache implementations along with an integration test that demonstrates cache performance under various levels of concurrency. 

Implementations include a synchronized LRU map, Guava and Caffeine.