### PR TITLE
Replace easy non-public Accumulo APIs

### DIFF
--- a/core/common-util/src/test/java/datawave/core/cache/CVCacheIT.java
+++ b/core/common-util/src/test/java/datawave/core/cache/CVCacheIT.java
@@ -15,7 +15,6 @@ import java.util.concurrent.Future;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
@@ -60,9 +59,10 @@ public class CVCacheIT {
             try {
                 cache.get(sequence);
             } catch (Exception e) {
-                boolean isBadArgumentException = e instanceof BadArgumentException;
+                // BadArgumentException extends IllegalArgumentException, so check for the parent type
+                boolean isIllegalArgumentException = e instanceof IllegalArgumentException;
                 boolean isUncheckedExecutionException = e instanceof UncheckedExecutionException;
-                assertTrue(isBadArgumentException || isUncheckedExecutionException);
+                assertTrue(isIllegalArgumentException || isUncheckedExecutionException);
             }
             count++;
         }

--- a/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryInstance.java
+++ b/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryInstance.java
@@ -31,8 +31,6 @@ import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.clientImpl.Credentials;
 import org.apache.accumulo.core.clientImpl.thrift.SecurityErrorCode;
-import org.apache.accumulo.core.util.ByteBufferUtil;
-import org.apache.accumulo.core.util.TextUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
@@ -122,12 +120,17 @@ public class InMemoryInstance implements Instance {
 
     @Override
     public Connector getConnector(String user, ByteBuffer pass) throws AccumuloException, AccumuloSecurityException {
-        return getConnector(user, ByteBufferUtil.toBytes(pass));
+        byte[] bytes = new byte[pass.remaining()];
+        pass.get(bytes);
+        return getConnector(user, bytes);
     }
 
     @Override
     public Connector getConnector(String user, CharSequence pass) throws AccumuloException, AccumuloSecurityException {
-        return getConnector(user, TextUtil.getBytes(new Text(pass.toString())));
+        Text text = new Text(pass.toString());
+        byte[] bytes = new byte[text.getLength()];
+        System.arraycopy(text.getBytes(), 0, bytes, 0, text.getLength());
+        return getConnector(user, bytes);
     }
 
     @Override

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardedTableTabletBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardedTableTabletBalancerTest.java
@@ -37,7 +37,6 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
-import org.apache.accumulo.core.util.MapCounter;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,6 +52,7 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 
 import datawave.common.test.integration.IntegrationTest;
+import datawave.util.MapCounter;
 
 public class ShardedTableTabletBalancerTest {
     private static final TableId TNAME = TableId.of("s");

--- a/warehouse/accumulo-extensions/src/test/java/datawave/util/MapCounter.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/util/MapCounter.java
@@ -1,0 +1,55 @@
+package datawave.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A simple utility class for counting occurrences of keys. Replaces the non-public org.apache.accumulo.core.util.MapCounter.
+ *
+ * @param <K>
+ *            the key type
+ */
+public class MapCounter<K> {
+    private final Map<K,Long> map = new HashMap<>();
+
+    /**
+     * Increment the count for the given key by the specified amount.
+     *
+     * @param key
+     *            the key to increment
+     * @param amount
+     *            the amount to add
+     * @return the new count
+     */
+    public long increment(K key, long amount) {
+        Long count = map.get(key);
+        if (count == null) {
+            count = 0L;
+        }
+        count += amount;
+        map.put(key, count);
+        return count;
+    }
+
+    /**
+     * Get the count for the given key.
+     *
+     * @param key
+     *            the key
+     * @return the count, or 0 if the key is not present
+     */
+    public long get(K key) {
+        Long count = map.get(key);
+        return count == null ? 0L : count;
+    }
+
+    /**
+     * Get the set of keys.
+     *
+     * @return the key set
+     */
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `BadArgumentException` with `IllegalArgumentException` in CVCacheIT
- Replace `ByteBufferUtil` and `TextUtil` with inline implementations in InMemoryInstance
- Create `datawave.util.MapCounter` to replace non-public `MapCounter` in ShardedTableTabletBalancerTest

Fixes #3348
Fixes #3349
Fixes #3350
Part of #2443