### PR TITLE
Replace deprecated Float, Long, Double, Boolean constructors

### DIFF
--- a/core/utils/type-utils/src/test/java/datawave/webservice/query/data/ObjectSizeOfTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/webservice/query/data/ObjectSizeOfTest.java
@@ -64,16 +64,16 @@ public class ObjectSizeOfTest {
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Character((char) 1)));
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Short((short) 1)));
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(1));
-        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Float(1)));
-        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Long(1)));
-        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Double(1)));
+        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Float.valueOf(1)));
+        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Long.valueOf(1)));
+        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Double.valueOf(1)));
     }
 
     @Test
     public void testObjects() {
         List<Object> list = new ArrayList<Object>(10);
-        list.add(new Long(1));
-        list.add(new Double(1));
+        list.add(Long.valueOf(1));
+        list.add(Double.valueOf(1));
         int overhead = 8;
         int arrayoverhead = 12;
         int reference = 4;

--- a/warehouse/query-core/src/main/java/datawave/core/iterators/GlobalIndexTermMatchingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/GlobalIndexTermMatchingIterator.java
@@ -178,7 +178,7 @@ public class GlobalIndexTermMatchingIterator extends GlobalIndexTermMatchingFilt
              * note that boolean will ONLY return true if the value in the map is 'true' or 'TRUE'. we don't need the above conditional, but we are being
              * defensive.
              */
-            uniqueTermsOnly = new Boolean(options.get(UNIQUE_TERMS_IN_FIELD));
+            uniqueTermsOnly = Boolean.parseBoolean(options.get(UNIQUE_TERMS_IN_FIELD));
 
         }
         return valid;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveArithmetic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveArithmetic.java
@@ -191,7 +191,7 @@ public abstract class DatawaveArithmetic extends JexlArithmetic {
         if (isFloatingPointNumber(left) || isFloatingPointNumber(right)) {
             double l = toDouble(left);
             double r = toDouble(right);
-            return new Double(l - r);
+            return Double.valueOf(l - r);
         }
 
         // if either are bigdecimal use that type


### PR DESCRIPTION
## Summary
Replace deprecated boxed type constructors with static factory methods:
- `new Float(1)` → `Float.valueOf(1)`
- `new Long(1)` → `Long.valueOf(1)`
- `new Double(l - r)` → `Double.valueOf(l - r)`
- `new Boolean(...)` → `Boolean.parseBoolean(...)`

## Files Changed
- `ObjectSizeOfTest.java` - 5 changes
- `DatawaveArithmetic.java` - 1 change
- `GlobalIndexTermMatchingIterator.java` - 1 change

Fixes #3292
Part of #2443