### PR TITLE
always set visibility for annotation source and updating ingest config/transformation for quickstart (#3269)

### DIFF
--- a/warehouse/ingest-annotation/src/main/java/datawave/ingest/annotation/mapreduce/handler/AnnotationHelper.java
+++ b/warehouse/ingest-annotation/src/main/java/datawave/ingest/annotation/mapreduce/handler/AnnotationHelper.java
@@ -271,7 +271,8 @@ public class AnnotationHelper {
         datawaveAnnotationBuilder.putMetadata("visibility", new String(visibility));
         datawaveAnnotationBuilder.putMetadata("created_date", DateHelper.format8601(new Date(event.getTimestamp())));
 
-        if (annotationBuilder.getSource() != null && !annotationBuilder.getSource().getSourceLabel().isEmpty()) {
+        // annotation source is required, but checking just in case
+        if (annotationBuilder.getSource() != null) {
             if (annotationSourceVisibilityInheritEvent) {
                 datawaveAnnotationBuilder.getSourceBuilder().putConfiguration("visibility", new String(visibility));
             } else {

--- a/warehouse/ingest-annotation/src/test/java/datawave/ingest/annotation/mapreduce/handler/AnnotationHelperTest.java
+++ b/warehouse/ingest-annotation/src/test/java/datawave/ingest/annotation/mapreduce/handler/AnnotationHelperTest.java
@@ -111,6 +111,32 @@ public class AnnotationHelperTest {
     }
 
     @Test
+    public void testProcessSingleAnnotationWithoutSource() throws IOException, InterruptedException {
+        // create test event record wrapper with minimum set of fields required for creating annotation mutations
+        RawRecordContainer event = new EventWithShardId("20251107_1");
+
+        long time = System.currentTimeMillis();
+        event.setDataType(TypeRegistry.getType("annotation"));
+        event.setTimestamp(time);
+        event.setVisibility(new ColumnVisibility("TEST_VISIBILITY"));
+        event.setId(UID.parse("a.b.c"));
+
+        // no fields are required
+        HashMultimap<String,NormalizedContentInterface> fields = HashMultimap.create();
+
+        annotationHelper.process(event, contextWriter, ctx, statusReporter, event.getId(), event.getVisibility().flatten(), event.getShardId().getBytes(),
+                        ClassLoader.getSystemResource("input/singleAnnotationWithoutSource.json").openStream().readAllBytes());
+        contextWriter.commit(ctx);
+
+        BulkIngestKey expectedKey = new BulkIngestKey(new Text("datawave.annotation"),
+                        new Key("20251107_1", "myannotation\0a.b.c\0testAnnotationType", "testAnnotationId\0testSegmentId1", "TEST_VISIBILITY", time));
+
+        // the first segment value should be protobuf that can be parsed by Segment class
+        Segment segment = Segment.parseFrom(contextWriter.getCache().get(expectedKey).stream().findFirst().get().get());
+        assertEquals("testSegmentId1", segment.getSegmentId(), "BulkIngestKey structure could potentially change as annotation-core library gets updated.");
+    }
+
+    @Test
     public void testProcessBulk() throws IOException {
         // create test event record wrapper with minimum set of fields required for creating annotation mutations
         RawRecordContainer event = new EventWithShardId("20251107_1");

--- a/warehouse/ingest-annotation/src/test/resources/input/doubleAnnotation.json
+++ b/warehouse/ingest-annotation/src/test/resources/input/doubleAnnotation.json
@@ -1,12 +1,22 @@
 {
-  "shard": "20251017_0",
+  "shard": "20160426_0",
   "dataType": "annotation",
-  "uid": "-1111.1111.-1111",
+  "uid": "2222.2222.-2222",
   "annotationType": "testAnnotationType",
   "annotationId": "testAnnotationId",
+  "source": {
+    "analyticHash": "testAnalyticHash",
+    "engine": "testEngine",
+    "model": "6.7",
+    "configuration": {
+      "flagOne": true,
+      "flagTwo": true
+    },
+    "sourceLabel": "testSourceLabel"
+  },
   "metadata": {
     "visibility": "PUBLIC",
-    "created_date": "2016-04-26T01:31:53Z"
+    "created_date": "2016-04-26T01:00:53Z"
   },
   "segments": [
     {
@@ -92,6 +102,16 @@
     "visibility": "PUBLIC",
     "created_date": "2016-04-26T01:00:53Z"
   },
+  "source": {
+    "analyticHash": "testAnalyticHash",
+    "engine": "testEngine",
+    "model": "6.7",
+    "configuration": {
+      "flagOne": true,
+      "flagTwo": true
+    },
+    "sourceLabel": "testSourceLabel"
+  },
   "segments": [
     {
       "segmentId": "testSegmentId1",
@@ -150,8 +170,8 @@
       "metadata": {
         "testMetadataKey3": "testMetadataValue3"
       },
-      "boundaryType": "POINT_LIST",
-      "bounds": {
+      "boundary": {
+        "boundaryType": "POINT_LIST"
       }
     },
     {
@@ -160,7 +180,7 @@
       "metadata": {
         "testMetadataKey4": "testMetadataValue4"
       },
-      "bounds": {
+      "boundary": {
         "boundaryType": "POINT_LIST"
       }
     }

--- a/warehouse/ingest-annotation/src/test/resources/input/singleAnnotationWithoutSource.json
+++ b/warehouse/ingest-annotation/src/test/resources/input/singleAnnotationWithoutSource.json
@@ -1,0 +1,89 @@
+{
+  "annotationType": "testAnnotationType",
+  "annotationId": "testAnnotationId",
+  "shard": "20251017_0",
+  "dataType": "testDataType",
+  "documentId": "testDocumentId",
+  "metadata": {
+    "visibility": "PUBLIC",
+    "created_date": "2025-10-17T10:30:00.0Z",
+    "test_metadata_key": "test_metadata_value"
+  },
+  "segments": [
+    {
+      "segmentId": "testSegmentId1",
+      "values": [
+        {
+          "value": "test1a",
+          "score": -83737019.1792235,
+          "extension": {
+            "extensionType": "testExentionType",
+            "barcodeType": "testBarcodeType"
+          }
+        },
+        {
+          "value": "test1b",
+          "score": 47053589.7620008
+        },
+        {
+          "value": "test1c",
+          "score": 32235234.64713955
+        },
+        {
+          "value": "test1d",
+          "score": 77675558.93612546
+        },
+        {
+          "value": "test1e",
+          "score": 7012998.240006313
+        }
+      ],
+      "metadata": {
+      },
+      "bounds": {
+        "boundaryType": "POINT_LIST",
+        "points": [
+          {
+            "x": -78087840.7337584,
+            "y": 56815415.1987268,
+            "label": "testPointLabel1"
+          }
+        ]
+      }
+    },
+    {
+      "segmentId": "testSegmentId2",
+      "bounds": {
+        "boundaryType": "POINT_LIST",
+        "points": [
+          {
+            "label": "testPointLabel2a"
+          },
+          {
+            "label": "testPointLabel2b"
+          }
+        ]
+      }
+    },
+    {
+      "segmentId": "testSegmentId3",
+      "values": [],
+      "metadata": {
+        "testMetadataKey3": "testMetadataValue3"
+      },
+      "bounds": {
+        "boundaryType": "POINT_LIST"
+      }
+    },
+    {
+      "segmentId": "testSegmentId3",
+      "values": [],
+      "metadata": {
+        "testMetadataKey4": "testMetadataValue4"
+      },
+      "bounds": {
+        "boundaryType": "POINT_LIST"
+      }
+    }
+  ]
+}

--- a/warehouse/ingest-configuration/src/main/resources/config/annotation-ingest-config.xml
+++ b/warehouse/ingest-configuration/src/main/resources/config/annotation-ingest-config.xml
@@ -36,6 +36,28 @@
     </property>
 
     <property>
+        <name>annotation.source.table.name</name>
+        <value>datawave.annotationSource</value>
+    </property>
+
+    <property>
+        <name>annotation.source.table.loader.priority</name>
+        <value>60</value>
+    </property>
+
+    <property>
+        <name>annotation.source.visibility.inherit.event</name>
+        <value>false</value>
+        <description>enable setting the visibility for annotation source from event</description>
+    </property>
+
+    <property>
+        <name>annotation.source.visibility.default</name>
+        <value>PRIVATE</value>
+        <description>default visibility to use for storing annotation source</description>
+    </property>
+
+    <property>
         <name>annotation.ingest.helper.class</name>
         <value>datawave.ingest.annotation.mapreduce.handler.SimpleAnnotationIngestHelper</value>
     </property>
@@ -61,6 +83,12 @@
         <name>annotation.raw.transform.config</name>
         <value>config/annotation-transform-config.xml</value>
         <description>used to transform raw annotation json view (xslt file with xml extension)</description>
+    </property>
+
+    <property>
+        <name>annotation.ignore.unknown.fields</name>
+        <value>false</value>
+        <description>ignore unknown fields when parsing the annotation json</description>
     </property>
 
     <property>

--- a/warehouse/ingest-configuration/src/main/resources/config/annotation-transform-config.xml
+++ b/warehouse/ingest-configuration/src/main/resources/config/annotation-transform-config.xml
@@ -12,7 +12,7 @@
         <xsl:map>
             <xsl:for-each select="map:keys(.)">
                 <xsl:variable name="key" select="."/>
-                <xsl:if test="$key != 'documentId' and $key != 'segments'">
+                <xsl:if test="$key != 'segments'">
                     <xsl:map-entry key="$key" select="$annotation($key)"/>
                 </xsl:if>
                 <xsl:if test="$key = 'segments'">
@@ -42,15 +42,15 @@
                 <xsl:map-entry key="'segmentId'" select="$segment('segmentId')"/>
             </xsl:if>
 
-            <!-- Rename values to segmentValue -->
-            <xsl:if test="map:contains($segment, 'values')">
-                <xsl:map-entry key="'segmentValue'" select="$segment('values')"/>
+            <!-- Rename bounds to boundary -->
+            <xsl:if test="map:contains($segment, 'bounds')">
+                <xsl:map-entry key="'boundary'" select="$segment('bounds')"/>
             </xsl:if>
 
             <!-- Copy any other fields that might exist -->
             <xsl:for-each select="map:keys($segment)">
                 <xsl:variable name="key" select="."/>
-                <xsl:if test="$key != 'segmentId' and $key != 'bounds' and $key != 'values'">
+                <xsl:if test="$key != 'segmentId' and $key != 'bounds' and $key != 'bounds'">
                     <xsl:map-entry key="$key" select="$segment($key)"/>
                 </xsl:if>
             </xsl:for-each>


### PR DESCRIPTION
annotation source should always be provided. i'm removing the logic that checks for source label which may be going away based on our discussions.