### PR TITLE
Remove unused SortedMapIterator import from ArrayIterator

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/ArrayIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/ArrayIterator.java
@@ -8,7 +8,6 @@ import java.util.LinkedList;
 
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
 
 import datawave.query.attributes.Document;
 import datawave.query.iterator.NestedIterator;
@@ -16,7 +15,7 @@ import datawave.query.iterator.NestedIterator;
 /**
  * A leaf node in a nested iterator tree. This is supposed to be a sample iterator that returns data from a sorted array.
  * <p>
- * This class is deprecated. A suitable replacement is an {@link IndexIteratorBridge} using a {@link SortedMapIterator}.
+ * This class is deprecated. A suitable replacement is an {@link IndexIteratorBridge} using a SortedMapIterator.
  *
  * @param <T>
  *            the type of the array iterator


### PR DESCRIPTION
## Summary
- Remove unused import of non-public SortedMapIterator
- Update javadoc to not use @link for the removed import

Fixes #3337
Part of #2443