### PR TITLE
Code changes to support main datawave using accumulo 2.1.4 instead of 2.1.4-5792fed3-bulkv2

### DIFF
--- a/core/in-memory-accumulo/pom.xml
+++ b/core/in-memory-accumulo/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.accumulo>2.1.4-5792fed3-bulkv2</version.accumulo>
+        <version.accumulo>2.1.4</version.accumulo>
         <version.hadoop>3.3.4</version.hadoop>
         <version.junit5>5.12.0</version.junit5>
         <version.log4j>2.25.3</version.log4j>

--- a/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryScannerBase.java
+++ b/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryScannerBase.java
@@ -161,9 +161,11 @@ public class InMemoryScannerBase extends ScannerOptions {
         SortedKeyValueIterator<Key,Value> injectedIterators = applyInjectedIterators(wrappedFilter);
         IteratorBuilder.IteratorBuilderEnv iterLoad = IteratorConfigUtil.loadIterConf(IteratorScope.scan, serverSideIteratorList, serverSideIteratorOptions,
                         conf);
-        SortedKeyValueIterator<Key,Value> result = iterEnv
-                        .getTopLevelIterator(IteratorConfigUtil.loadIterators(injectedIterators, iterLoad.env(iterEnv).build()));
-        return result;
+        try {
+            return iterEnv.getTopLevelIterator(IteratorConfigUtil.loadIterators(injectedIterators, iterLoad.env(iterEnv).build()));
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <sonar.exclusions>**/StandardLexer.java,**/*.js,**/*.css,**/*.html</sonar.exclusions>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
         <surefire.forkCount>1C</surefire.forkCount>
-        <version.accumulo>2.1.4-5792fed3-bulkv2</version.accumulo>
+        <version.accumulo>2.1.4</version.accumulo>
         <version.arquillian>1.4.1.Final</version.arquillian>
         <version.arquillian-weld-ee-embedded>1.0.0.Final</version.arquillian-weld-ee-embedded>
         <version.assertj>3.20.2</version.assertj>

--- a/warehouse/assemble/datawave/pom.xml
+++ b/warehouse/assemble/datawave/pom.xml
@@ -13,7 +13,7 @@
         <!-- jkube kubernetes-maven-plugin only has access to project properties so we redefine them to properly render the Dockerfile-->
         <project.version>${project.version}</project.version>
         <!--   used for image ghcr.io/nationalsecurityagency/datawave-stack-accumulo:${version.accumulo}     -->
-        <version.accumulo>2.1.3</version.accumulo>
+        <version.accumulo>2.1.4</version.accumulo>
     </properties>
     <dependencies>
         <!-- To ensure a consistent version is loaded -->

--- a/warehouse/assemble/datawave/pom.xml
+++ b/warehouse/assemble/datawave/pom.xml
@@ -12,8 +12,6 @@
     <properties>
         <!-- jkube kubernetes-maven-plugin only has access to project properties so we redefine them to properly render the Dockerfile-->
         <project.version>${project.version}</project.version>
-        <!--   used for image ghcr.io/nationalsecurityagency/datawave-stack-accumulo:${version.accumulo}     -->
-        <version.accumulo>2.1.4</version.accumulo>
     </properties>
     <dependencies>
         <!-- To ensure a consistent version is loaded -->

--- a/warehouse/query-core/src/main/java/datawave/mr/bulk/RecordIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/mr/bulk/RecordIterator.java
@@ -420,7 +420,12 @@ public class RecordIterator extends RangeSplit implements SortedKeyValueIterator
             SortedKeyValueIterator<Key,Value> visFilter = VisibilityFilter.wrap(topIter, auths, defaultSecurityLabel);
             IteratorBuilder.IteratorBuilderEnv iterLoad = IteratorConfigUtil.loadIterConf(IteratorScope.scan, Collections.emptyList(), Collections.emptyMap(),
                             acuTableConf);
-            return IteratorConfigUtil.loadIterators(visFilter, iterLoad.env(iterEnv).build());
+            try {
+                return IteratorConfigUtil.loadIterators(visFilter, iterLoad.env(iterEnv).build());
+            } catch (Exception e) {
+                log.error(e.getMessage(), e);
+                throw new IOException(e);
+            }
         }
 
         return topIter;

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScanner.java
@@ -671,12 +671,12 @@ public class RangeStreamScanner extends ScannerSession implements Callable<Range
                 ((RfileScanner) baseScanner).setRanges(Collections.singleton(currentRange));
 
             for (Column family : options.getFetchedColumns()) {
-                if (family.columnQualifier != null)
-                    baseScanner.fetchColumn(new Text(family.columnFamily), new Text(family.columnQualifier));
+                if (family.getColumnQualifier() != null)
+                    baseScanner.fetchColumn(new Text(family.getColumnFamily()), new Text(family.getColumnQualifier()));
                 else {
                     if (log.isTraceEnabled())
-                        log.trace("Setting column family " + new Text(family.columnFamily));
-                    baseScanner.fetchColumnFamily(new Text(family.columnFamily));
+                        log.trace("Setting column family " + new Text(family.getColumnFamily()));
+                    baseScanner.fetchColumnFamily(new Text(family.getColumnFamily()));
                 }
             }
             for (IteratorSetting setting : options.getIterators()) {

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RunningResource.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RunningResource.java
@@ -141,12 +141,12 @@ public class RunningResource extends AccumuloResource {
     public AccumuloResource setOptions(SessionOptions options) {
         // set the families
         for (Column family : options.getFetchedColumns()) {
-            if (family.columnQualifier != null)
-                baseScanner.fetchColumn(new Text(family.columnFamily), new Text(family.columnQualifier));
+            if (family.getColumnQualifier() != null)
+                baseScanner.fetchColumn(new Text(family.getColumnFamily()), new Text(family.getColumnQualifier()));
             else {
                 if (log.isTraceEnabled())
-                    log.trace("Setting column family " + new Text(family.columnFamily));
-                baseScanner.fetchColumnFamily(new Text(family.columnFamily));
+                    log.trace("Setting column family " + new Text(family.getColumnFamily()));
+                baseScanner.fetchColumnFamily(new Text(family.getColumnFamily()));
             }
         }
         for (IteratorSetting setting : options.getIterators()) {

--- a/warehouse/query-core/src/test/java/datawave/query/scanner/LocalBatchScanner.java
+++ b/warehouse/query-core/src/test/java/datawave/query/scanner/LocalBatchScanner.java
@@ -93,7 +93,7 @@ public class LocalBatchScanner extends SessionOptions implements BatchScanner {
             SortedKeyValueIterator<Key,Value> created = IteratorConfigUtil.loadIterators(base, iteratorBuilder);
             List<ByteSequence> columns = new ArrayList<>();
             for (Column c : fetchedColumns) {
-                columns.add(new ArrayByteSequence(c.columnFamily));
+                columns.add(new ArrayByteSequence(c.getColumnFamily()));
             }
 
             for (Range range : ranges) {
@@ -103,7 +103,7 @@ public class LocalBatchScanner extends SessionOptions implements BatchScanner {
                     created.next();
                 }
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
 

--- a/web-services/pom.xml
+++ b/web-services/pom.xml
@@ -29,8 +29,6 @@
         <module>annotations</module>
     </modules>
     <properties>
-        <accumulo.scope>provided</accumulo.scope>
-        <accumulo.version>${version.accumulo}</accumulo.version>
         <build.properties.0>default</build.properties.0>
         <!-- Control the rpm release number, for a final release change the rpm.release.number from the timestamp property to the number 1 -->
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>


### PR DESCRIPTION
Accumulo changes from 2.1.4-5792fed3-bulkv2 (pre-2.1.4 release) to 2.1.4 reuire datawave code changes.

accumulo class ColumnFamily changed fields columnFamily, columnQualifier, etc from public to private.  Wes houldn't have been using them anyway.
IteratorConfigUtil.loadIterators() declares throws ReflectiveOperationException even though that exception is caught internally and is thrown as a RuntimeException.  Also, this declaration is removed in accumulo 3.0.0.  

The microservices can be upgraded to accumulo 2.1.4 after there is a version of datawave that won't break at runtime while using accumulo 2.1.4. (illegal access)