### PR TITLE
consolidate abstract query test

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -16,8 +16,6 @@ import javax.inject.Inject;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
-import org.apache.commons.jexl3.parser.ParseException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -45,8 +43,6 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
-import datawave.query.jexl.JexlASTHelper;
-import datawave.query.jexl.visitors.TreeEqualityVisitor;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
@@ -131,11 +127,11 @@ public class ColorsTest extends AbstractQueryTest {
         logic.setCardinalityThreshold(0);
 
         // every test also exercises hit terms
-        withParameter(QueryParameters.HIT_LIST, "true");
+        givenParameter(QueryParameters.HIT_LIST, "true");
         logic.setHitList(true);
 
         // default to full date range
-        withDate(ColorsIngest.getStartDay(), ColorsIngest.getEndDay());
+        givenDate(ColorsIngest.getStartDay(), ColorsIngest.getEndDay());
     }
 
     @Override
@@ -171,16 +167,50 @@ public class ColorsTest extends AbstractQueryTest {
         return count;
     }
 
-    public ColorsTest withExpectedDays(String... days) {
+    public ColorsTest expectDays(String... days) {
         this.expectedDays.addAll(List.of(days));
         return this;
     }
 
-    public ColorsTest withExpectedShards(String day, int numShards) {
+    public ColorsTest expectShards(String day, int numShards) {
         for (int i = 0; i < numShards; i++) {
             this.expectedShards.add(day + "_" + i);
         }
         return this;
+    }
+
+    /**
+     * Extract the row from each event, recording both the day and shard.
+     */
+    public void assertExpectedShardsAndDays() {
+        if (expectedShards.isEmpty() && expectedDays.isEmpty()) {
+            return;
+        }
+
+        if (results.isEmpty()) {
+            fail("expected days or shards but had no results");
+        }
+
+        Set<String> days = new HashSet<>();
+        Set<String> shards = new HashSet<>();
+
+        for (Document result : results) {
+            Attribute<?> attr = result.get("RECORD_ID");
+            Key meta = attr.getMetadata();
+            String row = meta.getRow().toString();
+            String[] parts = row.split("_");
+            days.add(parts[0]);
+            shards.add(row);
+        }
+
+        if (!expectedDays.isEmpty()) {
+            assertEquals(expectedDays, days);
+        }
+
+        if (!expectedShards.isEmpty()) {
+            assertEquals(expectedShards, shards);
+
+        }
     }
 
     /**
@@ -230,138 +260,95 @@ public class ColorsTest extends AbstractQueryTest {
     @Override
     public void planAndExecuteQuery() throws Exception {
         super.planAndExecuteQuery();
-        assertResultCount();
         assertExpectedShardsAndDays();
-    }
-
-    /**
-     * Extract the row from each event, recording both the day and shard.
-     *
-     * @return the test suite
-     */
-    public ColorsTest assertExpectedShardsAndDays() {
-        if (expectedShards.isEmpty() && expectedDays.isEmpty()) {
-            return this;
-        }
-
-        if (results.isEmpty()) {
-            fail("expected days or shards but had no results");
-        }
-
-        Set<String> days = new HashSet<>();
-        Set<String> shards = new HashSet<>();
-
-        for (Document result : results) {
-            Attribute<?> attr = result.get("RECORD_ID");
-            Key meta = attr.getMetadata();
-            String row = meta.getRow().toString();
-            String[] parts = row.split("_");
-            days.add(parts[0]);
-            shards.add(row);
-        }
-
-        if (!expectedDays.isEmpty()) {
-            assertEquals(expectedDays, days);
-        }
-
-        if (!expectedShards.isEmpty()) {
-            assertEquals(expectedShards, shards);
-
-        }
-        return this;
-    }
-
-    public void assertPlannedQuery(String query) {
-        try {
-            ASTJexlScript expected = JexlASTHelper.parseAndFlattenJexlQuery(query);
-            ASTJexlScript plannedScript = logic.getConfig().getQueryTree();
-            if (!TreeEqualityVisitor.isEqual(expected, plannedScript)) {
-                log.info("expected: {}", query);
-                log.info("planned : {}", logic.getConfig().getQueryString());
-                fail("Planned query did not match expectation");
-            }
-        } catch (ParseException e) {
-            fail("Failed to parse query: " + query);
-        }
     }
 
     @Test
     public void testColorRed() throws Exception {
-        withQuery("COLOR == 'red'");
-        withRequiredAllOf("COLOR:red");
-        withResultCount(getTotalEventCount());
+        givenQuery("COLOR == 'red'");
+        expectPlan("COLOR == 'red'");
+        expectResultCount(getTotalEventCount());
+        expectHitTermsRequiredAllOf("COLOR:red");
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testColorYellow() throws Exception {
-        withQuery("COLOR == 'yellow'");
-        withRequiredAllOf("COLOR:yellow");
-        withResultCount(getTotalEventCount());
+        givenQuery("COLOR == 'yellow'");
+        expectPlan("COLOR == 'yellow'");
+        expectResultCount(getTotalEventCount());
+        expectHitTermsRequiredAllOf("COLOR:yellow");
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testColorBlue() throws Exception {
-        withQuery("COLOR == 'blue'");
-        withRequiredAllOf("COLOR:blue");
-        withResultCount(getTotalEventCount());
+        givenQuery("COLOR == 'blue'");
+        expectPlan("COLOR == 'blue'");
+        expectResultCount(getTotalEventCount());
+        expectHitTermsRequiredAllOf("COLOR:blue");
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testAllColors() throws Exception {
-        withQuery("COLOR == 'red' || COLOR == 'yellow' || COLOR == 'blue'");
-        withOptionalAnyOf("COLOR:red", "COLOR:yellow", "COLOR:blue");
-        withResultCount(3 * getTotalEventCount());
+        givenQuery("COLOR == 'red' || COLOR == 'yellow' || COLOR == 'blue'");
+        expectPlan("COLOR == 'red' || COLOR == 'yellow' || COLOR == 'blue'");
+        expectResultCount(3 * getTotalEventCount());
+        expectHitTermsOptionalAnyOf("COLOR:red", "COLOR:yellow", "COLOR:blue");
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testSearchAllShardsDefeatedAtFieldIndex() throws Exception {
-        withQuery("COLOR == 'red' && !(COLOR == 'red')");
-        withResultCount(0);
+        givenQuery("COLOR == 'red' && !(COLOR == 'red')");
+        expectPlan("COLOR == 'red' && !(COLOR == 'red')");
+        expectResultCount(0);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testSearchAllShardsDefeatedAtEvaluation() throws Exception {
-        withQuery("COLOR == 'red' && filter:includeRegex(COLOR, 'yellow')");
-        withResultCount(0);
+        givenQuery("COLOR == 'red' && filter:includeRegex(COLOR, 'yellow')");
+        expectPlan("COLOR == 'red' && filter:includeRegex(COLOR, 'yellow')");
+        expectResultCount(0);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testReturnedShardsForEarlierDate() throws Exception {
-        withQuery("COLOR == 'red'");
-        withRequiredAllOf("COLOR:red");
-        withDate("20250301", "20250301");
-        withResultCount(ColorsIngest.getNumShards());
-        withExpectedDays("20250301");
-        withExpectedShards("20250301", ColorsIngest.getNumShards());
+        givenDate("20250301", "20250301");
+        givenQuery("COLOR == 'red'");
+        expectPlan("COLOR == 'red'");
+        expectResultCount(ColorsIngest.getNumShards());
+        expectHitTermsRequiredAllOf("COLOR:red");
+        expectDays("20250301");
+        expectShards("20250301", ColorsIngest.getNumShards());
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testReturnedShardsForLaterDate() throws Exception {
-        withQuery("COLOR == 'red'");
-        withRequiredAllOf("COLOR:red");
-        withDate("20250331", "20250331");
-        withResultCount(ColorsIngest.getNewShards());
-        withExpectedDays("20250331");
-        withExpectedShards("20250331", ColorsIngest.getNewShards());
+        givenDate("20250331", "20250331");
+        givenQuery("COLOR == 'red'");
+        expectPlan("COLOR == 'red'");
+        expectResultCount(ColorsIngest.getNewShards());
+        expectHitTermsRequiredAllOf("COLOR:red");
+        expectDays("20250331");
+        expectShards("20250331", ColorsIngest.getNewShards());
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testReturnedShardsForQueryThatCrossesBoundary() throws Exception {
-        withQuery("COLOR == 'red'");
-        withRequiredAllOf("COLOR:red");
-        withDate("20250326", "20250327");
-        withResultCount(ColorsIngest.getNumShards() + ColorsIngest.getNewShards());
-        withExpectedDays("20250326", "20250327");
-        withExpectedShards("20250326", ColorsIngest.getNumShards());
-        withExpectedShards("20250327", ColorsIngest.getNewShards());
+        givenDate("20250326", "20250327");
+        givenQuery("COLOR == 'red'");
+        expectPlan("COLOR == 'red'");
+        expectResultCount(ColorsIngest.getNumShards() + ColorsIngest.getNewShards());
+        expectHitTermsRequiredAllOf("COLOR:red");
+        expectDays("20250326", "20250327");
+        expectShards("20250326", ColorsIngest.getNumShards());
+        expectShards("20250327", ColorsIngest.getNewShards());
         planAndExecuteQueryAgainstMultipleIndices();
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -1,42 +1,39 @@
 package datawave.query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 
-import javax.inject.Inject;
-
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.Authorizations;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.base.Preconditions;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.configuration.spring.SpringBean;
 import datawave.helpers.PrintUtility;
 import datawave.ingest.data.TypeRegistry;
 import datawave.query.attributes.Attribute;
@@ -44,27 +41,33 @@ import datawave.query.attributes.Document;
 import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.ColorsIngest;
 import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * A set of tests that exercises multi-shard, multi-day queries
  * <p>
  * Hit Term assertions are supported. Most queries should assert total documents returned and shards seen in the results.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
 public class ColorsTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(ColorsTest.class);
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public static Path folder;
 
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
 
     // this two client setup is a little odd, but it allows us to create tables once
@@ -75,23 +78,13 @@ public class ColorsTest extends AbstractQueryTest {
 
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        //  @formatter:off
-        return ShrinkWrap.create(JavaArchive.class)
-                .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                        "datawave.webservice.query.result.event")
-                .deleteClass(DefaultEdgeEventQueryLogic.class)
-                .deleteClass(RemoteEdgeDictionary.class)
-                .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                .addAsManifestResource(new StringAsset(
-                                "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                        "beans.xml");
-        //  @formatter:on
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
     }
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         InMemoryInstance i = new InMemoryInstance(ColorsTest.class.getName());
         client = new InMemoryAccumuloClient("", i);
 
@@ -106,8 +99,8 @@ public class ColorsTest extends AbstractQueryTest {
         PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
     }
 
-    @Before
-    public void setup() throws IOException {
+    @BeforeEach
+    public void beforeEach() throws IOException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         resetState();
         setClientForTest(client);
@@ -116,7 +109,7 @@ public class ColorsTest extends AbstractQueryTest {
         Preconditions.checkNotNull(hadoopConfig);
         logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
 
-        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(temporaryFolder.newFolder().toURI().toString());
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toFile().toString());
         logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
 
         logic.setMaxFieldIndexRangeSplit(1); // keep things simple
@@ -133,14 +126,9 @@ public class ColorsTest extends AbstractQueryTest {
         givenDate(ColorsIngest.getStartDay(), ColorsIngest.getEndDay());
     }
 
-    @Override
-    public ShardQueryLogic getLogic() {
-        return logic;
-    }
-
-    @After
-    public void after() {
-        super.after();
+    @AfterEach
+    public void afterEach() {
+        super.afterEach();
         resetState();
     }
 
@@ -154,8 +142,8 @@ public class ColorsTest extends AbstractQueryTest {
         expectedShards.clear();
     }
 
-    @AfterClass
-    public static void teardown() {
+    @AfterAll
+    public static void afterAll() {
         TypeRegistry.reset();
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -47,7 +47,6 @@ import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.ColorsIngest;
-import datawave.query.util.TestIndexTableNames;
 import datawave.util.TableName;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
@@ -213,53 +212,13 @@ public class ColorsTest extends AbstractQueryTest {
         }
     }
 
-    /**
-     * Supports running the same query against multiple types of index tables
-     *
-     * @return this class
-     * @throws Exception
-     *             if something goes wrong
-     */
-    public ColorsTest planAndExecuteQueryAgainstMultipleIndices() throws Exception {
-        for (String indexTableName : TestIndexTableNames.names()) {
-            logic.setIndexTableName(indexTableName);
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(true);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name " + indexTableName);
-            }
-
-            log.debug("=== using index: {} ===", indexTableName);
-            planAndExecuteQuery();
-
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(false);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name " + indexTableName);
-            }
-        }
-        return this;
+    @Override
+    protected void extraConfigurations() {
+        // no-op
     }
 
-    /**
-     * Delegate to super method to plan and execute the query and assert the hit terms
-     *
-     * @throws Exception
-     *             if something goes wrong
-     */
     @Override
-    public void planAndExecuteQuery() throws Exception {
-        super.planAndExecuteQuery();
+    protected void extraAssertions() {
         assertExpectedShardsAndDays();
     }
 
@@ -269,7 +228,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectPlan("COLOR == 'red'");
         expectResultCount(getTotalEventCount());
         expectHitTermsRequiredAllOf("COLOR:red");
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -278,7 +237,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectPlan("COLOR == 'yellow'");
         expectResultCount(getTotalEventCount());
         expectHitTermsRequiredAllOf("COLOR:yellow");
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -287,7 +246,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectPlan("COLOR == 'blue'");
         expectResultCount(getTotalEventCount());
         expectHitTermsRequiredAllOf("COLOR:blue");
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -296,7 +255,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectPlan("COLOR == 'red' || COLOR == 'yellow' || COLOR == 'blue'");
         expectResultCount(3 * getTotalEventCount());
         expectHitTermsOptionalAnyOf("COLOR:red", "COLOR:yellow", "COLOR:blue");
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -304,7 +263,7 @@ public class ColorsTest extends AbstractQueryTest {
         givenQuery("COLOR == 'red' && !(COLOR == 'red')");
         expectPlan("COLOR == 'red' && !(COLOR == 'red')");
         expectResultCount(0);
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -312,7 +271,7 @@ public class ColorsTest extends AbstractQueryTest {
         givenQuery("COLOR == 'red' && filter:includeRegex(COLOR, 'yellow')");
         expectPlan("COLOR == 'red' && filter:includeRegex(COLOR, 'yellow')");
         expectResultCount(0);
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -324,7 +283,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectHitTermsRequiredAllOf("COLOR:red");
         expectDays("20250301");
         expectShards("20250301", ColorsIngest.getNumShards());
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -336,7 +295,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectHitTermsRequiredAllOf("COLOR:red");
         expectDays("20250331");
         expectShards("20250331", ColorsIngest.getNewShards());
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
@@ -349,7 +308,7 @@ public class ColorsTest extends AbstractQueryTest {
         expectDays("20250326", "20250327");
         expectShards("20250326", ColorsIngest.getNumShards());
         expectShards("20250327", ColorsIngest.getNewShards());
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     // TODO: unique

--- a/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
@@ -75,6 +75,7 @@ public abstract class FunctionalSetTest {
         public void setup() {
             super.setup();
             logic.setCollapseUids(true);
+            logic.setRebuildDatatypeFilter(true);
         }
 
         @Override
@@ -103,6 +104,7 @@ public abstract class FunctionalSetTest {
         public void setup() {
             super.setup();
             logic.setCollapseUids(false);
+            logic.setRebuildDatatypeFilter(true);
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
@@ -13,7 +12,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.TreeSet;
 
 import javax.inject.Inject;
 
@@ -110,6 +108,8 @@ public class ShapesTest extends AbstractQueryTest {
 
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
+    private Set<String> expectedDatatypeFilter = null;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         MiniAccumuloConfig cfg = new MiniAccumuloConfig(temporaryFolder.newFolder(), PASSWORD);
@@ -169,12 +169,12 @@ public class ShapesTest extends AbstractQueryTest {
         logic.setCardinalityThreshold(0);
 
         // every test also exercises hit terms
-        withParameter(QueryParameters.HIT_LIST, "true");
+        givenParameter(QueryParameters.HIT_LIST, "true");
         logic.setHitList(true);
 
         logic.setCollapseUids(false); // index table will either have uids or not
 
-        withDate("20240201", "20240209");
+        givenDate("20240201", "20240209");
     }
 
     @After
@@ -189,6 +189,7 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setRebuildDatatypeFilter(false);
             logic.setPruneQueryByIngestTypes(false);
         }
+        expectedDatatypeFilter = null;
     }
 
     @AfterClass
@@ -196,8 +197,39 @@ public class ShapesTest extends AbstractQueryTest {
         TypeRegistry.reset();
     }
 
-    public void withExpected(Set<String> expected) {
-        this.expected.addAll(expected);
+    /**
+     * A wrapper around {@link #givenParameter(String, String)} for {@link QueryParameters#DATATYPE_FILTER_SET}.
+     *
+     * @param filter
+     *            the datatype filter
+     */
+    public void givenDatatypeFilter(String filter) {
+        givenParameter(QueryParameters.DATATYPE_FILTER_SET, filter);
+    }
+
+    /**
+     * Set the expected datatype filter.
+     *
+     * @param filter
+     *            the expected datatype filter
+     */
+    public void expectDatatypeFilter(Set<String> filter) {
+        if (expectedDatatypeFilter == null) {
+            expectedDatatypeFilter = new HashSet<>();
+        }
+        expectedDatatypeFilter.addAll(filter);
+    }
+
+    /**
+     * Assert the final datatype filter against the expectation, if an expectation was set
+     */
+    public void assertDatatypeFilter() {
+        if (expectedDatatypeFilter == null) {
+            return;
+        }
+        assertNotNull(logic);
+        assertNotNull(logic.getConfig());
+        assertEquals(expectedDatatypeFilter, logic.getConfig().getDatatypeFilter());
     }
 
     public void planAndExecuteQuery() throws Exception {
@@ -221,7 +253,7 @@ public class ShapesTest extends AbstractQueryTest {
 
             // plan, execute, assert hit terms
             super.planAndExecuteQuery();
-            assertUuids();
+            assertDatatypeFilter();
 
             switch (indexTableName) {
                 case TestIndexTableNames.SHARD_INDEX:
@@ -236,45 +268,6 @@ public class ShapesTest extends AbstractQueryTest {
         }
     }
 
-    public ShapesTest assertUuids() {
-        assertNotNull(expected);
-        assertNotNull(results);
-
-        Set<String> found = new HashSet<>();
-        for (Document result : results) {
-            Attribute<?> attr = result.get("UUID");
-            assertNotNull("result did not contain a UUID", attr);
-            String uuid = getUUID(attr);
-            found.add(uuid);
-        }
-
-        Set<String> missing = Sets.difference(expected, found);
-        if (!missing.isEmpty()) {
-            log.info("missing uuids: {}", missing);
-        }
-
-        Set<String> extra = Sets.difference(found, expected);
-        if (!extra.isEmpty()) {
-            log.info("extra uuids: {}", extra);
-        }
-
-        assertEquals(expected, new TreeSet<>(found));
-        return this;
-    }
-
-    public String getUUID(Attribute<?> attribute) {
-        boolean typed = attribute instanceof TypeAttribute;
-        assertTrue("Attribute was not a TypeAttribute, was: " + attribute.getClass(), typed);
-        TypeAttribute<?> uuid = (TypeAttribute<?>) attribute;
-        return uuid.getType().getDelegateAsString();
-    }
-
-    public void assertDatatypeFilter(Set<String> expected) {
-        assertNotNull(logic);
-        assertNotNull(logic.getConfig());
-        assertEquals(expected, logic.getConfig().getDatatypeFilter());
-    }
-
     @SafeVarargs
     public final Set<String> createSet(Set<String>... sets) {
         Set<String> s = new HashSet<>();
@@ -286,119 +279,121 @@ public class ShapesTest extends AbstractQueryTest {
 
     @Test
     public void testTriangles() throws Exception {
-        withQuery("SHAPE == 'triangle'");
-        withExpected(triangleUids);
-        withRequiredAllOf("SHAPE:triangle");
+        givenQuery("SHAPE == 'triangle'");
+        expectPlan("SHAPE == 'triangle'");
+        expectUUIDs(triangleUids);
+        expectHitTermsRequiredAllOf("SHAPE:triangle");
         planAndExecuteQuery();
     }
 
     @Test
     public void testQuadrilaterals() throws Exception {
-        withQuery("SHAPE == 'quadrilateral'");
-        withExpected(quadrilateralUids);
-        withRequiredAllOf("SHAPE:quadrilateral");
+        givenQuery("SHAPE == 'quadrilateral'");
+        expectPlan("SHAPE == 'quadrilateral'");
+        expectUUIDs(quadrilateralUids);
+        expectHitTermsRequiredAllOf("SHAPE:quadrilateral");
         planAndExecuteQuery();
     }
 
     @Test
     public void testPentagon() throws Exception {
-        withQuery("SHAPE == 'pentagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.pentagonUid));
-        withRequiredAllOf("SHAPE:pentagon");
+        givenQuery("SHAPE == 'pentagon'");
+        expectPlan("SHAPE == 'pentagon'");
+        expectUUIDs(Set.of(ShapesIngest.pentagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:pentagon");
         planAndExecuteQuery();
     }
 
     @Test
     public void testHexagon() throws Exception {
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectPlan("SHAPE == 'hexagon'");
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
         planAndExecuteQuery();
     }
 
     @Test
     public void testOctagon() throws Exception {
-        withQuery("SHAPE == 'octagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.octagonUid));
-        withRequiredAllOf("SHAPE:octagon");
+        givenQuery("SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'octagon'");
+        expectUUIDs(Set.of(ShapesIngest.octagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:octagon");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrianglesAndQuadrilaterals() throws Exception {
-        withQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
-        Set<String> uids = new HashSet<>();
-        uids.addAll(triangleUids);
-        uids.addAll(quadrilateralUids);
-        withExpected(uids);
-        withRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectUUIDs(createSet(triangleUids, quadrilateralUids));
+        expectHitTermsRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
         planAndExecuteQuery();
     }
 
     @Test
     public void testAllShapes() throws Exception {
-        withQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withExpected(allUids);
-        withRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral", "SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectUUIDs(allUids);
+        expectHitTermsRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral", "SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrianglesAndQuadrilateralsNoFilter() throws Exception {
-        withQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
-        Set<String> uids = new HashSet<>();
-        uids.addAll(triangleUids);
-        uids.addAll(quadrilateralUids);
-        withExpected(uids);
-        withRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectUUIDs(createSet(triangleUids, quadrilateralUids));
+        expectHitTermsRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrianglesAndQuadrilateralsCorrectFilter() throws Exception {
-        withQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,quadrilateral");
-        Set<String> uids = new HashSet<>();
-        uids.addAll(triangleUids);
-        uids.addAll(quadrilateralUids);
-        withExpected(uids);
-        withRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        givenDatatypeFilter("triangle,quadrilateral");
+        expectUUIDs(createSet(triangleUids, quadrilateralUids));
+        expectHitTermsRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrianglesAndQuadrilateralsFilterForTriangles() throws Exception {
-        withQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle");
-        withExpected(triangleUids);
-        withRequiredAllOf("SHAPE:triangle");
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        givenDatatypeFilter("triangle");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectUUIDs(triangleUids);
+        expectHitTermsRequiredAllOf("SHAPE:triangle");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrianglesAndQuadrilateralsFilterForQuadrilaterals() throws Exception {
-        withQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "quadrilateral");
-        withExpected(quadrilateralUids);
-        withRequiredAllOf("SHAPE:quadrilateral");
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        givenDatatypeFilter("quadrilateral");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
+        expectUUIDs(quadrilateralUids);
+        expectHitTermsRequiredAllOf("SHAPE:quadrilateral");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrailingRegexExpansionIntoSingleTerm() throws Exception {
-        withQuery("TYPE =~ 'acu.*'");
-        withQueryPlan("TYPE == 'acute'");
-        withExpected(Sets.newHashSet(ShapesIngest.acuteUid));
-        withRequiredAllOf("TYPE:acute");
+        givenQuery("TYPE =~ 'acu.*'");
+        expectPlan("TYPE == 'acute'");
+        expectUUIDs(Set.of(ShapesIngest.acuteUid));
+        expectHitTermsRequiredAllOf("TYPE:acute");
         planAndExecuteQuery();
     }
 
     @Test
     public void testTrailingRegexExpansionIntoMultipleTerms() throws Exception {
-        withQuery("TYPE =~ 'rhomb.*'");
-        withQueryPlan("TYPE == 'rhombus' || TYPE == 'rhomboid'");
-        withExpected(Sets.newHashSet(ShapesIngest.rhombusUid, ShapesIngest.rhomboidUid));
-        withRequiredAnyOf("TYPE:rhombus", "TYPE:rhomboid");
+        givenQuery("TYPE =~ 'rhomb.*'");
+        expectPlan("TYPE == 'rhombus' || TYPE == 'rhomboid'");
+        expectUUIDs(Set.of(ShapesIngest.rhombusUid, ShapesIngest.rhomboidUid));
+        expectHitTermsRequiredAnyOf("TYPE:rhombus", "TYPE:rhomboid");
         planAndExecuteQuery();
     }
 
@@ -414,38 +409,38 @@ public class ShapesTest extends AbstractQueryTest {
 
     @Test
     public void testLeadingRegexExpansionIntoSingleTerm() throws Exception {
-        withQuery("SHAPE =~ '.*angle'");
-        withQueryPlan("SHAPE == 'triangle'");
-        withExpected(triangleUids);
-        withRequiredAllOf("SHAPE:triangle");
+        givenQuery("SHAPE =~ '.*angle'");
+        expectPlan("SHAPE == 'triangle'");
+        expectUUIDs(triangleUids);
+        expectHitTermsRequiredAllOf("SHAPE:triangle");
         planAndExecuteQuery();
     }
 
     @Test
     public void testLeadingRegexExpansionIntoMultipleTerms() throws Exception {
-        withQuery("SHAPE =~ '.*gon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE =~ '.*gon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
         planAndExecuteQuery();
     }
 
     @Test
     public void testLeadingRegexExpansionIntoMultipleDatatypes() throws Exception {
-        withQuery("SHAPE =~ '.*gon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE =~ '.*gon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
         planAndExecuteQuery();
     }
 
     @Test
     public void testLeadingRegexExpansionIntoMultipleDatatypesWithDatatypeFilter() throws Exception {
-        withQuery("SHAPE =~ '.*gon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'octagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "pentagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.pentagonUid, ShapesIngest.octagonUid));
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:octagon");
+        givenQuery("SHAPE =~ '.*gon'");
+        givenDatatypeFilter("pentagon,octagon");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'octagon'");
+        expectUUIDs(Set.of(ShapesIngest.pentagonUid, ShapesIngest.octagonUid));
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:octagon");
         planAndExecuteQuery();
     }
 
@@ -453,74 +448,81 @@ public class ShapesTest extends AbstractQueryTest {
 
     @Test
     public void testSimpleQueryNoFilterSpecified() throws Exception {
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Collections.emptySet());
         planAndExecuteQuery();
-        assertDatatypeFilter(Collections.emptySet());
     }
 
     @Test
     public void testSimpleQueryNoFilterSpecifiedWithRebuild() throws Exception {
         logic.setRebuildDatatypeFilter(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(allTypes);
         planAndExecuteQuery();
-        assertDatatypeFilter(allTypes);
     }
 
     @Test
     public void testSimpleQueryNoFilterSpecifiedWithReduce() throws Exception {
         logic.setReduceIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Collections.emptySet());
         planAndExecuteQuery();
-        assertDatatypeFilter(Collections.emptySet());
     }
 
     @Test
     public void testSimpleQueryNoFilterSpecifiedWithPrune() throws Exception {
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(allTypes);
         planAndExecuteQuery();
-        assertDatatypeFilter(allTypes);
     }
 
     @Test
     public void testSimpleQueryNoFilterSpecifiedWithRebuildReduce() throws Exception {
         logic.setRebuildDatatypeFilter(true);
         logic.setReduceIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(allTypes);
         planAndExecuteQuery();
-        assertDatatypeFilter(allTypes);
     }
 
     @Test
     public void testSimpleQueryNoFilterSpecifiedWithRebuildPrune() throws Exception {
         logic.setRebuildDatatypeFilter(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
         planAndExecuteQuery();
-        assertDatatypeFilter(allTypes);
+        expectDatatypeFilter(allTypes);
     }
 
     @Test
     public void testSimpleQueryNoFilterSpecifiedWithReducePrune() throws Exception {
         logic.setReduceIngestTypes(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(allTypes);
         planAndExecuteQuery();
-        assertDatatypeFilter(allTypes);
     }
 
     @Test
@@ -528,92 +530,100 @@ public class ShapesTest extends AbstractQueryTest {
         logic.setRebuildDatatypeFilter(true);
         logic.setReduceIngestTypes(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(allTypes);
         planAndExecuteQuery();
-        assertDatatypeFilter(allTypes);
     }
 
     // simple query with filter
 
     @Test
     public void testSimpleQueryFilterFromParameters() throws Exception {
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testSimpleQueryFilterFromParametersWithRebuild() throws Exception {
         logic.setRebuildDatatypeFilter(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testSimpleQueryFilterFromParametersWithReduce() throws Exception {
         logic.setReduceIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testSimpleQueryFilterFromParametersWithPrune() throws Exception {
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testSimpleQueryFilterFromParametersWithRebuildReduce() throws Exception {
         logic.setRebuildDatatypeFilter(true);
         logic.setReduceIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testSimpleQueryFilterFromParametersWithRebuildPrune() throws Exception {
         logic.setRebuildDatatypeFilter(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testSimpleQueryFilterFromParametersWithReducePrune() throws Exception {
         logic.setReduceIngestTypes(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
@@ -621,112 +631,112 @@ public class ShapesTest extends AbstractQueryTest {
         logic.setRebuildDatatypeFilter(true);
         logic.setReduceIngestTypes(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("SHAPE == 'hexagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "hexagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon");
+        givenQuery("SHAPE == 'hexagon'");
+        givenDatatypeFilter("hexagon");
+        expectPlan("SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     // intersection with reduction possible
 
     @Test
     public void testIntersectionNoFilter() throws Exception {
-        withQuery("SHAPE == 'hexagon' && ONLY_HEX == 'hexa'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("SHAPE:hexagon", "ONLY_HEX:hexa");
+        givenQuery("SHAPE == 'hexagon' && ONLY_HEX == 'hexa'");
+        expectPlan("SHAPE == 'hexagon' && ONLY_HEX == 'hexa'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("SHAPE:hexagon", "ONLY_HEX:hexa");
+        expectDatatypeFilter(Collections.emptySet());
         planAndExecuteQuery();
-        assertDatatypeFilter(Collections.emptySet());
     }
 
     @Test
     public void testFinalDatatypeFilterWhenNoneSpecified() throws Exception {
-        withQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectDatatypeFilter(Collections.emptySet());
         planAndExecuteQuery();
-        assertDatatypeFilter(Collections.emptySet());
     }
 
     @Test
     public void testFinalDatatypeFilterFromParameters() throws Exception {
-        withQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "pentagon,hexagon,octagon");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        givenDatatypeFilter("pentagon,hexagon,octagon");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectDatatypeFilter(Set.of("pentagon", "hexagon", "octagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("pentagon", "hexagon", "octagon"));
     }
 
     @Test
     public void testBuildDatatypeFilterFromQueryFields() throws Exception {
         logic.setRebuildDatatypeFilter(true);
-        withQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
-        planAndExecuteQuery();
+        givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
         // SHAPE is common across all five datatypes
-        assertDatatypeFilter(Sets.newHashSet("triangle", "quadrilateral", "pentagon", "hexagon", "octagon"));
+        expectDatatypeFilter(Set.of("triangle", "quadrilateral", "pentagon", "hexagon", "octagon"));
+        planAndExecuteQuery();
     }
 
     @Test
     public void testReduceIngestTypesWithEmptyDatatypeFilter() throws Exception {
         // this parameter will not replace an empty datatype filter
         logic.setReduceIngestTypes(true);
-        withQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectDatatypeFilter(Collections.emptySet());
         planAndExecuteQuery();
-        assertDatatypeFilter(Collections.emptySet());
     }
 
     @Test
     public void testReduceIngestTypesWithDatatypeFilterFromParametersNoChange() throws Exception {
         // SHAPE is common to five datatypes, only three specified in parameter. Reducing does not change the filter.
         logic.setReduceIngestTypes(true);
-        withQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withQueryPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "pentagon,hexagon,octagon");
-        withExpected(otherUids);
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        givenDatatypeFilter("pentagon,hexagon,octagon");
+        expectUUIDs(otherUids);
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectDatatypeFilter(Set.of("pentagon", "hexagon", "octagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("pentagon", "hexagon", "octagon"));
     }
 
     @Test
     public void testReduceIngestTypesWithDatatypeFilterFromParameters() throws Exception {
         logic.setReduceIngestTypes(true);
-        withQuery("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        givenQuery("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        givenDatatypeFilter("pentagon,hexagon,octagon");
         // octagon datatype is pruned but the query remains intact
-        withQueryPlan("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.pentagonUid, ShapesIngest.hexagonUid));
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
-        withRequiredAnyOf("ONLY_PENTA:penta", "ONLY_HEX:hexa");
-
+        expectPlan("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        expectUUIDs(Set.of(ShapesIngest.pentagonUid, ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectHitTermsRequiredAnyOf("ONLY_PENTA:penta", "ONLY_HEX:hexa");
+        expectDatatypeFilter(Set.of("pentagon", "hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("pentagon", "hexagon"));
     }
 
     @Test
     public void testPruneIngestTypes() throws Exception {
         // octagon should be pruned given the fields unique to each datatype
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        givenQuery("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        givenDatatypeFilter("pentagon,hexagon,octagon");
         // octagon datatype is NOT pruned despite pruning the term from the query
-        withQueryPlan("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.pentagonUid, ShapesIngest.hexagonUid));
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
-        withRequiredAnyOf("ONLY_PENTA:penta", "ONLY_HEX:hexa");
-
+        expectPlan("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        expectUUIDs(Set.of(ShapesIngest.pentagonUid, ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectHitTermsRequiredAnyOf("ONLY_PENTA:penta", "ONLY_HEX:hexa");
+        expectDatatypeFilter(Set.of("pentagon", "hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("pentagon", "hexagon"));
     }
 
     @Test
@@ -734,110 +744,109 @@ public class ShapesTest extends AbstractQueryTest {
         // octagon datatype should be pruned given the fields unique to each datatype
         logic.setReduceIngestTypes(true);
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        givenQuery("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        givenDatatypeFilter("pentagon,hexagon,octagon");
         // octagon datatype is pruned
-        withQueryPlan("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.pentagonUid, ShapesIngest.hexagonUid));
-        withRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
-        withRequiredAnyOf("ONLY_PENTA:penta", "ONLY_HEX:hexa");
-
+        expectPlan("(SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon') && (ONLY_PENTA == 'penta' || ONLY_HEX == 'hexa')");
+        expectUUIDs(Set.of(ShapesIngest.pentagonUid, ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
+        expectHitTermsRequiredAnyOf("ONLY_PENTA:penta", "ONLY_HEX:hexa");
+        expectDatatypeFilter(Set.of("pentagon", "hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("pentagon", "hexagon"));
     }
 
     // test cases for when a user specifies a filter that does not match the query fields, a filter with more types
 
     @Test(expected = InvalidQueryException.class)
     public void testExclusiveFilter() throws Exception {
-        withQuery("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle");
-        withExpected(Collections.emptySet());
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle");
+        expectUUIDs(Collections.emptySet());
         planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
     }
 
     @Test(expected = InvalidQueryException.class)
     public void testExclusiveFilterWithReduce() throws Exception {
         logic.setReduceIngestTypes(true);
-        withQuery("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle");
-        withExpected(Collections.emptySet());
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle");
+        expectUUIDs(Collections.emptySet());
         planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
     }
 
     @Test(expected = InvalidQueryException.class)
     public void testExclusiveFilterWithRebuild() throws Exception {
         logic.setRebuildDatatypeFilter(true);
-        withQuery("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle");
-        withExpected(Collections.emptySet());
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle");
+        expectUUIDs(Collections.emptySet());
         planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
     }
 
     @Test(expected = InvalidQueryException.class)
     public void testExclusiveFilterWithPrune() throws Exception {
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle");
-        withExpected(Collections.emptySet());
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle");
+        expectUUIDs(Collections.emptySet());
         planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
     }
 
     @Test
     public void testFilterWithExtraTypes() throws Exception {
-        withQuery("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,quadrilateral,pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("ONLY_HEX:hexa");
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle,quadrilateral,pentagon,hexagon,octagon");
+        expectPlan("ONLY_HEX == 'hexa'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("ONLY_HEX:hexa");
+        expectDatatypeFilter(allTypes);
         planAndExecuteQuery();
-        assertPlannedQuery("ONLY_HEX == 'hexa'");
-        assertDatatypeFilter(allTypes);
     }
 
     @Test
     public void testFilterWithExtraTypesWithReduce() throws Exception {
         logic.setReduceIngestTypes(true);
-        withQuery("ONLY_HEX == 'hexa'");
-        withQueryPlan("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,quadrilateral,pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("ONLY_HEX:hexa");
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle,quadrilateral,pentagon,hexagon,octagon");
+        expectPlan("ONLY_HEX == 'hexa'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("ONLY_HEX:hexa");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testFilterWithExtraTypesWithRebuild() throws Exception {
         logic.setRebuildDatatypeFilter(true);
-        withQuery("ONLY_HEX == 'hexa'");
-        withQueryPlan("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,quadrilateral,pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("ONLY_HEX:hexa");
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle,quadrilateral,pentagon,hexagon,octagon");
+        expectPlan("ONLY_HEX == 'hexa'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("ONLY_HEX:hexa");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testFilterWithExtraTypesWithPrune() throws Exception {
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("ONLY_HEX == 'hexa'");
-        withQueryPlan("ONLY_HEX == 'hexa'");
-        withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,quadrilateral,pentagon,hexagon,octagon");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("ONLY_HEX:hexa");
+        givenQuery("ONLY_HEX == 'hexa'");
+        givenDatatypeFilter("triangle,quadrilateral,pentagon,hexagon,octagon");
+        expectPlan("ONLY_HEX == 'hexa'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("ONLY_HEX:hexa");
+        expectDatatypeFilter(Set.of("hexagon"));
         planAndExecuteQuery();
-        assertDatatypeFilter(Sets.newHashSet("hexagon"));
     }
 
     @Test
     public void testPruneNestedTermAllPermutations() throws Exception {
         // natural prune will drop the ONLY_QUAD term
         logic.setPruneQueryByIngestTypes(true);
-        withQuery("ONLY_HEX == 'hexa' && (SHAPE == 'hexagon' || ONLY_QUAD == 'square')");
-        withQueryPlan("ONLY_HEX == 'hexa' && SHAPE == 'hexagon'");
-        withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-        withRequiredAllOf("ONLY_HEX:hexa", "SHAPE:hexagon");
+        givenQuery("ONLY_HEX == 'hexa' && (SHAPE == 'hexagon' || ONLY_QUAD == 'square')");
+        expectPlan("ONLY_HEX == 'hexa' && SHAPE == 'hexagon'");
+        expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+        expectHitTermsRequiredAllOf("ONLY_HEX:hexa", "SHAPE:hexagon");
         planAndExecuteQuery();
     }
 
@@ -866,14 +875,14 @@ public class ShapesTest extends AbstractQueryTest {
                     logic.setRebuildDatatypeFilter(rebuildOption);
                     logic.getConfig().setDatatypeFilter(Collections.emptySet());
 
-                    withQuery(query);
+                    givenQuery(query);
                     if (pruneOption) {
-                        withQueryPlan(expectedPlan);
+                        expectPlan(expectedPlan);
                     } else {
-                        withQueryPlan(query);
+                        expectPlan(query);
                     }
-                    withExpected(Sets.newHashSet(ShapesIngest.hexagonUid));
-                    withRequiredAllOf("ONLY_HEX:hexa", "SHAPE:hexagon");
+                    expectUUIDs(Set.of(ShapesIngest.hexagonUid));
+                    expectHitTermsRequiredAllOf("ONLY_HEX:hexa", "SHAPE:hexagon");
                     planAndExecuteQuery();
                 }
             }
@@ -884,13 +893,11 @@ public class ShapesTest extends AbstractQueryTest {
     public void testSortQueryPreIndexWithImpliedCounts() throws Exception {
         try {
             // sorting via implied counts should push TYPE to the right of SHAPE
-            withQuery("TYPE == 'pentagon' || SHAPE == 'triangle'");
-            withQueryPlan("SHAPE == 'triangle' || TYPE == 'pentagon'");
-            withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,pentagon");
-
-            Set<String> expectedUids = new HashSet<>(triangleUids);
-            withExpected(expectedUids);
-            withRequiredAnyOf("TYPE:pentagon", "SHAPE:triangle");
+            givenQuery("TYPE == 'pentagon' || SHAPE == 'triangle'");
+            givenDatatypeFilter("triangle,pentagon");
+            expectPlan("SHAPE == 'triangle' || TYPE == 'pentagon'");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAnyOf("TYPE:pentagon", "SHAPE:triangle");
 
             disableAllSortOptions();
             logic.setSortQueryPreIndexWithImpliedCounts(true);
@@ -905,13 +912,12 @@ public class ShapesTest extends AbstractQueryTest {
         try {
             // SHAPE cardinality for triangle and pentagon types is 23
             // TYPE cardinality for triangle and pentagon types is 21
-            withQuery("SHAPE == 'triangle' || TYPE == 'pentagon'");
-            withQueryPlan("TYPE == 'pentagon' || SHAPE == 'triangle'");
-            withParameter(QueryParameters.DATATYPE_FILTER_SET, "triangle,pentagon");
+            givenQuery("SHAPE == 'triangle' || TYPE == 'pentagon'");
+            givenDatatypeFilter("triangle,pentagon");
+            expectPlan("TYPE == 'pentagon' || SHAPE == 'triangle'");
 
-            Set<String> expectedUids = new HashSet<>(triangleUids);
-            withExpected(expectedUids);
-            withRequiredAllOf("SHAPE:triangle");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
 
             disableAllSortOptions();
             logic.setSortQueryPreIndexWithFieldCounts(true);
@@ -934,10 +940,10 @@ public class ShapesTest extends AbstractQueryTest {
             saveIndexExpansionConfigs();
             forceIvarators();
 
-            withQuery("SHAPE == 'triangle' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withQueryPlan("SHAPE == 'triangle' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withExpected(triangleUids);
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectPlan("SHAPE == 'triangle' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
 
             planAndExecuteQuery();
         } finally {
@@ -958,10 +964,10 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setSortQueryPostIndexWithTermCounts(true);
             logic.setCardinalityThreshold(25);
 
-            withQuery("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withQueryPlan("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withExpected(Sets.newHashSet(ShapesIngest.acuteUid));
-            withRequiredAllOf("TYPE:acute", "SHAPE:triangle");
+            givenQuery("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectPlan("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectUUIDs(Set.of(ShapesIngest.acuteUid));
+            expectHitTermsRequiredAllOf("TYPE:acute", "SHAPE:triangle");
 
             planAndExecuteQuery();
         } finally {
@@ -984,10 +990,10 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setSortQueryPostIndexWithTermCounts(true);
             logic.setCardinalityThreshold(25);
 
-            withQuery("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withQueryPlan("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withExpected(Sets.newHashSet(ShapesIngest.acuteUid));
-            withRequiredAllOf("TYPE:acute", "SHAPE:triangle");
+            givenQuery("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectPlan("TYPE == 'acute' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectUUIDs(Set.of(ShapesIngest.acuteUid));
+            expectHitTermsRequiredAllOf("TYPE:acute", "SHAPE:triangle");
 
             planAndExecuteQuery();
         } finally {
@@ -1009,8 +1015,8 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setCardinalityThreshold(25);
 
             // this does not intersect
-            withQuery("SHAPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
-            withQueryPlan("SHAPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            givenQuery("SHAPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
+            expectPlan("SHAPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ 'tr.*?'))");
 
             planAndExecuteQuery();
         } finally {
@@ -1031,10 +1037,10 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setSortQueryPostIndexWithTermCounts(true);
             logic.setCardinalityThreshold(25);
 
-            withQuery("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
-            withQueryPlan("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
-            withExpected(Sets.newHashSet(ShapesIngest.equilateralUid));
-            withRequiredAllOf("TYPE:equilateral", "SHAPE:triangle");
+            givenQuery("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
+            expectPlan("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
+            expectUUIDs(Set.of(ShapesIngest.equilateralUid));
+            expectHitTermsRequiredAllOf("TYPE:equilateral", "SHAPE:triangle");
 
             planAndExecuteQuery();
         } finally {
@@ -1055,10 +1061,10 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setSortQueryPostIndexWithTermCounts(true);
             logic.setCardinalityThreshold(25);
 
-            withQuery("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
-            withQueryPlan("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
-            withExpected(Sets.newHashSet(ShapesIngest.equilateralUid));
-            withRequiredAllOf("TYPE:equilateral", "SHAPE:triangle");
+            givenQuery("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
+            expectPlan("TYPE == 'equilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
+            expectUUIDs(Set.of(ShapesIngest.equilateralUid));
+            expectHitTermsRequiredAllOf("TYPE:equilateral", "SHAPE:triangle");
 
             planAndExecuteQuery();
         } finally {
@@ -1080,8 +1086,8 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setCardinalityThreshold(25);
 
             // this does not intersect
-            withQuery("TYPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
-            withQueryPlan("TYPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
+            givenQuery("TYPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
+            expectPlan("TYPE == 'quadrilateral' && ((_Value_ = true) && (SHAPE =~ '.*angle'))");
             planAndExecuteQuery();
         } finally {
             reloadIndexExpansionConfigs();
@@ -1102,10 +1108,10 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setCardinalityThreshold(25);
 
             // right hand exceeded value marker does not have any backing data
-            withQuery("SHAPE == 'triangle' && (((_Value_ = true) && (SHAPE =~ 'tr.*?')) || ((_Value_ = true) && (SHAPE =~ 'zz.*?')))");
-            withQueryPlan("SHAPE == 'triangle' && (((_Value_ = true) && (SHAPE =~ 'tr.*?')) || ((_Value_ = true) && (SHAPE =~ 'zz.*?')))");
-            withExpected(new HashSet<>(triangleUids));
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle' && (((_Value_ = true) && (SHAPE =~ 'tr.*?')) || ((_Value_ = true) && (SHAPE =~ 'zz.*?')))");
+            expectPlan("SHAPE == 'triangle' && (((_Value_ = true) && (SHAPE =~ 'tr.*?')) || ((_Value_ = true) && (SHAPE =~ 'zz.*?')))");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
 
             planAndExecuteQuery();
         } finally {
@@ -1119,10 +1125,10 @@ public class ShapesTest extends AbstractQueryTest {
             saveIndexExpansionConfigs();
             forceIvarators();
 
-            withQuery("SHAPE == 'triangle' && ((_Bounded_ = true) && (EDGES > '2' && EDGES < '7'))");
-            withQueryPlan("SHAPE == 'triangle' && ((_Value_ = true) && ((_Bounded_ = true) && (EDGES > '+aE2' && EDGES < '+aE7')))");
-            withExpected(triangleUids);
-            withRequiredAllOf("SHAPE:triangle", "EDGES:3");
+            givenQuery("SHAPE == 'triangle' && ((_Bounded_ = true) && (EDGES > '2' && EDGES < '7'))");
+            expectPlan("SHAPE == 'triangle' && ((_Value_ = true) && ((_Bounded_ = true) && (EDGES > '+aE2' && EDGES < '+aE7')))");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle", "EDGES:3");
 
             planAndExecuteQuery();
         } finally {
@@ -1141,10 +1147,10 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setSortQueryPostIndexWithTermCounts(true);
             logic.setCardinalityThreshold(25);
 
-            withQuery("SHAPE == 'triangle' && ((_Bounded_ = true) && (EDGES > '2' && EDGES < '7'))");
-            withQueryPlan("SHAPE == 'triangle' && ((_Value_ = true) && ((_Bounded_ = true) && (EDGES > '+aE2' && EDGES < '+aE7')))");
-            withExpected(triangleUids);
-            withRequiredAllOf("SHAPE:triangle", "EDGES:3");
+            givenQuery("SHAPE == 'triangle' && ((_Bounded_ = true) && (EDGES > '2' && EDGES < '7'))");
+            expectPlan("SHAPE == 'triangle' && ((_Value_ = true) && ((_Bounded_ = true) && (EDGES > '+aE2' && EDGES < '+aE7')))");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle", "EDGES:3");
 
             planAndExecuteQuery();
         } finally {
@@ -1163,8 +1169,8 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setSortQueryPostIndexWithTermCounts(true);
             logic.setCardinalityThreshold(25);
 
-            withQuery("SHAPE == 'octagon' && ((_Bounded_ = true) && (EDGES > '2' && EDGES < '7'))");
-            withQueryPlan("SHAPE == 'octagon' && ((_Value_ = true) && ((_Bounded_ = true) && (EDGES > '+aE2' && EDGES < '+aE7')))");
+            givenQuery("SHAPE == 'octagon' && ((_Bounded_ = true) && (EDGES > '2' && EDGES < '7'))");
+            expectPlan("SHAPE == 'octagon' && ((_Value_ = true) && ((_Bounded_ = true) && (EDGES > '+aE2' && EDGES < '+aE7')))");
             planAndExecuteQuery();
         } finally {
             reloadIndexExpansionConfigs();
@@ -1198,9 +1204,10 @@ public class ShapesTest extends AbstractQueryTest {
 
     @Test
     public void testAttributeNormalizers() throws Exception {
-        withQuery("SHAPE == 'triangle'");
-        withExpected(new HashSet<>(triangleUids));
-        withRequiredAllOf("SHAPE:triangle");
+        givenQuery("SHAPE == 'triangle'");
+        expectPlan("SHAPE == 'triangle'");
+        expectUUIDs(triangleUids);
+        expectHitTermsRequiredAllOf("SHAPE:triangle");
         planAndExecuteQuery();
 
         assertAttributeNormalizer("EDGES", NumberType.class);
@@ -1219,9 +1226,10 @@ public class ShapesTest extends AbstractQueryTest {
             withIncludeFields(Set.of("EDGES", "UUID", "SHAPE"));
             logic.setReduceTypeMetadata(true);
 
-            withQuery("SHAPE == 'triangle'");
-            withExpected(new HashSet<>(triangleUids));
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle'");
+            expectPlan("SHAPE == 'triangle'");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
             assertAttributeNormalizer("EDGES", NumberType.class);
@@ -1244,9 +1252,10 @@ public class ShapesTest extends AbstractQueryTest {
             withExcludeFields(Set.of("ONLY_TRI", "PROPERTIES", "TYPE"));
             logic.setReduceTypeMetadata(true);
 
-            withQuery("SHAPE == 'triangle'");
-            withExpected(new HashSet<>(triangleUids));
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle'");
+            expectPlan("SHAPE == 'triangle'");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
             assertAttributeNormalizer("EDGES", NumberType.class);
@@ -1269,9 +1278,10 @@ public class ShapesTest extends AbstractQueryTest {
             withIncludeFields(Set.of("EDGES", "UUID", "SHAPE"));
             logic.setReduceTypeMetadataPerShard(true);
 
-            withQuery("SHAPE == 'triangle'");
-            withExpected(new HashSet<>(triangleUids));
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle'");
+            expectPlan("SHAPE == 'triangle'");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
             assertAttributeNormalizer("EDGES", NumberType.class);
@@ -1294,9 +1304,10 @@ public class ShapesTest extends AbstractQueryTest {
             withExcludeFields(Set.of("ONLY_TRI", "PROPERTIES", "TYPE"));
             logic.setReduceTypeMetadata(true);
 
-            withQuery("SHAPE == 'triangle'");
-            withExpected(new HashSet<>(triangleUids));
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle'");
+            expectPlan("SHAPE == 'triangle'");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
             assertAttributeNormalizer("EDGES", NumberType.class);
@@ -1321,9 +1332,9 @@ public class ShapesTest extends AbstractQueryTest {
             // disabling evaluation also disables hit term generation
             logic.setDisableEvaluation(true);
 
-            withQuery("SHAPE == 'triangle'");
-            withExpected(new HashSet<>(triangleUids));
-            withRequiredAllOf("SHAPE:triangle");
+            givenQuery("SHAPE == 'triangle'");
+            expectUUIDs(triangleUids);
+            expectHitTermsRequiredAllOf("SHAPE:triangle");
             assertThrows(AssertionError.class, this::planAndExecuteQuery);
         } finally {
             logic.setDisableEvaluation(false);
@@ -1331,11 +1342,11 @@ public class ShapesTest extends AbstractQueryTest {
     }
 
     private void withIncludeFields(Set<String> includes) {
-        parameters.put(QueryParameters.RETURN_FIELDS, Joiner.on(',').join(includes));
+        givenParameter(QueryParameters.RETURN_FIELDS, Joiner.on(',').join(includes));
     }
 
     private void withExcludeFields(Set<String> excludes) {
-        parameters.put(QueryParameters.DISALLOWLISTED_FIELDS, Joiner.on(',').join(excludes));
+        givenParameter(QueryParameters.DISALLOWLISTED_FIELDS, Joiner.on(',').join(excludes));
     }
 
     private void assertAttributeNormalizer(String field, Class<?> expectedNormalizer) {

--- a/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
@@ -9,7 +9,9 @@ import static org.junit.Assert.assertThrows;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -58,7 +60,6 @@ import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.ShapesIngest;
-import datawave.query.util.TestIndexTableNames;
 import datawave.util.TableName;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
@@ -109,6 +110,8 @@ public class ShapesTest extends AbstractQueryTest {
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
     private Set<String> expectedDatatypeFilter = null;
+    private final Map<String, Class<?>> expectedNormalizers = new HashMap<>();
+    private final Set<String> excludedFields = new HashSet<>();
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -190,6 +193,8 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setPruneQueryByIngestTypes(false);
         }
         expectedDatatypeFilter = null;
+        expectedNormalizers.clear();
+        excludedFields.clear();
     }
 
     @AfterClass
@@ -208,6 +213,22 @@ public class ShapesTest extends AbstractQueryTest {
     }
 
     /**
+     * Wrapper around {@link #givenParameter(String, String)} when using {@link QueryParameters#RETURN_FIELDS}
+     * @param includes the set of fields to include
+     */
+    public void givenIncludeFields(Set<String> includes) {
+        givenParameter(QueryParameters.RETURN_FIELDS, Joiner.on(',').join(includes));
+    }
+
+    /**
+     * Wrapper around {@link #givenParameter(String, String)} when using {@link QueryParameters#DISALLOWLISTED_FIELDS}
+     * @param excludes the set of fields to exclude
+     */
+    public void givenExcludeFields(Set<String> excludes) {
+        givenParameter(QueryParameters.DISALLOWLISTED_FIELDS, Joiner.on(',').join(excludes));
+    }
+
+    /**
      * Set the expected datatype filter.
      *
      * @param filter
@@ -221,50 +242,69 @@ public class ShapesTest extends AbstractQueryTest {
     }
 
     /**
+     * Set the expected field-normalizer pair
+     * @param field the field
+     * @param clazz the normalizer
+     */
+    public void expectAttributeNormalizer(String field, Class<?> clazz){
+        expectedNormalizers.put(field, clazz);
+    }
+
+    public void expect(){}
+
+    /**
+     * For this test we must reset the datatype filter each time
+     */
+    @Override
+    protected void extraConfigurations() {
+        // the backing config is stateful, have to reset the datatype filter
+        getLogic().getConfig().setDatatypeFilter(Collections.emptySet());
+    }
+
+    /**
+     * Assert the final datatype filter, if configured
+     */
+    @Override
+    protected void extraAssertions() {
+        assertDatatypeFilter();
+        assertAttributeNormalizer();
+    }
+
+    /**
      * Assert the final datatype filter against the expectation, if an expectation was set
      */
     public void assertDatatypeFilter() {
         if (expectedDatatypeFilter == null) {
             return;
         }
+
         assertNotNull(logic);
         assertNotNull(logic.getConfig());
         assertEquals(expectedDatatypeFilter, logic.getConfig().getDatatypeFilter());
     }
 
-    public void planAndExecuteQuery() throws Exception {
-        for (String indexTableName : TestIndexTableNames.names()) {
-            log.debug("=== using index: {} ===", indexTableName);
-            logic.setIndexTableName(indexTableName);
+    public void assertAttributeNormalizer() {
+        if (expectedNormalizers.isEmpty()) {
+            return;
+        }
 
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(true);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
+        for (Document result : results) {
+            for (String field : expectedNormalizers.keySet()) {
+                Class<?> expectedNormalizer = expectedNormalizers.get(field);
+                Attribute<?> attrs = result.get(field);
+                if (attrs instanceof TypeAttribute<?>) {
+                    TypeAttribute<?> attr = (TypeAttribute<?>) attrs;
+                    assertSame(expectedNormalizer, attr.getType().getClass());
+                }
             }
+        }
+    }
 
-            // the backing config is stateful, have to reset the datatype filter
-            logic.getConfig().setDatatypeFilter(Collections.emptySet());
-
-            // plan, execute, assert hit terms
-            super.planAndExecuteQuery();
-            assertDatatypeFilter();
-
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(false);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
-            }
+    // TODO: pull this into class level variable
+    private void assertFieldNotFound(String field) {
+        for (Document result : results) {
+            Attribute<?> attrs = result.get(field);
+            assertNull("Expected null value for field " + field, attrs);
         }
     }
 
@@ -352,8 +392,8 @@ public class ShapesTest extends AbstractQueryTest {
     @Test
     public void testTrianglesAndQuadrilateralsCorrectFilter() throws Exception {
         givenQuery("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
-        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
         givenDatatypeFilter("triangle,quadrilateral");
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'quadrilateral'");
         expectUUIDs(createSet(triangleUids, quadrilateralUids));
         expectHitTermsRequiredAnyOf("SHAPE:triangle", "SHAPE:quadrilateral");
         planAndExecuteQuery();
@@ -665,8 +705,8 @@ public class ShapesTest extends AbstractQueryTest {
     @Test
     public void testFinalDatatypeFilterFromParameters() throws Exception {
         givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
         givenDatatypeFilter("pentagon,hexagon,octagon");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
         expectUUIDs(otherUids);
         expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
         expectDatatypeFilter(Set.of("pentagon", "hexagon", "octagon"));
@@ -702,8 +742,8 @@ public class ShapesTest extends AbstractQueryTest {
         // SHAPE is common to five datatypes, only three specified in parameter. Reducing does not change the filter.
         logic.setReduceIngestTypes(true);
         givenQuery("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
-        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
         givenDatatypeFilter("pentagon,hexagon,octagon");
+        expectPlan("SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
         expectUUIDs(otherUids);
         expectHitTermsRequiredAnyOf("SHAPE:pentagon", "SHAPE:hexagon", "SHAPE:octagon");
         expectDatatypeFilter(Set.of("pentagon", "hexagon", "octagon"));
@@ -915,7 +955,6 @@ public class ShapesTest extends AbstractQueryTest {
             givenQuery("SHAPE == 'triangle' || TYPE == 'pentagon'");
             givenDatatypeFilter("triangle,pentagon");
             expectPlan("TYPE == 'pentagon' || SHAPE == 'triangle'");
-
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
 
@@ -1210,12 +1249,12 @@ public class ShapesTest extends AbstractQueryTest {
         expectHitTermsRequiredAllOf("SHAPE:triangle");
         planAndExecuteQuery();
 
-        assertAttributeNormalizer("EDGES", NumberType.class);
-        assertAttributeNormalizer("ONLY_TRI", LcNoDiacriticsType.class);
-        assertAttributeNormalizer("PROPERTIES", NoOpType.class);
-        assertAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
-        assertAttributeNormalizer("TYPE", LcNoDiacriticsType.class);
-        assertAttributeNormalizer("UUID", NoOpType.class);
+        expectAttributeNormalizer("EDGES", NumberType.class);
+        expectAttributeNormalizer("ONLY_TRI", LcNoDiacriticsType.class);
+        expectAttributeNormalizer("PROPERTIES", NoOpType.class);
+        expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
+        expectAttributeNormalizer("TYPE", LcNoDiacriticsType.class);
+        expectAttributeNormalizer("UUID", NoOpType.class);
     }
 
     // use projection to trigger reduction
@@ -1223,18 +1262,18 @@ public class ShapesTest extends AbstractQueryTest {
     public void testReduceTypeMetadataViaIncludeFields() throws Exception {
         boolean orig = logic.getReduceTypeMetadata();
         try {
-            withIncludeFields(Set.of("EDGES", "UUID", "SHAPE"));
             logic.setReduceTypeMetadata(true);
 
             givenQuery("SHAPE == 'triangle'");
+            givenIncludeFields(Set.of("EDGES", "UUID", "SHAPE"));
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
-            assertAttributeNormalizer("EDGES", NumberType.class);
-            assertAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
-            assertAttributeNormalizer("UUID", NoOpType.class);
+            expectAttributeNormalizer("EDGES", NumberType.class);
+            expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
+            expectAttributeNormalizer("UUID", NoOpType.class);
 
             assertFieldNotFound("ONLY_TRI");
             assertFieldNotFound("PROPERTIES");
@@ -1249,18 +1288,18 @@ public class ShapesTest extends AbstractQueryTest {
     public void testReduceTypeMetadataViaExcludeFields() throws Exception {
         boolean orig = logic.getReduceTypeMetadata();
         try {
-            withExcludeFields(Set.of("ONLY_TRI", "PROPERTIES", "TYPE"));
             logic.setReduceTypeMetadata(true);
 
             givenQuery("SHAPE == 'triangle'");
+            givenExcludeFields(Set.of("ONLY_TRI", "PROPERTIES", "TYPE"));
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
-            assertAttributeNormalizer("EDGES", NumberType.class);
-            assertAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
-            assertAttributeNormalizer("UUID", NoOpType.class);
+            expectAttributeNormalizer("EDGES", NumberType.class);
+            expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
+            expectAttributeNormalizer("UUID", NoOpType.class);
 
             assertFieldNotFound("ONLY_TRI");
             assertFieldNotFound("PROPERTIES");
@@ -1275,18 +1314,18 @@ public class ShapesTest extends AbstractQueryTest {
     public void testReduceTypeMetadataPerShardViaIncludeFields() throws Exception {
         boolean orig = logic.getReduceTypeMetadataPerShard();
         try {
-            withIncludeFields(Set.of("EDGES", "UUID", "SHAPE"));
             logic.setReduceTypeMetadataPerShard(true);
 
             givenQuery("SHAPE == 'triangle'");
+            givenIncludeFields(Set.of("EDGES", "UUID", "SHAPE"));
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
-            assertAttributeNormalizer("EDGES", NumberType.class);
-            assertAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
-            assertAttributeNormalizer("UUID", NoOpType.class);
+            expectAttributeNormalizer("EDGES", NumberType.class);
+            expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
+            expectAttributeNormalizer("UUID", NoOpType.class);
 
             assertFieldNotFound("ONLY_TRI");
             assertFieldNotFound("PROPERTIES");
@@ -1301,18 +1340,18 @@ public class ShapesTest extends AbstractQueryTest {
     public void testReduceTypeMetadataPerShardViaExcludeFields() throws Exception {
         boolean orig = logic.getReduceTypeMetadataPerShard();
         try {
-            withExcludeFields(Set.of("ONLY_TRI", "PROPERTIES", "TYPE"));
             logic.setReduceTypeMetadata(true);
 
             givenQuery("SHAPE == 'triangle'");
+            givenExcludeFields(Set.of("ONLY_TRI", "PROPERTIES", "TYPE"));
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
             planAndExecuteQuery();
 
-            assertAttributeNormalizer("EDGES", NumberType.class);
-            assertAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
-            assertAttributeNormalizer("UUID", NoOpType.class);
+            expectAttributeNormalizer("EDGES", NumberType.class);
+            expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
+            expectAttributeNormalizer("UUID", NoOpType.class);
 
             assertFieldNotFound("ONLY_TRI");
             assertFieldNotFound("PROPERTIES");
@@ -1338,31 +1377,6 @@ public class ShapesTest extends AbstractQueryTest {
             assertThrows(AssertionError.class, this::planAndExecuteQuery);
         } finally {
             logic.setDisableEvaluation(false);
-        }
-    }
-
-    private void withIncludeFields(Set<String> includes) {
-        givenParameter(QueryParameters.RETURN_FIELDS, Joiner.on(',').join(includes));
-    }
-
-    private void withExcludeFields(Set<String> excludes) {
-        givenParameter(QueryParameters.DISALLOWLISTED_FIELDS, Joiner.on(',').join(excludes));
-    }
-
-    private void assertAttributeNormalizer(String field, Class<?> expectedNormalizer) {
-        for (Document result : results) {
-            Attribute<?> attrs = result.get(field);
-            if (attrs instanceof TypeAttribute<?>) {
-                TypeAttribute<?> attr = (TypeAttribute<?>) attrs;
-                assertSame(expectedNormalizer, attr.getType().getClass());
-            }
-        }
-    }
-
-    private void assertFieldNotFound(String field) {
-        for (Document result : results) {
-            Attribute<?> attrs = result.get(field);
-            assertNull("Expected null value for field " + field, attrs);
         }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
@@ -1,21 +1,21 @@
 package datawave.query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-
-import javax.inject.Inject;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
@@ -24,27 +24,25 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.MiniAccumuloConfig;
 import org.apache.commons.collections.iterators.IteratorChain;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
-import datawave.configuration.spring.SpringBean;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NoOpType;
 import datawave.data.type.NumberType;
@@ -57,11 +55,9 @@ import datawave.query.exceptions.InvalidQueryException;
 import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.ShapesIngest;
 import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * A set of tests that emphasize the influence of datatypes on query planning and execution
@@ -72,20 +68,29 @@ import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
  * {@link IteratorChain} in a way that is incompatible with Accumulo's {@link SeekingFilter}. Namely, during a rebuild on a next call the ScannerHelper's call
  * to 'ChainIterator.next' will swap in a whole new seeking filter in a way that causes the call to 'range.clip' on SeekingFilter#222 to return null.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
 public class ShapesTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(ShapesTest.class);
 
-    @ClassRule
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public static Path folder;
 
     // temporary stores for when forcing ivarators via absurdly low index expansion thresholds
     private int maxUnfieldedExpansionThreshold;
     private int maxValueExpansionThreshold;
 
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
 
     @Override
@@ -110,12 +115,12 @@ public class ShapesTest extends AbstractQueryTest {
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
     private Set<String> expectedDatatypeFilter = null;
-    private final Map<String, Class<?>> expectedNormalizers = new HashMap<>();
+    private final Map<String,Class<?>> expectedNormalizers = new HashMap<>();
     private final Set<String> excludedFields = new HashSet<>();
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        MiniAccumuloConfig cfg = new MiniAccumuloConfig(temporaryFolder.newFolder(), PASSWORD);
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        MiniAccumuloConfig cfg = new MiniAccumuloConfig(folder.toFile(), PASSWORD);
         cfg.setNumTservers(1);
         mac = new MiniAccumuloCluster(cfg);
         mac.start();
@@ -131,30 +136,10 @@ public class ShapesTest extends AbstractQueryTest {
         PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
-        mac.stop();
-    }
-
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        //  @formatter:off
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class)
-                        .deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
-        //  @formatter:on
-    }
-
-    @Before
+    @BeforeEach
     public void beforeEach() throws IOException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-        resetState();
+        // resetState();
 
         setClientForTest(client);
 
@@ -162,7 +147,7 @@ public class ShapesTest extends AbstractQueryTest {
         Preconditions.checkNotNull(hadoopConfig);
         logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
 
-        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(temporaryFolder.newFolder().toURI().toString());
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toUri().toString());
         logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
 
         logic.setMaxFieldIndexRangeSplit(1); // keep things simple
@@ -180,10 +165,15 @@ public class ShapesTest extends AbstractQueryTest {
         givenDate("20240201", "20240209");
     }
 
-    @After
-    public void after() {
-        super.after();
+    @AfterEach
+    public void afterEach() {
+        super.afterEach();
         resetState();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        mac.stop();
     }
 
     private void resetState() {
@@ -197,7 +187,7 @@ public class ShapesTest extends AbstractQueryTest {
         excludedFields.clear();
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() {
         TypeRegistry.reset();
     }
@@ -214,7 +204,9 @@ public class ShapesTest extends AbstractQueryTest {
 
     /**
      * Wrapper around {@link #givenParameter(String, String)} when using {@link QueryParameters#RETURN_FIELDS}
-     * @param includes the set of fields to include
+     *
+     * @param includes
+     *            the set of fields to include
      */
     public void givenIncludeFields(Set<String> includes) {
         givenParameter(QueryParameters.RETURN_FIELDS, Joiner.on(',').join(includes));
@@ -222,7 +214,9 @@ public class ShapesTest extends AbstractQueryTest {
 
     /**
      * Wrapper around {@link #givenParameter(String, String)} when using {@link QueryParameters#DISALLOWLISTED_FIELDS}
-     * @param excludes the set of fields to exclude
+     *
+     * @param excludes
+     *            the set of fields to exclude
      */
     public void givenExcludeFields(Set<String> excludes) {
         givenParameter(QueryParameters.DISALLOWLISTED_FIELDS, Joiner.on(',').join(excludes));
@@ -243,14 +237,19 @@ public class ShapesTest extends AbstractQueryTest {
 
     /**
      * Set the expected field-normalizer pair
-     * @param field the field
-     * @param clazz the normalizer
+     *
+     * @param field
+     *            the field
+     * @param clazz
+     *            the normalizer
      */
-    public void expectAttributeNormalizer(String field, Class<?> clazz){
+    public void expectAttributeNormalizer(String field, Class<?> clazz) {
         expectedNormalizers.put(field, clazz);
     }
 
-    public void expect(){}
+    public void expectNoFields(String... fields) {
+        excludedFields.addAll(List.of(fields));
+    }
 
     /**
      * For this test we must reset the datatype filter each time
@@ -268,6 +267,7 @@ public class ShapesTest extends AbstractQueryTest {
     protected void extraAssertions() {
         assertDatatypeFilter();
         assertAttributeNormalizer();
+        assertFieldNotFound();
     }
 
     /**
@@ -300,11 +300,16 @@ public class ShapesTest extends AbstractQueryTest {
         }
     }
 
-    // TODO: pull this into class level variable
-    private void assertFieldNotFound(String field) {
+    private void assertFieldNotFound() {
+        if (excludedFields.isEmpty()) {
+            return;
+        }
+
         for (Document result : results) {
-            Attribute<?> attrs = result.get(field);
-            assertNull("Expected null value for field " + field, attrs);
+            for (String field : excludedFields) {
+                Attribute<?> attrs = result.get(field);
+                assertNull(attrs, "Expected null value for field " + field);
+            }
         }
     }
 
@@ -797,39 +802,43 @@ public class ShapesTest extends AbstractQueryTest {
 
     // test cases for when a user specifies a filter that does not match the query fields, a filter with more types
 
-    @Test(expected = InvalidQueryException.class)
-    public void testExclusiveFilter() throws Exception {
+    @Test
+    public void testExclusiveFilter() {
         givenQuery("ONLY_HEX == 'hexa'");
         givenDatatypeFilter("triangle");
         expectUUIDs(Collections.emptySet());
-        planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
+        // datatype filter will not find ONLY_HEX and throw exception
+        assertThrows(InvalidQueryException.class, this::planAndExecuteQuery);
     }
 
-    @Test(expected = InvalidQueryException.class)
-    public void testExclusiveFilterWithReduce() throws Exception {
+    @Test
+    public void testExclusiveFilterWithReduce() {
         logic.setReduceIngestTypes(true);
         givenQuery("ONLY_HEX == 'hexa'");
         givenDatatypeFilter("triangle");
         expectUUIDs(Collections.emptySet());
-        planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
+        // datatype filter will not find ONLY_HEX and throw exception
+        assertThrows(InvalidQueryException.class, this::planAndExecuteQuery);
     }
 
-    @Test(expected = InvalidQueryException.class)
-    public void testExclusiveFilterWithRebuild() throws Exception {
+    @Test
+    public void testExclusiveFilterWithRebuild() {
         logic.setRebuildDatatypeFilter(true);
         givenQuery("ONLY_HEX == 'hexa'");
         givenDatatypeFilter("triangle");
         expectUUIDs(Collections.emptySet());
-        planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
+        // datatype filter will not find ONLY_HEX and throw exception
+        assertThrows(InvalidQueryException.class, this::planAndExecuteQuery);
     }
 
-    @Test(expected = InvalidQueryException.class)
-    public void testExclusiveFilterWithPrune() throws Exception {
+    @Test
+    public void testExclusiveFilterWithPrune() {
         logic.setPruneQueryByIngestTypes(true);
         givenQuery("ONLY_HEX == 'hexa'");
         givenDatatypeFilter("triangle");
         expectUUIDs(Collections.emptySet());
-        planAndExecuteQuery(); // datatype filter will not find ONLY_HEX and throw exception
+        // datatype filter will not find ONLY_HEX and throw exception
+        assertThrows(InvalidQueryException.class, this::planAndExecuteQuery);
     }
 
     @Test
@@ -1247,7 +1256,6 @@ public class ShapesTest extends AbstractQueryTest {
         expectPlan("SHAPE == 'triangle'");
         expectUUIDs(triangleUids);
         expectHitTermsRequiredAllOf("SHAPE:triangle");
-        planAndExecuteQuery();
 
         expectAttributeNormalizer("EDGES", NumberType.class);
         expectAttributeNormalizer("ONLY_TRI", LcNoDiacriticsType.class);
@@ -1255,6 +1263,7 @@ public class ShapesTest extends AbstractQueryTest {
         expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
         expectAttributeNormalizer("TYPE", LcNoDiacriticsType.class);
         expectAttributeNormalizer("UUID", NoOpType.class);
+        planAndExecuteQuery();
     }
 
     // use projection to trigger reduction
@@ -1269,15 +1278,12 @@ public class ShapesTest extends AbstractQueryTest {
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
-            planAndExecuteQuery();
 
             expectAttributeNormalizer("EDGES", NumberType.class);
             expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
             expectAttributeNormalizer("UUID", NoOpType.class);
-
-            assertFieldNotFound("ONLY_TRI");
-            assertFieldNotFound("PROPERTIES");
-            assertFieldNotFound("TYPE");
+            expectNoFields("ONLY_TRI", "PROPERTIES", "TYPE");
+            planAndExecuteQuery();
         } finally {
             logic.setReduceTypeMetadata(orig);
         }
@@ -1295,15 +1301,12 @@ public class ShapesTest extends AbstractQueryTest {
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
-            planAndExecuteQuery();
 
             expectAttributeNormalizer("EDGES", NumberType.class);
             expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
             expectAttributeNormalizer("UUID", NoOpType.class);
-
-            assertFieldNotFound("ONLY_TRI");
-            assertFieldNotFound("PROPERTIES");
-            assertFieldNotFound("TYPE");
+            expectNoFields("ONLY_TRI", "PROPERTIES", "TYPE");
+            planAndExecuteQuery();
         } finally {
             logic.setReduceTypeMetadata(orig);
         }
@@ -1321,15 +1324,12 @@ public class ShapesTest extends AbstractQueryTest {
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
-            planAndExecuteQuery();
 
             expectAttributeNormalizer("EDGES", NumberType.class);
             expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
             expectAttributeNormalizer("UUID", NoOpType.class);
-
-            assertFieldNotFound("ONLY_TRI");
-            assertFieldNotFound("PROPERTIES");
-            assertFieldNotFound("TYPE");
+            expectNoFields("ONLY_TRI", "PROPERTIES", "TYPE");
+            planAndExecuteQuery();
         } finally {
             logic.setReduceTypeMetadataPerShard(orig);
         }
@@ -1347,15 +1347,12 @@ public class ShapesTest extends AbstractQueryTest {
             expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
-            planAndExecuteQuery();
 
             expectAttributeNormalizer("EDGES", NumberType.class);
             expectAttributeNormalizer("SHAPE", LcNoDiacriticsType.class);
             expectAttributeNormalizer("UUID", NoOpType.class);
-
-            assertFieldNotFound("ONLY_TRI");
-            assertFieldNotFound("PROPERTIES");
-            assertFieldNotFound("TYPE");
+            expectNoFields("ONLY_TRI", "PROPERTIES", "TYPE");
+            planAndExecuteQuery();
         } finally {
             logic.setReduceTypeMetadata(orig);
         }
@@ -1372,6 +1369,7 @@ public class ShapesTest extends AbstractQueryTest {
             logic.setDisableEvaluation(true);
 
             givenQuery("SHAPE == 'triangle'");
+            expectPlan("SHAPE == 'triangle'");
             expectUUIDs(triangleUids);
             expectHitTermsRequiredAllOf("SHAPE:triangle");
             assertThrows(AssertionError.class, this::planAndExecuteQuery);

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -26,8 +26,6 @@ import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.SizesIngest;
-import datawave.query.util.TestIndexTableNames;
-import datawave.util.TableName;
 import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
@@ -91,45 +89,14 @@ public class SizesTest extends AbstractQueryTest {
         TypeRegistry.reset();
     }
 
-    /**
-     * Plans and executes a query against multiple versions of a shard index
-     *
-     * @throws Exception
-     *             if something goes wrong
-     */
     @Override
-    public void planAndExecuteQuery() throws Exception {
-        for (String indexTableName : TestIndexTableNames.names()) {
-            logic.setIndexTableName(indexTableName);
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                    logic.setIndexTableName(TableName.SHARD_INDEX);
-                    break;
-                case TestIndexTableNames.NO_UID_INDEX:
-                    logic.setIndexTableName(TestIndexTableNames.NO_UID_INDEX);
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(true);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name " + indexTableName);
-            }
+    protected void extraConfigurations() {
+        // no-op
+    }
 
-            log.info("=== using index: {} ===", indexTableName);
-            super.planAndExecuteQuery();
-            // TODO: while generating random events also generate metadata so the framework can assert result counts
-
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(false);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name " + indexTableName);
-            }
-        }
+    @Override
+    protected void extraAssertions() {
+        // no-op
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -11,6 +11,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -81,7 +82,7 @@ public class SizesTest extends AbstractQueryTest {
 
     @Before
     public void setup() throws Exception {
-        withDate("20250606", "20250606");
+        givenDate("20250606", "20250606");
         setClientForTest(clientForSetup);
     }
 
@@ -114,10 +115,8 @@ public class SizesTest extends AbstractQueryTest {
                     throw new IllegalStateException("Unknown index table name " + indexTableName);
             }
 
-            log.debug("=== using index: {} ===", indexTableName);
-            planQuery();
-            executeQuery();
-            assertPlannedQuery();
+            log.info("=== using index: {} ===", indexTableName);
+            super.planAndExecuteQuery();
             // TODO: while generating random events also generate metadata so the framework can assert result counts
 
             switch (indexTableName) {
@@ -135,74 +134,77 @@ public class SizesTest extends AbstractQueryTest {
 
     @Test
     public void testSizeSmall() throws Exception {
-        withQuery("SIZE == 'small'");
-        withQueryPlan("SIZE == 'small'");
+        givenQuery("SIZE == 'small'");
+        expectPlan("SIZE == 'small'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeSmallAndUniqueColor() throws Exception {
-        withQuery("SIZE == 'small' && f:unique(COLOR)");
-        withQueryPlan("SIZE == 'small'");
+        givenQuery("SIZE == 'small' && f:unique(COLOR)");
+        expectPlan("SIZE == 'small'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeMediumAndUniqueColor() throws Exception {
-        withQuery("SIZE == 'medium' && f:unique(COLOR)");
-        withQueryPlan("SIZE == 'medium'");
+        givenQuery("SIZE == 'medium' && f:unique(COLOR)");
+        expectPlan("SIZE == 'medium'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeLargeAndUniqueColor() throws Exception {
-        withQuery("SIZE == 'large' && f:unique(COLOR)");
-        withQueryPlan("SIZE == 'large'");
+        givenQuery("SIZE == 'large' && f:unique(COLOR)");
+        expectPlan("SIZE == 'large'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeSmallAndGroupByColorShape() throws Exception {
-        withQuery("SIZE == 'small' && f:groupby(COLOR,SHAPE)");
-        withQueryPlan("SIZE == 'small'");
+        givenQuery("SIZE == 'small' && f:groupby(COLOR,SHAPE)");
+        expectPlan("SIZE == 'small'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testAllSizesAndGroupByColorShapeSize() throws Exception {
-        withQuery("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large') && f:groupby(COLOR,SHAPE,SIZE)");
-        withQueryPlan("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large')");
-        withResultCount(ingest.getNumShards() * ingest.getNumEventsPerShard());
+        givenQuery("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large') && f:groupby(COLOR,SHAPE,SIZE)");
+        expectPlan("(SIZE == 'small' || SIZE == 'medium' || SIZE == 'large')");
+        expectResultCount(ingest.getNumShards() * ingest.getNumEventsPerShard());
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeMedium() throws Exception {
-        withQuery("SIZE == 'medium'");
-        withQueryPlan("SIZE == 'medium'");
+        givenQuery("SIZE == 'medium'");
+        expectPlan("SIZE == 'medium'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testSizeLarge() throws Exception {
-        withQuery("SIZE == 'large'");
-        withQueryPlan("SIZE == 'large'");
+        givenQuery("SIZE == 'large'");
+        expectPlan("SIZE == 'large'");
         planAndExecuteQuery();
     }
 
     @Test
     public void testAllSizes() throws Exception {
-        withQuery("SIZE == 'small' || SIZE == 'medium' ||  SIZE == 'large'");
-        withQueryPlan("SIZE == 'small' || SIZE == 'medium' ||  SIZE == 'large'");
-        withResultCount(ingest.getNumShards() * ingest.getNumEventsPerShard());
+        givenQuery("SIZE == 'small' || SIZE == 'medium' ||  SIZE == 'large'");
+        expectPlan("SIZE == 'small' || SIZE == 'medium' ||  SIZE == 'large'");
+        expectResultCount(ingest.getNumShards() * ingest.getNumEventsPerShard());
         planAndExecuteQuery();
     }
 
+    @Ignore
     @Test
     public void testRandomQuery() throws Exception {
-        withQuery("SIZE == 'small' && COLOR == 'green' && SHAPE == 'triangle'");
-        withQueryPlan("SIZE == 'small' && COLOR == 'green' && SHAPE == 'triangle'");
-        withResultCount(0);
+        // there exist edge cases where no document satisfies this query due to random event generation.
+        // when event metadata is generated a random query can be constructed from the metadata
+        givenQuery("SIZE == 'small' && COLOR == 'green' && SHAPE == 'triangle'");
+        expectPlan("SIZE == 'small' && COLOR == 'green' && SHAPE == 'triangle'");
+        expectResultCount(0);
         planAndExecuteQuery();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -1,37 +1,40 @@
 package datawave.query;
 
-import javax.inject.Inject;
-
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.configuration.spring.SpringBean;
 import datawave.ingest.data.TypeRegistry;
 import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.SizesIngest;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * This suite of tests exercises many random events over a small number of shards
  */
-@RunWith(Arquillian.class)
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
 public class SizesTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(SizesTest.class);
@@ -44,8 +47,8 @@ public class SizesTest extends AbstractQueryTest {
     // utility for writing different index table structures
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
 
     @Override
@@ -53,23 +56,8 @@ public class SizesTest extends AbstractQueryTest {
         return logic;
     }
 
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        //  @formatter:off
-        return ShrinkWrap.create(JavaArchive.class)
-                .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                        "datawave.webservice.query.result.event")
-                .deleteClass(DefaultEdgeEventQueryLogic.class)
-                .deleteClass(RemoteEdgeDictionary.class)
-                .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                .addAsManifestResource(new StringAsset(
-                                "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                        "beans.xml");
-        //  @formatter:on
-    }
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         clientForSetup = new InMemoryAccumuloClient("", instance);
 
         ingest = new SizesIngest(clientForSetup);
@@ -78,14 +66,14 @@ public class SizesTest extends AbstractQueryTest {
         ingestUtil.write(clientForSetup, auths);
     }
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    public void beforeEach() throws Exception {
         givenDate("20250606", "20250606");
         setClientForTest(clientForSetup);
     }
 
-    @AfterClass
-    public static void teardown() {
+    @AfterAll
+    public static void afterAll() {
         TypeRegistry.reset();
     }
 
@@ -164,7 +152,7 @@ public class SizesTest extends AbstractQueryTest {
         planAndExecuteQuery();
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void testRandomQuery() throws Exception {
         // there exist edge cases where no document satisfies this query due to random event generation.

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -1,8 +1,9 @@
 package datawave.query.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.text.DateFormat;
@@ -13,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -27,11 +29,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 
 import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.microservice.query.QueryImpl;
+import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
+import datawave.query.attributes.TypeAttribute;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
@@ -43,15 +48,31 @@ import datawave.test.HitTermAssertions;
  * <p>
  * This test framework is compatible with either an {@link InMemoryInstance} or {@link MiniAccumuloCluster}. It only requires an {@link AccumuloClient}.
  * <p>
- * Features include
+ * Helper methods such as {@link #givenDate(String)} or {@link #givenQuery(String)} denote initial state while methods such as {@link #expectedResultCount} or
+ * {@link #expectHitTermsRequiredAllOf(String...)} denote expected final state.
+ * <p>
+ * Initial state methods include:
  * <ul>
- * <li>Defining lucene or jexl queries</li>
- * <li>Defining query parameters</li>
- * <li>Defining expected hit terms</li>
- * <li>Defining expected query plan</li>
- * <li>Defining expected result count</li>
- * <li>Defining expected result shards</li>
+ * <li>{@link #givenDate(String)} required</li>
+ * <li>{@link #givenDate(String, String)} required</li>
+ * <li>{@link #givenQuery(String)} required</li>
+ * <li>{@link #givenParameter(String, String)} optional</li>
+ * <li>{@link #givenParameters(Map)} optional</li>
  * </ul>
+ * <p>
+ * Final state methods include:
+ * <ul>
+ * <li>{@link #expectPlan(String)} required</li>
+ * <li>{@link #expectResultCount(int)} optional</li>
+ * <li>{@link #expectHitTermsRequiredAnyOf(String...)}</li>
+ * <li>{@link #expectHitTermsRequiredAllOf(String...)}</li>
+ * <li>{@link #expectHitTermsOptionalAnyOf(String...)}</li>
+ * <li>{@link #expectHitTermsOptionalAllOf(String...)}</li>
+ * </ul>
+ * Unit tests that extend this class should adhere to the method order presented above for the sake of consistency.
+ * <p>
+ * Additionally if a test is going to use {@link #givenParameter(String, String)} repeatedly for a one or more parameters it may be helped to wrap the method
+ * call like <code>withDatatypeFilter</code>
  */
 public abstract class AbstractQueryTest {
 
@@ -63,46 +84,56 @@ public abstract class AbstractQueryTest {
     protected final DateFormat format = new SimpleDateFormat("yyyyMMdd");
     protected final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
 
-    protected final HitTermAssertions hitTermAssertions = new HitTermAssertions();
-
     private AccumuloClient clientForTest;
 
-    // variables that support declarative style tests
-    private String query;
+    // initial state
     private String startDate;
     private String endDate;
+    private String query;
+    private final Map<String,String> parameters = new HashMap<>();
 
-    protected final Map<String,String> parameters = new HashMap<>();
-    protected final Set<String> expected = new HashSet<>();
+    // final state
+    private String expectedQueryPlan = null;
+    private int expectedResultCount = -1;
     protected final Set<Document> results = new HashSet<>();
-
-    // additional variables for declarative assertions
-    protected String plannedQuery = null;
-    protected int expectedResultCount = -1;
+    protected final Set<String> expectedUUIDs = new HashSet<>();
+    private final HitTermAssertions hitTermAssertions = new HitTermAssertions();
 
     public abstract ShardQueryLogic getLogic();
 
     @After
     public void after() {
-        query = null;
+        // reset initial state
         startDate = null;
         endDate = null;
+        query = null;
         parameters.clear();
-        expected.clear();
-        results.clear();
-        plannedQuery = null;
+
+        // reset expectations
+        expectedQueryPlan = null;
         expectedResultCount = -1;
+        results.clear();
+        expectedUUIDs.clear();
         hitTermAssertions.resetState();
     }
 
-    /**
-     * Set the query string
-     *
-     * @param query
-     *            the query string
-     */
-    public void withQuery(String query) {
-        this.query = query;
+    public void setClientForTest(AccumuloClient client) {
+        this.clientForTest = client;
+    }
+
+    protected String getQuery() {
+        Preconditions.checkNotNull(query, "query is null");
+        return query;
+    }
+
+    protected Date getStartDate() throws Exception {
+        assertNotNull(startDate);
+        return format.parse(startDate);
+    }
+
+    protected Date getEndDate() throws Exception {
+        assertNotNull(endDate);
+        return format.parse(endDate);
     }
 
     /**
@@ -111,8 +142,8 @@ public abstract class AbstractQueryTest {
      * @param date
      *            the date
      */
-    public void withDate(String date) {
-        withDate(date, date);
+    public void givenDate(String date) {
+        givenDate(date, date);
     }
 
     /**
@@ -123,9 +154,19 @@ public abstract class AbstractQueryTest {
      * @param endDate
      *            the end date
      */
-    public void withDate(String startDate, String endDate) {
+    public void givenDate(String startDate, String endDate) {
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    /**
+     * Set the query string
+     *
+     * @param query
+     *            the query string
+     */
+    public void givenQuery(String query) {
+        this.query = query;
     }
 
     /**
@@ -136,7 +177,7 @@ public abstract class AbstractQueryTest {
      * @param value
      *            the value
      */
-    public void withParameter(String key, String value) {
+    public void givenParameter(String key, String value) {
         parameters.put(key, value);
     }
 
@@ -146,8 +187,38 @@ public abstract class AbstractQueryTest {
      * @param parameters
      *            the map of parameters to set
      */
-    public void withParameters(Map<String,String> parameters) {
+    public void givenParameters(Map<String,String> parameters) {
         this.parameters.putAll(parameters);
+    }
+
+    /**
+     * Set the expected query plan
+     *
+     * @param queryPlan
+     *            the expected query plan
+     */
+    public void expectPlan(String queryPlan) {
+        this.expectedQueryPlan = queryPlan;
+    }
+
+    /**
+     * Set the expected number of results
+     *
+     * @param expectedResultCount
+     *            the expected number of results
+     */
+    public void expectResultCount(int expectedResultCount) {
+        this.expectedResultCount = expectedResultCount;
+    }
+
+    /**
+     * Set the expected UUIDs. Optional as not every test will have a 'UUID' field.
+     *
+     * @param expectedUUIDs
+     *            the expected uuids
+     */
+    public void expectUUIDs(Set<String> expectedUUIDs) {
+        this.expectedUUIDs.addAll(expectedUUIDs);
     }
 
     /**
@@ -156,7 +227,7 @@ public abstract class AbstractQueryTest {
      * @param hitTerms
      *            a collection of hit terms
      */
-    public void withRequiredAllOf(String... hitTerms) {
+    public void expectHitTermsRequiredAllOf(String... hitTerms) {
         hitTermAssertions.withRequiredAllOf(hitTerms);
     }
 
@@ -166,7 +237,7 @@ public abstract class AbstractQueryTest {
      * @param hitTerms
      *            a collection of hit terms
      */
-    public void withRequiredAnyOf(String... hitTerms) {
+    public void expectHitTermsRequiredAnyOf(String... hitTerms) {
         hitTermAssertions.withRequiredAnyOf(hitTerms);
     }
 
@@ -176,7 +247,7 @@ public abstract class AbstractQueryTest {
      * @param hitTerms
      *            a collection of hit terms
      */
-    public void withOptionalAllOf(String... hitTerms) {
+    public void expectHitTermsOptionalAllOf(String... hitTerms) {
         hitTermAssertions.withOptionalAllOf(hitTerms);
     }
 
@@ -186,25 +257,32 @@ public abstract class AbstractQueryTest {
      * @param hitTerms
      *            a collection of hit terms
      */
-    public void withOptionalAnyOf(String... hitTerms) {
+    public void expectHitTermsOptionalAnyOf(String... hitTerms) {
         hitTermAssertions.withOptionalAnyOf(hitTerms);
     }
 
-    public void withQueryPlan(String queryPlan) {
-        this.plannedQuery = queryPlan;
-    }
-
-    public void withResultCount(int expectedResultCount) {
-        this.expectedResultCount = expectedResultCount;
-    }
-
+    /**
+     * A core method that plans and executes the query
+     *
+     * @throws Exception
+     *             if something goes wrong
+     */
     public void planAndExecuteQuery() throws Exception {
         planQuery();
         executeQuery();
+        assertQueryPlan();
+        assertResultCount();
+        assertUuids();
         assertHitTerms();
     }
 
-    public void planQuery() throws Exception {
+    /**
+     * Configure the logic with start and end date, query parameters and plan the query.
+     *
+     * @throws Exception
+     *             if something goes wrong
+     */
+    private void planQuery() throws Exception {
         try {
             QueryImpl settings = new QueryImpl();
             settings.setBeginDate(getStartDate());
@@ -226,7 +304,10 @@ public abstract class AbstractQueryTest {
         }
     }
 
-    public void executeQuery() {
+    /**
+     * Iterate through the query and add all deserialized results to the set of result documents.
+     */
+    private void executeQuery() {
         results.clear();
         for (Map.Entry<Key,Value> entry : getLogic()) {
             Document d = deserializer.apply(entry).getValue();
@@ -236,34 +317,16 @@ public abstract class AbstractQueryTest {
         log.info("query retrieved {} results", results.size());
     }
 
-    public void assertResultCount() {
-        assertResultCount(expectedResultCount);
-    }
-
-    public void assertResultCount(int expected) {
-        assertNotEquals("Expected result count not set", -1, expected);
-        assertEquals(expected, results.size());
-    }
-
-    public void assertHitTerms() {
-        assertEquals(hitTermAssertions.hitTermExpected(), !results.isEmpty());
-        if (!results.isEmpty()) {
-            boolean validated = hitTermAssertions.assertHitTerms(results);
-            assertEquals(hitTermAssertions.hitTermExpected(), validated);
-        }
-    }
-
-    public void assertPlannedQuery() {
-        assertNotNull("Expected query plan not set", plannedQuery);
-        assertPlannedQuery(plannedQuery);
-    }
-
-    public void assertPlannedQuery(String query) {
+    /**
+     * Assert the final query plan against the expected query plan. This is a required assertion for every test.
+     */
+    private void assertQueryPlan() {
+        assertNotNull("The expected query plan must be set ", expectedQueryPlan);
         try {
-            ASTJexlScript expected = JexlASTHelper.parseAndFlattenJexlQuery(query);
+            ASTJexlScript expected = JexlASTHelper.parseAndFlattenJexlQuery(expectedQueryPlan);
             ASTJexlScript plannedScript = getLogic().getConfig().getQueryTree();
             if (!TreeEqualityVisitor.isEqual(expected, plannedScript)) {
-                log.info("expected: {}", query);
+                log.info("expected: {}", expectedQueryPlan);
                 log.info("planned : {}", getLogic().getConfig().getQueryString());
                 fail("Planned query did not match expectation");
             }
@@ -272,22 +335,63 @@ public abstract class AbstractQueryTest {
         }
     }
 
-    public void setClientForTest(AccumuloClient client) {
-        this.clientForTest = client;
+    /**
+     * An optional assertion for the total result count
+     */
+    private void assertResultCount() {
+        if (expectedResultCount != -1) {
+            assertEquals(expectedResultCount, results.size());
+        }
     }
 
-    protected String getQuery() {
-        Preconditions.checkNotNull(query, "query is null");
-        return query;
+    /**
+     * An optional assertion for the UUID field
+     */
+    public void assertUuids() {
+        if (expectedUUIDs.isEmpty()) {
+            return;
+        }
+
+        assertFalse("UUIDs are expected but results are empty", results.isEmpty());
+
+        Set<String> found = new HashSet<>();
+        for (Document result : results) {
+            Attribute<?> attr = result.get("UUID");
+            assertNotNull("result did not contain a UUID", attr);
+            String uuid = getUUID(attr);
+            found.add(uuid);
+        }
+
+        Set<String> missing = Sets.difference(expectedUUIDs, found);
+        if (!missing.isEmpty()) {
+            log.info("missing uuids: {}", missing);
+        }
+
+        Set<String> extra = Sets.difference(found, expectedUUIDs);
+        if (!extra.isEmpty()) {
+            log.info("extra uuids: {}", extra);
+        }
+
+        assertEquals(expectedUUIDs, new TreeSet<>(found));
     }
 
-    protected Date getStartDate() throws Exception {
-        assertNotNull(startDate);
-        return format.parse(startDate);
+    public String getUUID(Attribute<?> attribute) {
+        boolean typed = attribute instanceof TypeAttribute;
+        assertTrue("Attribute was not a TypeAttribute, was: " + attribute.getClass(), typed);
+        TypeAttribute<?> uuid = (TypeAttribute<?>) attribute;
+        return uuid.getType().getDelegateAsString();
     }
 
-    protected Date getEndDate() throws Exception {
-        assertNotNull(endDate);
-        return format.parse(endDate);
+    /**
+     * An optional assertion for hit terms
+     */
+    private void assertHitTerms() {
+        if (hitTermAssertions.hitTermExpected()) {
+            assertEquals(hitTermAssertions.hitTermExpected(), !results.isEmpty());
+            if (!results.isEmpty()) {
+                boolean validated = hitTermAssertions.assertHitTerms(results);
+                assertEquals(hitTermAssertions.hitTermExpected(), validated);
+            }
+        }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -1,10 +1,10 @@
 package datawave.query.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -24,7 +24,7 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.ParseException;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,8 +105,8 @@ public abstract class AbstractQueryTest {
 
     public abstract ShardQueryLogic getLogic();
 
-    @After
-    public void after() {
+    @AfterEach
+    public void afterEach() {
         // reset initial state
         startDate = null;
         endDate = null;
@@ -273,7 +273,7 @@ public abstract class AbstractQueryTest {
      */
     public void planAndExecuteQuery() throws Exception {
         for (String indexTableName : TestIndexTableNames.names()) {
-            log.debug("=== using index: {} ===", indexTableName);
+            log.info("=== using index: {} ===", indexTableName);
             getLogic().setIndexTableName(indexTableName);
 
             switch (indexTableName) {
@@ -370,7 +370,7 @@ public abstract class AbstractQueryTest {
      * Assert the final query plan against the expected query plan. This is a required assertion for every test.
      */
     private void assertQueryPlan() {
-        assertNotNull("The expected query plan must be set ", expectedQueryPlan);
+        assertNotNull(expectedQueryPlan, "The expected query plan must be set ");
         try {
             ASTJexlScript expected = JexlASTHelper.parseAndFlattenJexlQuery(expectedQueryPlan);
             ASTJexlScript plannedScript = getLogic().getConfig().getQueryTree();
@@ -401,12 +401,12 @@ public abstract class AbstractQueryTest {
             return;
         }
 
-        assertFalse("UUIDs are expected but results are empty", results.isEmpty());
+        assertFalse(results.isEmpty(), "UUIDs are expected but results are empty");
 
         Set<String> found = new HashSet<>();
         for (Document result : results) {
             Attribute<?> attr = result.get("UUID");
-            assertNotNull("result did not contain a UUID", attr);
+            assertNotNull(attr, "result did not contain a UUID");
             String uuid = getUUID(attr);
             found.add(uuid);
         }
@@ -426,7 +426,7 @@ public abstract class AbstractQueryTest {
 
     public String getUUID(Attribute<?> attribute) {
         boolean typed = attribute instanceof TypeAttribute;
-        assertTrue("Attribute was not a TypeAttribute, was: " + attribute.getClass(), typed);
+        assertTrue(typed, "Attribute was not a TypeAttribute, was: " + attribute.getClass());
         TypeAttribute<?> uuid = (TypeAttribute<?>) attribute;
         return uuid.getType().getDelegateAsString();
     }

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -38,6 +38,7 @@ import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.TypeAttribute;
 import datawave.query.function.deserializer.KryoDocumentDeserializer;
+import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.visitors.TreeEqualityVisitor;
 import datawave.query.tables.ShardQueryLogic;
@@ -73,6 +74,9 @@ import datawave.test.HitTermAssertions;
  * <p>
  * Additionally if a test is going to use {@link #givenParameter(String, String)} repeatedly for a one or more parameters it may be helped to wrap the method
  * call like <code>withDatatypeFilter</code>
+ * <p>
+ * This utility also provides native support for iteratively running the same query against multiple versions of the shard index table, as defined by
+ * {@link TestIndexTableNames#names()}. Extending classes must use the {@link IndexIngestUtil} to populate the extra tables with data.
  */
 public abstract class AbstractQueryTest {
 
@@ -262,18 +266,56 @@ public abstract class AbstractQueryTest {
     }
 
     /**
-     * A core method that plans and executes the query
+     * A core method that will execute the query against every supported type of index table, as defined in {@link TestIndexTableNames#names()}.
      *
      * @throws Exception
      *             if something goes wrong
      */
     public void planAndExecuteQuery() throws Exception {
+        for (String indexTableName : TestIndexTableNames.names()) {
+            log.debug("=== using index: {} ===", indexTableName);
+            getLogic().setIndexTableName(indexTableName);
+
+            switch (indexTableName) {
+                case TestIndexTableNames.SHARD_INDEX:
+                case TestIndexTableNames.NO_UID_INDEX:
+                    break;
+                case TestIndexTableNames.TRUNCATED_INDEX:
+                    getLogic().setUseTruncatedIndex(true);
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
+            }
+
+            planAndExecuteIndividualQuery();
+
+            switch (indexTableName) {
+                case TestIndexTableNames.SHARD_INDEX:
+                case TestIndexTableNames.NO_UID_INDEX:
+                    break;
+                case TestIndexTableNames.TRUNCATED_INDEX:
+                    getLogic().setUseTruncatedIndex(false);
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
+            }
+        }
+    }
+
+    /**
+     * A core method that plans and executes the query
+     *
+     * @throws Exception
+     *             if something goes wrong
+     */
+    private void planAndExecuteIndividualQuery() throws Exception {
         planQuery();
         executeQuery();
         assertQueryPlan();
         assertResultCount();
         assertUuids();
         assertHitTerms();
+        extraAssertions();
     }
 
     /**
@@ -296,6 +338,8 @@ public abstract class AbstractQueryTest {
             getLogic().setMaxEvaluationPipelines(1);
             getLogic().setHitList(true); // always ask for HIT_TERMs
 
+            extraConfigurations();
+
             GenericQueryConfiguration config = getLogic().initialize(clientForTest, settings, authSet);
             getLogic().setupQuery(config);
         } catch (Exception e) {
@@ -303,6 +347,11 @@ public abstract class AbstractQueryTest {
             throw e;
         }
     }
+
+    /**
+     * Extending classes may wish to perform additional 'just in time' configuration
+     */
+    protected abstract void extraConfigurations();
 
     /**
      * Iterate through the query and add all deserialized results to the set of result documents.
@@ -394,4 +443,9 @@ public abstract class AbstractQueryTest {
             }
         }
     }
+
+    /**
+     * Extending classes may insert additional assertions here.
+     */
+    protected abstract void extraAssertions();
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -273,32 +273,52 @@ public abstract class AbstractQueryTest {
      */
     public void planAndExecuteQuery() throws Exception {
         for (String indexTableName : TestIndexTableNames.names()) {
-            log.info("=== using index: {} ===", indexTableName);
-            getLogic().setIndexTableName(indexTableName);
-
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    getLogic().setUseTruncatedIndex(true);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
+            try {
+                log.info("=== using index: {} ===", indexTableName);
+                setupIndexTable(indexTableName);
+                planAndExecuteIndividualQuery();
+            } finally {
+                teardownIndexTable(indexTableName);
             }
+        }
+    }
 
-            planAndExecuteIndividualQuery();
+    /**
+     * Configure the logic based on the index table name
+     *
+     * @param indexTableName
+     *            the global index table name
+     */
+    private void setupIndexTable(String indexTableName) {
+        getLogic().setIndexTableName(indexTableName);
+        switch (indexTableName) {
+            case TestIndexTableNames.SHARD_INDEX:
+            case TestIndexTableNames.NO_UID_INDEX:
+                break;
+            case TestIndexTableNames.TRUNCATED_INDEX:
+                getLogic().setUseTruncatedIndex(true);
+                break;
+            default:
+                throw new IllegalStateException("Unknown index table name: " + indexTableName);
+        }
+    }
 
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    getLogic().setUseTruncatedIndex(false);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name: " + indexTableName);
-            }
+    /**
+     * Cleanup the logic based on the index table name
+     *
+     * @param indexTableName
+     *            the global index table name
+     */
+    private void teardownIndexTable(String indexTableName) {
+        switch (indexTableName) {
+            case TestIndexTableNames.SHARD_INDEX:
+            case TestIndexTableNames.NO_UID_INDEX:
+                break;
+            case TestIndexTableNames.TRUNCATED_INDEX:
+                getLogic().setUseTruncatedIndex(false);
+                break;
+            default:
+                throw new IllegalStateException("Unknown index table name: " + indexTableName);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
@@ -92,40 +92,14 @@ public class MultiNormalizerTest extends AbstractQueryTest {
         TypeRegistry.reset();
     }
 
-    /**
-     * Supports running the same query against multiple types of index tables
-     *
-     * @throws Exception
-     *             if something goes wrong
-     */
-    public void planAndExecuteQueryAgainstMultipleIndices() throws Exception {
-        for (String indexTableName : TestIndexTableNames.names()) {
-            logic.setIndexTableName(indexTableName);
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(true);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name " + indexTableName);
-            }
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
 
-            log.debug("=== using index: {} ===", indexTableName);
-            planAndExecuteQuery();
-
-            switch (indexTableName) {
-                case TestIndexTableNames.SHARD_INDEX:
-                case TestIndexTableNames.NO_UID_INDEX:
-                    break;
-                case TestIndexTableNames.TRUNCATED_INDEX:
-                    logic.setUseTruncatedIndex(false);
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown index table name " + indexTableName);
-            }
-        }
+    @Override
+    protected void extraAssertions() {
+        // no-op
     }
 
     @Test
@@ -134,84 +108,84 @@ public class MultiNormalizerTest extends AbstractQueryTest {
         expectPlan("COLOR == 'red'");
         expectHitTermsRequiredAllOf("COLOR:red");
         expectResultCount(20);
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
     }
 
     @Test
     public void testSizeOne() throws Exception {
+        givenDate("20250707");
         givenQuery("SIZE == '1'");
         expectPlan("SIZE == '+aE1' || SIZE == '1'");
-        givenDate("20250707");
-        expectHitTermsRequiredAllOf("SIZE:1");
         expectResultCount(1);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAllOf("SIZE:1");
+        planAndExecuteQuery();
 
-        expectPlan("SIZE == '+aE1' || SIZE == '1'");
         givenDate("20250708");
-        expectHitTermsRequiredAllOf("SIZE:1");
-        expectResultCount(1);
-        planAndExecuteQueryAgainstMultipleIndices();
-
         expectPlan("SIZE == '+aE1' || SIZE == '1'");
-        givenDate("20250707", "20250708");
+        expectResultCount(1);
         expectHitTermsRequiredAllOf("SIZE:1");
+        planAndExecuteQuery();
+
+        givenDate("20250707", "20250708");
+        expectPlan("SIZE == '+aE1' || SIZE == '1'");
         expectResultCount(2);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAllOf("SIZE:1");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testColorRedSizeSix() throws Exception {
+        givenDate("20250707");
         givenQuery("COLOR == 'red' && SIZE == '6'");
         expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
-        givenDate("20250707");
-        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
         expectResultCount(1);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
+        planAndExecuteQuery();
 
-        expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
         givenDate("20250708");
-        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
-        expectResultCount(1);
-        planAndExecuteQueryAgainstMultipleIndices();
-
         expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
-        givenDate("20250707", "20250708");
+        expectResultCount(1);
         expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
+        planAndExecuteQuery();
+
+        givenDate("20250707", "20250708");
+        expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
         expectResultCount(2);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testRangeSizeOneToTwo_firstDay() throws Exception {
         // range with text normalizer expands into value "10", while technically correct this is wrong for numeric data
+        givenDate("20250707");
         givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
         expectPlan("(SIZE == '1' || SIZE == '10' || SIZE == '2')");
-        givenDate("20250707");
-        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
         expectResultCount(3);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testRangeSizeOneToTwo_lastDay() throws Exception {
         // range with numeric normalizer does not expand into "10". This is more correct.
+        givenDate("20250708");
         givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
         expectPlan("(SIZE == '+aE1' || SIZE == '+aE2')");
-        givenDate("20250708");
-        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:2");
         expectResultCount(2);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:2");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testRangeSizeOneToTwo_bothDays() throws Exception {
         // range with both normalizers applied will expand into all values above, including the incorrect value "10"
+        givenDate("20250707", "20250708");
         givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
         expectPlan("(SIZE == '+aE1' || SIZE == '+aE2' || SIZE == '1' || SIZE == '10' || SIZE == '2')");
-        givenDate("20250707", "20250708");
-        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
         expectResultCount(5);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+        planAndExecuteQuery();
     }
 
     @Test
@@ -221,27 +195,27 @@ public class MultiNormalizerTest extends AbstractQueryTest {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(true);
 
             // range with text normalizer will incorrectly return result [SIZE:10]
+            givenDate("20250707");
             givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
             expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
-            givenDate("20250707");
-            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
             expectResultCount(3);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            planAndExecuteQuery();
 
             // because both ranges are pushed down to shard 20250708 and all normalized forms are applied at evaluation,
             // the text range will return the result with SIZE:10. While technically correct this was not the intent.
-            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
             givenDate("20250708");
-            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
             expectResultCount(3);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            planAndExecuteQuery();
 
             // for reasons stated above this query returns result SIZE:10 from both shards
-            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
             givenDate("20250707", "20250708");
-            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
             expectResultCount(6);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            planAndExecuteQuery();
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
         }
@@ -251,23 +225,23 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     public void testRangeSizeFourToTen() throws Exception {
         // range with text normalizer is not valid and thus finds zero hits
         givenQuery("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
-        expectPlan("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
         givenDate("20250707");
+        expectPlan("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
         expectResultCount(0);
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
 
         // range with numeric normalizer will find hits in the shard index and expand into discrete values
-        expectPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
         givenDate("20250708");
-        expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-        expectResultCount(7);
-        planAndExecuteQueryAgainstMultipleIndices();
-
         expectPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-        givenDate("20250707", "20250708");
-        expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
         expectResultCount(7);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        planAndExecuteQuery();
+
+        givenDate("20250707", "20250708");
+        expectPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+        expectResultCount(7);
+        expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        planAndExecuteQuery();
     }
 
     @Test(expected = DatawaveQueryException.class)
@@ -278,26 +252,26 @@ public class MultiNormalizerTest extends AbstractQueryTest {
 
             // numeric range still matches against numeric data that has a text normalizer
             // withQuery("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))"); // expected when validating bounded ranges
+            givenDate("20250707");
             givenQuery("(((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1')) || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
             expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            givenDate("20250707");
-            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
             expectResultCount(7);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            planAndExecuteQuery();
 
             // numeric range matches against numeric data with number normalizer
-            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             givenDate("20250708");
-            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(7);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            planAndExecuteQuery();
 
             // numeric range matches against numeric data with either a text or number normalizer
-            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             givenDate("20250707", "20250708");
-            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(14);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            planAndExecuteQuery();
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
         }
@@ -306,24 +280,24 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     @Test
     public void testRangeSizeFourToTenWithAnchor() throws Exception {
         // range with text normalizer will not find any hits
+        givenDate("20250707");
         givenQuery("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
         expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
-        givenDate("20250707");
         expectResultCount(0);
-        planAndExecuteQueryAgainstMultipleIndices();
+        planAndExecuteQuery();
 
         // range with numeric normalizer finds expected hits
-        expectPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
         givenDate("20250708");
-        expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-        expectResultCount(7);
-        planAndExecuteQueryAgainstMultipleIndices();
-
         expectPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-        givenDate("20250707", "20250708");
-        expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
         expectResultCount(7);
-        planAndExecuteQueryAgainstMultipleIndices();
+        expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        planAndExecuteQuery();
+
+        givenDate("20250707", "20250708");
+        expectPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+        expectResultCount(7);
+        expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        planAndExecuteQuery();
     }
 
     @Test(expected = DatawaveQueryException.class)
@@ -335,26 +309,26 @@ public class MultiNormalizerTest extends AbstractQueryTest {
             // range with text normalizer would ordinarily not find any hits but anchor term nominates candidates. At
             // evaluation multiple normalizers are applied, thus text number can match the numeric range
             // withQuery("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))"); // expected when validating bounded ranges
+            givenDate("20250707");
             givenQuery("COLOR == 'red' && (((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1')) || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
             expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            givenDate("20250707");
-            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
             expectResultCount(7);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            planAndExecuteQuery();
 
             // range with numeric normalizer finds expected hits
-            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             givenDate("20250708");
-            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(7);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            planAndExecuteQuery();
 
             // anchor term plus multi-normalization at evaluation time allows all valid hits to be found
-            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             givenDate("20250707", "20250708");
-            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(14);
-            planAndExecuteQueryAgainstMultipleIndices();
+            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            planAndExecuteQuery();
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
@@ -1,24 +1,23 @@
 package datawave.query.util;
 
-import javax.inject.Inject;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.configuration.spring.SpringBean;
 import datawave.ingest.data.TypeRegistry;
 import datawave.query.MultiNormalizerIngest;
 import datawave.query.QueryParameters;
@@ -26,19 +25,25 @@ import datawave.query.exceptions.DatawaveQueryException;
 import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * Test that simulates normalizer changes over time where some events have one normalizer applied but later a different normalizer is configured
  */
-@RunWith(Arquillian.class)
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
 public class MultiNormalizerTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(MultiNormalizerTest.class);
 
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
 
     @Override
@@ -50,23 +55,8 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     private static AccumuloClient clientForSetup;
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        //  @formatter:off
-        return ShrinkWrap.create(JavaArchive.class)
-                .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                        "datawave.webservice.query.result.event")
-                .deleteClass(DefaultEdgeEventQueryLogic.class)
-                .deleteClass(RemoteEdgeDictionary.class)
-                .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                .addAsManifestResource(new StringAsset(
-                                "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                        "beans.xml");
-        //  @formatter:on
-    }
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         clientForSetup = new InMemoryAccumuloClient("", instance);
 
         MultiNormalizerIngest ingest = new MultiNormalizerIngest(clientForSetup);
@@ -75,20 +65,16 @@ public class MultiNormalizerTest extends AbstractQueryTest {
         ingestUtil.write(clientForSetup, auths);
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         setClientForTest(clientForSetup);
         givenParameter(QueryParameters.HIT_LIST, "true");
-    }
-
-    @Before
-    public void setup() throws Exception {
         // default to full date range
         givenDate("20250707", "20250708");
     }
 
-    @AfterClass
-    public static void teardown() {
+    @AfterAll
+    public static void afterAll() {
         TypeRegistry.reset();
     }
 
@@ -244,7 +230,7 @@ public class MultiNormalizerTest extends AbstractQueryTest {
         planAndExecuteQuery();
     }
 
-    @Test(expected = DatawaveQueryException.class)
+    @Test
     public void testRangeSizeFourToTen_rangeExpansionDisabled() throws Exception {
         try {
             // simulate a bounded range expansion failure
@@ -257,21 +243,21 @@ public class MultiNormalizerTest extends AbstractQueryTest {
             expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(7);
             expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            planAndExecuteQuery();
+            assertThrows(DatawaveQueryException.class, this::planAndExecuteQuery);
 
             // numeric range matches against numeric data with number normalizer
             givenDate("20250708");
             expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(7);
             expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            planAndExecuteQuery();
+            assertThrows(DatawaveQueryException.class, this::planAndExecuteQuery);
 
             // numeric range matches against numeric data with either a text or number normalizer
             givenDate("20250707", "20250708");
             expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(14);
             expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            planAndExecuteQuery();
+            assertThrows(DatawaveQueryException.class, this::planAndExecuteQuery);
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
         }
@@ -300,7 +286,7 @@ public class MultiNormalizerTest extends AbstractQueryTest {
         planAndExecuteQuery();
     }
 
-    @Test(expected = DatawaveQueryException.class)
+    @Test
     public void testRangeSizeFourToTenWithAnchor_rangeExpansionDisabled() throws Exception {
         try {
             // simulate a bounded range expansion failure
@@ -314,21 +300,21 @@ public class MultiNormalizerTest extends AbstractQueryTest {
             expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(7);
             expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            planAndExecuteQuery();
+            assertThrows(DatawaveQueryException.class, this::planAndExecuteQuery);
 
             // range with numeric normalizer finds expected hits
             givenDate("20250708");
             expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(7);
             expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            planAndExecuteQuery();
+            assertThrows(DatawaveQueryException.class, this::planAndExecuteQuery);
 
             // anchor term plus multi-normalization at evaluation time allows all valid hits to be found
             givenDate("20250707", "20250708");
             expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
             expectResultCount(14);
             expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            planAndExecuteQuery();
+            assertThrows(DatawaveQueryException.class, this::planAndExecuteQuery);
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
@@ -78,13 +78,13 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     @Before
     public void beforeEach() {
         setClientForTest(clientForSetup);
-        withParameter(QueryParameters.HIT_LIST, "true");
+        givenParameter(QueryParameters.HIT_LIST, "true");
     }
 
     @Before
     public void setup() throws Exception {
         // default to full date range
-        withDate("20250707", "20250708");
+        givenDate("20250707", "20250708");
     }
 
     @AfterClass
@@ -114,8 +114,6 @@ public class MultiNormalizerTest extends AbstractQueryTest {
 
             log.debug("=== using index: {} ===", indexTableName);
             planAndExecuteQuery();
-            assertPlannedQuery();
-            assertResultCount();
 
             switch (indexTableName) {
                 case TestIndexTableNames.SHARD_INDEX:
@@ -132,87 +130,87 @@ public class MultiNormalizerTest extends AbstractQueryTest {
 
     @Test
     public void testColorRed() throws Exception {
-        withQuery("COLOR == 'red'");
-        withQueryPlan("COLOR == 'red'");
-        withRequiredAllOf("COLOR:red");
-        withResultCount(20);
+        givenQuery("COLOR == 'red'");
+        expectPlan("COLOR == 'red'");
+        expectHitTermsRequiredAllOf("COLOR:red");
+        expectResultCount(20);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testSizeOne() throws Exception {
-        withQuery("SIZE == '1'");
-        withQueryPlan("SIZE == '+aE1' || SIZE == '1'");
-        withDate("20250707");
-        withRequiredAllOf("SIZE:1");
-        withResultCount(1);
+        givenQuery("SIZE == '1'");
+        expectPlan("SIZE == '+aE1' || SIZE == '1'");
+        givenDate("20250707");
+        expectHitTermsRequiredAllOf("SIZE:1");
+        expectResultCount(1);
         planAndExecuteQueryAgainstMultipleIndices();
 
-        withQueryPlan("SIZE == '+aE1' || SIZE == '1'");
-        withDate("20250708");
-        withRequiredAllOf("SIZE:1");
-        withResultCount(1);
+        expectPlan("SIZE == '+aE1' || SIZE == '1'");
+        givenDate("20250708");
+        expectHitTermsRequiredAllOf("SIZE:1");
+        expectResultCount(1);
         planAndExecuteQueryAgainstMultipleIndices();
 
-        withQueryPlan("SIZE == '+aE1' || SIZE == '1'");
-        withDate("20250707", "20250708");
-        withRequiredAllOf("SIZE:1");
-        withResultCount(2);
+        expectPlan("SIZE == '+aE1' || SIZE == '1'");
+        givenDate("20250707", "20250708");
+        expectHitTermsRequiredAllOf("SIZE:1");
+        expectResultCount(2);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testColorRedSizeSix() throws Exception {
-        withQuery("COLOR == 'red' && SIZE == '6'");
-        withQueryPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
-        withDate("20250707");
-        withRequiredAllOf("COLOR:red", "SIZE:6");
-        withResultCount(1);
+        givenQuery("COLOR == 'red' && SIZE == '6'");
+        expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
+        givenDate("20250707");
+        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
+        expectResultCount(1);
         planAndExecuteQueryAgainstMultipleIndices();
 
-        withQueryPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
-        withDate("20250708");
-        withRequiredAllOf("COLOR:red", "SIZE:6");
-        withResultCount(1);
+        expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
+        givenDate("20250708");
+        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
+        expectResultCount(1);
         planAndExecuteQueryAgainstMultipleIndices();
 
-        withQueryPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
-        withDate("20250707", "20250708");
-        withRequiredAllOf("COLOR:red", "SIZE:6");
-        withResultCount(2);
+        expectPlan("COLOR == 'red' && (SIZE == '+aE6' || SIZE == '6')");
+        givenDate("20250707", "20250708");
+        expectHitTermsRequiredAllOf("COLOR:red", "SIZE:6");
+        expectResultCount(2);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testRangeSizeOneToTwo_firstDay() throws Exception {
         // range with text normalizer expands into value "10", while technically correct this is wrong for numeric data
-        withQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
-        withQueryPlan("(SIZE == '1' || SIZE == '10' || SIZE == '2')");
-        withDate("20250707");
-        withRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
-        withResultCount(3);
+        givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
+        expectPlan("(SIZE == '1' || SIZE == '10' || SIZE == '2')");
+        givenDate("20250707");
+        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+        expectResultCount(3);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testRangeSizeOneToTwo_lastDay() throws Exception {
         // range with numeric normalizer does not expand into "10". This is more correct.
-        withQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
-        withQueryPlan("(SIZE == '+aE1' || SIZE == '+aE2')");
-        withDate("20250708");
-        withRequiredAnyOf("SIZE:1", "SIZE:2");
-        withResultCount(2);
+        givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
+        expectPlan("(SIZE == '+aE1' || SIZE == '+aE2')");
+        givenDate("20250708");
+        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:2");
+        expectResultCount(2);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
     @Test
     public void testRangeSizeOneToTwo_bothDays() throws Exception {
         // range with both normalizers applied will expand into all values above, including the incorrect value "10"
-        withQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
-        withQueryPlan("(SIZE == '+aE1' || SIZE == '+aE2' || SIZE == '1' || SIZE == '10' || SIZE == '2')");
-        withDate("20250707", "20250708");
-        withRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
-        withResultCount(5);
+        givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
+        expectPlan("(SIZE == '+aE1' || SIZE == '+aE2' || SIZE == '1' || SIZE == '10' || SIZE == '2')");
+        givenDate("20250707", "20250708");
+        expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+        expectResultCount(5);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
@@ -223,26 +221,26 @@ public class MultiNormalizerTest extends AbstractQueryTest {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(true);
 
             // range with text normalizer will incorrectly return result [SIZE:10]
-            withQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
-            withQueryPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
-            withDate("20250707");
-            withRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
-            withResultCount(3);
+            givenQuery("((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2'))");
+            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
+            givenDate("20250707");
+            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            expectResultCount(3);
             planAndExecuteQueryAgainstMultipleIndices();
 
             // because both ranges are pushed down to shard 20250708 and all normalized forms are applied at evaluation,
             // the text range will return the result with SIZE:10. While technically correct this was not the intent.
-            withQueryPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
-            withDate("20250708");
-            withRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
-            withResultCount(3);
+            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
+            givenDate("20250708");
+            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            expectResultCount(3);
             planAndExecuteQueryAgainstMultipleIndices();
 
             // for reasons stated above this query returns result SIZE:10 from both shards
-            withQueryPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
-            withDate("20250707", "20250708");
-            withRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
-            withResultCount(6);
+            expectPlan("(((_Bounded_ = true) && (SIZE >= '+aE1' && SIZE <= '+aE2')) || ((_Bounded_ = true) && (SIZE >= '1' && SIZE <= '2')))");
+            givenDate("20250707", "20250708");
+            expectHitTermsRequiredAnyOf("SIZE:1", "SIZE:10", "SIZE:2");
+            expectResultCount(6);
             planAndExecuteQueryAgainstMultipleIndices();
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
@@ -252,23 +250,23 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     @Test
     public void testRangeSizeFourToTen() throws Exception {
         // range with text normalizer is not valid and thus finds zero hits
-        withQuery("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
-        withQueryPlan("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
-        withDate("20250707");
-        withResultCount(0);
+        givenQuery("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
+        expectPlan("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
+        givenDate("20250707");
+        expectResultCount(0);
         planAndExecuteQueryAgainstMultipleIndices();
 
         // range with numeric normalizer will find hits in the shard index and expand into discrete values
-        withQueryPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-        withDate("20250708");
-        withRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-        withResultCount(7);
+        expectPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+        givenDate("20250708");
+        expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        expectResultCount(7);
         planAndExecuteQueryAgainstMultipleIndices();
 
-        withQueryPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-        withDate("20250707", "20250708");
-        withRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-        withResultCount(7);
+        expectPlan("(SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+        givenDate("20250707", "20250708");
+        expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        expectResultCount(7);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
@@ -280,25 +278,25 @@ public class MultiNormalizerTest extends AbstractQueryTest {
 
             // numeric range still matches against numeric data that has a text normalizer
             // withQuery("((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))"); // expected when validating bounded ranges
-            withQuery("(((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1')) || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-            withQueryPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            withDate("20250707");
-            withRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            withResultCount(7);
+            givenQuery("(((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1')) || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
+            givenDate("20250707");
+            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectResultCount(7);
             planAndExecuteQueryAgainstMultipleIndices();
 
             // numeric range matches against numeric data with number normalizer
-            withQueryPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            withDate("20250708");
-            withRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            withResultCount(7);
+            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
+            givenDate("20250708");
+            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectResultCount(7);
             planAndExecuteQueryAgainstMultipleIndices();
 
             // numeric range matches against numeric data with either a text or number normalizer
-            withQueryPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            withDate("20250707", "20250708");
-            withRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            withResultCount(14);
+            expectPlan("((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
+            givenDate("20250707", "20250708");
+            expectHitTermsRequiredAnyOf("SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectResultCount(14);
             planAndExecuteQueryAgainstMultipleIndices();
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);
@@ -308,24 +306,23 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     @Test
     public void testRangeSizeFourToTenWithAnchor() throws Exception {
         // range with text normalizer will not find any hits
-        withQuery("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
-        withQueryPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
-        withDate("20250707");
-        withResultCount(0);
+        givenQuery("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
+        expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))");
+        givenDate("20250707");
+        expectResultCount(0);
         planAndExecuteQueryAgainstMultipleIndices();
-        assertResultCount(0);
 
         // range with numeric normalizer finds expected hits
-        withQueryPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-        withDate("20250708");
-        withRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-        withResultCount(7);
+        expectPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+        givenDate("20250708");
+        expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        expectResultCount(7);
         planAndExecuteQueryAgainstMultipleIndices();
 
-        withQueryPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-        withDate("20250707", "20250708");
-        withRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-        withResultCount(7);
+        expectPlan("COLOR == 'red' && (SIZE == '+aE4' || SIZE == '+aE5' || SIZE == '+aE6' || SIZE == '+aE7' || SIZE == '+aE8' || SIZE == '+aE9' || SIZE == '+bE1' || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+        givenDate("20250707", "20250708");
+        expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+        expectResultCount(7);
         planAndExecuteQueryAgainstMultipleIndices();
     }
 
@@ -338,25 +335,25 @@ public class MultiNormalizerTest extends AbstractQueryTest {
             // range with text normalizer would ordinarily not find any hits but anchor term nominates candidates. At
             // evaluation multiple normalizers are applied, thus text number can match the numeric range
             // withQuery("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10'))"); // expected when validating bounded ranges
-            withQuery("COLOR == 'red' && (((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1')) || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
-            withQueryPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            withDate("20250707");
-            withRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            withResultCount(7);
+            givenQuery("COLOR == 'red' && (((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1')) || ((_Bounded_ = true) && (SIZE >= '4' && SIZE <= '10')))");
+            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
+            givenDate("20250707");
+            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectResultCount(7);
             planAndExecuteQueryAgainstMultipleIndices();
 
             // range with numeric normalizer finds expected hits
-            withQueryPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            withDate("20250708");
-            withRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            withResultCount(7);
+            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
+            givenDate("20250708");
+            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectResultCount(7);
             planAndExecuteQueryAgainstMultipleIndices();
 
             // anchor term plus multi-normalization at evaluation time allows all valid hits to be found
-            withQueryPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
-            withDate("20250707", "20250708");
-            withRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
-            withResultCount(14);
+            expectPlan("COLOR == 'red' && ((_Bounded_ = true) && (SIZE >= '+aE4' && SIZE <= '+bE1'))");
+            givenDate("20250707", "20250708");
+            expectHitTermsRequiredAnyOf("COLOR:red", "SIZE:4", "SIZE:5", "SIZE:6", "SIZE:7", "SIZE:8", "SIZE:9", "SIZE:10");
+            expectResultCount(14);
             planAndExecuteQueryAgainstMultipleIndices();
         } finally {
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(false);

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -394,10 +394,10 @@
         <property name="tfAggregationThresholdMs" value="-1" />
         <!--   enable per-tablet pruning of certain query options     -->
         <property name="pruneQueryOptions" value="false" />
-        <property name="rebuildDatatypeFilter" value="true" />
+        <property name="rebuildDatatypeFilter" value="false" />
         <property name="rebuildDatatypeFilterPerShard" value="false" />
-        <property name="reduceIngestTypes" value="true"/>
-        <property name="reduceIngestTypesPerShard" value="true"/>
+        <property name="reduceIngestTypes" value="false"/>
+        <property name="reduceIngestTypesPerShard" value="false"/>
         <property name="reduceQueryFields" value="false" />
         <property name="reduceQueryFieldsPerShard" value="false" />
         <property name="reduceTypeMetadata" value="false" />


### PR DESCRIPTION
 - consolidate naming convention and method flow for AbstractQueryTest
 - native support for running test cases against each type of index (uid, no uid, and bitset)
 - upgraded from JUnit4 to JUnit5
 - migrated from Arquillian to Spring