### PR TITLE
Migrate Visibility tests to AbstractQueryTest framework

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/LongRunningQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LongRunningQueryTest.java
@@ -72,7 +72,7 @@ public class LongRunningQueryTest {
         client = testTableHelper.client;
 
         // Load data for the test
-        VisibilityWiseGuysIngest.writeItAll(client, VisibilityWiseGuysIngest.WhatKindaRange.DOCUMENT);
+        VisibilityWiseGuysIngest.writeItAll(client);
         PrintUtility.printTable(client, auths, TableName.SHARD);
         PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
         PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
@@ -93,7 +93,7 @@ public class LongRunningQueryTest {
 
     /**
      * A groupBy query is one type of query that is allowed to be "long running", so that type of query is used in this test.
-     *
+     * <p>
      * A long running query will return a ResultsPage with zero results if it has not completed within the query execution page timeout. This test expects at
      * least 2 pages (the exact number will depend on cpu speed). All but the lsat page should have 0 results and be marked as PARTIAL. The last page should
      * have 8 results and have a status of COMPLETE.

--- a/warehouse/query-core/src/test/java/datawave/query/planner/rules/FieldRuleTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/rules/FieldRuleTest.java
@@ -1,228 +1,140 @@
 package datawave.query.planner.rules;
 
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.jexl3.parser.ASTFunctionNode;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.JexlNode;
 import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import datawave.configuration.spring.SpringBean;
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.core.query.configuration.GenericQueryConfiguration;
-import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.QueryTestTableHelper;
-import datawave.query.RebuildingScannerTestHelper;
-import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.functions.JexlFunctionArgumentDescriptorFactory;
 import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.VisibilityWiseGuysIngestWithModel;
-import datawave.test.JexlNodeAssert;
-import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
-public abstract class FieldRuleTest {
-
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends FieldRuleTest {
-
-        @Override
-        protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
-            return VisibilityWiseGuysIngestWithModel.WhatKindaRange.SHARD;
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends FieldRuleTest {
-
-        @Override
-        protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
-            return VisibilityWiseGuysIngestWithModel.WhatKindaRange.DOCUMENT;
-        }
-    }
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class FieldRuleTest extends AbstractQueryTest {
 
     private static final Logger log = Logger.getLogger(FieldRuleTest.class);
     private static final Authorizations auths = new Authorizations("ALL", "E", "I");
-
-    @Inject
-    @SpringBean(name = "EventQuery")
-    protected ShardQueryLogic logic;
     protected Set<Authorizations> authSet = Collections.singleton(auths);
-    protected KryoDocumentDeserializer deserializer;
 
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-    private final Map<String,String> queryParameters = new HashMap<>();
-    private Date startDate;
-    private Date endDate;
-    private String query;
-    private String expectedPlan;
+    private static AccumuloClient clientForTest;
 
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
+
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
     }
 
-    @AfterClass
-    public static void teardown() {
-        TypeRegistry.reset();
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
-    @Before
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        InMemoryInstance instance = new InMemoryInstance(FieldRuleTest.class.getSimpleName());
+        clientForTest = new InMemoryAccumuloClient("", instance);
+        VisibilityWiseGuysIngestWithModel.writeItAll(clientForTest);
+    }
+
+    @BeforeEach
     public void setup() throws ParseException {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-
         this.logic.setFullTableScanEnabled(true);
         this.logic.setMaxEvaluationPipelines(1);
         this.logic.setQueryExecutionForPageTimeout(300000000000000L);
-        this.deserializer = new KryoDocumentDeserializer();
-        this.startDate = format.parse("20091231");
-        this.endDate = format.parse("20150101");
-    }
+        setClientForTest(clientForTest);
 
-    @After
-    public void tearDown() {
-        queryParameters.clear();
-    }
-
-    protected abstract VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange();
-
-    private void runTestQuery() throws Exception {
-        log.debug("test plan against expected plan");
-
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(this.startDate);
-        settings.setEndDate(this.endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(this.query);
-        settings.setParameters(this.queryParameters);
-        settings.setId(UUID.randomUUID());
-
-        log.debug("query: " + settings.getQuery());
-        log.debug("logic: " + settings.getQueryLogicName());
-
-        AccumuloClient client = createClient();
-        ShardQueryConfiguration config = (ShardQueryConfiguration) logic.initialize(client, settings, authSet);
-        config.setFieldRuleClassName(FieldRuleTest.NoSoupForYouRule.class.getName());
-
-        logic.setupQuery(config);
-
-        String plan = logic.getPlan(client, settings, authSet, true, true);
-
-        // order of terms in planned script is arbitrary, fall back to comparing the jexl trees
-        ASTJexlScript plannedScript = JexlASTHelper.parseJexlQuery(plan);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(this.expectedPlan);
-        JexlNodeAssert.assertThat(plannedScript).isEqualTo(expectedScript);
-    }
-
-    private AccumuloClient createClient() throws Exception {
-        AccumuloClient client = new QueryTestTableHelper(getClass().getName(), log, RebuildingScannerTestHelper.TEARDOWN.NEVER,
-                        RebuildingScannerTestHelper.INTERRUPT.NEVER).client;
-        VisibilityWiseGuysIngestWithModel.writeItAll(client, getRange());
-        PrintUtility.printTable(client, auths, TableName.SHARD);
-        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        return client;
-    }
-
-    private void givenQuery(String query) {
-        this.query = query;
-    }
-
-    private void givenExpectedPlan(String expectedPlan) {
-        this.expectedPlan = expectedPlan;
+        givenDate("20091231", "20150101");
+        getLogic().getConfig().setFieldRuleClassName(FieldRuleTest.NoSoupForYouRule.class.getName());
     }
 
     @Test
     public void testNoEffect() throws Exception {
         givenQuery("COLOR == 'blue'");
-        givenExpectedPlan("COLOR == 'blue' || HUE == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue' || HUE == 'blue'");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testNoSoupForYou() throws Exception {
         givenQuery("COLOR == 'blue' || SOUP == 'chicken noodle'");
-        givenExpectedPlan("COLOR == 'blue' || HUE == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue' || HUE == 'blue'");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testNoSoupForYouEither() throws Exception {
         givenQuery("COLOR == 'blue' || FOOD == 'soup'");
-        givenExpectedPlan("COLOR == 'blue' || HUE == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue' || HUE == 'blue'");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testNegatedSoup() throws Exception {
         // allow it because the query is self-enforcing a rule
         givenQuery("COLOR == 'blue' && FOOD != 'soup'");
-        givenExpectedPlan("(COLOR == 'blue' || HUE == 'blue') && !(FOOD == 'soup')");
-
-        runTestQuery();
+        expectPlan("(COLOR == 'blue' || HUE == 'blue') && !(FOOD == 'soup')");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testNoSoupForYouAND() throws Exception {
         givenQuery("COLOR == 'blue' && SOUP == 'chicken noodle'");
-        givenExpectedPlan("false");
-
-        runTestQuery();
+        expectPlan("false");
+        planAndExecuteQuery();
     }
 
     @Test
     public void testSoupNotIncluded() throws Exception {
         givenQuery("COLOR == 'blue' && filter:includeRegex(SOUP, 'chicken nood*')");
-        givenExpectedPlan("false");
-
-        runTestQuery();
+        expectPlan("false");
+        planAndExecuteQuery();
     }
 
     public static class NoSoupForYouRule extends FieldRule {

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/GroupingTest.java
@@ -1,13 +1,11 @@
 package datawave.query.transformer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -19,112 +17,78 @@ import java.util.SortedSet;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import javax.inject.Inject;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.log4j.Logger;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Sets;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.core.query.iterator.DatawaveTransformIterator;
 import datawave.helpers.PrintUtility;
 import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
 import datawave.query.QueryParameters;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.RebuildingScannerTestHelper;
 import datawave.query.common.grouping.AggregateOperation;
 import datawave.query.common.grouping.DocumentGrouper;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.iterator.QueryOptions;
 import datawave.query.language.parser.jexl.LuceneToJexlQueryParser;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.AbstractQueryTest;
+import datawave.query.util.TestIndexTableNames;
 import datawave.query.util.VisibilityWiseGuysIngest;
 import datawave.query.util.VisibilityWiseGuysIngestWithModel;
 import datawave.query.util.VisibilityWiseGuysNoGroupingIngestWithModel;
 import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.query.result.event.FieldBase;
 import datawave.webservice.result.DefaultEventQueryResponse;
 
 /**
  * Applies grouping to queries.
+ * <p>
+ * This test extensively modifies the flow of {@link AbstractQueryTest}.
  */
-public abstract class GroupingTest {
-
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends GroupingTest {
-
-        @Before
-        public void setup() throws ParseException {
-            super.setup();
-            logic.setCollapseUids(true);
-        }
-
-        @Override
-        protected String getRange() {
-            return "SHARD";
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends GroupingTest {
-
-        @Before
-        public void setup() throws ParseException {
-            super.setup();
-            logic.setCollapseUids(false);
-        }
-
-        @Override
-        protected String getRange() {
-            return "DOCUMENT";
-        }
-    }
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class GroupingTest extends AbstractQueryTest {
 
     private static class QueryResult {
-        private static final ObjectWriter writer = new ObjectMapper().enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME).writerWithDefaultPrettyPrinter();
 
         private final RebuildingScannerTestHelper.TEARDOWN teardown;
         private final RebuildingScannerTestHelper.INTERRUPT interrupt;
         private final DefaultEventQueryResponse response;
-        private final String json;
 
-        private QueryResult(RebuildingScannerTestHelper.TEARDOWN teardown, RebuildingScannerTestHelper.INTERRUPT interrupt, DefaultEventQueryResponse response)
-                        throws JsonProcessingException {
+        private QueryResult(RebuildingScannerTestHelper.TEARDOWN teardown, RebuildingScannerTestHelper.INTERRUPT interrupt,
+                        DefaultEventQueryResponse response) {
             this.teardown = teardown;
             this.interrupt = interrupt;
             this.response = response;
-            this.json = writer.writeValueAsString(response);
         }
     }
 
@@ -260,79 +224,94 @@ public abstract class GroupingTest {
     private static final EnumSet<RebuildingScannerTestHelper.INTERRUPT> INTERRUPTS = EnumSet.allOf(RebuildingScannerTestHelper.INTERRUPT.class);
     private static final Set<Authorizations> authSet = Collections.singleton(auths);
 
-    @Inject
-    @SpringBean(name = "metadataHelperCacheManager")
+    @Autowired
+    @Qualifier("metadataHelperCacheManager")
     private CacheManager cacheManager;
 
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
-    protected KryoDocumentDeserializer deserializer;
 
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-    private final Map<String,String> queryParameters = new HashMap<>();
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    /**
+     * Configure the provided {@link QueryParameters#GROUP_FIELDS}
+     *
+     * @param option
+     *            the option value
+     */
+    private void givenGroupFields(String option) {
+        givenParameter(QueryParameters.GROUP_FIELDS, option);
+    }
+
+    /**
+     * Configure the provided {@link QueryParameters#GROUP_FIELDS_BATCH_SIZE}
+     *
+     * @param option
+     *            the option value
+     */
+    private void givenGroupFieldsBatchSize(String option) {
+        givenParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, option);
+    }
+
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    @Override
+    public List<String> getIndexTableNames() {
+        return List.of(TableName.SHARD_INDEX, TestIndexTableNames.NO_UID_INDEX);
+    }
+
     private final Map<SortedSet<String>,Group> expectedGroups = new HashMap<>();
     private final List<QueryResult> queryResults = new ArrayList<>();
 
-    private String query;
-    private Date startDate;
-    private Date endDate;
-    private BiConsumer<AccumuloClient,String> dataWriter;
+    private Consumer<AccumuloClient> dataWriter;
 
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
-    }
-
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
     }
 
-    @Before
-    public void setup() throws ParseException {
+    @BeforeEach
+    public void beforeEach() throws ParseException {
         this.logic.setFullTableScanEnabled(true);
         this.logic.setMaxEvaluationPipelines(1);
         this.logic.setQueryExecutionForPageTimeout(300000000000000L);
-        this.deserializer = new KryoDocumentDeserializer();
-        this.startDate = format.parse("20091231");
-        this.endDate = format.parse("20150101");
+
+        givenDate("20091231", "20150101");
+
+        // every query eventually has the same query plan
+        expectPlan("UUID == 'capone' || UUID == 'corleone' || UUID == 'soprano'");
 
         // clear any cache updates from previous tests
         cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
     }
 
-    @After
-    public void tearDown() {
-        this.queryParameters.clear();
-        this.query = null;
-        this.startDate = null;
-        this.endDate = null;
+    @AfterEach
+    public void afterEach() {
         this.expectedGroups.clear();
         this.queryResults.clear();
         this.dataWriter = null;
     }
 
-    @AfterClass
-    public static void teardown() {
+    @AfterAll
+    public static void afterAll() {
         TypeRegistry.reset();
-    }
-
-    protected abstract String getRange();
-
-    private void givenQuery(String query) {
-        this.query = query;
-    }
-
-    private void givenQueryParameter(String key, String value) {
-        this.queryParameters.put(key, value);
     }
 
     private void expectGroup(Group group) {
@@ -344,9 +323,9 @@ public abstract class GroupingTest {
     }
 
     private void givenNonModelData() {
-        dataWriter = (client, range) -> {
+        dataWriter = (client) -> {
             try {
-                VisibilityWiseGuysIngest.writeItAll(client, range);
+                VisibilityWiseGuysIngest.writeItAll(client);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -354,9 +333,9 @@ public abstract class GroupingTest {
     }
 
     private void givenModelData() {
-        dataWriter = (client, range) -> {
+        dataWriter = (client) -> {
             try {
-                VisibilityWiseGuysIngestWithModel.writeItAll(client, range);
+                VisibilityWiseGuysIngestWithModel.writeItAll(client);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -364,9 +343,9 @@ public abstract class GroupingTest {
     }
 
     private void givenNonGroupedModelData() {
-        dataWriter = (client, range) -> {
+        dataWriter = (client) -> {
             try {
-                VisibilityWiseGuysNoGroupingIngestWithModel.writeItAll(client, range);
+                VisibilityWiseGuysNoGroupingIngestWithModel.writeItAll(client);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -445,48 +424,52 @@ public abstract class GroupingTest {
         // @formatter:on
     }
 
+    private RebuildingScannerTestHelper.TEARDOWN currentTeardown = null;
+    private RebuildingScannerTestHelper.INTERRUPT currentInterrupt = null;
+
     private void collectQueryResults() throws Exception {
         for (RebuildingScannerTestHelper.TEARDOWN teardown : TEARDOWNS) {
             for (RebuildingScannerTestHelper.INTERRUPT interrupt : INTERRUPTS) {
-                queryResults.add(getQueryResult(teardown, interrupt));
+                currentTeardown = teardown;
+                currentInterrupt = interrupt;
+
+                AccumuloClient client = createClient(teardown, interrupt);
+                setClientForTest(client);
+
+                planAndExecuteQuery();
             }
         }
     }
 
-    private QueryResult getQueryResult(RebuildingScannerTestHelper.TEARDOWN teardown, RebuildingScannerTestHelper.INTERRUPT interrupt) throws Exception {
-        // Initialize the query settings.
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(this.startDate);
-        settings.setEndDate(this.endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(this.query);
-        settings.setParameters(this.queryParameters);
-        settings.setId(UUID.randomUUID());
+    /**
+     * This method is overridden because of special result handling logic.
+     *
+     * @param logic
+     *            the query logic
+     */
+    @Override
+    protected void executeQuery(ShardQueryLogic logic) throws Exception {
+        try {
+            // Run the query and retrieve the response.
+            DocumentTransformer transformer = (DocumentTransformer) (logic.getTransformer(getSettings()));
+            List<Object> eventList = Lists.newArrayList(new DatawaveTransformIterator<>(logic.iterator(), transformer));
+            DefaultEventQueryResponse response = ((DefaultEventQueryResponse) transformer.createResponse(eventList));
 
-        log.debug("query: " + settings.getQuery());
-        log.debug("queryLogicName: " + settings.getQueryLogicName());
-
-        // Initialize the query logic.
-        AccumuloClient client = createClient(teardown, interrupt);
-        GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
-        logic.setupQuery(config);
-
-        // Run the query and retrieve the response.
-        DocumentTransformer transformer = (DocumentTransformer) (logic.getTransformer(settings));
-        List<Object> eventList = Lists.newArrayList(new DatawaveTransformIterator<>(logic.iterator(), transformer));
-        DefaultEventQueryResponse response = ((DefaultEventQueryResponse) transformer.createResponse(eventList));
-
-        // Return the test result.
-        return new QueryResult(teardown, interrupt, response);
+            // Return the test result.
+            QueryResult queryResult = new QueryResult(currentTeardown, currentInterrupt, response);
+            queryResults.add(queryResult);
+        } finally {
+            logic.close();
+        }
     }
 
     private AccumuloClient createClient(RebuildingScannerTestHelper.TEARDOWN teardown, RebuildingScannerTestHelper.INTERRUPT interrupt) throws Exception {
+        // TODO: use normal client for this
         AccumuloClient client = new QueryTestTableHelper(getClass().toString(), log, teardown, interrupt).client;
-        dataWriter.accept(client, getRange());
+        dataWriter.accept(client);
         PrintUtility.printTable(client, auths, TableName.SHARD);
         PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        PrintUtility.printTable(client, auths, TableName.METADATA);
         return client;
     }
 
@@ -494,10 +477,9 @@ public abstract class GroupingTest {
     public void testGroupByAgeAndGenderWithBatchSizeOfSix() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("AGE,$GENDER");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "AGE,$GENDER");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("FEMALE", "18").withCount(2));
         expectGroup(Group.of("MALE", "30").withCount(1));
@@ -510,8 +492,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
         assertResponseEventsAreIdenticalForAllTestResults();
     }
@@ -523,10 +503,9 @@ public abstract class GroupingTest {
     public void testGroupByAgeWithBatchSizeOfSix() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("AGE");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("18").withCount(2));
         expectGroup(Group.of("30").withCount(1));
@@ -538,7 +517,6 @@ public abstract class GroupingTest {
         expectGroup(Group.of("22").withCount(2));
 
         collectQueryResults();
-
         assertGroups();
     }
 
@@ -549,18 +527,15 @@ public abstract class GroupingTest {
     public void testGroupByGenderWithBatchSizeOfZero() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("GENDER");
+        givenGroupFieldsBatchSize("0");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GENDER");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "0");
 
         expectGroup(Group.of("MALE").withCount(10));
         expectGroup(Group.of("FEMALE").withCount(2));
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -571,18 +546,15 @@ public abstract class GroupingTest {
     public void testGroupByGenderWithBatchSizeOfSix() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("GENDER");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GENDER");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("MALE").withCount(10));
         expectGroup(Group.of("FEMALE").withCount(2));
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -593,19 +565,16 @@ public abstract class GroupingTest {
     public void testGroupByWithReducedResponse() throws Exception {
         givenNonModelData();
 
+        givenParameter(QueryOptions.REDUCED_RESPONSE, "true");
+        givenGroupFields("GENDER");
+        givenGroupFieldsBatchSize("0");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryOptions.REDUCED_RESPONSE, "true");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GENDER");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "0");
 
         expectGroup(Group.of("MALE").withCount(10));
         expectGroup(Group.of("FEMALE").withCount(2));
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
 
         // Verify that the column visibility was appropriately reduced
@@ -631,9 +600,8 @@ public abstract class GroupingTest {
     public void testGroupByRecord() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("RECORD");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "RECORD");
 
         expectGroup(Group.of("1").withCount(3));
         expectGroup(Group.of("2").withCount(3));
@@ -641,8 +609,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -653,9 +619,8 @@ public abstract class GroupingTest {
     public void testGroupByGenderAndRecord() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("GENDER,RECORD");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GENDER,RECORD");
 
         expectGroup(Group.of("FEMALE", "1").withCount(2));
         expectGroup(Group.of("FEMALE", "2").withCount(2));
@@ -665,8 +630,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -677,9 +640,8 @@ public abstract class GroupingTest {
     public void testGroupByJexlFunction() throws Exception {
         givenNonModelData();
 
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*' && f:groupby('$AGE','GENDER')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("FEMALE", "18").withCount(2));
         expectGroup(Group.of("MALE", "30").withCount(1));
@@ -692,8 +654,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -703,14 +663,17 @@ public abstract class GroupingTest {
     @Test
     public void testGroupBySingleField() throws Exception {
         givenNonModelData();
-        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY(AGE)");
-        givenQueryParameter(QueryParameters.RETURN_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.HIT_LIST, "true");
-        givenQueryParameter(QueryParameters.INCLUDE_GROUPING_CONTEXT, "true");
-        givenQueryParameter(QueryParameters.LIMIT_FIELDS, "_ANYFIELD_=100");
-        givenQueryParameter(QueryOptions.REDUCED_RESPONSE, "true");
-        logic.setCollectTimingDetails(true);
+
+        givenParameter(QueryParameters.RETURN_FIELDS, "AGE");
+        givenParameter(QueryParameters.HIT_LIST, "true");
+        givenParameter(QueryParameters.INCLUDE_GROUPING_CONTEXT, "true");
+        givenParameter(QueryParameters.LIMIT_FIELDS, "_ANYFIELD_=100");
+        givenParameter(QueryOptions.REDUCED_RESPONSE, "true");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY(AGE)");
+        expectPlan("(((_Eval_ = true) && (UUID =~ 'c.*?')) || ((_Eval_ = true) && (UUID =~ 's.*?')))");
+
+        logic.setCollectTimingDetails(true);
 
         expectGroup(Group.of("16").withCount(1));
         expectGroup(Group.of("18").withCount(2));
@@ -723,8 +686,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -735,11 +696,10 @@ public abstract class GroupingTest {
     public void testGroupByLuceneFunction() throws Exception {
         givenNonModelData();
 
-        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('AGE','$GENDER')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
-
+        givenGroupFieldsBatchSize("6");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('AGE','$GENDER')");
+        expectPlan("(((_Eval_ = true) && (UUID =~ 'c.*?')) || ((_Eval_ = true) && (UUID =~ 's.*?')))");
 
         expectGroup(Group.of("FEMALE", "18").withCount(2));
         expectGroup(Group.of("MALE", "30").withCount(1));
@@ -752,8 +712,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -764,11 +722,10 @@ public abstract class GroupingTest {
     public void testGroupByLuceneFunctionWithDuplicateValues() throws Exception {
         givenNonModelData();
 
-        givenQuery("(UUID:CORLEONE) and #GROUPBY('AGE','BIRTHDAY')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
-
+        givenGroupFieldsBatchSize("6");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:CORLEONE) and #GROUPBY('AGE','BIRTHDAY')");
+        expectPlan("UUID == 'corleone'");
 
         expectGroup(Group.of("4", "18").withCount(1));
         expectGroup(Group.of("5", "40").withCount(1));
@@ -779,8 +736,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -788,15 +743,14 @@ public abstract class GroupingTest {
     public void testGroupingByGenderAndAllAgeMetrics() throws Exception {
         givenNonModelData();
 
+        givenParameter(QueryParameters.MAX_FIELDS, "AGE");
+        givenParameter(QueryParameters.MIN_FIELDS, "AGE");
+        givenParameter(QueryParameters.SUM_FIELDS, "AGE");
+        givenParameter(QueryParameters.AVERAGE_FIELDS, "AGE");
+        givenParameter(QueryParameters.COUNT_FIELDS, "AGE");
+        givenGroupFields("GENDER");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GENDER");
-        givenQueryParameter(QueryParameters.MAX_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.MIN_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.SUM_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.AVERAGE_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.COUNT_FIELDS, "AGE");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("MALE").withCount(10)
                         .withAggregate(Aggregate.of("AGE").withCount("10").withMax("40").withMin("16").withSum("268").withAverage("26.8")));
@@ -805,8 +759,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -823,8 +775,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -832,8 +782,9 @@ public abstract class GroupingTest {
     public void testGroupingByGenderAndAllAgeMetricsUsingLuceneFunction() throws Exception {
         givenNonModelData();
 
-        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('$GENDER') and #SUM('AGE') and #MAX('AGE') and #MIN('AGE') and #AVERAGE('AGE') and #COUNT('AGE')");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('$GENDER') and #SUM('AGE') and #MAX('AGE') and #MIN('AGE') and #AVERAGE('AGE') and #COUNT('AGE')");
+        expectPlan("(((_Eval_ = true) && (UUID =~ 'c.*?')) || ((_Eval_ = true) && (UUID =~ 's.*?')))");
 
         expectGroup(Group.of("MALE").withCount(10)
                         .withAggregate(Aggregate.of("AGE").withCount("10").withMax("40").withMin("16").withSum("268").withAverage("26.8")));
@@ -842,8 +793,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -851,10 +800,9 @@ public abstract class GroupingTest {
     public void testGroupByAgeAndGenderWithBatchSizeOfSixUsingModel() throws Exception {
         givenModelData();
 
+        givenGroupFields("AG,GEN");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "AG,GEN");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("FEMALE", "18").withCount(2));
         expectGroup(Group.of("MALE", "30").withCount(1));
@@ -867,8 +815,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
         assertResponseEventsAreIdenticalForAllTestResults();
     }
@@ -878,10 +824,9 @@ public abstract class GroupingTest {
         // Set up the test.
         givenModelData();
 
+        givenGroupFields("AG");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "AG");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("18").withCount(2));
         expectGroup(Group.of("30").withCount(1));
@@ -894,8 +839,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -903,16 +846,14 @@ public abstract class GroupingTest {
     public void testGroupByGenderWithBatchSizeOfSixUsingModel() throws Exception {
         givenModelData();
 
+        givenGroupFields("GEN");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GEN");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("MALE").withCount(10));
         expectGroup(Group.of("FEMALE").withCount(2));
 
         collectQueryResults();
-
         assertGroups();
     }
 
@@ -920,16 +861,14 @@ public abstract class GroupingTest {
     public void testGroupByGenderWithBatchSizeOfZeroUsingModel() throws Exception {
         givenModelData();
 
+        givenGroupFields("GEN");
+        givenGroupFieldsBatchSize("0");
         givenQuery("UUID =~ '^[CS].*'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GEN");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "0");
 
         expectGroup(Group.of("MALE").withCount(10));
         expectGroup(Group.of("FEMALE").withCount(2));
 
         collectQueryResults();
-
         assertGroups();
     }
 
@@ -937,9 +876,8 @@ public abstract class GroupingTest {
     public void testGroupByJexlFunctionsUsingModel() throws Exception {
         givenModelData();
 
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ '^[CS].*' && f:groupby('AG','GEN')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
 
         expectGroup(Group.of("FEMALE", "18").withCount(2));
         expectGroup(Group.of("MALE", "30").withCount(1));
@@ -951,7 +889,6 @@ public abstract class GroupingTest {
         expectGroup(Group.of("MALE", "22").withCount(2));
 
         collectQueryResults();
-
         assertGroups();
     }
 
@@ -959,11 +896,10 @@ public abstract class GroupingTest {
     public void testGroupByLuceneFunctionUsingModel() throws Exception {
         givenModelData();
 
-        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('AG','GEN')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
-
+        givenGroupFieldsBatchSize("6");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('AG','GEN')");
+        expectPlan("(((_Eval_ = true) && (UUID =~ 'c.*?')) || ((_Eval_ = true) && (UUID =~ 's.*?')))");
 
         expectGroup(Group.of("FEMALE", "18").withCount(2));
         expectGroup(Group.of("MALE", "30").withCount(1));
@@ -975,7 +911,6 @@ public abstract class GroupingTest {
         expectGroup(Group.of("MALE", "22").withCount(2));
 
         collectQueryResults();
-
         assertGroups();
     }
 
@@ -983,15 +918,15 @@ public abstract class GroupingTest {
     public void testGroupingByGenderAndAllAgeMetricsUsingModel() throws Exception {
         givenModelData();
 
-        givenQuery("UUID =~ '^[CS].*'");
+        givenGroupFields("GEN");
+        givenGroupFieldsBatchSize("6");
+        givenParameter(QueryParameters.MAX_FIELDS, "AG");
+        givenParameter(QueryParameters.MIN_FIELDS, "AG");
+        givenParameter(QueryParameters.SUM_FIELDS, "AG");
+        givenParameter(QueryParameters.AVERAGE_FIELDS, "AG");
+        givenParameter(QueryParameters.COUNT_FIELDS, "AG");
 
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GEN");
-        givenQueryParameter(QueryParameters.MAX_FIELDS, "AG");
-        givenQueryParameter(QueryParameters.MIN_FIELDS, "AG");
-        givenQueryParameter(QueryParameters.SUM_FIELDS, "AG");
-        givenQueryParameter(QueryParameters.AVERAGE_FIELDS, "AG");
-        givenQueryParameter(QueryParameters.COUNT_FIELDS, "AG");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
+        givenQuery("UUID =~ '^[CS].*'");
 
         expectGroup(Group.of("MALE").withCount(10)
                         .withAggregate(Aggregate.of("AG").withCount("10").withMax("40").withMin("16").withSum("268").withAverage("26.8")));
@@ -1000,8 +935,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -1012,9 +945,8 @@ public abstract class GroupingTest {
     public void testGroupByRecordWithAggregation() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("RECORD");
         givenQuery("UUID =~ '^[CS].*' && f:sum('AGE') && f:min('GENDER') && f:max('GENDER') && f:average('BIRTHDAY') && f:count('GENDER', 'AGE', 'BIRTHDAY')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "RECORD");
 
         // @formatter:off
         expectGroup(Group.of("1").withCount(3)
@@ -1032,8 +964,6 @@ public abstract class GroupingTest {
         // @formatter:on
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -1044,12 +974,10 @@ public abstract class GroupingTest {
     public void testSummingNonNumericalValue() {
         givenNonModelData();
 
+        givenGroupFields("RECORD");
         givenQuery("UUID =~ '^[CS].*' && f:sum('GENDER')");
 
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "RECORD");
-
-        Assertions.assertThatIllegalArgumentException().isThrownBy(this::collectQueryResults)
-                        .withMessage("Unable to calculate a sum with non-numerical value 'MALE'");
+        assertThatIllegalArgumentException().isThrownBy(this::collectQueryResults).withMessage("Unable to calculate a sum with non-numerical value 'MALE'");
     }
 
     /**
@@ -1059,11 +987,10 @@ public abstract class GroupingTest {
     public void testAveragingNonNumericalValue() {
         givenNonModelData();
 
+        givenGroupFields("RECORD");
         givenQuery("UUID =~ '^[CS].*' && f:average('GENDER')");
 
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "RECORD");
-
-        Assertions.assertThatIllegalArgumentException().isThrownBy(this::collectQueryResults)
+        assertThatIllegalArgumentException().isThrownBy(this::collectQueryResults)
                         .withMessage("Character M is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.");
     }
 
@@ -1071,8 +998,10 @@ public abstract class GroupingTest {
     public void testGroupingWithModelByGenderAndAllAgeMetricsUsingLuceneFunction() throws Exception {
         givenModelData();
 
-        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('GEN') and #SUM('AG') and #MAX('AG') and #MIN('AG') and #AVERAGE('AG') and #COUNT('AG')");
         givenLuceneParserForLogic();
+
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('GEN') and #SUM('AG') and #MAX('AG') and #MIN('AG') and #AVERAGE('AG') and #COUNT('AG')");
+        expectPlan("(((_Eval_ = true) && (UUID =~ 'c.*?')) || ((_Eval_ = true) && (UUID =~ 's.*?')))");
 
         expectGroup(Group.of("MALE").withCount(10)
                         .withAggregate(Aggregate.of("AG").withCount("10").withMax("40").withMin("16").withSum("268").withAverage("26.8")));
@@ -1081,8 +1010,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -1095,8 +1022,9 @@ public abstract class GroupingTest {
         // Contains entries with identical values for fields that will be mapped to the same model mapping.
         givenNonGroupedModelData();
 
-        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('GEN') and #SUM('AG') and #MAX('AG') and #MIN('AG') and #AVERAGE('AG') and #COUNT('AG')");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:C* or UUID:S* ) and #GROUPBY('GEN') and #SUM('AG') and #MAX('AG') and #MIN('AG') and #AVERAGE('AG') and #COUNT('AG')");
+        expectPlan("(((_Eval_ = true) && (UUID =~ 'c.*?')) || ((_Eval_ = true) && (UUID =~ 's.*?')))");
 
         expectGroup(Group.of("MALE").withCount(2).withAggregate(Aggregate.of("AG").withCount("2").withMax("40").withMin("24").withSum("64").withAverage("32")));
         expectGroup(Group.of("FEMALE").withCount(1)
@@ -1104,8 +1032,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -1116,11 +1042,10 @@ public abstract class GroupingTest {
     public void testGroupingWhileTruncatingToYearViaLucene() throws Exception {
         givenNonModelData();
 
-        givenQuery("(UUID:CORLEONE) and #GROUPBY('GENDER','BIRTH_DATE[YEAR]')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
-
+        givenGroupFieldsBatchSize("6");
         givenLuceneParserForLogic();
+        givenQuery("(UUID:CORLEONE) and #GROUPBY('GENDER','BIRTH_DATE[YEAR]')");
+        expectPlan("UUID == 'corleone'");
 
         expectGroup(Group.of("1925-00-00T00:00:00.000", "FEMALE").withCount(1));
         expectGroup(Group.of("1925-00-00T00:00:00.000", "MALE").withCount(1));
@@ -1128,8 +1053,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -1140,9 +1063,9 @@ public abstract class GroupingTest {
     public void testGroupingWhileTruncatingToYearViaJexl() throws Exception {
         givenNonModelData();
 
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ 'CORLEONE' && f:groupby('GENDER','BIRTH_DATE[YEAR]')");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
+        expectPlan("UUID == 'corleone'");
 
         expectGroup(Group.of("1925-00-00T00:00:00.000", "FEMALE").withCount(1));
         expectGroup(Group.of("1925-00-00T00:00:00.000", "MALE").withCount(1));
@@ -1150,8 +1073,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 
@@ -1162,10 +1083,10 @@ public abstract class GroupingTest {
     public void testGroupingWhileTruncatingToYearViaQueryParameter() throws Exception {
         givenNonModelData();
 
+        givenGroupFields("GENDER,BIRTH_DATE[YEAR]");
+        givenGroupFieldsBatchSize("6");
         givenQuery("UUID =~ 'CORLEONE'");
-
-        givenQueryParameter(QueryParameters.GROUP_FIELDS, "GENDER,BIRTH_DATE[YEAR]");
-        givenQueryParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "6");
+        expectPlan("UUID == 'corleone'");
 
         expectGroup(Group.of("1925-00-00T00:00:00.000", "FEMALE").withCount(1));
         expectGroup(Group.of("1925-00-00T00:00:00.000", "MALE").withCount(1));
@@ -1173,8 +1094,6 @@ public abstract class GroupingTest {
 
         // Run the test queries and collect their results.
         collectQueryResults();
-
-        // Verify the results.
         assertGroups();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/NoExpansionTests.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/NoExpansionTests.java
@@ -1,189 +1,96 @@
 package datawave.query.transformer;
 
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
-import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
-import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.query.QueryParameters;
-import datawave.query.QueryTestTableHelper;
-import datawave.query.RebuildingScannerTestHelper;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
-import datawave.query.jexl.JexlASTHelper;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.VisibilityWiseGuysIngestWithModel;
-import datawave.test.JexlNodeAssert;
-import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * Tests for usage of #NO_EXPANSION in queries.
  */
-public abstract class NoExpansionTests {
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class NoExpansionTests extends AbstractQueryTest {
 
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends NoExpansionTests {
-
-        @Before
-        public void setup() throws ParseException {
-            super.setup();
-            logic.setCollapseUids(true);
-        }
-
-        @Override
-        protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
-            return VisibilityWiseGuysIngestWithModel.WhatKindaRange.SHARD;
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends NoExpansionTests {
-
-        @Before
-        public void setup() throws ParseException {
-            super.setup();
-            logic.setCollapseUids(false);
-        }
-
-        @Override
-        protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
-            return VisibilityWiseGuysIngestWithModel.WhatKindaRange.DOCUMENT;
-        }
-    }
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    private static final Logger log = Logger.getLogger(NoExpansionTests.class);
     private static final Authorizations auths = new Authorizations("ALL", "E", "I");
-
-    @Inject
-    @SpringBean(name = "EventQuery")
-    protected ShardQueryLogic logic;
     protected Set<Authorizations> authSet = Collections.singleton(auths);
-    protected KryoDocumentDeserializer deserializer;
+    private static AccumuloClient clientForSetup;
 
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-    private final Map<String,String> queryParameters = new HashMap<>();
-    private Date startDate;
-    private Date endDate;
-    private String query;
-    private String expectedPlan;
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
 
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
     }
 
-    @AfterClass
-    public static void teardown() {
-        TypeRegistry.reset();
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
-    @Before
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    /**
+     * Helper method for configuring {@link QueryParameters#NO_EXPANSION_FIELDS}
+     *
+     * @param field
+     *            the field or fields to set
+     */
+    protected void givenNoExpansion(String field) {
+        givenParameter(QueryParameters.NO_EXPANSION_FIELDS, field);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        InMemoryInstance instance = new InMemoryInstance(NoExpansionTests.class.getName());
+        clientForSetup = new InMemoryAccumuloClient("", instance);
+
+        // this helper class will generate the extra index tables
+        VisibilityWiseGuysIngestWithModel.writeItAll(clientForSetup);
+    }
+
+    @BeforeEach
     public void setup() throws ParseException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-
-        this.logic.setFullTableScanEnabled(true);
-        this.logic.setMaxEvaluationPipelines(1);
-        this.logic.setQueryExecutionForPageTimeout(300000000000000L);
-        this.deserializer = new KryoDocumentDeserializer();
-        this.startDate = format.parse("20091231");
-        this.endDate = format.parse("20150101");
-    }
-
-    @After
-    public void tearDown() {
-        queryParameters.clear();
-    }
-
-    protected abstract VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange();
-
-    private void runTestQuery() throws Exception {
-        log.debug("test plan against expected plan");
-
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(this.startDate);
-        settings.setEndDate(this.endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(this.query);
-        settings.setParameters(this.queryParameters);
-        settings.setId(UUID.randomUUID());
-
-        log.debug("query: " + settings.getQuery());
-        log.debug("logic: " + settings.getQueryLogicName());
-
-        AccumuloClient client = createClient();
-        GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
-        logic.setupQuery(config);
-
-        String plan = logic.getPlan(client, settings, authSet, true, true);
-
-        // order of terms in planned script is arbitrary, fall back to comparing the jexl trees
-        ASTJexlScript plannedScript = JexlASTHelper.parseJexlQuery(plan);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(this.expectedPlan);
-        JexlNodeAssert.assertThat(plannedScript).isEqualTo(expectedScript);
-    }
-
-    private AccumuloClient createClient() throws Exception {
-        AccumuloClient client = new QueryTestTableHelper(getClass().getName(), log, RebuildingScannerTestHelper.TEARDOWN.NEVER,
-                        RebuildingScannerTestHelper.INTERRUPT.NEVER).client;
-        VisibilityWiseGuysIngestWithModel.writeItAll(client, getRange());
-        PrintUtility.printTable(client, auths, TableName.SHARD);
-        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        return client;
-    }
-
-    private void givenQueryParameter(String key, String value) {
-        this.queryParameters.put(key, value);
-    }
-
-    private void givenQuery(String query) {
-        this.query = query;
-    }
-
-    private void givenExpectedPlan(String expectedPlan) {
-        this.expectedPlan = expectedPlan;
+        givenDate("20091231", "20150101");
+        setClientForTest(clientForSetup);
     }
 
     /**
@@ -192,9 +99,8 @@ public abstract class NoExpansionTests {
     @Test
     public void testDefaultQueryModelExpansion() throws Exception {
         givenQuery("COLOR == 'blue' && FASTENER == 'bolt'");
-        givenExpectedPlan("(COLOR == 'blue' || HUE == 'blue') && (FASTENER == 'bolt' || FIXTURE == 'bolt')");
-
-        runTestQuery();
+        expectPlan("(COLOR == 'blue' || HUE == 'blue') && (FASTENER == 'bolt' || FIXTURE == 'bolt')");
+        planAndExecuteQuery();
     }
 
     /**
@@ -203,9 +109,8 @@ public abstract class NoExpansionTests {
     @Test
     public void testNoExpansionViaFunction() throws Exception {
         givenQuery("COLOR == 'blue' && f:noExpansion(COLOR)");
-        givenExpectedPlan("COLOR == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue'");
+        planAndExecuteQuery();
     }
 
     /**
@@ -214,9 +119,8 @@ public abstract class NoExpansionTests {
     @Test
     public void testNoExpansionViaFunctionWithMultipleFields() throws Exception {
         givenQuery("COLOR == 'blue' && FASTENER == 'bolt' && f:noExpansion(COLOR,FASTENER)");
-        givenExpectedPlan("COLOR == 'blue' && FASTENER == 'bolt'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue' && FASTENER == 'bolt'");
+        planAndExecuteQuery();
     }
 
     /**
@@ -224,11 +128,10 @@ public abstract class NoExpansionTests {
      */
     @Test
     public void testNoExpansionViaQueryParameters() throws Exception {
+        givenNoExpansion("COLOR");
         givenQuery("COLOR == 'blue'");
-        givenQueryParameter(QueryParameters.NO_EXPANSION_FIELDS, "COLOR");
-        givenExpectedPlan("COLOR == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue'");
+        planAndExecuteQuery();
     }
 
     /**
@@ -236,11 +139,10 @@ public abstract class NoExpansionTests {
      */
     @Test
     public void testNoExpansionViaQueryParametersWithMultipleFields() throws Exception {
+        givenNoExpansion("COLOR,FASTENER");
         givenQuery("COLOR == 'blue' && FASTENER == 'bolt'");
-        givenQueryParameter(QueryParameters.NO_EXPANSION_FIELDS, "COLOR,FASTENER");
-        givenExpectedPlan("COLOR == 'blue' && FASTENER == 'bolt'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue' && FASTENER == 'bolt'");
+        planAndExecuteQuery();
     }
 
     /**
@@ -248,11 +150,10 @@ public abstract class NoExpansionTests {
      */
     @Test
     public void testNoExpansionViaFunctionAndQueryParameters() throws Exception {
+        givenNoExpansion("COLOR");
         givenQuery("COLOR == 'blue' && f:noExpansion(COLOR)");
-        givenQueryParameter(QueryParameters.NO_EXPANSION_FIELDS, "COLOR");
-        givenExpectedPlan("COLOR == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue'");
+        planAndExecuteQuery();
     }
 
     /**
@@ -261,10 +162,9 @@ public abstract class NoExpansionTests {
      */
     @Test
     public void testConflictingNoExpansionFields() throws Exception {
+        givenNoExpansion("HUE");
         givenQuery("COLOR == 'blue' && f:noExpansion(COLOR)");
-        givenQueryParameter(QueryParameters.NO_EXPANSION_FIELDS, "HUE");
-        givenExpectedPlan("COLOR == 'blue'");
-
-        runTestQuery();
+        expectPlan("COLOR == 'blue'");
+        planAndExecuteQuery();
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/QueryModelExpansionTests.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/QueryModelExpansionTests.java
@@ -1,197 +1,95 @@
 package datawave.query.transformer;
 
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.jexl3.parser.ASTJexlScript;
-import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
-import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.QueryTestTableHelper;
-import datawave.query.RebuildingScannerTestHelper;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
-import datawave.query.jexl.JexlASTHelper;
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.VisibilityWiseGuysIngestWithModel;
-import datawave.test.JexlNodeAssert;
-import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * Tests the expansion of queries from the query model.
  */
-public abstract class QueryModelExpansionTests {
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class QueryModelExpansionTests extends AbstractQueryTest {
 
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends QueryModelExpansionTests {
-
-        @Before
-        public void setup() throws ParseException {
-            super.setup();
-            logic.setCollapseUids(true);
-        }
-
-        @Override
-        protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
-            return VisibilityWiseGuysIngestWithModel.WhatKindaRange.SHARD;
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends QueryModelExpansionTests {
-
-        @Before
-        public void setup() throws ParseException {
-            super.setup();
-            logic.setCollapseUids(false);
-        }
-
-        @Override
-        protected VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange() {
-            return VisibilityWiseGuysIngestWithModel.WhatKindaRange.DOCUMENT;
-        }
-    }
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    private static final Logger log = Logger.getLogger(QueryModelExpansionTests.class);
     private static final Authorizations auths = new Authorizations("ALL", "E", "I");
-
-    @Inject
-    @SpringBean(name = "EventQuery")
-    protected ShardQueryLogic logic;
     protected Set<Authorizations> authSet = Collections.singleton(auths);
-    protected KryoDocumentDeserializer deserializer;
+    private static AccumuloClient clientForSetup;
 
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-    private final Map<String,String> queryParameters = new HashMap<>();
-    private Date startDate;
-    private Date endDate;
-    private String query;
-    private String expectedPlan;
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
 
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
     }
 
-    @AfterClass
-    public static void teardown() {
-        TypeRegistry.reset();
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
-    @Before
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        InMemoryInstance instance = new InMemoryInstance(NoExpansionTests.class.getName());
+        clientForSetup = new InMemoryAccumuloClient("", instance);
+
+        // this helper class will generate the extra index tables
+        VisibilityWiseGuysIngestWithModel.writeItAll(clientForSetup);
+    }
+
+    @BeforeEach
     public void setup() throws ParseException {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-
-        this.logic.setFullTableScanEnabled(true);
-        this.logic.setMaxEvaluationPipelines(1);
-        this.logic.setQueryExecutionForPageTimeout(300000000000000L);
-        this.deserializer = new KryoDocumentDeserializer();
-        this.startDate = format.parse("20091231");
-        this.endDate = format.parse("20150101");
-    }
-
-    @After
-    public void tearDown() {
-        queryParameters.clear();
-    }
-
-    protected abstract VisibilityWiseGuysIngestWithModel.WhatKindaRange getRange();
-
-    private void runTestQuery() throws Exception {
-        log.debug("test plan against expected plan");
-
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(this.startDate);
-        settings.setEndDate(this.endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(this.query);
-        settings.setParameters(this.queryParameters);
-        settings.setId(UUID.randomUUID());
-
-        log.debug("query: " + settings.getQuery());
-        log.debug("logic: " + settings.getQueryLogicName());
-
-        AccumuloClient client = createClient();
-        GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
-        logic.setupQuery(config);
-
-        String plan = logic.getPlan(client, settings, authSet, true, true);
-
-        // order of terms in planned script is arbitrary, fall back to comparing the jexl trees
-        ASTJexlScript plannedScript = JexlASTHelper.parseJexlQuery(plan);
-        ASTJexlScript expectedScript = JexlASTHelper.parseJexlQuery(this.expectedPlan);
-        JexlNodeAssert.assertThat(plannedScript).isEqualTo(expectedScript);
-    }
-
-    private AccumuloClient createClient() throws Exception {
-        AccumuloClient client = new QueryTestTableHelper(getClass().getName(), log, RebuildingScannerTestHelper.TEARDOWN.NEVER,
-                        RebuildingScannerTestHelper.INTERRUPT.NEVER).client;
-        VisibilityWiseGuysIngestWithModel.writeItAll(client, getRange());
-        PrintUtility.printTable(client, auths, TableName.SHARD);
-        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        return client;
-    }
-
-    private void givenQueryParameter(String key, String value) {
-        this.queryParameters.put(key, value);
-    }
-
-    private void givenQuery(String query) {
-        this.query = query;
-    }
-
-    private void givenExpectedPlan(String expectedPlan) {
-        this.expectedPlan = expectedPlan;
+        givenDate("20091231", "20150101");
+        setClientForTest(clientForSetup);
     }
 
     /**
      * Verify that expansion occurs for a standard forward mapping.
      */
     @Test
-    public void testBasicExpansion() {
+    public void testBasicExpansion() throws Exception {
         givenQuery("COLOR == 'blue'");
-        givenQuery("COLOR == 'blue' || HUE == 'blue'");
+        expectPlan("COLOR == 'blue' || HUE == 'blue'");
+        planAndExecuteQuery();
     }
 
     /**
@@ -200,9 +98,7 @@ public abstract class QueryModelExpansionTests {
     @Test
     public void testPatternedModelExpansion() throws Exception {
         givenQuery("NAM == 'amy'");
-        givenExpectedPlan("NAME == 'amy' || NOME == 'amy'");
-
-        runTestQuery();
+        expectPlan("NAME == 'amy' || NOME == 'amy'");
+        planAndExecuteQuery();
     }
-
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractQueryTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -158,6 +159,10 @@ public abstract class AbstractQueryTest {
         return format.parse(endDate);
     }
 
+    protected Map<String,String> getParameters() {
+        return parameters;
+    }
+
     /**
      * Set the query start and end date
      *
@@ -302,7 +307,7 @@ public abstract class AbstractQueryTest {
      *             if something goes wrong
      */
     public void planAndExecuteQuery(ShardQueryLogic logic) throws Exception {
-        for (String indexTableName : TestIndexTableNames.names()) {
+        for (String indexTableName : getIndexTableNames()) {
             try {
                 log.info("=== using index: {} ===", indexTableName);
                 setupIndexTable(indexTableName, logic);
@@ -311,6 +316,17 @@ public abstract class AbstractQueryTest {
                 teardownIndexTable(indexTableName, logic);
             }
         }
+    }
+
+    /**
+     * Extending classes may override this method.
+     * <p>
+     * <b>NOTE</b>: if a table name is added additional configuration may be necessary
+     *
+     * @return the list of index table names
+     */
+    protected List<String> getIndexTableNames() {
+        return TestIndexTableNames.names();
     }
 
     /**
@@ -349,7 +365,7 @@ public abstract class AbstractQueryTest {
             case TestIndexTableNames.NO_UID_INDEX:
                 break;
             case TestIndexTableNames.TRUNCATED_INDEX:
-                getLogic().setUseTruncatedIndex(false);
+                logic.setUseTruncatedIndex(false);
                 break;
             default:
                 throw new IllegalStateException("Unknown index table name: " + indexTableName);
@@ -384,14 +400,7 @@ public abstract class AbstractQueryTest {
      */
     private void planQuery(ShardQueryLogic logic) throws Exception {
         try {
-            QueryImpl settings = new QueryImpl();
-            settings.setBeginDate(getStartDate());
-            settings.setEndDate(getEndDate());
-            settings.setPagesize(Integer.MAX_VALUE);
-            settings.setQueryAuthorizations(getAuths().serialize());
-            settings.setQuery(getQuery());
-            settings.setParameters(parameters);
-            settings.setId(UUID.randomUUID());
+            QueryImpl settings = getSettings();
 
             logic.setMaxEvaluationPipelines(1);
             logic.setHitList(true); // always ask for HIT_TERMs
@@ -407,24 +416,48 @@ public abstract class AbstractQueryTest {
     }
 
     /**
+     * Get the {@link QueryImpl}
+     *
+     * @return the Query settings
+     * @throws Exception
+     *             if something goes wrong
+     */
+    protected QueryImpl getSettings() throws Exception {
+        QueryImpl settings = new QueryImpl();
+        settings.setBeginDate(getStartDate());
+        settings.setEndDate(getEndDate());
+        settings.setPagesize(Integer.MAX_VALUE);
+        settings.setQueryAuthorizations(getAuths().serialize());
+        settings.setQuery(getQuery());
+        settings.setParameters(parameters);
+        settings.setId(UUID.randomUUID());
+        return settings;
+    }
+
+    /**
      * Extending classes may wish to perform additional 'just in time' configuration
      */
     protected abstract void extraConfigurations();
 
     /**
      * Iterate through the query and add all deserialized results to the set of result documents.
+     * <p>
+     * Most tests should not override this method unless there is special result handling logic required
      *
      * @param logic
      *            the query logic
      */
-    private void executeQuery(ShardQueryLogic logic) {
-        results.clear();
-        for (Map.Entry<Key,Value> entry : logic) {
-            Document d = deserializer.apply(entry).getValue();
-            results.add(d);
+    protected void executeQuery(ShardQueryLogic logic) throws Exception {
+        try {
+            results.clear();
+            for (Map.Entry<Key,Value> entry : logic) {
+                Document d = deserializer.apply(entry).getValue();
+                results.add(d);
+            }
+        } finally {
+            logic.close();
+            log.info("query retrieved {} results", results.size());
         }
-        logic.close();
-        log.info("query retrieved {} results", results.size());
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysIngest.java
@@ -26,10 +26,6 @@ import datawave.util.TableName;
 
 public class VisibilityWiseGuysIngest {
 
-    public enum WhatKindaRange {
-        SHARD, DOCUMENT;
-    }
-
     private static final Type<?> lcNoDiacriticsType = new LcNoDiacriticsType();
     private static final Type<?> numberType = new NumberType();
     private static final Type<?> dateType = new DateType();
@@ -49,15 +45,11 @@ public class VisibilityWiseGuysIngest {
 
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
-    public static void writeItAll(AccumuloClient client, String range) throws Exception {
-        writeItAll(client, WhatKindaRange.valueOf(range));
-    }
-
-    public static void writeItAll(AccumuloClient client, WhatKindaRange range) throws Exception {
+    public static void writeItAll(AccumuloClient client) throws Exception {
 
         BatchWriter bw = null;
         BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(1000L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
-        Mutation mutation = null;
+        Mutation mutation;
 
         try {
             // write the shard table :
@@ -148,123 +140,97 @@ public class VisibilityWiseGuysIngest {
             // corleones
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("CORLEONE"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // sopranos
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("SOPRANO"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // capones
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("CAPONE"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
 
             // corleone names
             mutation = new Mutation(lcNoDiacriticsType.normalize("SANTINO"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FREDO"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("MICHAEL"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID, caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID, caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("CONSTANZIA"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("LUCA"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("VINCENT"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // soprano names
             mutation = new Mutation(lcNoDiacriticsType.normalize("ANTHONY"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("MEADOW"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // capone names
             mutation = new Mutation(lcNoDiacriticsType.normalize("ALPHONSE"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FRANK"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("RALPH"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
 
             // genders
             mutation = new Mutation(lcNoDiacriticsType.normalize("MALE"));
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID, caponeUID, corleoneUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID, caponeUID, corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FEMALE"));
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID, corleoneUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID, corleoneUID));
             bw.addMutation(mutation);
 
             // ages
             mutation = new Mutation(numberType.normalize("24"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("22"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("20"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("18"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID, corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID, corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("40"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID, caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID, caponeUID));
             bw.addMutation(mutation);
 
             mutation = new Mutation(numberType.normalize("16"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             mutation = new Mutation(numberType.normalize("30"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("34"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("20"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
 
         } finally {
@@ -449,20 +415,13 @@ public class VisibilityWiseGuysIngest {
         ingestUtil.write(client, auths);
     }
 
-    private static Value getValueForBuilderFor(String... in) {
+    private static Value getValue(String... uids) {
         Uid.List.Builder builder = Uid.List.newBuilder();
-        for (String s : in) {
+        for (String s : uids) {
             builder.addUID(s);
         }
-        builder.setCOUNT(in.length);
+        builder.setCOUNT(uids.length);
         builder.setIGNORE(false);
-        return new Value(builder.build().toByteArray());
-    }
-
-    private static Value getValueForNuthinAndYourHitsForFree() {
-        Uid.List.Builder builder = Uid.List.newBuilder();
-        builder.setCOUNT(50); // better not be zero!!!!
-        builder.setIGNORE(true); // better be true!!!
         return new Value(builder.build().toByteArray());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysIngestWithModel.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysIngestWithModel.java
@@ -1,13 +1,13 @@
 package datawave.query.util;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
@@ -25,13 +25,10 @@ import datawave.data.type.Type;
 import datawave.ingest.protobuf.Uid;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.index.day.IndexIngestUtil;
+import datawave.test.MacTestUtil;
 import datawave.util.TableName;
 
 public class VisibilityWiseGuysIngestWithModel {
-
-    public enum WhatKindaRange {
-        SHARD, DOCUMENT;
-    }
 
     private static final Type<?> lcNoDiacriticsType = new LcNoDiacriticsType();
     private static final Type<?> ipAddressType = new IpAddressType();
@@ -45,21 +42,13 @@ public class VisibilityWiseGuysIngestWithModel {
     protected static final ColumnVisibility columnVisibilityEnglish = new ColumnVisibility("ALL&E");
     protected static final ColumnVisibility columnVisibilityItalian = new ColumnVisibility("ALL&I");
     protected static final Value emptyValue = new Value(new byte[0]);
-    protected static final long timeStamp = 1356998400000l;
+    protected static final long timeStamp = 1356998400000L;
 
     public static final String corleoneUID = UID.builder().newId("Corleone".getBytes(), (Date) null).toString();
-    public static final String sopranoUID = UID.builder().newId("Soprano".toString().getBytes(), (Date) null).toString();
-    public static final String caponeUID = UID.builder().newId("Capone".toString().getBytes(), (Date) null).toString();
+    public static final String sopranoUID = UID.builder().newId("Soprano".getBytes(), (Date) null).toString();
+    public static final String caponeUID = UID.builder().newId("Capone".getBytes(), (Date) null).toString();
 
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
-
-    protected static String normalizeColVal(Map.Entry<String,String> colVal) throws Exception {
-        if ("FROM_ADDRESS".equals(colVal.getKey()) || "TO_ADDRESS".equals(colVal.getKey())) {
-            return ipAddressType.normalize(colVal.getValue());
-        } else {
-            return lcNoDiacriticsType.normalize(colVal.getValue());
-        }
-    }
 
     protected static String normalizerForColumn(String column) {
         if ("AGE".equals(column) || "MAGIC".equals(column) || "ETA".equals(column)) {
@@ -71,15 +60,17 @@ public class VisibilityWiseGuysIngestWithModel {
         }
     }
 
-    public static void writeItAll(AccumuloClient client, String range) throws Exception {
-        writeItAll(client, WhatKindaRange.valueOf(range));
-    }
+    public static void writeItAll(AccumuloClient client) throws Exception {
 
-    public static void writeItAll(AccumuloClient client, WhatKindaRange range) throws Exception {
+        TableOperations tops = client.tableOperations();
+        MacTestUtil.createOrRecreate(tops, TableName.METADATA);
+        MacTestUtil.createOrRecreate(tops, TableName.SHARD);
+        MacTestUtil.createOrRecreate(tops, TableName.SHARD_INDEX);
+        MacTestUtil.createOrRecreate(tops, TableName.SHARD_RINDEX);
 
         BatchWriter bw = null;
         BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(1000L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
-        Mutation mutation = null;
+        Mutation mutation;
 
         try {
             // write the shard table :
@@ -173,169 +164,131 @@ public class VisibilityWiseGuysIngestWithModel {
             // corleones
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("CORLEONE"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // names
             mutation = new Mutation(lcNoDiacriticsType.normalize("SANTINO"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FREDO"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("MICHAEL"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("CONSTANZIA"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("LUCA"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("VINCENT"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // genders
             mutation = new Mutation(lcNoDiacriticsType.normalize("MALE"));
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID, caponeUID));
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID, caponeUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FEMALE"));
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // ages
             mutation = new Mutation(numberType.normalize("24"));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("22"));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("20"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("18"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("40"));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // sopranos
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("SOPRANO"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(lcNoDiacriticsType.normalize("ANTHONY"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("MEADOW"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // genders
 
             // ages
             mutation = new Mutation(numberType.normalize("16"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("18"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // capones
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("CAPONE"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(lcNoDiacriticsType.normalize("ALPHONSE"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FRANK"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("RALPH"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("MICHAEL"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // genders
             // ages
             mutation = new Mutation(numberType.normalize("30"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("34"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("20"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(numberType.normalize("40"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // add some index-only fields
             mutation = new Mutation("chicago");
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation("newyork");
-            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation("newjersey");
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // add some tokens
-            addTokens(bw, range, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
-            addTokens(bw, range, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
-            addTokens(bw, range, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
+            addTokens(bw, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
+            addTokens(bw, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
+            addTokens(bw, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
         } finally {
             if (null != bw) {
                 bw.close();
@@ -348,186 +301,144 @@ public class VisibilityWiseGuysIngestWithModel {
             // write the reverse index table:
             // corleones
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("CORLEONE")).reverse());
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("SANTINO")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("FREDO")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MICHAEL")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("CONSTANZIA")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("LUCA")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("VINCENT")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // genders
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("FEMALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // ages
             mutation = new Mutation(new StringBuilder(numberType.normalize("24")).reverse());
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("22")).reverse());
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("20")).reverse());
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("18")).reverse());
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("40")).reverse());
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // sopranos
             // uuid
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("SOPRANO")).reverse());
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("ANTHONY")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MEADOW")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // genders
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("FEMALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // ages
             mutation = new Mutation(new StringBuilder(numberType.normalize("16")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("18")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // capones
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("CAPONE")).reverse());
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("ALPHONSE")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("FRANK")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("RALPH")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MICHAEL")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // genders
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // ages
             mutation = new Mutation(new StringBuilder(numberType.normalize("30")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("34")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("20")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder(numberType.normalize("40")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
 
             // add some index-only fields
             mutation = new Mutation(new StringBuilder("chicago").reverse());
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder("newyork").reverse());
-            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder("newjersey").reverse());
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
         } finally {
@@ -636,9 +547,9 @@ public class VisibilityWiseGuysIngestWithModel {
 
             bw.addMutation(mutation);
 
-            addFiTokens(bw, range, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
-            addFiTokens(bw, range, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
-            addFiTokens(bw, range, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
+            addFiTokens(bw, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
+            addFiTokens(bw, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
+            addFiTokens(bw, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
         } finally {
             if (null != bw) {
                 bw.close();
@@ -925,39 +836,30 @@ public class VisibilityWiseGuysIngestWithModel {
         ingestUtil.write(client, auths);
     }
 
-    private static Value getValueForBuilderFor(String... in) {
+    private static Value getValue(String... uids) {
         Uid.List.Builder builder = Uid.List.newBuilder();
-        for (String s : in) {
+        for (String s : uids) {
             builder.addUID(s);
         }
-        builder.setCOUNT(in.length);
+        builder.setCOUNT(uids.length);
         builder.setIGNORE(false);
         return new Value(builder.build().toByteArray());
     }
 
-    private static Value getValueForNuthinAndYourHitsForFree() {
-        Uid.List.Builder builder = Uid.List.newBuilder();
-        builder.setCOUNT(50); // better not be zero!!!!
-        builder.setIGNORE(true); // better be true!!!
-        return new Value(builder.build().toByteArray());
-    }
-
-    private static void addTokens(BatchWriter bw, WhatKindaRange range, String field, String phrase, String uid) throws MutationsRejectedException {
+    private static void addTokens(BatchWriter bw, String field, String phrase, String uid) throws MutationsRejectedException {
         Mutation mutation = new Mutation(lcNoDiacriticsType.normalize(phrase));
-        mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
-                        range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(uid));
+        mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp, getValue(uid));
         bw.addMutation(mutation);
 
         String[] tokens = phrase.split(" ");
         for (String token : tokens) {
             mutation = new Mutation(lcNoDiacriticsType.normalize(token));
-            mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(uid));
+            mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp, getValue(uid));
             bw.addMutation(mutation);
         }
     }
 
-    private static void addFiTokens(BatchWriter bw, WhatKindaRange range, String field, String phrase, String uid) throws MutationsRejectedException {
+    private static void addFiTokens(BatchWriter bw, String field, String phrase, String uid) throws MutationsRejectedException {
         Mutation fi = new Mutation(shard);
         fi.put("fi\u0000" + field.toUpperCase(), lcNoDiacriticsType.normalize(phrase) + "\u0000" + datatype + "\u0000" + uid, columnVisibility, timeStamp,
                         emptyValue);

--- a/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysNoGroupingIngestWithModel.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/VisibilityWiseGuysNoGroupingIngestWithModel.java
@@ -1,7 +1,6 @@
 package datawave.query.util;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -11,6 +10,7 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
 
@@ -23,13 +23,10 @@ import datawave.data.type.NumberType;
 import datawave.data.type.Type;
 import datawave.ingest.protobuf.Uid;
 import datawave.query.QueryTestTableHelper;
+import datawave.query.index.day.IndexIngestUtil;
 import datawave.util.TableName;
 
 public class VisibilityWiseGuysNoGroupingIngestWithModel {
-
-    public enum WhatKindaRange {
-        SHARD, DOCUMENT;
-    }
 
     private static final Type<?> lcNoDiacriticsType = new LcNoDiacriticsType();
     private static final Type<?> ipAddressType = new IpAddressType();
@@ -43,19 +40,13 @@ public class VisibilityWiseGuysNoGroupingIngestWithModel {
     protected static final ColumnVisibility columnVisibilityEnglish = new ColumnVisibility("ALL&E");
     protected static final ColumnVisibility columnVisibilityItalian = new ColumnVisibility("ALL&I");
     protected static final Value emptyValue = new Value(new byte[0]);
-    protected static final long timeStamp = 1356998400000l;
+    protected static final long timeStamp = 1356998400000L;
 
     public static final String corleoneUID = UID.builder().newId("Corleone".getBytes(), (Date) null).toString();
-    public static final String sopranoUID = UID.builder().newId("Soprano".toString().getBytes(), (Date) null).toString();
-    public static final String caponeUID = UID.builder().newId("Capone".toString().getBytes(), (Date) null).toString();
+    public static final String sopranoUID = UID.builder().newId("Soprano".getBytes(), (Date) null).toString();
+    public static final String caponeUID = UID.builder().newId("Capone".getBytes(), (Date) null).toString();
 
-    protected static String normalizeColVal(Map.Entry<String,String> colVal) throws Exception {
-        if ("FROM_ADDRESS".equals(colVal.getKey()) || "TO_ADDRESS".equals(colVal.getKey())) {
-            return ipAddressType.normalize(colVal.getValue());
-        } else {
-            return lcNoDiacriticsType.normalize(colVal.getValue());
-        }
-    }
+    private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
     protected static String normalizerForColumn(String column) {
         if ("AGE".equals(column) || "MAGIC".equals(column) || "ETA".equals(column)) {
@@ -67,15 +58,11 @@ public class VisibilityWiseGuysNoGroupingIngestWithModel {
         }
     }
 
-    public static void writeItAll(AccumuloClient client, String range) throws Exception {
-        writeItAll(client, WhatKindaRange.valueOf(range));
-    }
-
-    public static void writeItAll(AccumuloClient client, WhatKindaRange range) throws Exception {
+    public static void writeItAll(AccumuloClient client) throws Exception {
 
         BatchWriter bw = null;
         BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(1000L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
-        Mutation mutation = null;
+        Mutation mutation;
 
         try {
             // write the shard table :
@@ -148,81 +135,67 @@ public class VisibilityWiseGuysNoGroupingIngestWithModel {
             // corleones
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("CORLEONE"));
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // names
             mutation = new Mutation(lcNoDiacriticsType.normalize("SANTINO"));
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // genders
             mutation = new Mutation(lcNoDiacriticsType.normalize("MALE"));
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(lcNoDiacriticsType.normalize("FEMALE"));
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // ages
             mutation = new Mutation(numberType.normalize("24"));
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // sopranos
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("MEADOW"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // genders
 
             // ages
             mutation = new Mutation(numberType.normalize("18"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // capones
             // uuid
             mutation = new Mutation(lcNoDiacriticsType.normalize("MICHAEL"));
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // genders
             // ages
             mutation = new Mutation(numberType.normalize("40"));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
 
             // add some index-only fields
             mutation = new Mutation("chicago");
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation("newyork");
-            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation("newjersey");
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // add some tokens
-            addTokens(bw, range, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
-            addTokens(bw, range, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
-            addTokens(bw, range, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
+            addTokens(bw, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
+            addTokens(bw, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
+            addTokens(bw, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
         } finally {
             if (null != bw) {
                 bw.close();
@@ -235,82 +208,66 @@ public class VisibilityWiseGuysNoGroupingIngestWithModel {
             // write the reverse index table:
             // corleones
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("CORLEONE")).reverse());
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("SANTINO")).reverse());
-            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("NOME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // genders
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("GENERE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             // ages
             mutation = new Mutation(new StringBuilder(numberType.normalize("24")).reverse());
-            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("ETA".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
 
             // sopranos
             // uuid
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("SOPRANO")).reverse());
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MEADOW")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // genders
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("FEMALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
             // ages
             mutation = new Mutation(new StringBuilder(numberType.normalize("18")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
             // capones
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("CAPONE")).reverse());
-            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("UUID".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // names
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MICHAEL")).reverse());
-            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("NAME".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // genders
             mutation = new Mutation(new StringBuilder(lcNoDiacriticsType.normalize("MALE")).reverse());
-            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("GENDER".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             // ages
             mutation = new Mutation(new StringBuilder(numberType.normalize("40")).reverse());
-            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("AGE".toUpperCase(), shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
 
             // add some index-only fields
             mutation = new Mutation(new StringBuilder("chicago").reverse());
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(caponeUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(caponeUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder("newyork").reverse());
-            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(corleoneUID));
+            mutation.put("POSIZIONE", shard + "\u0000" + datatype, columnVisibilityItalian, timeStamp, getValue(corleoneUID));
             bw.addMutation(mutation);
             mutation = new Mutation(new StringBuilder("newjersey").reverse());
-            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(sopranoUID));
+            mutation.put("LOCATION", shard + "\u0000" + datatype, columnVisibilityEnglish, timeStamp, getValue(sopranoUID));
             bw.addMutation(mutation);
 
         } finally {
@@ -377,9 +334,9 @@ public class VisibilityWiseGuysNoGroupingIngestWithModel {
 
             bw.addMutation(mutation);
 
-            addFiTokens(bw, range, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
-            addFiTokens(bw, range, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
-            addFiTokens(bw, range, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
+            addFiTokens(bw, "QUOTE", "Im gonna make him an offer he cant refuse", corleoneUID);
+            addFiTokens(bw, "QUOTE", "If you can quote the rules then you can obey them", sopranoUID);
+            addFiTokens(bw, "QUOTE", "You can get much farther with a kind word and a gun than you can with a kind word alone", caponeUID);
         } finally {
             if (null != bw) {
                 bw.close();
@@ -624,41 +581,36 @@ public class VisibilityWiseGuysNoGroupingIngestWithModel {
                 bw.close();
             }
         }
+
+        // this is hacky and highlights an opportunity to improve the test framework
+        Authorizations auths = new Authorizations("ALL", "E", "I");
+        ingestUtil.write(client, auths);
     }
 
-    private static Value getValueForBuilderFor(String... in) {
+    private static Value getValue(String... uids) {
         Uid.List.Builder builder = Uid.List.newBuilder();
-        for (String s : in) {
+        for (String s : uids) {
             builder.addUID(s);
         }
-        builder.setCOUNT(in.length);
+        builder.setCOUNT(uids.length);
         builder.setIGNORE(false);
         return new Value(builder.build().toByteArray());
     }
 
-    private static Value getValueForNuthinAndYourHitsForFree() {
-        Uid.List.Builder builder = Uid.List.newBuilder();
-        builder.setCOUNT(50); // better not be zero!!!!
-        builder.setIGNORE(true); // better be true!!!
-        return new Value(builder.build().toByteArray());
-    }
-
-    private static void addTokens(BatchWriter bw, WhatKindaRange range, String field, String phrase, String uid) throws MutationsRejectedException {
+    private static void addTokens(BatchWriter bw, String field, String phrase, String uid) throws MutationsRejectedException {
         Mutation mutation = new Mutation(lcNoDiacriticsType.normalize(phrase));
-        mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
-                        range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(uid));
+        mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp, getValue(uid));
         bw.addMutation(mutation);
 
         String[] tokens = phrase.split(" ");
         for (String token : tokens) {
             mutation = new Mutation(lcNoDiacriticsType.normalize(token));
-            mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp,
-                            range == WhatKindaRange.SHARD ? getValueForNuthinAndYourHitsForFree() : getValueForBuilderFor(uid));
+            mutation.put(field.toUpperCase(), shard + "\u0000" + datatype, columnVisibility, timeStamp, getValue(uid));
             bw.addMutation(mutation);
         }
     }
 
-    private static void addFiTokens(BatchWriter bw, WhatKindaRange range, String field, String phrase, String uid) throws MutationsRejectedException {
+    private static void addFiTokens(BatchWriter bw, String field, String phrase, String uid) throws MutationsRejectedException {
         Mutation fi = new Mutation(shard);
         fi.put("fi\u0000" + field.toUpperCase(), lcNoDiacriticsType.normalize(phrase) + "\u0000" + datatype + "\u0000" + uid, columnVisibility, timeStamp,
                         emptyValue);


### PR DESCRIPTION
- Migrate a few tests to AbstractQueryTest framwork
- FieldRuleTest, GroupingTest, QueryModelExpansionTests, and NoExpansionTests now extend AbstractQueryTest
- AbstractQueryTest now allows extending classes to override which index tables are used.