### PR TITLE
Enable normalization again within _Eval_ phrases, and added _Norm_ query

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/QueryPropertyMarker.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/QueryPropertyMarker.java
@@ -36,6 +36,7 @@ public class QueryPropertyMarker {
         BOUNDED_RANGE("_Bounded_", false, false),
         LENIENT("_Lenient_", false, false),
         STRICT("_Strict_", false, false),
+        NORMALIZED("_Norm_", false, false),
         PLAN("plan", false, false);
 
         private final String label;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -6,6 +6,7 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EVALUATIO
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_TERM;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_VALUE;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.LENIENT;
+import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.NORMALIZED;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.STRICT;
 
 import java.text.MessageFormat;
@@ -156,11 +157,11 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
     @Override
     public Object visit(ASTAndNode node, Object data) {
         /*
-         * If we have an exceeded value or term predicate we can safely assume that expansion has occurred in the unfielded expansion along with all types If we
-         * have an evaluation only term predicate, then no need to apply normalizations If we have already expanded this node, then nothing to do
+         * If we have an exceeded value or term predicate we can safely assume that expansion has occurred in the unfielded expansion along with all types. If
+         * we marked the term explicitly as normalized then nothing to do. If we have already expanded this node, then nothing to do.
          */
         QueryPropertyMarker.Instance marker = QueryPropertyMarker.findInstance(node);
-        if (marker.isAnyTypeOf(EXCEEDED_VALUE, EXCEEDED_TERM, EVALUATION_ONLY) || this.expandedNodes.contains(node)) {
+        if (marker.isAnyTypeOf(EXCEEDED_VALUE, EXCEEDED_TERM, NORMALIZED) || this.expandedNodes.contains(node)) {
             return node;
         }
 
@@ -362,8 +363,13 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                                     JexlNode normalizedNode = JexlNodeFactory.buildUntypedNode(node, fieldName, normTerm);
                                     // if not index only, and we have a lossy normalized regex, then add the original regex as eval only
                                     if (!indexOnly && (!term.equals(normTerm)) && normalizer.normalizedRegexIsLossy(term)) {
-                                        JexlNode evalOnly = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(node, fieldName, term),
-                                                        EVALUATION_ONLY);
+                                        JexlNode nodeCopy = JexlNodeFactory.buildUntypedNode(node, fieldName, term);
+                                        JexlNode evalOnly = QueryPropertyMarker.create(nodeCopy, EVALUATION_ONLY);
+                                        // ensure we are wrapped (not done by QueryPropertyMarker if node.parent is a ref expression)
+                                        if (!(evalOnly instanceof ASTReferenceExpression)) {
+                                            evalOnly = JexlNodes.wrap(evalOnly);
+                                        }
+                                        evalOnly = QueryPropertyMarker.create(evalOnly, NORMALIZED);
                                         // ensure we are wrapped (not done by QueryPropertyMarker if node.parent is a ref expression)
                                         if (!(evalOnly instanceof ASTReferenceExpression)) {
                                             evalOnly = JexlNodes.wrap(evalOnly);

--- a/warehouse/query-core/src/test/java/datawave/query/NumericListQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/NumericListQueryTest.java
@@ -392,7 +392,7 @@ public abstract class NumericListQueryTest {
         extraParameters.put("return.fields", "SIZE,CANINE");
 
         String queryString = "((_Eval_ = true) && (SIZE == 90)) && CANINE == 'coyote'";
-        String expectedQueryPlan = "((_Eval_ = true) && (SIZE == 90)) && CANINE == 'coyote'";
+        String expectedQueryPlan = "((_Eval_ = true) && (SIZE == '+bE9')) && CANINE == 'coyote'";
 
         Set<String> goodResults = Sets.newHashSet("SIZE.CANINE.WILD.1:90,26.5", "CANINE.WILD.1:coyote");
 
@@ -408,7 +408,7 @@ public abstract class NumericListQueryTest {
 
         // this only works because the entire string '90,26.5' is included in the jexl context and we match against that
         String queryString = "SIZE =~'.*0.*' AND CANINE == 'coyote'";
-        String expectedQueryPlan = "((_Delayed_ = true) && (SIZE =~ '\\+[a-zA-Z]E.*0?\\.?.*|\\+AE0|![A-Za-z]E(.+|.*9\\.?.+)')) && ((_Eval_ = true) && (SIZE =~ '.*0.*')) && CANINE == 'coyote'";
+        String expectedQueryPlan = "CANINE == 'coyote' && ((_Delayed_ = true) && (SIZE =~ '\\+[a-zA-Z]E.*0?\\.?.*|\\+AE0|![A-Za-z]E(.+|.*9\\.?.+)')) && ((_Norm_ = true) && ((_Eval_ = true) && (SIZE =~ '.*0.*')))";
 
         Set<String> goodResults = Sets.newHashSet("REPTILE.PET.1:snake", "DOG.WILD.1:coyote", "CAT.WILD.1:tiger", "SIZE.CANINE.3:20,12.5",
                         "CANINE.WILD.1:coyote", "FISH.WILD.1:tuna", "BIRD.WILD.1:hawk");
@@ -424,7 +424,7 @@ public abstract class NumericListQueryTest {
         extraParameters.put("limit.fields", "SIZE=-1,BIRD=-1,CAT=-1,CANINE=-1,FISH=-1");
 
         String queryString = "SIZE =~ '20*'";
-        String expectedQueryPlan = "((_Eval_ = true) && (SIZE =~ '20*'))";
+        String expectedQueryPlan = "((_Eval_ = true) && (((_Norm_ = true) && (SIZE =~ '20*')) && SIZE =~ '\\+[a-z]E2'))";
 
         Set<String> goodResults = Sets.newHashSet();
 
@@ -441,7 +441,7 @@ public abstract class NumericListQueryTest {
         // 90 only exists by itself in the jexl context in its normalized form. Numeric regex handling should some day rectify this or perhaps we should
         // consider adding the non-normalized tokens to the context for certain OneToMany types.
         String queryString = "SIZE =~'.*5' AND CANINE == 'coyote'";
-        String expectedQueryPlan = "((_Eval_ = true) && (SIZE =~ '.*5')) && CANINE == 'coyote'";
+        String expectedQueryPlan = "CANINE == 'coyote' && ((_Eval_ = true) && (((_Norm_ = true) && (SIZE =~ '.*5')) && SIZE =~ '\\+[a-zA-Z]E.*5|![A-Za-z]E.*5'))";
 
         Set<String> goodResults = Sets.newHashSet("REPTILE.PET.1:snake", "DOG.WILD.1:coyote");
 

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExecutableExpansionVisitorTest.java
@@ -401,7 +401,7 @@ public abstract class ExecutableExpansionVisitorTest {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
 
-        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Eval_ = true) && (BAIL =~ '12340.*?'))";
+        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Norm_ = true) && ((_Eval_ = true) && (BAIL =~ '12340.*?')))";
         String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
         Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
                         TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));
@@ -449,7 +449,7 @@ public abstract class ExecutableExpansionVisitorTest {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
 
-        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Eval_ = true) && (_ANYFIELD_ =~ '12340.*?'))";
+        String expectedQueryStr = "(BAIL == '+eE1.2345' || BAIL == '+fE1.23401') && ((_Norm_ = true) && ((_Eval_ = true) && (_ANYFIELD_ =~ '12340.*?')))";
         String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
         Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
                         TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));
@@ -494,7 +494,7 @@ public abstract class ExecutableExpansionVisitorTest {
             runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
         }
 
-        String expectedQueryStr = "(UUID == 'capone' || UUID == 'soprano') && ((_Eval_ = true) && (BAIL =~ '.*?05'))";
+        String expectedQueryStr = "(UUID == 'capone' || UUID == 'soprano') && ((_Eval_ = true) && ((_Norm_ = true) && (BAIL =~ '.*?05')) && BAIL =~ '\\+[a-zA-Z]E.*?0?\\.?5|![A-Za-z]E.*?9?\\.?5')";
         String plan = JexlFormattedStringBuildingVisitor.buildQuery(logic.getConfig().getQueryTree());
         Assert.assertTrue("Expected equality: " + expectedQueryStr + " vs " + plan,
                         TreeEqualityVisitor.isEqual(JexlASTHelper.parseJexlQuery(expectedQueryStr), logic.getConfig().getQueryTree()));

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -7,6 +7,7 @@ import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.EXCEEDED_VALUE;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.INDEX_HOLE;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.LENIENT;
+import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.NORMALIZED;
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.STRICT;
 
 import java.util.ArrayList;
@@ -514,14 +515,14 @@ public class ExpandMultiNormalizedTermsTest {
 
         config.setQueryFieldsDatatypes(dataTypes);
 
-        List<String> markers = Arrays.asList(new String[] {INDEX_HOLE.getLabel(), DELAYED.getLabel(), EXCEEDED_OR.getLabel()});
+        List<String> markers = Arrays.asList(new String[] {INDEX_HOLE.getLabel(), DELAYED.getLabel(), EXCEEDED_OR.getLabel(), EVALUATION_ONLY.getLabel()});
         for (String marker : markers) {
             String original = "((" + marker + " = true) && (FOO == 'Bar'))";
             String expected = "((" + marker + " = true) && (FOO == 'bar'))";
             expandTerms(original, expected);
         }
 
-        markers = Arrays.asList(new String[] {EXCEEDED_TERM.getLabel(), EXCEEDED_VALUE.getLabel(), EVALUATION_ONLY.getLabel()});
+        markers = Arrays.asList(new String[] {EXCEEDED_TERM.getLabel(), EXCEEDED_VALUE.getLabel(), NORMALIZED.getLabel()});
         for (String marker : markers) {
             String original = "((" + marker + " = true) && (FOO == 'Bar'))";
             String expected = "((" + marker + " = true) && (FOO == 'Bar'))";


### PR DESCRIPTION
marker to avoid (re)normalization of the source