### PR TITLE
Replace deprecated Date(year, month, day) constructor

### DIFF
--- a/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/QueryExecutorBeanTest.java
@@ -14,6 +14,7 @@ import static org.powermock.reflect.Whitebox.setInternalState;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -620,8 +621,9 @@ public class QueryExecutorBeanTest {
 
     @Test
     public void testBeginDateAfterEndDate() throws Exception {
-        final Date beginDate = new Date(2018, 1, 2);
-        final Date endDate = new Date(2018, 1, 1);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        final Date beginDate = sdf.parse("2024-01-02");
+        final Date endDate = sdf.parse("2024-01-01");
 
         final MultivaluedMap<String,String> queryParameters = createNewQueryParameterMap();
         queryParameters.remove(QueryParameters.QUERY_BEGIN);


### PR DESCRIPTION
## Summary
Replace deprecated `Date(int, int, int)` constructor with `SimpleDateFormat.parse()`.

The `Date(year, month, day)` constructor has been deprecated since JDK 1.1.

## Changes
```java
// Before
final Date beginDate = new Date(2018, 1, 2);
final Date endDate = new Date(2018, 1, 1);

// After
SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
final Date beginDate = sdf.parse("2024-01-02");
final Date endDate = sdf.parse("2024-01-01");
```

## Files Changed
- `QueryExecutorBeanTest.java` - 2 changes (+ import)

Fixes #3293
Part of #2443