### PR TITLE
Generate word clouds from data stored in fields

### DIFF
--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
@@ -3,6 +3,7 @@ package datawave.util.keyword;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -47,12 +48,8 @@ public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
     }
 
     @Override
-    public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, TagCloudPartition.SCORE_TYPE scoreType) {
-        if (scoreType == TagCloudPartition.SCORE_TYPE.LOWER_IS_BETTER) {
-            return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).min(Double::compareTo).orElse(1.0);
-        } else {
-            return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).max(Double::compareTo).orElse(0d);
-        }
+    public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, Comparator<Double> comparator, double defaultScore) {
+        return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).sorted(comparator).findFirst().orElse(defaultScore);
     }
 
     @Override

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
@@ -3,11 +3,14 @@ package datawave.util.keyword;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Default implementations for pluggable utilities for generating tag clouds, includes mechanisms to partition keywords into separate tag clouds, combine or
@@ -15,6 +18,7 @@ import org.apache.accumulo.core.security.ColumnVisibility;
  */
 public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
     private static final long serialVersionUID = 652771994052429009L;
+    private static final String MULTI_VALUE_SEPARATOR = ",";
 
     @Override
     public Map<String,String> generateCombinedVisibility(Set<String> visibilities) {
@@ -31,34 +35,19 @@ public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
     }
 
     @Override
-    public String computeIndexKey(KeywordResults results, String keyword, boolean partitionOnLanguage) {
-        return (partitionOnLanguage ? results.getLanguage() + "%%" : "") + keyword;
-    }
+    public Map<String,String> generateCombinedMetadata(Map<String,Set<String>> metadata) {
+        Map<String,String> combined = new HashMap<>();
 
-    @Override
-    public String computeVisibilityKey(KeywordResults results, boolean partitionOnLanguage) {
-        return partitionOnLanguage ? results.getLanguage() : "";
-    }
-
-    @Override
-    public String computePartitionKey(Map.Entry<String,TagCloudEntry.Builder> entry, boolean partitionOnLanguage) {
-        final String key = entry.getKey();
-        final int pos = key.indexOf("%%");
-        if (pos > -1) {
-            return key.substring(0, pos);
-        } else {
-            return "";
+        for (Entry<String,Set<String>> entry : metadata.entrySet()) {
+            String joined = StringUtils.join(entry.getValue(), MULTI_VALUE_SEPARATOR);
+            combined.put(entry.getKey(), joined);
         }
-    }
 
-    @Override
-    public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores) {
-        return calculateScore(sourceScores, TagCloudPartition.SCORE_TYPE.LOWER_IS_BETTER);
+        return combined;
     }
 
     @Override
     public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, TagCloudPartition.SCORE_TYPE scoreType) {
-        // for now, choose the best (smallest) scored version of the tag.
         if (scoreType == TagCloudPartition.SCORE_TYPE.LOWER_IS_BETTER) {
             return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).min(Double::compareTo).orElse(1.0);
         } else {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/DefaultTagCloudUtils.java
@@ -14,7 +14,6 @@ import org.apache.accumulo.core.security.ColumnVisibility;
  * merge visibility strings, and calculate scores, source collections and frequencies of individual keywords based on observed results
  */
 public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
-
     private static final long serialVersionUID = 652771994052429009L;
 
     @Override
@@ -54,9 +53,17 @@ public class DefaultTagCloudUtils implements TagCloudUtils, Serializable {
 
     @Override
     public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores) {
-        // for now, choose the best (smallest) scored version of the tag.
-        return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).min(Double::compareTo).orElse(1.0);
+        return calculateScore(sourceScores, TagCloudPartition.SCORE_TYPE.LOWER_IS_BETTER);
+    }
 
+    @Override
+    public double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, TagCloudPartition.SCORE_TYPE scoreType) {
+        // for now, choose the best (smallest) scored version of the tag.
+        if (scoreType == TagCloudPartition.SCORE_TYPE.LOWER_IS_BETTER) {
+            return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).min(Double::compareTo).orElse(1.0);
+        } else {
+            return sourceScores.stream().map(TagCloudEntry.ScoreTuple::getScore).max(Double::compareTo).orElse(0d);
+        }
     }
 
     @Override

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
@@ -1,6 +1,5 @@
 package datawave.util.keyword;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,15 +141,7 @@ public class KeywordExtractor {
                 logger.debug("Extracted {} keywords from {} view.", keywords.size(), view);
             }
             if (!keywords.isEmpty()) {
-                Map<String,String> metadata = new HashMap<>();
-                metadata.put("type", KEYWORD_TYPE);
-                if (view != null && !view.isEmpty()) {
-                    metadata.put("view", view);
-                }
-                if (language != null && !language.isEmpty()) {
-                    metadata.put("language", language);
-                }
-                return new KeywordResults(source, content.getVisibility(), keywords, metadata);
+                return new KeywordResults(source, view, language, content.getVisibility(), keywords);
             }
         }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordExtractor.java
@@ -1,5 +1,6 @@
 package datawave.util.keyword;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,7 @@ public class KeywordExtractor {
     public static final String MAX_KEYWORDS = "max.keyword.count";
     public static final String MAX_SCORE = "max.score";
     public static final String MAX_CONTENT_CHARS = "max.content.chars";
+    public static final String KEYWORD_TYPE = "keyword";
 
     private final List<Map.Entry<String,VisibleContent>> orderedContent;
 
@@ -140,7 +142,15 @@ public class KeywordExtractor {
                 logger.debug("Extracted {} keywords from {} view.", keywords.size(), view);
             }
             if (!keywords.isEmpty()) {
-                return new KeywordResults(source, view, language, content.getVisibility(), keywords);
+                Map<String,String> metadata = new HashMap<>();
+                metadata.put("type", KEYWORD_TYPE);
+                if (view != null && !view.isEmpty()) {
+                    metadata.put("view", view);
+                }
+                if (language != null && !language.isEmpty()) {
+                    metadata.put("language", language);
+                }
+                return new KeywordResults(source, content.getVisibility(), keywords, metadata);
             }
         }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
@@ -7,69 +7,135 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.apache.hadoop.io.Writable;
+
+import com.google.gson.Gson;
 
 /**
  * Encapsulates results from a keyword extraction algorithm for a single document and provides serialization and deserialization mechanism
  */
-public class KeywordResults extends TagCloudInput {
-    // TODO-crwill9 this class should be decoupled from TagCloudInput
+public class KeywordResults implements Writable {
+
+    private static final Gson gson = new Gson();
+
+    /** the identifier for the source document */
+    String source;
+
+    /** the name of the view from which the keywords were extracted */
+    String view;
+
+    /** the language of the source document used for keyword extraction */
+    String language;
+
+    /** a visibility expression for these keyword results */
+    String visibility;
+
+    /** the keywords and scores produced by the extraction algorithm */
+    final Map<String,Double> keywords;
+
     public KeywordResults() {
-        this("", "", new LinkedHashMap<>(), new HashMap<>());
+        this("", "", "", "", new LinkedHashMap<>());
     }
 
-    public KeywordResults(String source, String visibility, Map<String,Double> results, Map<String,String> metadata) {
-        super(source, visibility, results, metadata);
+    public KeywordResults(String source, String view, String language, String visibility, Map<String,Double> results) {
+        this.source = source;
+        this.view = view;
+        this.language = language;
+        this.visibility = visibility;
+        this.keywords = results;
     }
 
-    public Map<String,Double> getKeywords() {
-        return getEntities();
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getView() {
+        return view;
+    }
+
+    public void setView(String view) {
+        this.view = view;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(String visibility) {
+        this.visibility = visibility;
     }
 
     public int getKeywordCount() {
-        return getEntities().size();
+        return keywords.size();
     }
 
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (!super.equals(other)) {
-            return false;
-        }
-        if (!(other instanceof KeywordResults)) {
-            return false;
-        }
-        return true;
+    public Map<String,Double> getKeywords() {
+        return keywords;
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
+    public String toJson() {
+        return gson.toJson(this);
+    }
+
+    public static KeywordResults fromJson(String json) {
+        return gson.fromJson(json, KeywordResults.class);
     }
 
     @Override
     public void readFields(DataInput dataInput) throws IOException {
         String clazz = dataInput.readUTF();
         if (!clazz.equals(KeywordResults.class.getCanonicalName())) {
-            throw new IllegalArgumentException("Incompatible DataInput");
+            throw new IllegalArgumentException("Incompatible dataInput");
         }
-
-        super.readFields(dataInput);
+        int sz = dataInput.readInt();
+        this.source = dataInput.readUTF();
+        this.view = dataInput.readUTF();
+        this.language = dataInput.readUTF();
+        this.visibility = dataInput.readUTF();
+        for (int i = 0; i < sz; i++) {
+            keywords.put(dataInput.readUTF(), dataInput.readDouble());
+        }
     }
 
     @Override
     public void write(DataOutput dataOutput) throws IOException {
-        // write the class first
+        // write the class name first so reading the first field can easily test for compatibility
         dataOutput.writeUTF(KeywordResults.class.getCanonicalName());
-        super.write(dataOutput);
+        dataOutput.writeInt(keywords.size());
+        dataOutput.writeUTF(source == null ? "" : source);
+        dataOutput.writeUTF(view == null ? "" : view);
+        dataOutput.writeUTF(language == null ? "" : language);
+        dataOutput.writeUTF(visibility == null ? "" : visibility);
+        for (Map.Entry<String,Double> e : keywords.entrySet()) {
+            dataOutput.writeUTF(e.getKey());
+            dataOutput.writeDouble(e.getValue());
+        }
     }
 
-    public static boolean canDeserialize(byte[] input) throws IOException {
-        try (ByteArrayInputStream in = new ByteArrayInputStream(input); DataInputStream dataInput = new DataInputStream(in)) {
+    /**
+     * Read the first string off the byte stream, it should be the class name if compatible
+     *
+     * @param bytes
+     * @return true if this byte stream can be deserialized, false otherwise
+     * @throws IOException
+     */
+    public static boolean canDeserialize(byte[] bytes) throws IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(bytes); DataInputStream dataInput = new DataInputStream(in)) {
             return dataInput.readUTF().equals(KeywordResults.class.getCanonicalName());
         }
     }

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
@@ -34,13 +34,13 @@ public class KeywordResults implements Writable {
     String visibility;
 
     /** the keywords and scores produced by the extraction algorithm */
-    final LinkedHashMap<String,Double> keywords;
+    final Map<String,Double> keywords;
 
     public KeywordResults() {
         this("", "", "", "", new LinkedHashMap<>());
     }
 
-    public KeywordResults(String source, String view, String language, String visibility, LinkedHashMap<String,Double> results) {
+    public KeywordResults(String source, String view, String language, String visibility, Map<String,Double> results) {
         this.source = source;
         this.view = view;
         this.language = language;
@@ -84,7 +84,7 @@ public class KeywordResults implements Writable {
         return keywords.size();
     }
 
-    public LinkedHashMap<String,Double> getKeywords() {
+    public Map<String,Double> getKeywords() {
         return keywords;
     }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
@@ -9,51 +9,26 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.apache.hadoop.io.Writable;
-
-import com.google.gson.Gson;
+import java.util.Objects;
 
 /**
  * Encapsulates results from a keyword extraction algorithm for a single document and provides serialization and deserialization mechanism
  */
-public class KeywordResults implements Writable {
-
-    private static final Gson gson = new Gson();
-
-    /** the identifier for the source document */
-    String source;
-
+public class KeywordResults extends TagCloudInput {
     /** the name of the view from which the keywords were extracted */
     String view;
 
     /** the language of the source document used for keyword extraction */
     String language;
 
-    /** a visibility expression for these keyword results */
-    String visibility;
-
-    /** the keywords and scores produced by the extraction algorithm */
-    final Map<String,Double> keywords;
-
     public KeywordResults() {
         this("", "", "", "", new LinkedHashMap<>());
     }
 
     public KeywordResults(String source, String view, String language, String visibility, Map<String,Double> results) {
-        this.source = source;
+        super(source, visibility, results);
         this.view = view;
         this.language = language;
-        this.visibility = visibility;
-        this.keywords = results;
-    }
-
-    public String getSource() {
-        return source;
-    }
-
-    public void setSource(String source) {
-        this.source = source;
     }
 
     public String getView() {
@@ -72,52 +47,59 @@ public class KeywordResults implements Writable {
         this.language = language;
     }
 
-    public String getVisibility() {
-        return visibility;
-    }
-
-    public void setVisibility(String visibility) {
-        this.visibility = visibility;
+    public Map<String,Double> getKeywords() {
+        return getEntities();
     }
 
     public int getKeywordCount() {
-        return keywords.size();
+        return getEntities().size();
     }
 
-    public Map<String,Double> getKeywords() {
-        return keywords;
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!super.equals(other)) {
+            return false;
+        }
+        if (!(other instanceof KeywordResults)) {
+            return false;
+        }
+
+        KeywordResults otherKeywordResults = (KeywordResults) other;
+        return Objects.equals(view, otherKeywordResults.view) && Objects.equals(language, otherKeywordResults.language);
     }
 
-    public String toJson() {
-        return gson.toJson(this);
-    }
-
-    public static KeywordResults fromJson(String json) {
-        return gson.fromJson(json, KeywordResults.class);
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), view, language);
     }
 
     @Override
     public void readFields(DataInput dataInput) throws IOException {
-        int sz = dataInput.readInt();
-        this.source = dataInput.readUTF();
+        String clazz = dataInput.readUTF();
+        if (!clazz.equals(KeywordResults.class.getCanonicalName())) {
+            throw new IllegalArgumentException("Incompatible DataInput");
+        }
+
+        super.readFields(dataInput);
         this.view = dataInput.readUTF();
         this.language = dataInput.readUTF();
-        this.visibility = dataInput.readUTF();
-        for (int i = 0; i < sz; i++) {
-            keywords.put(dataInput.readUTF(), dataInput.readDouble());
-        }
     }
 
     @Override
     public void write(DataOutput dataOutput) throws IOException {
-        dataOutput.writeInt(keywords.size());
-        dataOutput.writeUTF(source == null ? "" : source);
+        // write the class first
+        dataOutput.writeUTF(KeywordResults.class.getCanonicalName());
+        super.write(dataOutput);
         dataOutput.writeUTF(view == null ? "" : view);
         dataOutput.writeUTF(language == null ? "" : language);
-        dataOutput.writeUTF(visibility == null ? "" : visibility);
-        for (Map.Entry<String,Double> e : keywords.entrySet()) {
-            dataOutput.writeUTF(e.getKey());
-            dataOutput.writeDouble(e.getValue());
+    }
+
+    public static boolean canDeserialize(byte[] input) throws IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(input); DataInputStream dataInput = new DataInputStream(in)) {
+            return dataInput.readUTF().equals(KeywordResults.class.getCanonicalName());
         }
     }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/KeywordResults.java
@@ -7,44 +7,21 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Encapsulates results from a keyword extraction algorithm for a single document and provides serialization and deserialization mechanism
  */
 public class KeywordResults extends TagCloudInput {
-    /** the name of the view from which the keywords were extracted */
-    String view;
-
-    /** the language of the source document used for keyword extraction */
-    String language;
-
+    // TODO-crwill9 this class should be decoupled from TagCloudInput
     public KeywordResults() {
-        this("", "", "", "", new LinkedHashMap<>());
+        this("", "", new LinkedHashMap<>(), new HashMap<>());
     }
 
-    public KeywordResults(String source, String view, String language, String visibility, Map<String,Double> results) {
-        super(source, visibility, results);
-        this.view = view;
-        this.language = language;
-    }
-
-    public String getView() {
-        return view;
-    }
-
-    public void setView(String view) {
-        this.view = view;
-    }
-
-    public String getLanguage() {
-        return language;
-    }
-
-    public void setLanguage(String language) {
-        this.language = language;
+    public KeywordResults(String source, String visibility, Map<String,Double> results, Map<String,String> metadata) {
+        super(source, visibility, results, metadata);
     }
 
     public Map<String,Double> getKeywords() {
@@ -66,14 +43,12 @@ public class KeywordResults extends TagCloudInput {
         if (!(other instanceof KeywordResults)) {
             return false;
         }
-
-        KeywordResults otherKeywordResults = (KeywordResults) other;
-        return Objects.equals(view, otherKeywordResults.view) && Objects.equals(language, otherKeywordResults.language);
+        return true;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), view, language);
+        return super.hashCode();
     }
 
     @Override
@@ -84,8 +59,6 @@ public class KeywordResults extends TagCloudInput {
         }
 
         super.readFields(dataInput);
-        this.view = dataInput.readUTF();
-        this.language = dataInput.readUTF();
     }
 
     @Override
@@ -93,8 +66,6 @@ public class KeywordResults extends TagCloudInput {
         // write the class first
         dataOutput.writeUTF(KeywordResults.class.getCanonicalName());
         super.write(dataOutput);
-        dataOutput.writeUTF(view == null ? "" : view);
-        dataOutput.writeUTF(language == null ? "" : language);
     }
 
     public static boolean canDeserialize(byte[] input) throws IOException {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -106,22 +106,38 @@ public class TagCloud {
             for (TagCloudInput tagCloudInput : tagCloudPartition.getInputs()) {
                 for (final Map.Entry<String,Double> e : tagCloudInput.getEntities().entrySet()) {
                     final String partitionKey = partition + VALUE_SEPARATOR + e.getKey();
-                    TagCloudEntry.Builder b = index.computeIfAbsent(partitionKey,
-                                    k -> new TagCloudEntry.Builder(e.getKey(), tagCloudPartition.getScoreType()).withUtilities(utils));
+                    final TagCloudPartition.ScoreType scoreType = tagCloudPartition.getScoreType();
+                    TagCloudEntry.Builder b = index.computeIfAbsent(partitionKey, k -> new TagCloudEntry.Builder(e.getKey()).withUtilities(utils))
+                                    .withScoreComparator(getScoreComparator(scoreType)).withDefaultScore(getDefaultScore(scoreType));
                     // these are aggregated on the partition, not the partition/key combination
                     Map<String,Set<String>> partitionMetadata = metadata.computeIfAbsent(partition, k -> new HashMap<>());
                     for (Map.Entry<String,String> entryMetadata : tagCloudInput.getMetadata().entrySet()) {
                         Set<String> entryValues = partitionMetadata.computeIfAbsent(entryMetadata.getKey(), k -> new HashSet<>());
                         entryValues.add(entryMetadata.getValue());
                     }
-                    // TODO-crwill9 probably okay to pass partition here, but not sure why its needed at all
-                    b.addSourceScore(tagCloudInput.getSource(), e.getValue(), partition);
+                    b.addSourceScore(tagCloudInput.getSource(), e.getValue());
                 }
 
                 if (!tagCloudInput.getVisibility().isEmpty() && !tagCloudInput.getEntities().isEmpty()) {
                     Set<String> visibilityList = visibilities.computeIfAbsent(partition, k -> new TreeSet<>());
                     visibilityList.add(tagCloudInput.getVisibility());
                 }
+            }
+        }
+
+        private Comparator<Double> getScoreComparator(TagCloudPartition.ScoreType scoreType) {
+            if (scoreType == TagCloudPartition.ScoreType.HIGHER_IS_BETTER) {
+                return Comparator.<Double> naturalOrder().reversed();
+            } else {
+                return Comparator.naturalOrder();
+            }
+        }
+
+        private double getDefaultScore(TagCloudPartition.ScoreType scoreType) {
+            if (scoreType == TagCloudPartition.ScoreType.HIGHER_IS_BETTER) {
+                return 0;
+            } else {
+                return 1;
             }
         }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -103,7 +102,7 @@ public class TagCloud {
             final String source = results.getSource();
             final String language = results.getLanguage();
             final String visibility = results.getVisibility();
-            final LinkedHashMap<String,Double> resultsMap = results.getKeywords();
+            final Map<String,Double> resultsMap = results.getKeywords();
 
             for (final Map.Entry<String,Double> e : resultsMap.entrySet()) {
                 String key = utils.computeIndexKey(results, e.getKey(), partitionOnLanguage);

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -95,9 +95,6 @@ public class TagCloud {
         /** The maximum number of tags to keep per cloud. Zero means unlimited */
         int maxTags = 0;
 
-        /** Whether we should partition tag clouds based on language */
-        boolean partitionOnLanguage;
-
         /** The comparator of tuples to keep */
         Comparator<TagCloudEntry> comparator = TagCloudEntry.ORDER_BY_SCORE;
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -97,23 +97,22 @@ public class TagCloud {
 
         TagCloudUtils utils = new DefaultTagCloudUtils();
 
-        /** Add a set of keyword extraction results to the tag cloud to be built */
-        public void addResults(KeywordResults results) {
-            final String source = results.getSource();
-            final String language = results.getLanguage();
-            final String visibility = results.getVisibility();
-            final Map<String,Double> resultsMap = results.getKeywords();
+        /** Add a set of partitions to the tag cloud to be built */
+        public void addInput(TagCloudPartition tagCloudPartition) {
+            final String partition = tagCloudPartition.getPartition();
+            for (TagCloudInput tagCloudInput : tagCloudPartition.getInputs()) {
+                for (final Map.Entry<String,Double> e : tagCloudInput.getEntities().entrySet()) {
+                    final String partitionKey = partition + "%%" + e.getKey();
+                    TagCloudEntry.Builder b = index.computeIfAbsent(partitionKey,
+                                    k -> new TagCloudEntry.Builder(e.getKey(), tagCloudPartition.getScoreType()).withUtilities(utils));
+                    // TODO-crwill9 probably okay to pass partition here, but not sure why its needed at all
+                    b.addSourceScore(tagCloudInput.getSource(), e.getValue(), partition);
+                }
 
-            for (final Map.Entry<String,Double> e : resultsMap.entrySet()) {
-                String key = utils.computeIndexKey(results, e.getKey(), partitionOnLanguage);
-                TagCloudEntry.Builder b = index.computeIfAbsent(key, k -> new TagCloudEntry.Builder(e.getKey()).withUtilities(utils));
-                b.addSourceScore(source, e.getValue(), language);
-            }
-
-            if (!visibility.isEmpty() && !resultsMap.isEmpty()) {
-                String key = utils.computeVisibilityKey(results, partitionOnLanguage);
-                Set<String> visibilityList = visibilities.computeIfAbsent(key, k -> new TreeSet<>());
-                visibilityList.add(visibility);
+                if (!tagCloudInput.getVisibility().isEmpty() && !tagCloudInput.getEntities().isEmpty()) {
+                    Set<String> visibilityList = visibilities.computeIfAbsent(partition, k -> new TreeSet<>());
+                    visibilityList.add(tagCloudInput.getVisibility());
+                }
             }
         }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -18,8 +19,8 @@ public class TagCloud {
 
     static final Gson gson = new Gson();
 
-    /** the 'name' of this cloud, usually a language name */
-    final String name;
+    /** metadata for the cloud */
+    final Map<String,String> metadata;
 
     /** the 'visibility' of this cloud */
     final Map<String,String> visibility;
@@ -30,21 +31,21 @@ public class TagCloud {
     /**
      * Use the builder to create tag clouds
      *
-     * @param name
-     *            the name of the cloud, typically used for language
+     * @param metadata
+     *            metadata for the tag cloud
      * @param visibility
      *            the visibility of the cloud, some form of visibility marking
      * @param results
      *            the entries that belong in the tag cloud.
      */
-    protected TagCloud(String name, Map<String,String> visibility, SortedSet<TagCloudEntry> results) {
-        this.name = name;
+    protected TagCloud(Map<String,String> metadata, Map<String,String> visibility, SortedSet<TagCloudEntry> results) {
+        this.metadata = metadata;
         this.visibility = visibility;
         this.results = results;
     }
 
-    public String getName() {
-        return name;
+    public Map<String,String> getMetadata() {
+        return metadata;
     }
 
     public Map<String,String> getVisibility() {
@@ -80,8 +81,13 @@ public class TagCloud {
      */
     public static class Builder {
 
+        public static final String VALUE_SEPARATOR = "%%";
+
         /** Holds the index of tuples we're capture while building this object, used to calculate the final set of results in the finish() method. */
         final transient Map<String,TagCloudEntry.Builder> index = new HashMap<>();
+
+        /** Holds metadata for a given partition **/
+        final transient Map<String,Map<String,Set<String>>> metadata = new HashMap<>();
 
         /** Holds the set of visibility strings we've seen so far - this will be used for generating the overall visibility string */
         final transient Map<String,Set<String>> visibilities = new HashMap<>();
@@ -102,9 +108,15 @@ public class TagCloud {
             final String partition = tagCloudPartition.getPartition();
             for (TagCloudInput tagCloudInput : tagCloudPartition.getInputs()) {
                 for (final Map.Entry<String,Double> e : tagCloudInput.getEntities().entrySet()) {
-                    final String partitionKey = partition + "%%" + e.getKey();
+                    final String partitionKey = partition + VALUE_SEPARATOR + e.getKey();
                     TagCloudEntry.Builder b = index.computeIfAbsent(partitionKey,
                                     k -> new TagCloudEntry.Builder(e.getKey(), tagCloudPartition.getScoreType()).withUtilities(utils));
+                    // these are aggregated on the partition, not the partition/key combination
+                    Map<String,Set<String>> partitionMetadata = metadata.computeIfAbsent(partition, k -> new HashMap<>());
+                    for (Map.Entry<String,String> entryMetadata : tagCloudInput.getMetadata().entrySet()) {
+                        Set<String> entryValues = partitionMetadata.computeIfAbsent(entryMetadata.getKey(), k -> new HashSet<>());
+                        entryValues.add(entryMetadata.getValue());
+                    }
                     // TODO-crwill9 probably okay to pass partition here, but not sure why its needed at all
                     b.addSourceScore(tagCloudInput.getSource(), e.getValue(), partition);
                 }
@@ -143,23 +155,18 @@ public class TagCloud {
         }
 
         /**
-         * Indicate that we should build one tag cloud per language
-         *
-         * @param partitionOnLanguage
-         *            true if we should generate multiple tag clouds, one per language
-         * @return the builder.
-         */
-        public Builder withLanguagePartitions(boolean partitionOnLanguage) {
-            this.partitionOnLanguage = partitionOnLanguage;
-            return this;
-        }
-
-        /**
          * Indicate that we should use a specific utilities instance.
          */
         public Builder withTagCloudUtilities(TagCloudUtils utils) {
             this.utils = utils;
             return this;
+        }
+
+        private String getPartition(String partitionKey) {
+            int sepIndex = partitionKey.indexOf(VALUE_SEPARATOR);
+            String partition = sepIndex > -1 ? partitionKey.substring(0, sepIndex) : partitionKey;
+
+            return partition;
         }
 
         /**
@@ -179,8 +186,8 @@ public class TagCloud {
 
             // partition the index of keyword results into one priority queue per partition.
             for (Map.Entry<String,TagCloudEntry.Builder> e : index.entrySet()) {
-                String partitionKey = utils.computePartitionKey(e, partitionOnLanguage);
-                PriorityQueue<TagCloudEntry> resultsQueue = queueMap.computeIfAbsent(partitionKey, k -> new PriorityQueue<>(queueComparator));
+                String partition = getPartition(e.getKey());
+                PriorityQueue<TagCloudEntry> resultsQueue = queueMap.computeIfAbsent(partition, k -> new PriorityQueue<>(queueComparator));
                 resultsQueue.add(e.getValue().build());
                 if (maxTags > 0 && resultsQueue.size() > maxTags) {
                     resultsQueue.poll();
@@ -194,12 +201,13 @@ public class TagCloud {
             for (Map.Entry<String,PriorityQueue<TagCloudEntry>> e : queueMap.entrySet()) {
                 final SortedSet<TagCloudEntry> results = new TreeSet<>(comparator);
                 results.addAll(e.getValue());
-                Map<String,String> visibility = utils.generateCombinedVisibility(visibilities.get(e.getKey()));
-                tagClouds.add(new TagCloud(e.getKey(), visibility, results));
+                String partition = getPartition(e.getKey());
+                Map<String,String> visibility = utils.generateCombinedVisibility(visibilities.get(partition));
+                Map<String,String> tagCloudMetadata = utils.generateCombinedMetadata(this.metadata.get(partition));
+                tagClouds.add(new TagCloud(tagCloudMetadata, visibility, results));
             }
 
             return tagClouds;
         }
-
     }
 }

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloud.java
@@ -161,9 +161,7 @@ public class TagCloud {
 
         private String getPartition(String partitionKey) {
             int sepIndex = partitionKey.indexOf(VALUE_SEPARATOR);
-            String partition = sepIndex > -1 ? partitionKey.substring(0, sepIndex) : partitionKey;
-
-            return partition;
+            return sepIndex > -1 ? partitionKey.substring(0, sepIndex) : partitionKey;
         }
 
         /**

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudEntry.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudEntry.java
@@ -96,14 +96,15 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
      */
     public static class Builder {
         final String keyword;
-        final TagCloudPartition.SCORE_TYPE scoreType;
+
+        private Comparator<Double> scoreComparator;
+        private double defaultScore;
 
         final SortedSet<ScoreTuple> sourceScores = new TreeSet<>();
         TagCloudUtils utils = new DefaultTagCloudUtils();
 
-        public Builder(String keyword, TagCloudPartition.SCORE_TYPE scoreType) {
+        public Builder(String keyword) {
             this.keyword = keyword;
-            this.scoreType = scoreType;
         }
 
         public Builder withUtilities(TagCloudUtils utils) {
@@ -111,12 +112,22 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
             return this;
         }
 
-        public void addSourceScore(String source, double score, String language) {
-            sourceScores.add(new ScoreTuple(source, score, language));
+        public Builder withScoreComparator(Comparator<Double> scoreComparator) {
+            this.scoreComparator = scoreComparator;
+            return this;
+        }
+
+        public Builder withDefaultScore(double defaultScore) {
+            this.defaultScore = defaultScore;
+            return this;
+        }
+
+        public void addSourceScore(String source, double score) {
+            sourceScores.add(new ScoreTuple(source, score));
         }
 
         public TagCloudEntry build() {
-            final double score = utils.calculateScore(sourceScores, scoreType);
+            final double score = utils.calculateScore(sourceScores, scoreComparator, defaultScore);
             final Set<String> sources = utils.calculateSources(sourceScores);
             final int frequency = utils.calculateFrequency(sourceScores);
             return new TagCloudEntry(keyword, score, frequency, sources);
@@ -127,17 +138,10 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
     public static class ScoreTuple implements Comparable<ScoreTuple> {
         final String source;
         final double score;
-        // TODO-crwill9 rename to partition
-        final String language;
 
-        public ScoreTuple(String source, double score, String language) {
+        public ScoreTuple(String source, double score) {
             this.source = source;
             this.score = score;
-            this.language = language;
-        }
-
-        public String getLanguage() {
-            return language;
         }
 
         public double getScore() {
@@ -153,12 +157,12 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
             if (o == null || getClass() != o.getClass())
                 return false;
             ScoreTuple that = (ScoreTuple) o;
-            return Double.compare(score, that.score) == 0 && Objects.equal(source, that.source) && Objects.equal(language, that.language);
+            return Double.compare(score, that.score) == 0 && Objects.equal(source, that.source);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(source, score, language);
+            return Objects.hashCode(source, score);
         }
 
         @Override
@@ -169,8 +173,7 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
         //@formatter:off
         public static final Comparator<ScoreTuple> naturalOrder = nullsLast(Comparator
                 .comparingDouble(ScoreTuple::getScore)
-                .thenComparing(ScoreTuple::getSource)
-                .thenComparing(ScoreTuple::getLanguage));
+                .thenComparing(ScoreTuple::getSource));
         //@formatter:on
 
         public String toString() {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudEntry.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudEntry.java
@@ -96,11 +96,14 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
      */
     public static class Builder {
         final String keyword;
+        final TagCloudPartition.SCORE_TYPE scoreType;
+
         final SortedSet<ScoreTuple> sourceScores = new TreeSet<>();
         TagCloudUtils utils = new DefaultTagCloudUtils();
 
-        public Builder(String keyword) {
+        public Builder(String keyword, TagCloudPartition.SCORE_TYPE scoreType) {
             this.keyword = keyword;
+            this.scoreType = scoreType;
         }
 
         public Builder withUtilities(TagCloudUtils utils) {
@@ -113,7 +116,7 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
         }
 
         public TagCloudEntry build() {
-            final double score = utils.calculateScore(sourceScores);
+            final double score = utils.calculateScore(sourceScores, scoreType);
             final Set<String> sources = utils.calculateSources(sourceScores);
             final int frequency = utils.calculateFrequency(sourceScores);
             return new TagCloudEntry(keyword, score, frequency, sources);
@@ -124,6 +127,7 @@ public class TagCloudEntry implements Comparable<TagCloudEntry> {
     public static class ScoreTuple implements Comparable<ScoreTuple> {
         final String source;
         final double score;
+        // TODO-crwill9 rename to partition
         final String language;
 
         public ScoreTuple(String source, double score, String language) {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudInput.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudInput.java
@@ -36,15 +36,17 @@ public class TagCloudInput implements Writable {
     private String source;
     private String visibility;
     private Map<String,Double> entities;
+    private Map<String,String> metadata;
 
     private TagCloudInput() {
         // only to support deserialize()
     }
 
-    public TagCloudInput(String source, String visibility, Map<String,Double> entities) {
+    public TagCloudInput(String source, String visibility, Map<String,Double> entities, Map<String,String> metadata) {
         this.source = source;
         this.visibility = visibility;
         this.entities = entities;
+        this.metadata = metadata;
     }
 
     public Map<String,Double> getEntities() {
@@ -63,6 +65,14 @@ public class TagCloudInput implements Writable {
         this.source = source;
     }
 
+    public Map<String,String> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String,String> metadata) {
+        this.metadata = metadata;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (this == other) {
@@ -72,12 +82,13 @@ public class TagCloudInput implements Writable {
             return false;
         }
         TagCloudInput otherTci = (TagCloudInput) other;
-        return Objects.equals(source, otherTci.source) && Objects.equals(visibility, otherTci.visibility) && Objects.equals(entities, otherTci.entities);
+        return Objects.equals(source, otherTci.source) && Objects.equals(visibility, otherTci.visibility) && Objects.equals(entities, otherTci.entities)
+                        && Objects.equals(metadata, otherTci.metadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(source, visibility, entities);
+        return Objects.hash(source, visibility, entities, metadata);
     }
 
     @Override
@@ -88,6 +99,11 @@ public class TagCloudInput implements Writable {
         for (Map.Entry<String,Double> e : entities.entrySet()) {
             dataOutput.writeUTF(e.getKey());
             dataOutput.writeDouble(e.getValue());
+        }
+        dataOutput.writeInt(metadata.size());
+        for (Map.Entry<String,String> e : metadata.entrySet()) {
+            dataOutput.writeUTF(e.getKey());
+            dataOutput.writeUTF(e.getValue());
         }
     }
 
@@ -101,6 +117,13 @@ public class TagCloudInput implements Writable {
             String label = dataInput.readUTF();
             double score = dataInput.readDouble();
             entities.put(label, score);
+        }
+        int metadataCount = dataInput.readInt();
+        this.metadata = new HashMap<>();
+        for (int i = 0; i < metadataCount; i++) {
+            String key = dataInput.readUTF();
+            String value = dataInput.readUTF();
+            this.metadata.put(key, value);
         }
     }
 

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudInput.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudInput.java
@@ -1,0 +1,129 @@
+package datawave.util.keyword;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.hadoop.io.Writable;
+
+import com.google.gson.Gson;
+
+/**
+ * This is the base class used to generating TagClouds
+ */
+public class TagCloudInput implements Writable {
+    private static final Gson gson = new Gson();
+
+    public static String toJson(TagCloudInput input) {
+        return gson.toJson(input);
+    }
+
+    public static TagCloudInput fromJson(String json) {
+        return gson.fromJson(json, TagCloudInput.class);
+    }
+
+    public static TagCloudInput fromJson(String json, Class<? extends TagCloudInput> target) {
+        return gson.fromJson(json, target);
+    }
+
+    private String source;
+    private String visibility;
+    private Map<String,Double> entities;
+
+    private TagCloudInput() {
+        // only to support deserialize()
+    }
+
+    public TagCloudInput(String source, String visibility, Map<String,Double> entities) {
+        this.source = source;
+        this.visibility = visibility;
+        this.entities = entities;
+    }
+
+    public Map<String,Double> getEntities() {
+        return entities;
+    }
+
+    public String getVisibility() {
+        return visibility;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof TagCloudInput)) {
+            return false;
+        }
+        TagCloudInput otherTci = (TagCloudInput) other;
+        return Objects.equals(source, otherTci.source) && Objects.equals(visibility, otherTci.visibility) && Objects.equals(entities, otherTci.entities);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(source, visibility, entities);
+    }
+
+    @Override
+    public void write(DataOutput dataOutput) throws IOException {
+        dataOutput.writeUTF(source == null ? "" : source);
+        dataOutput.writeUTF(visibility == null ? "" : visibility);
+        dataOutput.writeInt(entities.size());
+        for (Map.Entry<String,Double> e : entities.entrySet()) {
+            dataOutput.writeUTF(e.getKey());
+            dataOutput.writeDouble(e.getValue());
+        }
+    }
+
+    @Override
+    public void readFields(DataInput dataInput) throws IOException {
+        source = dataInput.readUTF();
+        visibility = dataInput.readUTF();
+        int entityCount = dataInput.readInt();
+        entities = new HashMap<>();
+        for (int i = 0; i < entityCount; i++) {
+            String label = dataInput.readUTF();
+            double score = dataInput.readDouble();
+            entities.put(label, score);
+        }
+    }
+
+    public static byte[] serialize(Writable results) throws IOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(); DataOutputStream dataOutput = new DataOutputStream(out)) {
+            results.write(dataOutput);
+            out.flush();
+            return out.toByteArray();
+        }
+    }
+
+    public static TagCloudInput deserialize(byte[] input) throws IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(input); DataInputStream dataInput = new DataInputStream(in)) {
+            TagCloudInput results = new TagCloudInput();
+            results.readFields(dataInput);
+            return results;
+        }
+    }
+
+    public static TagCloudInput deserialize(DataInput dataInput) throws IOException {
+        TagCloudInput input = new TagCloudInput();
+        input.readFields(dataInput);
+
+        return input;
+    }
+}

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudPartition.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudPartition.java
@@ -17,7 +17,7 @@ import org.apache.hadoop.io.Writable;
  * Used to partition TagCloudInput
  */
 public class TagCloudPartition implements Writable {
-    public enum SCORE_TYPE {
+    public enum ScoreType {
         LOWER_IS_BETTER, HIGHER_IS_BETTER
     }
 
@@ -27,7 +27,7 @@ public class TagCloudPartition implements Writable {
     // TODO-crwill9 this may not be necessary
     private String label;
     private List<TagCloudInput> inputs;
-    private SCORE_TYPE scoreType;
+    private ScoreType scoreType;
 
     public TagCloudPartition() {
         this(EMPTY_PARTITION);
@@ -42,10 +42,10 @@ public class TagCloudPartition implements Writable {
     }
 
     public TagCloudPartition(String partition, String label, List<TagCloudInput> inputs) {
-        this(partition, label, SCORE_TYPE.LOWER_IS_BETTER, inputs);
+        this(partition, label, ScoreType.LOWER_IS_BETTER, inputs);
     }
 
-    public TagCloudPartition(String partition, String label, SCORE_TYPE scoreType, List<TagCloudInput> inputs) {
+    public TagCloudPartition(String partition, String label, ScoreType scoreType, List<TagCloudInput> inputs) {
         this.partition = partition;
         this.label = label;
         this.scoreType = scoreType;
@@ -70,7 +70,7 @@ public class TagCloudPartition implements Writable {
         return inputs;
     }
 
-    public SCORE_TYPE getScoreType() {
+    public ScoreType getScoreType() {
         return scoreType;
     }
 
@@ -113,7 +113,7 @@ public class TagCloudPartition implements Writable {
         this.partition = dataInput.readUTF();
         this.label = dataInput.readUTF();
         String scoreTypeName = dataInput.readUTF();
-        this.scoreType = SCORE_TYPE.valueOf(scoreTypeName);
+        this.scoreType = ScoreType.valueOf(scoreTypeName);
         int inputCount = dataInput.readInt();
         this.inputs = new ArrayList<>();
         for (int i = 0; i < inputCount; i++) {

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudPartition.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudPartition.java
@@ -1,0 +1,148 @@
+package datawave.util.keyword;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.hadoop.io.Writable;
+
+/**
+ * Used to partition TagCloudInput
+ */
+public class TagCloudPartition implements Writable {
+    public enum SCORE_TYPE {
+        LOWER_IS_BETTER, HIGHER_IS_BETTER
+    }
+
+    private static final String EMPTY_PARTITION = "";
+
+    private String partition;
+    // TODO-crwill9 this may not be necessary
+    private String label;
+    private List<TagCloudInput> inputs;
+    private SCORE_TYPE scoreType;
+
+    public TagCloudPartition() {
+        this(EMPTY_PARTITION);
+    }
+
+    public TagCloudPartition(String partition) {
+        this(partition, partition);
+    }
+
+    public TagCloudPartition(String partition, String label) {
+        this(partition, label, new ArrayList<>());
+    }
+
+    public TagCloudPartition(String partition, String label, List<TagCloudInput> inputs) {
+        this(partition, label, SCORE_TYPE.LOWER_IS_BETTER, inputs);
+    }
+
+    public TagCloudPartition(String partition, String label, SCORE_TYPE scoreType, List<TagCloudInput> inputs) {
+        this.partition = partition;
+        this.label = label;
+        this.scoreType = scoreType;
+        this.inputs = inputs;
+    }
+
+    public void addInput(TagCloudInput input) {
+        inputs.add(input);
+    }
+
+    public String getPartition() {
+        return partition;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public List<TagCloudInput> getInputs() {
+        // TODO-crwill9 no real reason to do this
+        // return List.copyOf(inputs);
+        return inputs;
+    }
+
+    public SCORE_TYPE getScoreType() {
+        return scoreType;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof TagCloudPartition)) {
+            return false;
+        }
+        TagCloudPartition otherPartition = (TagCloudPartition) other;
+        return Objects.equals(partition, otherPartition.partition) && Objects.equals(label, otherPartition.label)
+                        && Objects.equals(scoreType, otherPartition.scoreType) && Objects.equals(inputs, otherPartition.inputs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partition, label, scoreType, inputs);
+    }
+
+    @Override
+    public void write(DataOutput dataOutput) throws IOException {
+        dataOutput.writeUTF(TagCloudPartition.class.getCanonicalName());
+        dataOutput.writeUTF(this.partition);
+        dataOutput.writeUTF(this.label);
+        dataOutput.writeUTF(this.scoreType.name());
+        dataOutput.writeInt(this.inputs.size());
+        for (TagCloudInput input : this.inputs) {
+            input.write(dataOutput);
+        }
+    }
+
+    @Override
+    public void readFields(DataInput dataInput) throws IOException {
+        String clazz = dataInput.readUTF();
+        if (!clazz.equals(TagCloudPartition.class.getCanonicalName())) {
+            throw new IllegalArgumentException("Incompatible DataInput");
+        }
+        this.partition = dataInput.readUTF();
+        this.label = dataInput.readUTF();
+        String scoreTypeName = dataInput.readUTF();
+        this.scoreType = SCORE_TYPE.valueOf(scoreTypeName);
+        int inputCount = dataInput.readInt();
+        this.inputs = new ArrayList<>();
+        for (int i = 0; i < inputCount; i++) {
+            TagCloudInput input = TagCloudInput.deserialize(dataInput);
+            this.inputs.add(input);
+        }
+    }
+
+    public static boolean canDeserialize(byte[] input) throws IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(input); DataInputStream dataInput = new DataInputStream(in)) {
+            return dataInput.readUTF().equals(TagCloudPartition.class.getCanonicalName());
+        }
+    }
+
+    public static TagCloudPartition deserialize(byte[] input) throws IOException {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(input); DataInputStream dataInput = new DataInputStream(in)) {
+            TagCloudPartition partition = new TagCloudPartition();
+            partition.readFields(dataInput);
+            return partition;
+        }
+    }
+
+    public static byte[] serialize(Writable writable) {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream(); DataOutputStream dataOutput = new DataOutputStream(out)) {
+            writable.write(dataOutput);
+            out.flush();
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudUtils.java
@@ -1,6 +1,7 @@
 package datawave.util.keyword;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,11 +33,11 @@ public interface TagCloudUtils {
      *
      * @param sourceScores
      *            a list of scores
-     * @param scoreType
-     *            the orientation of the scores
+     * @param comparator
+     *            the comparator for the scores
      * @return the final keyword score
      */
-    double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, TagCloudPartition.SCORE_TYPE scoreType);
+    double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, Comparator<Double> comparator, double defaultScore);
 
     /**
      * given a set of ScoreTuples, calculate the resulting source set for the keyword entry

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudUtils.java
@@ -19,51 +19,13 @@ public interface TagCloudUtils {
     Map<String,String> generateCombinedVisibility(Set<String> visibilities);
 
     /**
-     * find the index key from the keyword results and keyword. Usually,the index key just the keyword, but when we're partitioning by language, we'll add the
-     * language at the beginning of the key and use this for dividing into multiple tag clouds later.
+     * Aggregate metadata from multiple sources, combining multi-valued entries into a flattened string
      *
-     * @param results
-     *            the keyword results to drive key creation
-     * @param keyword
-     *            the keyword to drive key creation
-     * @param partitionOnLanguage
-     *            whether we should partition tag clouds on language
-     * @return the index key for the results entries.
+     * @param metadata
+     *            the metadata to combine
+     * @return a flattened map of metadata
      */
-    String computeIndexKey(KeywordResults results, String keyword, boolean partitionOnLanguage);
-
-    /**
-     * find the key to use for the visibility map. We have one set of visibilities for every partition. The key produced here should be identical to the
-     * computePartitionKey for the same input.
-     *
-     * @param results
-     *            the keyword results to drive key creation.
-     * @param partitionOnLanguage
-     *            whether we should partition tag clouds on language
-     * @return the key to use for tracking visibility sets.
-     */
-    String computeVisibilityKey(KeywordResults results, boolean partitionOnLanguage);
-
-    /**
-     * find the partition key from the index entry. If we're partitioning by language this will be the language, otherwise this will return an empty string.
-     * This can be used for both the visibilities map and tag cloud names.
-     *
-     * @param entry
-     *            the entry to use to determine the partition key
-     * @param partitionOnLanguage
-     *            whether we should partition tag clouds on language
-     * @return the partition key.
-     */
-    String computePartitionKey(Map.Entry<String,TagCloudEntry.Builder> entry, boolean partitionOnLanguage);
-
-    /**
-     * given a set of ScoreTuples, calculate the resulting score for the keyword entry
-     *
-     * @param sourceScores
-     *            a list of scores
-     * @return the final keyword score
-     */
-    double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores);
+    Map<String,String> generateCombinedMetadata(Map<String,Set<String>> metadata);
 
     /**
      * given a set of ScoreTuples, calculate the resulting score for the keyword entry

--- a/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudUtils.java
+++ b/warehouse/keyword-common/src/main/java/datawave/util/keyword/TagCloudUtils.java
@@ -66,6 +66,17 @@ public interface TagCloudUtils {
     double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores);
 
     /**
+     * given a set of ScoreTuples, calculate the resulting score for the keyword entry
+     *
+     * @param sourceScores
+     *            a list of scores
+     * @param scoreType
+     *            the orientation of the scores
+     * @return the final keyword score
+     */
+    double calculateScore(Collection<TagCloudEntry.ScoreTuple> sourceScores, TagCloudPartition.SCORE_TYPE scoreType);
+
+    /**
      * given a set of ScoreTuples, calculate the resulting source set for the keyword entry
      *
      * @param sourceScores

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/KeywordResultsTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/KeywordResultsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -14,6 +15,9 @@ public class KeywordResultsTest {
     static final String EXPECTED_LANGUAGE = "ENGLISH";
     static final String EXPECTED_VIEW = "NEWS_VIEW";
     static final String EXPECTED_VISIBILITY = "NEWS_VISIBILITY";
+    static final String EXPECTED_TYPE = "NEWS_TYPE";
+
+    static final Map<String,String> EXPECTED_METADATA = Map.of("view", EXPECTED_VIEW, "language", EXPECTED_LANGUAGE, "type", EXPECTED_TYPE);
 
     static final LinkedHashMap<String,Double> EXPECTED_NEWS_OUTPUT = new LinkedHashMap<>();
     static {
@@ -30,19 +34,20 @@ public class KeywordResultsTest {
         assertTrue(results.getKeywords().isEmpty());
         assertEquals(0, results.getKeywordCount());
         assertTrue(results.getSource().isEmpty());
-        assertTrue(results.getLanguage().isEmpty());
+        // TODO-crwill9 another behavior change here, can't direct getLanguage()
+        assertTrue(results.getMetadata().isEmpty());
         assertTrue(results.getVisibility().isEmpty());
 
     }
 
     @Test
     public void testConstructFull() {
-        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
+        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT, EXPECTED_METADATA);
         assertEquals(4, results.getKeywordCount());
         assertEquals(EXPECTED_NEWS_OUTPUT, results.getKeywords());
         assertEquals(EXPECTED_SOURCE, results.getSource());
-        assertEquals(EXPECTED_VIEW, results.getView());
-        assertEquals(EXPECTED_LANGUAGE, results.getLanguage());
+        assertEquals(EXPECTED_VIEW, results.getMetadata().get("view"));
+        assertEquals(EXPECTED_LANGUAGE, results.getMetadata().get("language"));
         assertEquals(EXPECTED_VISIBILITY, results.getVisibility());
 
     }
@@ -55,33 +60,33 @@ public class KeywordResultsTest {
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());
-        assertEquals(results.getLanguage(), deserialized.getLanguage());
+        assertEquals(results.getMetadata().get("language"), deserialized.getMetadata().get("language"));
         assertEquals(results.getVisibility(), deserialized.getVisibility());
     }
 
     @Test
     public void testSerializeDeserializePopulated() throws IOException {
-        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
+        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT, EXPECTED_METADATA);
         byte[] serialized = KeywordResults.serialize(results);
         KeywordResults deserialized = KeywordResults.deserialize(serialized);
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());
-        assertEquals(results.getView(), deserialized.getView());
-        assertEquals(results.getLanguage(), deserialized.getLanguage());
+        assertEquals(results.getMetadata().get("view"), deserialized.getMetadata().get("view"));
+        assertEquals(results.getMetadata().get("language"), deserialized.getMetadata().get("language"));
         assertEquals(results.getVisibility(), deserialized.getVisibility());
     }
 
     @Test
     public void testSerializeDeserializeJsonPopulated() throws IOException {
-        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
+        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT, EXPECTED_METADATA);
         String resultsJson = TagCloudInput.toJson(results);
         KeywordResults deserialized = (KeywordResults) TagCloudInput.fromJson(resultsJson, KeywordResults.class);
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());
-        assertEquals(results.getView(), deserialized.getView());
-        assertEquals(results.getLanguage(), deserialized.getLanguage());
+        assertEquals(results.getMetadata().get("view"), deserialized.getMetadata().get("view"));
+        assertEquals(results.getMetadata().get("language"), deserialized.getMetadata().get("language"));
         assertEquals(results.getVisibility(), deserialized.getVisibility());
     }
 }

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/KeywordResultsTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/KeywordResultsTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -15,9 +14,6 @@ public class KeywordResultsTest {
     static final String EXPECTED_LANGUAGE = "ENGLISH";
     static final String EXPECTED_VIEW = "NEWS_VIEW";
     static final String EXPECTED_VISIBILITY = "NEWS_VISIBILITY";
-    static final String EXPECTED_TYPE = "NEWS_TYPE";
-
-    static final Map<String,String> EXPECTED_METADATA = Map.of("view", EXPECTED_VIEW, "language", EXPECTED_LANGUAGE, "type", EXPECTED_TYPE);
 
     static final LinkedHashMap<String,Double> EXPECTED_NEWS_OUTPUT = new LinkedHashMap<>();
     static {
@@ -34,20 +30,19 @@ public class KeywordResultsTest {
         assertTrue(results.getKeywords().isEmpty());
         assertEquals(0, results.getKeywordCount());
         assertTrue(results.getSource().isEmpty());
-        // TODO-crwill9 another behavior change here, can't direct getLanguage()
-        assertTrue(results.getMetadata().isEmpty());
+        assertTrue(results.getLanguage().isEmpty());
         assertTrue(results.getVisibility().isEmpty());
 
     }
 
     @Test
     public void testConstructFull() {
-        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT, EXPECTED_METADATA);
+        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
         assertEquals(4, results.getKeywordCount());
         assertEquals(EXPECTED_NEWS_OUTPUT, results.getKeywords());
         assertEquals(EXPECTED_SOURCE, results.getSource());
-        assertEquals(EXPECTED_VIEW, results.getMetadata().get("view"));
-        assertEquals(EXPECTED_LANGUAGE, results.getMetadata().get("language"));
+        assertEquals(EXPECTED_VIEW, results.getView());
+        assertEquals(EXPECTED_LANGUAGE, results.getLanguage());
         assertEquals(EXPECTED_VISIBILITY, results.getVisibility());
 
     }
@@ -60,33 +55,33 @@ public class KeywordResultsTest {
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());
-        assertEquals(results.getMetadata().get("language"), deserialized.getMetadata().get("language"));
+        assertEquals(results.getLanguage(), deserialized.getLanguage());
         assertEquals(results.getVisibility(), deserialized.getVisibility());
     }
 
     @Test
     public void testSerializeDeserializePopulated() throws IOException {
-        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT, EXPECTED_METADATA);
+        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
         byte[] serialized = KeywordResults.serialize(results);
         KeywordResults deserialized = KeywordResults.deserialize(serialized);
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());
-        assertEquals(results.getMetadata().get("view"), deserialized.getMetadata().get("view"));
-        assertEquals(results.getMetadata().get("language"), deserialized.getMetadata().get("language"));
+        assertEquals(results.getView(), deserialized.getView());
+        assertEquals(results.getLanguage(), deserialized.getLanguage());
         assertEquals(results.getVisibility(), deserialized.getVisibility());
     }
 
     @Test
     public void testSerializeDeserializeJsonPopulated() throws IOException {
-        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT, EXPECTED_METADATA);
-        String resultsJson = TagCloudInput.toJson(results);
-        KeywordResults deserialized = (KeywordResults) TagCloudInput.fromJson(resultsJson, KeywordResults.class);
+        KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
+        String resultsJson = results.toJson();
+        KeywordResults deserialized = KeywordResults.fromJson(resultsJson);
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());
-        assertEquals(results.getMetadata().get("view"), deserialized.getMetadata().get("view"));
-        assertEquals(results.getMetadata().get("language"), deserialized.getMetadata().get("language"));
+        assertEquals(results.getView(), deserialized.getView());
+        assertEquals(results.getLanguage(), deserialized.getLanguage());
         assertEquals(results.getVisibility(), deserialized.getVisibility());
     }
 }

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/KeywordResultsTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/KeywordResultsTest.java
@@ -75,8 +75,8 @@ public class KeywordResultsTest {
     @Test
     public void testSerializeDeserializeJsonPopulated() throws IOException {
         KeywordResults results = new KeywordResults(EXPECTED_SOURCE, EXPECTED_VIEW, EXPECTED_LANGUAGE, EXPECTED_VISIBILITY, EXPECTED_NEWS_OUTPUT);
-        String resultsJson = results.toJson();
-        KeywordResults deserialized = KeywordResults.fromJson(resultsJson);
+        String resultsJson = TagCloudInput.toJson(results);
+        KeywordResults deserialized = (KeywordResults) TagCloudInput.fromJson(resultsJson, KeywordResults.class);
         assertEquals(results.getKeywordCount(), deserialized.getKeywordCount());
         assertEquals(results.getKeywords(), deserialized.getKeywords());
         assertEquals(results.getSource(), deserialized.getSource());

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
@@ -119,7 +119,7 @@ public class TagCloudTest {
             metadata.put("view", "content");
             metadata.put("language", "english");
             metadata.put("type", "keyword");
-            partition.addInput(new KeywordResults(source, "visibility", parsedContent, metadata));
+            partition.addInput(new TagCloudInput(source, "visibility", parsedContent, metadata));
         }
 
         return partition;

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -102,23 +101,24 @@ public class TagCloudTest {
 
     // -- utilities to set up test data.
 
-    public static KeywordResults[] createData() {
+    public static TagCloudPartition createData() {
         return createDataFromArrays(testData, testSources);
     }
 
-    public static KeywordResults[] createDataWithOverlaps() {
+    public static TagCloudPartition createDataWithOverlaps() {
         return createDataFromArrays(testDataWithOverlaps, testSourcesWithOverlaps);
     }
 
-    public static KeywordResults[] createDataFromArrays(String[] data, String[] sources) {
-        KeywordResults[] result = new KeywordResults[data.length];
+    public static TagCloudPartition createDataFromArrays(String[] data, String[] sources) {
+        TagCloudPartition partition = new TagCloudPartition();
         for (int i = 0; i < data.length; i++) {
             String content = data[i];
             LinkedHashMap<String,Double> parsedContent = parseContent(content);
             String source = sources[i];
-            result[i] = new KeywordResults(source, "content", "english", "visibility", parsedContent);
+            partition.addInput(new KeywordResults(source, "content", "english", "visibility", parsedContent));
         }
-        return result;
+
+        return partition;
     }
 
     public static LinkedHashMap<String,Double> parseContent(String content) {
@@ -136,9 +136,9 @@ public class TagCloudTest {
     @Test
     public void testSerializationLifecycle() {
         // validates serialization.
-        KeywordResults[] testInput = createData();
+        TagCloudPartition testInput = createData();
         TagCloud.Builder builder = new TagCloud.Builder();
-        Arrays.stream(testInput).forEach(builder::addResults);
+        builder.addInput(testInput);
 
         List<TagCloud> cloud = builder.build();
         assertEquals(1, cloud.size());
@@ -152,9 +152,9 @@ public class TagCloudTest {
 
     @Test
     public void testBuilderWithNoLimit() {
-        KeywordResults[] testInput = createData();
+        TagCloudPartition testInput = createData();
         TagCloud.Builder builder = new TagCloud.Builder();
-        Arrays.stream(testInput).forEach(builder::addResults);
+        builder.addInput(testInput);
         List<TagCloud> cloud = builder.build();
 
         assertEquals(1, cloud.size());
@@ -164,9 +164,9 @@ public class TagCloudTest {
 
     @Test
     public void testBuilderWithLimit() {
-        KeywordResults[] testInput = createData();
+        TagCloudPartition testInput = createData();
         TagCloud.Builder builder = new TagCloud.Builder().withMaxTags(10);
-        Arrays.stream(testInput).forEach(builder::addResults);
+        builder.addInput(testInput);
         List<TagCloud> cloud = builder.build();
 
         assertEquals(1, cloud.size());
@@ -178,9 +178,9 @@ public class TagCloudTest {
     public void testBuilderWithAlternateComparator() {
         final Comparator<TagCloudEntry> comparator = TagCloudEntry.ORDER_BY_FREQUENCY;
 
-        KeywordResults[] testInput = createDataWithOverlaps();
+        TagCloudPartition testInput = createDataWithOverlaps();
         TagCloud.Builder builder = new TagCloud.Builder().withComparator(comparator);
-        Arrays.stream(testInput).forEach(builder::addResults);
+        builder.addInput(testInput);
         List<TagCloud> cloud = builder.build();
 
         assertEquals(1, cloud.size());
@@ -191,14 +191,26 @@ public class TagCloudTest {
 
     @Test
     public void testBuilderWithLanguages() {
-        KeywordResults[] testInput = createDataWithOverlaps();
-        testInput[0].setLanguage("ONE");
-        testInput[1].setLanguage("TWO");
-        testInput[2].setLanguage("THREE");
-        testInput[3].setLanguage("ONE");
+        TagCloudPartition testInput = createDataWithOverlaps();
+        ((KeywordResults)testInput.getInputs().get(0)).setLanguage("ONE");
+        ((KeywordResults)testInput.getInputs().get(1)).setLanguage("TWO");
+        ((KeywordResults)testInput.getInputs().get(2)).setLanguage("THREE");
+        ((KeywordResults)testInput.getInputs().get(3)).setLanguage("ONE");
+
+        TagCloudPartition one = new TagCloudPartition("ONE");
+        one.addInput(testInput.getInputs().get(0));
+        one.addInput(testInput.getInputs().get(3));
+
+        TagCloudPartition two = new TagCloudPartition("TWO");
+        two.addInput(testInput.getInputs().get(1));
+
+        TagCloudPartition three = new TagCloudPartition("THREE");
+        three.addInput(testInput.getInputs().get(2));
 
         TagCloud.Builder builder = new TagCloud.Builder().withLanguagePartitions(true);
-        Arrays.stream(testInput).forEach(builder::addResults);
+        builder.addInput(one);
+        builder.addInput(two);
+        builder.addInput(three);
         List<TagCloud> cloud = builder.build();
 
         assertEquals(3, cloud.size());

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
@@ -115,7 +115,11 @@ public class TagCloudTest {
             String content = data[i];
             LinkedHashMap<String,Double> parsedContent = parseContent(content);
             String source = sources[i];
-            partition.addInput(new KeywordResults(source, "content", "english", "visibility", parsedContent));
+            Map<String,String> metadata = new HashMap<>();
+            metadata.put("view", "content");
+            metadata.put("language", "english");
+            metadata.put("type", "keyword");
+            partition.addInput(new KeywordResults(source, "visibility", parsedContent, metadata));
         }
 
         return partition;
@@ -142,11 +146,13 @@ public class TagCloudTest {
 
         List<TagCloud> cloud = builder.build();
         assertEquals(1, cloud.size());
-        assertEquals("", cloud.get(0).getName());
+        // TODO-crwill9 talk to drew to see if this is an okay shift
+        assertEquals("english", cloud.get(0).getMetadata().get("language"));
         String result = cloud.get(0).toString();
         TagCloud deser = TagCloud.fromJson(result);
 
-        assertEquals("", deser.getName());
+        // TODO-crwill9 talk to drew to see if this is an okay shift
+        assertEquals("english", deser.getMetadata().get("language"));
         assertTagCloudResults(26, 0.0092, 0.5552, TagCloudEntry.ORDER_BY_SCORE, deser.getResults());
     }
 
@@ -158,7 +164,8 @@ public class TagCloudTest {
         List<TagCloud> cloud = builder.build();
 
         assertEquals(1, cloud.size());
-        assertEquals("", cloud.get(0).getName());
+        // TODO-crwill9 talk to drew to see if this is an okay shift
+        assertEquals("english", cloud.get(0).getMetadata().get("language"));
         assertTagCloudResults(26, 0.0092, 0.5552, TagCloudEntry.ORDER_BY_SCORE, cloud.get(0).getResults());
     }
 
@@ -170,7 +177,8 @@ public class TagCloudTest {
         List<TagCloud> cloud = builder.build();
 
         assertEquals(1, cloud.size());
-        assertEquals("", cloud.get(0).getName());
+        // TODO-crwill9 talk to drew to see if this is an okay shift
+        assertEquals("english", cloud.get(0).getMetadata().get("language"));
         assertTagCloudResults(10, 0.0092, 0.0951, TagCloudEntry.ORDER_BY_SCORE, cloud.get(0).getResults());
     }
 
@@ -184,7 +192,8 @@ public class TagCloudTest {
         List<TagCloud> cloud = builder.build();
 
         assertEquals(1, cloud.size());
-        assertEquals("", cloud.get(0).getName());
+        // TODO-crwill9 talk to drew to see if this is an okay shift
+        assertEquals("english", cloud.get(0).getMetadata().get("language"));
         assertTagCloudResults(19, 0.0092, 0.3884, comparator, cloud.get(0).getResults());
         assertFirstAndLastFrequency(3, 1, cloud.get(0).getResults());
     }
@@ -192,10 +201,10 @@ public class TagCloudTest {
     @Test
     public void testBuilderWithLanguages() {
         TagCloudPartition testInput = createDataWithOverlaps();
-        ((KeywordResults)testInput.getInputs().get(0)).setLanguage("ONE");
-        ((KeywordResults)testInput.getInputs().get(1)).setLanguage("TWO");
-        ((KeywordResults)testInput.getInputs().get(2)).setLanguage("THREE");
-        ((KeywordResults)testInput.getInputs().get(3)).setLanguage("ONE");
+        testInput.getInputs().get(0).getMetadata().put("language", "ONE");
+        testInput.getInputs().get(1).getMetadata().put("language", "TWO");
+        testInput.getInputs().get(2).getMetadata().put("language", "THREE");
+        testInput.getInputs().get(3).getMetadata().put("language", "ONE");
 
         TagCloudPartition one = new TagCloudPartition("ONE");
         one.addInput(testInput.getInputs().get(0));
@@ -207,7 +216,7 @@ public class TagCloudTest {
         TagCloudPartition three = new TagCloudPartition("THREE");
         three.addInput(testInput.getInputs().get(2));
 
-        TagCloud.Builder builder = new TagCloud.Builder().withLanguagePartitions(true);
+        TagCloud.Builder builder = new TagCloud.Builder();
         builder.addInput(one);
         builder.addInput(two);
         builder.addInput(three);
@@ -220,8 +229,8 @@ public class TagCloudTest {
         Map<String,TagCloud> resultsMap = new HashMap<>();
 
         for (TagCloud c : cloud) {
-            unseenLanguages.remove(c.getName());
-            resultsMap.put(c.getName(), c);
+            unseenLanguages.remove(c.getMetadata().get("language"));
+            resultsMap.put(c.getMetadata().get("language"), c);
         }
         assertTrue("We expected to observe the following languages, but did not: " + unseenLanguages, unseenLanguages.isEmpty());
 

--- a/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
+++ b/warehouse/keyword-common/src/test/java/datawave/util/keyword/TagCloudTest.java
@@ -201,20 +201,21 @@ public class TagCloudTest {
     @Test
     public void testBuilderWithLanguages() {
         TagCloudPartition testInput = createDataWithOverlaps();
-        testInput.getInputs().get(0).getMetadata().put("language", "ONE");
-        testInput.getInputs().get(1).getMetadata().put("language", "TWO");
-        testInput.getInputs().get(2).getMetadata().put("language", "THREE");
-        testInput.getInputs().get(3).getMetadata().put("language", "ONE");
+        List<TagCloudInput> inputs = testInput.getInputs();
+        inputs.get(0).getMetadata().put("language", "ONE");
+        inputs.get(1).getMetadata().put("language", "TWO");
+        inputs.get(2).getMetadata().put("language", "THREE");
+        inputs.get(3).getMetadata().put("language", "ONE");
 
         TagCloudPartition one = new TagCloudPartition("ONE");
-        one.addInput(testInput.getInputs().get(0));
-        one.addInput(testInput.getInputs().get(3));
+        one.addInput(inputs.get(0));
+        one.addInput(inputs.get(3));
 
         TagCloudPartition two = new TagCloudPartition("TWO");
-        two.addInput(testInput.getInputs().get(1));
+        two.addInput(inputs.get(1));
 
         TagCloudPartition three = new TagCloudPartition("THREE");
-        three.addInput(testInput.getInputs().get(2));
+        three.addInput(inputs.get(2));
 
         TagCloud.Builder builder = new TagCloud.Builder();
         builder.addInput(one);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -77,6 +77,10 @@ import datawave.webservice.query.exception.QueryException;
  */
 @SuppressWarnings("unused")
 public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements CheckpointableQueryLogic {
+    /**
+     * Used to allow a request to have a specific version response
+     */
+    public static final String TAG_CLOUD_VERSION = "tag.cloud.version";
 
     /**
      * Used to specify that a tag cloud should consist of merged results for all documents or for individual results for individual documents.
@@ -117,8 +121,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     private Set<TagCloudInputTransformer<?>> transformers = new HashSet<>();
     private List<Entry<Key,Value>> externalData = new ArrayList<>();
-
-    final private IteratorChain<Entry<Key,Value>> iteratorChain = new IteratorChain<>();
+    private String responseVersion;
 
     public KeywordQueryLogic() {
         super();
@@ -131,6 +134,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         this.config = new KeywordQueryConfiguration(keywordQueryLogic.config);
         this.externalData = keywordQueryLogic.externalData;
         this.transformers = keywordQueryLogic.transformers;
+        this.responseVersion = keywordQueryLogic.responseVersion;
     }
 
     /**
@@ -222,6 +226,9 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
             log.warn("Could not parse parameter " + TAG_CLOUD_MAX + " (value: " + maxCloudTagsString + " as integer, ignoring.");
         }
 
+        String responseVersion = settings.findParameter(TAG_CLOUD_VERSION).getParameterValue().trim();
+        setResponseVersion(responseVersion);
+
         if (!settings.getQuery().isEmpty()) {
             // Execute the query logic.
             final Collection<String> queryTerms = extractQueryTerms(settings);
@@ -257,6 +264,8 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         this.config = (KeywordQueryConfiguration) genericConfig;
 
         try {
+            final IteratorChain<Entry<Key,Value>> iteratorChain = new IteratorChain<>();
+
             if (genericConfig.getQuery() != null && !genericConfig.getQuery().getQuery().isEmpty()) {
                 final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), this.queryThreads,
                                 config.getQuery());
@@ -269,11 +278,11 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
                 // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
                 final Iterator<Entry<Key,Value>> scanIterator = scanner.iterator();
-                this.iteratorChain.addIterator(scanIterator);
+                iteratorChain.addIterator(scanIterator);
                 this.scanner = scanner;
             }
             if (this.externalData != null && !this.externalData.isEmpty()) {
-                this.iteratorChain.addIterator(this.externalData.iterator());
+                iteratorChain.addIterator(this.externalData.iterator());
             }
 
             this.iterator = iteratorChain;
@@ -392,7 +401,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     @Override
     public QueryLogicTransformer<Entry<Key,Value>,TagCloudPartition> getTransformer(Query settings) {
-        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory, transformers);
+        return new TagCloudTransformer(responseVersion, settings, config.getState(), this.markingFunctions, this.responseObjectFactory, transformers);
     }
 
     @Override
@@ -594,6 +603,12 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
                 identifierMap.put(key, identifier);
                 log.debug("Added identifier " + identifier + "for key: " + key);
             }
+        }
+    }
+
+    public void setResponseVersion(String responseVersion) {
+        if (!responseVersion.isBlank()) {
+            this.responseVersion = responseVersion;
         }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -1,9 +1,14 @@
 package datawave.query.tables.keyword;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+<<<<<<< HEAD
 import java.util.LinkedList;
+=======
+import java.util.Iterator;
+>>>>>>> 08ea60dba2 (WIP: first cut, push data to TagCloudTransformer)
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -102,12 +107,19 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
     public static final String PARENT_ONLY = "\1";
     public static final String ALL = "\u10FFFF";
 
+    /**
+     * Fields that will be extracted from events for inclusion in the tag cloud, may be comma-delimited or null/empty
+     */
+    public static final String TAG_CLOUD_FIELDS = "tag.cloud.fields";
+
     private int queryThreads = 100;
 
     @VisibleForTesting
     protected ScannerFactory scannerFactory;
 
     private KeywordQueryConfiguration config;
+
+    private Map<String,List<KeywordResults>> fieldedKeywordResults;;
 
     public KeywordQueryLogic() {
         super();
@@ -243,7 +255,34 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
                             config.getMaxContentChars(), config.getState().getPreferredViews(), config.getState().getLanguageMap());
             scanner.addScanIterator(cfg);
 
-            this.iterator = scanner.iterator();
+            // TODO alternate tie in for the external fieldedKeywordResults, may be necessary to deal with empty results from the views, then its transparent to
+            // the TagCloudTransformer
+            // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
+            final Iterator<Entry<Key,Value>> scanIterator = scanner.iterator();
+            this.iterator = new Iterator<>() {
+                private boolean padResults = !scanIterator.hasNext();
+
+                @Override
+                public boolean hasNext() {
+                    return padResults || scanIterator.hasNext();
+                }
+
+                @Override
+                public Entry<Key,Value> next() {
+                    if (padResults) {
+                        padResults = false;
+                        try {
+                            return Map.entry(new Key(), new Value(KeywordResults.serialize(new KeywordResults())));
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    return scanIterator.next();
+                }
+            };
+
+            // this.iterator = scanner.iterator();
             this.scanner = scanner;
 
         } catch (TableNotFoundException e) {
@@ -361,7 +400,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     @Override
     public QueryLogicTransformer<Entry<Key,Value>,KeywordResults> getTransformer(Query settings) {
-        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory);
+        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory, fieldedKeywordResults);
     }
 
     @Override
@@ -501,6 +540,14 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         scannerFactory = new ScannerFactory(client);
 
         setupQuery(contentQueryConfig);
+    }
+
+    public void setFieldedKeywordResults(Map<String,List<KeywordResults>> fieldedKeywordResults) {
+        this.fieldedKeywordResults = fieldedKeywordResults;
+    }
+
+    public Map<String,List<KeywordResults>> getFieldedKeywordResults() {
+        return this.fieldedKeywordResults;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -1,10 +1,10 @@
 package datawave.query.tables.keyword;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -47,7 +47,6 @@ import datawave.query.iterator.logic.KeywordExtractingIterator;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.tables.keyword.transform.KeywordResultsTransformer;
 import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
-import datawave.query.tables.keyword.transform.TagCloudPartitionTransformer;
 import datawave.query.transformer.TagCloudTransformer;
 import datawave.util.keyword.TagCloudPartition;
 import datawave.util.keyword.TagCloudUtils;
@@ -116,9 +115,10 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     private KeywordQueryConfiguration config;
 
-    private List<TagCloudPartition> externalTagCloudPartitions;
-    private List<TagCloudInputTransformer<?>> transformers = new ArrayList<>();
-    final private TagCloudPartitionTransformer partitionTransformer = new TagCloudPartitionTransformer();
+    private Set<TagCloudInputTransformer<?>> transformers = new HashSet<>();
+    private List<Entry<Key,Value>> externalData = new ArrayList<>();
+
+    final private IteratorChain<Entry<Key,Value>> iteratorChain = new IteratorChain<>();
 
     public KeywordQueryLogic() {
         super();
@@ -129,8 +129,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         this.queryThreads = keywordQueryLogic.queryThreads;
         this.scannerFactory = keywordQueryLogic.scannerFactory;
         this.config = new KeywordQueryConfiguration(keywordQueryLogic.config);
-
-        this.externalTagCloudPartitions = keywordQueryLogic.externalTagCloudPartitions;
+        this.externalData = keywordQueryLogic.externalData;
         this.transformers = keywordQueryLogic.transformers;
     }
 
@@ -258,45 +257,29 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         this.config = (KeywordQueryConfiguration) genericConfig;
 
         try {
-            final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), this.queryThreads,
-                            config.getQuery());
-            scanner.setRanges(config.getState().getRanges());
+            if (genericConfig.getQuery() != null && !genericConfig.getQuery().getQuery().isEmpty()) {
+                final BatchScanner scanner = this.scannerFactory.newScanner(config.getTableName(), config.getAuthorizations(), this.queryThreads,
+                                config.getQuery());
+                scanner.setRanges(config.getState().getRanges());
 
-            final IteratorSetting cfg = new IteratorSetting(60, "keyword-extractor", KeywordExtractingIterator.class);
-            KeywordExtractingIterator.setOptions(cfg, config.getMinNgrams(), config.getMaxNgrams(), config.getMaxKeywords(), config.getMaxScore(),
-                            config.getMaxContentChars(), config.getState().getPreferredViews(), config.getState().getLanguageMap());
-            scanner.addScanIterator(cfg);
+                final IteratorSetting cfg = new IteratorSetting(60, "keyword-extractor", KeywordExtractingIterator.class);
+                KeywordExtractingIterator.setOptions(cfg, config.getMinNgrams(), config.getMaxNgrams(), config.getMaxKeywords(), config.getMaxScore(),
+                                config.getMaxContentChars(), config.getState().getPreferredViews(), config.getState().getLanguageMap());
+                scanner.addScanIterator(cfg);
 
-            // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
-            final Iterator<Entry<Key,Value>> scanIterator = scanner.iterator();
-            this.iterator = scanIterator;
-            if (externalTagCloudPartitions != null) {
-                Iterator<Entry<Key,Value>> fieldedKeywordIterator = prepareFieldedIterator(externalTagCloudPartitions);
-                this.iterator = new IteratorChain<>(scanIterator, fieldedKeywordIterator);
+                // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
+                final Iterator<Entry<Key,Value>> scanIterator = scanner.iterator();
+                this.iteratorChain.addIterator(scanIterator);
+                this.scanner = scanner;
+            }
+            if (this.externalData != null && !this.externalData.isEmpty()) {
+                this.iteratorChain.addIterator(this.externalData.iterator());
             }
 
-            this.scanner = scanner;
-
+            this.iterator = iteratorChain;
         } catch (TableNotFoundException e) {
             throw new RuntimeException("Table not found: " + this.getTableName(), e);
         }
-    }
-
-    /**
-     * convert partitions into key/value pairs so they can be intermixed with what is coming off the KeywordExtractingIterator
-     *
-     * @param partitions
-     * @return
-     * @throws IOException
-     */
-    private Iterator<Entry<Key,Value>> prepareFieldedIterator(List<TagCloudPartition> partitions) throws IOException {
-        List<Entry<Key,Value>> convertedList = new ArrayList<>();
-
-        for (TagCloudPartition partition : partitions) {
-            convertedList.add(partitionTransformer.encode(partition));
-        }
-
-        return convertedList.iterator();
     }
 
     /**
@@ -552,20 +535,17 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
     }
 
     /**
-     * Allows inclusion of extracted data externally to be included in the tag clouds generated from this logic. These partitions will be combined with all data
+     * Allows inclusion of extracted data externally to be included in the tag clouds generated from this logic. This data will be combined with all data
      * collected from this logic and returned together
      *
-     * @param externalTagCloudPartitions
+     * @param externalData
+     *            data that should be included in the iterator provided from an external source
+     * @param transformers
+     *            the transformers that can decode the external data
      */
-    public void setExternalTagCloudPartitions(List<TagCloudPartition> externalTagCloudPartitions) {
-        this.externalTagCloudPartitions = externalTagCloudPartitions;
-        if (!this.transformers.contains(partitionTransformer)) {
-            this.transformers.add(partitionTransformer);
-        }
-    }
-
-    public List<TagCloudPartition> getExternalTagCloudPartitions() {
-        return externalTagCloudPartitions;
+    public void setExternalData(List<Entry<Key,Value>> externalData, Set<TagCloudInputTransformer<?>> transformers) {
+        this.externalData = externalData;
+        this.transformers.addAll(transformers);
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -5,11 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-<<<<<<< HEAD
-import java.util.LinkedList;
-=======
 import java.util.Iterator;
->>>>>>> 08ea60dba2 (WIP: first cut, push data to TagCloudTransformer)
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,8 +45,11 @@ import datawave.query.QueryParameters;
 import datawave.query.config.KeywordQueryConfiguration;
 import datawave.query.iterator.logic.KeywordExtractingIterator;
 import datawave.query.tables.ScannerFactory;
+import datawave.query.tables.keyword.transform.KeywordResultsTransformer;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
+import datawave.query.tables.keyword.transform.TagCloudPartitionTransformer;
 import datawave.query.transformer.TagCloudTransformer;
-import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudPartition;
 import datawave.util.keyword.TagCloudUtils;
 import datawave.webservice.query.exception.QueryException;
 
@@ -109,11 +109,6 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
     public static final String PARENT_ONLY = "\1";
     public static final String ALL = "\u10FFFF";
 
-    /**
-     * Fields that will be extracted from events for inclusion in the tag cloud, may be comma-delimited or null/empty
-     */
-    public static final String TAG_CLOUD_FIELDS = "tag.cloud.fields";
-
     private int queryThreads = 100;
 
     @VisibleForTesting
@@ -121,7 +116,9 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     private KeywordQueryConfiguration config;
 
-    private Map<String,List<KeywordResults>> fieldedKeywordResults;;
+    private List<TagCloudPartition> externalTagCloudPartitions;
+    private List<TagCloudInputTransformer<?>> transformers = new ArrayList<>();
+    final private TagCloudPartitionTransformer partitionTransformer = new TagCloudPartitionTransformer();
 
     public KeywordQueryLogic() {
         super();
@@ -132,6 +129,9 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         this.queryThreads = keywordQueryLogic.queryThreads;
         this.scannerFactory = keywordQueryLogic.scannerFactory;
         this.config = new KeywordQueryConfiguration(keywordQueryLogic.config);
+
+        this.externalTagCloudPartitions = keywordQueryLogic.externalTagCloudPartitions;
+        this.transformers = keywordQueryLogic.transformers;
     }
 
     /**
@@ -191,6 +191,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         // add the views from the config with lower priority.
         preferredViews.addAll(getPreferredViews());
 
+        // TODO-crwill9 do we need to support this for field extraction too? probably
         // Determine whether we include the content of child events
         String end;
         p = settings.findParameter(QueryParameters.CONTENT_VIEW_ALL);
@@ -222,15 +223,24 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
             log.warn("Could not parse parameter " + TAG_CLOUD_MAX + " (value: " + maxCloudTagsString + " as integer, ignoring.");
         }
 
-        // Execute the query logic.
-        final Collection<String> queryTerms = extractQueryTerms(settings);
+        if (!settings.getQuery().isEmpty()) {
+            // Execute the query logic.
+            final Collection<String> queryTerms = extractQueryTerms(settings);
 
-        // Populate the identifier and language maps based on the data included for each document in the query.
-        extractIdentifiersAndLanguages(queryTerms, state.getIdentifierMap(), state.getLanguageMap());
+            // Populate the identifier and language maps based on the data included for each document in the query.
+            extractIdentifiersAndLanguages(queryTerms, state.getIdentifierMap(), state.getLanguageMap());
 
-        // Configure ranges for finding content.
-        final Collection<Range> ranges = createRanges(queryTerms, end);
-        state.setRanges(ranges);
+            // Configure ranges for finding content.
+            final Collection<Range> ranges = createRanges(queryTerms, end);
+            state.setRanges(ranges);
+
+            // TODO-crwill9 not sure how I feel about this setup... probably should happen elsewhere
+            // since this iterator will be returning KeywordResults, setup a transformer
+            KeywordResultsTransformer transformer = new KeywordResultsTransformer();
+            transformer.setLanguagePartitioned(config.getState().isLanguagePartitioned());
+            transformer.setIdentifierMap(state.getIdentifierMap());
+            transformers.add(transformer);
+        }
 
         return config;
     }
@@ -260,8 +270,8 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
             // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
             final Iterator<Entry<Key,Value>> scanIterator = scanner.iterator();
             this.iterator = scanIterator;
-            if (fieldedKeywordResults != null) {
-                Iterator<Entry<Key,Value>> fieldedKeywordIterator = prepareFieldedIterator(fieldedKeywordResults);
+            if (externalTagCloudPartitions != null) {
+                Iterator<Entry<Key,Value>> fieldedKeywordIterator = prepareFieldedIterator(externalTagCloudPartitions);
                 this.iterator = new IteratorChain<>(scanIterator, fieldedKeywordIterator);
             }
 
@@ -272,20 +282,18 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         }
     }
 
-    private Iterator<Entry<Key,Value>> prepareFieldedIterator(Map<String,List<KeywordResults>> fieldedKeywordResults) throws IOException {
-        List<Entry<Key,Value>> convertedList = new ArrayList<>(fieldedKeywordResults.entrySet().size());
+    /**
+     * convert partitions into key/value pairs so they can be intermixed with what is coming off the KeywordExtractingIterator
+     *
+     * @param partitions
+     * @return
+     * @throws IOException
+     */
+    private Iterator<Entry<Key,Value>> prepareFieldedIterator(List<TagCloudPartition> partitions) throws IOException {
+        List<Entry<Key,Value>> convertedList = new ArrayList<>();
 
-        for (String field : fieldedKeywordResults.keySet()) {
-            for (KeywordResults result : fieldedKeywordResults.get(field)) {
-                String source = result.getSource();
-                String[] splits = source.split("/");
-                if (splits.length != 3) {
-                    throw new IllegalStateException("unknown source format: " + source);
-                }
-                Key key = new Key(splits[0], splits[1] + "\u0000" + splits[2], result.getLanguage());
-                convertedList.add(Map.entry(key, new Value(KeywordResults.serialize(result))));
-            }
-
+        for (TagCloudPartition partition : partitions) {
+            convertedList.add(partitionTransformer.encode(partition));
         }
 
         return convertedList.iterator();
@@ -400,8 +408,8 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
     }
 
     @Override
-    public QueryLogicTransformer<Entry<Key,Value>,KeywordResults> getTransformer(Query settings) {
-        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory);
+    public QueryLogicTransformer<Entry<Key,Value>,TagCloudPartition> getTransformer(Query settings) {
+        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory, transformers);
     }
 
     @Override
@@ -543,12 +551,21 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
         setupQuery(contentQueryConfig);
     }
 
-    public void setFieldedKeywordResults(Map<String,List<KeywordResults>> fieldedKeywordResults) {
-        this.fieldedKeywordResults = fieldedKeywordResults;
+    /**
+     * Allows inclusion of extracted data externally to be included in the tag clouds generated from this logic. These partitions will be combined with all data
+     * collected from this logic and returned together
+     *
+     * @param externalTagCloudPartitions
+     */
+    public void setExternalTagCloudPartitions(List<TagCloudPartition> externalTagCloudPartitions) {
+        this.externalTagCloudPartitions = externalTagCloudPartitions;
+        if (!this.transformers.contains(partitionTransformer)) {
+            this.transformers.add(partitionTransformer);
+        }
     }
 
-    public Map<String,List<KeywordResults>> getFieldedKeywordResults() {
-        return this.fieldedKeywordResults;
+    public List<TagCloudPartition> getExternalTagCloudPartitions() {
+        return externalTagCloudPartitions;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordQueryLogic.java
@@ -1,6 +1,7 @@
 package datawave.query.tables.keyword;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +26,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.collections4.iterators.IteratorChain;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -255,39 +257,38 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
                             config.getMaxContentChars(), config.getState().getPreferredViews(), config.getState().getLanguageMap());
             scanner.addScanIterator(cfg);
 
-            // TODO alternate tie in for the external fieldedKeywordResults, may be necessary to deal with empty results from the views, then its transparent to
-            // the TagCloudTransformer
             // wrap the scanIterator in case there is nothing there and we have external content that needs to be transformed
             final Iterator<Entry<Key,Value>> scanIterator = scanner.iterator();
-            this.iterator = new Iterator<>() {
-                private boolean padResults = !scanIterator.hasNext();
+            this.iterator = scanIterator;
+            if (fieldedKeywordResults != null) {
+                Iterator<Entry<Key,Value>> fieldedKeywordIterator = prepareFieldedIterator(fieldedKeywordResults);
+                this.iterator = new IteratorChain<>(scanIterator, fieldedKeywordIterator);
+            }
 
-                @Override
-                public boolean hasNext() {
-                    return padResults || scanIterator.hasNext();
-                }
-
-                @Override
-                public Entry<Key,Value> next() {
-                    if (padResults) {
-                        padResults = false;
-                        try {
-                            return Map.entry(new Key(), new Value(KeywordResults.serialize(new KeywordResults())));
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
-
-                    return scanIterator.next();
-                }
-            };
-
-            // this.iterator = scanner.iterator();
             this.scanner = scanner;
 
         } catch (TableNotFoundException e) {
             throw new RuntimeException("Table not found: " + this.getTableName(), e);
         }
+    }
+
+    private Iterator<Entry<Key,Value>> prepareFieldedIterator(Map<String,List<KeywordResults>> fieldedKeywordResults) throws IOException {
+        List<Entry<Key,Value>> convertedList = new ArrayList<>(fieldedKeywordResults.entrySet().size());
+
+        for (String field : fieldedKeywordResults.keySet()) {
+            for (KeywordResults result : fieldedKeywordResults.get(field)) {
+                String source = result.getSource();
+                String[] splits = source.split("/");
+                if (splits.length != 3) {
+                    throw new IllegalStateException("unknown source format: " + source);
+                }
+                Key key = new Key(splits[0], splits[1] + "\u0000" + splits[2], result.getLanguage());
+                convertedList.add(Map.entry(key, new Value(KeywordResults.serialize(result))));
+            }
+
+        }
+
+        return convertedList.iterator();
     }
 
     /**
@@ -400,7 +401,7 @@ public class KeywordQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implemen
 
     @Override
     public QueryLogicTransformer<Entry<Key,Value>,KeywordResults> getTransformer(Query settings) {
-        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory, fieldedKeywordResults);
+        return new TagCloudTransformer(settings, config.getState(), this.markingFunctions, this.responseObjectFactory);
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordUUIDChainStrategy.java
@@ -25,7 +25,7 @@ import datawave.query.tables.keyword.extractor.TagCloudInputExtractor;
 public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>,Entry<Key,Value>> {
     public static final String CATEGORY_PARAMETER = "tag.cloud.category";
     private static final String KEYWORD_CATEGORY = "keyword";
-    private static final String DEFAULT_CATEGORY = KEYWORD_CATEGORY;
+    private static final String DEFAULT_CATEGORIES = KEYWORD_CATEGORY;
 
     /**
      * configurable batch size in the chain, -1 is no batching
@@ -87,7 +87,7 @@ public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>
     private String[] getCategories(Query settings) {
         String categoryParam = settings.findParameter(CATEGORY_PARAMETER).getParameterValue();
         if (categoryParam.isEmpty()) {
-            categoryParam = DEFAULT_CATEGORY;
+            categoryParam = DEFAULT_CATEGORIES;
         }
         return categoryParam.split(",");
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordUUIDChainStrategy.java
@@ -1,6 +1,9 @@
 package datawave.query.tables.keyword;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -13,17 +16,22 @@ import datawave.core.query.logic.QueryLogic;
 import datawave.microservice.query.Query;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.chained.strategy.FullChainStrategy;
+import datawave.query.tables.keyword.extractor.TagCloudInputExtractor;
 
 /**
  * Strategy for chaining UUID lookup and keyword extraction queries together, delegates to StatefulKeywordUUIDChainStrategy to handle individual batches of
  * lookups.
  */
 public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>,Entry<Key,Value>> {
+    public static final String CATEGORY_PARAMETER = "tag.cloud.category";
+    private static final String KEYWORD_CATEGORY = "keyword";
+    private static final String DEFAULT_CATEGORY = KEYWORD_CATEGORY;
 
     /**
      * configurable batch size in the chain, -1 is no batching
      */
     private int batchSize = -1;
+    private List<TagCloudInputExtractor> extractors = Collections.emptyList();
 
     @Override
     protected Query buildLatterQuery(Query initialQuery, Iterator<Entry<Key,Value>> initialQueryResults, String latterLogicName) {
@@ -34,6 +42,9 @@ public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>
     public Iterator<Entry<Key,Value>> runChainedQuery(AccumuloClient client, Query initialQuery, Set<Authorizations> auths,
                     Iterator<Entry<Key,Value>> initialQueryResults, QueryLogic<Entry<Key,Value>> latterQueryLogic) {
 
+        final List<TagCloudInputExtractor> activeExtractors = getActiveExtractors(initialQuery);
+        final boolean buildKeywordCloud = isKeywordCloudRequested(initialQuery);
+
         Iterator<Entry<Key,Value>> wrapped = new Iterator<>() {
             private Iterator<Entry<Key,Value>> batchIterator;
 
@@ -41,7 +52,8 @@ public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>
             public boolean hasNext() {
                 while (batchIterator == null || (!batchIterator.hasNext() && initialQueryResults.hasNext())) {
                     try {
-                        StatefulKeywordUUIDChainStrategy statefulChainStrategy = new StatefulKeywordUUIDChainStrategy(initialQuery, latterQueryLogic);
+                        StatefulKeywordUUIDChainStrategy statefulChainStrategy = new StatefulKeywordUUIDChainStrategy(initialQuery, latterQueryLogic,
+                                        activeExtractors, buildKeywordCloud);
                         statefulChainStrategy.setBatchSize(batchSize);
                         batchIterator = statefulChainStrategy.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
                     } catch (Exception e) {
@@ -66,11 +78,75 @@ public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>
         return wrapped;
     }
 
+    /**
+     * Extract configured categories from the query, or default if empty
+     *
+     * @param settings
+     * @return
+     */
+    private String[] getCategories(Query settings) {
+        String categoryParam = settings.findParameter(CATEGORY_PARAMETER).getParameterValue();
+        if (categoryParam.isEmpty()) {
+            categoryParam = DEFAULT_CATEGORY;
+        }
+        return categoryParam.split(",");
+    }
+
+    /**
+     * Check if the keyword cloud should be constructed
+     *
+     * @param settings
+     * @return
+     */
+    private boolean isKeywordCloudRequested(Query settings) {
+        String[] categories = getCategories(settings);
+        for (String category : categories) {
+            if (category.equals(KEYWORD_CATEGORY)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * pull parameters to determine which type of tag cloud we are generating. All extraction is triggered beyond this point for the given ids
+     *
+     * @param settings
+     * @return
+     */
+    private List<TagCloudInputExtractor> getActiveExtractors(Query settings) {
+        List<TagCloudInputExtractor> activeExtractors = new ArrayList<>();
+
+        for (String name : getCategories(settings)) {
+            boolean found = false;
+            for (TagCloudInputExtractor extractor : extractors) {
+                if (extractor.getName().equals(name) && !activeExtractors.contains(extractor)) {
+                    activeExtractors.add(extractor);
+                    found = true;
+                }
+            }
+            if (!found && !name.equals(KEYWORD_CATEGORY)) {
+                throw new IllegalArgumentException("invalid category specified: " + name + " for property " + CATEGORY_PARAMETER);
+            }
+        }
+
+        return activeExtractors;
+    }
+
     public void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
     }
 
     public int getBatchSize() {
         return batchSize;
+    }
+
+    public List<TagCloudInputExtractor> getExtractors() {
+        return extractors;
+    }
+
+    public void setExtractors(List<TagCloudInputExtractor> extractors) {
+        this.extractors = extractors;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/KeywordUUIDChainStrategy.java
@@ -41,7 +41,7 @@ public class KeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>
             public boolean hasNext() {
                 while (batchIterator == null || (!batchIterator.hasNext() && initialQueryResults.hasNext())) {
                     try {
-                        StatefulKeywordUUIDChainStrategy statefulChainStrategy = new StatefulKeywordUUIDChainStrategy(initialQuery);
+                        StatefulKeywordUUIDChainStrategy statefulChainStrategy = new StatefulKeywordUUIDChainStrategy(initialQuery, latterQueryLogic);
                         statefulChainStrategy.setBatchSize(batchSize);
                         batchIterator = statefulChainStrategy.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
                     } catch (Exception e) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
@@ -1,14 +1,8 @@
 package datawave.query.tables.keyword;
 
-import static datawave.query.jexl.JexlASTHelper.deconstructIdentifier;
-import static datawave.query.tables.keyword.KeywordQueryLogic.TAG_CLOUD_FIELDS;
-
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,33 +24,31 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.function.deserializer.DocumentDeserializer;
 import datawave.query.tables.chained.strategy.FullChainStrategy;
-import datawave.util.keyword.KeywordResults;
-import datawave.util.keyword.TokenScore;
+import datawave.query.tables.keyword.extractor.TagCloudInputExtractor;
+import datawave.query.tables.keyword.extractor.TagCloudInputExtractorException;
+import datawave.util.keyword.TagCloudPartition;
 
 /**
  * Strategy for chaining UUID lookup and keyword extraction queries together. Grabs the results of the lookupUUID query and uses these to generate the query
  * terms that are fed into a keyword extraction query.
  */
 public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Key,Value>,Entry<Key,Value>> {
-
     private static final Logger log = Logger.getLogger(StatefulKeywordUUIDChainStrategy.class);
 
     private int batchSize = -1;
     protected DocumentDeserializer deserializer;
     private final QueryLogic<Entry<Key,Value>> nextLogic;
+    // configured extractors to use on the data from nextLogic
+    private final List<TagCloudInputExtractor> extractors;
+    // will be true when a keyword query should be run, false otherwise
+    private final boolean runKeywordQuery;
 
-    private final List<String> tagCloudFields;
-
-    public StatefulKeywordUUIDChainStrategy(Query settings, QueryLogic<Entry<Key,Value>> nextLogic) {
+    public StatefulKeywordUUIDChainStrategy(Query settings, QueryLogic<Entry<Key,Value>> nextLogic, List<TagCloudInputExtractor> extractors,
+                    boolean runKeywordQuery) {
         this.deserializer = DocumentSerialization.getDocumentDeserializer(settings);
         this.nextLogic = nextLogic;
-
-        tagCloudFields = new ArrayList<>();
-        QueryImpl.Parameter tagCloudFieldsParam = settings.findParameter(TAG_CLOUD_FIELDS);
-        if (tagCloudFieldsParam != null) {
-            String[] fields = tagCloudFieldsParam.getParameterValue().split(",");
-            tagCloudFields.addAll(Arrays.asList(fields));
-        }
+        this.extractors = extractors;
+        this.runKeywordQuery = runKeywordQuery;
     }
 
     public int getBatchSize() {
@@ -67,28 +59,24 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
         this.batchSize = batchSize;
     }
 
-    // @Override
-    // public Iterator<Entry<Key,Value>> runChainedQuery(AccumuloClient client, Query initialQuery, Set<Authorizations> auths,
-    // Iterator<Entry<Key,Value>> initialQueryResults, QueryLogic<Entry<Key,Value>> latterQueryLogic) throws Exception {
-    // // TODO maybe interface this? not sure we really have many use cases for this concept
-    // if (latterQueryLogic instanceof KeywordQueryLogic) {
-    // KeywordQueryLogic keywordQueryLogic = (KeywordQueryLogic) latterQueryLogic;
-    // keywordQueryLogic.setFieldedKeywordResults(fieldedKeywordResults);
-    // }
-    // return super.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
-    // }
-
     @Override
     protected Query buildLatterQuery(Query initialQuery, Iterator<Entry<Key,Value>> initialQueryResults, String latterLogicName) {
         log.debug("buildLatterQuery() called...");
 
+        log.debug("initializing extractors");
+        for (TagCloudInputExtractor tagCloudInputExtractor : extractors) {
+            tagCloudInputExtractor.initialize(initialQuery);
+        }
+
+        log.debug("building query and extracting data");
         String queryString = captureResultsAndBuildQuery(initialQueryResults, batchSize);
 
         if (log.isDebugEnabled()) {
             log.debug("latter query is " + queryString);
         }
 
-        if (queryString == null || queryString.isBlank()) {
+        // as long as there are extractors it is okay for an empty query string, if neither there is nothing to do
+        if (extractors.isEmpty() && (queryString == null || queryString.isBlank())) {
             return null;
         }
 
@@ -107,19 +95,9 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
         return q;
     }
 
+    // TODO-crwill9 better refine this javadoc
     /**
-     * Generates queries for the KeywordQueryLogic. Minimally they will include things like:
-     *
-     * <pre>
-     *      DOCUMENT:row/dataType/uid
-     * </pre>
-     *
-     * But they will also potentially be enriched with the identifier, which appears in the HIT_TERM field of the lookupUUID response, and the LANGUAGE of the
-     * original document, so they will look like:
-     *
-     * <pre>
-     *     DOCUMENT:row/datatype/uid!PAGEID:12345%LANGUAGE:ENGLISH
-     * </pre>
+     * Generates queries for the KeywordQueryLogic and run extractors
      *
      * @param initialQueryResults
      *            the raw results from the lookup uuid query, pre-transformation.
@@ -130,8 +108,6 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
      */
     public String captureResultsAndBuildQuery(Iterator<Entry<Key,Value>> initialQueryResults, int batchSize) {
         int count = 0;
-
-        Map<String,List<KeywordResults>> fieldedKeywordResults = new HashMap<>();
 
         Set<String> queryTerms = new HashSet<>();
         while (initialQueryResults.hasNext() && (batchSize == -1 || count < batchSize)) {
@@ -152,66 +128,91 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
             Document document = documentEntry.getValue();
             final Map<String,Attribute<? extends Comparable<?>>> documentData = document.getDictionary();
 
-            List<String> identifiers = null;
-            List<String> languages = null;
             String docId = row + "/" + dataType + "/" + uid;
 
-            Map<String,List<TokenScore>> fieldLabels = new HashMap<>();
-            for (Entry<String,Attribute<? extends Comparable<?>>> data : documentData.entrySet()) {
-                if (data.getKey().equals("LANGUAGE")) {
-                    languages = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
-                } else if (data.getKey().equals("HIT_TERM")) {
-                    identifiers = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
-                } else {
-                    String baseField = deconstructIdentifier(data.getKey());
-                    if (tagCloudFields.contains(baseField)) {
-                        List<String> labels = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
-                        List<TokenScore> existing = fieldLabels.computeIfAbsent(baseField, k -> new ArrayList<>());
-
-                        // TODO pull a score (if configured) and remove anything below the threshold
-                        labels.forEach(label -> existing.add(new TokenScore(label, 1.0f)));
-                    }
+            // apply all extractors to the document
+            for (TagCloudInputExtractor extractor : extractors) {
+                try {
+                    extractor.extract(documentKey, documentData);
+                } catch (TagCloudInputExtractorException e) {
+                    throw new RuntimeException("Failed to extractor failed to extract: " + extractor, e);
                 }
             }
 
-            // build up the results for each field found
-            for (String field : fieldLabels.keySet()) {
-                List<TokenScore> labels = fieldLabels.get(field);
-                LinkedHashMap<String,Double> mapped = new LinkedHashMap<>();
-                labels.forEach(label -> mapped.put(label.getToken(), label.getScore()));
-                KeywordResults kr = new KeywordResults(docId, "event:" + field, field, entry.getKey().getColumnVisibility().toString(), mapped);
-                fieldedKeywordResults.computeIfAbsent(field, k -> new ArrayList<>()).add(kr);
+            if (runKeywordQuery) {
+                // run query term extraction for next logic if needed
+                queryTerms.add(extractKeywordQueryTerm(docId, documentData));
             }
 
-            String queryTerm = "DOCUMENT:" + docId;
-            String language, identifier;
-            if (((identifier = KeywordQueryUtil.chooseBestIdentifier(identifiers)) != null)) {
-                if (log.isTraceEnabled()) {
-                    log.trace("Chose best identifier '" + identifier + "' from '" + identifiers + "' for query " + queryTerm);
-                }
-                queryTerm += "!" + identifier;
-            } else if (log.isTraceEnabled()) {
-                log.trace("No identifier found for query " + queryTerm);
-            }
-
-            if (((language = KeywordQueryUtil.chooseBestLanguage(languages)) != null)) {
-                if (log.isTraceEnabled()) {
-                    log.trace("Chose best language '" + languages + "' from '" + languages + "' for query " + queryTerm);
-                }
-                queryTerm += "%LANGUAGE:" + language;
-            } else if (log.isTraceEnabled()) {
-                log.trace("No language found for query " + queryTerm);
-            }
-
-            queryTerms.add(queryTerm);
             count++;
         }
 
         if (nextLogic instanceof KeywordQueryLogic) {
+            // get all partitions from configured extractors
+            List<TagCloudPartition> extractedPartitions = new ArrayList<>();
+            for (TagCloudInputExtractor extractor : extractors) {
+                extractedPartitions.add(extractor.get());
+                extractor.clear();
+            }
+
             KeywordQueryLogic keywordQueryLogic = (KeywordQueryLogic) nextLogic;
-            keywordQueryLogic.setFieldedKeywordResults(fieldedKeywordResults);
+            // pass the extracted partitions on to the keyword query logic
+            keywordQueryLogic.setExternalTagCloudPartitions(extractedPartitions);
         }
 
         return queryTerms.isEmpty() ? null : StringUtils.join(queryTerms, " ");
+    }
+
+    /**
+     * Generates queries for the KeywordQueryLogic. Minimally they will include things like:
+     *
+     * <pre>
+     *      DOCUMENT:row/dataType/uid
+     * </pre>
+     *
+     * But they will also potentially be enriched with the identifier, which appears in the HIT_TERM field of the lookupUUID response, and the LANGUAGE of the
+     * original document, so they will look like:
+     *
+     * <pre>
+     *     DOCUMENT:row/datatype/uid!PAGEID:12345%LANGUAGE:ENGLISH
+     * </pre>
+     *
+     * @param docId
+     * @param documentData
+     * @return
+     */
+    private String extractKeywordQueryTerm(String docId, Map<String,Attribute<? extends Comparable<?>>> documentData) {
+        List<String> identifiers = null;
+        List<String> languages = null;
+
+        for (Entry<String,Attribute<? extends Comparable<?>>> data : documentData.entrySet()) {
+            if (data.getKey().equals("LANGUAGE")) {
+                languages = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
+            } else if (data.getKey().equals("HIT_TERM")) {
+                identifiers = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
+            }
+        }
+
+        String queryTerm = "DOCUMENT:" + docId;
+        String language, identifier;
+        if (((identifier = KeywordQueryUtil.chooseBestIdentifier(identifiers)) != null)) {
+            if (log.isTraceEnabled()) {
+                log.trace("Chose best identifier '" + identifier + "' from '" + identifiers + "' for query " + queryTerm);
+            }
+            queryTerm += "!" + identifier;
+        } else if (log.isTraceEnabled()) {
+            log.trace("No identifier found for query " + queryTerm);
+        }
+
+        if (((language = KeywordQueryUtil.chooseBestLanguage(languages)) != null)) {
+            if (log.isTraceEnabled()) {
+                log.trace("Chose best language '" + languages + "' from '" + languages + "' for query " + queryTerm);
+            }
+            queryTerm += "%LANGUAGE:" + language;
+        } else if (log.isTraceEnabled()) {
+            log.trace("No language found for query " + queryTerm);
+        }
+
+        return queryTerm;
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
@@ -76,7 +76,7 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
         }
 
         // as long as there are extractors it is okay for an empty query string, if neither there is nothing to do
-        if (extractors.isEmpty() && (queryString == null || queryString.isBlank())) {
+        if (extractors.isEmpty() && StringUtils.isBlank(queryString)) {
             return null;
         }
 

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
@@ -26,6 +26,7 @@ import datawave.query.function.deserializer.DocumentDeserializer;
 import datawave.query.tables.chained.strategy.FullChainStrategy;
 import datawave.query.tables.keyword.extractor.TagCloudInputExtractor;
 import datawave.query.tables.keyword.extractor.TagCloudInputExtractorException;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
 import datawave.util.keyword.TagCloudPartition;
 
 /**
@@ -149,15 +150,21 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
 
         if (nextLogic instanceof KeywordQueryLogic) {
             // get all partitions from configured extractors
-            List<TagCloudPartition> extractedPartitions = new ArrayList<>();
+            List<Entry<Key,Value>> encodedData = new ArrayList<>();
+            Set<TagCloudInputTransformer<?>> transformers = new HashSet<>();
             for (TagCloudInputExtractor extractor : extractors) {
-                extractedPartitions.add(extractor.get());
+                TagCloudInputTransformer<TagCloudPartition> transformer = extractor.getInputTransformer();
+                transformers.add(transformer);
+                TagCloudPartition partition = extractor.get();
+                Entry<Key,Value> transformed = transformer.encode(partition);
+
+                encodedData.add(transformed);
                 extractor.clear();
             }
 
             KeywordQueryLogic keywordQueryLogic = (KeywordQueryLogic) nextLogic;
             // pass the extracted partitions on to the keyword query logic
-            keywordQueryLogic.setExternalTagCloudPartitions(extractedPartitions);
+            keywordQueryLogic.setExternalData(encodedData, transformers);
         }
 
         return queryTerms.isEmpty() ? null : StringUtils.join(queryTerms, " ");

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/StatefulKeywordUUIDChainStrategy.java
@@ -1,7 +1,14 @@
 package datawave.query.tables.keyword;
 
+import static datawave.query.jexl.JexlASTHelper.deconstructIdentifier;
+import static datawave.query.tables.keyword.KeywordQueryLogic.TAG_CLOUD_FIELDS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -15,6 +22,7 @@ import org.apache.log4j.Logger;
 
 import com.google.common.base.Preconditions;
 
+import datawave.core.query.logic.QueryLogic;
 import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
 import datawave.query.DocumentSerialization;
@@ -22,6 +30,8 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.function.deserializer.DocumentDeserializer;
 import datawave.query.tables.chained.strategy.FullChainStrategy;
+import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TokenScore;
 
 /**
  * Strategy for chaining UUID lookup and keyword extraction queries together. Grabs the results of the lookupUUID query and uses these to generate the query
@@ -33,9 +43,20 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
 
     private int batchSize = -1;
     protected DocumentDeserializer deserializer;
+    private final QueryLogic<Entry<Key,Value>> nextLogic;
 
-    public StatefulKeywordUUIDChainStrategy(Query settings) {
+    private final List<String> tagCloudFields;
+
+    public StatefulKeywordUUIDChainStrategy(Query settings, QueryLogic<Entry<Key,Value>> nextLogic) {
         this.deserializer = DocumentSerialization.getDocumentDeserializer(settings);
+        this.nextLogic = nextLogic;
+
+        tagCloudFields = new ArrayList<>();
+        QueryImpl.Parameter tagCloudFieldsParam = settings.findParameter(TAG_CLOUD_FIELDS);
+        if (tagCloudFieldsParam != null) {
+            String[] fields = tagCloudFieldsParam.getParameterValue().split(",");
+            tagCloudFields.addAll(Arrays.asList(fields));
+        }
     }
 
     public int getBatchSize() {
@@ -45,6 +66,17 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
     public void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
     }
+
+    // @Override
+    // public Iterator<Entry<Key,Value>> runChainedQuery(AccumuloClient client, Query initialQuery, Set<Authorizations> auths,
+    // Iterator<Entry<Key,Value>> initialQueryResults, QueryLogic<Entry<Key,Value>> latterQueryLogic) throws Exception {
+    // // TODO maybe interface this? not sure we really have many use cases for this concept
+    // if (latterQueryLogic instanceof KeywordQueryLogic) {
+    // KeywordQueryLogic keywordQueryLogic = (KeywordQueryLogic) latterQueryLogic;
+    // keywordQueryLogic.setFieldedKeywordResults(fieldedKeywordResults);
+    // }
+    // return super.runChainedQuery(client, initialQuery, auths, initialQueryResults, latterQueryLogic);
+    // }
 
     @Override
     protected Query buildLatterQuery(Query initialQuery, Iterator<Entry<Key,Value>> initialQueryResults, String latterLogicName) {
@@ -98,6 +130,9 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
      */
     public String captureResultsAndBuildQuery(Iterator<Entry<Key,Value>> initialQueryResults, int batchSize) {
         int count = 0;
+
+        Map<String,List<KeywordResults>> fieldedKeywordResults = new HashMap<>();
+
         Set<String> queryTerms = new HashSet<>();
         while (initialQueryResults.hasNext() && (batchSize == -1 || count < batchSize)) {
             Entry<Key,Value> entry = initialQueryResults.next();
@@ -119,16 +154,36 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
 
             List<String> identifiers = null;
             List<String> languages = null;
+            String docId = row + "/" + dataType + "/" + uid;
 
+            Map<String,List<TokenScore>> fieldLabels = new HashMap<>();
             for (Entry<String,Attribute<? extends Comparable<?>>> data : documentData.entrySet()) {
                 if (data.getKey().equals("LANGUAGE")) {
                     languages = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
                 } else if (data.getKey().equals("HIT_TERM")) {
                     identifiers = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
+                } else {
+                    String baseField = deconstructIdentifier(data.getKey());
+                    if (tagCloudFields.contains(baseField)) {
+                        List<String> labels = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
+                        List<TokenScore> existing = fieldLabels.computeIfAbsent(baseField, k -> new ArrayList<>());
+
+                        // TODO pull a score (if configured) and remove anything below the threshold
+                        labels.forEach(label -> existing.add(new TokenScore(label, 1.0f)));
+                    }
                 }
             }
 
-            String queryTerm = "DOCUMENT:" + row + "/" + dataType + "/" + uid;
+            // build up the results for each field found
+            for (String field : fieldLabels.keySet()) {
+                List<TokenScore> labels = fieldLabels.get(field);
+                LinkedHashMap<String,Double> mapped = new LinkedHashMap<>();
+                labels.forEach(label -> mapped.put(label.getToken(), label.getScore()));
+                KeywordResults kr = new KeywordResults(docId, "event:" + field, field, entry.getKey().getColumnVisibility().toString(), mapped);
+                fieldedKeywordResults.computeIfAbsent(field, k -> new ArrayList<>()).add(kr);
+            }
+
+            String queryTerm = "DOCUMENT:" + docId;
             String language, identifier;
             if (((identifier = KeywordQueryUtil.chooseBestIdentifier(identifiers)) != null)) {
                 if (log.isTraceEnabled()) {
@@ -150,6 +205,11 @@ public class StatefulKeywordUUIDChainStrategy extends FullChainStrategy<Entry<Ke
 
             queryTerms.add(queryTerm);
             count++;
+        }
+
+        if (nextLogic instanceof KeywordQueryLogic) {
+            KeywordQueryLogic keywordQueryLogic = (KeywordQueryLogic) nextLogic;
+            keywordQueryLogic.setFieldedKeywordResults(fieldedKeywordResults);
         }
 
         return queryTerms.isEmpty() ? null : StringUtils.join(queryTerms, " ");

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
@@ -12,6 +12,8 @@ import org.apache.log4j.Logger;
 
 import datawave.query.attributes.Attribute;
 import datawave.query.tables.keyword.KeywordQueryUtil;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
+import datawave.query.tables.keyword.transform.TagCloudPartitionTransformer;
 import datawave.util.keyword.TagCloudInput;
 import datawave.util.keyword.TagCloudPartition;
 
@@ -85,6 +87,11 @@ public class FieldedTagCloudInputExtractor implements TagCloudInputExtractor {
     @Override
     public String getName() {
         return category;
+    }
+
+    @Override
+    public TagCloudInputTransformer<TagCloudPartition> getInputTransformer() {
+        return TagCloudPartitionTransformer.getInstance();
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
@@ -63,7 +63,7 @@ public class FieldedTagCloudInputExtractor implements TagCloudInputExtractor {
             }
         }
 
-        TagCloudInput tagCloudInput = new TagCloudInput(docId, source.getColumnVisibility().toString(), extractedFields);
+        TagCloudInput tagCloudInput = new TagCloudInput(docId, source.getColumnVisibility().toString(), extractedFields, Map.of("type", category));
 
         if (this.partition == null) {
             this.partition = new TagCloudPartition(this.category, this.category, TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, new ArrayList<>());

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
@@ -1,0 +1,158 @@
+package datawave.query.tables.keyword.extractor;
+
+import static datawave.query.jexl.JexlASTHelper.deconstructIdentifier;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.log4j.Logger;
+
+import datawave.query.attributes.Attribute;
+import datawave.query.tables.keyword.KeywordQueryUtil;
+import datawave.util.keyword.TagCloudInput;
+import datawave.util.keyword.TagCloudPartition;
+
+public class FieldedTagCloudInputExtractor implements TagCloudInputExtractor {
+    private static final Logger log = Logger.getLogger(FieldedTagCloudInputExtractor.class);
+    private static final String DEFAULT_SCORE = "1.0";
+    private static final double DEFAULT_MIN_SCORE = .6;
+
+    private String category;
+    private List<String> fields;
+    private Map<String,String> fieldToScoreField = new HashMap<>();
+    // TODO-crwill9 ehh
+    private String defaultScore = DEFAULT_SCORE;
+    private double minScore = DEFAULT_MIN_SCORE;
+    private TagCloudPartition partition;
+
+    public FieldedTagCloudInputExtractor() {}
+
+    @Override
+    public void extract(Key source, Map<String,Attribute<? extends Comparable<?>>> documentData) {
+        String docId = getDocId(source);
+
+        Map<String,Double> extractedFields = new HashMap<>();
+        for (Map.Entry<String,Attribute<? extends Comparable<?>>> data : documentData.entrySet()) {
+            String baseField = deconstructIdentifier(data.getKey());
+            String group = null;
+            if (this.fields.contains(baseField)) {
+                int dotIndex = data.getKey().indexOf(".");
+                if (dotIndex > -1) {
+                    group = data.getKey().substring(dotIndex + 1);
+                }
+
+                // default score
+                String score = this.defaultScore;
+                try {
+                    score = getScoreField(baseField, group, documentData);
+                } catch (TagCloudInputExtractorException e) {
+                    log.warn("failed to extract score for field: " + baseField + " on doc: " + docId + " Defaulting score: " + score, e);
+                }
+
+                if (Double.parseDouble(score) > this.minScore) {
+                    List<String> values = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
+                    for (String value : values) {
+                        extractedFields.put(value, Double.parseDouble(score));
+                    }
+                } else if (log.isDebugEnabled()) {
+                    log.debug("excluding " + baseField + " " + score + " < " + minScore + " threshold for doc " + docId);
+                }
+            }
+        }
+
+        TagCloudInput tagCloudInput = new TagCloudInput(docId, source.getColumnVisibility().toString(), extractedFields);
+
+        if (this.partition == null) {
+            this.partition = new TagCloudPartition(this.category, this.category, TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, new ArrayList<>());
+        }
+
+        this.partition.addInput(tagCloudInput);
+    }
+
+    @Override
+    public TagCloudPartition get() {
+        return partition;
+    }
+
+    @Override
+    public void clear() {
+        partition = null;
+    }
+
+    @Override
+    public String getName() {
+        return category;
+    }
+
+    /**
+     * a score field is presumed to be the same group, but with the score field name
+     *
+     * @param baseField
+     * @param group
+     * @param documentData
+     * @return
+     * @throws TagCloudInputExtractorException
+     */
+    private String getScoreField(String baseField, String group, Map<String,Attribute<? extends Comparable<?>>> documentData)
+                    throws TagCloudInputExtractorException {
+        String scoreField = this.fieldToScoreField.get(baseField);
+        if (scoreField == null) {
+            return this.defaultScore;
+        }
+
+        for (Map.Entry<String,Attribute<? extends Comparable<?>>> data : documentData.entrySet()) {
+            // exact match for field
+            if ((group == null && data.getKey().equals(scoreField)) || (group != null && data.getKey().equals(scoreField + "." + group))) {
+                List<String> values = KeywordQueryUtil.getStringValuesFromAttribute(data.getValue());
+                if (values.size() == 1) {
+                    return values.get(0);
+                }
+            }
+        }
+
+        throw new TagCloudInputExtractorException("Unexpected number of values for field: " + baseField + " score field: " + scoreField + "." + group);
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setFields(List<String> fields) {
+        this.fields = fields;
+    }
+
+    public List<String> getFields() {
+        return fields;
+    }
+
+    public void setFieldToScoreField(Map<String,String> fieldToScoreField) {
+        this.fieldToScoreField = fieldToScoreField;
+    }
+
+    public Map<String,String> getFieldToScoreField() {
+        return fieldToScoreField;
+    }
+
+    public void setDefaultScore(String defaultScore) {
+        this.defaultScore = defaultScore;
+    }
+
+    public String getDefaultScore() {
+        return defaultScore;
+    }
+
+    public void setMinScore(double minScore) {
+        this.minScore = minScore;
+    }
+
+    public double getMinScore() {
+        return minScore;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/FieldedTagCloudInputExtractor.java
@@ -66,7 +66,7 @@ public class FieldedTagCloudInputExtractor implements TagCloudInputExtractor {
         TagCloudInput tagCloudInput = new TagCloudInput(docId, source.getColumnVisibility().toString(), extractedFields, Map.of("type", category));
 
         if (this.partition == null) {
-            this.partition = new TagCloudPartition(this.category, this.category, TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, new ArrayList<>());
+            this.partition = new TagCloudPartition(this.category, this.category, TagCloudPartition.ScoreType.HIGHER_IS_BETTER, new ArrayList<>());
         }
 
         this.partition.addInput(tagCloudInput);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/ParameterFieldedTagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/ParameterFieldedTagCloudInputExtractor.java
@@ -1,0 +1,49 @@
+package datawave.query.tables.keyword.extractor;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import datawave.microservice.query.Query;
+
+/**
+ * Works identically to the ParameterFieldedTagCloudInputExtractor except can be configured with query parameters
+ */
+public class ParameterFieldedTagCloudInputExtractor extends FieldedTagCloudInputExtractor {
+    public static final String CATEGORY = "tag.cloud.user.category";
+    public static final String FIELDS = "tag.cloud.user.fields";
+    public static final String FIELDS_TO_SCORE_FIELDS = "tag.cloud.user.score.fields.map";
+    public static final String DEFAULT_SCORE = "tag.cloud.user.score.default";
+
+    @Override
+    public void initialize(Query settings) {
+        String category = settings.findParameter(CATEGORY).getParameterValue();
+        setCategory(category != null ? category.trim() : "");
+
+        String fields = settings.findParameter(FIELDS).getParameterValue();
+        if (fields != null) {
+            String[] fieldSplits = fields.split(",");
+            setFields(Arrays.stream(fieldSplits).map(String::trim).collect(Collectors.toList()));
+        }
+
+        String scoreFields = settings.findParameter(FIELDS_TO_SCORE_FIELDS).getParameterValue();
+        if (scoreFields != null) {
+            String[] splits = scoreFields.split(",");
+            Map<String,String> scoreFieldMap = new HashMap<>();
+            for (String candidate : splits) {
+                String[] kvSplits = candidate.split("=");
+                if (kvSplits.length != 2) {
+                    throw new IllegalArgumentException(FIELDS_TO_SCORE_FIELDS + " malformed, field1=score_field1,field2=score_field2,field3=score_field3");
+                }
+                scoreFieldMap.put(kvSplits[0], kvSplits[1]);
+            }
+            setFieldToScoreField(scoreFieldMap);
+        }
+
+        String defaultScore = settings.findParameter(DEFAULT_SCORE).getParameterValue();
+        if (defaultScore != null) {
+            setDefaultScore(defaultScore);
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/TagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/TagCloudInputExtractor.java
@@ -1,0 +1,35 @@
+package datawave.query.tables.keyword.extractor;
+
+import java.util.Map;
+
+import org.apache.accumulo.core.data.Key;
+
+import com.google.common.base.Preconditions;
+
+import datawave.microservice.query.Query;
+import datawave.query.attributes.Attribute;
+import datawave.util.keyword.TagCloudPartition;
+
+public interface TagCloudInputExtractor {
+    default String getDocId(Key source) {
+        String row = source.getRow().toString();
+        String cf = source.getColumnFamily().toString();
+        int index = cf.indexOf("\0");
+        Preconditions.checkArgument(-1 != index);
+
+        String dataType = cf.substring(0, index);
+        String uid = cf.substring(index + 1);
+
+        return row + "/" + dataType + "/" + uid;
+    }
+
+    default void initialize(Query settings) {}
+
+    String getName();
+
+    void extract(Key source, Map<String,Attribute<? extends Comparable<?>>> documentData) throws TagCloudInputExtractorException;
+
+    TagCloudPartition get();
+
+    void clear();
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/TagCloudInputExtractor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/TagCloudInputExtractor.java
@@ -8,6 +8,7 @@ import com.google.common.base.Preconditions;
 
 import datawave.microservice.query.Query;
 import datawave.query.attributes.Attribute;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
 import datawave.util.keyword.TagCloudPartition;
 
 public interface TagCloudInputExtractor {
@@ -32,4 +33,6 @@ public interface TagCloudInputExtractor {
     TagCloudPartition get();
 
     void clear();
+
+    TagCloudInputTransformer<TagCloudPartition> getInputTransformer();
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/TagCloudInputExtractorException.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/extractor/TagCloudInputExtractorException.java
@@ -1,0 +1,7 @@
+package datawave.query.tables.keyword.extractor;
+
+public class TagCloudInputExtractorException extends Exception {
+    public TagCloudInputExtractorException(String message) {
+        super(message);
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
@@ -1,0 +1,61 @@
+package datawave.query.tables.keyword.transform;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudPartition;
+
+public class KeywordResultsTransformer implements TagCloudInputTransformer<KeywordResults> {
+    private static final String LABEL = "keywords";
+
+    private boolean languagePartitioned = true;
+    private Map<String,String> identifierMap = new HashMap<>();
+
+    @Override
+    public Entry<Key,Value> encode(KeywordResults input) {
+        // TODO-crwill9 if we push this all the way into the iterator
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    @Override
+    public boolean canDecode(Entry<Key,Value> input) {
+        try {
+            return KeywordResults.canDeserialize(input.getValue().get());
+        } catch (IOException e) {
+            throw new RuntimeException("error checking decoding " + input.getKey(), e);
+        }
+    }
+
+    @Override
+    public TagCloudPartition decode(Entry<Key,Value> input) {
+        KeywordResults keywordResults;
+        try {
+            keywordResults = KeywordResults.deserialize(input.getValue().get());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not deserialize KeywordResults from K/V " + input.getKey(), e);
+        }
+
+        final String identifier = identifierMap.get(keywordResults.getSource());
+        if (identifier != null) {
+            // update the source from the identifier map.
+            keywordResults.setSource(identifier);
+        }
+
+        return new TagCloudPartition(languagePartitioned ? keywordResults.getLanguage() : "", LABEL, List.of(keywordResults));
+    }
+
+    public void setIdentifierMap(Map<String,String> identifierMap) {
+        this.identifierMap = identifierMap;
+    }
+
+    public void setLanguagePartitioned(boolean languagePartitioned) {
+        this.languagePartitioned = languagePartitioned;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
@@ -10,10 +10,11 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
 import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudInput;
 import datawave.util.keyword.TagCloudPartition;
 
 public class KeywordResultsTransformer implements TagCloudInputTransformer<KeywordResults> {
-    private static final String LABEL = "keywords";
+    public static final String LABEL = "keywords";
 
     private boolean languagePartitioned = true;
     private Map<String,String> identifierMap = new HashMap<>();
@@ -48,12 +49,27 @@ public class KeywordResultsTransformer implements TagCloudInputTransformer<Keywo
             keywordResults.setSource(identifier);
         }
 
+        TagCloudInput tagCloudInput = getTagCloudInput(keywordResults);
+
         String partition = "";
-        if (languagePartitioned && keywordResults.getMetadata().get("language") != null) {
-            partition = keywordResults.getMetadata().get("language");
+        if (languagePartitioned && !keywordResults.getLanguage().isEmpty()) {
+            partition = keywordResults.getLanguage();
         }
 
-        return new TagCloudPartition(partition, LABEL, List.of(keywordResults));
+        return new TagCloudPartition(partition, LABEL, List.of(tagCloudInput));
+    }
+
+    private TagCloudInput getTagCloudInput(KeywordResults keywordResults) {
+        Map<String,String> metadata = new HashMap<>();
+        metadata.put("type", LABEL);
+        if (!keywordResults.getView().isEmpty()) {
+            metadata.put("view", keywordResults.getView());
+        }
+        if (!keywordResults.getLanguage().isEmpty()) {
+            metadata.put("language", keywordResults.getLanguage());
+        }
+
+        return new TagCloudInput(keywordResults.getSource(), keywordResults.getVisibility(), keywordResults.getKeywords(), metadata);
     }
 
     public void setIdentifierMap(Map<String,String> identifierMap) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -57,6 +58,25 @@ public class KeywordResultsTransformer implements TagCloudInputTransformer<Keywo
         }
 
         return new TagCloudPartition(partition, LABEL, List.of(tagCloudInput));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof KeywordResultsTransformer)) {
+            return false;
+        }
+
+        KeywordResultsTransformer otherTransformer = (KeywordResultsTransformer) other;
+        return Objects.equals(languagePartitioned, otherTransformer.languagePartitioned) && Objects.equals(identifierMap, otherTransformer.identifierMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(languagePartitioned, identifierMap);
     }
 
     private TagCloudInput getTagCloudInput(KeywordResults keywordResults) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/KeywordResultsTransformer.java
@@ -48,7 +48,12 @@ public class KeywordResultsTransformer implements TagCloudInputTransformer<Keywo
             keywordResults.setSource(identifier);
         }
 
-        return new TagCloudPartition(languagePartitioned ? keywordResults.getLanguage() : "", LABEL, List.of(keywordResults));
+        String partition = "";
+        if (languagePartitioned && keywordResults.getMetadata().get("language") != null) {
+            partition = keywordResults.getMetadata().get("language");
+        }
+
+        return new TagCloudPartition(partition, LABEL, List.of(keywordResults));
     }
 
     public void setIdentifierMap(Map<String,String> identifierMap) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/TagCloudInputTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/TagCloudInputTransformer.java
@@ -1,0 +1,16 @@
+package datawave.query.tables.keyword.transform;
+
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import datawave.util.keyword.TagCloudPartition;
+
+public interface TagCloudInputTransformer<K> {
+    Entry<Key,Value> encode(K input);
+
+    boolean canDecode(Entry<Key,Value> input);
+
+    TagCloudPartition decode(Entry<Key,Value> input);
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/TagCloudPartitionTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/TagCloudPartitionTransformer.java
@@ -1,0 +1,36 @@
+package datawave.query.tables.keyword.transform;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+
+import datawave.util.keyword.TagCloudPartition;
+
+public class TagCloudPartitionTransformer implements TagCloudInputTransformer<TagCloudPartition> {
+
+    @Override
+    public Entry<Key,Value> encode(TagCloudPartition partition) {
+        return Map.entry(new Key(), new Value(TagCloudPartition.serialize(partition)));
+    }
+
+    @Override
+    public boolean canDecode(Entry<Key,Value> input) {
+        try {
+            return TagCloudPartition.canDeserialize(input.getValue().get());
+        } catch (IOException e) {
+            throw new RuntimeException("error checking decoding " + input.getKey(), e);
+        }
+    }
+
+    @Override
+    public TagCloudPartition decode(Entry<Key,Value> input) {
+        try {
+            return TagCloudPartition.deserialize(input.getValue().get());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not deserialize KeywordResults from K/V " + input.getKey(), e);
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/TagCloudPartitionTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/keyword/transform/TagCloudPartitionTransformer.java
@@ -10,6 +10,18 @@ import org.apache.accumulo.core.data.Value;
 import datawave.util.keyword.TagCloudPartition;
 
 public class TagCloudPartitionTransformer implements TagCloudInputTransformer<TagCloudPartition> {
+    private final static TagCloudPartitionTransformer instance = new TagCloudPartitionTransformer();
+
+    /**
+     * Has no state and is thread safe, use a singleton
+     *
+     * @return
+     */
+    public static TagCloudPartitionTransformer getInstance() {
+        return instance;
+    }
+
+    private TagCloudPartitionTransformer() {}
 
     @Override
     public Entry<Key,Value> encode(TagCloudPartition partition) {

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
@@ -27,20 +27,41 @@ import datawave.webservice.result.keyword.TagCloudResponseBase;
 /** Transforms the Key/Values returned by the KeywordExtractionIterator into KeywordResults and then Tag Clouds Responses */
 @SuppressWarnings("rawtypes")
 public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,TagCloudPartition> {
+    public static final ResponseVersion DEFAULT_VERSION = ResponseVersion.V1;
 
+    private final ResponseVersion responseVersion;
     protected final Authorizations auths;
     protected final ResponseObjectFactory responseObjectFactory;
     protected final KeywordQueryState state;
     private final Set<TagCloudInputTransformer<?>> transformers;
 
+    public enum ResponseVersion {
+        V1, V2
+    }
+
     // TODO-crwill9 pass in state data, not the state object so this is more reusable
-    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory,
-                    Set<TagCloudInputTransformer<?>> transformers) {
+    public TagCloudTransformer(String responseVersion, Query query, KeywordQueryState state, MarkingFunctions markingFunctions,
+                    ResponseObjectFactory responseObjectFactory, Set<TagCloudInputTransformer<?>> transformers) {
         super(markingFunctions);
+        this.responseVersion = getResponseVersion(responseVersion);
         this.auths = new Authorizations(query.getQueryAuthorizations().split(","));
         this.responseObjectFactory = responseObjectFactory;
         this.state = state;
         this.transformers = transformers;
+    }
+
+    private ResponseVersion getResponseVersion(String responseVersion) {
+        if (responseVersion == null) {
+            return DEFAULT_VERSION;
+        }
+
+        if (responseVersion.equals("1") || responseVersion.equals("v1") || responseVersion.equals("V1")) {
+            return ResponseVersion.V1;
+        } else if (responseVersion.equals("2") || responseVersion.equals("v2") || responseVersion.equals("V2")) {
+            return ResponseVersion.V2;
+        }
+
+        return DEFAULT_VERSION;
     }
 
     /**
@@ -139,17 +160,53 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
         List<TagCloudBase> tagClouds = new ArrayList<>();
         for (TagCloud tagCloudResult : tagCloudResultsList) {
             TagCloudBase tagCloud = responseObjectFactory.getTagCloud();
-            if (tagCloudResult.getMetadata() != null && !tagCloudResult.getMetadata().isEmpty()) {
-                tagCloud.setMetadata(tagCloudResult.getMetadata());
-            }
-            if (!tagCloudResult.getVisibility().isEmpty()) {
-                tagCloud.setMarkings(tagCloudResult.getVisibility());
-            }
-            tagCloud.setTags(generateTagCloudEntries(tagCloudResult));
+            configureTagCloud(tagCloud, tagCloudResult);
             tagClouds.add(tagCloud);
         }
         response.setTagClouds(tagClouds);
         return response;
+    }
+
+    public ResponseVersion getResponseVersion() {
+        return responseVersion;
+    }
+
+    private void configureV1TagCloud(TagCloudBase base, TagCloud tagCloud) {
+        if (tagCloud.getMetadata() != null) {
+            String language = tagCloud.getMetadata().get("language");
+            if (language != null) {
+                base.setLanguage(language);
+            } else {
+                String type = tagCloud.getMetadata().get("type");
+                if (type != null) {
+                    base.setLanguage(type);
+                }
+            }
+        }
+        if (!tagCloud.getVisibility().isEmpty()) {
+            base.setMarkings(tagCloud.getVisibility());
+        }
+        base.setTags(generateTagCloudEntries(tagCloud));
+    }
+
+    private void configureV2TagCloud(TagCloudBase base, TagCloud tagCloud) {
+        if (tagCloud.getMetadata() != null && !tagCloud.getMetadata().isEmpty()) {
+            base.setMetadata(tagCloud.getMetadata());
+        }
+        if (!tagCloud.getVisibility().isEmpty()) {
+            base.setMarkings(tagCloud.getVisibility());
+        }
+        base.setTags(generateTagCloudEntries(tagCloud));
+    }
+
+    private void configureTagCloud(TagCloudBase base, TagCloud tagCloud) {
+        if (responseVersion == ResponseVersion.V1) {
+            configureV1TagCloud(base, tagCloud);
+        } else if (responseVersion == ResponseVersion.V2) {
+            configureV2TagCloud(base, tagCloud);
+        } else {
+            throw new UnsupportedOperationException("cannot configure response for " + responseVersion);
+        }
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
@@ -1,6 +1,5 @@
 package datawave.query.transformer;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -12,13 +11,12 @@ import org.apache.accumulo.core.security.Authorizations;
 
 import datawave.core.query.logic.BaseQueryLogicTransformer;
 import datawave.marking.MarkingFunctions;
-import datawave.marking.MarkingFunctions.Exception;
 import datawave.microservice.query.Query;
-import datawave.query.table.parser.KeywordKeyValueFactory;
 import datawave.query.tables.keyword.KeywordQueryState;
-import datawave.util.keyword.KeywordResults;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
 import datawave.util.keyword.TagCloud;
 import datawave.util.keyword.TagCloudEntry;
+import datawave.util.keyword.TagCloudPartition;
 import datawave.webservice.query.result.event.ResponseObjectFactory;
 import datawave.webservice.result.BaseQueryResponse;
 import datawave.webservice.result.keyword.TagCloudBase;
@@ -27,17 +25,21 @@ import datawave.webservice.result.keyword.TagCloudResponseBase;
 
 /** Transforms the Key/Values returned by the KeywordExtractionIterator into KeywordResults and then Tag Clouds Responses */
 @SuppressWarnings("rawtypes")
-public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,KeywordResults> {
+public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Value>,TagCloudPartition> {
 
     protected final Authorizations auths;
     protected final ResponseObjectFactory responseObjectFactory;
     protected final KeywordQueryState state;
+    private final List<TagCloudInputTransformer<?>> transformers;
 
-    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory) {
+    // TODO-crwill9 pass in state data, not the state object so this is more reusable
+    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory,
+                    List<TagCloudInputTransformer<?>> transformers) {
         super(markingFunctions);
         this.auths = new Authorizations(query.getQueryAuthorizations().split(","));
         this.responseObjectFactory = responseObjectFactory;
         this.state = state;
+        this.transformers = transformers;
     }
 
     /**
@@ -48,7 +50,7 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
      * @return KeywordResults object containing the transformed entry.
      */
     @Override
-    public KeywordResults transform(Entry<Key,Value> entry) {
+    public TagCloudPartition transform(Entry<Key,Value> entry) {
         // each contains the serialized keywords for individual documents.
         if (entry.getKey() == null && entry.getValue() == null) {
             return null;
@@ -58,21 +60,13 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
             throw new IllegalArgumentException("Null key or value. Key:" + entry.getKey() + ", Value: " + entry.getValue());
         }
 
-        try {
-            final KeywordKeyValueFactory.KeywordKeyValue kkv = KeywordKeyValueFactory.parse(entry.getKey(), entry.getValue(), auths, markingFunctions);
-            final KeywordResults keywordResults = KeywordResults.deserialize(kkv.getContents());
-            final String identifier = state.getIdentifierMap().get(keywordResults.getSource());
-            if (identifier != null) {
-                // update the source from the identifier map.
-                keywordResults.setSource(identifier);
+        for (TagCloudInputTransformer<?> transformer : transformers) {
+            if (transformer.canDecode(entry)) {
+                return transformer.decode(entry);
             }
-
-            // todo: preserve shard, datatype, uid, markings, timestamp?
-
-            return keywordResults;
-        } catch (Exception | IOException e1) {
-            throw new IllegalArgumentException("Unable to parse keyword extraction results", e1);
         }
+
+        throw new IllegalArgumentException("Unable to parse keyword extraction results " + entry.getKey());
     }
 
     /**
@@ -84,19 +78,27 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
      */
     @Override
     public BaseQueryResponse createResponse(List<Object> resultList) {
-        final List<KeywordResults> keywordResultsList = resultList.stream().map(o -> (KeywordResults) o).collect(Collectors.toList());
+        final List<TagCloudPartition> inputList = resultList.stream().map(o -> (TagCloudPartition) o).collect(Collectors.toList());
         List<TagCloud> tagClouds = new ArrayList<>();
-        tagClouds.addAll(buildTagCloud(state.isGenerateCloud(), keywordResultsList));
+        tagClouds.addAll(buildTagCloud(state.isGenerateCloud(), inputList));
 
         return generateTagCloudResponse(tagClouds);
     }
 
-    // TODO document
-    private List<TagCloud> buildTagCloud(boolean merged, List<KeywordResults> resultList) {
+    /**
+     * Transform a list of partitions into a query response containing tag clouds either merged into a single tag cloud, or into one tag cloud per partition
+     *
+     * @param merged
+     *            if the tag clouds should be merged
+     * @param resultList
+     *            the partitions to add to the tag cloud(s)
+     * @return a non-null list of tag clouds
+     */
+    private List<TagCloud> buildTagCloud(boolean merged, List<TagCloudPartition> resultList) {
         List<TagCloud> results = new ArrayList<>();
         TagCloud.Builder builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);
-        for (KeywordResults result : resultList) {
-            builder.addResults(result);
+        for (TagCloudPartition result : resultList) {
+            builder.addInput(result);
             if (!merged) {
                 results.addAll(builder.build());
                 builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);
@@ -108,44 +110,6 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
         }
 
         return results;
-    }
-
-    /**
-     * Transform a list of results generated by the transform method into a query response containing tag clouds for individual documents potentially grouped by
-     * language.
-     *
-     * @param resultList
-     *            the results to add to the response that were created by the transform method
-     * @return a tag cloud response that includes one or more tag clouds.
-     */
-    // TODO delete
-    protected TagCloudResponseBase createIndividualCloudResponse(List<KeywordResults> resultList) {
-        // collect the results for individual documents into individual word clouds.
-        List<TagCloud> tagCloudResults = new ArrayList<>();
-        for (KeywordResults result : resultList) {
-            final TagCloud.Builder builder = getTagCloudBuilder();
-            builder.addResults(result);
-            tagCloudResults.addAll(builder.build());
-        }
-        return generateTagCloudResponse(tagCloudResults);
-    }
-
-    /**
-     * Transform a list of results generated by the transform method into a query response. This method merges results for all documents returned into one or
-     * more tag clouds potentially grouped by language and ordered by frequency.
-     *
-     * @param resultList
-     *            the results to add to the response that were created by the transform method
-     * @return a tag cloud response that includes one or more tag clouds.
-     */
-    // TODO delete
-    protected TagCloudResponseBase createMergedCloudResponse(List<KeywordResults> resultList) {
-        // collect the keywords for individual documents into a single word cloud.
-        final TagCloud.Builder builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);
-        for (KeywordResults result : resultList) {
-            builder.addResults(result);
-        }
-        return generateTagCloudResponse(builder.build());
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
@@ -3,7 +3,6 @@ package datawave.query.transformer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
@@ -33,15 +32,12 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
     protected final Authorizations auths;
     protected final ResponseObjectFactory responseObjectFactory;
     protected final KeywordQueryState state;
-    private final Map<String,List<KeywordResults>> fieldedKeywordResults;
 
-    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory,
-                    Map<String,List<KeywordResults>> fieldedKeywordResults) {
+    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory) {
         super(markingFunctions);
         this.auths = new Authorizations(query.getQueryAuthorizations().split(","));
         this.responseObjectFactory = responseObjectFactory;
         this.state = state;
-        this.fieldedKeywordResults = fieldedKeywordResults;
     }
 
     /**
@@ -90,16 +86,12 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
     public BaseQueryResponse createResponse(List<Object> resultList) {
         final List<KeywordResults> keywordResultsList = resultList.stream().map(o -> (KeywordResults) o).collect(Collectors.toList());
         List<TagCloud> tagClouds = new ArrayList<>();
-        if (fieldedKeywordResults != null) {
-            for (String field : fieldedKeywordResults.keySet()) {
-                tagClouds.addAll(buildTagCloud(state.isGenerateCloud(), fieldedKeywordResults.get(field)));
-            }
-        }
         tagClouds.addAll(buildTagCloud(state.isGenerateCloud(), keywordResultsList));
 
         return generateTagCloudResponse(tagClouds);
     }
 
+    // TODO document
     private List<TagCloud> buildTagCloud(boolean merged, List<KeywordResults> resultList) {
         List<TagCloud> results = new ArrayList<>();
         TagCloud.Builder builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);
@@ -126,6 +118,7 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
      *            the results to add to the response that were created by the transform method
      * @return a tag cloud response that includes one or more tag clouds.
      */
+    // TODO delete
     protected TagCloudResponseBase createIndividualCloudResponse(List<KeywordResults> resultList) {
         // collect the results for individual documents into individual word clouds.
         List<TagCloud> tagCloudResults = new ArrayList<>();
@@ -145,6 +138,7 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
      *            the results to add to the response that were created by the transform method
      * @return a tag cloud response that includes one or more tag clouds.
      */
+    // TODO delete
     protected TagCloudResponseBase createMergedCloudResponse(List<KeywordResults> resultList) {
         // collect the keywords for individual documents into a single word cloud.
         final TagCloud.Builder builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
@@ -3,6 +3,7 @@ package datawave.query.transformer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
@@ -32,12 +33,15 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
     protected final Authorizations auths;
     protected final ResponseObjectFactory responseObjectFactory;
     protected final KeywordQueryState state;
+    private final Map<String,List<KeywordResults>> fieldedKeywordResults;
 
-    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory) {
+    public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory,
+                    Map<String,List<KeywordResults>> fieldedKeywordResults) {
         super(markingFunctions);
         this.auths = new Authorizations(query.getQueryAuthorizations().split(","));
         this.responseObjectFactory = responseObjectFactory;
         this.state = state;
+        this.fieldedKeywordResults = fieldedKeywordResults;
     }
 
     /**
@@ -84,12 +88,34 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
      */
     @Override
     public BaseQueryResponse createResponse(List<Object> resultList) {
-        //@formatter:off
         final List<KeywordResults> keywordResultsList = resultList.stream().map(o -> (KeywordResults) o).collect(Collectors.toList());
-        return state.isGenerateCloud() ?
-                createMergedCloudResponse(keywordResultsList) :
-                createIndividualCloudResponse(keywordResultsList);
-        //@formatter:on
+        List<TagCloud> tagClouds = new ArrayList<>();
+        if (fieldedKeywordResults != null) {
+            for (String field : fieldedKeywordResults.keySet()) {
+                tagClouds.addAll(buildTagCloud(state.isGenerateCloud(), fieldedKeywordResults.get(field)));
+            }
+        }
+        tagClouds.addAll(buildTagCloud(state.isGenerateCloud(), keywordResultsList));
+
+        return generateTagCloudResponse(tagClouds);
+    }
+
+    private List<TagCloud> buildTagCloud(boolean merged, List<KeywordResults> resultList) {
+        List<TagCloud> results = new ArrayList<>();
+        TagCloud.Builder builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);
+        for (KeywordResults result : resultList) {
+            builder.addResults(result);
+            if (!merged) {
+                results.addAll(builder.build());
+                builder = getTagCloudBuilder().withComparator(TagCloudEntry.ORDER_BY_FREQUENCY);
+            }
+        }
+
+        if (merged) {
+            results.addAll(builder.build());
+        }
+
+        return results;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
@@ -3,6 +3,7 @@ package datawave.query.transformer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.accumulo.core.data.Key;
@@ -30,11 +31,11 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
     protected final Authorizations auths;
     protected final ResponseObjectFactory responseObjectFactory;
     protected final KeywordQueryState state;
-    private final List<TagCloudInputTransformer<?>> transformers;
+    private final Set<TagCloudInputTransformer<?>> transformers;
 
     // TODO-crwill9 pass in state data, not the state object so this is more reusable
     public TagCloudTransformer(Query query, KeywordQueryState state, MarkingFunctions markingFunctions, ResponseObjectFactory responseObjectFactory,
-                    List<TagCloudInputTransformer<?>> transformers) {
+                    Set<TagCloudInputTransformer<?>> transformers) {
         super(markingFunctions);
         this.auths = new Authorizations(query.getQueryAuthorizations().split(","));
         this.responseObjectFactory = responseObjectFactory;

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/TagCloudTransformer.java
@@ -122,9 +122,6 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
         if (state.getMaxCloudTags() > 0) {
             builder.withMaxTags(state.getMaxCloudTags());
         }
-        if (state.isLanguagePartitioned()) {
-            builder.withLanguagePartitions(true);
-        }
         return builder;
     }
 
@@ -141,8 +138,8 @@ public class TagCloudTransformer extends BaseQueryLogicTransformer<Entry<Key,Val
         List<TagCloudBase> tagClouds = new ArrayList<>();
         for (TagCloud tagCloudResult : tagCloudResultsList) {
             TagCloudBase tagCloud = responseObjectFactory.getTagCloud();
-            if (!tagCloudResult.getName().isBlank()) {
-                tagCloud.setLanguage(tagCloudResult.getName());
+            if (tagCloudResult.getMetadata() != null && !tagCloudResult.getMetadata().isEmpty()) {
+                tagCloud.setMetadata(tagCloudResult.getMetadata());
             }
             if (!tagCloudResult.getVisibility().isEmpty()) {
                 tagCloud.setMarkings(tagCloudResult.getVisibility());

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/KeywordExtractingIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/KeywordExtractingIteratorTest.java
@@ -195,7 +195,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
+        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
     }
 
     /**
@@ -230,7 +230,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
+        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
     }
 
     /**
@@ -266,7 +266,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
+        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
     }
 
     /**
@@ -301,7 +301,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
+        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
     }
 
     /**
@@ -335,6 +335,6 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
+        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/logic/KeywordExtractingIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/logic/KeywordExtractingIteratorTest.java
@@ -195,7 +195,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
+        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
     }
 
     /**
@@ -230,7 +230,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
+        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
     }
 
     /**
@@ -266,7 +266,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
+        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
     }
 
     /**
@@ -301,7 +301,7 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
+        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
     }
 
     /**
@@ -335,6 +335,6 @@ public class KeywordExtractingIteratorTest extends EasyMockSupport {
         assertEquals(row, topKey.getRow());
         assertEquals(Constants.D_COLUMN_FAMILY, topKey.getColumnFamily());
         assertTrue(topKey.getColumnQualifier().toString().startsWith(dtUid));
-        assertEquals(expectedKeywordExtractor.extractKeywords(), KeywordResults.deserialize(iterator.getTopValue().get()));
+        assertEquals(expectedKeywordExtractor.extractKeywords().toJson(), KeywordResults.deserialize(iterator.getTopValue().get()).toJson());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ResponseQueryDriver.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ResponseQueryDriver.java
@@ -1,0 +1,32 @@
+package datawave.query.tables;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.collections4.iterators.TransformIterator;
+
+import datawave.core.query.cache.ResultsPage;
+import datawave.core.query.configuration.GenericQueryConfiguration;
+import datawave.core.query.logic.BaseQueryLogic;
+import datawave.core.query.logic.QueryLogicTransformer;
+import datawave.webservice.result.BaseQueryResponse;
+
+public class ResponseQueryDriver<K> {
+    private BaseQueryLogic<K> logic;
+
+    public ResponseQueryDriver(BaseQueryLogic<K> logic) {
+        this.logic = logic;
+    }
+
+    public BaseQueryResponse drive(GenericQueryConfiguration config) {
+        List<K> results = new ArrayList<>();
+        QueryLogicTransformer transformer = logic.getTransformer(config.getQuery());
+        TransformIterator transformerIterator = logic.getTransformIterator(config.getQuery());
+        while (transformerIterator.hasNext()) {
+            K o = (K) transformerIterator.next();
+            results.add(o);
+        }
+        ResultsPage<K> resultsPage = new ResultsPage<>(results);
+        return transformer.createResponse(resultsPage);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -1,7 +1,7 @@
 package datawave.query.tables.keyword;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -108,7 +108,21 @@ public class KeywordQueryLogicFunctionalTest {
         queryDriver = new ResponseQueryDriver<>(logic);
     }
 
-    private DefaultTagCloud getKeywordCloud(String docId) {
+    private DefaultTagCloud getExpectedCloud(String version, Map<String,String> metadata, List<DefaultTagCloudEntry> entries) {
+        DefaultTagCloud expectedCloud = new DefaultTagCloud();
+        if (version.equals("1")) {
+            expectedCloud.setLanguage(metadata.get("language") != null ? metadata.get("language") : metadata.get("type"));
+        } else {
+            expectedCloud.setMetadata(metadata);
+        }
+        expectedCloud.setMarkings(Map.of("visibility", "[ALL]"));
+        expectedCloud.setTags(entries);
+        expectedCloud.setIntermediateResult(false);
+
+        return expectedCloud;
+    }
+
+    private DefaultTagCloud getKeywordCloud(String docId, String version) {
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
         entries.add(createTagCloudEntry("kind word", 0.2052, 1, List.of(docId)));
         entries.add(createTagCloudEntry("kind", 0.2546, 1, List.of(docId)));
@@ -119,25 +133,38 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("much farther", 0.5903, 1, List.of(docId)));
 
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
+        expectedCloud.setMarkings(Map.of("visibility", "[ALL]"));
         expectedCloud.setTags(entries);
-        expectedCloud.setMetadata(Map.of("view", "CONTENT", "type", KeywordResultsTransformer.LABEL));
+        if (version.equals("1")) {
+            expectedCloud.setLanguage("keywords");
+        } else {
+            expectedCloud.setMetadata(Map.of("view", "CONTENT", "type", KeywordResultsTransformer.LABEL));
+        }
         expectedCloud.setIntermediateResult(false);
         return expectedCloud;
     }
 
     @Test
-    public void simpleTest() throws Exception {
+    public void simpleV1Test() throws Exception {
         String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
         String queryString = "DOCUMENT:" + docId;
 
-        addExpectedTagCloud(getKeywordCloud(docId));
-
+        addExpectedTagCloud(getKeywordCloud(docId, "1"));
         runTestQuery(queryString);
     }
 
     @Test
-    public void simpleWithOnlyExternalHitsTest() throws Exception {
+    public void simpleV2Test() throws Exception {
+        String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
+        String queryString = "DOCUMENT:" + docId;
+
+        extraParameters.put("tag.cloud.version", "2");
+        addExpectedTagCloud(getKeywordCloud(docId, "2"));
+        runTestQuery(queryString);
+    }
+
+    @Test
+    public void simpleWithOnlyExternalHitsV1Test() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
         TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", List
@@ -148,18 +175,32 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("y", .8, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
-        DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setMetadata(Map.of("type", "demo"));
-        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
-        expectedCloud.setTags(entries);
-        expectedCloud.setIntermediateResult(false);
-        addExpectedTagCloud(expectedCloud);
+        addExpectedTagCloud(getExpectedCloud("1", Map.of("type", "demo"), entries));
 
         runTestQuery(queryString);
     }
 
     @Test
-    public void multipleExternalHitsTest() throws Exception {
+    public void simpleWithOnlyExternalHitsV2Test() throws Exception {
+        String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
+
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", List
+                        .of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo"))));
+        logic.setExternalData(List.of(tagCloudPartitionTransformer.encode(externalPartition)), Set.of(tagCloudPartitionTransformer));
+
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("y", .8, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+
+        extraParameters.put("tag.cloud.version", "2");
+        addExpectedTagCloud(getExpectedCloud("2", Map.of("type", "demo"), entries));
+
+        runTestQuery(queryString);
+    }
+
+    @Test
+    public void multipleExternalHitsV1Test() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
         TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
@@ -172,18 +213,35 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("y", .9, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
-        DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setMetadata(Map.of("type", "demo"));
-        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
-        expectedCloud.setTags(entries);
-        expectedCloud.setIntermediateResult(false);
-        addExpectedTagCloud(expectedCloud);
+
+        addExpectedTagCloud(getExpectedCloud("1", Map.of("type", "demo"), entries));
 
         runTestQuery(queryString);
     }
 
     @Test
-    public void mixedHitTest() throws Exception {
+    public void multipleExternalHitsV2Test() throws Exception {
+        String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
+
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
+        logic.setExternalData(List.of(tagCloudPartitionTransformer.encode(externalPartition)), Set.of(tagCloudPartitionTransformer));
+
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        entries.add(createTagCloudEntry("x", .5, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("y", .9, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
+
+        extraParameters.put("tag.cloud.version", "2");
+        addExpectedTagCloud(getExpectedCloud("2", Map.of("type", "demo"), entries));
+
+        runTestQuery(queryString);
+    }
+
+    @Test
+    public void mixedHitV1Test() throws Exception {
         String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
         String queryString = "DOCUMENT:" + docId;
 
@@ -197,13 +255,32 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("y", .9, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
         entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
-        DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setMetadata(Map.of("type", "demo"));
-        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
-        expectedCloud.setTags(entries);
-        expectedCloud.setIntermediateResult(false);
-        addExpectedTagCloud(expectedCloud);
-        addExpectedTagCloud(getKeywordCloud(docId));
+
+        addExpectedTagCloud(getExpectedCloud("1", Map.of("type", "demo"), entries));
+        addExpectedTagCloud(getKeywordCloud(docId, "1"));
+
+        runTestQuery(queryString);
+    }
+
+    @Test
+    public void mixedHitV2Test() throws Exception {
+        String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
+        String queryString = "DOCUMENT:" + docId;
+
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
+        logic.setExternalData(List.of(tagCloudPartitionTransformer.encode(externalPartition)), Set.of(tagCloudPartitionTransformer));
+
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        entries.add(createTagCloudEntry("y", .9, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+
+        extraParameters.put("tag.cloud.version", "2");
+        addExpectedTagCloud(getExpectedCloud("2", Map.of("type", "demo"), entries));
+        addExpectedTagCloud(getKeywordCloud(docId, "2"));
 
         runTestQuery(queryString);
     }
@@ -240,12 +317,16 @@ public class KeywordQueryLogicFunctionalTest {
         assertEquals(expectedResults.size(), response.getTagClouds().size());
 
         // check the response clouds are expected
+        List<TagCloudBase> found = new ArrayList<>();
         for (TagCloudBase tagCloud : response.getTagClouds()) {
-            assertTrue(isExpectedTagCloud((DefaultTagCloud) tagCloud));
+            if (!expectedResults.contains(tagCloud)) {
+                fail("unexpected tag cloud: " + tagCloud);
+            }
+            found.add(tagCloud);
         }
 
         // nothing still expected
-        assertEquals(0, expectedResults.size());
+        assertEquals(found.size(), expectedResults.size());
     }
 
     private boolean isExpectedTagCloud(DefaultTagCloud tagCloud) {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -45,7 +44,8 @@ import datawave.query.tables.ResponseQueryDriver;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.WiseGuysIngest;
 import datawave.util.TableName;
-import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudInput;
+import datawave.util.keyword.TagCloudPartition;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.webservice.result.keyword.DefaultTagCloud;
 import datawave.webservice.result.keyword.DefaultTagCloudEntry;
@@ -104,11 +104,7 @@ public class KeywordQueryLogicFunctionalTest {
         queryDriver = new ResponseQueryDriver<>(logic);
     }
 
-    @Test
-    public void simpleTest() throws Exception {
-        String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
-        String queryString = "DOCUMENT:" + docId;
-
+    private DefaultTagCloud getKeywordCloud(String docId) {
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
         entries.add(createTagCloudEntry("kind word", 0.2052, 1, List.of(docId)));
         entries.add(createTagCloudEntry("kind", 0.2546, 1, List.of(docId)));
@@ -122,7 +118,15 @@ public class KeywordQueryLogicFunctionalTest {
         expectedCloud.setMarkings(Map.of("visibility", "ALL"));
         expectedCloud.setTags(entries);
         expectedCloud.setIntermediateResult(false);
-        addExpectedTagCloud(expectedCloud);
+        return expectedCloud;
+    }
+
+    @Test
+    public void simpleTest() throws Exception {
+        String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
+        String queryString = "DOCUMENT:" + docId;
+
+        addExpectedTagCloud(getKeywordCloud(docId));
 
         runTestQuery(queryString);
     }
@@ -131,13 +135,9 @@ public class KeywordQueryLogicFunctionalTest {
     public void simpleWithOnlyExternalHitsTest() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
-        List<KeywordResults> keywordResultsList = new ArrayList<>();
-        LinkedHashMap<String,Double> labels = new LinkedHashMap<>();
-        labels.put("x", .5d);
-        labels.put("y", .8d);
-        labels.put("z", 1d);
-        keywordResultsList.add(new KeywordResults("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "event:FOO", "FOO", "ALL", labels));
-        logic.setFieldedKeywordResults(Map.of("FOO", keywordResultsList));
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO",
+                        List.of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d))));
+        logic.setExternalTagCloudPartitions(List.of(externalPartition));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
         entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
@@ -157,19 +157,14 @@ public class KeywordQueryLogicFunctionalTest {
     public void multipleExternalHitsTest() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
-        List<KeywordResults> keywordResultsList = new ArrayList<>();
-        LinkedHashMap<String,Double> labels = new LinkedHashMap<>();
-        labels.put("x", .5d);
-        labels.put("y", .8d);
-        labels.put("z", 1d);
-        keywordResultsList.add(new KeywordResults("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "event:FOO", "FOO", "ALL", labels));
-        keywordResultsList.add(new KeywordResults("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "event:FOO", "FOO", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d)));
-        logic.setFieldedKeywordResults(Map.of("FOO", keywordResultsList));
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER,
+                        List.of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d)),
+                                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d))));
+        logic.setExternalTagCloudPartitions(List.of(externalPartition));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
-        // TODO combining the tag clouds keeps the LOWEST score... not the highest score... may need to be able to adjust this in the TagCloudTransformer or maybe its fine
-        entries.add(createTagCloudEntry("x", .5, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
-        entries.add(createTagCloudEntry("y", .9, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
+        entries.add(createTagCloudEntry("x", .5, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("y", .9, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
@@ -178,6 +173,32 @@ public class KeywordQueryLogicFunctionalTest {
         expectedCloud.setTags(entries);
         expectedCloud.setIntermediateResult(false);
         addExpectedTagCloud(expectedCloud);
+
+        runTestQuery(queryString);
+    }
+
+    @Test
+    public void mixedHitTest() throws Exception {
+        String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
+        String queryString = "DOCUMENT:" + docId;
+
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER,
+                        List.of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d)),
+                                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d))));
+        logic.setExternalTagCloudPartitions(List.of(externalPartition));
+
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        entries.add(createTagCloudEntry("y", .9, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
+        DefaultTagCloud expectedCloud = new DefaultTagCloud();
+        expectedCloud.setLanguage("FOO");
+        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
+        expectedCloud.setTags(entries);
+        expectedCloud.setIntermediateResult(false);
+        addExpectedTagCloud(expectedCloud);
+        addExpectedTagCloud(getKeywordCloud(docId));
 
         runTestQuery(queryString);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -1,11 +1,16 @@
 package datawave.query.tables.keyword;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -16,7 +21,6 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,17 +36,21 @@ import org.junit.runner.RunWith;
 
 import datawave.configuration.spring.SpringBean;
 import datawave.core.query.configuration.GenericQueryConfiguration;
-import datawave.core.query.logic.QueryLogicTransformer;
 import datawave.helpers.PrintUtility;
 import datawave.ingest.data.TypeRegistry;
 import datawave.microservice.query.QueryImpl;
 import datawave.query.ExcerptTest;
 import datawave.query.QueryTestTableHelper;
+import datawave.query.tables.ResponseQueryDriver;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.WiseGuysIngest;
 import datawave.util.TableName;
 import datawave.util.keyword.KeywordResults;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
+import datawave.webservice.result.keyword.DefaultTagCloud;
+import datawave.webservice.result.keyword.DefaultTagCloudEntry;
+import datawave.webservice.result.keyword.DefaultTagCloudResponse;
+import datawave.webservice.result.keyword.TagCloudBase;
 
 @RunWith(Arquillian.class)
 public class KeywordQueryLogicFunctionalTest {
@@ -57,7 +65,9 @@ public class KeywordQueryLogicFunctionalTest {
     protected KeywordQueryLogic logic;
 
     private final Map<String,String> extraParameters = new HashMap<>();
-    private final Set<String> expectedResults = new HashSet<>();
+    private final List<DefaultTagCloud> expectedResults = new ArrayList<>();
+
+    private ResponseQueryDriver<Entry<Key,Value>> queryDriver;
 
     @Deployment
     public static JavaArchive createDeployment() throws Exception {
@@ -90,23 +100,100 @@ public class KeywordQueryLogicFunctionalTest {
     public void setup() throws ParseException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         log.setLevel(Level.TRACE);
+
+        queryDriver = new ResponseQueryDriver<>(logic);
     }
 
     @Test
     public void simpleTest() throws Exception {
-        String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzua";
+        String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
+        String queryString = "DOCUMENT:" + docId;
 
-        addExpectedResult(
-                        "{\"source\":\"20130101_0/test/-cvy0gj.tlf59s.-duxzua\",\"view\":\"CONTENT\",\"language\":\"\",\"visibility\":\"ALL\",\"keywords\":{\"get much\":0.5903,\"kind\":0.2546,\"kind word\":0.2052,\"kind word alone\":0.4375,\"much farther\":0.5903,\"word\":0.2857,\"word alone\":0.534}}");
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        entries.add(createTagCloudEntry("kind word", 0.2052, 1, List.of(docId)));
+        entries.add(createTagCloudEntry("kind", 0.2546, 1, List.of(docId)));
+        entries.add(createTagCloudEntry("word", 0.2857, 1, List.of(docId)));
+        entries.add(createTagCloudEntry("kind word alone", 0.4375, 1, List.of(docId)));
+        entries.add(createTagCloudEntry("word alone", 0.534, 1, List.of(docId)));
+        entries.add(createTagCloudEntry("get much", 0.5903, 1, List.of(docId)));
+        entries.add(createTagCloudEntry("much farther", 0.5903, 1, List.of(docId)));
+
+        DefaultTagCloud expectedCloud = new DefaultTagCloud();
+        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
+        expectedCloud.setTags(entries);
+        expectedCloud.setIntermediateResult(false);
+        addExpectedTagCloud(expectedCloud);
 
         runTestQuery(queryString);
     }
 
-    @SuppressWarnings("SameParameterValue")
-    protected void addExpectedResult(String keywords) {
-        if (StringUtils.isNotBlank(keywords)) {
-            expectedResults.add(keywords);
-        }
+    @Test
+    public void simpleWithOnlyExternalHitsTest() throws Exception {
+        String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
+
+        List<KeywordResults> keywordResultsList = new ArrayList<>();
+        LinkedHashMap<String,Double> labels = new LinkedHashMap<>();
+        labels.put("x", .5d);
+        labels.put("y", .8d);
+        labels.put("z", 1d);
+        keywordResultsList.add(new KeywordResults("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "event:FOO", "FOO", "ALL", labels));
+        logic.setFieldedKeywordResults(Map.of("FOO", keywordResultsList));
+
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("y", .8, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        DefaultTagCloud expectedCloud = new DefaultTagCloud();
+        expectedCloud.setLanguage("FOO");
+        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
+        expectedCloud.setTags(entries);
+        expectedCloud.setIntermediateResult(false);
+        addExpectedTagCloud(expectedCloud);
+
+        runTestQuery(queryString);
+    }
+
+    @Test
+    public void multipleExternalHitsTest() throws Exception {
+        String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
+
+        List<KeywordResults> keywordResultsList = new ArrayList<>();
+        LinkedHashMap<String,Double> labels = new LinkedHashMap<>();
+        labels.put("x", .5d);
+        labels.put("y", .8d);
+        labels.put("z", 1d);
+        keywordResultsList.add(new KeywordResults("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "event:FOO", "FOO", "ALL", labels));
+        keywordResultsList.add(new KeywordResults("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "event:FOO", "FOO", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d)));
+        logic.setFieldedKeywordResults(Map.of("FOO", keywordResultsList));
+
+        List<DefaultTagCloudEntry> entries = new ArrayList<>();
+        // TODO combining the tag clouds keeps the LOWEST score... not the highest score... may need to be able to adjust this in the TagCloudTransformer or maybe its fine
+        entries.add(createTagCloudEntry("x", .5, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
+        entries.add(createTagCloudEntry("y", .9, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
+        entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
+        entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
+        DefaultTagCloud expectedCloud = new DefaultTagCloud();
+        expectedCloud.setLanguage("FOO");
+        expectedCloud.setMarkings(Map.of("visibility", "ALL"));
+        expectedCloud.setTags(entries);
+        expectedCloud.setIntermediateResult(false);
+        addExpectedTagCloud(expectedCloud);
+
+        runTestQuery(queryString);
+    }
+
+    private void addExpectedTagCloud(DefaultTagCloud expected) {
+        expectedResults.add(expected);
+    }
+
+    private DefaultTagCloudEntry createTagCloudEntry(String term, double score, int frequency, List<String> sources) {
+        DefaultTagCloudEntry entry = new DefaultTagCloudEntry();
+        entry.setTerm(term);
+        entry.setScore(score);
+        entry.setFrequency(frequency);
+        entry.setSources(sources);
+
+        return entry;
     }
 
     protected void runTestQuery(String queryString) throws Exception {
@@ -123,20 +210,36 @@ public class KeywordQueryLogicFunctionalTest {
         GenericQueryConfiguration config = logic.initialize(connector, settings, authSet);
         logic.setupQuery(config);
 
-        QueryLogicTransformer<Map.Entry<Key,Value>,KeywordResults> transformer = logic.getTransformer(config.getQuery());
-        Set<String> unexpectedFields = new HashSet<>();
+        DefaultTagCloudResponse response = (DefaultTagCloudResponse) queryDriver.drive(config);
+        assertEquals(expectedResults.size(), response.getTagClouds().size());
 
-        for (Map.Entry<Key,Value> entry : logic) {
-            KeywordResults kr = transformer.transform(entry);
-            String content = kr.toJson();
-            if (!expectedResults.remove(content)) {
-                unexpectedFields.add(content);
-            }
-
+        // check the response clouds are expected
+        for (TagCloudBase tagCloud : response.getTagClouds()) {
+            assertTrue(isExpectedTagCloud((DefaultTagCloud) tagCloud));
         }
 
-        assertTrue("unexpected fields returned: " + unexpectedFields, unexpectedFields.isEmpty());
-        assertTrue(expectedResults + " was not empty", expectedResults.isEmpty());
+        // nothing still expected
+        assertEquals(0, expectedResults.size());
+    }
+
+    private boolean isExpectedTagCloud(DefaultTagCloud tagCloud) {
+        DefaultTagCloud expected = null;
+        for (DefaultTagCloud expectedCloud : expectedResults) {
+            if (Objects.equals(expectedCloud.getLanguage(), tagCloud.getLanguage())) {
+                List<DefaultTagCloudEntry> expectedTags = expectedCloud.getTags();
+                if (expectedTags.containsAll(tagCloud.getTags()) && tagCloud.getTags().containsAll(expectedTags)) {
+                    expected = expectedCloud;
+                    break;
+                }
+            }
+        }
+
+        if (expected != null) {
+            expectedResults.remove(expected);
+            return true;
+        }
+
+        return false;
     }
 
     @AfterClass

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -43,6 +43,7 @@ import datawave.query.QueryTestTableHelper;
 import datawave.query.tables.ResponseQueryDriver;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.tables.keyword.transform.KeywordResultsTransformer;
+import datawave.query.tables.keyword.transform.TagCloudPartitionTransformer;
 import datawave.query.util.WiseGuysIngest;
 import datawave.util.TableName;
 import datawave.util.keyword.TagCloudInput;
@@ -64,6 +65,8 @@ public class KeywordQueryLogicFunctionalTest {
     @Inject
     @SpringBean(name = "KeywordQuery")
     protected KeywordQueryLogic logic;
+
+    private final TagCloudPartitionTransformer tagCloudPartitionTransformer = TagCloudPartitionTransformer.getInstance();
 
     private final Map<String,String> extraParameters = new HashMap<>();
     private final List<DefaultTagCloud> expectedResults = new ArrayList<>();
@@ -139,7 +142,7 @@ public class KeywordQueryLogicFunctionalTest {
 
         TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", List
                         .of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo"))));
-        logic.setExternalTagCloudPartitions(List.of(externalPartition));
+        logic.setExternalData(List.of(tagCloudPartitionTransformer.encode(externalPartition)), Set.of(tagCloudPartitionTransformer));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
         entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
@@ -162,7 +165,7 @@ public class KeywordQueryLogicFunctionalTest {
         TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
-        logic.setExternalTagCloudPartitions(List.of(externalPartition));
+        logic.setExternalData(List.of(tagCloudPartitionTransformer.encode(externalPartition)), Set.of(tagCloudPartitionTransformer));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
         entries.add(createTagCloudEntry("x", .5, 2, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
@@ -187,7 +190,7 @@ public class KeywordQueryLogicFunctionalTest {
         TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
-        logic.setExternalTagCloudPartitions(List.of(externalPartition));
+        logic.setExternalData(List.of(tagCloudPartitionTransformer.encode(externalPartition)), Set.of(tagCloudPartitionTransformer));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
         entries.add(createTagCloudEntry("x", .5, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -159,7 +159,7 @@ public class KeywordQueryLogicFunctionalTest {
     public void multipleExternalHitsTest() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
-        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, List.of(
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
         logic.setExternalTagCloudPartitions(List.of(externalPartition));
@@ -184,7 +184,7 @@ public class KeywordQueryLogicFunctionalTest {
         String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
         String queryString = "DOCUMENT:" + docId;
 
-        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, List.of(
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.ScoreType.HIGHER_IS_BETTER, List.of(
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
                         new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
         logic.setExternalTagCloudPartitions(List.of(externalPartition));

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -117,6 +117,7 @@ public class KeywordQueryLogicFunctionalTest {
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
         expectedCloud.setMarkings(Map.of("visibility", "ALL"));
         expectedCloud.setTags(entries);
+        expectedCloud.setMetadata(Map.of("view", "CONTENT", "type", "keyword"));
         expectedCloud.setIntermediateResult(false);
         return expectedCloud;
     }
@@ -135,8 +136,8 @@ public class KeywordQueryLogicFunctionalTest {
     public void simpleWithOnlyExternalHitsTest() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
-        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO",
-                        List.of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d))));
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", List
+                        .of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo"))));
         logic.setExternalTagCloudPartitions(List.of(externalPartition));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
@@ -144,7 +145,7 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("y", .8, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setLanguage("FOO");
+        expectedCloud.setMetadata(Map.of("type", "demo"));
         expectedCloud.setMarkings(Map.of("visibility", "ALL"));
         expectedCloud.setTags(entries);
         expectedCloud.setIntermediateResult(false);
@@ -157,9 +158,9 @@ public class KeywordQueryLogicFunctionalTest {
     public void multipleExternalHitsTest() throws Exception {
         String queryString = "DOCUMENT:20130101_0/test/-cvy0gj.tlf59s.-duxzuab";
 
-        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER,
-                        List.of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d)),
-                                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d))));
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, List.of(
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuab", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
         logic.setExternalTagCloudPartitions(List.of(externalPartition));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
@@ -168,7 +169,7 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuab")));
         entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzuabc")));
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setLanguage("FOO");
+        expectedCloud.setMetadata(Map.of("type", "demo"));
         expectedCloud.setMarkings(Map.of("visibility", "ALL"));
         expectedCloud.setTags(entries);
         expectedCloud.setIntermediateResult(false);
@@ -182,9 +183,9 @@ public class KeywordQueryLogicFunctionalTest {
         String docId = "20130101_0/test/-cvy0gj.tlf59s.-duxzua";
         String queryString = "DOCUMENT:" + docId;
 
-        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER,
-                        List.of(new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d)),
-                                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d))));
+        TagCloudPartition externalPartition = new TagCloudPartition("FOO", "FOO", TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, List.of(
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .5d, "y", .8d, "z", 1d), Map.of("type", "demo")),
+                        new TagCloudInput("20130101_0/test/-cvy0gj.tlf59s.-duxzua", "ALL", Map.of("x", .3d, "y", .9d, "a", .7d), Map.of("type", "demo"))));
         logic.setExternalTagCloudPartitions(List.of(externalPartition));
 
         List<DefaultTagCloudEntry> entries = new ArrayList<>();
@@ -193,7 +194,7 @@ public class KeywordQueryLogicFunctionalTest {
         entries.add(createTagCloudEntry("z", 1, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
         entries.add(createTagCloudEntry("a", .7, 1, List.of("20130101_0/test/-cvy0gj.tlf59s.-duxzua")));
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
-        expectedCloud.setLanguage("FOO");
+        expectedCloud.setMetadata(Map.of("type", "demo"));
         expectedCloud.setMarkings(Map.of("visibility", "ALL"));
         expectedCloud.setTags(entries);
         expectedCloud.setIntermediateResult(false);
@@ -246,7 +247,7 @@ public class KeywordQueryLogicFunctionalTest {
     private boolean isExpectedTagCloud(DefaultTagCloud tagCloud) {
         DefaultTagCloud expected = null;
         for (DefaultTagCloud expectedCloud : expectedResults) {
-            if (Objects.equals(expectedCloud.getLanguage(), tagCloud.getLanguage())) {
+            if (Objects.equals(expectedCloud.getMetadata(), tagCloud.getMetadata())) {
                 List<DefaultTagCloudEntry> expectedTags = expectedCloud.getTags();
                 if (expectedTags.containsAll(tagCloud.getTags()) && tagCloud.getTags().containsAll(expectedTags)) {
                     expected = expectedCloud;

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicFunctionalTest.java
@@ -42,6 +42,7 @@ import datawave.query.ExcerptTest;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.tables.ResponseQueryDriver;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.tables.keyword.transform.KeywordResultsTransformer;
 import datawave.query.util.WiseGuysIngest;
 import datawave.util.TableName;
 import datawave.util.keyword.TagCloudInput;
@@ -117,7 +118,7 @@ public class KeywordQueryLogicFunctionalTest {
         DefaultTagCloud expectedCloud = new DefaultTagCloud();
         expectedCloud.setMarkings(Map.of("visibility", "ALL"));
         expectedCloud.setTags(entries);
-        expectedCloud.setMetadata(Map.of("view", "CONTENT", "type", "keyword"));
+        expectedCloud.setMetadata(Map.of("view", "CONTENT", "type", KeywordResultsTransformer.LABEL));
         expectedCloud.setIntermediateResult(false);
         return expectedCloud;
     }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
@@ -191,7 +191,8 @@ public class KeywordQueryLogicTest {
         baseResults.put("kind", 0.2546);
         baseResults.put("kind word", 0.2052);
 
-        KeywordResults results = new KeywordResults("someSource", "someView", "someLanguage", "someVisibility", baseResults);
+        KeywordResults results = new KeywordResults("someSource", "someVisibility", baseResults,
+                        Map.of("view", "someView", "language", "someLanguage", "type", "someType"));
 
         Key dataKey = new Key("20241218_0", "d", "sampleCsv" + '\u0000' + "1.2.3" + '\u0000' + "someView", "A");
         Value viewValue = new Value(KeywordResults.serialize(results));
@@ -208,8 +209,9 @@ public class KeywordQueryLogicTest {
 
         verifyAll();
 
-        TagCloudPartition expected = new TagCloudPartition("someLanguage", "keywords", List.of(new KeywordResults("someSource", "someView", "someLanguage",
-                        "someVisibility", Map.of("get much", 0.5903, "kind", 0.2546, "kind word", 0.2052))));
+        TagCloudPartition expected = new TagCloudPartition("someLanguage", "keywords",
+                        List.of(new KeywordResults("someSource", "someVisibility", Map.of("get much", 0.5903, "kind", 0.2546, "kind word", 0.2052),
+                                        Map.of("view", "someView", "language", "someLanguage", "type", "someType"))));
         assertEquals(expected, base);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
@@ -47,7 +47,9 @@ import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
 import datawave.query.config.KeywordQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
+import datawave.query.tables.keyword.transform.KeywordResultsTransformer;
 import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudInput;
 import datawave.util.keyword.TagCloudPartition;
 import datawave.webservice.query.exception.QueryException;
 
@@ -191,8 +193,7 @@ public class KeywordQueryLogicTest {
         baseResults.put("kind", 0.2546);
         baseResults.put("kind word", 0.2052);
 
-        KeywordResults results = new KeywordResults("someSource", "someVisibility", baseResults,
-                        Map.of("view", "someView", "language", "someLanguage", "type", "someType"));
+        KeywordResults results = new KeywordResults("someSource", "someView", "someLanguage", "someVisibility", baseResults);
 
         Key dataKey = new Key("20241218_0", "d", "sampleCsv" + '\u0000' + "1.2.3" + '\u0000' + "someView", "A");
         Value viewValue = new Value(KeywordResults.serialize(results));
@@ -209,9 +210,9 @@ public class KeywordQueryLogicTest {
 
         verifyAll();
 
-        TagCloudPartition expected = new TagCloudPartition("someLanguage", "keywords",
-                        List.of(new KeywordResults("someSource", "someVisibility", Map.of("get much", 0.5903, "kind", 0.2546, "kind word", 0.2052),
-                                        Map.of("view", "someView", "language", "someLanguage", "type", "someType"))));
+        TagCloudPartition expected = new TagCloudPartition("someLanguage", KeywordResultsTransformer.LABEL,
+                        List.of(new TagCloudInput("someSource", "someVisibility", Map.of("get much", 0.5903, "kind", 0.2546, "kind word", 0.2052),
+                                        Map.of("view", "someView", "language", "someLanguage", "type", KeywordResultsTransformer.LABEL))));
         assertEquals(expected, base);
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
@@ -17,9 +17,11 @@ import static org.powermock.api.easymock.PowerMock.verifyAll;
 
 import java.util.AbstractMap;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -29,6 +31,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.collections.iterators.ArrayListIterator;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,6 +77,7 @@ public class KeywordQueryLogicTest {
 
         keywordQueryLogic.scannerFactory = mockScannerFactory;
         when(mockScannerFactory.newScanner(any(), any(), anyInt(), any())).thenReturn(mockScanner);
+        when(mockScanner.iterator()).thenReturn(new ArrayListIterator());
         when(mockKeywordConfig.getState()).thenReturn(mockKeywordState);
     }
 
@@ -84,12 +88,18 @@ public class KeywordQueryLogicTest {
 
     @Test
     public void setupQueryValidConfigurationSetsUpScanner() throws Exception {
+        Query settings = new QueryImpl();
+        settings.setQuery("not null");
+        when(mockKeywordConfig.getQuery()).thenReturn(settings);
         keywordQueryLogic.setupQuery(mockKeywordConfig);
         verify(mockScanner).setRanges(any());
     }
 
     @Test
     public void setupQueryWithViewNameSetsIteratorSetting() throws Exception {
+        Query settings = new QueryImpl();
+        settings.setQuery("not null");
+        when(mockKeywordConfig.getQuery()).thenReturn(settings);
         keywordQueryLogic.setupQuery(mockKeywordConfig);
         keywordQueryLogic.getConfig().getState().getPreferredViews().add("FOO");
         verify(mockScanner).addScanIterator(any());
@@ -97,8 +107,50 @@ public class KeywordQueryLogicTest {
 
     @Test
     public void setupQueryTableNotFoundThrowsRuntimeException() throws Exception {
+        Query settings = new QueryImpl();
+        settings.setQuery("not null");
+        when(mockKeywordConfig.getQuery()).thenReturn(settings);
         when(mockScannerFactory.newScanner(any(), any(), anyInt(), any())).thenThrow(TableNotFoundException.class);
         assertThrows(RuntimeException.class, () -> keywordQueryLogic.setupQuery(mockKeywordConfig));
+    }
+
+    @Test
+    public void setupNoQuery() throws Exception {
+        keywordQueryLogic.setupQuery(mockKeywordConfig);
+        assertFalse(keywordQueryLogic.iterator().hasNext());
+    }
+
+    @Test
+    public void setupExternalDataQuery() throws Exception {
+        keywordQueryLogic.setExternalData(List.of(Map.entry(new Key("externalKey"), new Value("externalValue"))), Set.of());
+        keywordQueryLogic.setupQuery(mockKeywordConfig);
+        Iterator<Entry<Key,Value>> itr = keywordQueryLogic.iterator();
+        assertTrue(itr.hasNext());
+        Entry<Key,Value> entry = itr.next();
+        assertEquals(new Key("externalKey"), entry.getKey());
+        assertEquals(new Value("externalValue"), entry.getValue());
+        assertFalse(itr.hasNext());
+    }
+
+    @Test
+    public void cloneExternalTest() throws Exception {
+        keywordQueryLogic.setExternalData(List.of(Map.entry(new Key("externalKey"), new Value("externalValue"))), Set.of());
+        keywordQueryLogic.setupQuery(mockKeywordConfig);
+        Iterator<Entry<Key,Value>> itr = keywordQueryLogic.iterator();
+        assertTrue(itr.hasNext());
+        Entry<Key,Value> entry = itr.next();
+        assertEquals(new Key("externalKey"), entry.getKey());
+        assertEquals(new Value("externalValue"), entry.getValue());
+        assertFalse(itr.hasNext());
+
+        KeywordQueryLogic clone = (KeywordQueryLogic) keywordQueryLogic.clone();
+        clone.setupQuery(mockKeywordConfig);
+        itr = clone.iterator();
+        assertTrue(itr.hasNext());
+        entry = itr.next();
+        assertEquals(new Key("externalKey"), entry.getKey());
+        assertEquals(new Value("externalValue"), entry.getValue());
+        assertFalse(itr.hasNext());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordQueryLogicTest.java
@@ -18,6 +18,7 @@ import static org.powermock.api.easymock.PowerMock.verifyAll;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,6 +48,7 @@ import datawave.microservice.query.QueryImpl;
 import datawave.query.config.KeywordQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudPartition;
 import datawave.webservice.query.exception.QueryException;
 
 @SuppressWarnings("rawtypes")
@@ -201,12 +203,14 @@ public class KeywordQueryLogicTest {
         replayAll();
 
         logic.initialize(mockClient, settings, Set.of(auths));
-        QueryLogicTransformer<Map.Entry<Key,Value>,KeywordResults> transformer = logic.getTransformer(settings);
-        KeywordResults base = transformer.transform(entry);
-        String json = base.toJson();
-        assertEquals("{\"source\":\"someSource\",\"view\":\"someView\",\"language\":\"someLanguage\",\"visibility\":\"someVisibility\",\"keywords\":{\"get much\":0.5903,\"kind\":0.2546,\"kind word\":0.2052}}",
-                        json);
+        QueryLogicTransformer<Map.Entry<Key,Value>,TagCloudPartition> transformer = logic.getTransformer(settings);
+        TagCloudPartition base = transformer.transform(entry);
+
         verifyAll();
+
+        TagCloudPartition expected = new TagCloudPartition("someLanguage", "keywords", List.of(new KeywordResults("someSource", "someView", "someLanguage",
+                        "someVisibility", Map.of("get much", 0.5903, "kind", 0.2546, "kind word", 0.2052))));
+        assertEquals(expected, base);
     }
 
     private static class TestKeywordQuery extends KeywordQueryLogic {
@@ -244,7 +248,7 @@ public class KeywordQueryLogicTest {
         }
 
         @Override
-        public QueryLogicTransformer<Map.Entry<Key,Value>,KeywordResults> getTransformer(Query settings) {
+        public QueryLogicTransformer<Map.Entry<Key,Value>,TagCloudPartition> getTransformer(Query settings) {
             return null;
         }
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
@@ -337,7 +337,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         TagCloudPartition partition = tagCloudPartitions.get(0);
         assertEquals("external", partition.getPartition());
         assertEquals("external", partition.getLabel());
-        assertEquals(TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, partition.getScoreType());
+        assertEquals(TagCloudPartition.ScoreType.HIGHER_IS_BETTER, partition.getScoreType());
         assertEquals(1, partition.getInputs().size());
         TagCloudInput tagCloudInput = partition.getInputs().get(0);
         assertNotNull(tagCloudInput);

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.Key;
@@ -36,6 +37,7 @@ import datawave.query.attributes.TypeAttribute;
 import datawave.query.config.KeywordQueryConfiguration;
 import datawave.query.function.serializer.DocumentSerializer;
 import datawave.query.tables.keyword.extractor.FieldedTagCloudInputExtractor;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
 import datawave.util.keyword.KeywordResults;
 import datawave.util.keyword.TagCloudInput;
 import datawave.util.keyword.TagCloudPartition;
@@ -95,7 +97,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordUUIDChainStrategy strategy = new KeywordUUIDChainStrategy();
 
-        mockLogic.setExternalTagCloudPartitions(List.of());
+        mockLogic.setExternalData(List.of(), Set.of());
 
         replayAll();
 
@@ -124,7 +126,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
-        mockLogic.setExternalTagCloudPartitions(List.of());
+        mockLogic.setExternalData(List.of(), Set.of());
 
         replayAll();
 
@@ -177,7 +179,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
-        mockLogic.setExternalTagCloudPartitions(List.of());
+        mockLogic.setExternalData(List.of(), Set.of());
 
         replayAll();
 
@@ -243,7 +245,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
-        mockLogic.setExternalTagCloudPartitions(List.of());
+        mockLogic.setExternalData(List.of(), Set.of());
 
         replayAll();
 
@@ -305,8 +307,9 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
 
-        Capture<List<TagCloudPartition>> externalPartitions = newCapture();
-        mockLogic.setExternalTagCloudPartitions(capture(externalPartitions));
+        Capture<List<Entry<Key,Value>>> externalData = newCapture();
+        Capture<Set<TagCloudInputTransformer<?>>> transformers = newCapture();
+        mockLogic.setExternalData(capture(externalData), capture(transformers));
 
         replayAll();
 
@@ -331,10 +334,15 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         assertFalse(result.hasNext());
 
-        List<TagCloudPartition> tagCloudPartitions = externalPartitions.getValue();
-        assertNotNull(tagCloudPartitions);
-        assertEquals(1, tagCloudPartitions.size());
-        TagCloudPartition partition = tagCloudPartitions.get(0);
+        Set<TagCloudInputTransformer<?>> capturedTransformers = transformers.getValue();
+        assertNotNull(capturedTransformers);
+        assertEquals(1, capturedTransformers.size());
+        List<Entry<Key,Value>> capturedExternalData = externalData.getValue();
+        assertNotNull(capturedExternalData);
+        assertEquals(1, capturedExternalData.size());
+        TagCloudInputTransformer theTransformer = capturedTransformers.iterator().next();
+        TagCloudPartition partition = theTransformer.decode(capturedExternalData.get(0));
+        assertNotNull(partition);
         assertEquals("external", partition.getPartition());
         assertEquals("external", partition.getLabel());
         assertEquals(TagCloudPartition.ScoreType.HIGHER_IS_BETTER, partition.getScoreType());

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
@@ -83,8 +83,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         String colf = "d";
         String colq = dt + "\0" + uid + "\0CONTENT";
         Key documentKey = new Key(shard, colf, colq);
-        Value v = new Value(KeywordResults
-                        .serialize(new KeywordResults(identifier, visibility, results, Map.of("view", view, "language", language, "type", "keywords"))));
+        Value v = new Value(KeywordResults.serialize(new KeywordResults(identifier, view, language, visibility, results)));
         return Map.entry(documentKey, v);
     }
 
@@ -142,8 +141,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
         assertEquals("PAGE_ID:12345", keywordResults.getSource());
-        assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
-        assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
+        assertEquals("CONTENT", keywordResults.getView());
+        assertEquals("ENGLISH", keywordResults.getLanguage());
         assertEquals("PUBLIC", keywordResults.getVisibility());
 
         assertNotNull(keywordResults.getKeywords().get("cat"));
@@ -197,8 +196,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12345", keywordResults.getSource());
-            assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
-            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
+            assertEquals("CONTENT", keywordResults.getView());
+            assertEquals("ENGLISH", keywordResults.getLanguage());
             assertEquals("PUBLIC", keywordResults.getVisibility());
 
             assertNotNull(keywordResults.getKeywords().get("cat"));
@@ -210,8 +209,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12346", keywordResults.getSource());
-            assertEquals("INDEXABLE_TEXT", keywordResults.getMetadata().get("view"));
-            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
+            assertEquals("INDEXABLE_TEXT", keywordResults.getView());
+            assertEquals("ENGLISH", keywordResults.getLanguage());
             assertEquals("PUBLIC", keywordResults.getVisibility());
             assertNotNull(keywordResults.getKeywords().get("bird"));
         }
@@ -263,8 +262,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12345", keywordResults.getSource());
-            assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
-            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
+            assertEquals("CONTENT", keywordResults.getView());
+            assertEquals("ENGLISH", keywordResults.getLanguage());
             assertNotNull(keywordResults.getKeywords().get("cat"));
         }
 
@@ -274,8 +273,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12346", keywordResults.getSource());
-            assertEquals("INDEXABLE_TEXT", keywordResults.getMetadata().get("view"));
-            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
+            assertEquals("INDEXABLE_TEXT", keywordResults.getView());
+            assertEquals("ENGLISH", keywordResults.getLanguage());
             assertNotNull(keywordResults.getKeywords().get("bird"));
         }
     }
@@ -324,8 +323,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
         assertEquals("PAGE_ID:12345", keywordResults.getSource());
-        assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
-        assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
+        assertEquals("CONTENT", keywordResults.getView());
+        assertEquals("ENGLISH", keywordResults.getLanguage());
         assertEquals("PUBLIC", keywordResults.getVisibility());
 
         assertNotNull(keywordResults.getKeywords().get("cat"));

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
@@ -1,6 +1,6 @@
 package datawave.query.tables.keyword;
 
-import static datawave.query.tables.keyword.KeywordQueryLogic.TAG_CLOUD_FIELDS;
+import static datawave.query.tables.keyword.KeywordUUIDChainStrategy.CATEGORY_PARAMETER;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,7 +35,10 @@ import datawave.query.attributes.Document;
 import datawave.query.attributes.TypeAttribute;
 import datawave.query.config.KeywordQueryConfiguration;
 import datawave.query.function.serializer.DocumentSerializer;
+import datawave.query.tables.keyword.extractor.FieldedTagCloudInputExtractor;
 import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudInput;
+import datawave.util.keyword.TagCloudPartition;
 
 public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
@@ -61,7 +63,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
     public Entry<Key,Value> createDocument(String shard, String dt, String uid, String language, String identifier) {
         String colf = dt + "\0" + uid;
-        Key documentKey = new Key(shard, colf);
+        Key documentKey = new Key(shard, colf, "", "ALL");
 
         Document d = new Document();
 
@@ -93,7 +95,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordUUIDChainStrategy strategy = new KeywordUUIDChainStrategy();
 
-        mockLogic.setFieldedKeywordResults(new HashMap<>());
+        mockLogic.setExternalTagCloudPartitions(List.of());
 
         replayAll();
 
@@ -122,7 +124,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
-        mockLogic.setFieldedKeywordResults(new HashMap<>());
+        mockLogic.setExternalTagCloudPartitions(List.of());
 
         replayAll();
 
@@ -175,7 +177,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
-        mockLogic.setFieldedKeywordResults(new HashMap<>());
+        mockLogic.setExternalTagCloudPartitions(List.of());
 
         replayAll();
 
@@ -241,7 +243,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
-        mockLogic.setFieldedKeywordResults(new HashMap<>());
+        mockLogic.setExternalTagCloudPartitions(List.of());
 
         replayAll();
 
@@ -279,7 +281,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
     @Test
     public void singleFieldedTest() throws Exception {
-        settings.addParameter(TAG_CLOUD_FIELDS, "FOO,BAR");
+        settings.addParameter(CATEGORY_PARAMETER, "external,keyword");
 
         List<Entry<Key,Value>> input = List.of(createDocument("20250412", "test", "-cvy0gj.tlf59s.-duxzua", "ENGLISH", "PAGE_ID:12345"));
 
@@ -292,14 +294,19 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
                         .of(createKeywordResults("20250412", "test", "-cvy0gj.tlf59s.-duxzua", "ENGLISH", "PAGE_ID:12345", "CONTENT", "PUBLIC", results));
 
         KeywordUUIDChainStrategy strategy = new KeywordUUIDChainStrategy();
+        FieldedTagCloudInputExtractor fieldedExtractor = new FieldedTagCloudInputExtractor();
+        fieldedExtractor.setFields(List.of("FOO", "BAR"));
+        fieldedExtractor.setCategory("external");
+        strategy.setExtractors(List.of(fieldedExtractor));
+
         Capture<Query> intermediateSettings = Capture.newInstance();
 
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
 
-        Capture<Map<String,List<KeywordResults>>> fieldedKeywordResultsMap = newCapture();
-        mockLogic.setFieldedKeywordResults(capture(fieldedKeywordResultsMap));
+        Capture<List<TagCloudPartition>> externalPartitions = newCapture();
+        mockLogic.setExternalTagCloudPartitions(capture(externalPartitions));
 
         replayAll();
 
@@ -324,32 +331,21 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         assertFalse(result.hasNext());
 
-        Map<String,List<KeywordResults>> capturedMap = fieldedKeywordResultsMap.getValue();
-        assertNotNull(capturedMap);
-        assertEquals(2, capturedMap.keySet().size());
-        List<KeywordResults> fooResults = capturedMap.get("FOO");
-        List<KeywordResults> barResults = capturedMap.get("BAR");
-        assertNotNull(fooResults);
-        assertNotNull(barResults);
-        assertEquals(1, fooResults.size());
-        assertEquals(1, barResults.size());
-        assertEquals(1, fooResults.get(0).getKeywordCount());
-        assertEquals("event:FOO", fooResults.get(0).getView());
-        assertEquals("20250412/test/-cvy0gj.tlf59s.-duxzua", fooResults.get(0).getSource());
-        assertEquals("FOO", fooResults.get(0).getLanguage());
-        Map<String,Double> keywords = fooResults.get(0).getKeywords();
-        assertNotNull(keywords);
-        assertEquals(1, keywords.size());
-        assertEquals(Double.valueOf(1), keywords.get("x"));
-
-        assertEquals(1, barResults.get(0).getKeywordCount());
-        assertEquals("event:BAR", barResults.get(0).getView());
-        assertEquals("20250412/test/-cvy0gj.tlf59s.-duxzua", barResults.get(0).getSource());
-        assertEquals("BAR", barResults.get(0).getLanguage());
-        keywords = barResults.get(0).getKeywords();
-        assertNotNull(keywords);
-        assertEquals(1, keywords.size());
-        assertEquals(Double.valueOf(1), keywords.get("y"));
+        List<TagCloudPartition> tagCloudPartitions = externalPartitions.getValue();
+        assertNotNull(tagCloudPartitions);
+        assertEquals(1, tagCloudPartitions.size());
+        TagCloudPartition partition = tagCloudPartitions.get(0);
+        assertEquals("external", partition.getPartition());
+        assertEquals("external", partition.getLabel());
+        assertEquals(TagCloudPartition.SCORE_TYPE.HIGHER_IS_BETTER, partition.getScoreType());
+        assertEquals(1, partition.getInputs().size());
+        TagCloudInput tagCloudInput = partition.getInputs().get(0);
+        assertNotNull(tagCloudInput);
+        assertEquals("20250412/test/-cvy0gj.tlf59s.-duxzua", tagCloudInput.getSource());
+        assertEquals("ALL", tagCloudInput.getVisibility());
+        assertEquals(2, tagCloudInput.getEntities().size());
+        Map<String,Double> expectedEntites = Map.of("x", 1d, "y", 1d);
+        assertEquals(expectedEntites, tagCloudInput.getEntities());
     }
 
 }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
@@ -83,7 +83,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         String colf = "d";
         String colq = dt + "\0" + uid + "\0CONTENT";
         Key documentKey = new Key(shard, colf, colq);
-        Value v = new Value(KeywordResults.serialize(new KeywordResults(identifier, view, language, visibility, results)));
+        Value v = new Value(KeywordResults
+                        .serialize(new KeywordResults(identifier, visibility, results, Map.of("view", view, "language", language, "type", "keywords"))));
         return Map.entry(documentKey, v);
     }
 
@@ -141,8 +142,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
         assertEquals("PAGE_ID:12345", keywordResults.getSource());
-        assertEquals("CONTENT", keywordResults.getView());
-        assertEquals("ENGLISH", keywordResults.getLanguage());
+        assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
+        assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
         assertEquals("PUBLIC", keywordResults.getVisibility());
 
         assertNotNull(keywordResults.getKeywords().get("cat"));
@@ -196,8 +197,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12345", keywordResults.getSource());
-            assertEquals("CONTENT", keywordResults.getView());
-            assertEquals("ENGLISH", keywordResults.getLanguage());
+            assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
+            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
             assertEquals("PUBLIC", keywordResults.getVisibility());
 
             assertNotNull(keywordResults.getKeywords().get("cat"));
@@ -209,8 +210,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12346", keywordResults.getSource());
-            assertEquals("INDEXABLE_TEXT", keywordResults.getView());
-            assertEquals("ENGLISH", keywordResults.getLanguage());
+            assertEquals("INDEXABLE_TEXT", keywordResults.getMetadata().get("view"));
+            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
             assertEquals("PUBLIC", keywordResults.getVisibility());
             assertNotNull(keywordResults.getKeywords().get("bird"));
         }
@@ -262,8 +263,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12345", keywordResults.getSource());
-            assertEquals("CONTENT", keywordResults.getView());
-            assertEquals("ENGLISH", keywordResults.getLanguage());
+            assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
+            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
             assertNotNull(keywordResults.getKeywords().get("cat"));
         }
 
@@ -273,8 +274,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         {
             KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
             assertEquals("PAGE_ID:12346", keywordResults.getSource());
-            assertEquals("INDEXABLE_TEXT", keywordResults.getView());
-            assertEquals("ENGLISH", keywordResults.getLanguage());
+            assertEquals("INDEXABLE_TEXT", keywordResults.getMetadata().get("view"));
+            assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
             assertNotNull(keywordResults.getKeywords().get("bird"));
         }
     }
@@ -323,8 +324,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
         assertEquals("PAGE_ID:12345", keywordResults.getSource());
-        assertEquals("CONTENT", keywordResults.getView());
-        assertEquals("ENGLISH", keywordResults.getLanguage());
+        assertEquals("CONTENT", keywordResults.getMetadata().get("view"));
+        assertEquals("ENGLISH", keywordResults.getMetadata().get("language"));
         assertEquals("PUBLIC", keywordResults.getVisibility());
 
         assertNotNull(keywordResults.getKeywords().get("cat"));

--- a/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/keyword/KeywordUUIDChainStrategyTest.java
@@ -1,8 +1,10 @@
 package datawave.query.tables.keyword;
 
+import static datawave.query.tables.keyword.KeywordQueryLogic.TAG_CLOUD_FIELDS;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.newCapture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -10,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -64,6 +67,8 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         d.put("LANGUAGE", new TypeAttribute<>(new NoOpType(language), documentKey, true));
         d.put("HIT_TERM", new Content(identifier, documentKey, true));
+        d.put("FOO", new TypeAttribute<>(new NoOpType("x"), documentKey, true));
+        d.put("BAR", new TypeAttribute<>(new NoOpType("y"), documentKey, true));
 
         Entry<Key,Document> entry = Map.entry(documentKey, d);
 
@@ -88,7 +93,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
 
         KeywordUUIDChainStrategy strategy = new KeywordUUIDChainStrategy();
 
-        /* don't expect _anything_ to happen here */
+        mockLogic.setFieldedKeywordResults(new HashMap<>());
 
         replayAll();
 
@@ -117,6 +122,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
+        mockLogic.setFieldedKeywordResults(new HashMap<>());
 
         replayAll();
 
@@ -169,6 +175,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
+        mockLogic.setFieldedKeywordResults(new HashMap<>());
 
         replayAll();
 
@@ -234,6 +241,7 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
         expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
         mockLogic.setupQuery(eq(mockConfig));
         expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
+        mockLogic.setFieldedKeywordResults(new HashMap<>());
 
         replayAll();
 
@@ -267,6 +275,81 @@ public class KeywordUUIDChainStrategyTest extends EasyMockSupport {
             assertEquals("ENGLISH", keywordResults.getLanguage());
             assertNotNull(keywordResults.getKeywords().get("bird"));
         }
+    }
+
+    @Test
+    public void singleFieldedTest() throws Exception {
+        settings.addParameter(TAG_CLOUD_FIELDS, "FOO,BAR");
+
+        List<Entry<Key,Value>> input = List.of(createDocument("20250412", "test", "-cvy0gj.tlf59s.-duxzua", "ENGLISH", "PAGE_ID:12345"));
+
+        LinkedHashMap<String,Double> results = new LinkedHashMap<>();
+        results.put("cat", 0.2);
+        results.put("cat food", 0.3);
+        results.put("dog", 0.4);
+
+        List<Entry<Key,Value>> intermediateInput = List
+                        .of(createKeywordResults("20250412", "test", "-cvy0gj.tlf59s.-duxzua", "ENGLISH", "PAGE_ID:12345", "CONTENT", "PUBLIC", results));
+
+        KeywordUUIDChainStrategy strategy = new KeywordUUIDChainStrategy();
+        Capture<Query> intermediateSettings = Capture.newInstance();
+
+        expect(mockLogic.initialize(eq(mockAccumulo), capture(intermediateSettings), eq(null))).andReturn(mockConfig).once();
+        mockLogic.setupQuery(eq(mockConfig));
+        expect(mockLogic.iterator()).andReturn(intermediateInput.iterator()).once();
+
+        Capture<Map<String,List<KeywordResults>>> fieldedKeywordResultsMap = newCapture();
+        mockLogic.setFieldedKeywordResults(capture(fieldedKeywordResultsMap));
+
+        replayAll();
+
+        Iterator<Entry<Key,Value>> result = strategy.runChainedQuery(mockAccumulo, settings, null, input.iterator(), mockLogic);
+
+        verifyAll();
+
+        assertEquals("DOCUMENT:20250412/test/-cvy0gj.tlf59s.-duxzua!PAGE_ID:12345%LANGUAGE:ENGLISH", intermediateSettings.getValue().getQuery());
+
+        assertTrue(result.hasNext());
+        Entry<Key,Value> next = result.next();
+
+        assertEquals("20250412 d:test%00;-cvy0gj.tlf59s.-duxzua%00;CONTENT [] 9223372036854775807 false", next.getKey().toString());
+
+        KeywordResults keywordResults = KeywordResults.deserialize(next.getValue().get());
+        assertEquals("PAGE_ID:12345", keywordResults.getSource());
+        assertEquals("CONTENT", keywordResults.getView());
+        assertEquals("ENGLISH", keywordResults.getLanguage());
+        assertEquals("PUBLIC", keywordResults.getVisibility());
+
+        assertNotNull(keywordResults.getKeywords().get("cat"));
+
+        assertFalse(result.hasNext());
+
+        Map<String,List<KeywordResults>> capturedMap = fieldedKeywordResultsMap.getValue();
+        assertNotNull(capturedMap);
+        assertEquals(2, capturedMap.keySet().size());
+        List<KeywordResults> fooResults = capturedMap.get("FOO");
+        List<KeywordResults> barResults = capturedMap.get("BAR");
+        assertNotNull(fooResults);
+        assertNotNull(barResults);
+        assertEquals(1, fooResults.size());
+        assertEquals(1, barResults.size());
+        assertEquals(1, fooResults.get(0).getKeywordCount());
+        assertEquals("event:FOO", fooResults.get(0).getView());
+        assertEquals("20250412/test/-cvy0gj.tlf59s.-duxzua", fooResults.get(0).getSource());
+        assertEquals("FOO", fooResults.get(0).getLanguage());
+        Map<String,Double> keywords = fooResults.get(0).getKeywords();
+        assertNotNull(keywords);
+        assertEquals(1, keywords.size());
+        assertEquals(Double.valueOf(1), keywords.get("x"));
+
+        assertEquals(1, barResults.get(0).getKeywordCount());
+        assertEquals("event:BAR", barResults.get(0).getView());
+        assertEquals("20250412/test/-cvy0gj.tlf59s.-duxzua", barResults.get(0).getSource());
+        assertEquals("BAR", barResults.get(0).getLanguage());
+        keywords = barResults.get(0).getKeywords();
+        assertNotNull(keywords);
+        assertEquals(1, keywords.size());
+        assertEquals(Double.valueOf(1), keywords.get("y"));
     }
 
 }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/TagCloudTransformerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/TagCloudTransformerTest.java
@@ -1,0 +1,290 @@
+package datawave.query.transformer;
+
+import static datawave.query.transformer.TagCloudTransformer.DEFAULT_VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.junit.Before;
+import org.junit.Test;
+
+import datawave.core.query.result.event.DefaultResponseObjectFactory;
+import datawave.marking.MarkingFunctions;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.tables.keyword.KeywordQueryState;
+import datawave.query.tables.keyword.transform.KeywordResultsTransformer;
+import datawave.query.tables.keyword.transform.TagCloudInputTransformer;
+import datawave.query.tables.keyword.transform.TagCloudPartitionTransformer;
+import datawave.util.keyword.DefaultTagCloudUtils;
+import datawave.util.keyword.KeywordResults;
+import datawave.util.keyword.TagCloudInput;
+import datawave.util.keyword.TagCloudPartition;
+import datawave.webservice.result.keyword.DefaultTagCloud;
+import datawave.webservice.result.keyword.DefaultTagCloudResponse;
+
+public class TagCloudTransformerTest {
+    private Query query;
+    private KeywordQueryState state;
+
+    private static final Map<String,Double> ENTITY_MAP = Map.of("x", .8, "y", .3, "z", .1);
+
+    @Before
+    public void setup() {
+        query = new QueryImpl();
+        query.setQueryAuthorizations("A,B,C");
+
+        state = new KeywordQueryState();
+        state.setTagCloudUtils(new DefaultTagCloudUtils());
+    }
+
+    @Test
+    public void nullVersionTest() {
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of());
+        assertEquals(DEFAULT_VERSION, transformer.getResponseVersion());
+    }
+
+    @Test
+    public void version1Test() {
+        TagCloudTransformer transformer = new TagCloudTransformer("1", query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V1, transformer.getResponseVersion());
+        transformer = new TagCloudTransformer("v1", query, new KeywordQueryState(), new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V1, transformer.getResponseVersion());
+        transformer = new TagCloudTransformer("V1", query, new KeywordQueryState(), new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V1, transformer.getResponseVersion());
+    }
+
+    @Test
+    public void version2Test() {
+        TagCloudTransformer transformer = new TagCloudTransformer("2", query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V2, transformer.getResponseVersion());
+        transformer = new TagCloudTransformer("v2", query, new KeywordQueryState(), new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V2, transformer.getResponseVersion());
+        transformer = new TagCloudTransformer("V2", query, new KeywordQueryState(), new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V2, transformer.getResponseVersion());
+    }
+
+    @Test
+    public void defaultVersionTest() {
+        TagCloudTransformer transformer = new TagCloudTransformer("3", query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of());
+        assertEquals(DEFAULT_VERSION, transformer.getResponseVersion());
+        transformer = new TagCloudTransformer("v3", query, new KeywordQueryState(), new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(DEFAULT_VERSION, transformer.getResponseVersion());
+        transformer = new TagCloudTransformer("V3", query, new KeywordQueryState(), new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(DEFAULT_VERSION, transformer.getResponseVersion());
+    }
+
+    @Test
+    public void defaultIsV1Test() {
+        assertEquals(DEFAULT_VERSION, TagCloudTransformer.ResponseVersion.V1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void transformNoTransformerTest() {
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of());
+        transformer.transform(Map.entry(new Key(), new Value()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void transformCantDecodeTest() {
+        NeverDecodingTagCloudInputTransformer neverDecodingTagCloudInputTransformer = new NeverDecodingTagCloudInputTransformer();
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of(neverDecodingTagCloudInputTransformer));
+        transformer.transform(Map.entry(new Key(), new Value()));
+    }
+
+    @Test
+    public void transformTest() {
+        EmptyTagCloudInputTransformer emptyTagCloudInputTransformer = new EmptyTagCloudInputTransformer();
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of(emptyTagCloudInputTransformer));
+        TagCloudPartition partition = transformer.transform(Map.entry(new Key(), new Value()));
+        assertNotNull(partition);
+        assertEquals(new TagCloudPartition(), partition);
+    }
+
+    @Test
+    public void transformMultipleTest() {
+        NeverDecodingTagCloudInputTransformer neverDecodingTagCloudInputTransformer = new NeverDecodingTagCloudInputTransformer();
+        EmptyTagCloudInputTransformer emptyTagCloudInputTransformer = new EmptyTagCloudInputTransformer();
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of(neverDecodingTagCloudInputTransformer, emptyTagCloudInputTransformer));
+        TagCloudPartition partition = transformer.transform(Map.entry(new Key(), new Value()));
+        assertNotNull(partition);
+        assertEquals(new TagCloudPartition(), partition);
+    }
+
+    @Test
+    public void transformKeywordResultsTest() throws IOException {
+        KeywordResults keywordResults = new KeywordResults("source", "view", "language", "vis", ENTITY_MAP);
+        Key k = new Key();
+        Value v = new Value(KeywordResults.serialize(keywordResults));
+
+        KeywordResultsTransformer keywordResultsTransformer = new KeywordResultsTransformer();
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of(keywordResultsTransformer));
+        TagCloudPartition partition = transformer.transform(Map.entry(k, v));
+        assertNotNull(partition);
+        assertEquals("language", partition.getPartition());
+        assertEquals(TagCloudPartition.ScoreType.LOWER_IS_BETTER, partition.getScoreType());
+        assertEquals(1, partition.getInputs().size());
+        assertEquals("vis", partition.getInputs().get(0).getVisibility());
+        assertEquals("source", partition.getInputs().get(0).getSource());
+        assertEquals(ENTITY_MAP, partition.getInputs().get(0).getEntities());
+        assertEquals(Map.of("view", "view", "language", "language", "type", "keywords"), partition.getInputs().get(0).getMetadata());
+    }
+
+    @Test
+    public void transformTagCloudPartitionTest() {
+        Map<String,String> metadata = Map.of("type", "data");
+        TagCloudPartitionTransformer tagCloudPartitionTransformer = TagCloudPartitionTransformer.getInstance();
+        TagCloudPartition p = new TagCloudPartition("data");
+        p.addInput(new TagCloudInput("source", "vis", ENTITY_MAP, metadata));
+        Entry<Key,Value> entry = tagCloudPartitionTransformer.encode(p);
+
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, new KeywordQueryState(), new MarkingFunctions.Default(),
+                        new DefaultResponseObjectFactory(), Set.of(tagCloudPartitionTransformer));
+        TagCloudPartition transformed = transformer.transform(entry);
+        assertEquals(p, transformed);
+    }
+
+    @Test
+    public void createResponseLanguageV1Test() {
+        Map<String,String> metadata = Map.of("type", "data", "language", "english");
+        TagCloudPartition p = new TagCloudPartition("data");
+        p.addInput(new TagCloudInput("source", "vis", ENTITY_MAP, metadata));
+
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, state, new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V1, transformer.getResponseVersion());
+
+        Object o = transformer.createResponse(List.of(p));
+        assertTrue(o instanceof DefaultTagCloudResponse);
+        DefaultTagCloudResponse response = (DefaultTagCloudResponse) o;
+        assertEquals(1, response.getTagClouds().size());
+        assertTrue(response.getTagClouds().get(0) instanceof DefaultTagCloud);
+        DefaultTagCloud tagCloud = (DefaultTagCloud) response.getTagClouds().get(0);
+        assertEquals("english", tagCloud.getLanguage());
+        assertNull(tagCloud.getMetadata());
+        assertEquals(3, tagCloud.getTags().size());
+    }
+
+    @Test
+    public void createResponseLanguageV2Test() {
+        Map<String,String> metadata = Map.of("type", "data", "language", "english");
+        TagCloudPartition p = new TagCloudPartition("data");
+        p.addInput(new TagCloudInput("source", "vis", ENTITY_MAP, metadata));
+
+        TagCloudTransformer transformer = new TagCloudTransformer("2", query, state, new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V2, transformer.getResponseVersion());
+
+        Object o = transformer.createResponse(List.of(p));
+        assertTrue(o instanceof DefaultTagCloudResponse);
+        DefaultTagCloudResponse response = (DefaultTagCloudResponse) o;
+        assertEquals(1, response.getTagClouds().size());
+        assertTrue(response.getTagClouds().get(0) instanceof DefaultTagCloud);
+        DefaultTagCloud tagCloud = (DefaultTagCloud) response.getTagClouds().get(0);
+        assertEquals(metadata, tagCloud.getMetadata());
+        assertNull(tagCloud.getLanguage());
+        assertEquals(3, tagCloud.getTags().size());
+    }
+
+    @Test
+    public void createResponseNoLanguageV1Test() {
+        Map<String,String> metadata = Map.of("type", "data");
+        TagCloudPartition p = new TagCloudPartition("data");
+        p.addInput(new TagCloudInput("source", "vis", ENTITY_MAP, metadata));
+
+        TagCloudTransformer transformer = new TagCloudTransformer(null, query, state, new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V1, transformer.getResponseVersion());
+
+        Object o = transformer.createResponse(List.of(p));
+        assertTrue(o instanceof DefaultTagCloudResponse);
+        DefaultTagCloudResponse response = (DefaultTagCloudResponse) o;
+        assertEquals(1, response.getTagClouds().size());
+        assertTrue(response.getTagClouds().get(0) instanceof DefaultTagCloud);
+        DefaultTagCloud tagCloud = (DefaultTagCloud) response.getTagClouds().get(0);
+        assertEquals("data", tagCloud.getLanguage());
+        assertNull(tagCloud.getMetadata());
+        assertEquals(3, tagCloud.getTags().size());
+    }
+
+    @Test
+    public void createResponseNoLanguageV2Test() {
+        Map<String,String> metadata = Map.of("type", "data");
+        TagCloudPartition p = new TagCloudPartition("data");
+        p.addInput(new TagCloudInput("source", "vis", ENTITY_MAP, metadata));
+
+        TagCloudTransformer transformer = new TagCloudTransformer("2", query, state, new MarkingFunctions.Default(), new DefaultResponseObjectFactory(),
+                        Set.of());
+        assertEquals(TagCloudTransformer.ResponseVersion.V2, transformer.getResponseVersion());
+
+        Object o = transformer.createResponse(List.of(p));
+        assertTrue(o instanceof DefaultTagCloudResponse);
+        DefaultTagCloudResponse response = (DefaultTagCloudResponse) o;
+        assertEquals(1, response.getTagClouds().size());
+        assertTrue(response.getTagClouds().get(0) instanceof DefaultTagCloud);
+        DefaultTagCloud tagCloud = (DefaultTagCloud) response.getTagClouds().get(0);
+        assertEquals(metadata, tagCloud.getMetadata());
+        assertNull(tagCloud.getLanguage());
+        assertEquals(3, tagCloud.getTags().size());
+    }
+
+    private static class EmptyTagCloudInputTransformer implements TagCloudInputTransformer {
+
+        @Override
+        public Map.Entry<Key,Value> encode(Object input) {
+            return null;
+        }
+
+        @Override
+        public TagCloudPartition decode(Map.Entry input) {
+            return new TagCloudPartition();
+        }
+
+        @Override
+        public boolean canDecode(Map.Entry input) {
+            return true;
+        }
+    }
+
+    private static class NeverDecodingTagCloudInputTransformer implements TagCloudInputTransformer {
+
+        @Override
+        public Map.Entry<Key,Value> encode(Object input) {
+            return null;
+        }
+
+        @Override
+        public TagCloudPartition decode(Map.Entry input) {
+            return null;
+        }
+
+        @Override
+        public boolean canDecode(Map.Entry input) {
+            return false;
+        }
+    }
+}

--- a/web-services/client/src/main/java/datawave/webservice/result/keyword/DefaultTagCloud.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/keyword/DefaultTagCloud.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -33,6 +35,9 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
     @XmlJavaTypeAdapter(StringMapAdapter.class)
     private HashMap<String,String> markings = null;
 
+    @XmlElement(name = "language")
+    private String language = null;
+
     @XmlElement(name = "metadata")
     @XmlJavaTypeAdapter(StringMapAdapter.class)
     private Map<String,String> metadata = null;
@@ -57,6 +62,16 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
             this.markings = null;
         }
         super.setMarkings(this.markings);
+    }
+
+    @Override
+    public String getLanguage() {
+        return language;
+    }
+
+    @Override
+    public void setLanguage(String language) {
+        this.language = language;
     }
 
     @Override
@@ -108,8 +123,12 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
             if (message.markings != null)
                 output.writeObject(1, message.markings, MapSchema.SCHEMA, false);
 
+            if (message.language != null) {
+                output.writeString(2, message.language, false);
+            }
+
             if (message.metadata != null) {
-                output.writeObject(2, message.metadata, MapSchema.SCHEMA, false);
+                output.writeObject(3, message.metadata, MapSchema.SCHEMA, false);
             }
 
             if (message.tags != null) {
@@ -119,7 +138,7 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
                         if (schema == null) {
                             schema = field.cachedSchema();
                         }
-                        output.writeObject(3, field, schema, true);
+                        output.writeObject(4, field, schema, true);
                     }
                 }
             }
@@ -135,10 +154,13 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
                         input.mergeObject(message.markings, MapSchema.SCHEMA);
                         break;
                     case 2:
+                        message.language = input.readString();
+                        break;
+                    case 3:
                         message.metadata = new HashMap<>();
                         input.mergeObject(message.metadata, MapSchema.SCHEMA);
                         break;
-                    case 3:
+                    case 4:
                         if (message.tags == null)
                             message.tags = new ArrayList<>();
                         if (null == schema) {
@@ -160,8 +182,10 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
                 case 1:
                     return "markings";
                 case 2:
-                    return "metadata";
+                    return "language";
                 case 3:
+                    return "metadata";
+                case 4:
                     return "tags";
                 default:
                     return null;
@@ -176,8 +200,30 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
         final HashMap<String,Integer> fieldMap = new HashMap<String,Integer>();
         {
             fieldMap.put("markings", 1);
-            fieldMap.put("metadata", 2);
-            fieldMap.put("tags", 3);
+            fieldMap.put("language", 2);
+            fieldMap.put("metadata", 3);
+            fieldMap.put("tags", 4);
         }
     };
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof DefaultTagCloud)) {
+            return false;
+        }
+
+        DefaultTagCloud otherCloud = (DefaultTagCloud) other;
+        return Objects.equals(this.markings, otherCloud.markings) && Objects.equals(this.language, otherCloud.language)
+                        && Objects.equals(this.metadata, otherCloud.metadata) && this.tags.size() == otherCloud.tags.size()
+                        && new HashSet<>(this.tags).containsAll(otherCloud.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(markings, language, metadata, tags);
+    }
 }

--- a/web-services/client/src/main/java/datawave/webservice/result/keyword/DefaultTagCloud.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/keyword/DefaultTagCloud.java
@@ -33,8 +33,9 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
     @XmlJavaTypeAdapter(StringMapAdapter.class)
     private HashMap<String,String> markings = null;
 
-    @XmlElement(name = "language")
-    private String language = null;
+    @XmlElement(name = "metadata")
+    @XmlJavaTypeAdapter(StringMapAdapter.class)
+    private Map<String,String> metadata = null;
 
     @XmlElementWrapper(name = "tags")
     @XmlElement(name = "tag")
@@ -59,13 +60,13 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
     }
 
     @Override
-    public String getLanguage() {
-        return language;
+    public void setMetadata(Map<String,String> metadata) {
+        this.metadata = metadata;
     }
 
     @Override
-    public void setLanguage(String language) {
-        this.language = language;
+    public Map<String,String> getMetadata() {
+        return metadata;
     }
 
     public List<DefaultTagCloudEntry> getTags() {
@@ -107,8 +108,8 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
             if (message.markings != null)
                 output.writeObject(1, message.markings, MapSchema.SCHEMA, false);
 
-            if (message.language != null) {
-                output.writeString(2, message.language, false);
+            if (message.metadata != null) {
+                output.writeObject(2, message.metadata, MapSchema.SCHEMA, false);
             }
 
             if (message.tags != null) {
@@ -134,7 +135,8 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
                         input.mergeObject(message.markings, MapSchema.SCHEMA);
                         break;
                     case 2:
-                        message.language = input.readString();
+                        message.metadata = new HashMap<>();
+                        input.mergeObject(message.metadata, MapSchema.SCHEMA);
                         break;
                     case 3:
                         if (message.tags == null)
@@ -158,7 +160,7 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
                 case 1:
                     return "markings";
                 case 2:
-                    return "language";
+                    return "metadata";
                 case 3:
                     return "tags";
                 default:
@@ -174,7 +176,7 @@ public class DefaultTagCloud extends TagCloudBase<DefaultTagCloud,DefaultTagClou
         final HashMap<String,Integer> fieldMap = new HashMap<String,Integer>();
         {
             fieldMap.put("markings", 1);
-            fieldMap.put("language", 2);
+            fieldMap.put("metadata", 2);
             fieldMap.put("tags", 3);
         }
     };

--- a/web-services/client/src/main/java/datawave/webservice/result/keyword/DefaultTagCloudEntry.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/keyword/DefaultTagCloudEntry.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -174,4 +175,27 @@ public class DefaultTagCloudEntry extends TagCloudEntryBase<DefaultTagCloudEntry
             fieldMap.put("sources", 5);
         }
     };
+
+    @Override
+    public boolean equals(Object other) {
+        if (super.equals(other)) {
+            return true;
+        }
+
+        if (!(other instanceof DefaultTagCloudEntry)) {
+            return false;
+        }
+
+        DefaultTagCloudEntry otherEntry = (DefaultTagCloudEntry) other;
+
+        // @formatter: off
+        return Objects.equals(frequency, otherEntry.frequency) && Objects.equals(term, otherEntry.term) && Objects.equals(score, otherEntry.score)
+                        && Objects.equals(sources, otherEntry.sources);
+        // @formatter: on
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(frequency, term, score, sources);
+    }
 }

--- a/web-services/client/src/main/java/datawave/webservice/result/keyword/TagCloudBase.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/keyword/TagCloudBase.java
@@ -44,6 +44,10 @@ public abstract class TagCloudBase<T,E extends TagCloudEntryBase<E>> implements 
 
     public abstract Map<String,String> getMetadata();
 
+    public abstract String getLanguage();
+
+    public abstract void setLanguage(String language);
+
     public abstract List<E> getTags();
 
     public abstract void setTags(List<E> tags);

--- a/web-services/client/src/main/java/datawave/webservice/result/keyword/TagCloudBase.java
+++ b/web-services/client/src/main/java/datawave/webservice/result/keyword/TagCloudBase.java
@@ -40,9 +40,9 @@ public abstract class TagCloudBase<T,E extends TagCloudEntryBase<E>> implements 
         this.intermediateResult = intermediateResult;
     }
 
-    public abstract String getLanguage();
+    public abstract void setMetadata(Map<String,String> metadata);
 
-    public abstract void setLanguage(String language);
+    public abstract Map<String,String> getMetadata();
 
     public abstract List<E> getTags();
 

--- a/web-services/deploy/configuration/src/main/resources/datawave/query/KeywordExtractionQueryLogicFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/KeywordExtractionQueryLogicFactory.xml
@@ -19,6 +19,8 @@
                     </util:set>
                 </property>
                 <property name="connPoolName" value="UUID" />
+                <!-- required for field extraction -->
+                <property name="includeGroupingContext" value="true" />
             </bean>
         </property>
         <property name="logic2" ref="KeywordQuery"/>


### PR DESCRIPTION
In addition to generating tag clouds from keywords extracted from content, this feature adds the ability to use data stored in record/document fields to generate tag cloud.

Per @FineAndDandy still have some additional tests and docs to write, but this should be reviewable in the meantime 