### PR TITLE
Integrate class cache

### DIFF
--- a/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/BaseType.java
@@ -13,7 +13,7 @@ import datawave.webservice.query.data.ObjectSizeOf;
 
 public class BaseType<T extends Comparable<T> & Serializable> implements Serializable, Type<T>, ObjectSizeOf {
 
-    private static final long serialVersionUID = 5354270429891763693L;
+    private static final long serialVersionUID = -3747720721391071135L;
     private static final long STATIC_SIZE = PrecomputedSizes.STRING_STATIC_REF + Sizer.REFERENCE + Sizer.REFERENCE;
 
     protected T delegate;
@@ -34,7 +34,8 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
     }
 
     public void setDelegateFromString(String in) {
-        setDelegate(normalizer.denormalize(in));
+        T denormalized = normalizer.denormalize(in);
+        setDelegate(denormalized);
     }
 
     public void setDelegate(T delegate) {
@@ -91,7 +92,8 @@ public class BaseType<T extends Comparable<T> & Serializable> implements Seriali
 
     @Override
     public void normalizeAndSetNormalizedValue(T valueToNormalize) {
-        setNormalizedValue(normalizer.normalizeDelegateType(valueToNormalize));
+        String normalized = normalizer.normalizeDelegateType(valueToNormalize);
+        setNormalizedValue(normalized);
     }
 
     public void validate() {

--- a/core/utils/type-utils/src/main/java/datawave/data/type/TypeFactory.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/TypeFactory.java
@@ -65,4 +65,13 @@ public class TypeFactory {
     public long getCacheSize() {
         return typeCache.estimatedSize();
     }
+
+    /**
+     * Perform pending maintenance tasks, which tasks are performed are implementation specific.
+     * <p>
+     * <b>Note:</b> there should be no need to call this method in production code. This is useful for unit tests.
+     */
+    public void cleanup() {
+        typeCache.cleanUp();
+    }
 }

--- a/core/utils/type-utils/src/main/java/datawave/data/type/TypeFactory.java
+++ b/core/utils/type-utils/src/main/java/datawave/data/type/TypeFactory.java
@@ -2,9 +2,8 @@ package datawave.data.type;
 
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 /**
  * TypeFactory that uses an internal loading cache to limit new Type objects
@@ -33,15 +32,12 @@ public class TypeFactory {
      */
     public TypeFactory(int size, int timeout) {
         //  @formatter:off
-        typeCache = CacheBuilder.newBuilder()
+        typeCache = Caffeine.newBuilder()
                         .maximumSize(size)
                         .expireAfterWrite(timeout, TimeUnit.MINUTES)
-                        .build(new CacheLoader<>() {
-                            @Override
-                            public Type<?> load(String className) throws Exception {
-                                Class<?> clazz = Class.forName(className);
-                                return (Type<?>) clazz.getDeclaredConstructor().newInstance();
-                            }
+                        .build(className-> {
+                            Class<?> clazz = Class.forName(className);
+                            return (Type<?>) clazz.getDeclaredConstructor().newInstance();
                         });
         //  @formatter:on
     }
@@ -67,6 +63,6 @@ public class TypeFactory {
      * @return the current cache size
      */
     public long getCacheSize() {
-        return typeCache.size();
+        return typeCache.estimatedSize();
     }
 }

--- a/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -46,14 +46,17 @@ public class TypeFactoryTest {
         TypeFactory factory = new TypeFactory(1, 15);
 
         Type<?> typeOne = factory.createType(LcType.class.getName());
-        Type<?> typeTwo = factory.createType(IpAddressType.class.getName());
-        Type<?> typeThree = factory.createType(IpAddressType.class.getName());
+
+        // the Caffeine cache is not immediately consistent so give the eviction thread time to do its job.
+        for (int i = 0; i < 50; i++) {
+            Type<?> left = factory.createType(IpAddressType.class.getName());
+            Type<?> right = factory.createType(IpAddressType.class.getName());
+            // same type created in a row with a cache size of one will return the same type instance
+            assertSame(left, right);
+        }
+
+        // creating a new LcType should return a new instance due to the low cache size
         Type<?> typeFour = factory.createType(LcType.class.getName());
-
-        // same type created in a row with a cache size of one will return the same type instance
-        assertSame(typeTwo, typeThree);
-
-        // same type created with other types between will return different instances
         assertNotSame(typeOne, typeFour);
 
         assertEquals(1, factory.getCacheSize());

--- a/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -59,6 +59,9 @@ public class TypeFactoryTest {
         Type<?> typeFour = factory.createType(LcType.class.getName());
         assertNotSame(typeOne, typeFour);
 
+        //  trigger maintenance tasks (i.e., eviction of old entries)
+        factory.cleanup();
+
         assertEquals(1, factory.getCacheSize());
     }
 

--- a/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -59,7 +59,7 @@ public class TypeFactoryTest {
         Type<?> typeFour = factory.createType(LcType.class.getName());
         assertNotSame(typeOne, typeFour);
 
-        //  trigger maintenance tasks (i.e., eviction of old entries)
+        // trigger maintenance tasks (i.e., eviction of old entries)
         factory.cleanup();
 
         assertEquals(1, factory.getCacheSize());

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -21,6 +21,8 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
+import datawave.core.cache.CaffeineClassCache;
+import datawave.core.cache.ClassCache;
 import datawave.query.Constants;
 import datawave.query.jexl.DatawaveJexlContext;
 
@@ -40,6 +42,9 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     // cache computation to avoid repeated calculation
     protected int hashcode = Integer.MIN_VALUE;
     protected long sizeInBytes = Long.MIN_VALUE;
+
+    // used by Document, Attributes and TypeAttribute
+    protected static final ThreadLocal<ClassCache> classCache = ThreadLocal.withInitial(CaffeineClassCache::new);
 
     public Attribute() {}
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
@@ -20,22 +20,18 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
-import datawave.core.cache.CaffeineClassCache;
-import datawave.core.cache.ClassCache;
 import datawave.marking.MarkingFunctions;
 import datawave.query.collections.FunctionalSet;
 import datawave.query.jexl.DatawaveJexlContext;
 
 public class Attributes extends AttributeBag<Attributes> implements Serializable {
 
-    private static final long serialVersionUID = 4677957768640489928L;
+    private static final long serialVersionUID = 6225336487950799972L;
     private static final Logger log = Logger.getLogger(Attributes.class);
     private Set<Attribute<? extends Comparable<?>>> attributes;
     private int _count = 0;
     // cache the size in bytes as it can be expensive to compute on the fly if we have many attributes
     private long _bytes = super.sizeInBytes(16) + 16 + 48;
-
-    private static final ClassCache classCache = new CaffeineClassCache();
 
     /**
      * Should sizes of documents be tracked
@@ -150,7 +146,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
             String attrClassName = WritableUtils.readString(in);
             Class<?> clz = null;
             try {
-                clz = classCache.get(attrClassName);
+                clz = classCache.get().get(attrClassName);
             } catch (ClassNotFoundException e) {
                 throw new RuntimeException(e);
             }
@@ -351,7 +347,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
         Class<?> clz;
         try {
             // Get the Class for the name of the class of the concrete Attribute
-            clz = classCache.get(clazzName);
+            clz = classCache.get().get(clazzName);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attributes.java
@@ -20,10 +20,11 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
+import datawave.core.cache.CaffeineClassCache;
+import datawave.core.cache.ClassCache;
 import datawave.marking.MarkingFunctions;
 import datawave.query.collections.FunctionalSet;
 import datawave.query.jexl.DatawaveJexlContext;
-import datawave.query.util.cache.ClassCache;
 
 public class Attributes extends AttributeBag<Attributes> implements Serializable {
 
@@ -34,7 +35,7 @@ public class Attributes extends AttributeBag<Attributes> implements Serializable
     // cache the size in bytes as it can be expensive to compute on the fly if we have many attributes
     private long _bytes = super.sizeInBytes(16) + 16 + 48;
 
-    private static final ClassCache classCache = new ClassCache();
+    private static final ClassCache classCache = new CaffeineClassCache();
 
     /**
      * Should sizes of documents be tracked

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
@@ -4,6 +4,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 
 import org.apache.accumulo.core.data.Key;
@@ -20,7 +21,7 @@ import datawave.query.collections.FunctionalSet;
 import datawave.query.jexl.DatawaveJexlContext;
 
 public class Content extends Attribute<Content> implements Serializable {
-    private static final long serialVersionUID = -642410227862723970L;
+    private static final long serialVersionUID = -7916992260001007223L;
 
     private static final Type<?> normalizer = new LcNoDiacriticsType();
 
@@ -157,12 +158,15 @@ public class Content extends Attribute<Content> implements Serializable {
         this.toKeep = input.readBoolean();
         boolean hasSource = input.readBoolean();
         if (hasSource) {
-            String clazz = input.readString();
-            Class sourceClass;
             try {
-                sourceClass = Class.forName(clazz);
-                source = (Attribute<?>) sourceClass.newInstance();
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                String className = input.readString();
+                Class<?> clazz = classCache.get().get(className);
+                if(Attribute.class.isAssignableFrom(clazz)) {
+                    source = (Attribute<?>) clazz.getDeclaredConstructor().newInstance();
+                } else {
+                    throw new RuntimeException("could not instantiate " + className);
+                }
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                 throw new RuntimeException("could not parse source", e);
             }
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Content.java
@@ -158,16 +158,17 @@ public class Content extends Attribute<Content> implements Serializable {
         this.toKeep = input.readBoolean();
         boolean hasSource = input.readBoolean();
         if (hasSource) {
+            String className = null;
             try {
-                String className = input.readString();
+                className = input.readString();
                 Class<?> clazz = classCache.get().get(className);
                 if(Attribute.class.isAssignableFrom(clazz)) {
                     source = (Attribute<?>) clazz.getDeclaredConstructor().newInstance();
                 } else {
-                    throw new RuntimeException("could not instantiate " + className);
+                    throw new RuntimeException(className + " does not extend " + Attribute.class.getSimpleName());
                 }
             } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-                throw new RuntimeException("could not parse source", e);
+                throw new RuntimeException("Could not instantiate " + className, e);
             }
 
             source.read(kryo, input);

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -33,6 +33,8 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 
+import datawave.core.cache.CaffeineClassCache;
+import datawave.core.cache.ClassCache;
 import datawave.marking.MarkingFunctions;
 import datawave.query.Constants;
 import datawave.query.collections.FunctionalSet;
@@ -43,7 +45,6 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.query.predicate.EventDataQueryFilter;
 import datawave.query.predicate.ValueToAttributes;
 import datawave.query.util.TypeMetadata;
-import datawave.query.util.cache.ClassCache;
 import datawave.util.time.DateHelper;
 
 public class Document extends AttributeBag<Document> implements Serializable {
@@ -53,7 +54,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
 
     public static final String DOCKEY_FIELD_NAME = "RECORD_ID";
 
-    private static final ClassCache classCache = new ClassCache();
+    private static final ClassCache classCache = new CaffeineClassCache();
 
     //  @formatter:off
     private static final LoadingCache<Text, Long> timestampCache = CacheBuilder.newBuilder()

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Document.java
@@ -33,8 +33,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 
-import datawave.core.cache.CaffeineClassCache;
-import datawave.core.cache.ClassCache;
 import datawave.marking.MarkingFunctions;
 import datawave.query.Constants;
 import datawave.query.collections.FunctionalSet;
@@ -48,13 +46,11 @@ import datawave.query.util.TypeMetadata;
 import datawave.util.time.DateHelper;
 
 public class Document extends AttributeBag<Document> implements Serializable {
-    private static final long serialVersionUID = -377226620954754934L;
+    private static final long serialVersionUID = -7939658996525050446L;
 
     private static final Logger log = Logger.getLogger(Document.class);
 
     public static final String DOCKEY_FIELD_NAME = "RECORD_ID";
-
-    private static final ClassCache classCache = new CaffeineClassCache();
 
     //  @formatter:off
     private static final LoadingCache<Text, Long> timestampCache = CacheBuilder.newBuilder()
@@ -865,7 +861,7 @@ public class Document extends AttributeBag<Document> implements Serializable {
         Class<?> clz;
         try {
             // Get the Class for the name of the class of the concrete Attribute
-            clz = classCache.get(clazzName);
+            clz = classCache.get().get(clazzName);
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -18,13 +18,14 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
+import datawave.core.cache.CaffeineClassCache;
+import datawave.core.cache.ClassCache;
 import datawave.data.type.DatawaveTypeIndex;
 import datawave.data.type.NoOpType;
 import datawave.data.type.OneToManyNormalizerType;
 import datawave.data.type.Type;
 import datawave.query.collections.FunctionalSet;
 import datawave.query.jexl.DatawaveJexlContext;
-import datawave.query.util.cache.ClassCache;
 import datawave.webservice.query.data.ObjectSizeOf;
 
 public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttribute<T>> implements Serializable {
@@ -33,7 +34,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
 
     private static final Logger log = Logger.getLogger(TypeAttribute.class);
 
-    private static final ClassCache classCache = new ClassCache();
+    private static final ClassCache classCache = new CaffeineClassCache();
 
     private Type<T> datawaveType;
 

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/TypeAttribute.java
@@ -18,8 +18,6 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
-import datawave.core.cache.CaffeineClassCache;
-import datawave.core.cache.ClassCache;
 import datawave.data.type.DatawaveTypeIndex;
 import datawave.data.type.NoOpType;
 import datawave.data.type.OneToManyNormalizerType;
@@ -30,15 +28,12 @@ import datawave.webservice.query.data.ObjectSizeOf;
 
 public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttribute<T>> implements Serializable {
 
-    private static final long serialVersionUID = 7264249641813898860L;
+    private static final long serialVersionUID = -6108667228858778287L;
 
     private static final Logger log = Logger.getLogger(TypeAttribute.class);
 
-    private static final ClassCache classCache = new CaffeineClassCache();
-
     private Type<T> datawaveType;
 
-    private int hashCode = Integer.MIN_VALUE;
     private String delegateString = null;
 
     protected TypeAttribute() {
@@ -101,7 +96,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
         }
         readMetadata(in);
         if (datawaveType == null) {
-            datawaveType = (Type) new NoOpType();
+            datawaveType = (Type<T>) new NoOpType();
         }
         this.datawaveType.setDelegateFromString(WritableUtils.readString(in));
         this.toKeep = WritableUtils.readVInt(in) != 0;
@@ -126,7 +121,7 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
         }
 
         if (o instanceof TypeAttribute) {
-            TypeAttribute other = (TypeAttribute) o;
+            TypeAttribute<T> other = (TypeAttribute<T>) o;
             return this.getType().equals(other.getType()) && (0 == this.compareMetadata(other));
         }
 
@@ -190,17 +185,18 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
         }
         super.readMetadata(kryo, input);
         if (datawaveType == null) {
-            datawaveType = (Type) new NoOpType();
+            datawaveType = (Type<T>) new NoOpType();
         }
         this.datawaveType.read(kryo, input);
         this.toKeep = input.readBoolean();
-        this.hashCode = input.readInt(true);
+        this.hashcode = input.readInt(true);
     }
 
+    @SuppressWarnings("unchecked")
     private void setDatawaveType(String datawaveTypeString)
                     throws InstantiationException, IllegalAccessException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
-        Class<?> clazz = classCache.get(datawaveTypeString);
-        Constructor<Type> constructor = (Constructor<Type>) clazz.getDeclaredConstructor();
+        Class<?> clazz = classCache.get().get(datawaveTypeString);
+        Constructor<Type<T>> constructor = (Constructor<Type<T>>) clazz.getDeclaredConstructor();
         this.datawaveType = constructor.newInstance();
     }
 
@@ -210,8 +206,8 @@ public class TypeAttribute<T extends Comparable<T>> extends Attribute<TypeAttrib
      * @see Attribute#deepCopy()
      */
     @Override
-    public TypeAttribute copy() {
-        return new TypeAttribute(this.getType(), this.getMetadata(), this.isToKeep());
+    public TypeAttribute<T> copy() {
+        return new TypeAttribute<>(this.getType(), this.getMetadata(), this.isToKeep());
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/util/cache/ClassCache.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/cache/ClassCache.java
@@ -14,7 +14,10 @@ import datawave.query.attributes.TypeAttribute;
  * Cache for Class instances.
  * <p>
  * Used by {@link TypeAttribute} and {@link Attributes}
+ * <p>
+ * Replaced by {@link datawave.core.cache.CaffeineClassCache}
  */
+@Deprecated(forRemoval = true)
 public class ClassCache {
 
     //  @formatter:off

--- a/warehouse/query-core/src/test/java/datawave/query/function/serializer/DocumentSerializationIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/serializer/DocumentSerializationIT.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -28,6 +29,7 @@ import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberType;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.AttributeFactory;
+import datawave.query.attributes.Content;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.DocumentKey;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
@@ -56,6 +58,8 @@ public class DocumentSerializationIT {
     public void setup() {
         TypeMetadata metadata = new TypeMetadata();
         metadata.put("FIELD_A", datatype, LcNoDiacriticsType.class.getTypeName());
+        metadata.put("FIELD_B", datatype, LcNoDiacriticsType.class.getTypeName());
+        metadata.put("FIELD_C", datatype, LcNoDiacriticsType.class.getTypeName());
         metadata.put("NUM", datatype, NumberType.class.getTypeName());
         metadata.put("DATE", datatype, DateType.class.getTypeName());
 
@@ -143,9 +147,16 @@ public class DocumentSerializationIT {
 
     private Document createDocument() {
         Document doc = new Document();
-        doc.put("FIELD_A", createAttribute("FIELD_A", "some text"));
-        doc.put("FIELD_A", createAttribute("FIELD_A", "more text"));
-        doc.put("FIELD_A", createAttribute("FIELD_A", "less text"));
+        Set<String> fields = Set.of("FIELD_A", "FIELD_B", "FIELD_C");
+        for (String field : fields) {
+            for (int i = 0; i < 6; i++) {
+                doc.put(field, createAttribute(field, "some random text: " + i));
+            }
+        }
+        for (int i = 0; i < 10; i++) {
+            Content content = new Content("token " + i, documentKey, true);
+            doc.put("CONTENT", content);
+        }
         doc.put("NUM", createAttribute("NUM", "23"));
         doc.put("DATE", createAttribute("DATE", DateHelper.format(System.currentTimeMillis())));
 


### PR DESCRIPTION
- TypeFactory now uses a CaffeineCache
- Document, Attributes, Content use a ThreadLocal Caffeine cache found in the Attribute class
- Updated DocumentSerializationIT for better coverage