### PR TITLE
Force additional cache cleanup to avoid intermittent test failure

### DIFF
--- a/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -52,7 +52,9 @@ public class TypeFactoryTest {
         // same type created in a row with a cache size of one will return the same type instance
         assertSame(left, right);
 
-        // trigger maintenance task to evict the LcType
+        // at this point the cache could contain both the LcType and the IpAddressType if the eviction thread
+        // has not run. Triggering the eviction thread will evict the oldest type (the LcType) leaving just
+        // the IpAddressType. This sets the condition for creating a new instance of the LcType below.
         factory.cleanup();
 
         // creating a new LcType should return a new instance due to the low cache size

--- a/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/TypeFactoryTest.java
@@ -47,13 +47,13 @@ public class TypeFactoryTest {
 
         Type<?> typeOne = factory.createType(LcType.class.getName());
 
-        // the Caffeine cache is not immediately consistent so give the eviction thread time to do its job.
-        for (int i = 0; i < 50; i++) {
-            Type<?> left = factory.createType(IpAddressType.class.getName());
-            Type<?> right = factory.createType(IpAddressType.class.getName());
-            // same type created in a row with a cache size of one will return the same type instance
-            assertSame(left, right);
-        }
+        Type<?> left = factory.createType(IpAddressType.class.getName());
+        Type<?> right = factory.createType(IpAddressType.class.getName());
+        // same type created in a row with a cache size of one will return the same type instance
+        assertSame(left, right);
+
+        // trigger maintenance task to evict the LcType
+        factory.cleanup();
 
         // creating a new LcType should return a new instance due to the low cache size
         Type<?> typeFour = factory.createType(LcType.class.getName());


### PR DESCRIPTION
The fix is an additional call to `factory.cleanup()`