### PR TITLE
Fixes per-request AnnotationManager resource leakage by introducing a request context object

### DIFF
--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
@@ -88,106 +88,9 @@ public class AnnotationManagerBean implements AnnotationManager {
     @SpringBean(name = "AnnotationManagerConfig")
     private AnnotationManagerConfig config;
 
-    // Per-request stateful variables, managed internally.
-    private Set<Authorizations> authorizations;
-    private AccumuloClient client;
-    private LookupUUIDService lookupUUIDService;
-    private AnnotationDataAccess annotationDataAccess;
-
-    // Per-request, cache lookups for unique analytic source hashes so we don't do them more than once.
-    // TODO: make this a proper cross-request cache?
-    private final Map<String,Optional<AnnotationSource>> retrievedSourcesCache = new HashMap<>();
-
     @VisibleForTesting
     public void setEJBContext(EJBContext ctx) {
         this.ctx = ctx;
-    }
-
-    /**
-     * Calculate the auths for this query based on the principal and the queryAuths if any.
-     *
-     * @param queryAuths
-     *            the auths to downgrade to, or null if no downgrade is desired
-     * @param principal
-     *            the caller principal
-     * @return a Set of authorizations to use for this query
-     * @throws QueryException
-     *             and exception if there was a problem calculating the auths
-     */
-    private static Set<Authorizations> getUserAuthorizations(@SuppressWarnings("SameParameterValue") String queryAuths, DatawavePrincipal principal)
-                    throws QueryException {
-        try {
-            if (queryAuths == null) {
-                return AuthorizationsUtil.buildAuthorizations(principal.getAuthorizations());
-            } else {
-                final String downgradedAuths = AuthorizationsUtil.downgradeUserAuths(queryAuths, principal, principal);
-                return AuthorizationsUtil.buildAuthorizations(Collections.singleton(AuthorizationsUtil.splitAuths(downgradedAuths)));
-            }
-
-        } catch (Exception e) {
-            throw new QueryException("Failed to get user query authorizations", e);
-        }
-    }
-
-    public AccumuloClient initializeAccumuloClient() throws QueryException {
-        if (client == null || authorizations == null) {
-            final Principal p = ctx.getCallerPrincipal();
-            final boolean isDatawavePrincipal = DatawavePrincipal.class.isAssignableFrom(p.getClass());
-            final DatawavePrincipal dp = isDatawavePrincipal ? (DatawavePrincipal) p : null;
-            final String userDn = dp != null ? dp.getUserDN().subjectDN() : p.getName();
-            final Collection<String> proxyServers = dp != null ? dp.getProxyServers() : null;
-
-            // TODO: allow downgrade?
-            // String queryAuths = queryParameters.getFirst(QueryParameters.QUERY_AUTHORIZATIONS);
-            authorizations = getUserAuthorizations(null, dp);
-
-            UUID transactionUUID = java.util.UUID.randomUUID();
-            Map<String,String> trackingMap = connectionFactory.getTrackingMap(Thread.currentThread().getStackTrace());
-            if (trackingMap != null) {
-                trackingMap.put("query.user", "user");
-                trackingMap.put("query.id", transactionUUID.toString());
-                trackingMap.put("query.query", "something else");
-            }
-            accumuloConnectionRequestBean.requestBegin(transactionUUID.toString(), userDn, trackingMap);
-            try {
-                client = connectionFactory.getClient(userDn, proxyServers, config.getConnPoolName(), config.getPriority(), trackingMap);
-            } catch (Exception e) {
-                throw new QueryException("Unable to get Accumulo client, exception encountered: ", e);
-            } finally {
-                accumuloConnectionRequestBean.requestEnd(transactionUUID.toString());
-            }
-        }
-        return client;
-    }
-
-    public void returnAccumuloClient() {
-        try {
-            connectionFactory.returnClient(client);
-        } catch (Exception e) {
-            log.warn("Error when returning client", e);
-        }
-    }
-
-    public LookupUUIDService initializeLookupUUIDService() throws QueryException {
-        if (lookupUUIDService == null) {
-            final AccumuloClient client = initializeAccumuloClient();
-            lookupUUIDService = new LookupUUIDService(config.getLookupUUIDServiceConfig(), client, authorizations, responseObjectFactory,
-                            config.getLookupUUIDQueryLogic());
-        }
-        return lookupUUIDService;
-    }
-
-    public AnnotationDataAccess initializeAnnotationService() throws QueryException {
-        if (annotationDataAccess == null) {
-            final AccumuloClient client = initializeAccumuloClient();
-            final AccumuloAnnotationSerializer annotationSerializer = new AccumuloAnnotationSerializer(config.getAnnotationConfig().getVisibilityTransformer(),
-                            config.getAnnotationConfig().getTimestampTransformer());
-            final AccumuloAnnotationSourceSerializer annotationSourceSerializer = new AccumuloAnnotationSourceSerializer(
-                            config.getAnnotationConfig().getVisibilityTransformer(), config.getAnnotationConfig().getTimestampTransformer());
-            annotationDataAccess = new AnnotationDataAccess(client, authorizations, config.getAnnotationConfig().getAnnotationTableName(),
-                            config.getAnnotationConfig().getAnnotationSourceTableName(), annotationSerializer, annotationSourceSerializer);
-        }
-        return annotationDataAccess;
     }
 
     @GET
@@ -195,8 +98,9 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Produces("application/json")
     @Override
     public Response getAnnotationSource(@PathParam("analyticHash") String analyticHash) {
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
             Optional<AnnotationSource> results = annotationDataAccess.getAnnotationSource(analyticHash);
             if (results.isEmpty()) {
                 return jsonNotFound("No annotation source found for analyticHash: " + analyticHash);
@@ -207,9 +111,8 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
-
     }
 
     @GET
@@ -218,12 +121,13 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotationTypes(@PathParam("idType") String idType, @PathParam("id") String id) {
         // TODO sanitize input to make sure it contains nothing weird like nulls.
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
-            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadata = lookupDocumentIdentifier(context, idType, id);
             if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
             final Map<Metadata,Collection<String>> results = new HashMap<>();
             for (Metadata md : metadata) {
                 final Collection<String> types = annotationDataAccess.getAnnotationTypes(md.getRow(), md.getDataType(), md.getInternalId());
@@ -240,7 +144,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -250,18 +154,19 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotationsFor(@PathParam("idType") String idType, @PathParam("id") String id) {
         // TODO sanitize input to make sure it contains nothing weird like nulls.
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
-            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadata = lookupDocumentIdentifier(context, idType, id);
             if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
 
             final List<Annotation> results = new ArrayList<>();
             for (Metadata md : metadata) {
                 final List<Annotation> annotations = annotationDataAccess.getAnnotations(md.getRow(), md.getDataType(), md.getInternalId());
                 if (!annotations.isEmpty()) {
-                    List<Annotation> annotationsWithSources = lookupAndInjectAnnotationSources(annotations);
+                    List<Annotation> annotationsWithSources = lookupAndInjectAnnotationSources(context, annotations);
                     results.addAll(annotationsWithSources);
                 }
             }
@@ -274,7 +179,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -284,19 +189,20 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotationsByType(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationType") String annotationType) {
         // TODO sanitize input to make sure it contains nothing weird like nulls.
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
-            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadata = lookupDocumentIdentifier(context, idType, id);
             if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
 
             final List<Annotation> results = new ArrayList<>();
             for (Metadata md : metadata) {
                 final List<Annotation> annotations = annotationDataAccess.getAnnotationsForType(md.getRow(), md.getDataType(), md.getInternalId(),
                                 annotationType);
                 if (!annotations.isEmpty()) {
-                    List<Annotation> annotationsWithSources = lookupAndInjectAnnotationSources(annotations);
+                    List<Annotation> annotationsWithSources = lookupAndInjectAnnotationSources(context, annotations);
                     results.addAll(annotationsWithSources);
                 }
             }
@@ -309,7 +215,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -318,18 +224,19 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Produces("application/json")
     @Override
     public Response getAnnotation(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId) {
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
-            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadata = lookupDocumentIdentifier(context, idType, id);
             if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
 
             final List<Annotation> results = new ArrayList<>();
             for (Metadata md : metadata) {
                 final Optional<Annotation> annotations = annotationDataAccess.getAnnotation(md.getRow(), md.getDataType(), md.getInternalId(), annotationId);
                 if (annotations.isPresent()) {
-                    Annotation annotationWithSource = lookupAndInjectAnnotationSource(annotations.get());
+                    Annotation annotationWithSource = lookupAndInjectAnnotationSource(context, annotations.get());
                     results.add(annotationWithSource);
                 }
             }
@@ -342,7 +249,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -352,6 +259,7 @@ public class AnnotationManagerBean implements AnnotationManager {
     @RolesAllowed({"AnnotationWriter"})
     @Override
     public Response addAnnotation(@PathParam("idType") String idType, @PathParam("id") String id, String body) {
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
             final Annotation rawAnnotation = AnnotationJsonUtils.annotationFromJson(body);
             final Validator<Annotation> validator = AnnotationValidators.getAnnotationValidator();
@@ -362,7 +270,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonError(message);
             }
 
-            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadataList = lookupDocumentIdentifier(context, idType, id);
             if (metadataList.isEmpty()) {
                 final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
                 log.info(message);
@@ -384,7 +292,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                     .build();
             //@formatter:on
 
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
             Optional<Annotation> addResult = annotationDataAccess.addAnnotation(localizedAnnotation);
             if (addResult.isPresent()) {
                 log.debug("Successfully added annotation: {}", addResult.get());
@@ -406,7 +314,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -417,6 +325,7 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response updateAnnotation(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId,
                     String body) {
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
             final Annotation rawAnnotation = AnnotationJsonUtils.annotationFromJson(body);
             final Validator<Annotation> validator = AnnotationValidators.getAnnotationValidator();
@@ -427,7 +336,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                 return jsonError(message);
             }
 
-            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadataList = lookupDocumentIdentifier(context, idType, id);
             if (metadataList.isEmpty()) {
                 final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
                 log.info(message);
@@ -449,7 +358,7 @@ public class AnnotationManagerBean implements AnnotationManager {
                     .build();
             //@formatter:on
 
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
             Optional<Annotation> addResult = annotationDataAccess.updateAnnotation(localizedAnnotation);
             if (addResult.isPresent()) {
                 log.debug("Successfully updated annotation: {}", addResult.get());
@@ -470,7 +379,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -480,12 +389,13 @@ public class AnnotationManagerBean implements AnnotationManager {
     @Override
     public Response getAnnotationSegment(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId,
                     @PathParam("segmentHash") String segmentHash) {
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
-            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadata = lookupDocumentIdentifier(context, idType, id);
             if (metadata.isEmpty()) {
                 return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
             }
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
 
             final Map<Metadata,Annotation> annotationResults = new HashMap<>();
             for (Metadata md : metadata) {
@@ -520,7 +430,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -531,10 +441,11 @@ public class AnnotationManagerBean implements AnnotationManager {
     @RolesAllowed({"AnnotationWriter"})
     @Override
     public Response addSegment(@PathParam("idType") String idType, @PathParam("id") String id, @PathParam("annotationId") String annotationId, String body) {
+        final RequestContext context = new RequestContext(config, ctx, connectionFactory, accumuloConnectionRequestBean, responseObjectFactory);
         try {
             Segment segment = AnnotationJsonUtils.segmentFromJson(body);
 
-            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id);
+            final List<Metadata> metadataList = lookupDocumentIdentifier(context, idType, id);
             if (metadataList.isEmpty()) {
                 final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
                 log.info(message);
@@ -547,7 +458,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             }
             final Metadata metadata = metadataList.get(0);
 
-            final AnnotationDataAccess annotationDataAccess = initializeAnnotationService();
+            final AnnotationDataAccess annotationDataAccess = context.initializeAnnotationService();
             annotationDataAccess.addSegment(metadata.getRow(), metadata.getDataType(), metadata.getInternalId(), annotationId, segment);
             return jsonOk(segment.getSegmentHash());
         } catch (InvalidProtocolBufferException e) {
@@ -559,7 +470,7 @@ public class AnnotationManagerBean implements AnnotationManager {
             log.error(message, e);
             return jsonError(message);
         } finally {
-            returnAccumuloClient();
+            context.returnAccumuloClient();
         }
     }
 
@@ -587,7 +498,7 @@ public class AnnotationManagerBean implements AnnotationManager {
      * @throws QueryException
      *             if the id is malformed.
      */
-    private List<Metadata> lookupDocumentIdentifier(String idType, String id) throws QueryException {
+    private List<Metadata> lookupDocumentIdentifier(RequestContext context, String idType, String id) throws QueryException {
         // If the idType is RECORD_ID or DOCUMENT, treat the id provided as an internal id and perform a direct lookup
         // against the annotations table, if that's enabled.
         if (idType.equals("DOCUMENT") || idType.equals("RECORD_ID")) {
@@ -600,7 +511,7 @@ public class AnnotationManagerBean implements AnnotationManager {
         }
 
         // Otherwise, use the lookup uuid service to perform a lookup to find the internal id in the shard table.
-        final LookupUUIDService lookup = initializeLookupUUIDService();
+        final LookupUUIDService lookup = context.initializeLookupUUIDService();
         return lookup.executeLookupUUIDQuery(idType, id);
     }
 
@@ -612,10 +523,10 @@ public class AnnotationManagerBean implements AnnotationManager {
      *            the annotations to inject sources into
      * @return return annotations with sources injected where possible.
      */
-    private List<Annotation> lookupAndInjectAnnotationSources(List<Annotation> annotations) {
+    private List<Annotation> lookupAndInjectAnnotationSources(RequestContext context, List<Annotation> annotations) {
         final List<Annotation> results = new ArrayList<>();
         for (Annotation a : annotations) {
-            results.add(lookupAndInjectAnnotationSource(a));
+            results.add(lookupAndInjectAnnotationSource(context, a));
         }
         return results;
     }
@@ -624,7 +535,7 @@ public class AnnotationManagerBean implements AnnotationManager {
      * Given an annotation, retrieve the annotation source information that is referenced by their analyticHash. Employs a per-request hash so we don't look up
      * a single source multiple times.
      */
-    private Annotation lookupAndInjectAnnotationSource(Annotation a) {
+    private Annotation lookupAndInjectAnnotationSource(RequestContext context, Annotation a) {
         // no need to inject a source if we already have one.
         if (a.hasSource()) {
             log.warn("Strange, this annotation already has a source. Annotation {}/{}/{} {}, using analyticHash {}", a.getShard(), a.getDataType(), a.getUid(),
@@ -640,9 +551,7 @@ public class AnnotationManagerBean implements AnnotationManager {
 
         // do the deed and cache the results.
         final String analyticHash = a.getAnalyticSourceHash();
-        final Optional<AnnotationSource> result = retrievedSourcesCache.computeIfAbsent(analyticHash,
-                        key -> annotationDataAccess.getAnnotationSource(analyticHash));
-
+        final Optional<AnnotationSource> result = context.getAnnotationSource(analyticHash);
         if (result.isPresent()) {
             return injectAnnotationSource(a, result.get());
         } else {
@@ -707,5 +616,222 @@ public class AnnotationManagerBean implements AnnotationManager {
     @VisibleForTesting
     protected AnnotationManagerConfig getConfig() {
         return config;
+    }
+
+    /** Per-request initialization code and related state */
+    protected static final class RequestContext {
+
+        private final AnnotationManagerConfig config;
+        private final AccumuloConnectionFactory connectionFactory;
+        private final AccumuloConnectionRequestBean accumuloConnectionRequestBean;
+        private final ResponseObjectFactory responseObjectFactory;
+
+        /** the user performing this request */
+        private final DatawavePrincipal datawavePrincipal;
+
+        /** the dn of the user performing this request */
+        private final String userDn;
+
+        /** proxy servers involved in this request */
+        private final Collection<String> proxyServers;
+
+        /** quthorizations pulled from the query parameters for this request */
+        private final String queryAuths;
+
+        /** the final set of merged query and user authorizations. */
+        private Set<Authorizations> authorizations;
+
+        /** the accumulo client to use for this request - obtained from the connection pool and must be returned. */
+        private AccumuloClient client;
+
+        /** used to lookup uuids and obtain internal identifiers, scoped to the caller's authorizations */
+        private LookupUUIDService lookupUUIDService;
+
+        /** used to _read_ annotations directly from accumulo, scoped to the caller's authorizations */
+        private AnnotationDataAccess annotationDataAccess;
+
+        /** Cache lookups for unique analytic source hashes so we don't perform lookups more than once. TODO: make this a proper cross-request cache? */
+        private final Map<String,Optional<AnnotationSource>> retrievedSourcesCache = new HashMap<>();
+
+        /** Lookup an annotation source or retrieve it from the cache */
+        public Optional<AnnotationSource> getAnnotationSource(String analyticHash) {
+            return retrievedSourcesCache.computeIfAbsent(analyticHash, key -> annotationDataAccess.getAnnotationSource(analyticHash));
+        }
+
+        /**
+         * Initialize the request context with the objects needed to perform various request state initialization. Validation of the objects provided is
+         * performed in the various initialize methods exposed by this class. Each of the objects provided as parameters are expected to be shared across many
+         * requests.
+         *
+         * @param config
+         *            the annotation manager configuration
+         * @param ctx
+         *            the ejb context - used for retrieving the principal for he qrequest
+         * @param connectionFactory
+         *            the accumulo connection factory - used for getting accumulo clients
+         * @param accumuloConnectionRequestBean
+         *            the accumulo connection request bean - used for tracking accumulo clients rerquests
+         * @param responseObjectFactory
+         *            the response object factory used for creating LookupUUID responses.
+         */
+        protected RequestContext(AnnotationManagerConfig config, EJBContext ctx, AccumuloConnectionFactory connectionFactory,
+                        AccumuloConnectionRequestBean accumuloConnectionRequestBean, ResponseObjectFactory responseObjectFactory) {
+            this.config = config;
+            this.connectionFactory = connectionFactory;
+            this.accumuloConnectionRequestBean = accumuloConnectionRequestBean;
+            this.responseObjectFactory = responseObjectFactory;
+
+            final Principal p = ctx.getCallerPrincipal();
+            final boolean isDatawavePrincipal = DatawavePrincipal.class.isAssignableFrom(p.getClass());
+            final DatawavePrincipal dp = isDatawavePrincipal ? (DatawavePrincipal) p : null;
+
+            this.userDn = dp != null ? dp.getUserDN().subjectDN() : p.getName();
+            this.proxyServers = dp != null ? dp.getProxyServers() : null;
+            this.datawavePrincipal = dp;
+
+            // TODO: allow downgrading by reading query auths from query parameters.
+            this.queryAuths = null;
+        }
+
+        /**
+         * Calculate the authorizations for this request based on the principal and the queryAuths if any.
+         *
+         * @return a valid set of query auths, will throw an exception if this isn't possible.
+         * @throws QueryException
+         *             and exception if there was a problem calculating the auths
+         */
+        private Set<Authorizations> initializeAuthorizations() throws QueryException {
+            if (authorizations == null) {
+                log.trace("Initializing authorizations: userDn: {}, query: {}", userDn, queryAuths);
+                if (datawavePrincipal == null) {
+                    throw new QueryException("Failed to get user principal from request, unable to proceed");
+                }
+
+                try {
+                    if (queryAuths == null) {
+                        authorizations = AuthorizationsUtil.buildAuthorizations(datawavePrincipal.getAuthorizations());
+                    } else {
+                        final String downgradedAuths = AuthorizationsUtil.downgradeUserAuths(queryAuths, datawavePrincipal, datawavePrincipal);
+                        authorizations = AuthorizationsUtil.buildAuthorizations(Collections.singleton(AuthorizationsUtil.splitAuths(downgradedAuths)));
+                    }
+
+                } catch (Exception e) {
+                    throw new QueryException("Failed to get user query authorizations", e);
+                }
+
+                log.debug("Authorizations initialized: userDn: {}, query: {}, final auths: {}", userDn, queryAuths, authorizations);
+            }
+            return authorizations;
+        }
+
+        /**
+         * Initialize the accumulo client
+         *
+         * @return a valid client, will throw an exception if this isn't possibly
+         * @throws QueryException
+         *             if the client can't be initialized.
+         */
+        protected AccumuloClient initializeAccumuloClient() throws QueryException {
+            if (client == null) {
+                log.trace("Initializing accumulo client");
+                UUID transactionUUID = java.util.UUID.randomUUID();
+
+                if (connectionFactory == null) {
+                    throw new QueryException("The accumulo connection factory isn't present, unable to proceed");
+                }
+
+                Map<String,String> trackingMap = connectionFactory.getTrackingMap(Thread.currentThread().getStackTrace());
+                if (trackingMap != null) {
+                    trackingMap.put("query.user", userDn);
+                    trackingMap.put("query.id", transactionUUID.toString());
+                    trackingMap.put("query.query", "annotation manager");
+                } else {
+                    log.info("Accumulo connection tracking map was null, this isn't fatal, but odd.");
+                }
+
+                if (accumuloConnectionRequestBean == null) {
+                    throw new QueryException("The accumulo connection request manager isn't present, unable to proceed");
+                }
+
+                accumuloConnectionRequestBean.requestBegin(transactionUUID.toString(), userDn, trackingMap);
+                try {
+                    client = connectionFactory.getClient(userDn, proxyServers, config.getConnPoolName(), config.getPriority(), trackingMap);
+                } catch (Exception e) {
+                    throw new QueryException("Unable to get Accumulo client, exception encountered: ", e);
+                } finally {
+                    accumuloConnectionRequestBean.requestEnd(transactionUUID.toString());
+                }
+                log.debug("Accumulo client initialized successfully");
+
+            }
+            return client;
+        }
+
+        /**
+         * Initialize the lookup uuid service
+         *
+         * @return a valid lookup uuid service, throws an exception if this isn't possible.
+         * @throws QueryException
+         *             if the lookup uuid service can't be initialized.
+         */
+        protected LookupUUIDService initializeLookupUUIDService() throws QueryException {
+            if (lookupUUIDService == null) {
+
+                if (config == null) {
+                    throw new QueryException("The lookup uuid service configuration isn't present, unable to proceed");
+                }
+
+                if (responseObjectFactory == null) {
+                    throw new QueryException("The response object factory isn't present, unable to proceed");
+                }
+
+                log.trace("Initializing lookupUUIDService");
+                final Set<Authorizations> authorizations = initializeAuthorizations();
+                final AccumuloClient client = initializeAccumuloClient();
+                lookupUUIDService = new LookupUUIDService(config.getLookupUUIDServiceConfig(), client, authorizations, responseObjectFactory,
+                                config.getLookupUUIDQueryLogic());
+                log.debug("LookupUUID service initialized successfully");
+            }
+            return lookupUUIDService;
+        }
+
+        /**
+         * Initialize the annotation service, specifically the data access layer.
+         *
+         * @return a valid annotation data access object, throws an exception if this isn't possible.
+         * @throws QueryException
+         *             if the annotation data access object can't be initialized.
+         */
+        protected AnnotationDataAccess initializeAnnotationService() throws QueryException {
+            if (annotationDataAccess == null) {
+                log.trace("Initializing annotation data access layer");
+                final Set<Authorizations> authorizations = initializeAuthorizations();
+                final AccumuloClient client = initializeAccumuloClient();
+                final AccumuloAnnotationSerializer annotationSerializer = new AccumuloAnnotationSerializer(
+                                config.getAnnotationConfig().getVisibilityTransformer(), config.getAnnotationConfig().getTimestampTransformer());
+                final AccumuloAnnotationSourceSerializer annotationSourceSerializer = new AccumuloAnnotationSourceSerializer(
+                                config.getAnnotationConfig().getVisibilityTransformer(), config.getAnnotationConfig().getTimestampTransformer());
+                annotationDataAccess = new AnnotationDataAccess(client, authorizations, config.getAnnotationConfig().getAnnotationTableName(),
+                                config.getAnnotationConfig().getAnnotationSourceTableName(), annotationSerializer, annotationSourceSerializer);
+                log.debug("Annotation data access layer initialized successfully");
+            }
+            return annotationDataAccess;
+        }
+
+        /**
+         * Return the accumulo client currently held by this class. If there's a problem returning the client, logs a warning. Sets the internal client state to
+         * null.
+         */
+        protected void returnAccumuloClient() {
+            try {
+                log.trace("Returning accumulo client");
+                connectionFactory.returnClient(client);
+                log.debug("Accumulo client returned");
+            } catch (Exception e) {
+                log.warn("Error when returning client", e);
+            } finally {
+                client = null;
+            }
+        }
     }
 }

--- a/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanFunctionalTest.java
+++ b/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanFunctionalTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -85,32 +86,34 @@ public class AnnotationManagerBeanFunctionalTest {
 
     @Mock
     @Produces
-    private static EJBContext ctx;
+    private EJBContext ctx;
 
     @Mock
     @Produces
-    private static AccumuloConnectionFactory connectionFactory;
+    private AccumuloConnectionFactory connectionFactory;
 
     @Mock
     @Produces
-    private static QueryExecutorBean queryExecutorBean;
+    private QueryExecutorBean queryExecutorBean;
 
     @Mock
     @Produces
-    private static QueryLogicFactory queryLogicFactory;
+    private QueryLogicFactory queryLogicFactory;
 
     @Mock
     @Produces
-    private static UserOperations userOperations;
+    private UserOperations userOperations;
 
     @Mock
-    private static AccumuloConnectionRequestBean accumuloConnectionRequestBean;
+    private AccumuloConnectionRequestBean accumuloConnectionRequestBean;
 
     @Produces
     private static final ResponseObjectFactory responseObjectFactory = new DefaultResponseObjectFactory();
 
     @Inject
-    @SpringBean(name = "AnnotationManager")
+    @SpringBean(name = "AnnotationManagerConfig")
+    protected AnnotationManagerConfig annotationManagerConfig;
+
     protected AnnotationManager annotationManager;
 
     @Deployment
@@ -142,7 +145,7 @@ public class AnnotationManagerBeanFunctionalTest {
     }
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setupTestData() throws Exception {
 
         QueryTestTableHelper queryTestTableHelper = new QueryTestTableHelper(ExcerptTest.DocumentRangeTest.class.toString(), log);
         client = queryTestTableHelper.client;
@@ -159,7 +162,7 @@ public class AnnotationManagerBeanFunctionalTest {
         AccumuloAnnotationSerializer annotationSerializer = new AccumuloAnnotationSerializer(visibilityTransformer, timestampTransformer);
         AccumuloAnnotationSourceSerializer annotationSourceSerializer = new AccumuloAnnotationSourceSerializer(visibilityTransformer, timestampTransformer);
 
-        Authorizations auths = new Authorizations("ALL", "PUBLIC");
+        Authorizations auths = new Authorizations("ALL", "PUBLIC", "PRIVATE");
         testDao = new AnnotationDataAccess(client, Set.of(auths), annotationTableName, annotationSourceTableName, annotationSerializer,
                         annotationSourceSerializer);
 
@@ -182,6 +185,12 @@ public class AnnotationManagerBeanFunctionalTest {
         PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
         PrintUtility.printTable(client, auths, annotationTableName);
         PrintUtility.printTable(client, auths, annotationSourceTableName);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        log.setLevel(Level.TRACE);
 
         ctx = EasyMock.createMock(EJBContext.class);
 
@@ -197,7 +206,7 @@ public class AnnotationManagerBeanFunctionalTest {
         //@formatter:on
 
         DatawavePrincipal principal = new DatawavePrincipal(List.of(user));
-        EasyMock.expect(ctx.getCallerPrincipal()).andReturn(principal).anyTimes();
+        EasyMock.expect(ctx.getCallerPrincipal()).andReturn(principal).times(1);
 
         connectionFactory = EasyMock.createMock(AccumuloConnectionFactory.class);
         EasyMock.expect(connectionFactory.getTrackingMap(EasyMock.anyObject())).andReturn(new HashMap<>()).anyTimes();
@@ -223,11 +232,40 @@ public class AnnotationManagerBeanFunctionalTest {
         accumuloConnectionRequestBean = EasyMock.createMock(AccumuloConnectionRequestBean.class);
 
         EasyMock.replay(ctx, connectionFactory);
+
+        annotationManager = new AnnotationManagerBean();
+
+        // Inject mocks and config into private fields
+        setField(annotationManager, "ctx", ctx);
+        setField(annotationManager, "connectionFactory", connectionFactory);
+        setField(annotationManager, "accumuloConnectionRequestBean", accumuloConnectionRequestBean);
+        setField(annotationManager, "config", annotationManagerConfig);
+        setField(annotationManager, "responseObjectFactory", responseObjectFactory);
+
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
     }
 
     public static void addAnnotationTestData(AccumuloClient client) {
         // TODO: add annotation source data
         testDao.addAnnotation(generateCorleoneAnnotation());
+        testDao.addAnnotation(generatePrivateAnnotation());
     }
 
     public static Annotation generateCorleoneAnnotation() {
@@ -253,12 +291,27 @@ public class AnnotationManagerBeanFunctionalTest {
         //@formatter:on
     }
 
-    @Before
-    public void setup() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-        log.setLevel(Level.TRACE);
-        AnnotationManagerBean bean = (AnnotationManagerBean) annotationManager;
-        bean.setEJBContext(ctx);
+    public static Annotation generatePrivateAnnotation() {
+        AnnotationSource baseAnnotationSource = generateTestAnnotationSource();
+        AnnotationSource annotationSource = AnnotationUtils.injectAnnotationSourceHashes(baseAnnotationSource);
+
+        Map<String,String> metadata = new HashMap<>();
+        metadata.put("UUID", "BRASI");
+        metadata.put("visibility", "PRIVATE");
+        metadata.put("created_date", "2025-10-02T00:00:00.000Z");
+
+        //@formatter:off
+        return Annotation.newBuilder()
+                .setShard("20130102_0")
+                .setDataType("test")
+                .setUid("-a4vymb.ntjagn.-pyz1jv")
+                .setAnnotationType("corleoneAnnotationType")
+                .setDocumentId("BRASI")
+                .setSource(annotationSource)
+                .addAllSegments(List.of(generateMultiTestSegment()))
+                .putAllMetadata(metadata)
+                .build();
+        //@formatter:on
     }
 
     @Test
@@ -434,6 +487,91 @@ public class AnnotationManagerBeanFunctionalTest {
         assertFalse(annotationList.isEmpty());
         assertEquals(1, annotationList.size());
         assertAnnotationsEqual(expectedAnnotation, annotationList.iterator().next());
+    }
+
+    @Test
+    public void testGetPrivateAnnotationFailure() {
+        Annotation testAnnotation = generateTestAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        Response response = annotationManager.getAnnotation("DOCUMENT", "20130102_0/test/-a4vymb.ntjagn.-pyz1jv", "A9F9A0B4");
+        assertResponseStatus(404, response);
+    }
+
+    @Test
+    public void testGetPrivateAnnotationSuccess() {
+        //@formatter:off
+        DatawaveUser user = new DatawaveUser(
+                SubjectIssuerDNPair.of("testUser"),
+                DatawaveUser.UserType.USER,
+                List.of("ALL", "PUBLIC","PRIVATE"),
+                null,
+                null,
+                -1L
+        );
+        //@formatter:on
+
+        DatawavePrincipal principal = new DatawavePrincipal(List.of(user));
+        EasyMock.reset(ctx);
+        EasyMock.expect(ctx.getCallerPrincipal()).andReturn(principal).times(1);
+        EasyMock.replay(ctx);
+
+        Annotation testAnnotation = generatePrivateAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        Response response = annotationManager.getAnnotation("DOCUMENT", "20130102_0/test/-a4vymb.ntjagn.-pyz1jv", "A9F9A0B4");
+        assertResponseStatus(200, response);
+        List<Annotation> annotationList = assertExpectedEntity(List.class, response);
+        assertFalse(annotationList.isEmpty());
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.iterator().next());
+    }
+
+    @Test
+    public void testValidatePrivateAuthorizationReset() {
+        Annotation testAnnotation = generatePrivateAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+
+        // validates that authorizations are reset across multiple calls.
+        //@formatter:off
+        DatawaveUser privateUser = new DatawaveUser(
+                SubjectIssuerDNPair.of("testUser"),
+                DatawaveUser.UserType.USER,
+                List.of("ALL", "PUBLIC","PRIVATE"),
+                null,
+                null,
+                -1L
+        );
+        //@formatter:on
+
+        DatawavePrincipal privatePrincipal = new DatawavePrincipal(List.of(privateUser));
+        EasyMock.reset(ctx);
+        EasyMock.expect(ctx.getCallerPrincipal()).andReturn(privatePrincipal).times(1);
+        EasyMock.replay(ctx);
+
+        Response privateResponse = annotationManager.getAnnotation("DOCUMENT", "20130102_0/test/-a4vymb.ntjagn.-pyz1jv", "A9F9A0B4");
+        assertResponseStatus(200, privateResponse);
+        List<Annotation> privateAnnotationList = assertExpectedEntity(List.class, privateResponse);
+        assertFalse(privateAnnotationList.isEmpty());
+        assertEquals(1, privateAnnotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, privateAnnotationList.iterator().next());
+
+        //@formatter:off
+        DatawaveUser publicUser = new DatawaveUser(
+                SubjectIssuerDNPair.of("testUser"),
+                DatawaveUser.UserType.USER,
+                List.of("ALL", "PUBLIC"),
+                null,
+                null,
+                -1L
+        );
+        //@formatter:on
+
+        DatawavePrincipal publicPrincipal = new DatawavePrincipal(List.of(publicUser));
+        EasyMock.reset(ctx);
+        EasyMock.expect(ctx.getCallerPrincipal()).andReturn(publicPrincipal).times(1);
+        EasyMock.replay(ctx);
+
+        Response publicannotationResponse = annotationManager.getAnnotation("DOCUMENT", "20130102_0/test/-a4vymb.ntjagn.-pyz1jv", "A9F9A0B4");
+        assertResponseStatus(404, publicannotationResponse);
     }
 
     @Test

--- a/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanRequestStateTest.java
+++ b/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanRequestStateTest.java
@@ -1,0 +1,148 @@
+package datawave.webservice.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.ejb.EJBContext;
+import javax.ws.rs.core.Response;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import datawave.annotation.data.transform.DefaultTimestampTransformer;
+import datawave.annotation.data.transform.DefaultVisibilityTransformer;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.query.config.annotation.AnnotationConfig;
+import datawave.security.authorization.DatawavePrincipal;
+import datawave.security.authorization.DatawaveUser;
+import datawave.security.authorization.SubjectIssuerDNPair;
+import datawave.webservice.query.runner.AccumuloConnectionRequestBean;
+
+/**
+ * Unit tests verifying that per-request state in {@link AnnotationManagerBean} is properly implemented by observing interactions with the Accumulo connection
+ * factory and connection request bean.
+ */
+public class AnnotationManagerBeanRequestStateTest {
+
+    @Mock
+    private EJBContext ctx;
+
+    @Mock
+    private AccumuloConnectionFactory connectionFactory;
+
+    @Mock
+    private AccumuloConnectionRequestBean accumuloConnectionRequestBean;
+
+    @Mock
+    private AccumuloClient accumuloClient;
+
+    private AnnotationManagerBean bean;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        bean = new AnnotationManagerBean();
+
+        // Build a real AnnotationManagerConfig with a real AnnotationConfig
+        AnnotationConfig annotationConfig = new AnnotationConfig();
+        annotationConfig.setAnnotationTableName("annotation");
+        annotationConfig.setAnnotationSourceTableName("annotationSource");
+        annotationConfig.setVisibilityTransformer(new DefaultVisibilityTransformer());
+        annotationConfig.setTimestampTransformer(new DefaultTimestampTransformer());
+
+        AnnotationManagerConfig config = new AnnotationManagerConfig();
+        config.setAnnotationConfig(annotationConfig);
+        config.setConnPoolName("default");
+        config.setPriority(AccumuloConnectionFactory.Priority.NORMAL);
+        config.setEnableInternalIdLookup(true);
+
+        // Inject mocks and config into private fields
+        setField(bean, "ctx", ctx);
+        setField(bean, "connectionFactory", connectionFactory);
+        setField(bean, "accumuloConnectionRequestBean", accumuloConnectionRequestBean);
+        setField(bean, "config", config);
+
+        // Set up the principal
+        DatawaveUser user = new DatawaveUser(SubjectIssuerDNPair.of("testUser"), DatawaveUser.UserType.USER, List.of("ALL", "PUBLIC"), null, null, -1L);
+        DatawavePrincipal principal = new DatawavePrincipal(List.of(user));
+        when(ctx.getCallerPrincipal()).thenReturn(principal);
+
+        // Set up connection factory to return a mock client
+        when(connectionFactory.getTrackingMap(any())).thenReturn(new HashMap<>());
+        when(connectionFactory.getClient(any(), any(), any(), any(), any())).thenReturn(accumuloClient);
+    }
+
+    @Test
+    public void testConnectionFactoryIsCalledOncePerRequest() throws Exception {
+        // First request
+        bean.getAnnotationSource("hash1");
+
+        // Second request on the same bean instance (simulates EJB pool reuse)
+        bean.getAnnotationSource("hash2");
+
+        // The client should have been obtained twice — once per request,
+        // proving state was properly reset between requests.
+        verify(connectionFactory, times(2)).getClient(any(), any(), any(), any(), any());
+
+        // And the client should have been returned to the pool twice
+        verify(connectionFactory, times(2)).returnClient(any());
+    }
+
+    @Test
+    public void testConnectionBeanIsCalledOncePerRequest() throws Exception {
+        // First request
+        bean.getAnnotationSource("hash1");
+
+        // Second request on the same bean instance (simulates EJB pool reuse)
+        bean.getAnnotationSource("hash2");
+
+        // The client should have been obtained twice — once per request,
+        // proving state was properly reset between requests.
+        verify(accumuloConnectionRequestBean, times(2)).requestBegin(any(), any(), any());
+
+        // And the client should have been returned to the pool twice
+        verify(accumuloConnectionRequestBean, times(2)).requestEnd(any());
+    }
+
+    @Test
+    public void testConnectionFactoryFailureImpactsSecondRequest() throws Exception {
+        // Simulate an error during client acquisition on the second call
+        when(connectionFactory.getClient(any(), any(), any(), any(), any())).thenReturn(accumuloClient).thenThrow(new RuntimeException("connection failure"));
+
+        // First request
+        bean.getAnnotationSource("hash1");
+
+        // Second request will fail during initialization
+        Response response = bean.getAnnotationSource("hash2");
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
The AnnotationManagerBean's lifecycle as a stateless bean meant we were caching some objects across requests. This updates the AnnotationManagerBean to maintain per-reuqest state explicitly instead of assuming the bean framework will do it for us.