### PR TITLE
Eliminate unnecessary column visibility creation

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -28,6 +28,8 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
 
     private static final Logger log = Logger.getLogger(Attribute.class);
     private static final Text EMPTY_TEXT = new Text();
+    private static final byte[] EMPTY_BYTES = new byte[0];
+    private static final ByteSequence EMPTY_BYTE_SEQUENCE = new ArrayByteSequence(new byte[0]);
 
     /**
      * The metadata for this attribute. Really only the column visibility and timestamp are preserved in this metadata when serializing and deserializing.
@@ -57,6 +59,18 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
             return metadata.getColumnVisibilityParsed();
         }
         return Constants.EMPTY_VISIBILITY;
+    }
+
+    /**
+     * Some callers only require the raw bytes
+     *
+     * @return the byte array that backs the column visibility
+     */
+    public byte[] getColumnVisibilityBytes() {
+        if (isMetadataSet()) {
+            return metadata.getColumnVisibilityData().getBackingArray();
+        }
+        return Constants.EMPTY_BYTES;
     }
 
     public void setColumnVisibility(ColumnVisibility columnVisibility) {
@@ -94,7 +108,22 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
         }
     }
 
-    private static final ByteSequence EMPTY_BYTE_SEQUENCE = new ArrayByteSequence(new byte[0]);
+    /**
+     * Set the metadata for this attribute. This method allows a trusted caller to directly set the column visibility via a byte array. Assumes that the bytes
+     * came from a {@link ColumnVisibility} object which has already parsed, verified and flattened the visibility string.
+     *
+     * @param vis
+     *            the column visibility bytes
+     * @param ts
+     *            the timestamp
+     */
+    protected void setMetadata(byte[] vis, long ts) {
+        if (metadata != null) {
+            metadata = new Key(metadata.getRow().getBytes(), metadata.getColumnFamily().getBytes(), metadata.getColumnQualifier().getBytes(), vis, ts);
+        } else {
+            metadata = new Key(EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES, vis, ts);
+        }
+    }
 
     /*
      * Given a key, set the metadata. Expected input keys can be an event key, an fi key, or a tf key. Expected metadata is row=shardid, cf = type\0uid; cq =
@@ -168,7 +197,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected void writeMetadata(DataOutput out) throws IOException {
         out.writeBoolean(isMetadataSet());
         if (isMetadataSet()) {
-            byte[] cvBytes = getColumnVisibility().getExpression();
+            byte[] cvBytes = getColumnVisibilityBytes();
 
             WritableUtils.writeVInt(out, cvBytes.length);
 
@@ -180,7 +209,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected void writeMetadata(Kryo kryo, Output output) {
         output.writeBoolean(isMetadataSet());
         if (isMetadataSet()) {
-            byte[] cvBytes = getColumnVisibility().getExpression();
+            byte[] cvBytes = getColumnVisibilityBytes();
             output.writeInt(cvBytes.length, true);
             output.writeBytes(cvBytes);
             output.writeLong(getTimestamp());
@@ -204,8 +233,10 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     protected void readMetadata(Kryo kryo, Input input) {
         if (input.readBoolean()) {
             int size = input.readInt(true);
-
-            this.setMetadata(new ColumnVisibility(input.readBytes(size)), input.readLong());
+            byte[] cvBytes = input.readBytes(size);
+            long timestamp = input.readLong();
+            // trust the column visibility from the payload
+            setMetadata(cvBytes, timestamp);
         } else {
             this.clearMetadata();
         }

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -71,7 +71,7 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
      */
     public byte[] getColumnVisibilityBytes() {
         if (isMetadataSet()) {
-            byte[] data = metadata.getColumnVisibilityData().getBackingArray();
+            byte[] data = metadata.getColumnVisibilityData().toArray();
             return Arrays.copyOf(data, data.length);
         }
         return EMPTY_BYTES;

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Attribute.java
@@ -1,8 +1,11 @@
 package datawave.query.attributes;
 
+import static datawave.query.Constants.EMPTY_BYTES;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.accumulo.core.data.ArrayByteSequence;
@@ -28,7 +31,6 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
 
     private static final Logger log = Logger.getLogger(Attribute.class);
     private static final Text EMPTY_TEXT = new Text();
-    private static final byte[] EMPTY_BYTES = new byte[0];
     private static final ByteSequence EMPTY_BYTE_SEQUENCE = new ArrayByteSequence(new byte[0]);
 
     /**
@@ -62,15 +64,17 @@ public abstract class Attribute<T extends Comparable<T>> implements WritableComp
     }
 
     /**
-     * Some callers only require the raw bytes
+     * Get a copy byte array that backs the {@link ColumnVisibility}. This avoids the expensive parse call found in the default constructor for the
+     * ColumnVisibility.
      *
-     * @return the byte array that backs the column visibility
+     * @return a copy of the byte array that backs the column visibility
      */
     public byte[] getColumnVisibilityBytes() {
         if (isMetadataSet()) {
-            return metadata.getColumnVisibilityData().getBackingArray();
+            byte[] data = metadata.getColumnVisibilityData().getBackingArray();
+            return Arrays.copyOf(data, data.length);
         }
-        return Constants.EMPTY_BYTES;
+        return EMPTY_BYTES;
     }
 
     public void setColumnVisibility(ColumnVisibility columnVisibility) {

--- a/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
+++ b/warehouse/query-core/src/main/java/datawave/query/attributes/Cardinality.java
@@ -115,12 +115,12 @@ public class Cardinality extends Attribute<Cardinality> {
                 return -1;
             }
         } else if (this.isMetadataSet()) {
-            byte[] cvBytes = this.getColumnVisibility().getExpression();
+            byte[] cvBytes = this.getColumnVisibilityBytes();
             if (null == cvBytes) {
                 cvBytes = Constants.EMPTY_BYTES;
             }
 
-            byte[] otherCVBytes = other.getColumnVisibility().getExpression();
+            byte[] otherCVBytes = other.getColumnVisibilityBytes();
             if (null == otherCVBytes) {
                 otherCVBytes = Constants.EMPTY_BYTES;
             }

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TypeAttributeTest.java
@@ -2,10 +2,13 @@ package datawave.query.attributes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.ByteArrayOutputStream;
 
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.security.ColumnVisibility;
 import org.junit.Test;
 
 import com.esotericsoftware.kryo.Kryo;
@@ -49,5 +52,27 @@ public class TypeAttributeTest extends AttributeTest {
         assertInstanceOf(TypeAttribute.class, type);
         assertInstanceOf(NoOpType.class, type.getType());
         assertEquals("delegate value as string", type.getData().toString());
+    }
+
+    @Test
+    public void testColumnVisibilityImmutability() {
+        NoOpType type = new NoOpType("no op value");
+        Key docKey = new Key("shard", "datatype\0uid", "", "VIZ-A");
+
+        TypeAttribute<?> attr = new TypeAttribute<>(type, docKey, false);
+
+        ColumnVisibility first = attr.getColumnVisibility();
+        ColumnVisibility second = attr.getColumnVisibility();
+        // verify we didn't accidentally go down the empty CV path
+        assertEquals("VIZ-A", new String(first.getExpression()));
+        // turns out 'getColumnVisibility' is not immutable
+        assertSame(first.getExpression(), second.getExpression());
+
+        // verify that the following method call is immutable and returns the correct visibility
+        byte[] left = attr.getColumnVisibilityBytes();
+        byte[] right = attr.getColumnVisibilityBytes();
+        assertEquals("VIZ-A", new String(left));
+        assertEquals("VIZ-A", new String(right));
+        assertNotSame(left, right);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/function/serializer/KryoDocumentSerDeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/serializer/KryoDocumentSerDeTest.java
@@ -2,10 +2,13 @@ package datawave.query.function.serializer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 
 import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.security.ColumnVisibility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +27,7 @@ import datawave.data.type.PointType;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.AttributeFactory;
 import datawave.query.attributes.Document;
+import datawave.query.attributes.DocumentKey;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.util.TypeMetadata;
 
@@ -35,6 +39,7 @@ public abstract class KryoDocumentSerDeTest {
     protected final KryoDocumentSerializer serializer = new KryoDocumentSerializer();
     protected final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
 
+    private final ColumnVisibility visibility = new ColumnVisibility("PUBLIC&(FOO|BAR)");
     private final String datatype = "datatype";
     private final Key documentKey = new Key("row", "datatype\0uid");
 
@@ -60,6 +65,9 @@ public abstract class KryoDocumentSerDeTest {
         d.put("NUM", createAttribute("NUM", "25"));
         d.put("NUM_LIST", createAttribute("NUM_LIST", "22,23,24"));
         d.put("POINT", createAttribute("POINT", "POINT(10 10)"));
+
+        Key metadata = new Key("row", "datatype\0uid", "", visibility, 0L);
+        d.put(Document.DOCKEY_FIELD_NAME, new DocumentKey(metadata, true));
     }
 
     private TypeMetadata getTypeMetadata() {
@@ -89,7 +97,7 @@ public abstract class KryoDocumentSerDeTest {
             int max = 1_000_000;
             for (int i = 1; i <= max; i++) {
                 byte[] bytes = serializer.serialize(d);
-                assertTrue(450 < bytes.length && bytes.length <= 460);
+                assertTrue(500 < bytes.length && bytes.length <= 510, "data length is: " + bytes.length);
             }
         }
     }
@@ -101,9 +109,13 @@ public abstract class KryoDocumentSerDeTest {
 
             int max = 1_000_000;
             for (int i = 1; i <= max; i++) {
-                ByteArrayInputStream bais = new ByteArrayInputStream(data);
-                Document d = deserializer.deserialize(bais);
-                assertEquals(12, d.size());
+                try (var bais = new ByteArrayInputStream(data)) {
+                    Document d = deserializer.deserialize(bais);
+                    assertEquals(13, d.size());
+                } catch (IOException e) {
+                    fail("failed to deserialize document");
+                    throw new RuntimeException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
- Attribute has method that allows access to the raw ColumnVisibility bytes without reparsing the visibility
- Attribute has method that allows setting a ColumnVisibility from the raw bytes without reparsing the visibility

Practically this eliminates creating two ColumnVisibility objects when reading an Attribute's metadata.