### PR TITLE
BoundedRangeDetectionVisitor no longer needs the MetadataHelper

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeDetectionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeDetectionVisitor.java
@@ -2,6 +2,7 @@ package datawave.query.jexl.visitors;
 
 import static datawave.query.jexl.nodes.QueryPropertyMarker.MarkerType.BOUNDED_RANGE;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
@@ -22,23 +23,40 @@ import datawave.query.jexl.LiteralRange;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.util.MetadataHelper;
 
+/**
+ * Visitor determines if any bounded ranges exist for non-event fields
+ */
 public class BoundedRangeDetectionVisitor extends ShortCircuitBaseVisitor {
 
     ShardQueryConfiguration config;
     MetadataHelper helper;
 
+    private Set<String> nonEventFields;
+
+    @Deprecated(since = "7.35.0", forRemoval = true)
     public BoundedRangeDetectionVisitor(ShardQueryConfiguration config, MetadataHelper metadataHelper) {
         this.config = config;
         this.helper = metadataHelper;
     }
 
-    @SuppressWarnings("unchecked")
+    public BoundedRangeDetectionVisitor(Set<String> nonEventFields) {
+        this.nonEventFields = nonEventFields;
+    }
+
+    @Deprecated(since = "7.35.0", forRemoval = true)
     public static boolean mustExpandBoundedRange(ShardQueryConfiguration config, MetadataHelper metadataHelper, JexlNode script) {
-        BoundedRangeDetectionVisitor visitor = new BoundedRangeDetectionVisitor(config, metadataHelper);
+        try {
+            Set<String> nonEventFields = metadataHelper.getNonEventFields(config.getDatatypeFilter());
+            return mustExpandBoundedRange(script, nonEventFields);
+        } catch (TableNotFoundException e) {
+            throw new DatawaveFatalQueryException("Metadata table not found", e);
+        }
+    }
 
+    public static boolean mustExpandBoundedRange(JexlNode node, Set<String> nonEventFields) {
+        BoundedRangeDetectionVisitor visitor = new BoundedRangeDetectionVisitor(nonEventFields);
         AtomicBoolean hasBounded = new AtomicBoolean(false);
-        script.jjtAccept(visitor, hasBounded);
-
+        node.jjtAccept(visitor, hasBounded);
         return hasBounded.get();
     }
 
@@ -46,15 +64,10 @@ public class BoundedRangeDetectionVisitor extends ShortCircuitBaseVisitor {
     public Object visit(ASTAndNode node, Object data) {
         if (QueryPropertyMarker.findInstance(node).isType(BOUNDED_RANGE)) {
             LiteralRange<?> range = JexlASTHelper.findRange().getRange(node);
-            try {
-                if (null != data && helper.getNonEventFields(config.getDatatypeFilter()).contains(range.getFieldName())) {
-                    AtomicBoolean hasBounded = (AtomicBoolean) data;
-                    hasBounded.set(true);
-                }
-            } catch (TableNotFoundException e) {
-                throw new DatawaveFatalQueryException("Cannot access metadata", e);
+            if (data != null && nonEventFields.contains(range.getFieldName())) {
+                AtomicBoolean hasBounded = (AtomicBoolean) data;
+                hasBounded.set(true);
             }
-
             return false;
         } else {
             return super.visit(node, data);
@@ -63,25 +76,19 @@ public class BoundedRangeDetectionVisitor extends ShortCircuitBaseVisitor {
 
     @Override
     public Object visit(ASTERNode node, Object data) {
-        try {
-            if (null != data && helper.getNonEventFields(config.getDatatypeFilter()).contains(JexlASTHelper.getIdentifier(node))) {
-                AtomicBoolean hasBounded = (AtomicBoolean) data;
-                hasBounded.set(true);
-            }
-        } catch (TableNotFoundException e) {
-            throw new DatawaveFatalQueryException("Cannot access metadata", e);
+        if (data != null && nonEventFields.contains(JexlASTHelper.getIdentifier(node))) {
+            AtomicBoolean hasBounded = (AtomicBoolean) data;
+            hasBounded.set(true);
         }
-
         return false;
     }
 
     @Override
     public Object visit(ASTNRNode node, Object data) {
-        if (null != data) {
+        if (data != null) {
             AtomicBoolean hasBounded = (AtomicBoolean) data;
             hasBounded.set(true);
         }
-
         return false;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1010,7 +1010,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (disableBoundedLookup) {
             // protection mechanism. If we disable bounded ranges and have a
             // LT,GT or ER node, we should expand it
-            if (BoundedRangeDetectionVisitor.mustExpandBoundedRange(config, metadataHelper, config.getQueryTree())) {
+            if (BoundedRangeDetectionVisitor.mustExpandBoundedRange(config.getQueryTree(), getNonEventFields())) {
                 disableBoundedLookup = false;
             }
         }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BoundedRangeDetectionVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BoundedRangeDetectionVisitorTest.java
@@ -3,6 +3,10 @@ package datawave.query.jexl.visitors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.ParseException;
 import org.junit.Before;
@@ -21,17 +25,20 @@ import datawave.query.util.MockMetadataHelper;
 public class BoundedRangeDetectionVisitorTest {
     private ShardQueryConfiguration config;
     private MockMetadataHelper helper;
+    private Set<String> nonEventFields;
 
     @Before
     public void init() throws Exception {
-        this.config = ShardQueryConfiguration.create();
         Multimap<String,Type<?>> queryFieldsDatatypes = HashMultimap.create();
         queryFieldsDatatypes.put("FOO", new StringType());
 
-        config.setQueryFieldsDatatypes(queryFieldsDatatypes);
+        this.config = ShardQueryConfiguration.create();
+        this.config.setQueryFieldsDatatypes(queryFieldsDatatypes);
 
         this.helper = new MockMetadataHelper();
         this.helper.setNonEventFields(queryFieldsDatatypes.keySet());
+
+        this.nonEventFields = new HashSet<>(queryFieldsDatatypes.keySet());
     }
 
     @Test
@@ -55,9 +62,28 @@ public class BoundedRangeDetectionVisitorTest {
     }
 
     private void test(String query, boolean expected) {
+        testWithHelper(query, expected);
+        testWithoutHelper(query, expected);
+    }
+
+    // current path
+    private void testWithHelper(String query, boolean expected) {
         try {
             ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
-            assertEquals(expected, BoundedRangeDetectionVisitor.mustExpandBoundedRange(config, helper, script));
+            Set<String> nonEventFields = helper.getNonEventFields(config.getDatatypeFilter());
+            assertEquals(expected, BoundedRangeDetectionVisitor.mustExpandBoundedRange(script, nonEventFields));
+        } catch (ParseException e) {
+            fail("Failed to parse query: " + query);
+        } catch (TableNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // future path
+    private void testWithoutHelper(String query, boolean expected) {
+        try {
+            ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
+            assertEquals(expected, BoundedRangeDetectionVisitor.mustExpandBoundedRange(script, nonEventFields));
         } catch (ParseException e) {
             fail("Failed to parse query: " + query);
         }


### PR DESCRIPTION
- Add constructor to BoundedRangeDetectionVisitor that avoid the MetadataHelper
- Deprecate constructor that uses the MetadataHelper
- DefaultQueryPlanner now uses the non-deprecated constructor