### PR TITLE
Replace non-public CloneConfigurationImpl with builder

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionUtils.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionUtils.java
@@ -22,7 +22,6 @@ import org.apache.accumulo.core.client.admin.CloneConfiguration;
 import org.apache.accumulo.core.client.admin.CompactionConfig;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
-import org.apache.accumulo.core.clientImpl.CloneConfigurationImpl;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
@@ -211,7 +210,7 @@ public abstract class IndexConversionUtils {
     protected void cloneAndCompactMac(TableOperations tops, String tableName) {
         try {
             //  @formatter:off
-            CloneConfiguration cloneConfiguration = new CloneConfigurationImpl()
+            CloneConfiguration cloneConfiguration = CloneConfiguration.builder()
                     .setFlush(true)
                     .setKeepOffline(false)
                     .build();


### PR DESCRIPTION
## Summary
- Replace non-public `org.apache.accumulo.core.clientImpl.CloneConfigurationImpl` with public `CloneConfiguration.builder()` pattern

Fixes #3376
Part of #2443