### PR TITLE
Add IndexExpansionQueryTest

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/TimeoutExceptionIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/TimeoutExceptionIterator.java
@@ -51,6 +51,22 @@ public class TimeoutExceptionIterator extends WrappingIterator {
         super.init(source, options, env);
     }
 
+    /**
+     * The state and next key should be persisted through a teardown/rebuild
+     *
+     * @param env
+     *            the {@link IteratorEnvironment}
+     * @return a copy of the {@link TimeoutExceptionIterator}
+     */
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+        TimeoutExceptionIterator copy = new TimeoutExceptionIterator();
+        copy.setSource(getSource().deepCopy(env));
+        copy.state = state;
+        copy.nextKey = nextKey;
+        return copy;
+    }
+
     @Override
     public boolean hasTop() {
         switch (state) {

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -1884,7 +1884,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         });
     }
 
-    private ASTJexlScript timedExpandRanges(QueryStopwatch timers, String stage, final ASTJexlScript script, ShardQueryConfiguration config,
+    protected ASTJexlScript timedExpandRanges(QueryStopwatch timers, String stage, final ASTJexlScript script, ShardQueryConfiguration config,
                     MetadataHelper metadataHelper, ScannerFactory scannerFactory) throws DatawaveQueryException {
         config.setQueryTree(script);
         TraceStopwatch innerStopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - " + stage);

--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -76,11 +76,17 @@ public class ColorsTest extends AbstractQueryTest {
     private final Set<String> expectedDays = new HashSet<>();
     private final Set<String> expectedShards = new HashSet<>();
 
+    private static final Authorizations auths = new Authorizations("ALL");
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
     @Override
     public ShardQueryLogic getLogic() {
         return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
     @BeforeAll

--- a/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/CompositeFunctionsTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.TimeZone;
 
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,6 +55,8 @@ public class CompositeFunctionsTest extends AbstractQueryTest {
 
     @TempDir
     public static Path folder;
+
+    private static final Authorizations auths = new Authorizations("ALL");
 
     protected static AccumuloClient client = null;
 
@@ -104,6 +107,11 @@ public class CompositeFunctionsTest extends AbstractQueryTest {
     @Override
     public ShardQueryLogic getLogic() {
         return eventQueryLogic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
@@ -409,8 +409,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addDelayIterator(timeoutDelayMS);
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeDelayIterator();
@@ -422,10 +420,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addDelayIterator();
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
-            // need to make sure the secondary order assertions still happen?
         } finally {
             removeDelayIterator();
         }
@@ -436,8 +431,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
@@ -449,8 +442,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
@@ -462,8 +453,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
@@ -476,8 +465,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
@@ -490,8 +477,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
@@ -504,8 +489,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeIOExceptionIterator();
@@ -518,8 +501,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeIOExceptionIterator();
@@ -532,8 +513,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
-            expectRegexExpansionTime(scanThresholdMS);
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
@@ -573,8 +552,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            expectRegexExpansionTime(scanThresholdMS);
+            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
             assertThrows(NullPointerException.class, this::planAndExecuteQuery);
         } finally {
@@ -587,8 +565,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            expectRegexExpansionTime(scanThresholdMS);
+            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
             assertThrows(NullPointerException.class, this::planAndExecuteQuery);
         } finally {
@@ -616,8 +593,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            expectRegexExpansionTime(scanThresholdMS);
+            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
             assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
         } finally {
@@ -631,8 +607,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            expectRegexExpansionTime(scanThresholdMS);
+            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
             assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
         } finally {
@@ -647,7 +622,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
             expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            expectRegexExpansionTime(scanThresholdMS);
             planAndExecuteQuery();
         } finally {
             removeIOExceptionIterator();
@@ -674,8 +648,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            expectRegexExpansionTime(scanThresholdMS);
+            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
             assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
         } finally {
@@ -714,8 +687,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -728,8 +699,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -742,8 +711,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -757,8 +724,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -772,8 +737,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -787,8 +750,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -802,8 +763,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -817,8 +776,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            expectPlan("_NOFIELD_ == 'a1b2c3'");
-            expectRegexExpansionTime(scanThresholdMS);
+            // expectPlan("_NOFIELD_ == 'a1b2c3'");
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {

--- a/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
@@ -1,0 +1,1063 @@
+package datawave.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.iteratorsImpl.system.IterationInterruptedException;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.accumulo.minicluster.MiniAccumuloConfig;
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.iterators.IteratorTimeoutException;
+import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.exceptions.DatawaveQueryException;
+import datawave.query.index.day.IndexIngestUtil;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.jexl.lookups.IndexLookup;
+import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.planner.QueryPlanner;
+import datawave.query.tables.ScannerFactory;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.util.AbstractQueryTest;
+import datawave.query.util.IndexExpansionIngest;
+import datawave.query.util.MetadataHelper;
+import datawave.query.util.QueryStopwatch;
+import datawave.query.util.TestIndexTableNames;
+import datawave.test.MacTestUtil;
+import datawave.util.TableName;
+
+/**
+ * A suite of tests that validate timeout-based index expansion. Other index expansion tests verify threshold based expansion.
+ * <p>
+ * Each base test case has the following eleven permutations
+ * <ul>
+ * <li>timeout on initial seek</li>
+ * <li>timeout on next</li>
+ * <li>NPE on seek</li>
+ * <li>NPE on next</li>
+ * <li>NPE on random operation</li>
+ * <li>IteratorInterruptedException on seek</li>
+ * <li>IteratorInterruptedException on next</li>
+ * <li>IteratorInterruptedException on random operation</li>
+ * <li>IteratorTimeoutException on seek</li>
+ * <li>IteratorTimeoutException on next</li>
+ * <li>IteratorTimeoutException on random operation</li>
+ * </ul>
+ */
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class IndexExpansionQueryTest extends AbstractQueryTest {
+
+    private static final Logger log = LoggerFactory.getLogger(IndexExpansionQueryTest.class);
+
+    protected static final String PASSWORD = "password";
+    protected static final Authorizations auths = new Authorizations("VIZ-A", "VIZ-B", "VIZ-C");
+    protected static MiniAccumuloCluster mac;
+    protected static AccumuloClient client = null;
+    protected static TableOperations tops = null;
+
+    // switch between MiniAccumuloCluster and InMemoryAccumulo
+    private static final boolean useMAC = false;
+
+    // switch between old code and new code
+    private final boolean useNewIndexLookups = false;
+
+    // 10 values per prefix, low expansion thresholds, low scan thresholds
+    // using this tests can simulate exceptions or timeouts on initial seek vs. next calls
+    private long expansionThreshold = 500;
+    private final long scanThresholdMS = 50L;
+    private final int iterationDelayMS = 10;
+    private final int timeoutDelayMS = 30_000;
+
+    private long expectedRegexExpansionTime = -1;
+    private long expectedRangeExpansionTime = -1;
+
+    @TempDir
+    public static Path folder;
+
+    @Autowired
+    @Qualifier("EventQueryNoRules")
+    protected ShardQueryLogic logic;
+
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
+    }
+
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    @Override
+    protected void extraAssertions() {
+        QueryPlanner planner = logic.getQueryPlanner();
+        assertInstanceOf(StageTimingDefaultQueryPlanner.class, planner);
+        StageTimingDefaultQueryPlanner stagePlanner = (StageTimingDefaultQueryPlanner) planner;
+        log.info("range expansion: {} ms", stagePlanner.getExpandRangeStage());
+        log.info("regex expansion: {} ms", stagePlanner.getExpandRegexStage());
+
+        if (expectedRangeExpansionTime >= 0) {
+            assertRangeTime(expectedRangeExpansionTime);
+        }
+
+        if (expectedRegexExpansionTime >= 0) {
+            assertRegexTime(expectedRegexExpansionTime);
+        }
+    }
+
+    protected void assertRegexTime(long expected) {
+        QueryPlanner planner = logic.getQueryPlanner();
+        assertInstanceOf(StageTimingDefaultQueryPlanner.class, planner);
+        StageTimingDefaultQueryPlanner stagePlanner = (StageTimingDefaultQueryPlanner) planner;
+
+        if (stagePlanner.getExpandRegexStage() < expected) {
+            // assume that faster is better, for now
+            return;
+        }
+
+        String msg = "expected: " + expected + " but was " + stagePlanner.getExpandRegexStage();
+        long delta = (long) Math.max((expected * 0.1), 250);
+        assertEquals(expected, stagePlanner.getExpandRegexStage(), delta, msg);
+    }
+
+    protected void assertRangeTime(long expected) {
+        QueryPlanner planner = logic.getQueryPlanner();
+        assertInstanceOf(StageTimingDefaultQueryPlanner.class, planner);
+        StageTimingDefaultQueryPlanner stagePlanner = (StageTimingDefaultQueryPlanner) planner;
+
+        if (stagePlanner.getExpandRangeStage() < expected) {
+            // assume that faster is better
+            return;
+        }
+
+        String msg = "expected: " + expected + " but was " + stagePlanner.getExpandRangeStage();
+        long delta = (long) Math.max((expected * 0.1), 250);
+        assertEquals(expected, stagePlanner.getExpandRangeStage(), delta, msg);
+    }
+
+    protected void expectRegexExpansionTime(long time) {
+        expectedRegexExpansionTime = time;
+    }
+
+    protected void expectRangeExpansionTime(long time) {
+        expectedRangeExpansionTime = time;
+    }
+
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        if (useMAC) {
+            MiniAccumuloConfig cfg = new MiniAccumuloConfig(folder.toFile(), PASSWORD);
+            cfg.setNumTservers(1);
+            mac = new MiniAccumuloCluster(cfg);
+            mac.start();
+
+            client = mac.createAccumuloClient("root", new PasswordToken(PASSWORD));
+        } else {
+            // do not use a rebuilding scanner because the test requires exceptions to propagate
+            // all the way back to the client.
+            InMemoryInstance instance = new InMemoryInstance(IndexExpansionQueryTest.class.getName());
+            client = new InMemoryAccumuloClient("root", instance);
+        }
+
+        // grant root user all auths so they can scan the tables
+        SecurityOperations sops = client.securityOperations();
+        sops.changeUserAuthorizations("root", auths);
+        tops = client.tableOperations();
+
+        IndexExpansionIngest.write(client, auths);
+
+        IndexIngestUtil ingestUtil = new IndexIngestUtil();
+        ingestUtil.write(client, auths);
+
+        for (String tableName : indexTableNames()) {
+            MacTestUtil.compactTable(tops, tableName);
+        }
+        MacTestUtil.compactTable(tops, TableName.METADATA);
+    }
+
+    private StageTimingDefaultQueryPlanner stageQueryPlanner;
+
+    @BeforeEach
+    public void beforeEach() {
+        setClientForTest(client);
+
+        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        Preconditions.checkNotNull(hadoopConfig);
+        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
+
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toUri().toString());
+        logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
+
+        logic.setUseNewIndexLookups(useNewIndexLookups);
+        logic.getQueryPlanner().setRules(Collections.emptySet());
+
+        logic.setMaxIndexScanTimeMillis(scanThresholdMS);
+        logic.setMaxAnyFieldScanTimeMillis(scanThresholdMS);
+
+        logic.setMaxUnfieldedExpansionThreshold((int) expansionThreshold);
+        logic.setMaxValueExpansionThreshold((int) expansionThreshold);
+
+        logic.setInitialMaxTermThreshold(1_000);
+        logic.setIntermediateMaxTermThreshold(1_000);
+        logic.setIndexedMaxTermThreshold(1_000);
+        logic.setFinalMaxTermThreshold(1_000);
+
+        stageQueryPlanner = new StageTimingDefaultQueryPlanner();
+        logic.setQueryPlanner(stageQueryPlanner);
+
+        givenDate("20250101", "20250105");
+    }
+
+    /**
+     * Get all forward index table names along with the reverse index
+     *
+     * @return the set of index table names
+     */
+    protected static Set<String> indexTableNames() {
+        Set<String> names = new HashSet<>(TestIndexTableNames.names());
+        names.add(TableName.SHARD_RINDEX);
+        return names;
+    }
+
+    @Test
+    public void testFieldedRegexTimeoutOnInitialSeek() throws Exception {
+        try {
+            addDelayIterator(timeoutDelayMS);
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testFieldedRegexTimeoutOnNext() throws Exception {
+        try {
+            addDelayIterator();
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testFieldedRegexNPEOnSeek() throws Exception {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testFieldedRegexNPEOnNext() throws Exception {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testFieldedRegexNPERandom() throws Exception {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on seek
+    @Test
+    public void testFieldedRegexIIEOnInitialSeek() throws Exception {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on next
+    @Test
+    public void testFieldedRegexIIEOnNext() throws Exception {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on next
+    @Test
+    public void testFieldedRegexITEOnNext() throws Exception {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on random operation
+    @Test
+    public void testFieldedRegexITEOnRandom() throws Exception {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on random operation
+    @Test
+    public void testFieldedRegexIIEOnRandom() throws Exception {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
+            givenQuery("FIELD_A =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedRegexTimeoutOnInitialSeek() {
+        try {
+            addDelayIterator(timeoutDelayMS);
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedRegexTimeoutOnNext() {
+        try {
+            addDelayIterator();
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            // need to make sure the secondary order assertions still happen?
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedRegexNPEOnSeek() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedRegexNPEOnNext() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedRegexNPERandom() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on seek
+    @Test
+    public void testUnfieldedRegexIIEOnInitialSeek() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on next
+    @Test
+    public void testUnfieldedRegexIIEOnNext() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on next
+    @Test
+    public void testUnfieldedRegexITEOnNext() {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on random operation
+    @Test
+    public void testUnfieldedRegexITEOnRandom() {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on random operation
+    @Test
+    public void testUnfieldedRegexIIEOnRandom() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
+            givenQuery("_ANYFIELD_ =~ 'a.*'");
+            expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // This enters an infinite loop
+    @Test
+    @Disabled
+    public void testBoundedRangeTimeoutOnInitialSeek() throws Exception {
+        try {
+            addDelayIterator(timeoutDelayMS);
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testBoundedRangeTimeoutOnNext() throws Exception {
+        try {
+            addDelayIterator();
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testBoundedRangeNPEOnSeek() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
+            assertThrows(NullPointerException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testBoundedRangeNPEOnNext() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
+            assertThrows(NullPointerException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testBoundedRangeNPERandom() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
+            assertThrows(NullPointerException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on seek
+    @Test
+    public void testBoundedRangeIIEOnInitialSeek() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
+            assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on next
+    @Test
+    public void testBoundedRangeIIEOnNext() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
+            assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on next
+    @Test
+    public void testBoundedRangeITEOnNext() throws Exception {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on random operation
+    @Test
+    public void testBoundedRangeITEOnRandom() throws Exception {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on random operation
+    @Test
+    public void testBoundedRangeIIEOnRandom() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
+            givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            expectRegexExpansionTime(scanThresholdMS);
+            // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
+            assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedLiteralTimeoutOnInitialSeek() {
+        try {
+            addDelayIterator(timeoutDelayMS);
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedLiteralTimeoutOnNext() {
+        try {
+            addDelayIterator();
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedLiteralNPEOnSeek() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedLiteralNPEOnNext() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testUnfieldedLiteralNPERandom() {
+        try {
+            addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on seek
+    @Test
+    public void testUnfieldedLiteralIIEOnInitialSeek() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on next
+    @Test
+    public void testUnfieldedLiteralIIEOnNext() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on next
+    @Test
+    public void testUnfieldedLiteralITEOnNext() {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IteratorTimeoutException on random operation
+    @Test
+    public void testUnfieldedLiteralITEOnRandom() {
+        try {
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    // IterationInterruptedException on random operation
+    @Test
+    public void testUnfieldedLiteralIIEOnRandom() {
+        try {
+            addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
+            givenQuery("_ANYFIELD_ == 'a1b2c3'");
+            expectPlan("_NOFIELD_ == 'a1b2c3'");
+            expectRegexExpansionTime(scanThresholdMS);
+            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
+            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+        } finally {
+            removeRuntimeExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testMultiTermFieldedRegexTimeout() throws Exception {
+        try {
+            SortedSet<String> fields = new TreeSet<>(Set.of("FIELD_A", "FIELD_B", "FIELD_C", "FIELD_D", "FIELD_E"));
+            SortedSet<String> prefixes = new TreeSet<>(Set.of("aa", "ab", "ac", "ad", "ae"));
+
+            String query = buildFieldedRegexQuery(fields, prefixes);
+            String plan = buildValueExceededPlan(fields, prefixes);
+
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery(query);
+            expectPlan(plan);
+            expectRegexExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testMultiTermUnfieldedRegex() {
+        try {
+            SortedSet<String> prefixes = new TreeSet<>(Set.of("aa", "ab", "ac", "ad", "ae"));
+            String query = buildUnfieldedRegexQuery(prefixes);
+
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery(query);
+            expectPlan(null); // no plan expected
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testMultiTermBoundedRange() throws Exception {
+        try {
+            SortedSet<String> fields = new TreeSet<>(Set.of("FIELD_A", "FIELD_B", "FIELD_C", "FIELD_D", "FIELD_E"));
+            String query = buildBoundedRangeQuery(fields);
+            String plan = buildValueExceededRangePlan(fields);
+
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            givenQuery(query);
+            expectPlan(plan);
+            expectRangeExpansionTime(scanThresholdMS);
+            planAndExecuteQuery();
+        } finally {
+            removeIOExceptionIterator();
+        }
+    }
+
+    @Test
+    public void testMultiTermUnfieldedLiteral() {
+
+    }
+
+    protected String buildFieldedRegexQuery(Set<String> fields, Set<String> values) {
+        List<String> terms = new ArrayList<>();
+        for (String field : fields) {
+            for (String value : values) {
+                terms.add(field + " =~ '" + value + ".*'");
+            }
+        }
+        return Joiner.on(" || ").join(terms);
+    }
+
+    protected String buildUnfieldedRegexQuery(Set<String> values) {
+        List<String> terms = new ArrayList<>();
+        for (String value : values) {
+            terms.add("_ANYFIELD_ =~ '" + value + ".*'");
+        }
+        return Joiner.on(" || ").join(terms);
+    }
+
+    protected String buildBoundedRangeQuery(Set<String> fields) {
+        List<String> terms = new ArrayList<>();
+        for (String field : fields) {
+            terms.add("((_Bounded_ = true) && (" + field + " >= 'a' && " + field + " <= 'z'))");
+        }
+        return Joiner.on(" || ").join(terms);
+    }
+
+    protected String buildValueExceededPlan(Set<String> fields, Set<String> values) {
+        List<String> terms = new ArrayList<>();
+        for (String field : fields) {
+            for (String value : values) {
+                terms.add("((_Value_ = true) && (" + field + " =~ '" + value + ".*'))");
+            }
+        }
+        return Joiner.on(" || ").join(terms);
+    }
+
+    protected String buildValueExceededRangePlan(Set<String> fields) {
+        List<String> terms = new ArrayList<>();
+        for (String field : fields) {
+            terms.add("((_Value_ = true) && ((_Bounded_ = true) && (" + field + " >= 'a' && " + field + " <= 'z')))");
+        }
+        return Joiner.on(" || ").join(terms);
+    }
+
+    protected void addDelayIterator() {
+        addDelayIterator(iterationDelayMS);
+    }
+
+    protected void addDelayIterator(int delay) {
+        for (String tableName : indexTableNames()) {
+            Map<String,String> properties = new HashMap<>();
+            properties.put("table.iterator.scan.delay", "1,datawave.test.iter.DelayIterator");
+            properties.put("table.iterator.scan.delay.opt.delay", String.valueOf(delay));
+            MacTestUtil.addPropertiesAndWait(tops, tableName, properties);
+        }
+    }
+
+    protected void removeDelayIterator() {
+        for (String tableName : indexTableNames()) {
+            Set<String> properties = new HashSet<>();
+            properties.add("table.iterator.scan.delay");
+            properties.add("table.iterator.scan.delay.opt.delay");
+            MacTestUtil.removePropertiesAndWait(tops, tableName, properties);
+        }
+    }
+
+    protected void addRuntimeExceptionIterator(String clazz, String msg, String when) {
+        for (String tableName : indexTableNames()) {
+            Map<String,String> properties = new HashMap<>();
+            properties.put("table.iterator.scan.rex", "2,datawave.test.iter.RuntimeExceptionIterator");
+            properties.put("table.iterator.scan.rex.opt.exception.class", String.valueOf(clazz));
+            properties.put("table.iterator.scan.rex.opt.exception.message", String.valueOf(msg));
+            switch (when) {
+                case "seek":
+                    properties.put("table.iterator.scan.rex.opt.fireOnSeek", "true");
+                    break;
+                case "next":
+                    properties.put("table.iterator.scan.rex.opt.fireOnNext", "true");
+                    break;
+                case "random":
+                    properties.put("table.iterator.scan.rex.opt.fireRandomly", "true");
+                    break;
+                default:
+                    throw new IllegalStateException("unknown state: " + when);
+            }
+            MacTestUtil.addPropertiesAndWait(tops, tableName, properties);
+        }
+    }
+
+    protected void removeRuntimeExceptionIterator() {
+        for (String tableName : indexTableNames()) {
+            Set<String> properties = new HashSet<>();
+            properties.add("table.iterator.scan.rex");
+            properties.add("table.iterator.scan.rex.opt.exception.class");
+            properties.add("table.iterator.scan.rex.opt.exception.message");
+            properties.add("table.iterator.scan.rex.opt.fireOnSeek");
+            properties.add("table.iterator.scan.rex.opt.fireOnNext");
+            properties.add("table.iterator.scan.rex.opt.fireRandomly");
+            MacTestUtil.removePropertiesAndWait(tops, tableName, properties);
+        }
+    }
+
+    protected void addIOExceptionIterator(String clazz, String msg, String when) {
+        for (String tableName : indexTableNames()) {
+            Map<String,String> properties = new HashMap<>();
+            properties.put("table.iterator.scan.ioex", "3,datawave.test.iter.IOExceptionIterator");
+            properties.put("table.iterator.scan.ioex.opt.exception.class", String.valueOf(clazz));
+            properties.put("table.iterator.scan.ioex.opt.exception.message", String.valueOf(msg));
+            switch (when) {
+                case "seek":
+                    properties.put("table.iterator.scan.ioex.opt.fireOnSeek", "true");
+                    break;
+                case "next":
+                    properties.put("table.iterator.scan.ioex.opt.fireOnNext", "true");
+                    break;
+                case "random":
+                    properties.put("table.iterator.scan.ioex.opt.fireRandomly", "true");
+                    break;
+                default:
+                    throw new IllegalStateException("unknown state: " + when);
+            }
+            MacTestUtil.addPropertiesAndWait(tops, tableName, properties);
+        }
+    }
+
+    protected void removeIOExceptionIterator() {
+        for (String tableName : indexTableNames()) {
+            Set<String> properties = new HashSet<>();
+            properties.add("table.iterator.scan.ioex");
+            properties.add("table.iterator.scan.ioex.opt.exception.class");
+            properties.add("table.iterator.scan.ioex.opt.exception.message");
+            properties.add("table.iterator.scan.ioex.opt.fireOnSeek");
+            properties.add("table.iterator.scan.ioex.opt.fireOnNext");
+            properties.add("table.iterator.scan.ioex.opt.fireRandomly");
+            MacTestUtil.removePropertiesAndWait(tops, tableName, properties);
+        }
+    }
+
+    /**
+     * A simple stub that allows the test framework to grab the total elapsed time spend in certain stages of query planning.
+     */
+    private static class StageTimingDefaultQueryPlanner extends DefaultQueryPlanner {
+
+        private long expandRegexStage = 0L;
+        private long expandRangeStage = 0L;
+
+        @Override
+        protected ASTJexlScript timedExpandRegex(QueryStopwatch timers, String stage, final ASTJexlScript script, ShardQueryConfiguration config,
+                        MetadataHelper metadataHelper, ScannerFactory scannerFactory, Map<String,IndexLookup> indexLookupMap) throws DatawaveQueryException {
+            long start = System.currentTimeMillis();
+            try {
+                return super.timedExpandRegex(timers, stage, script, config, metadataHelper, scannerFactory, indexLookupMap);
+            } finally {
+                expandRegexStage = System.currentTimeMillis() - start;
+                log.info("expand regexes: {}", expandRegexStage);
+            }
+        }
+
+        @Override
+        protected ASTJexlScript timedExpandRanges(QueryStopwatch timers, String stage, final ASTJexlScript script, ShardQueryConfiguration config,
+                        MetadataHelper metadataHelper, ScannerFactory scannerFactory) throws DatawaveQueryException {
+            long start = System.currentTimeMillis();
+            try {
+                return super.timedExpandRanges(timers, stage, script, config, metadataHelper, scannerFactory);
+            } finally {
+                expandRangeStage = System.currentTimeMillis() - start;
+                log.info("expand ranges: {}", expandRangeStage);
+            }
+        }
+
+        public long getExpandRegexStage() {
+            return expandRegexStage;
+        }
+
+        public long getExpandRangeStage() {
+            return expandRangeStage;
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ShapesTest.java
@@ -85,6 +85,8 @@ public class ShapesTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(ShapesTest.class);
 
+    private static final Authorizations auths = new Authorizations("ALL");
+
     @TempDir
     public static Path folder;
 
@@ -99,6 +101,11 @@ public class ShapesTest extends AbstractQueryTest {
     @Override
     public ShardQueryLogic getLogic() {
         return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
     protected static final String PASSWORD = "password";

--- a/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/SizesTest.java
@@ -1,6 +1,7 @@
 package datawave.query;
 
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,8 @@ public class SizesTest extends AbstractQueryTest {
     private static AccumuloClient clientForSetup;
     private static SizesIngest ingest;
 
+    private static final Authorizations auths = new Authorizations("ALL");
+
     // utility for writing different index table structures
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
@@ -54,6 +57,11 @@ public class SizesTest extends AbstractQueryTest {
     @Override
     public ShardQueryLogic getLogic() {
         return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
     @BeforeAll

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BaseIndexExpansionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BaseIndexExpansionTest.java
@@ -2,6 +2,8 @@ package datawave.query.jexl.visitors;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -10,14 +12,19 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.accumulo.minicluster.MiniAccumuloConfig;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.commons.jexl3.parser.ParseException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,11 +50,15 @@ public abstract class BaseIndexExpansionTest {
 
     private static final Logger log = LoggerFactory.getLogger(BaseIndexExpansionTest.class);
 
+    @TempDir
+    public static Path folder;
+
     protected static final String DEFAULT_DATE = "20250606";
     protected static final String DEFAULT_DATATYPE = "datatype";
     protected static final Value EMPTY_VALUE = new Value();
 
     private static final Authorizations AUTHS = new Authorizations("ALL");
+    private static final String PASSWORD = "PASSWORD";
 
     protected static AccumuloClient client;
     protected static TableOperations tops;
@@ -60,10 +71,23 @@ public abstract class BaseIndexExpansionTest {
     protected MockMetadataHelper helper;
     protected Map<String,IndexLookup> lookupMap;
 
+    private static final boolean useMAC = true;
+    private static MiniAccumuloCluster mac;
+
     @BeforeAll
     public static void setup() throws Exception {
-        InMemoryInstance instance = new InMemoryInstance();
-        client = new InMemoryAccumuloClient("root", instance);
+        if (useMAC) {
+            MiniAccumuloConfig cfg = new MiniAccumuloConfig(folder.toFile(), PASSWORD);
+            cfg.setNumTservers(1);
+            mac = new MiniAccumuloCluster(cfg);
+            mac.start();
+            client = mac.createAccumuloClient("root", new PasswordToken(PASSWORD));
+            client.securityOperations().changeUserAuthorizations("root", AUTHS);
+        } else {
+            InMemoryInstance instance = new InMemoryInstance();
+            client = new InMemoryAccumuloClient("root", instance);
+        }
+
         tops = client.tableOperations();
     }
 
@@ -84,6 +108,13 @@ public abstract class BaseIndexExpansionTest {
         scannerFactory = new ScannerFactory(client);
         helper = new MockMetadataHelper();
         lookupMap = new HashMap<>();
+    }
+
+    @AfterAll
+    public static void afterAll() throws IOException {
+        if (mac != null) {
+            mac.close();
+        }
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -82,9 +82,6 @@ public abstract class AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractQueryTest.class);
 
-    protected static Authorizations auths = new Authorizations("ALL");
-    protected static Set<Authorizations> authSet = Collections.singleton(auths);
-
     protected final DateFormat format = new SimpleDateFormat("yyyyMMdd");
     protected final KryoDocumentDeserializer deserializer = new KryoDocumentDeserializer();
 
@@ -107,6 +104,13 @@ public abstract class AbstractQueryTest {
     private boolean queryPlanAssertionEnabled = true;
 
     public abstract ShardQueryLogic getLogic();
+
+    /**
+     * Authorizations may be different depending on the test
+     *
+     * @return some auths
+     */
+    public abstract Authorizations getAuths();
 
     @AfterEach
     public void afterEach() {
@@ -384,7 +388,7 @@ public abstract class AbstractQueryTest {
             settings.setBeginDate(getStartDate());
             settings.setEndDate(getEndDate());
             settings.setPagesize(Integer.MAX_VALUE);
-            settings.setQueryAuthorizations(auths.serialize());
+            settings.setQueryAuthorizations(getAuths().serialize());
             settings.setQuery(getQuery());
             settings.setParameters(parameters);
             settings.setId(UUID.randomUUID());
@@ -394,7 +398,7 @@ public abstract class AbstractQueryTest {
 
             extraConfigurations();
 
-            GenericQueryConfiguration config = logic.initialize(clientForTest, settings, authSet);
+            GenericQueryConfiguration config = logic.initialize(clientForTest, settings, Collections.singleton(getAuths()));
             logic.setupQuery(config);
         } catch (Exception e) {
             log.info("exception while planning query", e);

--- a/warehouse/query-core/src/test/java/datawave/query/util/IndexExpansionIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/IndexExpansionIngest.java
@@ -45,10 +45,10 @@ public class IndexExpansionIngest {
 
     public static void write(AccumuloClient client, Authorizations auths) throws Exception {
         TableOperations tops = client.tableOperations();
-        tops.create(SHARD);
-        tops.create(SHARD_INDEX);
-        tops.create(SHARD_RINDEX);
-        tops.create(METADATA);
+        MacTestUtil.createOrRecreate(tops, SHARD);
+        MacTestUtil.createOrRecreate(tops, SHARD_INDEX);
+        MacTestUtil.createOrRecreate(tops, SHARD_RINDEX);
+        MacTestUtil.createOrRecreate(tops, METADATA);
 
         Map<String,String> additions = new HashMap<>();
         IteratorUtil.IteratorScope[] scopes = IteratorUtil.IteratorScope.values();

--- a/warehouse/query-core/src/test/java/datawave/query/util/IndexExpansionIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/IndexExpansionIngest.java
@@ -1,0 +1,176 @@
+package datawave.query.util;
+
+import static datawave.util.TableName.METADATA;
+import static datawave.util.TableName.SHARD;
+import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.util.TableName.SHARD_RINDEX;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.LongCombiner;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.io.Text;
+
+import datawave.data.ColumnFamilyConstants;
+import datawave.ingest.protobuf.Uid;
+import datawave.test.MacTestUtil;
+import datawave.util.TableName;
+
+public class IndexExpansionIngest {
+
+    private static final Set<String> fields = Set.of("FIELD_A", "FIELD_B", "FIELD_C", "FIELD_D", "FIELD_E");
+    private static final Set<String> dates = Set.of("20250101", "20250102", "20250103", "20250104", "20250105");
+    private static final Set<String> datatypes = Set.of("datatype-a", "datatype-b", "datatype-c", "datatype-d", "datatype-e");
+
+    private static final Long ts = 1707045600000L;
+    private static final Value EMPTY_VALUE = new Value();
+
+    private static final Set<String> extraIndexedFields = Set.of("FIELD_X");
+
+    private static final int maxValuesPerPrefix = 10;
+
+    public static void write(AccumuloClient client, Authorizations auths) throws Exception {
+        TableOperations tops = client.tableOperations();
+        tops.create(SHARD);
+        tops.create(SHARD_INDEX);
+        tops.create(SHARD_RINDEX);
+        tops.create(METADATA);
+
+        Map<String,String> additions = new HashMap<>();
+        IteratorUtil.IteratorScope[] scopes = IteratorUtil.IteratorScope.values();
+        for (IteratorUtil.IteratorScope scope : scopes) {
+            String name = "table.iterator." + scope.name() + ".UIDAggregator";
+            String opt = "table.iterator." + scope.name() + ".UIDAggregator.opt.*";
+
+            additions.put(name, "19,datawave.iterators.TotalAggregatingIterator");
+            additions.put(opt, "datawave.ingest.table.aggregator.KeepCountOnlyUidAggregator");
+        }
+        MacTestUtil.addPropertiesAndWait(tops, SHARD_INDEX, additions);
+        MacTestUtil.addPropertiesAndWait(tops, SHARD_RINDEX, additions);
+
+        writeMetadata(client);
+        writeShardIndex(client, auths);
+    }
+
+    private static void writeMetadata(AccumuloClient client) throws Exception {
+        BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(1000L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
+        try (BatchWriter bw = client.createBatchWriter(TableName.METADATA, bwConfig)) {
+            for (String field : fields) {
+                Mutation m = new Mutation(field);
+                for (String datatype : datatypes) {
+                    Text cq = new Text(datatype);
+                    m.put(ColumnFamilyConstants.COLF_I, cq, EMPTY_VALUE);
+                    m.put(ColumnFamilyConstants.COLF_E, cq, EMPTY_VALUE);
+                    for (String date : dates) {
+                        m.put(ColumnFamilyConstants.COLF_F, new Text(datatype + '\u0000' + date), createValue(12L));
+                    }
+                }
+                bw.addMutation(m);
+            }
+
+            String lastDate = new TreeSet<>(dates).last();
+            for (String field : extraIndexedFields) {
+                Mutation m = new Mutation(field);
+                for (String datatype : datatypes) {
+                    Text cq = new Text(datatype);
+                    m.put(ColumnFamilyConstants.COLF_I, cq, EMPTY_VALUE);
+                    m.put(ColumnFamilyConstants.COLF_E, cq, EMPTY_VALUE);
+                    m.put(ColumnFamilyConstants.COLF_F, new Text(datatype + '\u0000' + lastDate), createValue(12L));
+                }
+                bw.addMutation(m);
+            }
+
+            // write num_shards cache
+            String firstDate = new TreeSet<>(dates).first();
+            Mutation m = new Mutation("num_shards");
+            m.put("ns", firstDate + "_2", EMPTY_VALUE);
+            bw.addMutation(m);
+        }
+    }
+
+    private static void writeShardIndex(AccumuloClient client, Authorizations auths) throws Exception {
+        ColumnVisibility viz = new ColumnVisibility(auths.iterator().next());
+        Set<String> prefixes = Set.of("aa", "ab", "ac", "ad", "ae");
+
+        BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(1000L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
+        try (BatchWriter bw = client.createBatchWriter(TableName.SHARD_INDEX, bwConfig)) {
+            for (String prefix : prefixes) {
+                for (int i = 0; i < maxValuesPerPrefix; i++) {
+                    String value = prefix + RandomStringUtils.randomAlphabetic(3, 6).toLowerCase();
+                    Mutation m = new Mutation(value);
+                    for (String field : fields) {
+                        Text cf = new Text(field);
+                        for (String date : dates) {
+                            for (String datatype : datatypes) {
+                                Text cq = new Text(date + "_2\0" + datatype);
+                                m.put(cf, cq, viz, getUidList());
+                            }
+                        }
+                    }
+                    bw.addMutation(m);
+                }
+            }
+
+            // extra indexed fields have data at the very end of range
+            String lastDate = new TreeSet<>(dates).last();
+            for (int i = 0; i < maxValuesPerPrefix; i++) {
+                String value = "af" + RandomStringUtils.randomAlphabetic(3, 6).toLowerCase();
+                Mutation m = new Mutation(value);
+                for (String field : extraIndexedFields) {
+                    Text cf = new Text(field);
+                    for (String datatype : datatypes) {
+                        Text cq = new Text(lastDate + "_2\0" + datatype);
+                        m.put(cf, cq, viz, getUidList());
+                    }
+                }
+                bw.addMutation(m);
+            }
+
+            // unfielded literal expansion data
+            String value = "a1b2c3";
+            Mutation m = new Mutation(value);
+            for (String field : fields) {
+                Text cf = new Text(field);
+                for (String datatype : datatypes) {
+                    Text cq = new Text(lastDate + "_1\0" + datatype);
+                    m.put(cf, cq, viz, getUidList());
+                }
+            }
+            bw.addMutation(m);
+        }
+    }
+
+    private static final LongCombiner.VarLenEncoder encoder = new LongCombiner.VarLenEncoder();
+
+    private static Value createValue(long count) {
+        return new Value(encoder.encode(count));
+    }
+
+    private static final Random rand = new Random();
+
+    private static Value getUidList() {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.setIGNORE(false);
+        int count = 1 + rand.nextInt(18);
+        builder.setCOUNT(count);
+        for (int i = 0; i < count; i++) {
+            builder.addUID(RandomStringUtils.randomAlphabetic(12));
+        }
+        return new Value(builder.build().toByteArray());
+    }
+
+}

--- a/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
@@ -3,6 +3,7 @@ package datawave.query.util;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +43,8 @@ public class MultiNormalizerTest extends AbstractQueryTest {
 
     private static final Logger log = LoggerFactory.getLogger(MultiNormalizerTest.class);
 
+    private static final Authorizations auths = new Authorizations("ALL");
+
     @Autowired
     @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
@@ -49,6 +52,11 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     @Override
     public ShardQueryLogic getLogic() {
         return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
     private static final InMemoryInstance instance = new InMemoryInstance(MultiNormalizerTest.class.getName());

--- a/warehouse/query-core/src/test/java/datawave/test/MacTestUtil.java
+++ b/warehouse/query-core/src/test/java/datawave/test/MacTestUtil.java
@@ -10,8 +10,11 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import datawave.accumulo.inmemory.InMemoryTableOperations;
 
 /**
  * A collection of useful utilities for tests that rely on {@link MiniAccumuloCluster}.
@@ -57,6 +60,32 @@ public class MacTestUtil {
                 tops.delete(tableName);
             } catch (AccumuloException | AccumuloSecurityException | TableNotFoundException e) {
                 throw new RuntimeException("Failed to delete table: " + tableName, e);
+            }
+        }
+    }
+
+    /**
+     * Compact the given table
+     *
+     * @param tops
+     *            the {@link TableOperations}
+     * @param tableName
+     *            the table to compact
+     */
+    public static void compactTable(TableOperations tops, String tableName) {
+        if (tops instanceof InMemoryTableOperations) {
+            log.warn("cannot compact {} via InMemoryTableOperations", tableName);
+            return;
+        }
+
+        if (tops.exists(tableName)) {
+            try {
+                Text start = new Text("");
+                Text end = new Text("~");
+                tops.compact(tableName, start, end, true, true);
+                log.info("compacted table: {}", tableName);
+            } catch (TableNotFoundException | AccumuloException | AccumuloSecurityException e) {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/test/iter/DelayIterator.java
+++ b/warehouse/query-core/src/test/java/datawave/test/iter/DelayIterator.java
@@ -99,6 +99,7 @@ public class DelayIterator implements SortedKeyValueIterator<Key,Value>, OptionD
     public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
         DelayIterator copy = new DelayIterator();
         copy.source = source.deepCopy(env);
+        copy.delay = delay;
         return copy;
     }
 

--- a/warehouse/query-core/src/test/java/datawave/test/iter/IOExceptionIterator.java
+++ b/warehouse/query-core/src/test/java/datawave/test/iter/IOExceptionIterator.java
@@ -108,7 +108,7 @@ public class IOExceptionIterator implements SortedKeyValueIterator<Key,Value>, O
 
     @Override
     public void next() throws IOException {
-        if (fireOnNext) {
+        if (fireOnNext() || fireRandomly()) {
             fireException();
         }
         tk = null;
@@ -118,21 +118,27 @@ public class IOExceptionIterator implements SortedKeyValueIterator<Key,Value>, O
             tv = source.getTopValue();
             source.next();
         }
-        if (fireRandomly && random.nextInt(10) == 0) {
-            fireException();
-        }
     }
 
     @Override
     public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
-        if (fireOnSeek) {
+        if (fireOnSeek() || fireRandomly()) {
             fireException();
         }
         source.seek(range, columnFamilies, inclusive);
-        if (fireRandomly && random.nextInt(10) == 0) {
-            fireException();
-        }
         next();
+    }
+
+    private boolean fireOnSeek() {
+        return fireOnSeek;
+    }
+
+    private boolean fireOnNext() {
+        return fireOnNext;
+    }
+
+    private boolean fireRandomly() {
+        return fireRandomly && random.nextInt(3) == 0;
     }
 
     private void fireException() throws IOException {
@@ -158,6 +164,11 @@ public class IOExceptionIterator implements SortedKeyValueIterator<Key,Value>, O
     public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
         IOExceptionIterator copy = new IOExceptionIterator();
         copy.source = source.deepCopy(env);
+        copy.exceptionClazz = exceptionClazz;
+        copy.exceptionMsg = exceptionMsg;
+        copy.fireOnSeek = fireOnSeek;
+        copy.fireOnNext = fireOnNext;
+        copy.fireRandomly = fireRandomly;
         return copy;
     }
 

--- a/warehouse/query-core/src/test/java/datawave/test/iter/RuntimeExceptionIterator.java
+++ b/warehouse/query-core/src/test/java/datawave/test/iter/RuntimeExceptionIterator.java
@@ -108,7 +108,7 @@ public class RuntimeExceptionIterator implements SortedKeyValueIterator<Key,Valu
 
     @Override
     public void next() throws IOException {
-        if (fireOnNext) {
+        if (fireOnNext() || fireRandomly()) {
             fireException();
         }
         tk = null;
@@ -118,21 +118,27 @@ public class RuntimeExceptionIterator implements SortedKeyValueIterator<Key,Valu
             tv = source.getTopValue();
             source.next();
         }
-        if (fireRandomly && random.nextInt(10) == 0) {
-            fireException();
-        }
     }
 
     @Override
     public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
-        if (fireOnSeek) {
+        if (fireOnSeek() || fireRandomly()) {
             fireException();
         }
         source.seek(range, columnFamilies, inclusive);
-        if (fireRandomly && random.nextInt(10) == 0) {
-            fireException();
-        }
         next();
+    }
+
+    private boolean fireOnSeek() {
+        return fireOnSeek;
+    }
+
+    private boolean fireOnNext() {
+        return fireOnNext;
+    }
+
+    private boolean fireRandomly() {
+        return fireRandomly && random.nextInt(3) == 0;
     }
 
     private void fireException() {
@@ -158,6 +164,11 @@ public class RuntimeExceptionIterator implements SortedKeyValueIterator<Key,Valu
     public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
         RuntimeExceptionIterator copy = new RuntimeExceptionIterator();
         copy.source = source.deepCopy(env);
+        copy.exceptionClazz = exceptionClazz;
+        copy.exceptionMsg = exceptionMsg;
+        copy.fireOnSeek = fireOnSeek;
+        copy.fireOnNext = fireOnNext;
+        copy.fireRandomly = fireRandomly;
         return copy;
     }
 

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -154,6 +154,12 @@
         </property>
     </bean>
 
+    <!-- used by the IndexExpansionQueryTest -->
+    <bean id="EventQueryNoRules" scope="prototype"  parent="EventQuery">
+        <property name="logicDescription" value="Event query with no pushdown rules" />
+        <property name="queryPlanner" ref="DefaultQueryPlannerNoRules" />
+    </bean>
+
     <bean id="EventQuery" scope="prototype"  parent="BaseEventQuery">
         <property name="logicDescription" value="Event query" />
         <property name="configuredProfiles" >
@@ -572,6 +578,12 @@
 
     <bean id="DefaultQueryPlanner" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner" >
         <property name="transformRules" ref="transformRuleList" />
+        <property name="visitorManager" ref="TimedVisitorManager"/>
+    </bean>
+
+    <!-- used by the IndexExpansionQueryTest -->
+    <bean id="DefaultQueryPlannerNoRules" scope="prototype" class="datawave.query.planner.DefaultQueryPlanner" >
+        <!--        <property name="transformRules" ref="transformRuleList" />-->
         <property name="visitorManager" ref="TimedVisitorManager"/>
     </bean>
 

--- a/warehouse/query-core/src/test/resources/log4j.properties
+++ b/warehouse/query-core/src/test/resources/log4j.properties
@@ -29,3 +29,12 @@ log4j.logger.org.apache.accumulo=INFO
 
 #log4j.logger.datawave.query.iterator.facets=DEBUG
 #log4j.logger.datawave.query.tables.facets=DEBUG
+
+# suppress bean provider messages
+log4j.logger.datawave.configuration.spring=ERROR
+
+# suppress noisy MiniAccumuloCluster logging
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.apache.accumulo.miniclusterImpl=ERROR
+log4j.logger.org.apache.accumulo.start.classloader=ERROR
+log4j.logger.io.micrometer=ERROR


### PR DESCRIPTION
Documented current behavior for fielded regex expansion, unfielded regex expansion, unfielded literal expansion and bounded range expansion under a variet of conditions.

Update DelayIterator, IOExceptionIterator and RuntimeExceptionIterator so internal state survives a teardown-rebuild.

Updated MacTestUtil with a compaction method.

Updated AbstractQueryTest and extending classes to support unique authorizations/visibilities per test.

Updated test log4j.properties to suppress noisy messages from MiniAccumuloCluster setup/execution.

Added an EventQuery and DefaultQueryPlanner to the test QueryLogicFactory.xml that does not use pushdown rules. This was done to support the IndexExpansionQueryTest.