### PR TITLE
Replace non-public ClassLoaderUtil with standard Java reflection

### DIFF
--- a/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryInstanceOperations.java
+++ b/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryInstanceOperations.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.admin.ActiveCompaction;
@@ -97,8 +96,8 @@ class InMemoryInstanceOperations implements InstanceOperations {
     @Override
     public boolean testClassLoad(String className, String asTypeName) throws AccumuloException, AccumuloSecurityException {
         try {
-            ClassLoaderUtil.loadClass(className, Class.forName(asTypeName));
-        } catch (ClassNotFoundException e) {
+            Class.forName(className).asSubclass(Class.forName(asTypeName));
+        } catch (ClassNotFoundException | ClassCastException e) {
             log.warn("Could not find class named '" + className + "' in testClassLoad.", e);
             return false;
         }

--- a/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryNamespaceOperations.java
+++ b/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryNamespaceOperations.java
@@ -25,7 +25,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 
-import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceExistsException;
@@ -128,8 +127,8 @@ class InMemoryNamespaceOperations extends NamespaceOperationsHelper {
     public boolean testClassLoad(String namespace, String className, String asTypeName)
                     throws AccumuloException, AccumuloSecurityException, NamespaceNotFoundException {
         try {
-            ClassLoaderUtil.loadClass(className, Class.forName(asTypeName));
-        } catch (ClassNotFoundException e) {
+            Class.forName(className).asSubclass(Class.forName(asTypeName));
+        } catch (ClassNotFoundException | ClassCastException e) {
             log.warn("Could not load class '" + className + "' with type name '" + asTypeName + "' in testClassLoad()", e);
             return false;
         }

--- a/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryTableOperations.java
+++ b/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryTableOperations.java
@@ -33,7 +33,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 
-import org.apache.accumulo.core.classloader.ClassLoaderUtil;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -532,8 +531,8 @@ public class InMemoryTableOperations extends TableOperationsHelper {
     public boolean testClassLoad(String tableName, String className, String asTypeName)
                     throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
         try {
-            ClassLoaderUtil.loadClass(className, Class.forName(asTypeName));
-        } catch (ClassNotFoundException e) {
+            Class.forName(className).asSubclass(Class.forName(asTypeName));
+        } catch (ClassNotFoundException | ClassCastException e) {
             log.warn("Could not load class '" + className + "' with type name '" + asTypeName + "' in testClassLoad().", e);
             return false;
         }


### PR DESCRIPTION
## Summary
- Replace non-public `org.apache.accumulo.core.classloader.ClassLoaderUtil` with standard Java reflection
- Use `Class.forName(className).asSubclass(Class.forName(asTypeName))` which provides equivalent functionality

## Files Changed
- `core/in-memory-accumulo/.../InMemoryTableOperations.java`
- `core/in-memory-accumulo/.../InMemoryNamespaceOperations.java`
- `core/in-memory-accumulo/.../InMemoryInstanceOperations.java`

Fixes #3163
Part of #2443

🤖 Generated with [Claude Code](https://claude.com/claude-code)