### PR TITLE
Replace non-public BadArgumentException and MapCounter

### DIFF
--- a/core/common-util/src/test/java/datawave/core/cache/CVCacheIT.java
+++ b/core/common-util/src/test/java/datawave/core/cache/CVCacheIT.java
@@ -15,7 +15,6 @@ import java.util.concurrent.Future;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.core.util.BadArgumentException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
@@ -60,9 +59,9 @@ public class CVCacheIT {
             try {
                 cache.get(sequence);
             } catch (Exception e) {
-                boolean isBadArgumentException = e instanceof BadArgumentException;
+                boolean isIllegalArgumentException = e instanceof IllegalArgumentException;
                 boolean isUncheckedExecutionException = e instanceof UncheckedExecutionException;
-                assertTrue(isBadArgumentException || isUncheckedExecutionException);
+                assertTrue(isIllegalArgumentException || isUncheckedExecutionException);
             }
             count++;
         }

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardedTableTabletBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardedTableTabletBalancerTest.java
@@ -37,7 +37,6 @@ import org.apache.accumulo.core.metadata.schema.Ample;
 import org.apache.accumulo.core.spi.balancer.data.TServerStatus;
 import org.apache.accumulo.core.spi.balancer.data.TabletMigration;
 import org.apache.accumulo.core.spi.balancer.data.TabletServerId;
-import org.apache.accumulo.core.util.MapCounter;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,6 +52,7 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 
 import datawave.common.test.integration.IntegrationTest;
+import datawave.util.MapCounter;
 
 public class ShardedTableTabletBalancerTest {
     private static final TableId TNAME = TableId.of("s");

--- a/warehouse/accumulo-extensions/src/test/java/datawave/util/MapCounter.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/util/MapCounter.java
@@ -1,0 +1,51 @@
+package datawave.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A simple utility class for counting occurrences of keys. Replacement for non-public org.apache.accumulo.core.util.MapCounter.
+ *
+ * @param <K>
+ *            the type of keys maintained by this counter
+ */
+public class MapCounter<K> {
+
+    private final Map<K,Long> counts = new HashMap<>();
+
+    /**
+     * Increment the count for the given key.
+     *
+     * @param key
+     *            the key to increment
+     * @param amount
+     *            the amount to increment by
+     * @return the new count for the key
+     */
+    public long increment(K key, long amount) {
+        long newValue = counts.getOrDefault(key, 0L) + amount;
+        counts.put(key, newValue);
+        return newValue;
+    }
+
+    /**
+     * Get the count for the given key.
+     *
+     * @param key
+     *            the key to look up
+     * @return the count for the key, or 0 if not present
+     */
+    public long get(K key) {
+        return counts.getOrDefault(key, 0L);
+    }
+
+    /**
+     * Get the set of keys in this counter.
+     *
+     * @return the set of keys
+     */
+    public Set<K> keySet() {
+        return counts.keySet();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace non-public `BadArgumentException` with `IllegalArgumentException` in CVCacheIT
- Create DataWave `MapCounter` utility class to replace non-public Accumulo `MapCounter`
- Update ShardedTableTabletBalancerTest to use DataWave MapCounter

Fixes #3348
Fixes #3350
Part of #2443