### PR TITLE
Replace deprecated Byte, Character, Short constructors

### DIFF
--- a/core/utils/type-utils/src/test/java/datawave/webservice/query/data/ObjectSizeOfTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/webservice/query/data/ObjectSizeOfTest.java
@@ -60,9 +60,9 @@ public class ObjectSizeOfTest {
     @Test
     public void testNumbers() {
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Boolean.TRUE));
-        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Byte((byte) 1)));
-        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Character((char) 1)));
-        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Short((short) 1)));
+        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Byte.valueOf((byte) 1)));
+        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Character.valueOf((char) 1)));
+        assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(Short.valueOf((short) 1)));
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(1));
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Float(1)));
         assertEquals(16, ObjectSizeOf.Sizer.getObjectSize(new Long(1)));


### PR DESCRIPTION
## Summary
Replace deprecated boxed type constructors with static factory methods:
- `new Byte((byte) 1)` → `Byte.valueOf((byte) 1)`
- `new Character((char) 1)` → `Character.valueOf((char) 1)`
- `new Short((short) 1)` → `Short.valueOf((short) 1)`

## Files Changed
- `ObjectSizeOfTest.java` - 3 changes

Fixes #3298
Part of #2443