### PR TITLE
Integrate ScanMonitor into UnfieldedLiteralIndexLookup

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BaseRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BaseRegexIndexLookup.java
@@ -65,14 +65,17 @@ public abstract class BaseRegexIndexLookup extends AsyncIndexLookup {
                 future.get();
             }
         } catch (Exception e) {
-            handleException();
+            handleException(e);
         }
     }
 
     /**
      * Extending classes deal with exceptions differently
+     *
+     * @param e
+     *            the exception
      */
-    protected abstract void handleException();
+    protected abstract void handleException(Exception e);
 
     /**
      * Reverses the value coming off the shard reverse index

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/BoundedRangeIndexLookup.java
@@ -135,9 +135,7 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
                 }
 
             } catch (Exception e) {
-                log.error("Exception seen: {}", e.getMessage());
-                // mark the field as threshold exceeded regardless of the exception type
-                markExceeded();
+                handleException(e);
             } finally {
                 if (log.isTraceEnabled()) {
                     log.trace("closing scanner");
@@ -267,15 +265,19 @@ public class BoundedRangeIndexLookup extends AsyncIndexLookup {
             }
         } catch (Exception e) {
             // any exception causes the range to marked as value exceeded
-            markExceeded();
+            handleException(e);
         }
     }
 
     /**
      * Manipulates the {@link #indexLookupMap} so the bounded range term will be wrapped with an exceeded value marker.
+     *
+     * @param e
+     *            the exception
      */
-    protected void markExceeded() {
-        log.debug("marking range as exceeded");
+    protected void handleException(Exception e) {
+        log.warn("BoundedRangeIndexLookup saw exception: {}", e.getMessage());
+        log.debug("marking bounded range as value exceeded");
         indexLookupMap.put(field, "");
         indexLookupMap.get(field).setThresholdExceeded();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldExpansionIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldExpansionIndexLookup.java
@@ -1,13 +1,12 @@
 package datawave.query.jexl.lookups;
 
+import static datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.EXPANSION_HINT_KEY;
+
 import java.util.HashSet;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.Scanner;
@@ -15,6 +14,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 
 import datawave.core.iterators.FieldExpansionIterator;
 import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.tables.ScannerFactory;
 import datawave.util.time.DateHelper;
 
@@ -35,12 +36,9 @@ public class FieldExpansionIndexLookup extends AsyncIndexLookup {
     private static final Logger log = LoggerFactory.getLogger(FieldExpansionIndexLookup.class);
 
     protected String term;
-    protected Future<Boolean> timedScanFuture;
-    protected AtomicLong lookupStartTimeMillis = new AtomicLong(Long.MAX_VALUE);
-    protected CountDownLatch lookupStartedLatch;
-    protected CountDownLatch lookupStoppedLatch;
+    protected Range range;
 
-    private Scanner scanner;
+    private Future<?> future;
 
     public FieldExpansionIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, String term, Set<String> fields,
                     ExecutorService execService) {
@@ -50,6 +48,7 @@ public class FieldExpansionIndexLookup extends AsyncIndexLookup {
         if (fields != null) {
             this.fields.addAll(fields);
         }
+        this.range = getScanRange();
     }
 
     @Override
@@ -57,10 +56,31 @@ public class FieldExpansionIndexLookup extends AsyncIndexLookup {
         if (indexLookupMap == null) {
             indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
 
-            try {
-                scanner = scannerFactory.newSingleScanner(getTableName(), config.getAuthorizations(), config.getQuery());
+            Preconditions.checkNotNull(monitor, "FieldExpansionIndexLookup requires a ScanMonitor");
+            Runnable runnable = createRunnable(getTableName(), config.getAuthorizations().iterator().next());
 
-                Range range = getScanRange();
+            future = execService.submit(runnable);
+            monitor.registerTask(future, config.getMaxAnyFieldScanTimeMillis());
+        }
+    }
+
+    /**
+     * The created runnable handles everything with configuring a scanner, parsing results and putting them into the {@link #indexLookupMap} and handling
+     * exceptions.
+     * <p>
+     * Note: it is critical that any scanner created here is used with a try-with-resources block.
+     *
+     * @param tableName
+     *            the table to be scanned
+     * @param auths
+     *            the authorizations
+     * @return a Runnable that wraps a scanner
+     */
+    protected Runnable createRunnable(String tableName, Authorizations auths) {
+        return () -> {
+            try (Scanner scanner = config.getClient().createScanner(tableName, auths)) {
+                String hintKey = config.getTableHints().containsKey(EXPANSION_HINT_KEY) ? EXPANSION_HINT_KEY : config.getIndexTableName();
+                scanner.setExecutionHints(Map.of(tableName, hintKey));
                 scanner.setRange(range);
 
                 for (String field : fields) {
@@ -70,16 +90,25 @@ public class FieldExpansionIndexLookup extends AsyncIndexLookup {
                 IteratorSetting setting = createIteratorSetting();
                 scanner.addScanIterator(setting);
 
-                timedScanFuture = execService.submit(createTimedCallable(scanner));
+                for (Map.Entry<Key,Value> entry : scanner) {
+                    Key key = entry.getKey();
+                    if (log.isTraceEnabled()) {
+                        log.trace("tk: {}", key.toStringNoTime());
+                    }
+                    String field = key.getColumnFamily().toString();
+                    String value = key.getRow().toString();
+                    indexLookupMap.put(field, value);
+                }
+
             } catch (Exception e) {
-                log.error("Error expanding term into discrete fields", e);
-                // close scanner in case of an exception prior to execution of future
-                scannerFactory.close(scanner);
-                throw new RuntimeException(e);
+                log.error("Exception seen while expanding unfielded literal:", e);
+                handleException();
+            } finally {
+                if (log.isTraceEnabled()) {
+                    log.trace("closing scanner");
+                }
             }
-            // Note: scanners should never be closed here in a 'finally' block. The createTimedCallable
-            // method will close the scanner via scannerFactory.close(scanner)
-        }
+        };
     }
 
     private Range getScanRange() {
@@ -108,67 +137,26 @@ public class FieldExpansionIndexLookup extends AsyncIndexLookup {
 
     @Override
     public IndexLookupMap lookup() {
-        try {
-            timedScanWait(timedScanFuture, lookupStartedLatch, lookupStoppedLatch, lookupStartTimeMillis, config.getMaxAnyFieldScanTimeMillis());
-        } finally {
-            if (scanner != null) {
-                scannerFactory.close(scanner);
-            }
-        }
-
+        await();
         return indexLookupMap;
     }
 
-    protected Callable<Boolean> createTimedCallable(final Scanner scanner) {
-        lookupStartedLatch = new CountDownLatch(1);
-        lookupStoppedLatch = new CountDownLatch(1);
-
-        return () -> {
-            try {
-                lookupStartTimeMillis.set(System.currentTimeMillis());
-                lookupStartedLatch.countDown();
-
-                final Text holder = new Text();
-
-                try {
-                    for (Entry<Key,Value> entry : scanner) {
-                        // check for interrupt which may be triggered by closing the batch scanner
-                        if (Thread.interrupted()) {
-                            throw new InterruptedException();
-                        }
-
-                        if (log.isTraceEnabled()) {
-                            log.trace("Index entry: {}", entry.getKey());
-                        }
-
-                        entry.getKey().getRow(holder);
-                        String row = holder.toString();
-
-                        entry.getKey().getColumnFamily(holder);
-                        String columnFamily = holder.toString();
-
-                        // We are only returning a mapping of field name to field value, no need to
-                        // determine cardinality and such at this point.
-                        if (log.isTraceEnabled()) {
-                            log.trace("put {}:{}", columnFamily, row);
-                        }
-                        indexLookupMap.put(columnFamily, row);
-
-                        // if we passed the term expansion threshold, then simply return
-                        if (indexLookupMap.isKeyThresholdExceeded()) {
-                            break;
-                        }
-                    }
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                } finally {
-                    scannerFactory.close(scanner);
-                }
-
-                return true;
-            } finally {
-                lookupStoppedLatch.countDown();
+    protected void await() {
+        try {
+            if (future != null) {
+                future.get();
             }
-        };
+        } catch (Exception e) {
+            handleException();
+        }
+    }
+
+    /**
+     * Any exception indicates a failure to expand the unfielded literal and should fail the query.
+     * <p>
+     * A {@link DatawaveFatalQueryException} is thrown instead of a raw exception.
+     */
+    protected void handleException() {
+        throw new DatawaveFatalQueryException("Failed to expand unfielded literal");
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldNameIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldNameIndexLookup.java
@@ -33,6 +33,7 @@ import datawave.query.tables.ScannerSession;
  * An asynchronous index lookup which Looks up field names from the index which match the provided set of terms, and optionally limits them to the specified
  * fields
  */
+@Deprecated
 public class FieldNameIndexLookup extends AsyncIndexLookup {
     private static final Logger log = Logger.getLogger(FieldNameIndexLookup.class);
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/FieldedRegexIndexLookup.java
@@ -93,8 +93,7 @@ public class FieldedRegexIndexLookup extends BaseRegexIndexLookup {
                 }
 
             } catch (Exception e) {
-                log.error("Unexpected exception seen", e);
-                handleException();
+                handleException(e);
             }
         };
     }
@@ -124,10 +123,14 @@ public class FieldedRegexIndexLookup extends BaseRegexIndexLookup {
      * An exception while expanding a fielded regex retains the field but clears all collected values, if any such values exist.
      * <p>
      * The entry is then marked as threshold exceeded.
+     *
+     * @param e
+     *            the exception
      */
     @Override
-    protected void handleException() {
-        log.debug("marking regex as exceeded");
+    protected void handleException(Exception e) {
+        log.warn("FieldedRegexIndexLookup saw exception: {}", e.getMessage());
+        log.debug("marking fielded regex as exceeded value");
         indexLookupMap.setExceptionSeen(true);
         indexLookupMap.setTimeoutExceeded(true); // stub this out
         indexLookupMap.put(field, "");

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedLiteralIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedLiteralIndexLookup.java
@@ -31,16 +31,16 @@ import datawave.util.time.DateHelper;
 /**
  * An {@link IndexLookup} that wraps {@link FieldExpansionIterator}.
  */
-public class FieldExpansionIndexLookup extends AsyncIndexLookup {
+public class UnfieldedLiteralIndexLookup extends AsyncIndexLookup {
 
-    private static final Logger log = LoggerFactory.getLogger(FieldExpansionIndexLookup.class);
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedLiteralIndexLookup.class);
 
     protected String term;
     protected Range range;
 
     private Future<?> future;
 
-    public FieldExpansionIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, String term, Set<String> fields,
+    public UnfieldedLiteralIndexLookup(ShardQueryConfiguration config, ScannerFactory scannerFactory, String term, Set<String> fields,
                     ExecutorService execService) {
         super(config, scannerFactory, true, execService);
         this.term = term;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedLiteralIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedLiteralIndexLookup.java
@@ -56,7 +56,7 @@ public class UnfieldedLiteralIndexLookup extends AsyncIndexLookup {
         if (indexLookupMap == null) {
             indexLookupMap = new IndexLookupMap(config.getMaxUnfieldedExpansionThreshold(), config.getMaxValueExpansionThreshold());
 
-            Preconditions.checkNotNull(monitor, "FieldExpansionIndexLookup requires a ScanMonitor");
+            Preconditions.checkNotNull(monitor, "UnfieldedLiteralIndexLookup requires a ScanMonitor");
             Runnable runnable = createRunnable(getTableName(), config.getAuthorizations().iterator().next());
 
             future = execService.submit(runnable);
@@ -101,8 +101,7 @@ public class UnfieldedLiteralIndexLookup extends AsyncIndexLookup {
                 }
 
             } catch (Exception e) {
-                log.error("Exception seen while expanding unfielded literal:", e);
-                handleException();
+                handleException(e);
             } finally {
                 if (log.isTraceEnabled()) {
                     log.trace("closing scanner");
@@ -147,7 +146,7 @@ public class UnfieldedLiteralIndexLookup extends AsyncIndexLookup {
                 future.get();
             }
         } catch (Exception e) {
-            handleException();
+            handleException(e);
         }
     }
 
@@ -155,8 +154,13 @@ public class UnfieldedLiteralIndexLookup extends AsyncIndexLookup {
      * Any exception indicates a failure to expand the unfielded literal and should fail the query.
      * <p>
      * A {@link DatawaveFatalQueryException} is thrown instead of a raw exception.
+     *
+     * @param e
+     *            the exception
      */
-    protected void handleException() {
+    protected void handleException(Exception e) {
+        log.warn("UnfieldedLiteralIndexLookup saw exception: {}", e.getMessage());
+        log.debug("unfielded literal expansion failed, failing the query");
         throw new DatawaveFatalQueryException("Failed to expand unfielded literal");
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/lookups/UnfieldedRegexIndexLookup.java
@@ -95,8 +95,7 @@ public class UnfieldedRegexIndexLookup extends BaseRegexIndexLookup {
 
             } catch (Exception e) {
                 // assume any exception is indicative of a timeout
-                handleException();
-                log.error(e.getMessage(), e);
+                handleException(e);
             }
         };
     }
@@ -123,9 +122,14 @@ public class UnfieldedRegexIndexLookup extends BaseRegexIndexLookup {
 
     /**
      * An exception while expanding an unfielded regex clears the entire index lookup map.
+     *
+     * @param e
+     *            the exception
      */
     @Override
-    protected void handleException() {
+    protected void handleException(Exception e) {
+        log.warn("UnfieldedRegexIndexLookup saw exception: {}", e.getMessage());
+        log.debug("unfielded regex marked as timeout, this will fail the query");
         indexLookupMap.setExceptionSeen(true);
         indexLookupMap.setTimeoutExceeded(true);
         indexLookupMap.setUnfieldedTimeoutSeen();

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
@@ -31,10 +31,10 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.JexlNodeFactory;
 import datawave.query.jexl.lookups.AsyncIndexLookup;
 import datawave.query.jexl.lookups.EmptyIndexLookup;
-import datawave.query.jexl.lookups.FieldExpansionIndexLookup;
 import datawave.query.jexl.lookups.IndexLookup;
 import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods;
 import datawave.query.jexl.lookups.ShardIndexQueryTableStaticMethods.RefactoredRangeDescription;
+import datawave.query.jexl.lookups.UnfieldedLiteralIndexLookup;
 import datawave.query.jexl.lookups.UnfieldedRegexIndexLookup;
 import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.tables.ScannerFactory;
@@ -153,14 +153,14 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
 
     @Override
     public Object visit(ASTEQNode node, Object data) {
-        return buildIndexLookup(node, true, negated, () -> createFieldNameIndexLookup(node));
+        return buildIndexLookup(node, true, negated, () -> createUnfieldedLiteralIndexLookup(node));
     }
 
     @Override
     public Object visit(ASTNENode node, Object data) {
         toggleNegation();
         try {
-            return buildIndexLookup(node, true, negated, () -> createFieldNameIndexLookup(node));
+            return buildIndexLookup(node, true, negated, () -> createUnfieldedLiteralIndexLookup(node));
         } finally {
             toggleNegation();
         }
@@ -250,9 +250,9 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
      *
      * @param node
      *            the JexlNode
-     * @return a {@link FieldExpansionIndexLookup}
+     * @return a {@link UnfieldedLiteralIndexLookup}
      */
-    protected IndexLookup createFieldNameIndexLookup(JexlNode node) {
+    protected IndexLookup createUnfieldedLiteralIndexLookup(JexlNode node) {
         String term = (String) JexlASTHelper.getLiteralValue(node);
 
         Preconditions.checkNotNull(term);
@@ -269,7 +269,7 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
                 return new EmptyIndexLookup(config);
             }
 
-            AsyncIndexLookup lookup = new FieldExpansionIndexLookup(config, scannerFactory, term, fields, executor);
+            AsyncIndexLookup lookup = new UnfieldedLiteralIndexLookup(config, scannerFactory, term, fields, executor);
             lookup.setScanMonitor(monitor);
             return lookup;
         } catch (TableNotFoundException e) {

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/UnfieldedIndexExpansionVisitor.java
@@ -269,7 +269,9 @@ public class UnfieldedIndexExpansionVisitor extends RegexIndexExpansionVisitor {
                 return new EmptyIndexLookup(config);
             }
 
-            return new FieldExpansionIndexLookup(config, scannerFactory, term, fields, executor);
+            AsyncIndexLookup lookup = new FieldExpansionIndexLookup(config, scannerFactory, term, fields, executor);
+            lookup.setScanMonitor(monitor);
+            return lookup;
         } catch (TableNotFoundException e) {
             throw new RuntimeException(e);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
@@ -676,8 +676,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "seek");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -688,8 +687,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -700,8 +698,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -713,8 +710,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "seek");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -726,8 +722,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -739,8 +734,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "next");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeIOExceptionIterator();
         }
@@ -752,8 +746,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeIOExceptionIterator();
         }
@@ -765,8 +758,7 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
         try {
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            // This should be a DatawaveFatalException. We should not be passing up raw runtime exceptions.
-            assertThrows(RuntimeException.class, this::planAndExecuteQuery);
+            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
         } finally {
             removeRuntimeExceptionIterator();
         }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/UnfieldedLiteralIndexLookupTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/lookups/UnfieldedLiteralIndexLookupTest.java
@@ -17,11 +17,11 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.query.tables.ScannerFactory;
 
 /**
- * Tests for the {@link FieldExpansionIndexLookup}
+ * Tests for the {@link UnfieldedLiteralIndexLookup}
  */
-public class FieldExpansionIndexLookupTest extends BaseIndexLookupTest {
+public class UnfieldedLiteralIndexLookupTest extends BaseIndexLookupTest {
 
-    private static final Logger log = LoggerFactory.getLogger(FieldExpansionIndexLookupTest.class);
+    private static final Logger log = LoggerFactory.getLogger(UnfieldedLiteralIndexLookupTest.class);
 
     @Test
     public void testValueDoesNotExpand() {
@@ -117,7 +117,7 @@ public class FieldExpansionIndexLookupTest extends BaseIndexLookupTest {
 
     private AsyncIndexLookup createLookup(String value) {
         ScannerFactory scannerFactory = new ScannerFactory(client);
-        AsyncIndexLookup lookup = new FieldExpansionIndexLookup(config, scannerFactory, value, indexedFields, executor);
+        AsyncIndexLookup lookup = new UnfieldedLiteralIndexLookup(config, scannerFactory, value, indexedFields, executor);
         lookup.setScanMonitor(monitor);
         return lookup;
     }


### PR DESCRIPTION
- integrate ScanMonitor into UnfieldedLiteralIndexLookup
- rename FieldExpansionIndexLookup to UnfieldedLiteralIndexLookup so it matches naming convention of other lookups
- standardize exception handling per review comment from https://github.com/NationalSecurityAgency/datawave/pull/3446