### PR TITLE
Remove deprecated TabletLocator methods

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownFunction.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.clientImpl.TabletLocator;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.hadoop.io.Text;
@@ -41,13 +40,8 @@ public class PushdownFunction implements Function<QueryData,List<ScannerChunk>> 
     // table id, used to apply execution hints
     protected TableId tableId;
 
-    @Deprecated
-    public PushdownFunction(TabletLocator tabletLocator, ShardQueryConfiguration config, Collection<IteratorSetting> settings, TableId tableId) {
-        this(config, settings, tableId);
-    }
-
     /**
-     * Preferred constructor
+     * Constructor
      *
      * @param config
      *            the config

--- a/warehouse/query-core/src/main/java/datawave/query/tables/BatchScannerSession.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/BatchScannerSession.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.accumulo.core.client.ScannerBase;
-import org.apache.accumulo.core.clientImpl.TabletLocator;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
@@ -729,11 +728,6 @@ public class BatchScannerSession extends ScannerSession implements Iterator<Resu
     public void addVisitor(Function<ScannerChunk,ScannerChunk> visitorFunction) {
         visitorFunctions.add(visitorFunction);
 
-    }
-
-    @Deprecated(forRemoval = true)
-    public void setTabletLocator(TabletLocator tl) {
-        // no-op
     }
 
     public void setBackoffEnabled(boolean backoffEnabled) {


### PR DESCRIPTION
## Summary
Remove deprecated methods that use non-public TabletLocator class.

## Files Changed
- `BatchScannerSession.java` - Remove `setTabletLocator(TabletLocator)` method (was a no-op)
- `PushdownFunction.java` - Remove constructor with TabletLocator parameter

## Notes
These methods were deprecated in PR #3246 and are no longer functional since TabletLocator usage was removed from BulkInputFormat.

Fixes #3319
Part of #2443