### PR TITLE
Replace StringBuffer with StringBuilder

### DIFF
--- a/core/utils/type-utils/src/test/java/datawave/data/normalizer/GeometryNormalizerTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/normalizer/GeometryNormalizerTest.java
@@ -98,7 +98,7 @@ public class GeometryNormalizerTest {
 
         assertEquals(3746, allRanges.size());
 
-        StringBuffer result = new StringBuffer();
+        StringBuilder result = new StringBuilder();
         for (ByteArrayRange range : allRanges) {
             result.append(Hex.encodeHexString(range.getStart()));
             result.append(Hex.encodeHexString(range.getEnd()));

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDataTypeHandler.java
@@ -351,7 +351,7 @@ public class ProtobufEdgeDataTypeHandler<KEYIN,KEYOUT,VALUEOUT> implements Exten
 
         log.info("Found edge definitions for " + edges.keySet().size() + " data types.");
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("Data Types With Defined Edges: ");
         for (String t : edges.keySet()) {
             sb.append(t).append(" ");

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/Identity.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/Identity.java
@@ -9,7 +9,7 @@ public class Identity {
     private String hasher = "MD5";
     private MessageDigest md;
     private static final String HEXITS = "0123456789abcdef";
-    private StringBuffer sb = new StringBuffer();
+    private StringBuilder sb = new StringBuilder();
     private static Logger log = Logger.getLogger(Identity.class);
 
     public Identity() {
@@ -44,7 +44,7 @@ public class Identity {
     }
 
     public String toHex(byte[] me) {
-        StringBuffer buf = new StringBuffer(me.length * 2);
+        StringBuilder buf = new StringBuilder(me.length * 2);
 
         for (int i = 0; i < me.length; i++) {
             buf.append(HEXITS.charAt((me[i] >>> 4) & 0xf));

--- a/warehouse/query-core/src/main/java/datawave/query/planner/rules/RegexReplacementTransformRule.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/rules/RegexReplacementTransformRule.java
@@ -49,7 +49,7 @@ public class RegexReplacementTransformRule implements NodeTransformRule {
     private String processPattern(String regex) {
         boolean changed = false;
         Matcher matcher = pattern.matcher(regex);
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (matcher.find()) {
             matcher.appendReplacement(sb, replacement);
             changed = true;

--- a/warehouse/query-core/src/main/java/datawave/query/util/cache/DatatypeLoader.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/cache/DatatypeLoader.java
@@ -118,7 +118,7 @@ public class DatatypeLoader extends AccumuloLoader<String,Multimap<String,Type<?
                     String row = key.getRow().toString().toUpperCase();
 
                     if (reverse)
-                        row = new StringBuffer(row).reverse().toString();
+                        row = new StringBuilder(row).reverse().toString();
 
                     Multimap<String,Type<?>> typedNormalizers = entryCache.get(row);
 

--- a/warehouse/query-core/src/main/java/datawave/query/util/cache/IndexedFieldLoader.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/cache/IndexedFieldLoader.java
@@ -131,7 +131,7 @@ public class IndexedFieldLoader extends AccumuloLoader<String,Set<String>> {
                     String row = key.getRow().toString().toUpperCase();
 
                     if (reverse)
-                        row = new StringBuffer(row).reverse().toString();
+                        row = new StringBuilder(row).reverse().toString();
 
                     Set<String> typedNormalizers = entryCache.get(row);
 

--- a/warehouse/query-core/src/main/java/datawave/query/util/cache/NormalizerLoader.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/cache/NormalizerLoader.java
@@ -121,7 +121,7 @@ public class NormalizerLoader extends AccumuloLoader<String,Multimap<String,Type
                     String row = key.getRow().toString().toUpperCase();
 
                     if (reverse)
-                        row = new StringBuffer(row).reverse().toString();
+                        row = new StringBuilder(row).reverse().toString();
 
                     Multimap<String,Type<?>> typedNormalizers = entryCache.get(row);
 


### PR DESCRIPTION
## Summary
Replace legacy `StringBuffer` usage with `StringBuilder` for improved performance. `StringBuilder` is preferred for single-threaded use as it is not synchronized (introduced in Java 5).

## Files Changed
- `Identity.java` - 2 changes
- `RegexReplacementTransformRule.java` - 1 change
- `IndexedFieldLoader.java` - 1 change
- `DatatypeLoader.java` - 1 change
- `NormalizerLoader.java` - 1 change
- `ProtobufEdgeDataTypeHandler.java` - 1 change
- `GeometryNormalizerTest.java` - 1 change

All usages are local variables or fields used in single-threaded contexts, making this a safe mechanical replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)