### PR TITLE
Re-allow normalization within an evaluation-only clause, and update the

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTerms.java
@@ -160,7 +160,7 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
          * have an evaluation only term predicate, then no need to apply normalizations If we have already expanded this node, then nothing to do
          */
         QueryPropertyMarker.Instance marker = QueryPropertyMarker.findInstance(node);
-        if (marker.isAnyTypeOf(EXCEEDED_VALUE, EXCEEDED_TERM, EVALUATION_ONLY) || this.expandedNodes.contains(node)) {
+        if (marker.isAnyTypeOf(EXCEEDED_VALUE, EXCEEDED_TERM) || this.expandedNodes.contains(node)) {
             return node;
         }
 
@@ -362,15 +362,21 @@ public class ExpandMultiNormalizedTerms extends RebuildingVisitor {
                                     JexlNode normalizedNode = JexlNodeFactory.buildUntypedNode(node, fieldName, normTerm);
                                     // if not index only, and we have a lossy normalized regex, then add the original regex as eval only
                                     if (!indexOnly && (!term.equals(normTerm)) && normalizer.normalizedRegexIsLossy(term)) {
-                                        JexlNode evalOnly = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(node, fieldName, term),
-                                                        EVALUATION_ONLY);
-                                        // ensure we are wrapped (not done by QueryPropertyMarker if node.parent is a ref expression)
-                                        if (!(evalOnly instanceof ASTReferenceExpression)) {
-                                            evalOnly = JexlNodes.wrap(evalOnly);
+                                        // if this whole phrase is already wrapped with an evaluation-only marker, then just leave the original
+                                        // regex as is
+                                        if (QueryPropertyMarker.isAncestorMarked(node, EVALUATION_ONLY)) {
+                                            normalizedNodes.add(JexlNodeFactory.buildUntypedNode(node, fieldName, term));
+                                        } else {
+                                            JexlNode evalOnly = QueryPropertyMarker.create(JexlNodeFactory.buildUntypedNode(node, fieldName, term),
+                                                            EVALUATION_ONLY);
+                                            // ensure we are wrapped (not done by QueryPropertyMarker if node.parent is a ref expression)
+                                            if (!(evalOnly instanceof ASTReferenceExpression)) {
+                                                evalOnly = JexlNodes.wrap(evalOnly);
+                                            }
+                                            // now we need to combine these two nodes so that both are required
+                                            JexlNode combined = JexlNodeFactory.createAndNode(Arrays.asList(new JexlNode[] {evalOnly, normalizedNode}));
+                                            normalizedNodes.add(combined);
                                         }
-                                        // now we need to combine these two nodes so that both are required
-                                        JexlNode combined = JexlNodeFactory.createAndNode(Arrays.asList(new JexlNode[] {evalOnly, normalizedNode}));
-                                        normalizedNodes.add(combined);
                                     } else {
                                         normalizedNodes.add(normalizedNode);
                                     }

--- a/warehouse/query-core/src/test/java/datawave/query/NumericListQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/NumericListQueryTest.java
@@ -392,7 +392,7 @@ public abstract class NumericListQueryTest {
         extraParameters.put("return.fields", "SIZE,CANINE");
 
         String queryString = "((_Eval_ = true) && (SIZE == 90)) && CANINE == 'coyote'";
-        String expectedQueryPlan = "((_Eval_ = true) && (SIZE == 90)) && CANINE == 'coyote'";
+        String expectedQueryPlan = "((_Eval_ = true) && (SIZE == '+bE9')) && CANINE == 'coyote'";
 
         Set<String> goodResults = Sets.newHashSet("SIZE.CANINE.WILD.1:90,26.5", "CANINE.WILD.1:coyote");
 

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -514,14 +514,14 @@ public class ExpandMultiNormalizedTermsTest {
 
         config.setQueryFieldsDatatypes(dataTypes);
 
-        List<String> markers = Arrays.asList(new String[] {INDEX_HOLE.getLabel(), DELAYED.getLabel(), EXCEEDED_OR.getLabel()});
+        List<String> markers = Arrays.asList(new String[] {INDEX_HOLE.getLabel(), DELAYED.getLabel(), EXCEEDED_OR.getLabel(), EVALUATION_ONLY.getLabel()});
         for (String marker : markers) {
             String original = "((" + marker + " = true) && (FOO == 'Bar'))";
             String expected = "((" + marker + " = true) && (FOO == 'bar'))";
             expandTerms(original, expected);
         }
 
-        markers = Arrays.asList(new String[] {EXCEEDED_TERM.getLabel(), EXCEEDED_VALUE.getLabel(), EVALUATION_ONLY.getLabel()});
+        markers = Arrays.asList(new String[] {EXCEEDED_TERM.getLabel(), EXCEEDED_VALUE.getLabel()});
         for (String marker : markers) {
             String original = "((" + marker + " = true) && (FOO == 'Bar'))";
             String expected = "((" + marker + " = true) && (FOO == 'Bar'))";


### PR DESCRIPTION
lossy-regex to avoid adding the lossy regex if already nested in an evaluation-only clause.