### PR TITLE
Integrate ScanMonitor into RegexIndexLookups

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/JexlNodeFactory.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/JexlNodeFactory.java
@@ -104,7 +104,7 @@ public class JexlNodeFactory {
         }
 
         // no expansions needed if the field name threshold is exceeded
-        if (fieldsToValues.isKeyThresholdExceeded()) {
+        if (fieldsToValues.isKeyThresholdExceeded() || fieldsToValues.isUnfieldedTimeoutSeen()) {
             throw new DatawaveFatalQueryException("Failed to expand unfielded term");
         }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/AsyncIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/AsyncIndexLookup.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.log4j.Logger;
@@ -32,11 +31,6 @@ public abstract class AsyncIndexLookup extends IndexLookup {
 
     // flag for unfielded lookups
     protected final boolean unfieldedLookup;
-
-    // track state for common index expansion failures
-    protected final AtomicBoolean exceededTimeoutThreshold = new AtomicBoolean(false);
-    protected final AtomicBoolean exceededValueThreshold = new AtomicBoolean(false);
-    protected final AtomicBoolean exceptionSeen = new AtomicBoolean(false);
 
     protected ScanMonitor monitor;
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BaseRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BaseRegexIndexLookup.java
@@ -2,16 +2,14 @@ package datawave.query.jexl.lookups;
 
 import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.data.Range;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import datawave.core.iterators.TimeoutExceptionIterator;
-import datawave.core.iterators.TimeoutIterator;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
 
@@ -26,7 +24,7 @@ public abstract class BaseRegexIndexLookup extends AsyncIndexLookup {
     protected final Range range;
     protected final boolean reverse;
 
-    protected final CountDownLatch latch;
+    protected Future<?> future;
 
     // used when scanning the shard reverse index
     private final StringBuilder sb = new StringBuilder();
@@ -37,7 +35,6 @@ public abstract class BaseRegexIndexLookup extends AsyncIndexLookup {
         this.pattern = pattern;
         this.range = range;
         this.reverse = reverse;
-        this.latch = new CountDownLatch(1);
     }
 
     protected String getTableName() {
@@ -52,13 +49,6 @@ public abstract class BaseRegexIndexLookup extends AsyncIndexLookup {
         return config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : tableName;
     }
 
-    protected IteratorSetting createTimeoutIterator() {
-        long maxTime = (long) (config.getMaxIndexScanTimeMillis() * 1.25);
-        IteratorSetting iterator = new IteratorSetting(5, TimeoutIterator.class);
-        iterator.addOption(TimeoutIterator.MAX_SESSION_TIME, Long.valueOf(maxTime).toString());
-        return iterator;
-    }
-
     /**
      * Extending classes decide how to build a regex iterator depending on if the regex is fielded or not
      *
@@ -66,26 +56,23 @@ public abstract class BaseRegexIndexLookup extends AsyncIndexLookup {
      */
     protected abstract IteratorSetting createRegexIterator();
 
-    protected IteratorSetting createTimeoutExceptionIterator() {
-        return new IteratorSetting(config.getBaseIteratorPriority() + 100, TimeoutExceptionIterator.class);
-    }
-
     /**
      * Waits for the future to complete before returning the index lookup map
      */
     protected void await() {
-        synchronized (latch) {
-            if (latch.getCount() == 1) {
-                try {
-                    latch.await();
-                } catch (InterruptedException e) {
-                    log.error(e.getMessage(), e);
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
+        try {
+            if (future != null) {
+                future.get();
             }
+        } catch (Exception e) {
+            handleException();
         }
     }
+
+    /**
+     * Extending classes deal with exceptions differently
+     */
+    protected abstract void handleException();
 
     /**
      * Reverses the value coming off the shard reverse index

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -87,14 +87,13 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
      * This method is responsible for creating a Runnable, submitting it to the executor and registering the future with the {@link ScanMonitor}.
      */
     @Override
-    public synchronized void submit() {
+    public void submit() {
         if (indexLookupMap == null) {
+            Preconditions.checkNotNull(monitor, "BoundedRangeIndexLookup requires a ScanMonitor");
             indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
 
             Runnable runnable = createRunnable(getTableName(), config.getAuthorizations().iterator().next());
             future = execService.submit(runnable);
-
-            Preconditions.checkNotNull(monitor, "BoundedRange index expansion requires a ScanMonitor");
             monitor.registerTask(future, config.getMaxIndexScanTimeMillis());
         }
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -12,9 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 
 import datawave.core.iterators.FieldedRegexExpansionIterator;
-import datawave.core.iterators.TimeoutExceptionIterator;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.time.DateHelper;
@@ -34,7 +35,10 @@ public class FieldedRegexIndexLookup extends BaseRegexIndexLookup {
                     Range range, boolean reverse) {
         super(config, scannerFactory, false, execService, pattern, range, reverse);
         this.field = field;
-        log.info("Created FieldedRegexIndexLookup with field {} and pattern {}", field, pattern);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Created FieldedRegexIndexLookup with field {} and pattern {}", field, pattern);
+        }
     }
 
     @Override
@@ -46,63 +50,53 @@ public class FieldedRegexIndexLookup extends BaseRegexIndexLookup {
             if (config.getMaxIndexScanTimeMillis() == 0) {
                 indexLookupMap.put(field, "");
                 indexLookupMap.get(field).setThresholdExceeded();
-                latch.countDown();
                 return;
             }
 
-            execService.submit(() -> {
-                String tableName = getTableName();
-                try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
-                    String hintKey = getHintKey(tableName);
-                    scanner.setExecutionHints(Map.of(tableName, hintKey));
+            Preconditions.checkNotNull(monitor, "FieldedRegexIndexLookup requires a ScanMonitor");
+            Runnable runnable = createRunnable();
 
-                    IteratorSetting timeoutIterator = createTimeoutIterator();
-                    scanner.addScanIterator(timeoutIterator);
+            future = execService.submit(runnable);
+            monitor.registerTask(future, config.getMaxIndexScanTimeMillis());
+        }
+    }
 
-                    IteratorSetting regexIterator = createRegexIterator();
-                    scanner.addScanIterator(regexIterator);
+    /**
+     * The created runnable handles everything with configuring a scanner, parsing results and putting them into the {@link #indexLookupMap} and handling
+     * exceptions.
+     * <p>
+     * Note: it is critical that any scanner created here is used with a try-with-resources block.
+     *
+     */
+    protected Runnable createRunnable() {
+        return () -> {
+            String tableName = getTableName();
+            try (Scanner scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
+                String hintKey = getHintKey(tableName);
+                scanner.setExecutionHints(Map.of(tableName, hintKey));
 
-                    IteratorSetting timeoutExceptionIterator = createTimeoutExceptionIterator();
-                    scanner.addScanIterator(timeoutExceptionIterator);
+                IteratorSetting regexIterator = createRegexIterator();
+                scanner.addScanIterator(regexIterator);
 
-                    scanner.setRange(range);
+                scanner.setRange(range);
 
-                    scanner.fetchColumnFamily(new Text(field));
+                scanner.fetchColumnFamily(new Text(field));
 
-                    for (Map.Entry<Key,Value> entry : scanner) {
-                        Key key = entry.getKey();
-
-                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
-                            exceededTimeoutThreshold.set(true);
-                            indexLookupMap.setTimeoutExceeded(true);
-                            indexLookupMap.put(field, "");
-                            indexLookupMap.get(field).setThresholdExceeded();
-                            break;
-                        }
-
-                        String value = key.getRow().toString();
-                        if (reverse) {
-                            value = reverse(value);
-                        }
-
-                        indexLookupMap.put(field, value);
+                for (Map.Entry<Key,Value> entry : scanner) {
+                    Key key = entry.getKey();
+                    String value = key.getRow().toString();
+                    if (reverse) {
+                        value = reverse(value);
                     }
 
-                } catch (ExceededThresholdException e) {
-                    log.warn("ExceededThresholdException", e);
-                    exceededValueThreshold.set(true);
-                    indexLookupMap.get(field).setThresholdExceeded();
-                } catch (Exception e) {
-                    exceptionSeen.set(true);
-                    indexLookupMap.setExceptionSeen(true);
-                    indexLookupMap.setTimeoutExceeded(true); // stub this out
-                    indexLookupMap.get(field).setThresholdExceeded();
-                    log.error("Unexpected exception seen", e);
-                } finally {
-                    latch.countDown();
+                    indexLookupMap.put(field, value);
                 }
-            });
-        }
+
+            } catch (Exception e) {
+                log.error("Unexpected exception seen", e);
+                handleException();
+            }
+        };
     }
 
     @Override
@@ -124,5 +118,19 @@ public class FieldedRegexIndexLookup extends BaseRegexIndexLookup {
     public IndexLookupMap lookup() {
         await();
         return indexLookupMap;
+    }
+
+    /**
+     * An exception while expanding a fielded regex retains the field but clears all collected values, if any such values exist.
+     * <p>
+     * The entry is then marked as threshold exceeded.
+     */
+    @Override
+    protected void handleException() {
+        log.debug("marking regex as exceeded");
+        indexLookupMap.setExceptionSeen(true);
+        indexLookupMap.setTimeoutExceeded(true); // stub this out
+        indexLookupMap.put(field, "");
+        indexLookupMap.get(field).setThresholdExceeded();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/IndexLookupMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/IndexLookupMap.java
@@ -22,6 +22,7 @@ public class IndexLookupMap implements Map<String,ValueSet>, Serializable {
     // recorded state about the index lookup operation
     private boolean exceptionSeen = false;
     private boolean timeoutExceeded = false;
+    private boolean unfieldedTimeoutSeen = false;
 
     public IndexLookupMap(int keyThreshold, int valueThreshold) {
         this.keyThreshold = keyThreshold;
@@ -30,6 +31,14 @@ public class IndexLookupMap implements Map<String,ValueSet>, Serializable {
 
     public boolean isKeyThresholdExceeded() {
         return this.exceededKeyThreshold;
+    }
+
+    public boolean isUnfieldedTimeoutSeen() {
+        return this.unfieldedTimeoutSeen;
+    }
+
+    public void setUnfieldedTimeoutSeen() {
+        this.unfieldedTimeoutSeen = true;
     }
 
     public int size() {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/RegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/RegexIndexLookup.java
@@ -46,6 +46,7 @@ import datawave.webservice.query.exception.PreConditionFailedQueryException;
 /**
  * An asynchronous index lookup which looks up concrete values for the specified regex term.
  */
+@Deprecated
 public class RegexIndexLookup extends AsyncIndexLookup {
 
     private static final Object LOCK = new Object();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
@@ -122,19 +122,6 @@ public class UnfieldedRegexIndexLookup extends BaseRegexIndexLookup {
     }
 
     /**
-     * Wait for the future to complete before returning the {@link IndexLookupMap}
-     */
-    protected void await() {
-        try {
-            if (future != null) {
-                future.get();
-            }
-        } catch (Exception e) {
-            handleException();
-        }
-    }
-
-    /**
      * An exception while expanding an unfielded regex clears the entire index lookup map.
      */
     @Override

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -15,8 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 
-import datawave.core.iterators.TimeoutExceptionIterator;
 import datawave.core.iterators.UnfieldedRegexExpansionIterator;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.tables.ScannerFactory;
@@ -51,53 +52,53 @@ public class UnfieldedRegexIndexLookup extends BaseRegexIndexLookup {
         if (indexLookupMap == null) {
             indexLookupMap = new IndexLookupMap(keyThreshold, valueThreshold);
 
-            execService.submit(() -> {
-                String tableName = reverse ? config.getReverseIndexTableName() : getTableName();
-                try (var scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
-                    String hintKey = getHintKey(tableName);
-                    scanner.setExecutionHints(Map.of(tableName, hintKey));
+            Preconditions.checkNotNull(monitor, "UnfieldedRegexIndexLookup requires a ScanMonitor");
+            Runnable runnable = createRunnable();
 
-                    // use a different timeout threshold for unfielded expansions
-                    IteratorSetting timeoutIterator = createTimeoutIterator();
-                    scanner.addScanIterator(timeoutIterator);
-
-                    IteratorSetting regexIterator = createRegexIterator();
-                    scanner.addScanIterator(regexIterator);
-
-                    IteratorSetting timeoutExceptionIterator = createTimeoutExceptionIterator();
-                    scanner.addScanIterator(timeoutExceptionIterator);
-
-                    scanner.setRange(range);
-
-                    for (String field : fields) {
-                        scanner.fetchColumnFamily(new Text(field));
-                    }
-
-                    for (Map.Entry<Key,Value> entry : scanner) {
-                        Key key = entry.getKey();
-
-                        if (TimeoutExceptionIterator.exceededTimedValue(entry)) {
-                            indexLookupMap.setTimeoutExceeded(true);
-                            indexLookupMap.clear(); // reset state so that ANYFIELD is marked NOFIELD
-                            break;
-                        }
-
-                        String value = key.getRow().toString();
-                        String field = key.getColumnFamily().toString();
-                        if (reverse) {
-                            value = reverse(value);
-                        }
-                        indexLookupMap.put(field, value);
-                    }
-
-                } catch (Exception e) {
-                    indexLookupMap.setExceptionSeen(true);
-                    log.error(e.getMessage(), e);
-                } finally {
-                    latch.countDown();
-                }
-            });
+            future = execService.submit(runnable);
+            monitor.registerTask(future, config.getMaxAnyFieldScanTimeMillis());
         }
+    }
+
+    /**
+     * The created runnable handles everything with configuring a scanner, parsing results and putting them into the {@link #indexLookupMap} and handling
+     * exceptions.
+     * <p>
+     * Note: it is critical that any scanner created here is used with a try-with-resources block.
+     *
+     */
+    protected Runnable createRunnable() {
+        return () -> {
+            String tableName = reverse ? config.getReverseIndexTableName() : getTableName();
+            try (Scanner scanner = config.getClient().createScanner(tableName, config.getAuthorizations().iterator().next())) {
+                String hintKey = getHintKey(tableName);
+                scanner.setExecutionHints(Map.of(tableName, hintKey));
+
+                IteratorSetting regexIterator = createRegexIterator();
+                scanner.addScanIterator(regexIterator);
+
+                scanner.setRange(range);
+
+                for (String field : fields) {
+                    scanner.fetchColumnFamily(new Text(field));
+                }
+
+                for (Map.Entry<Key,Value> entry : scanner) {
+                    Key key = entry.getKey();
+                    String value = key.getRow().toString();
+                    String field = key.getColumnFamily().toString();
+                    if (reverse) {
+                        value = reverse(value);
+                    }
+                    indexLookupMap.put(field, value);
+                }
+
+            } catch (Exception e) {
+                // assume any exception is indicative of a timeout
+                handleException();
+                log.error(e.getMessage(), e);
+            }
+        };
     }
 
     @Override
@@ -118,5 +119,29 @@ public class UnfieldedRegexIndexLookup extends BaseRegexIndexLookup {
     public IndexLookupMap lookup() {
         await();
         return indexLookupMap;
+    }
+
+    /**
+     * Wait for the future to complete before returning the {@link IndexLookupMap}
+     */
+    protected void await() {
+        try {
+            if (future != null) {
+                future.get();
+            }
+        } catch (Exception e) {
+            handleException();
+        }
+    }
+
+    /**
+     * An exception while expanding an unfielded regex clears the entire index lookup map.
+     */
+    @Override
+    protected void handleException() {
+        indexLookupMap.setExceptionSeen(true);
+        indexLookupMap.setTimeoutExceeded(true);
+        indexLookupMap.setUnfieldedTimeoutSeen();
+        indexLookupMap.clear();
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitor.java
@@ -40,6 +40,7 @@ import datawave.query.exceptions.DoNotPerformOptimizedQueryException;
 import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.lookups.AsyncIndexLookup;
 import datawave.query.jexl.lookups.FieldedRegexIndexLookup;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.jexl.lookups.IndexLookupMap;
@@ -690,6 +691,10 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
             logResult(currentNode, fieldsToTerms);
         }
 
+        if (fieldsToTerms.isUnfieldedTimeoutSeen()) {
+            throw new DatawaveFatalQueryException("Failed to expand unfielded term");
+        }
+
         if (futureJexlNode.isIgnoreComposites()) {
             // composites should be removed prior to building the index expansion iterators
             // and should never be returned to the webservice
@@ -699,6 +704,7 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         JexlNode newNode;
 
         // If we have no children, it's impossible to find any records, so this query returns no results
+        // unless the expansion is unfielded in which case throw an exception. handle that case above.
         if (fieldsToTerms.isEmpty()) {
             // if there was no field expansion then replace _ANYFIELD_ with _NOFIELD_, the RangeStream will drop
             // this term from the query
@@ -738,7 +744,10 @@ public class RegexIndexExpansionVisitor extends BaseIndexExpansionVisitor {
         validatePattern(pattern);
 
         RefactoredRangeDescription description = getRegexRange(field, pattern);
-        return new FieldedRegexIndexLookup(config, scannerFactory, executor, field, pattern, description.range, description.isForReverseIndex);
+        AsyncIndexLookup lookup = new FieldedRegexIndexLookup(config, scannerFactory, executor, field, pattern, description.range,
+                        description.isForReverseIndex);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
@@ -29,6 +29,7 @@ import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.EmptyUnfieldedTermExpansionException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
+import datawave.query.jexl.lookups.AsyncIndexLookup;
 import datawave.query.jexl.lookups.EmptyIndexLookup;
 import datawave.query.jexl.lookups.FieldExpansionIndexLookup;
 import datawave.query.jexl.lookups.IndexLookup;
@@ -297,7 +298,10 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
             return new EmptyIndexLookup(config);
         }
 
-        return new UnfieldedRegexIndexLookup(config, scannerFactory, executor, pattern, description.range, description.isForReverseIndex, expansionFields);
+        AsyncIndexLookup lookup = new UnfieldedRegexIndexLookup(config, scannerFactory, executor, pattern, description.range, description.isForReverseIndex,
+                        expansionFields);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
@@ -106,7 +106,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     private static final boolean useMAC = false;
 
     // switch between old code and new code
-    private final boolean useNewIndexLookups = false;
+    private final boolean useNewIndexLookups = true;
 
     // 10 values per prefix, low expansion thresholds, low scan thresholds
     // using this tests can simulate exceptions or timeouts on initial seek vs. next calls

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BaseIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/BaseIndexLookupTest.java
@@ -64,6 +64,9 @@ public abstract class BaseIndexLookupTest {
 
     private final StringBuilder sb = new StringBuilder();
 
+    protected ScanMonitor monitor;
+    private ExecutorService monitorExecutor;
+
     @BeforeAll
     public static void setup() throws Exception {
         InMemoryInstance instance = new InMemoryInstance();
@@ -93,11 +96,16 @@ public abstract class BaseIndexLookupTest {
         query = null;
         result = null;
         executor = Executors.newFixedThreadPool(5);
+
+        monitor = ScanMonitor.of("query-id", null);
+        monitorExecutor = Executors.newSingleThreadExecutor();
+        monitorExecutor.submit(monitor);
     }
 
     @AfterEach
     public void afterEach() {
         executor.shutdownNow();
+        monitorExecutor.shutdownNow();
     }
 
     protected void addDelayIterator(int delay) {

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldExpansionIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldExpansionIndexLookupTest.java
@@ -117,6 +117,8 @@ public class FieldExpansionIndexLookupTest extends BaseIndexLookupTest {
 
     private AsyncIndexLookup createLookup(String value) {
         ScannerFactory scannerFactory = new ScannerFactory(client);
-        return new FieldExpansionIndexLookup(config, scannerFactory, value, indexedFields, executor);
+        AsyncIndexLookup lookup = new FieldExpansionIndexLookup(config, scannerFactory, value, indexedFields, executor);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldedRegexIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/FieldedRegexIndexLookupTest.java
@@ -1,6 +1,5 @@
 package datawave.query.jexl.lookups;
 
-import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -72,17 +71,6 @@ public class FieldedRegexIndexLookupTest extends BaseIndexLookupTest {
         executeLookup();
         assertResultFields(Set.of("FIELD_A"));
         assertResultValues("FIELD_A", Set.of("bar", "baz"));
-    }
-
-    @Test
-    public void testExpansionTimeoutForcedFailure() {
-        write("bar", "FIELD_A");
-        write("baz", "FIELD_A", EXCEPTEDVALUE);
-        withQuery("FIELD_A =~ 'ba.*'");
-        executeLookup();
-        assertResultFields(Set.of("FIELD_A"));
-        assertThrows(ExceededThresholdException.class, () -> assertResultValues("FIELD_A", Set.of("bar")));
-        assertTimeoutExceeded();
     }
 
     @Test
@@ -165,7 +153,7 @@ public class FieldedRegexIndexLookupTest extends BaseIndexLookupTest {
 
             withQuery("FIELD_A =~ 'ba.*'");
             executeLookup();
-            assertResultFields(Collections.emptySet());
+            assertResultFields(Set.of("FIELD_A"));
             assertExceptionSeen();
         } finally {
             removeRuntimeExceptionIterator();
@@ -184,7 +172,7 @@ public class FieldedRegexIndexLookupTest extends BaseIndexLookupTest {
 
             withQuery("FIELD_A =~ 'ba.*'");
             executeLookup();
-            assertResultFields(Collections.emptySet());
+            assertResultFields(Set.of("FIELD_A"));
             assertExceptionSeen();
         } finally {
             removeRuntimeExceptionIterator();
@@ -242,6 +230,8 @@ public class FieldedRegexIndexLookupTest extends BaseIndexLookupTest {
 
     private AsyncIndexLookup createLookup(String field, String value, Range range, boolean reverse) {
         ScannerFactory scannerFactory = new ScannerFactory(client);
-        return new FieldedRegexIndexLookup(config, scannerFactory, executor, field, value, range, reverse);
+        AsyncIndexLookup lookup = new FieldedRegexIndexLookup(config, scannerFactory, executor, field, value, range, reverse);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookupTest.java
@@ -1,6 +1,5 @@
 package datawave.query.jexl.lookups;
 
-import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -77,22 +76,11 @@ public class UnfieldedRegexIndexLookupTest extends BaseIndexLookupTest {
     }
 
     @Test
-    public void testSimulatedTimeout() throws Exception {
-        write("bar", "FIELD_A");
-        write("baz", "FIELD_A");
-        write("baz-kaboom", "FIELD_A", EXCEPTEDVALUE);
-        withQuery("_ANYFIELD_ =~ 'ba.*'");
-        executeLookup();
-        assertTimeoutExceeded();
-        assertResultFields(Collections.emptySet());
-    }
-
-    @Test
     public void testExpansionTimeoutOnInitialSeek() throws Exception {
-        long origIndexScanTime = config.getMaxIndexScanTimeMillis();
+        long origIndexScanTime = config.getMaxAnyFieldScanTimeMillis();
         try {
             addDelayIterator(10);
-            config.setMaxIndexScanTimeMillis(5);
+            config.setMaxAnyFieldScanTimeMillis(5);
 
             // ensure the test always hits the timeout
             for (int i = 0; i < 15; i++) {
@@ -105,16 +93,16 @@ public class UnfieldedRegexIndexLookupTest extends BaseIndexLookupTest {
             assertResultFields(Collections.emptySet());
         } finally {
             removeDelayIterator();
-            config.setMaxIndexScanTimeMillis(origIndexScanTime);
+            config.setMaxAnyFieldScanTimeMillis(origIndexScanTime);
         }
     }
 
     @Test
     public void testExpansionTimeoutOnNext() throws Exception {
-        long origIndexScanTime = config.getMaxIndexScanTimeMillis();
+        long origIndexScanTime = config.getMaxAnyFieldScanTimeMillis();
         try {
             addDelayIterator(1);
-            config.setMaxIndexScanTimeMillis(5);
+            config.setMaxAnyFieldScanTimeMillis(5);
 
             // ensure the test always hits the timeout
             for (int i = 0; i < 15; i++) {
@@ -127,7 +115,7 @@ public class UnfieldedRegexIndexLookupTest extends BaseIndexLookupTest {
             assertResultFields(Collections.emptySet());
         } finally {
             removeDelayIterator();
-            config.setMaxIndexScanTimeMillis(origIndexScanTime);
+            config.setMaxAnyFieldScanTimeMillis(origIndexScanTime);
         }
     }
 
@@ -274,6 +262,8 @@ public class UnfieldedRegexIndexLookupTest extends BaseIndexLookupTest {
      */
     private AsyncIndexLookup createLookup(String regex, Range range, boolean reverse, Set<String> fields) {
         ScannerFactory scannerFactory = new ScannerFactory(client);
-        return new UnfieldedRegexIndexLookup(config, scannerFactory, executor, regex, range, reverse, fields);
+        AsyncIndexLookup lookup = new UnfieldedRegexIndexLookup(config, scannerFactory, executor, regex, range, reverse, fields);
+        lookup.setScanMonitor(monitor);
+        return lookup;
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/RegexIndexExpansionVisitorIT.java
@@ -1,7 +1,5 @@
 package datawave.query.jexl.visitors;
 
-import static datawave.core.iterators.TimeoutExceptionIterator.EXCEPTEDVALUE;
-
 import java.util.Set;
 
 import org.apache.commons.jexl3.parser.ASTJexlScript;
@@ -142,26 +140,20 @@ public class RegexIndexExpansionVisitorIT extends BaseIndexExpansionTest {
     }
 
     @Test
-    public void testSimulatedTimeout() throws Exception {
-        write("bar", "FIELD_A");
-        write("bat", "FIELD_A", EXCEPTEDVALUE);
-        write("baz", "FIELD_A");
-        String query = "FIELD_A =~ 'ba.*'";
-        String expected = "((_Value_ = true) && (FIELD_A =~ 'ba.*'))";
-        driveExpansion(query, expected);
-    }
-
-    @Test
     public void testZeroTimeout() throws Exception {
         write("bar", "FIELD_A");
         write("bat", "FIELD_A");
         write("baz", "FIELD_A");
         String query = "FIELD_A =~ 'ba.*'";
-        // new index lookups treat zero timeout as 'don't even run the scan'
-        // String expected = "((_Value_ = true) && (FIELD_A =~ 'ba.*'))";
-        String expected = "FIELD_A == 'bar' || FIELD_A == 'bat' || FIELD_A == 'baz'";
         config.setMaxIndexScanTimeMillis(0L);
-        driveExpansion(query, expected);
+        if (config.isUseNewIndexLookups()) {
+            // new index lookups treat zero timeout as 'don't even run the scan'
+            String expected = "((_Value_ = true) && (FIELD_A =~ 'ba.*'))";
+            driveExpansion(query, expected);
+        } else {
+            String expected = "FIELD_A == 'bar' || FIELD_A == 'bat' || FIELD_A == 'baz'";
+            driveExpansion(query, expected);
+        }
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitorIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitorIT.java
@@ -179,16 +179,6 @@ public class UnfieldedIndexExpansionVisitorIT extends BaseIndexExpansionTest {
     }
 
     @Test
-    public void testRegexExceedsTimeThresholds() {
-        write("bar", "FIELD_A");
-        write("bat", "FIELD_B", EXCEPTEDVALUE); // should simulate a timeout
-        write("baz", "FIELD_C");
-        String query = "_ANYFIELD_ =~ 'ba.*'";
-        String expected = "_NOFIELD_ =~ 'ba.*'";
-        assertThrows(DatawaveFatalQueryException.class, () -> driveExpansion(query, expected));
-    }
-
-    @Test
     public void testEqualityExceedsValueThreshold() throws Exception {
         write("bar", "FIELD_A");
         write("bar", "FIELD_B");


### PR DESCRIPTION
Integrate ScanMonitor into RegexIndexLookups

Deprecate RegexIndexLookup

Fix error case when an unfielded term fails before returning any results. Previously exception handling logic required at least one field to be present and that is not always the case.

Update unit tests with correct assertions

Remove exception tracking from AsyncIndexLookup