### PR TITLE
Replace deprecated Job() constructor with Job.getInstance()

### DIFF
--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/MultiTableRRRangePartitionerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/partition/MultiTableRRRangePartitionerTest.java
@@ -46,7 +46,7 @@ public class MultiTableRRRangePartitionerTest {
 
     @Before
     public void before() throws IOException {
-        mockJob = new Job();
+        mockJob = Job.getInstance();
         configuration = mockJob.getConfiguration();
         configuration.set("job.output.table.names", TableName.SHARD);
         configuration.setBoolean(TableSplitsCache.REFRESH_SPLITS, false);


### PR DESCRIPTION
## Summary
Replace deprecated Hadoop `new Job()` constructor with `Job.getInstance()`.

## Changes
```java
// Before
mockJob = new Job();

// After
mockJob = Job.getInstance();
```

## Files Changed
- `MultiTableRRRangePartitionerTest.java` - 1 change

Note: This is separate from the fix in `MultiTableRangePartitionerTest.java` which was already addressed in a previous PR.

Fixes #3294
Part of #2443