### PR TITLE
Fixes pom version for some modules in version7.29-loe1 branch

### DIFF
--- a/warehouse/annotation-core/pom.xml
+++ b/warehouse/annotation-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave</groupId>
         <artifactId>datawave-warehouse-parent</artifactId>
-        <version>7.30.0-SNAPSHOT</version>
+        <version>7.29.5-SNAPSHOT</version>
     </parent>
     <artifactId>datawave-annotation-core</artifactId>
     <properties>

--- a/warehouse/ingest-annotation/pom.xml
+++ b/warehouse/ingest-annotation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave</groupId>
         <artifactId>datawave-warehouse-parent</artifactId>
-        <version>7.33.0-SNAPSHOT</version>
+        <version>7.29.5-SNAPSHOT</version>
     </parent>
     <artifactId>datawave-ingest-annotation</artifactId>
     <packaging>jar</packaging>

--- a/web-services/annotations/pom.xml
+++ b/web-services/annotations/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.webservices</groupId>
         <artifactId>datawave-ws-parent</artifactId>
-        <version>7.33.0-SNAPSHOT</version>
+        <version>7.29.5-SNAPSHOT</version>
     </parent>
     <artifactId>datawave-ws-annotations</artifactId>
     <packaging>ejb</packaging>


### PR DESCRIPTION
* When cherry-picking new modules that added pom, their versions needed to be adjusted to match 7.29.5-SNAPSHOT, the current version of the release/version7.29-loe1 branch.