### PR TITLE
Fixed two cases where an empty exclude was needed to override default behavior

### DIFF
--- a/microservices/services/query-executor/service/pom.xml
+++ b/microservices/services/query-executor/service/pom.xml
@@ -380,9 +380,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- This was added to ensure that nested test classes are run. -->
+                <!-- This empty exclude overrides the default exclusion pattern for inner classes -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude />
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/microservices/starters/query/pom.xml
+++ b/microservices/starters/query/pom.xml
@@ -237,9 +237,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- This was added to ensure that nested test classes are run. -->
+                <!-- This empty exclude overrides the default exclusion pattern for inner classes -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude />
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
* By default [surefire excludes tests in inner classes](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes), so it's necessary to explicitly clear the default to run them.