### PR TITLE
Add ScanMonitor for external scan monitoring

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/EmptyQueryPlanStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/EmptyQueryPlanStream.java
@@ -1,0 +1,36 @@
+package datawave.query.index.lookup;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.apache.commons.jexl3.parser.JexlNode;
+
+import datawave.query.CloseableIterable;
+import datawave.query.planner.QueryPlan;
+import datawave.query.util.EmptyCloseableIterator;
+
+/**
+ * An empty {@link QueryPlanStream}
+ */
+public class EmptyQueryPlanStream implements QueryPlanStream {
+
+    public static EmptyQueryPlanStream of() {
+        return new EmptyQueryPlanStream();
+    }
+
+    @Override
+    public CloseableIterable<QueryPlan> streamPlans(JexlNode node) {
+        return new EmptyCloseableIterator<>();
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public Iterator<QueryPlan> iterator() {
+        return Collections.emptyIterator();
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/AsyncIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/AsyncIndexLookup.java
@@ -38,6 +38,8 @@ public abstract class AsyncIndexLookup extends IndexLookup {
     protected final AtomicBoolean exceededValueThreshold = new AtomicBoolean(false);
     protected final AtomicBoolean exceptionSeen = new AtomicBoolean(false);
 
+    protected ScanMonitor monitor;
+
     public AsyncIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, boolean unfieldedLookup, ExecutorService execService) {
         super(config, scannerFactory);
         this.unfieldedLookup = unfieldedLookup;
@@ -45,6 +47,10 @@ public abstract class AsyncIndexLookup extends IndexLookup {
 
         this.maxUnfieldedExpansionThreshold = config.getMaxUnfieldedExpansionThreshold();
         this.maxValueExpansionThreshold = config.getMaxValueExpansionThreshold();
+    }
+
+    public void setScanMonitor(ScanMonitor monitor) {
+        this.monitor = monitor;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -4,41 +4,33 @@ import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPA
 
 import java.text.MessageFormat;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.IteratorSetting;
-import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import com.google.common.base.Preconditions;
 
-import datawave.core.common.logging.ThreadConfigurableLogger;
 import datawave.core.iterators.BoundedRangeExpansionIterator;
 import datawave.core.iterators.CompositeSeekingIterator;
-import datawave.core.iterators.TimeoutExceptionIterator;
-import datawave.core.iterators.TimeoutIterator;
 import datawave.data.type.DiscreteIndexType;
 import datawave.query.Constants;
 import datawave.query.config.ShardQueryConfiguration;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.IllegalRangeArgumentException;
 import datawave.query.jexl.LiteralRange;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.time.DateHelper;
 import datawave.webservice.query.exception.DatawaveErrorCode;
-import datawave.webservice.query.exception.NotFoundQueryException;
 import datawave.webservice.query.exception.QueryException;
 
 /**
@@ -47,16 +39,21 @@ import datawave.webservice.query.exception.QueryException;
  * A fielded bounded range is already executable so this lookup is allowed to hit timeout or value thresholds.
  */
 public class BoundedRangeIndexLookup extends AsyncIndexLookup {
-    private static final Logger log = ThreadConfigurableLogger.getLogger(BoundedRangeIndexLookup.class);
+
+    private static final Logger log = LoggerFactory.getLogger(BoundedRangeIndexLookup.class);
 
     private final LiteralRange<?> literalRange;
+    protected final String field;
+    protected final CountDownLatch startLatch;
+    protected final CountDownLatch stopLatch;
 
-    protected Future<Boolean> timedScanFuture;
-    protected AtomicLong lookupStartTimeMillis = new AtomicLong(Long.MAX_VALUE);
-    protected CountDownLatch lookupStartedLatch;
-    protected CountDownLatch lookupStoppedLatch;
+    // variables to support range creation
+    private final String startDay;
+    private final String endDay;
+    private final String lower;
+    private final String upper;
 
-    protected BatchScanner bs;
+    private final Range scanRange;
 
     /**
      *
@@ -73,210 +70,224 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
         super(config, scannerFactory, false, execService);
         this.literalRange = literalRange;
         this.fields = Collections.singleton(literalRange.getFieldName());
+        this.field = literalRange.getFieldName();
+        this.startLatch = new CountDownLatch(1);
+        this.stopLatch = new CountDownLatch(1);
+
+        // setup variables for creating scan ranges
+        this.startDay = DateHelper.format(config.getBeginDate());
+        this.endDay = DateHelper.format(config.getEndDate());
+
+        this.lower = literalRange.getLower().toString();
+        this.upper = literalRange.getUpper().toString();
+
+        // create the scan range here to surface an illegal range exception
+        this.scanRange = createScanRange(lower, upper, endDay);
     }
 
     @Override
     public synchronized void submit() {
         if (indexLookupMap == null) {
-            String startDay = DateHelper.format(config.getBeginDate());
-            String endDay = DateHelper.format(config.getEndDate());
-
-            // build the start and end range for the scanner
-            // Key for global index is Row-> Normalized FieldValue, CF-> FieldName,
-            // CQ->shard_id\x00datatype
             indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
 
-            IteratorSetting fairnessIterator = null;
-            if (config.getMaxIndexScanTimeMillis() > 0) {
-                // The fairness iterator solves the problem whereby we have runaway iterators as a result of an evaluation that never finds anything
-                fairnessIterator = new IteratorSetting(5, TimeoutIterator.class);
-
-                long maxTime = config.getMaxIndexScanTimeMillis();
-                if (maxTime < Long.MAX_VALUE / 2)
-                    maxTime *= 2;
-                fairnessIterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
-
-            }
-
-            String lower = literalRange.getLower().toString(), upper = literalRange.getUpper().toString();
-
-            Key startKey;
-            if (literalRange.isLowerInclusive()) { // inclusive
-                startKey = new Key(new Text(lower));
-            } else { // non-inclusive
-                startKey = new Key(new Text(lower + "\0"));
-            }
-
-            Key endKey;
-            if (literalRange.isUpperInclusive()) {
-                // we should have our end key be the end of the range if we are going to use the WRI
-                endKey = new Key(new Text(upper), new Text(literalRange.getFieldName()), new Text(endDay + Constants.MAX_UNICODE_STRING));
-            } else {
-                endKey = new Key(new Text(upper));
-            }
-
-            Range range;
-            try {
-                range = new Range(startKey, true, endKey, literalRange.isUpperInclusive());
-            } catch (IllegalArgumentException e) {
-                QueryException qe = new QueryException(DatawaveErrorCode.RANGE_CREATE_ERROR, e, MessageFormat.format("{0}", this.literalRange));
-                log.debug(qe);
-                throw new IllegalRangeArgumentException(qe);
-            }
-
-            log.debug("Range: " + range);
-            bs = null;
-            try {
-                // the 'newScanner' method in the ScannerFactory has no knowledge about the 'expansion' hint, so determine hint here
-                String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : config.getIndexTableName();
-
-                bs = scannerFactory.newScanner(getTableName(), config.getAuthorizations(), config.getNumQueryThreads(), config.getQuery(), hintKey);
-
-                bs.setRanges(Collections.singleton(range));
-                bs.fetchColumnFamily(new Text(literalRange.getFieldName()));
-
-                IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 20, "BoundedRangeExpansionIterator",
-                                BoundedRangeExpansionIterator.class);
-                setting.addOption(BoundedRangeExpansionIterator.START_DATE, startDay);
-                setting.addOption(BoundedRangeExpansionIterator.END_DATE, endDay);
-                if (!config.getDatatypeFilter().isEmpty()) {
-                    setting.addOption(BoundedRangeExpansionIterator.DATATYPES_OPT, config.getDatatypeFilterAsString());
-                }
-                bs.addScanIterator(setting);
-
-                // If this is a composite field, with multiple terms, we need to setup our query to filter based on each component of the composite range
-                if (!config.getCompositeToFieldMap().get(literalRange.getFieldName()).isEmpty()) {
-
-                    String compositeSeparator = null;
-                    if (config.getCompositeFieldSeparators() != null)
-                        compositeSeparator = config.getCompositeFieldSeparators().get(literalRange.getFieldName());
-
-                    if (compositeSeparator != null && (lower.contains(compositeSeparator) || upper.contains(compositeSeparator))) {
-                        IteratorSetting compositeIterator = new IteratorSetting(config.getBaseIteratorPriority() + 51, CompositeSeekingIterator.class);
-
-                        compositeIterator.addOption(CompositeSeekingIterator.COMPONENT_FIELDS,
-                                        StringUtils.collectionToCommaDelimitedString(config.getCompositeToFieldMap().get(literalRange.getFieldName())));
-
-                        for (String fieldName : config.getCompositeToFieldMap().get(literalRange.getFieldName())) {
-                            DiscreteIndexType<?> type = config.getFieldToDiscreteIndexTypes().get(fieldName);
-                            if (type != null)
-                                compositeIterator.addOption(fieldName + CompositeSeekingIterator.DISCRETE_INDEX_TYPE, type.getClass().getName());
-                        }
-
-                        compositeIterator.addOption(CompositeSeekingIterator.SEPARATOR, compositeSeparator);
-
-                        bs.addScanIterator(compositeIterator);
-                    }
-                }
-
-                if (null != fairnessIterator) {
-                    IteratorSetting timeoutSetting = new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
-                    bs.addScanIterator(timeoutSetting);
-                }
-
-                timedScanFuture = execService.submit(createTimedCallable(bs.iterator()));
-            } catch (TableNotFoundException e) {
-                NotFoundQueryException qe = new NotFoundQueryException(DatawaveErrorCode.TABLE_NOT_FOUND, e,
-                                MessageFormat.format("Table: {0}", config.getIndexTableName()));
-                log.error(qe);
-                throw new DatawaveFatalQueryException(qe);
-            }
-            // Note: scanners should never be closed here in a 'finally' block. The lookup()
-            // method will close the scanner via scannerFactory.close(scanner)
+            Runnable runnable = createRunnable(getTableName(), config.getAuthorizations().iterator().next());
+            Future<?> future = execService.submit(runnable);
+            Preconditions.checkNotNull(monitor, "BoundedRange index expansion requires a ScanMonitor");
+            monitor.registerTask(future, config.getMaxIndexScanTimeMillis());
         }
+    }
+
+    protected Runnable createRunnable(String tableName, Authorizations auths) {
+        return () -> {
+            startLatch.countDown();
+            try (var scanner = config.getClient().createScanner(tableName, auths)) {
+                String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : config.getIndexTableName();
+                scanner.setExecutionHints(Map.of(tableName, hintKey));
+                scanner.setRange(scanRange);
+                scanner.fetchColumnFamily(literalRange.getFieldName());
+
+                IteratorSetting rangeIterator = createRangeIterator(startDay, endDay);
+                scanner.addScanIterator(rangeIterator);
+
+                IteratorSetting compositeIterator = createCompositeIterator(lower, upper);
+                if (compositeIterator != null) {
+                    scanner.addScanIterator(compositeIterator);
+                }
+
+                for (Map.Entry<Key,Value> entry : scanner) {
+                    Key key = entry.getKey();
+                    log.info("tk: {}", key.toStringNoTime());
+                    indexLookupMap.put(field, key.getRow().toString());
+                }
+
+            } catch (Exception e) {
+                log.error("Exception seen");
+                // mark the field as threshold exceeded regardless of the exception type
+                indexLookupMap.put(field, "");
+                indexLookupMap.get(field).setThresholdExceeded();
+            } finally {
+                log.info("closing scanner");
+                stopLatch.countDown();
+            }
+        };
+    }
+
+    /**
+     * Create the {@link BoundedRangeExpansionIterator} and configure with start and end dates. Optionally configure a datatype filter.
+     *
+     * @param startDay
+     *            the start date
+     * @param endDay
+     *            the end date
+     * @return a {@link BoundedRangeExpansionIterator}
+     */
+    protected IteratorSetting createRangeIterator(String startDay, String endDay) {
+        int priority = config.getBaseIteratorPriority() + 20;
+        IteratorSetting setting = new IteratorSetting(priority, "BoundedRangeExpansionIterator", BoundedRangeExpansionIterator.class);
+        setting.addOption(BoundedRangeExpansionIterator.START_DATE, startDay);
+        setting.addOption(BoundedRangeExpansionIterator.END_DATE, endDay);
+        if (!config.getDatatypeFilter().isEmpty()) {
+            setting.addOption(BoundedRangeExpansionIterator.DATATYPES_OPT, config.getDatatypeFilterAsString());
+        }
+        return setting;
+    }
+
+    /**
+     * Create the scan {@link Range} given a range's lower and upper bounds, along with the end date
+     *
+     * @param lower
+     *            the lower bound
+     * @param upper
+     *            the upper bound
+     * @param endDay
+     *            the end date
+     * @return the Accumulo scan range
+     */
+    protected Range createScanRange(String lower, String upper, String endDay) {
+        Key startKey;
+        if (literalRange.isLowerInclusive()) { // inclusive
+            startKey = new Key(new Text(lower));
+        } else { // non-inclusive
+            startKey = new Key(new Text(lower + "\0"));
+        }
+
+        Key endKey;
+        if (literalRange.isUpperInclusive()) {
+            // we should have our end key be the end of the range if we are going to use the WRI
+            endKey = new Key(new Text(upper), new Text(literalRange.getFieldName()), new Text(endDay + Constants.MAX_UNICODE_STRING));
+        } else {
+            endKey = new Key(new Text(upper));
+        }
+
+        Range range;
+        try {
+            range = new Range(startKey, true, endKey, literalRange.isUpperInclusive());
+        } catch (IllegalArgumentException e) {
+            QueryException qe = new QueryException(DatawaveErrorCode.RANGE_CREATE_ERROR, e, MessageFormat.format("{0}", this.literalRange));
+            log.debug("exception: {}", qe.getMessage());
+            throw new IllegalRangeArgumentException(qe);
+        }
+
+        log.debug("Range: {}", range);
+        return range;
+    }
+
+    /**
+     * Create a {@link CompositeSeekingIterator} IFF the range contains a composite separator
+     *
+     * @param lower
+     *            the lower bound
+     * @param upper
+     *            the upper bound
+     * @return a composite seeking iterator
+     */
+    protected IteratorSetting createCompositeIterator(String lower, String upper) {
+        if (config.getCompositeToFieldMap().get(literalRange.getFieldName()).isEmpty()) {
+            return null;
+        }
+
+        if (config.getCompositeFieldSeparators() == null || config.getCompositeFieldSeparators().isEmpty()) {
+            return null;
+        }
+
+        // If this is a composite field, with multiple terms, we need to set up our query to filter based on each component of the composite range
+        String compositeSeparator = config.getCompositeFieldSeparators().get(literalRange.getFieldName());
+        if (compositeSeparator == null) {
+            return null;
+        }
+
+        if (!lower.contains(compositeSeparator) && !upper.contains(compositeSeparator)) {
+            return null;
+        }
+
+        IteratorSetting setting = new IteratorSetting(config.getBaseIteratorPriority() + 51, CompositeSeekingIterator.class);
+
+        setting.addOption(CompositeSeekingIterator.COMPONENT_FIELDS,
+                        StringUtils.collectionToCommaDelimitedString(config.getCompositeToFieldMap().get(literalRange.getFieldName())));
+
+        for (String fieldName : config.getCompositeToFieldMap().get(literalRange.getFieldName())) {
+            DiscreteIndexType<?> type = config.getFieldToDiscreteIndexTypes().get(fieldName);
+            if (type != null)
+                setting.addOption(fieldName + CompositeSeekingIterator.DISCRETE_INDEX_TYPE, type.getClass().getName());
+        }
+
+        setting.addOption(CompositeSeekingIterator.SEPARATOR, compositeSeparator);
+        return setting;
     }
 
     @Override
     public synchronized IndexLookupMap lookup() {
-        if (bs != null) {
-            try {
-                timedScanWait(timedScanFuture, lookupStartedLatch, lookupStoppedLatch, lookupStartTimeMillis, config.getMaxIndexScanTimeMillis());
-            } finally {
-                scannerFactory.close(bs);
-                bs = null;
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("Found " + indexLookupMap.size() + " matching terms for range: " + indexLookupMap);
-            }
-        }
-
+        await();
         return indexLookupMap;
     }
 
-    protected Callable<Boolean> createTimedCallable(final Iterator<Entry<Key,Value>> iter) {
-        lookupStartedLatch = new CountDownLatch(1);
-        lookupStoppedLatch = new CountDownLatch(1);
+    /**
+     * Wait for the future to complete before returning the {@link IndexLookupMap}
+     */
+    protected void await() {
 
-        return () -> {
-            try {
-                lookupStartTimeMillis.set(System.currentTimeMillis());
-                lookupStartedLatch.countDown();
-
-                Text holder = new Text();
-                try {
-                    if (log.isTraceEnabled()) {
-                        log.trace("Do we have next? " + iter.hasNext());
+        synchronized (startLatch) {
+            switch ((int) startLatch.getCount()) {
+                case 0:
+                    // scan task already started, fall through to stop latch
+                    break;
+                case 1:
+                    // scan task submitted but not running yet
+                    try {
+                        startLatch.await();
+                    } catch (Exception e) {
+                        // any exception at this stage marks the range as value exceeded
+                        markExceeded();
                     }
-
-                    while (iter.hasNext()) {
-
-                        Entry<Key,Value> entry = iter.next();
-                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
-                            throw new Exception("Timeout exceeded for bounded range lookup");
-                        }
-
-                        Key k = entry.getKey();
-
-                        if (log.isTraceEnabled()) {
-                            log.trace("Forward Index entry: " + entry.getKey());
-                        }
-
-                        k.getRow(holder);
-                        String uniqueTerm = holder.toString();
-
-                        k.getColumnFamily(holder);
-                        String field = holder.toString();
-
-                        // safety check...
-                        Preconditions.checkState(field.equals(literalRange.getFieldName()),
-                                        "Got an unexpected field name when expanding range" + field + " " + literalRange.getFieldName());
-
-                        // obtaining the size of a map can be expensive,
-                        // instead
-                        // track the count of each unique item added.
-                        indexLookupMap.put(field, uniqueTerm);
-
-                        // If this range expands into to many values, we can
-                        // stop
-                        if (indexLookupMap.get(field).isThresholdExceeded()) {
-                            return true;
-                        }
-                    }
-                } catch (Exception e) {
-                    log.info("Failed or timed out expanding range fields: " + e.getMessage());
-                    if (log.isDebugEnabled()) {
-                        log.debug("Failed or Timed out ", e);
-                    }
-                    // Only if not doing an unfielded lookup should we mark all fields as having an exceeded threshold
-                    if (!unfieldedLookup) {
-                        for (String field : fields) {
-                            if (log.isTraceEnabled()) {
-                                log.trace("field is " + field);
-                                log.trace("field is " + (null == indexLookupMap));
-                            }
-                            indexLookupMap.put(field, "");
-                            indexLookupMap.get(field).setThresholdExceeded();
-                        }
-                    } else {
-                        indexLookupMap.setKeyThresholdExceeded();
-                    }
-                    return false;
-                }
-                return true;
-            } finally {
-                lookupStoppedLatch.countDown();
+                    break;
+                default:
+                    throw new IllegalStateException("start latch count should be zero or one, but was: " + startLatch.getCount());
             }
-        };
+        }
+
+        synchronized (stopLatch) {
+            switch ((int) stopLatch.getCount()) {
+                case 0:
+                    // scan task completed prior to calling await(), nothing left to do
+                    break;
+                case 1:
+                    // scan task executing, wait for completion
+                    try {
+                        stopLatch.await();
+                    } catch (Exception e) {
+                        // any exception at this stage marks the range as value exceeded
+                        markExceeded();
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("stop latch count should be zero or one, but was: " + stopLatch.getCount());
+            }
+        }
+    }
+
+    protected void markExceeded() {
+        log.debug("marking range as exceeded");
+        indexLookupMap.put(field, "");
+        indexLookupMap.get(field).setThresholdExceeded();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -83,6 +83,9 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
         this.scanRange = createScanRange(lower, upper, endDay);
     }
 
+    /**
+     * This method is responsible for creating a Runnable, submitting it to the executor and registering the future with the {@link ScanMonitor}.
+     */
     @Override
     public synchronized void submit() {
         if (indexLookupMap == null) {
@@ -96,6 +99,18 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
         }
     }
 
+    /**
+     * The created runnable handles everything with configuring a scanner, parsing results and putting them into the {@link #indexLookupMap} and handling
+     * exceptions.
+     * <p>
+     * Note: it is critical that any scanner created here is used with a try-with-resources block.
+     *
+     * @param tableName
+     *            the table to be scanned
+     * @param auths
+     *            the authorizations
+     * @return a Runnable that wraps a scanner
+     */
     protected Runnable createRunnable(String tableName, Authorizations auths) {
         return () -> {
             try (Scanner scanner = config.getClient().createScanner(tableName, auths)) {
@@ -123,8 +138,7 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
             } catch (Exception e) {
                 log.error("Exception seen: {}", e.getMessage());
                 // mark the field as threshold exceeded regardless of the exception type
-                indexLookupMap.put(field, "");
-                indexLookupMap.get(field).setThresholdExceeded();
+                markExceeded();
             } finally {
                 if (log.isTraceEnabled()) {
                     log.trace("closing scanner");
@@ -258,6 +272,9 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
         }
     }
 
+    /**
+     * Manipulates the {@link #indexLookupMap} so the bounded range term will be wrapped with an exceeded value marker.
+     */
     protected void markExceeded() {
         log.debug("marking range as exceeded");
         indexLookupMap.put(field, "");

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -246,42 +246,38 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
      */
     protected void await() {
 
-        synchronized (startLatch) {
-            switch ((int) startLatch.getCount()) {
-                case 0:
-                    // scan task already started, fall through to stop latch
-                    break;
-                case 1:
-                    // scan task submitted but not running yet
-                    try {
-                        startLatch.await();
-                    } catch (Exception e) {
-                        // any exception at this stage marks the range as value exceeded
-                        markExceeded();
-                    }
-                    break;
-                default:
-                    throw new IllegalStateException("start latch count should be zero or one, but was: " + startLatch.getCount());
-            }
+        switch ((int) startLatch.getCount()) {
+            case 0:
+                // scan task already started, fall through to stop latch
+                break;
+            case 1:
+                // scan task submitted but not running yet
+                try {
+                    startLatch.await();
+                } catch (Exception e) {
+                    // any exception at this stage marks the range as value exceeded
+                    markExceeded();
+                }
+                break;
+            default:
+                throw new IllegalStateException("start latch count should be zero or one, but was: " + startLatch.getCount());
         }
 
-        synchronized (stopLatch) {
-            switch ((int) stopLatch.getCount()) {
-                case 0:
-                    // scan task completed prior to calling await(), nothing left to do
-                    break;
-                case 1:
-                    // scan task executing, wait for completion
-                    try {
-                        stopLatch.await();
-                    } catch (Exception e) {
-                        // any exception at this stage marks the range as value exceeded
-                        markExceeded();
-                    }
-                    break;
-                default:
-                    throw new IllegalStateException("stop latch count should be zero or one, but was: " + stopLatch.getCount());
-            }
+        switch ((int) stopLatch.getCount()) {
+            case 0:
+                // scan task completed prior to calling await(), nothing left to do
+                break;
+            case 1:
+                // scan task executing, wait for completion
+                try {
+                    stopLatch.await();
+                } catch (Exception e) {
+                    // any exception at this stage marks the range as value exceeded
+                    markExceeded();
+                }
+                break;
+            default:
+                throw new IllegalStateException("stop latch count should be zero or one, but was: " + stopLatch.getCount());
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -116,17 +116,21 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
 
                 for (Map.Entry<Key,Value> entry : scanner) {
                     Key key = entry.getKey();
-                    log.info("tk: {}", key.toStringNoTime());
+                    if (log.isTraceEnabled()) {
+                        log.trace("tk: {}", key.toStringNoTime());
+                    }
                     indexLookupMap.put(field, key.getRow().toString());
                 }
 
             } catch (Exception e) {
-                log.error("Exception seen");
+                log.error("Exception seen: {}", e.getMessage());
                 // mark the field as threshold exceeded regardless of the exception type
                 indexLookupMap.put(field, "");
                 indexLookupMap.get(field).setThresholdExceeded();
             } finally {
-                log.info("closing scanner");
+                if (log.isTraceEnabled()) {
+                    log.trace("closing scanner");
+                }
                 stopLatch.countDown();
             }
         };
@@ -188,7 +192,9 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
             throw new IllegalRangeArgumentException(qe);
         }
 
-        log.debug("Range: {}", range);
+        if (log.isDebugEnabled()) {
+            log.debug("Range: {}", range);
+        }
         return range;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -97,7 +98,7 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
 
     protected Runnable createRunnable(String tableName, Authorizations auths) {
         return () -> {
-            try (var scanner = config.getClient().createScanner(tableName, auths)) {
+            try (Scanner scanner = config.getClient().createScanner(tableName, auths)) {
                 String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : config.getIndexTableName();
                 scanner.setExecutionHints(Map.of(tableName, hintKey));
                 scanner.setRange(scanRange);
@@ -248,7 +249,9 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
      */
     protected void await() {
         try {
-            future.get();
+            if (future != null) {
+                future.get();
+            }
         } catch (Exception e) {
             // any exception causes the range to marked as value exceeded
             markExceeded();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -5,7 +5,6 @@ import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPA
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -44,8 +43,6 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
 
     private final LiteralRange<?> literalRange;
     protected final String field;
-    protected final CountDownLatch startLatch;
-    protected final CountDownLatch stopLatch;
 
     // variables to support range creation
     private final String startDay;
@@ -54,6 +51,8 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
     private final String upper;
 
     private final Range scanRange;
+
+    protected Future<?> future;
 
     /**
      *
@@ -71,8 +70,6 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
         this.literalRange = literalRange;
         this.fields = Collections.singleton(literalRange.getFieldName());
         this.field = literalRange.getFieldName();
-        this.startLatch = new CountDownLatch(1);
-        this.stopLatch = new CountDownLatch(1);
 
         // setup variables for creating scan ranges
         this.startDay = DateHelper.format(config.getBeginDate());
@@ -91,7 +88,8 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
             indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
 
             Runnable runnable = createRunnable(getTableName(), config.getAuthorizations().iterator().next());
-            Future<?> future = execService.submit(runnable);
+            future = execService.submit(runnable);
+
             Preconditions.checkNotNull(monitor, "BoundedRange index expansion requires a ScanMonitor");
             monitor.registerTask(future, config.getMaxIndexScanTimeMillis());
         }
@@ -99,7 +97,6 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
 
     protected Runnable createRunnable(String tableName, Authorizations auths) {
         return () -> {
-            startLatch.countDown();
             try (var scanner = config.getClient().createScanner(tableName, auths)) {
                 String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : config.getIndexTableName();
                 scanner.setExecutionHints(Map.of(tableName, hintKey));
@@ -131,7 +128,6 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
                 if (log.isTraceEnabled()) {
                     log.trace("closing scanner");
                 }
-                stopLatch.countDown();
             }
         };
     }
@@ -251,44 +247,16 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
      * Wait for the future to complete before returning the {@link IndexLookupMap}
      */
     protected void await() {
-
-        switch ((int) startLatch.getCount()) {
-            case 0:
-                // scan task already started, fall through to stop latch
-                break;
-            case 1:
-                // scan task submitted but not running yet
-                try {
-                    startLatch.await();
-                } catch (Exception e) {
-                    // any exception at this stage marks the range as value exceeded
-                    markExceeded("start");
-                }
-                break;
-            default:
-                throw new IllegalStateException("start latch count should be zero or one, but was: " + startLatch.getCount());
-        }
-
-        switch ((int) stopLatch.getCount()) {
-            case 0:
-                // scan task completed prior to calling await(), nothing left to do
-                break;
-            case 1:
-                // scan task executing, wait for completion
-                try {
-                    stopLatch.await();
-                } catch (Exception e) {
-                    // any exception at this stage marks the range as value exceeded
-                    markExceeded("executing");
-                }
-                break;
-            default:
-                throw new IllegalStateException("stop latch count should be zero or one, but was: " + stopLatch.getCount());
+        try {
+            future.get();
+        } catch (Exception e) {
+            // any exception causes the range to marked as value exceeded
+            markExceeded();
         }
     }
 
-    protected void markExceeded(String context) {
-        log.debug("marking range as exceeded: {}", context);
+    protected void markExceeded() {
+        log.debug("marking range as exceeded");
         indexLookupMap.put(field, "");
         indexLookupMap.get(field).setThresholdExceeded();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -256,7 +256,7 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
                     startLatch.await();
                 } catch (Exception e) {
                     // any exception at this stage marks the range as value exceeded
-                    markExceeded();
+                    markExceeded("start");
                 }
                 break;
             default:
@@ -273,7 +273,7 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
                     stopLatch.await();
                 } catch (Exception e) {
                     // any exception at this stage marks the range as value exceeded
-                    markExceeded();
+                    markExceeded("executing");
                 }
                 break;
             default:
@@ -281,8 +281,8 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
         }
     }
 
-    protected void markExceeded() {
-        log.debug("marking range as exceeded");
+    protected void markExceeded(String context) {
+        log.debug("marking range as exceeded: {}", context);
         indexLookupMap.put(field, "");
         indexLookupMap.get(field).setThresholdExceeded();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
@@ -1,0 +1,126 @@
+package datawave.query.jexl.lookups;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple runnable that registers futures and cancels them when the timeout is exceeded.
+ */
+public class ScanMonitor implements Runnable {
+
+    private static final Logger log = LoggerFactory.getLogger(ScanMonitor.class);
+
+    private final Map<String,IndexScanTask> tasks = new HashMap<>();
+
+    private int taskID = 0;
+    private final long monitorIntervalMillis;
+
+    public ScanMonitor() {
+        this(5L);
+    }
+
+    public ScanMonitor(long monitorIntervalMillis) {
+        this.monitorIntervalMillis = monitorIntervalMillis;
+    }
+
+    /**
+     * Registers the future along with the timeout
+     *
+     * @param future
+     *            the future
+     * @param timeout
+     *            the timeout
+     */
+    public void registerTask(Future<?> future, long timeout) {
+        synchronized (tasks) {
+            log.info("registering task: {}", taskID);
+            tasks.put(String.valueOf(taskID++), new IndexScanTask(future, timeout));
+        }
+    }
+
+    public void registerTask(Future<?> future, CountDownLatch latch, long timeout) {
+        synchronized (tasks) {
+            log.info("registering task: {}", taskID);
+            tasks.put(String.valueOf(taskID++), new IndexScanTask(future, latch, timeout));
+        }
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+
+            // always check for interrupts first
+            if (Thread.currentThread().isInterrupted()) {
+                log.info("thread interrupted, stopping");
+                break;
+            }
+
+            synchronized (tasks) {
+                long currentTime = System.currentTimeMillis();
+                Set<String> keys = new HashSet<>(tasks.keySet());
+                for (String key : keys) {
+                    IndexScanTask task = tasks.get(key);
+                    if (task.isDone(currentTime)) {
+                        log.info("closing task {}", key);
+                        task.cancelFuture();
+                        synchronized (tasks) {
+                            log.info("removing task {}", key);
+                            tasks.remove(key);
+                        }
+                    }
+                }
+            }
+
+            try {
+                Thread.sleep(monitorIntervalMillis);
+            } catch (InterruptedException e) {
+                log.warn("interrupted");
+                // break;
+            }
+        }
+    }
+
+    private static class IndexScanTask {
+
+        private final Future<?> future;
+        private final long start;
+        private final long timeout;
+
+        private CountDownLatch latch;
+
+        public IndexScanTask(Future<?> future, long timeout) {
+            this.future = future;
+            this.start = System.currentTimeMillis();
+            this.timeout = timeout;
+        }
+
+        public IndexScanTask(Future<?> future, CountDownLatch latch, long timeout) {
+            this.future = future;
+            this.start = System.currentTimeMillis();
+            this.timeout = timeout;
+            this.latch = latch;
+        }
+
+        public boolean isDone(long current) {
+            long elapsed = current - start;
+            return elapsed >= timeout;
+        }
+
+        public void cancelFuture() {
+            if (future != null && !future.isCancelled()) {
+                if (latch != null) {
+                    latch.countDown();
+                }
+                future.cancel(true);
+            }
+        }
+    }
+
+}

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
@@ -4,8 +4,9 @@ import static java.lang.Thread.currentThread;
 import static java.lang.Thread.sleep;
 
 import java.io.Closeable;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -28,7 +29,7 @@ public class ScanMonitor implements Runnable, Closeable {
     private static final long DEFAULT_INTERVAL_MILLIS = 25L;
 
     private int taskID = 0;
-    private final Map<String,IndexScanTask> tasks = new HashMap<>();
+    private final Map<String,IndexScanTask> tasks = new ConcurrentHashMap<>();
 
     private final long monitorIntervalMillis;
     private final ExecutorService executor;
@@ -94,10 +95,7 @@ public class ScanMonitor implements Runnable, Closeable {
         }
         String id = String.valueOf(taskID++);
         IndexScanTask task = new IndexScanTask(future, timeout);
-
-        synchronized (tasks) {
-            tasks.put(id, task);
-        }
+        tasks.put(id, task);
     }
 
     @Override
@@ -112,19 +110,17 @@ public class ScanMonitor implements Runnable, Closeable {
                 break;
             }
 
-            synchronized (tasks) {
-                long currentTime = System.currentTimeMillis();
-                var iter = tasks.keySet().iterator();
-                while (iter.hasNext()) {
-                    String key = iter.next();
-                    IndexScanTask task = tasks.get(key);
-                    if (task.isDone(currentTime)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("closing task {}", key);
-                        }
-                        task.cancelFuture();
-                        iter.remove();
+            long currentTime = System.currentTimeMillis();
+            Iterator<String> iter = tasks.keySet().iterator();
+            while (iter.hasNext()) {
+                String key = iter.next();
+                IndexScanTask task = tasks.get(key);
+                if (task.isComplete(currentTime)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("closing task {}", key);
                     }
+                    task.cancelFuture();
+                    iter.remove();
                 }
             }
 
@@ -146,22 +142,43 @@ public class ScanMonitor implements Runnable, Closeable {
         }
     }
 
+    /**
+     * A utility class that associates a future with a timeout
+     */
     private static class IndexScanTask {
 
         private final Future<?> future;
-        private final long start;
-        private final long timeout;
+        private final long startMillis;
+        private final long timeoutMillis;
 
-        public IndexScanTask(Future<?> future, long timeout) {
+        /**
+         * Simple constructor that accepts a future and a timeout
+         *
+         * @param future
+         *            the future
+         * @param timeoutMillis
+         *            the timeout in milliseconds
+         */
+        public IndexScanTask(Future<?> future, long timeoutMillis) {
             this.future = future;
-            this.start = System.currentTimeMillis();
-            this.timeout = timeout;
+            this.startMillis = System.currentTimeMillis();
+            this.timeoutMillis = timeoutMillis;
         }
 
-        public boolean isDone(long current) {
-            return future.isDone() || future.isCancelled() || (current - start >= timeout);
+        /**
+         * A task is complete if the future is done or canceled, or if the timeout is exceeded
+         *
+         * @param currentMillis
+         *            the current time since the task was registered
+         * @return true if the task is complete
+         */
+        public boolean isComplete(long currentMillis) {
+            return future.isDone() || future.isCancelled() || (currentMillis - startMillis >= timeoutMillis);
         }
 
+        /**
+         * Cancels the future if it exists and is not already canceled
+         */
         public void cancelFuture() {
             if (future != null && !future.isCancelled()) {
                 future.cancel(true);

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
@@ -1,30 +1,83 @@
 package datawave.query.jexl.lookups;
 
+import static java.lang.Thread.currentThread;
+import static java.lang.Thread.sleep;
+
+import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
 /**
- * A simple runnable that registers futures and cancels them when the timeout is exceeded.
+ * A simple runnable that registers futures and cancels them when the timeout is exceeded. Monitoring happens in an internal executor.
+ * <p>
+ * No further configuration is necessary after calling {@link ScanMonitor#of(String, QueryUncaughtExceptionHandler)}
  */
-public class ScanMonitor implements Runnable {
+public class ScanMonitor implements Runnable, Closeable {
 
     private static final Logger log = LoggerFactory.getLogger(ScanMonitor.class);
 
-    private final Map<String,IndexScanTask> tasks = new HashMap<>();
+    private static final long DEFAULT_INTERVAL_MILLIS = 25L;
 
     private int taskID = 0;
-    private final long monitorIntervalMillis;
+    private final Map<String,IndexScanTask> tasks = new HashMap<>();
 
-    public ScanMonitor() {
-        this(5L);
+    private final long monitorIntervalMillis;
+    private final ExecutorService executor;
+
+    /**
+     * Static entrypoint that creates a {@link ScanMonitor} for a given query id and exception handler. This constructor uses the
+     * {@link #DEFAULT_INTERVAL_MILLIS} of 25 milliseconds.
+     *
+     * @param id
+     *            the query id
+     * @param handler
+     *            the uncaught exception handler
+     * @return a {@link ScanMonitor}
+     */
+    public static ScanMonitor of(String id, QueryUncaughtExceptionHandler handler) {
+        return new ScanMonitor(DEFAULT_INTERVAL_MILLIS, id, handler);
     }
 
-    public ScanMonitor(long monitorIntervalMillis) {
+    /**
+     * Static entrypoint that creates a {@link ScanMonitor} for a given monitor interval, query id and exception handler
+     *
+     * @param monitorIntervalMillis
+     *            the interval between monitoring checks in milliseconds
+     * @param id
+     *            the query id
+     * @param handler
+     *            the uncaught exception handler
+     * @return a {@link ScanMonitor}
+     */
+    public static ScanMonitor of(long monitorIntervalMillis, String id, QueryUncaughtExceptionHandler handler) {
+        return new ScanMonitor(monitorIntervalMillis, id, handler);
+    }
+
+    /**
+     * Private constructor creates a thread factory, executor and submits this runnable
+     *
+     * @param monitorIntervalMillis
+     *            the interval between monitoring checks
+     * @param id
+     *            the query id
+     * @param handler
+     *            the uncaught exception handler
+     */
+    private ScanMonitor(long monitorIntervalMillis, String id, QueryUncaughtExceptionHandler handler) {
         this.monitorIntervalMillis = monitorIntervalMillis;
+
+        ScanMonitorThreadFactory threadFactory = new ScanMonitorThreadFactory(id, handler);
+        this.executor = Executors.newSingleThreadExecutor(threadFactory);
+        this.executor.submit(this);
     }
 
     /**
@@ -50,7 +103,7 @@ public class ScanMonitor implements Runnable {
         while (true) {
 
             // always check for interrupts first
-            if (Thread.currentThread().isInterrupted()) {
+            if (currentThread().isInterrupted()) {
                 log.info("thread interrupted, stopping");
                 break;
             }
@@ -70,11 +123,18 @@ public class ScanMonitor implements Runnable {
             }
 
             try {
-                Thread.sleep(monitorIntervalMillis);
+                sleep(monitorIntervalMillis);
             } catch (InterruptedException e) {
                 log.info("thread interrupted, stopping");
                 break;
             }
+        }
+    }
+
+    @Override
+    public void close() {
+        if (executor != null && !executor.isShutdown()) {
+            executor.shutdownNow();
         }
     }
 
@@ -102,4 +162,26 @@ public class ScanMonitor implements Runnable {
         }
     }
 
+    /**
+     * A simple thread factory for the {@link ScanMonitor}
+     */
+    protected static class ScanMonitorThreadFactory implements ThreadFactory {
+        private final String queryId;
+        private final QueryUncaughtExceptionHandler uncaughtExceptionHandler;
+        private final ThreadFactory threadFactory = Executors.defaultThreadFactory();
+
+        public ScanMonitorThreadFactory(String queryId, QueryUncaughtExceptionHandler uncaughtExceptionHandler) {
+            this.queryId = queryId;
+            this.uncaughtExceptionHandler = uncaughtExceptionHandler;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = threadFactory.newThread(r);
+            thread.setName(queryId + " monitor");
+            thread.setDaemon(true);
+            thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+            return thread;
+        }
+    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
@@ -89,7 +89,9 @@ public class ScanMonitor implements Runnable, Closeable {
      *            the timeout
      */
     public void registerTask(Future<?> future, long timeout) {
-        log.info("registering task: {}", taskID);
+        if (log.isTraceEnabled()) {
+            log.trace("registering task: {}", taskID);
+        }
         String id = String.valueOf(taskID++);
         IndexScanTask task = new IndexScanTask(future, timeout);
 
@@ -104,7 +106,9 @@ public class ScanMonitor implements Runnable, Closeable {
 
             // always check for interrupts first
             if (currentThread().isInterrupted()) {
-                log.info("thread interrupted, stopping");
+                if (log.isDebugEnabled()) {
+                    log.debug("thread interrupted, stopping");
+                }
                 break;
             }
 
@@ -115,7 +119,9 @@ public class ScanMonitor implements Runnable, Closeable {
                     String key = iter.next();
                     IndexScanTask task = tasks.get(key);
                     if (task.isDone(currentTime)) {
-                        log.info("closing task {}", key);
+                        if (log.isDebugEnabled()) {
+                            log.debug("closing task {}", key);
+                        }
                         task.cancelFuture();
                         iter.remove();
                     }
@@ -125,7 +131,9 @@ public class ScanMonitor implements Runnable, Closeable {
             try {
                 sleep(monitorIntervalMillis);
             } catch (InterruptedException e) {
-                log.info("thread interrupted, stopping");
+                if (log.isDebugEnabled()) {
+                    log.debug("thread interrupted, stopping");
+                }
                 break;
             }
         }
@@ -151,8 +159,7 @@ public class ScanMonitor implements Runnable, Closeable {
         }
 
         public boolean isDone(long current) {
-            long elapsed = current - start;
-            return elapsed >= timeout;
+            return future.isDone() || future.isCancelled() || (current - start >= timeout);
         }
 
         public void cancelFuture() {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/ScanMonitor.java
@@ -1,10 +1,7 @@
 package datawave.query.jexl.lookups;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
@@ -39,16 +36,12 @@ public class ScanMonitor implements Runnable {
      *            the timeout
      */
     public void registerTask(Future<?> future, long timeout) {
-        synchronized (tasks) {
-            log.info("registering task: {}", taskID);
-            tasks.put(String.valueOf(taskID++), new IndexScanTask(future, timeout));
-        }
-    }
+        log.info("registering task: {}", taskID);
+        String id = String.valueOf(taskID++);
+        IndexScanTask task = new IndexScanTask(future, timeout);
 
-    public void registerTask(Future<?> future, CountDownLatch latch, long timeout) {
         synchronized (tasks) {
-            log.info("registering task: {}", taskID);
-            tasks.put(String.valueOf(taskID++), new IndexScanTask(future, latch, timeout));
+            tasks.put(id, task);
         }
     }
 
@@ -64,16 +57,14 @@ public class ScanMonitor implements Runnable {
 
             synchronized (tasks) {
                 long currentTime = System.currentTimeMillis();
-                Set<String> keys = new HashSet<>(tasks.keySet());
-                for (String key : keys) {
+                var iter = tasks.keySet().iterator();
+                while (iter.hasNext()) {
+                    String key = iter.next();
                     IndexScanTask task = tasks.get(key);
                     if (task.isDone(currentTime)) {
                         log.info("closing task {}", key);
                         task.cancelFuture();
-                        synchronized (tasks) {
-                            log.info("removing task {}", key);
-                            tasks.remove(key);
-                        }
+                        iter.remove();
                     }
                 }
             }
@@ -81,8 +72,8 @@ public class ScanMonitor implements Runnable {
             try {
                 Thread.sleep(monitorIntervalMillis);
             } catch (InterruptedException e) {
-                log.warn("interrupted");
-                // break;
+                log.info("thread interrupted, stopping");
+                break;
             }
         }
     }
@@ -93,19 +84,10 @@ public class ScanMonitor implements Runnable {
         private final long start;
         private final long timeout;
 
-        private CountDownLatch latch;
-
         public IndexScanTask(Future<?> future, long timeout) {
             this.future = future;
             this.start = System.currentTimeMillis();
             this.timeout = timeout;
-        }
-
-        public IndexScanTask(Future<?> future, CountDownLatch latch, long timeout) {
-            this.future = future;
-            this.start = System.currentTimeMillis();
-            this.timeout = timeout;
-            this.latch = latch;
         }
 
         public boolean isDone(long current) {
@@ -115,9 +97,6 @@ public class ScanMonitor implements Runnable {
 
         public void cancelFuture() {
             if (future != null && !future.isCancelled()) {
-                if (latch != null) {
-                    latch.countDown();
-                }
                 future.cancel(true);
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -26,11 +26,13 @@ import datawave.query.jexl.lookups.AsyncIndexLookup;
 import datawave.query.jexl.lookups.ExceededThresholdException;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.jexl.lookups.IndexLookupMap;
+import datawave.query.jexl.lookups.ScanMonitor;
 import datawave.query.planner.pushdown.CostEstimator;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.MetadataHelper;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
 
 /**
  * Abstract class which provides a framework for visitors which perform index lookups based on the contents of the Jexl tree
@@ -55,6 +57,9 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
     protected ExecutorService executor;
     protected Map<String,IndexLookup> lookupMap;
     protected List<FutureJexlNode> futureJexlNodes;
+
+    protected ScanMonitor monitor = new ScanMonitor();
+    private ExecutorService monitorExecutor;
 
     protected String stage = "default";
 
@@ -94,6 +99,21 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
         }
     }
 
+    protected void setupMonitorExecutor() {
+        String id = "(unknown)";
+        if (config.getQuery() != null && config.getQuery().getId() != null) {
+            id = config.getQuery().getId().toString();
+        }
+        this.monitorExecutor = Executors.newSingleThreadExecutor(new ScanMonitorThreadFactory(id, config.getQuery().getUncaughtExceptionHandler()));
+        this.monitorExecutor.submit(monitor);
+    }
+
+    protected void shutdownMonitorExecutor() {
+        if (monitorExecutor != null) {
+            monitorExecutor.shutdownNow();
+        }
+    }
+
     /**
      * The expand method is the entrypoint which should be called to run index expansion on a given Jexl tree.
      *
@@ -106,6 +126,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
     @SuppressWarnings("unchecked")
     protected <T extends JexlNode> T expand(T script) {
         setupExecutor();
+        setupMonitorExecutor();
         try {
             if (null == config.getQueryFieldsDatatypes()) {
                 QueryException qe = new QueryException(DatawaveErrorCode.DATATYPESFORINDEXFIELDS_MULTIMAP_MISSING);
@@ -119,6 +140,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
             return rebuiltScript;
         } finally {
             shutdownExecutor();
+            shutdownMonitorExecutor();
         }
     }
 
@@ -319,4 +341,28 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
             return thread;
         }
     }
+
+    /**
+     * A simple thread factory for the {@link ScanMonitor}
+     */
+    protected static class ScanMonitorThreadFactory implements ThreadFactory {
+        private final String queryId;
+        private final QueryUncaughtExceptionHandler uncaughtExceptionHandler;
+        private final ThreadFactory threadFactory = Executors.defaultThreadFactory();
+
+        public ScanMonitorThreadFactory(String queryId, QueryUncaughtExceptionHandler uncaughtExceptionHandler) {
+            this.queryId = queryId;
+            this.uncaughtExceptionHandler = uncaughtExceptionHandler;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = threadFactory.newThread(r);
+            thread.setName(queryId + " monitor");
+            thread.setDaemon(true);
+            thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+            return thread;
+        }
+    }
+
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BaseIndexExpansionVisitor.java
@@ -58,8 +58,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
     protected Map<String,IndexLookup> lookupMap;
     protected List<FutureJexlNode> futureJexlNodes;
 
-    protected ScanMonitor monitor = new ScanMonitor();
-    private ExecutorService monitorExecutor;
+    protected ScanMonitor monitor;
 
     protected String stage = "default";
 
@@ -99,19 +98,18 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
         }
     }
 
-    protected void setupMonitorExecutor() {
+    protected void setupScanMonitor() {
         String id = "(unknown)";
         if (config.getQuery() != null && config.getQuery().getId() != null) {
             id = config.getQuery().getId().toString();
         }
-        this.monitorExecutor = Executors.newSingleThreadExecutor(new ScanMonitorThreadFactory(id, config.getQuery().getUncaughtExceptionHandler()));
-        this.monitorExecutor.submit(monitor);
+
+        QueryUncaughtExceptionHandler handler = config.getQuery().getUncaughtExceptionHandler();
+        monitor = ScanMonitor.of(id, handler);
     }
 
-    protected void shutdownMonitorExecutor() {
-        if (monitorExecutor != null) {
-            monitorExecutor.shutdownNow();
-        }
+    protected void shutdownMonitor() {
+        monitor.close();
     }
 
     /**
@@ -126,7 +124,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
     @SuppressWarnings("unchecked")
     protected <T extends JexlNode> T expand(T script) {
         setupExecutor();
-        setupMonitorExecutor();
+        setupScanMonitor();
         try {
             if (null == config.getQueryFieldsDatatypes()) {
                 QueryException qe = new QueryException(DatawaveErrorCode.DATATYPESFORINDEXFIELDS_MULTIMAP_MISSING);
@@ -140,7 +138,7 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
             return rebuiltScript;
         } finally {
             shutdownExecutor();
-            shutdownMonitorExecutor();
+            shutdownMonitor();
         }
     }
 
@@ -341,28 +339,4 @@ public abstract class BaseIndexExpansionVisitor extends RebuildingVisitor {
             return thread;
         }
     }
-
-    /**
-     * A simple thread factory for the {@link ScanMonitor}
-     */
-    protected static class ScanMonitorThreadFactory implements ThreadFactory {
-        private final String queryId;
-        private final QueryUncaughtExceptionHandler uncaughtExceptionHandler;
-        private final ThreadFactory threadFactory = Executors.defaultThreadFactory();
-
-        public ScanMonitorThreadFactory(String queryId, QueryUncaughtExceptionHandler uncaughtExceptionHandler) {
-            this.queryId = queryId;
-            this.uncaughtExceptionHandler = uncaughtExceptionHandler;
-        }
-
-        @Override
-        public Thread newThread(Runnable r) {
-            Thread thread = threadFactory.newThread(r);
-            thread.setName(queryId + " monitor");
-            thread.setDaemon(true);
-            thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
-            return thread;
-        }
-    }
-
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitor.java
@@ -19,9 +19,10 @@ import datawave.query.exceptions.IllegalRangeArgumentException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.LiteralRange;
+import datawave.query.jexl.lookups.AsyncIndexLookup;
+import datawave.query.jexl.lookups.BoundedRangeIndexLookup;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.jexl.lookups.IndexLookupMap;
-import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.MetadataHelper;
@@ -106,7 +107,9 @@ public class BoundedRangeIndexExpansionVisitor extends BaseIndexExpansionVisitor
     }
 
     protected IndexLookup createLookup(LiteralRange<?> range) {
-        return ShardIndexQueryTableStaticMethods.expandRange(config, scannerFactory, range, executor);
+        AsyncIndexLookup lookup = new BoundedRangeIndexLookup(config, scannerFactory, range, executor);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -3099,7 +3099,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         });
     }
 
-    private QueryPlanStream getQueryPlanStream(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelper metadataHelper) {
+    protected QueryPlanStream getQueryPlanStream(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelper metadataHelper) {
 
         if (config.isUseShardedIndex()) {
             return getDayIndexStream(config);

--- a/warehouse/query-core/src/main/java/datawave/query/util/EmptyCloseableIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/EmptyCloseableIterator.java
@@ -1,0 +1,26 @@
+package datawave.query.util;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+
+import datawave.query.CloseableIterable;
+
+/**
+ * An empty {@link CloseableIterable}
+ *
+ * @param <T>
+ *            the type
+ */
+public class EmptyCloseableIterator<T> implements CloseableIterable<T> {
+
+    @Override
+    public void close() throws IOException {
+        // no-op
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return Collections.emptyIterator();
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
@@ -27,7 +27,6 @@ import org.apache.accumulo.minicluster.MiniAccumuloConfig;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -49,6 +48,8 @@ import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.DatawaveQueryException;
 import datawave.query.index.day.IndexIngestUtil;
+import datawave.query.index.lookup.EmptyQueryPlanStream;
+import datawave.query.index.lookup.QueryPlanStream;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.planner.DefaultQueryPlanner;
@@ -109,7 +110,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
 
     // 10 values per prefix, low expansion thresholds, low scan thresholds
     // using this tests can simulate exceptions or timeouts on initial seek vs. next calls
-    private long expansionThreshold = 500;
+    private final long expansionThreshold = 500;
     private final long scanThresholdMS = 50L;
     private final int iterationDelayMS = 10;
     private final int timeoutDelayMS = 30_000;
@@ -155,30 +156,25 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         QueryPlanner planner = logic.getQueryPlanner();
         assertInstanceOf(StageTimingDefaultQueryPlanner.class, planner);
         StageTimingDefaultQueryPlanner stagePlanner = (StageTimingDefaultQueryPlanner) planner;
-
-        if (stagePlanner.getExpandRegexStage() < expected) {
-            // assume that faster is better, for now
-            return;
-        }
-
-        String msg = "expected: " + expected + " but was " + stagePlanner.getExpandRegexStage();
-        long delta = (long) Math.max((expected * 0.1), 250);
-        assertEquals(expected, stagePlanner.getExpandRegexStage(), delta, msg);
+        assertStageTime(expected, stagePlanner.getExpandRegexStage());
     }
 
     protected void assertRangeTime(long expected) {
         QueryPlanner planner = logic.getQueryPlanner();
         assertInstanceOf(StageTimingDefaultQueryPlanner.class, planner);
         StageTimingDefaultQueryPlanner stagePlanner = (StageTimingDefaultQueryPlanner) planner;
+        assertStageTime(expected, stagePlanner.getExpandRangeStage());
+    }
 
-        if (stagePlanner.getExpandRangeStage() < expected) {
+    protected void assertStageTime(long expected, long time) {
+        if (time < expected) {
             // assume that faster is better
             return;
         }
 
-        String msg = "expected: " + expected + " but was " + stagePlanner.getExpandRangeStage();
-        long delta = (long) Math.max((expected * 0.1), 250);
-        assertEquals(expected, stagePlanner.getExpandRangeStage(), delta, msg);
+        String msg = "expected: " + expected + " but was " + time;
+        long delta = (long) Math.max((expected * 0.1), 500);
+        assertEquals(expected, time, delta, msg);
     }
 
     protected void expectRegexExpansionTime(long time) {
@@ -366,7 +362,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testFieldedRegexITEOnNext() throws Exception {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "next");
             givenQuery("FIELD_A =~ 'a.*'");
             expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
             expectRegexExpansionTime(scanThresholdMS);
@@ -380,7 +376,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testFieldedRegexITEOnRandom() throws Exception {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("FIELD_A =~ 'a.*'");
             expectPlan("((_Value_ = true) && (FIELD_A =~ 'a.*'))");
             expectRegexExpansionTime(scanThresholdMS);
@@ -487,7 +483,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedRegexITEOnNext() {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "next");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
@@ -499,7 +495,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedRegexITEOnRandom() {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
@@ -521,7 +517,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
 
     // This enters an infinite loop
     @Test
-    @Disabled
     public void testBoundedRangeTimeoutOnInitialSeek() throws Exception {
         try {
             addDelayIterator(timeoutDelayMS);
@@ -548,40 +543,37 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     }
 
     @Test
-    public void testBoundedRangeNPEOnSeek() {
+    public void testBoundedRangeNPEOnSeek() throws Exception {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
-            assertThrows(NullPointerException.class, this::planAndExecuteQuery);
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            planAndExecuteQuery();
         } finally {
             removeRuntimeExceptionIterator();
         }
     }
 
     @Test
-    public void testBoundedRangeNPEOnNext() {
+    public void testBoundedRangeNPEOnNext() throws Exception {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
-            assertThrows(NullPointerException.class, this::planAndExecuteQuery);
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            planAndExecuteQuery();
         } finally {
             removeRuntimeExceptionIterator();
         }
     }
 
     @Test
-    public void testBoundedRangeNPERandom() {
+    public void testBoundedRangeNPERandom() throws Exception {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
             expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             expectRegexExpansionTime(scanThresholdMS);
-            // this is a perfectly valid query and should not be failing due to a NPE thrown all the up the stack
-            assertThrows(NullPointerException.class, this::planAndExecuteQuery);
+            planAndExecuteQuery();
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -589,13 +581,12 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
 
     // IterationInterruptedException on seek
     @Test
-    public void testBoundedRangeIIEOnInitialSeek() {
+    public void testBoundedRangeIIEOnInitialSeek() throws Exception {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
-            assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            planAndExecuteQuery();
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -603,13 +594,12 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
 
     // IterationInterruptedException on next
     @Test
-    public void testBoundedRangeIIEOnNext() {
+    public void testBoundedRangeIIEOnNext() throws Exception {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
-            assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            planAndExecuteQuery();
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -619,7 +609,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testBoundedRangeITEOnNext() throws Exception {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "next");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
             expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             planAndExecuteQuery();
@@ -632,7 +622,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testBoundedRangeITEOnRandom() throws Exception {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
             expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
             expectRegexExpansionTime(scanThresholdMS);
@@ -644,13 +634,12 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
 
     // IterationInterruptedException on random operation
     @Test
-    public void testBoundedRangeIIEOnRandom() {
+    public void testBoundedRangeIIEOnRandom() throws Exception {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z'))");
-            // expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
-            // this is throwing an IterationInterruptedException all the way up and failing a perfectly valid query
-            assertThrows(IterationInterruptedException.class, this::planAndExecuteQuery);
+            expectPlan("((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'z')))");
+            planAndExecuteQuery();
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -748,7 +737,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedLiteralITEOnNext() {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "next");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
@@ -761,7 +750,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedLiteralITEOnRandom() {
         try {
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
@@ -776,7 +765,6 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // expectPlan("_NOFIELD_ == 'a1b2c3'");
             // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
             assertThrows(RuntimeException.class, this::planAndExecuteQuery);
         } finally {
@@ -793,7 +781,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
             String query = buildFieldedRegexQuery(fields, prefixes);
             String plan = buildValueExceededPlan(fields, prefixes);
 
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery(query);
             expectPlan(plan);
             expectRegexExpansionTime(scanThresholdMS);
@@ -809,7 +797,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
             SortedSet<String> prefixes = new TreeSet<>(Set.of("aa", "ab", "ac", "ad", "ae"));
             String query = buildUnfieldedRegexQuery(prefixes);
 
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery(query);
             expectPlan(null); // no plan expected
             assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
@@ -825,7 +813,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
             String query = buildBoundedRangeQuery(fields);
             String plan = buildValueExceededRangePlan(fields);
 
-            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "ITE for test", "random");
+            addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery(query);
             expectPlan(plan);
             expectRangeExpansionTime(scanThresholdMS);
@@ -942,12 +930,12 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         }
     }
 
-    protected void addIOExceptionIterator(String clazz, String msg, String when) {
+    protected void addIOExceptionIterator(String clazz, String when) {
         for (String tableName : indexTableNames()) {
             Map<String,String> properties = new HashMap<>();
             properties.put("table.iterator.scan.ioex", "3,datawave.test.iter.IOExceptionIterator");
             properties.put("table.iterator.scan.ioex.opt.exception.class", String.valueOf(clazz));
-            properties.put("table.iterator.scan.ioex.opt.exception.message", String.valueOf(msg));
+            properties.put("table.iterator.scan.ioex.opt.exception.message", "ITE for test");
             switch (when) {
                 case "seek":
                     properties.put("table.iterator.scan.ioex.opt.fireOnSeek", "true");
@@ -1008,6 +996,21 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
                 expandRangeStage = System.currentTimeMillis() - start;
                 log.info("expand ranges: {}", expandRangeStage);
             }
+        }
+
+        /**
+         * Stub out the {@link QueryPlanStream} with an {@link EmptyQueryPlanStream}
+         *
+         * @param config
+         *            the shard query config
+         * @param scannerFactory
+         *            the scanner factory
+         * @param metadataHelper
+         *            the metadata helper
+         * @return an {@link EmptyQueryPlanStream}
+         */
+        protected QueryPlanStream getQueryPlanStream(ShardQueryConfiguration config, ScannerFactory scannerFactory, MetadataHelper metadataHelper) {
+            return EmptyQueryPlanStream.of();
         }
 
         public long getExpandRegexStage() {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BoundedRangeIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BoundedRangeIndexLookupTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -71,6 +72,9 @@ public class BoundedRangeIndexLookupTest extends EasyMockSupport {
     private ShardQueryConfiguration largeConfig;
     private ScannerFactory largeScannerFactory;
 
+    private ScanMonitor monitor;
+    private ExecutorService monitorExecutor;
+
     @BeforeClass
     public static void setupClass() throws Exception {
         cluster = new MiniAccumuloCluster(temporaryFolder.newFolder(), PASSWORD);
@@ -95,11 +99,16 @@ public class BoundedRangeIndexLookupTest extends EasyMockSupport {
         // large lookup
         largeConfig = new ShardQueryConfiguration();
         largeScannerFactory = createMock(ScannerFactory.class);
+
+        monitor = new ScanMonitor(25_000);
+        monitorExecutor = Executors.newFixedThreadPool(1);
+        monitorExecutor.execute(monitor);
     }
 
     @After
     public void teardown() {
         executorService.shutdownNow();
+        monitorExecutor.shutdownNow();
     }
 
     public static void writeData() throws Exception {
@@ -255,7 +264,9 @@ public class BoundedRangeIndexLookupTest extends EasyMockSupport {
     }
 
     private BoundedRangeIndexLookup createLookup(LiteralRange<?> range) {
-        return new BoundedRangeIndexLookup(config, scannerFactory, range, executorService);
+        BoundedRangeIndexLookup lookup = new BoundedRangeIndexLookup(config, scannerFactory, range, executorService);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 
     private void withDateRange(String start, String end) {
@@ -282,6 +293,7 @@ public class BoundedRangeIndexLookupTest extends EasyMockSupport {
         return values;
     }
 
+    @Ignore
     @Test
     public void largeRowInBoundedRangeTest() throws TableNotFoundException {
         ExecutorService s = Executors.newSingleThreadExecutor();

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BoundedRangeIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BoundedRangeIndexLookupTest.java
@@ -73,7 +73,6 @@ public class BoundedRangeIndexLookupTest extends EasyMockSupport {
     private ScannerFactory largeScannerFactory;
 
     private ScanMonitor monitor;
-    private ExecutorService monitorExecutor;
 
     @BeforeClass
     public static void setupClass() throws Exception {
@@ -100,15 +99,13 @@ public class BoundedRangeIndexLookupTest extends EasyMockSupport {
         largeConfig = new ShardQueryConfiguration();
         largeScannerFactory = createMock(ScannerFactory.class);
 
-        monitor = new ScanMonitor(25_000);
-        monitorExecutor = Executors.newFixedThreadPool(1);
-        monitorExecutor.execute(monitor);
+        monitor = ScanMonitor.of(25_000, "test", null);
     }
 
     @After
     public void teardown() {
         executorService.shutdownNow();
-        monitorExecutor.shutdownNow();
+        monitor.close();
     }
 
     public static void writeData() throws Exception {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/BoundedRangeIndexExpansionVisitorIT.java
@@ -1,7 +1,5 @@
 package datawave.query.jexl.visitors;
 
-import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
-
 import java.util.Set;
 
 import org.apache.commons.jexl3.parser.ASTJexlScript;
@@ -58,16 +56,6 @@ public class BoundedRangeIndexExpansionVisitorIT extends BaseIndexExpansionTest 
     @Test
     public void testExpansionSkipsCompositeField() {
         // really, verify that composite fields are retained
-    }
-
-    @Test
-    public void testSimulatedTimeout() throws Exception {
-        write("a", "FIELD_A");
-        write("b", "FIELD_A", EXCEPTEDVALUE);
-        write("c", "FIELD_A");
-        String query = "((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'c'))";
-        String expected = "((_Value_ = true) && ((_Bounded_ = true) && (FIELD_A >= 'a' && FIELD_A <= 'c')))";
-        driveExpansion(query, expected);
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/ExpandMultiNormalizedTermsTest.java
@@ -263,6 +263,23 @@ public class ExpandMultiNormalizedTermsTest {
         expandTerms(original, expected);
     }
 
+    // Accumulo will throw an exception when creating a range with a lower bound of '4' and an upper bound of '10'
+    @Test
+    public void testBoundedMultiNormalizedBoundsIllegalRange() throws ParseException {
+        Multimap<String,Type<?>> dataTypes = HashMultimap.create();
+        dataTypes.putAll("FOO", Sets.newHashSet(new TrimLeadingZerosType(), new StringType()));
+
+        helper.setIndexedFields(dataTypes.keySet());
+        helper.setIndexOnlyFields(dataTypes.keySet());
+        helper.addTermFrequencyFields(dataTypes.keySet());
+
+        config.setQueryFieldsDatatypes(dataTypes);
+
+        String original = "((_Bounded_ = true) && (FOO > 4 && FOO < 10))";
+        String expected = "((_Bounded_ = true) && (FOO > '4' && FOO < '10'))";
+        expandTerms(original, expected);
+    }
+
     @Test
     public void testBoundedMultiNormalizedBounds3() throws ParseException {
         Multimap<String,Type<?>> dataTypes = HashMultimap.create();

--- a/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/GeoSortedQueryDataTest.java
@@ -85,7 +85,7 @@ import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 @RunWith(Arquillian.class)
 public class GeoSortedQueryDataTest {
 
-    private static final int NUM_SHARDS = 241;
+    private static final int NUM_SHARDS = 3;
     private static final String DATA_TYPE_NAME = "wkt";
     private static final String INGEST_HELPER_CLASS = TestIngestHelper.class.getName();
     private static final String FIELD_NAME = "GEO_FIELD";
@@ -96,7 +96,7 @@ public class GeoSortedQueryDataTest {
     private static final SimpleDateFormat formatter = new SimpleDateFormat(formatPattern);
 
     private static final String BEGIN_DATE = "20000101 000000.000";
-    private static final String END_DATE = "20500101 000000.000";
+    private static final String END_DATE = "20000102 000000.000";
 
     private static final String USER = "testcorp";
     private static final String USER_DN = "cn=test.testcorp.com, ou=datawave, ou=development, o=testcorp, c=us";
@@ -272,6 +272,12 @@ public class GeoSortedQueryDataTest {
             }
             writer.close();
         }
+
+        try (var bw = client.createBatchWriter(TableName.METADATA, new BatchWriterConfig())) {
+            Mutation m = new Mutation("num_shards");
+            m.put("ns", "20000101_3", new Value());
+            bw.addMutation(m);
+        }
     }
 
     @Before
@@ -279,8 +285,8 @@ public class GeoSortedQueryDataTest {
         // increase the depth threshold
         logic.setMaxDepthThreshold(10);
 
-        logic.setIntermediateMaxTermThreshold(50);
-        logic.setIndexedMaxTermThreshold(50);
+        logic.setIntermediateMaxTermThreshold(250);
+        logic.setIndexedMaxTermThreshold(250);
 
         // set the pushdown threshold really high to avoid collapsing uids into shards (overrides setCollapseUids if #terms is greater than this threshold)
         ((DefaultQueryPlanner) (logic.getQueryPlanner())).setPushdownThreshold(1000000);

--- a/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/IndexQueryLogicTest.java
@@ -1,6 +1,7 @@
 package datawave.query.tables;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import datawave.core.query.result.event.DefaultResponseObjectFactory;
 import datawave.marking.MarkingFunctions;
 import datawave.query.Constants;
 import datawave.query.QueryTestTableHelper;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.planner.DatePartitionedQueryPlanner;
 import datawave.query.testframework.AbstractFunctionalQuery;
 import datawave.query.testframework.AccumuloSetup;
@@ -89,6 +91,14 @@ public class IndexQueryLogicTest extends AbstractFunctionalQuery {
         this.logic.setMetadataHelperFactory(new MetadataHelperFactory());
         this.logic.setQueryPlanner(new DatePartitionedQueryPlanner());
         this.logic.setResponseObjectFactory(new DefaultResponseObjectFactory());
+
+        // setup the hadoop configuration
+        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
+
+        // setup a directory for cache results
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(temporaryFolder.newFolder().toURI().toString());
+        logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
 
         // init must set auths
         testInit();

--- a/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MultiNormalizerTest.java
@@ -2,6 +2,10 @@ package datawave.query.util;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collections;
+
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.junit.jupiter.api.AfterAll;
@@ -9,6 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +22,8 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.google.common.base.Preconditions;
+
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.ingest.data.TypeRegistry;
@@ -24,6 +31,7 @@ import datawave.query.MultiNormalizerIngest;
 import datawave.query.QueryParameters;
 import datawave.query.exceptions.DatawaveQueryException;
 import datawave.query.index.day.IndexIngestUtil;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.ShardQueryLogic;
 
@@ -44,6 +52,9 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     private static final Logger log = LoggerFactory.getLogger(MultiNormalizerTest.class);
 
     private static final Authorizations auths = new Authorizations("ALL");
+
+    @TempDir
+    public static Path folder;
 
     @Autowired
     @Qualifier("EventQuery")
@@ -77,6 +88,14 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     public void beforeEach() {
         setClientForTest(clientForSetup);
         givenParameter(QueryParameters.HIT_LIST, "true");
+
+        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        Preconditions.checkNotNull(hadoopConfig);
+        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
+
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toUri().toString());
+        logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
+
         // default to full date range
         givenDate("20250707", "20250708");
     }
@@ -239,7 +258,7 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     }
 
     @Test
-    public void testRangeSizeFourToTen_rangeExpansionDisabled() throws Exception {
+    public void testRangeSizeFourToTen_rangeExpansionDisabled() {
         try {
             // simulate a bounded range expansion failure
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(true);
@@ -295,7 +314,7 @@ public class MultiNormalizerTest extends AbstractQueryTest {
     }
 
     @Test
-    public void testRangeSizeFourToTenWithAnchor_rangeExpansionDisabled() throws Exception {
+    public void testRangeSizeFourToTenWithAnchor_rangeExpansionDisabled() {
         try {
             // simulate a bounded range expansion failure
             ((DefaultQueryPlanner) logic.getQueryPlanner()).setDisableBoundedLookup(true);

--- a/warehouse/query-core/src/test/java/datawave/test/iter/DelayIterator.java
+++ b/warehouse/query-core/src/test/java/datawave/test/iter/DelayIterator.java
@@ -81,6 +81,7 @@ public class DelayIterator implements SortedKeyValueIterator<Key,Value>, OptionD
                 Thread.sleep(delay);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted delay iterator", e);
             }
         }
     }


### PR DESCRIPTION
Add ScanMonitor for external scan monitoring

BoundedRangeIndexLookup now delegates scan termination responsibility to ScanMonitor.

Add EmptyCloseableIterator and EmptyQueryPlanStream for ease of testing

Update bounded range tests in IndexExpansionQueryTest that previously documented incorrect behavior with the correct final state, i.e. bounded ranges marked as value exceeded in the case of an exception.