### PR TITLE
Replace IterationInterruptedException with class name check

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
@@ -14,7 +14,6 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +25,7 @@ import datawave.next.async.RunnableWithContext;
 import datawave.next.stats.DocIdQueryIteratorStats;
 import datawave.next.stats.DocumentIteratorStats;
 import datawave.query.iterator.QueryOptions;
+import datawave.query.util.AccumuloExceptionUtils;
 
 /**
  * A runnable that handles async scanning of a tablet to find document candidates.
@@ -65,8 +65,12 @@ public class DocumentIdProducer implements RunnableWithContext {
                 try {
                     executeScan();
                     executing = false;
-                } catch (IterationInterruptedException e) {
-                    log.warn("time sliced, resubmitting scan for {}", getContext());
+                } catch (RuntimeException e) {
+                    if (AccumuloExceptionUtils.isIterationInterruptedException(e)) {
+                        log.warn("time sliced, resubmitting scan for {}", getContext());
+                    } else {
+                        throw e;
+                    }
                 }
             }
         } catch (Exception e) {

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
@@ -16,7 +16,6 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.accumulo.core.security.Authorizations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +30,7 @@ import datawave.next.retrieval.DocumentIterator;
 import datawave.next.retrieval.DocumentIteratorOptions;
 import datawave.next.stats.ScanTimeStats;
 import datawave.query.iterator.QueryOptions;
+import datawave.query.util.AccumuloExceptionUtils;
 
 /**
  * Retrieves the document specified by the {@link KeyWithContext}.
@@ -95,8 +95,12 @@ public class DocumentRangeScan implements RunnableWithContext {
                         executeDocumentScan();
                     }
                     executing = false;
-                } catch (IterationInterruptedException e) {
-                    log.warn("time sliced, resubmitting scan for {}", getContext());
+                } catch (RuntimeException e) {
+                    if (AccumuloExceptionUtils.isIterationInterruptedException(e)) {
+                        log.warn("time sliced, resubmitting scan for {}", getContext());
+                    } else {
+                        throw e;
+                    }
                 }
             }
         } catch (Exception e) {

--- a/warehouse/query-core/src/main/java/datawave/query/function/AbstractVersionFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/AbstractVersionFilter.java
@@ -19,7 +19,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparator;
@@ -33,6 +32,7 @@ import datawave.data.type.util.NumericalEncoder;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.iterator.SourcedOptions;
+import datawave.query.util.AccumuloExceptionUtils;
 
 /**
  * This filter validates events in the shard table based on their association with one or more configured data types and number-normalized "version" fields
@@ -693,11 +693,14 @@ public abstract class AbstractVersionFilter<A> {
                     isValid = validate(range);
                 }
             }
-        } catch (final IterationInterruptedException e) {
+        } catch (final RuntimeException e) {
             // Re-throw iteration interrupted as-is since this is an expected event from
             // a client going away. Re-throwing as-is will let the
             // tserver catch and ignore it as intended.
-            throw e;
+            if (AccumuloExceptionUtils.isIterationInterruptedException(e)) {
+                throw e;
+            }
+            throw new RuntimeException("error determining version applicability for " + range, e);
         } catch (final Exception e) {
             throw new IOException("Unable to validate uid " + uid + " for data type " + dataType, e);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/function/DescendantCountFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/DescendantCountFunction.java
@@ -19,7 +19,6 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
-import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
@@ -32,6 +31,7 @@ import datawave.data.hash.UID;
 import datawave.data.hash.UIDConstants;
 import datawave.query.Constants;
 import datawave.query.iterator.QueryOptions;
+import datawave.query.util.AccumuloExceptionUtils;
 import datawave.query.util.Tuple3;
 
 /**
@@ -327,12 +327,15 @@ public class DescendantCountFunction implements SourcedFunction<Tuple3<Range,Key
 
             // and return the count
             return uids.size();
-        } catch (IterationInterruptedException e) {
+        } catch (RuntimeException e) {
             // Re-throw iteration interrupted as-is since this is an expected event from
             // a client going away. Re-throwing as an IOException will cause the tserver
             // to catch the exception and log a warning. Re-throwing as-is will let the
             // tserver catch and ignore it as intended.
-            throw e;
+            if (AccumuloExceptionUtils.isIterationInterruptedException(e)) {
+                throw e;
+            }
+            throw new IOException("Error aggregating event", e);
         } catch (Exception e) {
             throw new IOException("Error aggregating event", e);
         }
@@ -425,12 +428,15 @@ public class DescendantCountFunction implements SourcedFunction<Tuple3<Range,Key
             final CountResult result = new CountResult(numberOfImmediateChildren, numberOfDescendants);
             result.setSkippedDescendants(skippedSomeDescendants);
             return result;
-        } catch (IterationInterruptedException e) {
+        } catch (RuntimeException e) {
             // Re-throw iteration interrupted as-is since this is an expected event from
             // a client going away. Re-throwing as an IOException will cause the tserver
             // to catch the exception and log a warning. Re-throwing as-is will let the
             // tserver catch and ignore it as intended.
-            throw e;
+            if (AccumuloExceptionUtils.isIterationInterruptedException(e)) {
+                throw e;
+            }
+            throw new IOException("Error aggregating event", e);
         } catch (Exception e) {
             throw new IOException("Error aggregating event", e);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/AndIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/AndIterator.java
@@ -16,7 +16,6 @@ import java.util.TreeSet;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 
@@ -29,6 +28,7 @@ import datawave.query.iterator.NestedIterator;
 import datawave.query.iterator.Util;
 import datawave.query.iterator.Util.Transformer;
 import datawave.query.iterator.waitwindow.WaitWindowObserver;
+import datawave.query.util.AccumuloExceptionUtils;
 
 /**
  * Performs a merge join of the child iterators. It is expected that all child iterators return values in sorted order.
@@ -380,12 +380,15 @@ public class AndIterator<T extends Comparable<T>> implements NestedIterator<T> {
             try {
                 try {
                     child.seek(range, columnFamilies, inclusive);
-                } catch (IterationInterruptedException e2) {
-                    // throw IterationInterrupted exceptions as-is with no modifications so the QueryIterator can handle it
-                    throw e2;
                 } catch (WaitWindowOverrunException e) {
                     log.debug(id + ": AndIterator.seek() passing through WaitWindowOverrunException: " + e.getMessage());
                     throw e;
+                } catch (RuntimeException e2) {
+                    // throw IterationInterrupted exceptions as-is with no modifications so the QueryIterator can handle it
+                    if (AccumuloExceptionUtils.isIterationInterruptedException(e2)) {
+                        throw e2;
+                    }
+                    throw e2;
                 } catch (Exception e2) {
                     if (child.isNonEventField()) {
                         // dropping a non-event term from the query means that the accuracy of the query
@@ -404,8 +407,11 @@ public class AndIterator<T extends Comparable<T>> implements NestedIterator<T> {
                 // When comparing possible yield keys in the AndIterator, we choose the highest
                 // key because the uids of the sources need to be equal to return a match
                 this.waitWindowObserver.propagateException(null, true, false, e);
-            } catch (IterationInterruptedException iie) {
+            } catch (RuntimeException iie) {
                 // allow the QueryIterator to handle these exceptions
+                if (AccumuloExceptionUtils.isIterationInterruptedException(iie)) {
+                    throw iie;
+                }
                 throw iie;
             } catch (Exception e) {
                 include.remove();
@@ -543,8 +549,11 @@ public class AndIterator<T extends Comparable<T>> implements NestedIterator<T> {
             } catch (WaitWindowOverrunException wwoe) {
                 log.debug(id + ": AndIterator.advanceIterators() passing through WaitWindowOverrunException: " + wwoe.getMessage());
                 throw wwoe;
-            } catch (IterationInterruptedException ie) {
+            } catch (RuntimeException ie) {
                 // allow the QueryIterator to handle these exceptions
+                if (AccumuloExceptionUtils.isIterationInterruptedException(ie)) {
+                    throw ie;
+                }
                 throw ie;
             } catch (Exception e) {
                 seenException = true;

--- a/warehouse/query-core/src/main/java/datawave/query/util/AccumuloExceptionUtils.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/AccumuloExceptionUtils.java
@@ -1,0 +1,78 @@
+package datawave.query.util;
+
+/**
+ * Utility methods for handling Accumulo exceptions without importing non-public APIs.
+ * <p>
+ * These methods check exception types by class name to avoid dependencies on non-public Accumulo APIs that may change between versions.
+ */
+public final class AccumuloExceptionUtils {
+
+    private static final String ITERATION_INTERRUPTED_EXCEPTION = "org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException";
+    private static final String TABLET_CLOSED_EXCEPTION = "org.apache.accumulo.tserver.tablet.TabletClosedException";
+    private static final String SCAN_TIMED_OUT_EXCEPTION = "org.apache.accumulo.core.clientImpl.ThriftScanner$ScanTimedOutException";
+
+    private AccumuloExceptionUtils() {
+        // utility class
+    }
+
+    /**
+     * Check if the throwable is an IterationInterruptedException.
+     * <p>
+     * This is thrown by Accumulo when an iteration is interrupted, typically due to a client disconnecting or a scan timeout.
+     *
+     * @param t
+     *            the throwable to check
+     * @return true if the throwable is an IterationInterruptedException
+     */
+    public static boolean isIterationInterruptedException(Throwable t) {
+        return isExceptionOfType(t, ITERATION_INTERRUPTED_EXCEPTION);
+    }
+
+    /**
+     * Check if the throwable is a TabletClosedException.
+     * <p>
+     * This is thrown by Accumulo when a tablet server closes a tablet during a scan.
+     *
+     * @param t
+     *            the throwable to check
+     * @return true if the throwable is a TabletClosedException
+     */
+    public static boolean isTabletClosedException(Throwable t) {
+        return isExceptionOfType(t, TABLET_CLOSED_EXCEPTION);
+    }
+
+    /**
+     * Check if the throwable is a ScanTimedOutException.
+     * <p>
+     * This is thrown by Accumulo when a scan times out.
+     *
+     * @param t
+     *            the throwable to check
+     * @return true if the throwable is a ScanTimedOutException
+     */
+    public static boolean isScanTimedOutException(Throwable t) {
+        return isExceptionOfType(t, SCAN_TIMED_OUT_EXCEPTION);
+    }
+
+    /**
+     * Check if the throwable or any of its causes is one of the known Accumulo interruption exceptions (IterationInterruptedException, TabletClosedException,
+     * ScanTimedOutException).
+     *
+     * @param t
+     *            the throwable to check
+     * @return true if any exception in the chain is an interruption exception
+     */
+    public static boolean isInterruptionException(Throwable t) {
+        while (t != null) {
+            if (isIterationInterruptedException(t) || isTabletClosedException(t) || isScanTimedOutException(t)) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
+    }
+
+    private static boolean isExceptionOfType(Throwable t, String className) {
+        return t != null && t.getClass().getName().equals(className);
+    }
+}


### PR DESCRIPTION
## Summary
- Add AccumuloExceptionUtils utility class to check for Accumulo exceptions by class name
- Replace direct imports of non-public IterationInterruptedException
- Updated 5 files to use the utility

## Files Changed
- **AccumuloExceptionUtils.java** (new) - Utility for checking Accumulo exception types by class name
- DocumentRangeScan.java
- DocumentIdProducer.java  
- DescendantCountFunction.java
- AbstractVersionFilter.java
- AndIterator.java

Fixes #3336
Part of #2443