### PR TITLE
Replace ClientContext.getTableId with public API

### DIFF
--- a/core/connection-pool/src/main/java/datawave/core/common/connection/AccumuloConnectionFactory.java
+++ b/core/connection-pool/src/main/java/datawave/core/common/connection/AccumuloConnectionFactory.java
@@ -5,10 +5,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.clientImpl.ClientContext;
 
 import datawave.core.common.result.ConnectionPool;
-import datawave.webservice.common.connection.WrappedAccumuloClient;
 
 public interface AccumuloConnectionFactory extends AutoCloseable {
 
@@ -110,21 +108,4 @@ public interface AccumuloConnectionFactory extends AutoCloseable {
      * @return A map representation
      */
     Map<String,String> getTrackingMap(StackTraceElement[] stackTrace);
-
-    /**
-     * Utility method to unwrap the ClientContext instance within {@link WrappedAccumuloClient} as needed
-     *
-     * @param accumuloClient
-     *            {@link AccumuloClient} instance
-     * @return {@link WrappedAccumuloClient#getReal()}, if applicable; accumuloClient itself, if it implements {@link ClientContext}; otherwise returns null
-     */
-    static ClientContext getClientContext(AccumuloClient accumuloClient) {
-        ClientContext cc = null;
-        if (accumuloClient instanceof WrappedAccumuloClient) {
-            cc = (ClientContext) ((WrappedAccumuloClient) accumuloClient).getReal();
-        } else if (accumuloClient instanceof ClientContext) {
-            cc = (ClientContext) accumuloClient;
-        }
-        return cc;
-    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/scheduler/PushdownScheduler.java
@@ -14,7 +14,6 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.clientImpl.ClientContext;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.Value;
@@ -28,7 +27,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
-import datawave.core.common.connection.AccumuloConnectionFactory;
 import datawave.core.common.logging.ThreadConfigurableLogger;
 import datawave.core.query.configuration.QueryData;
 import datawave.core.query.configuration.Result;
@@ -156,8 +154,7 @@ public class PushdownScheduler extends Scheduler {
         if (client instanceof InMemoryAccumuloClient) {
             tableId = TableId.of(config.getTableName());
         } else {
-            ClientContext ctx = AccumuloConnectionFactory.getClientContext(client);
-            tableId = ctx.getTableId(tableName);
+            tableId = TableId.of(client.tableOperations().tableIdMap().get(tableName));
         }
 
         Iterator<List<ScannerChunk>> chunkIter = Iterators.transform(getQueryDataIterator(), getPushdownFunction());


### PR DESCRIPTION
## Summary
- Remove `getClientContext` utility from `AccumuloConnectionFactory`
- Update `PushdownScheduler` to use `tableOperations().tableIdMap()`

Fixes #3339
Part of #2443