### PR TITLE
Fix incorrect WrappedConnector check in ScannerFactory

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/ScannerFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ScannerFactory.java
@@ -33,7 +33,7 @@ import datawave.mr.bulk.RfileScanner;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.stats.ScanSessionStats;
 import datawave.query.util.QueryScannerHelper;
-import datawave.webservice.common.connection.WrappedConnector;
+import datawave.webservice.common.connection.WrappedAccumuloClient;
 
 public class ScannerFactory {
 
@@ -136,7 +136,7 @@ public class ScannerFactory {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("Created ScannerFactory {}, wrapped={}", System.identityHashCode(this), (client instanceof WrappedConnector));
+            log.debug("Created ScannerFactory {}, wrapped={}", System.identityHashCode(this), (client instanceof WrappedAccumuloClient));
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `WrappedConnector` with `WrappedAccumuloClient` in debug log check
- The client field is `AccumuloClient`, not `Connector`

Fixes #3335
Part of #2443