### PR TITLE
compose more tweaks

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
@@ -139,6 +139,11 @@ function datawaveWebIsDeployed() {
    return 0
 }
 
+function datawaveWebReadyToStart() {
+    ss -ln | grep 8020 && ss -ln | grep 2181 && ss -ln | grep 9997 && return 0
+    return 1
+}
+
 function datawaveWebStart() {
 
     local debug=false
@@ -149,6 +154,24 @@ function datawaveWebStart() {
 
     hadoopIsRunning || hadoopStart || return 1
     accumuloIsRunning || accumuloStart || return 1
+
+    # We need to wait until Hadoop, Zookeeper, and Accumulo are completely ready before starting web
+    local pollInterval=5
+    local maxAttempts=20
+
+    info "Polling for dependent services every ${pollInterval} seconds (${maxAttempts} attempts max)"
+
+    for (( i=1; i<=${maxAttempts}; i++ ))
+    do
+       if datawaveWebReadyToStart ; then
+          echo "    Hadoop, Zookeeper and Accumulo now ready (${i}/${maxAttempts})"
+          break
+       fi
+       echo "    -- Dependent services not ready yet (${i}/${maxAttempts})"
+
+       sleep $pollInterval
+    done
+    datawaveWebReadyToStart || return 1
 
     if datawaveWebIsRunning ; then
        info "Wildfly is already running"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -389,8 +389,8 @@ services:
       test: curl -f http://localhost:8080/querymetric/mgmt/health
       interval: 5s
       timeout: 1s
-      start_period: 20s
-      retries: 8
+      start_period: 40s
+      retries: 10
     depends_on:
       authorization:
         condition: service_healthy


### PR DESCRIPTION
When attempting to bring up the docker compose environment the quickstart container sometimes is unable to bring up the web service. Waiting for the dependent services to come up first seems to resolve this.