### PR TITLE
Migrate ShapesTest to use index table names

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -318,10 +318,6 @@ public class ColorsTest {
                 case TestIndexTableNames.TRUNCATED_INDEX:
                     logic.setUseTruncatedIndex(true);
                     break;
-                case TestIndexTableNames.SHARDED_DAY_INDEX:
-                case TestIndexTableNames.SHARDED_YEAR_INDEX:
-                    logic.setUseShardedIndex(true);
-                    break;
                 default:
                     throw new IllegalStateException("Unknown index table name " + indexTableName);
             }
@@ -335,10 +331,6 @@ public class ColorsTest {
                     break;
                 case TestIndexTableNames.TRUNCATED_INDEX:
                     logic.setUseTruncatedIndex(false);
-                    break;
-                case TestIndexTableNames.SHARDED_DAY_INDEX:
-                case TestIndexTableNames.SHARDED_YEAR_INDEX:
-                    logic.setUseShardedIndex(false);
                     break;
                 default:
                     throw new IllegalStateException("Unknown index table name " + indexTableName);

--- a/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
@@ -67,12 +67,14 @@ import datawave.query.attributes.Document;
 import datawave.query.attributes.TypeAttribute;
 import datawave.query.exceptions.InvalidQueryException;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.ShapesIngest;
+import datawave.query.util.TestIndexTableNames;
 import datawave.test.HitTermAssertions;
 import datawave.util.TableName;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
@@ -86,7 +88,8 @@ import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
  * {@link IteratorChain} in a way that is incompatible with Accumulo's {@link SeekingFilter}. Namely, during a rebuild on a next call the ScannerHelper's call
  * to 'ChainIterator.next' will swap in a whole new seeking filter in a way that causes the call to 'range.clip' on SeekingFilter#222 to return null.
  */
-public abstract class ShapesTest {
+@RunWith(Arquillian.class)
+public class ShapesTest {
 
     private static final Logger log = LoggerFactory.getLogger(ShapesTest.class);
     protected Authorizations auths = new Authorizations("ALL");
@@ -102,6 +105,7 @@ public abstract class ShapesTest {
     @Inject
     @SpringBean(name = "EventQuery")
     protected ShardQueryLogic logic;
+
     protected KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
     private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
     private AccumuloClient clientForTest;
@@ -130,72 +134,31 @@ public abstract class ShapesTest {
 
     private final Set<String> allTypes = Sets.newHashSet("triangle", "quadrilateral", "pentagon", "hexagon", "octagon");
 
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends ShapesTest {
+    protected static AccumuloClient client = null;
 
-        protected static AccumuloClient client = null;
+    private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
-        @BeforeClass
-        public static void setUp() throws Exception {
-            MiniAccumuloConfig cfg = new MiniAccumuloConfig(temporaryFolder.newFolder(), PASSWORD);
-            cfg.setNumTservers(1);
-            mac = new MiniAccumuloCluster(cfg);
-            mac.start();
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MiniAccumuloConfig cfg = new MiniAccumuloConfig(temporaryFolder.newFolder(), PASSWORD);
+        cfg.setNumTservers(1);
+        mac = new MiniAccumuloCluster(cfg);
+        mac.start();
 
-            client = mac.createAccumuloClient("root", new PasswordToken(PASSWORD));
-            ShapesIngest.writeData(client, ShapesIngest.RangeType.SHARD);
+        client = mac.createAccumuloClient("root", new PasswordToken(PASSWORD));
+        ShapesIngest.writeData(client, ShapesIngest.RangeType.SHARD);
 
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
+        Authorizations auths = new Authorizations("ALL");
+        ingestUtil.write(client, auths);
 
-        @Before
-        public void beforeEach() throws IOException {
-            super.beforeEach();
-            setClientForTest(client);
-            logic.setCollapseUids(true);
-        }
-
-        @AfterClass
-        public static void tearDown() throws Exception {
-            mac.stop();
-        }
+        PrintUtility.printTable(client, auths, TableName.SHARD);
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
     }
 
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends ShapesTest {
-        protected static AccumuloClient client = null;
-
-        @BeforeClass
-        public static void setUp() throws Exception {
-            MiniAccumuloConfig cfg = new MiniAccumuloConfig(temporaryFolder.newFolder(), PASSWORD);
-            cfg.setNumTservers(1);
-
-            mac = new MiniAccumuloCluster(cfg);
-            mac.start();
-
-            client = mac.createAccumuloClient("root", new PasswordToken(PASSWORD));
-            ShapesIngest.writeData(client, ShapesIngest.RangeType.DOCUMENT);
-
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void beforeEach() throws IOException {
-            super.beforeEach();
-            setClientForTest(client);
-            logic.setCollapseUids(false);
-        }
-
-        @AfterClass
-        public static void tearDown() throws Exception {
-            mac.stop();
-        }
+    @AfterClass
+    public static void tearDown() throws Exception {
+        mac.stop();
     }
 
     @Deployment
@@ -218,6 +181,8 @@ public abstract class ShapesTest {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         resetState();
 
+        setClientForTest(client);
+
         URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
         Preconditions.checkNotNull(hadoopConfig);
         logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
@@ -234,6 +199,8 @@ public abstract class ShapesTest {
         // every test also exercises hit terms
         withParameter(QueryParameters.HIT_LIST, "true");
         logic.setHitList(true);
+
+        logic.setCollapseUids(false); // index table will either have uids or not
     }
 
     @After
@@ -331,10 +298,40 @@ public abstract class ShapesTest {
     }
 
     public ShapesTest planAndExecuteQuery() throws Exception {
-        planQuery();
-        executeQuery();
-        assertUuids();
-        assertHitTerms();
+        for (String indexTableName : TestIndexTableNames.names()) {
+            log.debug("=== using index: {} ===", indexTableName);
+            logic.setIndexTableName(indexTableName);
+
+            switch (indexTableName) {
+                case TestIndexTableNames.SHARD_INDEX:
+                case TestIndexTableNames.NO_UID_INDEX:
+                    break;
+                case TestIndexTableNames.TRUNCATED_INDEX:
+                    logic.setUseTruncatedIndex(true);
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
+            }
+
+            // the backing config is stateful, have to reset the datatype filter
+            logic.getConfig().setDatatypeFilter(Collections.emptySet());
+
+            planQuery();
+            executeQuery();
+            assertUuids();
+            assertHitTerms();
+
+            switch (indexTableName) {
+                case TestIndexTableNames.SHARD_INDEX:
+                case TestIndexTableNames.NO_UID_INDEX:
+                    break;
+                case TestIndexTableNames.TRUNCATED_INDEX:
+                    logic.setUseTruncatedIndex(false);
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
+            }
+        }
         return this;
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -2,7 +2,6 @@ package datawave.query;
 
 import javax.inject.Inject;
 
-import datawave.util.TableName;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -27,6 +26,7 @@ import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.SizesIngest;
 import datawave.query.util.TestIndexTableNames;
+import datawave.util.TableName;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
@@ -37,12 +37,12 @@ public class SizesTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(SizesTest.class);
 
-    //  static utilities for test
+    // static utilities for test
     private static final InMemoryInstance instance = new InMemoryInstance(SizesTest.class.getName());
     private static AccumuloClient clientForSetup;
     private static SizesIngest ingest;
 
-    //  utility for writing different index table structures
+    // utility for writing different index table structures
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
     @Inject
@@ -119,7 +119,7 @@ public class SizesTest extends AbstractQueryTest {
             planQuery();
             executeQuery();
             assertPlannedQuery();
-            //  TODO: while generating random events also generate metadata so the framework can assert result counts
+            // TODO: while generating random events also generate metadata so the framework can assert result counts
 
             switch (indexTableName) {
                 case TestIndexTableNames.SHARD_INDEX:

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -2,6 +2,7 @@ package datawave.query;
 
 import javax.inject.Inject;
 
+import datawave.util.TableName;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,9 +37,13 @@ public class SizesTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(SizesTest.class);
 
-    private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
-
+    //  static utilities for test
+    private static final InMemoryInstance instance = new InMemoryInstance(SizesTest.class.getName());
     private static AccumuloClient clientForSetup;
+    private static SizesIngest ingest;
+
+    //  utility for writing different index table structures
+    private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
     @Inject
     @SpringBean(name = "EventQuery")
@@ -66,10 +71,9 @@ public class SizesTest extends AbstractQueryTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        InMemoryInstance instance = new InMemoryInstance(SizesTest.class.getName());
         clientForSetup = new InMemoryAccumuloClient("", instance);
 
-        SizesIngest ingest = new SizesIngest(clientForSetup);
+        ingest = new SizesIngest(clientForSetup);
         ingest.write();
 
         ingestUtil.write(clientForSetup, auths);
@@ -99,14 +103,13 @@ public class SizesTest extends AbstractQueryTest {
             logic.setIndexTableName(indexTableName);
             switch (indexTableName) {
                 case TestIndexTableNames.SHARD_INDEX:
+                    logic.setIndexTableName(TableName.SHARD_INDEX);
+                    break;
                 case TestIndexTableNames.NO_UID_INDEX:
+                    logic.setIndexTableName(TestIndexTableNames.NO_UID_INDEX);
                     break;
                 case TestIndexTableNames.TRUNCATED_INDEX:
                     logic.setUseTruncatedIndex(true);
-                    break;
-                case TestIndexTableNames.SHARDED_DAY_INDEX:
-                case TestIndexTableNames.SHARDED_YEAR_INDEX:
-                    logic.setUseShardedIndex(true);
                     break;
                 default:
                     throw new IllegalStateException("Unknown index table name " + indexTableName);
@@ -115,7 +118,8 @@ public class SizesTest extends AbstractQueryTest {
             log.debug("=== using index: {} ===", indexTableName);
             planQuery();
             executeQuery();
-            // TODO: assert based on test metadata
+            assertPlannedQuery();
+            //  TODO: while generating random events also generate metadata so the framework can assert result counts
 
             switch (indexTableName) {
                 case TestIndexTableNames.SHARD_INDEX:
@@ -123,10 +127,6 @@ public class SizesTest extends AbstractQueryTest {
                     break;
                 case TestIndexTableNames.TRUNCATED_INDEX:
                     logic.setUseTruncatedIndex(false);
-                    break;
-                case TestIndexTableNames.SHARDED_DAY_INDEX:
-                case TestIndexTableNames.SHARDED_YEAR_INDEX:
-                    logic.setUseShardedIndex(false);
                     break;
                 default:
                     throw new IllegalStateException("Unknown index table name " + indexTableName);
@@ -137,60 +137,73 @@ public class SizesTest extends AbstractQueryTest {
     @Test
     public void testSizeSmall() throws Exception {
         withQuery("SIZE == 'small'");
+        withQueryPlan("SIZE == 'small'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeSmallAndUniqueColor() throws Exception {
         withQuery("SIZE == 'small' && f:unique(COLOR)");
+        withQueryPlan("SIZE == 'small'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeMediumAndUniqueColor() throws Exception {
         withQuery("SIZE == 'medium' && f:unique(COLOR)");
+        withQueryPlan("SIZE == 'medium'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeLargeAndUniqueColor() throws Exception {
         withQuery("SIZE == 'large' && f:unique(COLOR)");
+        withQueryPlan("SIZE == 'large'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeSmallAndGroupByColorShape() throws Exception {
         withQuery("SIZE == 'small' && f:groupby(COLOR,SHAPE)");
+        withQueryPlan("SIZE == 'small'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testAllSizesAndGroupByColorShapeSize() throws Exception {
         withQuery("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large') && f:groupby(COLOR,SHAPE,SIZE)");
+        withQueryPlan("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large')");
+        withResultCount(ingest.getNumShards() * ingest.getNumEventsPerShard());
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeMedium() throws Exception {
         withQuery("SIZE == 'medium'");
+        withQueryPlan("SIZE == 'medium'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeLarge() throws Exception {
         withQuery("SIZE == 'large'");
+        withQueryPlan("SIZE == 'large'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testAllSizes() throws Exception {
         withQuery("SIZE == 'small' || SIZE == 'medium' ||  SIZE == 'large'");
+        withQueryPlan("SIZE == 'small' || SIZE == 'medium' ||  SIZE == 'large'");
+        withResultCount(ingest.getNumShards() * ingest.getNumEventsPerShard());
         planAndExecuteQuery();
     }
 
     @Test
     public void testRandomQuery() throws Exception {
         withQuery("SIZE == 'small' && COLOR == 'green' && SHAPE == 'triangle'");
+        withQueryPlan("SIZE == 'small' && COLOR == 'green' && SHAPE == 'triangle'");
+        withResultCount(0);
         planAndExecuteQuery();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractQueryTest {
     private final Set<String> expected = new HashSet<>();
     private final Set<Document> results = new HashSet<>();
 
-    //  additional variables for declarative assertions
+    // additional variables for declarative assertions
     private String plannedQuery = null;
     private int expectedResultCount = -1;
 
@@ -129,7 +129,7 @@ public abstract class AbstractQueryTest {
         hitTermAssertions.withRequiredAnyOf(hitTerms);
     }
 
-    public void withQueryPlan(String queryPlan){
+    public void withQueryPlan(String queryPlan) {
         this.plannedQuery = queryPlan;
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -1,6 +1,7 @@
 package datawave.query.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -77,6 +78,10 @@ public abstract class AbstractQueryTest {
     private final Set<String> expected = new HashSet<>();
     private final Set<Document> results = new HashSet<>();
 
+    //  additional variables for declarative assertions
+    private String plannedQuery = null;
+    private int expectedResultCount = -1;
+
     public abstract ShardQueryLogic getLogic();
 
     @After
@@ -87,6 +92,8 @@ public abstract class AbstractQueryTest {
         parameters.clear();
         expected.clear();
         results.clear();
+        plannedQuery = null;
+        expectedResultCount = -1;
     }
 
     public void withQuery(String query) {
@@ -120,6 +127,14 @@ public abstract class AbstractQueryTest {
      */
     public void withRequiredAnyOf(String... hitTerms) {
         hitTermAssertions.withRequiredAnyOf(hitTerms);
+    }
+
+    public void withQueryPlan(String queryPlan){
+        this.plannedQuery = queryPlan;
+    }
+
+    public void withResultCount(int expectedResultCount) {
+        this.expectedResultCount = expectedResultCount;
     }
 
     public void planAndExecuteQuery() throws Exception {
@@ -160,7 +175,12 @@ public abstract class AbstractQueryTest {
         log.info("query retrieved {} results", results.size());
     }
 
+    public void assertResultCount() {
+        assertResultCount(expectedResultCount);
+    }
+
     public void assertResultCount(int expected) {
+        assertNotEquals("Expected result count not set", -1, expected);
         assertEquals(expected, results.size());
     }
 
@@ -171,6 +191,11 @@ public abstract class AbstractQueryTest {
             assertEquals(hitTermAssertions.hitTermExpected(), validated);
         }
         hitTermAssertions.resetState();
+    }
+
+    public void assertPlannedQuery() {
+        assertNotNull("Expected query plan not set", plannedQuery);
+        assertPlannedQuery(plannedQuery);
     }
 
     public void assertPlannedQuery(String query) {

--- a/warehouse/query-core/src/test/java/datawave/query/util/SizesIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/SizesIngest.java
@@ -330,6 +330,10 @@ public class SizesIngest {
         return NUM_SHARDS;
     }
 
+    public int getNumEventsPerShard() {
+        return EVENTS_PER_SHARD;
+    }
+
     protected String normalizerNameForField(String field) {
         switch (field) {
             case "COLOR":

--- a/warehouse/query-core/src/test/java/datawave/query/util/TestIndexTableNames.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/TestIndexTableNames.java
@@ -4,19 +4,26 @@ import java.util.List;
 
 import datawave.util.TableName;
 
+/**
+ * This utility allows unit tests to iterate through all possible global index table formats
+ * <p>
+ * A standard shard index contains uids
+ * <p>
+ * A 'no uid' index does not contain uids
+ * <p>
+ * A truncated index collapses all keys for a day and tracks shard offsets in a bitset
+ */
 public class TestIndexTableNames {
 
     public static final String SHARD_INDEX = TableName.SHARD_INDEX;
     public static final String NO_UID_INDEX = "noUidIndex";
     public static final String TRUNCATED_INDEX = TableName.TRUNCATED_SHARD_INDEX;
-    public static final String SHARDED_DAY_INDEX = TableName.SHARD_DAY_INDEX;
-    public static final String SHARDED_YEAR_INDEX = TableName.SHARD_YEAR_INDEX;
 
     private TestIndexTableNames() {
         // enforce static access
     }
 
     public static List<String> names() {
-        return List.of(SHARD_INDEX, NO_UID_INDEX, TRUNCATED_INDEX, SHARDED_DAY_INDEX, SHARDED_YEAR_INDEX);
+        return List.of(SHARD_INDEX, NO_UID_INDEX, TRUNCATED_INDEX);
     }
 }


### PR DESCRIPTION
- removed sharded index tables from the test rotation until better support exists
- migrate ShapesTest to use index table names