### PR TITLE
CountQuery supports intermediate results

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/CountingShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/CountingShardQueryLogic.java
@@ -32,6 +32,9 @@ import datawave.query.transformer.ShardQueryCountTableTransformer;
 public class CountingShardQueryLogic extends ShardQueryLogic {
     private static final Logger log = Logger.getLogger(CountingShardQueryLogic.class);
 
+    // the time to wait before returning an intermediate result
+    private long pageWaitTimeMillis = 0L;
+
     public CountingShardQueryLogic() {
         super();
     }
@@ -59,7 +62,7 @@ public class CountingShardQueryLogic extends ShardQueryLogic {
 
     @Override
     public TransformIterator getTransformIterator(Query settings) {
-        return new CountAggregatingIterator(this.iterator(), getTransformer(settings), this.markingFunctions);
+        return new CountAggregatingIterator(this.iterator(), getTransformer(settings), this.markingFunctions, getPageWaitTimeMillis());
     }
 
     @Override
@@ -86,4 +89,21 @@ public class CountingShardQueryLogic extends ShardQueryLogic {
         return scheduler;
     }
 
+    /**
+     * This query logic always supports intermediate results
+     *
+     * @return true
+     */
+    @Override
+    public boolean isLongRunningQuery() {
+        return true;
+    }
+
+    public long getPageWaitTimeMillis() {
+        return pageWaitTimeMillis;
+    }
+
+    public void setPageWaitTimeMillis(long pageWaitTimeMillis) {
+        this.pageWaitTimeMillis = pageWaitTimeMillis;
+    }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountAggregatingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountAggregatingIterator.java
@@ -1,9 +1,17 @@
 package datawave.query.tables.shard;
 
+import static datawave.core.iterators.ResultCountingIterator.ResultCountTuple;
+
 import java.io.ByteArrayInputStream;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -15,89 +23,194 @@ import org.apache.log4j.Logger;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
-import datawave.core.iterators.ResultCountingIterator;
 import datawave.marking.MarkingFunctions;
+import datawave.webservice.query.result.event.DefaultEvent;
 
 /**
- *
+ * A transformer that aggregates query results into a count.
+ * <p>
+ * Aggregation happens in a separate thread so that an intermediate result can be returned to the RunningQuery.
  */
 public class CountAggregatingIterator extends TransformIterator {
     private static final Logger log = Logger.getLogger(CountAggregatingIterator.class);
 
-    private Long count = 0l;
-    private boolean firstTime = true;
+    private static final long DEFAULT_PAGE_WAIT_TIME_MILLIS = 3_600_000L;
 
-    protected Set<ColumnVisibility> columnVisibilities = Sets.newHashSet();
+    private boolean done = false;
+    private final AtomicBoolean executing = new AtomicBoolean(true);
+    private final CountDownLatch latch = new CountDownLatch(1);
 
-    private final MarkingFunctions markingFunctions;
+    private final long pageWaitTimeMillis;
 
-    private Kryo kryo = new Kryo();
+    private final CountEntryAggregator aggregator;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
+    /**
+     * Constructor with that uses {@link #DEFAULT_PAGE_WAIT_TIME_MILLIS}
+     *
+     * @param iterator
+     *            the iterator
+     * @param transformer
+     *            the transformer
+     * @param markingFunctions
+     *            the marking functions
+     */
     public CountAggregatingIterator(Iterator<Entry<Key,Value>> iterator, Transformer transformer, MarkingFunctions markingFunctions) {
+        this(iterator, transformer, markingFunctions, DEFAULT_PAGE_WAIT_TIME_MILLIS);
+    }
+
+    /**
+     * Constructor that uses provided page wait time millis
+     *
+     * @param iterator
+     *            the iterator
+     * @param transformer
+     *            the transformer
+     * @param markingFunctions
+     *            the marking functions
+     * @param pageWaitTimeMillis
+     *            the time to wait for the next page
+     */
+    @SuppressWarnings("unchecked")
+    public CountAggregatingIterator(Iterator<Entry<Key,Value>> iterator, Transformer transformer, MarkingFunctions markingFunctions, long pageWaitTimeMillis) {
         super(iterator, transformer);
-        this.markingFunctions = markingFunctions;
+        this.aggregator = new CountEntryAggregator(transformer, markingFunctions);
+        this.pageWaitTimeMillis = pageWaitTimeMillis;
+
+        CountAggregatingRunnable runnable = new CountAggregatingRunnable(iterator, aggregator, executing, latch);
+        executor.execute(runnable);
     }
 
     @Override
     public boolean hasNext() {
-        if (count == -1) {
-            return false;
-        }
-
-        boolean hasNext = false;
-        if (getIterator().hasNext()) {
-            hasNext = true;
-            do {
-                @SuppressWarnings("unchecked")
-                Entry<Key,Value> entry = (Entry<Key,Value>) getIterator().next();
-
-                if (null == entry || entry.getKey() == null || entry.getValue() == null) {
-                    hasNext = false;
-                    break;
-                }
-
-                // Unpack the kryo serialized object, it contains the count and the accumulated visibility
-                ResultCountingIterator.ResultCountTuple tuple = unpackValue(entry.getValue());
-
-                // Merge the columnVisibilities
-                this.columnVisibilities.add(tuple.getVisibility());
-
-                this.count += tuple.getCount();
-            } while (getIterator().hasNext());
-        } else if (firstTime) {
-            firstTime = false;
-            count = 0l;
-
-            columnVisibilities.add(new ColumnVisibility(""));
-
-            return true;
-        }
-
-        return hasNext;
-    }
-
-    private ResultCountingIterator.ResultCountTuple unpackValue(Value value) {
-        ByteArrayInputStream bais = new ByteArrayInputStream(value.get());
-        Input input = new Input(bais);
-        return kryo.readObject(input, ResultCountingIterator.ResultCountTuple.class);
+        return !done;
     }
 
     @Override
     public Object next() {
-        ColumnVisibility cv = null;
-
         try {
-            // Calculate the columnVisibility for this key from the combination.
-            cv = markingFunctions.combine(columnVisibilities);
+            latch.await(pageWaitTimeMillis, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            log.error("Could not create combined columnVisibilities for the count", e);
-            return null;
+            // nope
         }
 
-        Object obj = getTransformer().transform(Maps.immutableEntry(count, cv));
-        count = -1l;
-        return obj;
+        if (executing.get()) {
+            return getIntermediateEvent();
+        } else {
+            done = true;
+            return aggregator.getAggregatedEvent();
+        }
+    }
+
+    /**
+     * Build a {@link DefaultEvent} with the intermediate result flag set to true
+     *
+     * @return an intermediate result
+     */
+    private Object getIntermediateEvent() {
+        DefaultEvent event = new DefaultEvent();
+        event.setIntermediateResult(true);
+        return event;
+    }
+
+    /**
+     * Encapsulate aggregation logic here
+     */
+    private static class CountEntryAggregator {
+
+        private long count = 0L;
+        private final Set<ColumnVisibility> cvs = new HashSet<>();
+
+        private final Transformer transformer;
+        private final MarkingFunctions markingFunctions;
+
+        public CountEntryAggregator(Transformer transformer, MarkingFunctions markingFunctions) {
+            this.transformer = transformer;
+            this.markingFunctions = markingFunctions;
+        }
+
+        public void addCount(long count) {
+            this.count += count;
+        }
+
+        public void addColumnVisibility(ColumnVisibility cv) {
+            this.cvs.add(cv);
+        }
+
+        @SuppressWarnings("unchecked")
+        public Object getAggregatedEvent() {
+            if (cvs.isEmpty() && count == 0L) {
+                cvs.add(new ColumnVisibility(""));
+            }
+
+            ColumnVisibility cv = getCombinedColumnVisibility();
+            return transformer.transform(Maps.immutableEntry(count, cv));
+        }
+
+        private ColumnVisibility getCombinedColumnVisibility() {
+            try {
+                return markingFunctions.combine(cvs);
+            } catch (Exception e) {
+                log.error("Could not combine columnVisibilities for the count", e);
+                return null;
+            }
+        }
+    }
+
+    /**
+     * A runnable that pulls {@link ResultCountTuple} from the iterator and passes them to the {@link CountEntryAggregator}
+     */
+    private static class CountAggregatingRunnable implements Runnable {
+        private final Kryo kryo = new Kryo();
+
+        private final Iterator<Entry<Key,Value>> iterator;
+        private final CountEntryAggregator aggregator;
+        private final AtomicBoolean executing;
+        private final CountDownLatch latch;
+
+        public CountAggregatingRunnable(Iterator<Entry<Key,Value>> iterator, CountEntryAggregator aggregator, AtomicBoolean executing, CountDownLatch latch) {
+            this.iterator = iterator;
+            this.aggregator = aggregator;
+            this.executing = executing;
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() {
+            try {
+                log.info("Beginning count aggregation");
+                while (iterator.hasNext()) {
+                    Entry<Key,Value> entry = iterator.next();
+                    if (null == entry || entry.getKey() == null || entry.getValue() == null) {
+                        continue;
+                    }
+
+                    // Unpack the kryo serialized object, it contains the count and the accumulated visibility
+                    ResultCountTuple tuple = unpackValue(entry.getValue());
+                    aggregator.addColumnVisibility(tuple.getVisibility());
+                    aggregator.addCount(tuple.getCount());
+                }
+            } finally {
+                log.info("Finished count aggregation");
+                executing.set(false);
+                latch.countDown();
+            }
+        }
+
+        /**
+         * Deserialize the value
+         *
+         * @param value
+         *            the value
+         * @return a {@link ResultCountTuple}
+         */
+        private ResultCountTuple unpackValue(Value value) {
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(value.get()); Input input = new Input(bais)) {
+                return kryo.readObject(input, ResultCountTuple.class);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountAggregatingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountAggregatingIterator.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
@@ -119,7 +120,7 @@ public class CountAggregatingIterator extends TransformIterator {
      */
     private static class CountEntryAggregator {
 
-        private long count = 0L;
+        private final AtomicLong count = new AtomicLong(0L);
         private final Set<ColumnVisibility> cvs = new HashSet<>();
 
         private final Transformer transformer;
@@ -131,7 +132,7 @@ public class CountAggregatingIterator extends TransformIterator {
         }
 
         public void addCount(long count) {
-            this.count += count;
+            this.count.addAndGet(count);
         }
 
         public void addColumnVisibility(ColumnVisibility cv) {
@@ -140,12 +141,12 @@ public class CountAggregatingIterator extends TransformIterator {
 
         @SuppressWarnings("unchecked")
         public Object getAggregatedEvent() {
-            if (cvs.isEmpty() && count == 0L) {
+            if (cvs.isEmpty() && count.get() == 0L) {
                 cvs.add(new ColumnVisibility(""));
             }
 
             ColumnVisibility cv = getCombinedColumnVisibility();
-            return transformer.transform(Maps.immutableEntry(count, cv));
+            return transformer.transform(Maps.immutableEntry(count.get(), cv));
         }
 
         private ColumnVisibility getCombinedColumnVisibility() {

--- a/warehouse/query-core/src/test/java/datawave/query/IntermediateResultsQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IntermediateResultsQueryTest.java
@@ -1,0 +1,509 @@
+package datawave.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.minicluster.MiniAccumuloCluster;
+import org.apache.accumulo.minicluster.MiniAccumuloConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.core.query.cache.ResultsPage;
+import datawave.microservice.querymetric.QueryMetricFactoryImpl;
+import datawave.query.index.day.IndexIngestUtil;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.tables.CountingShardQueryLogic;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.util.AbstractQueryTest;
+import datawave.query.util.ShapesIngest;
+import datawave.security.authorization.DatawavePrincipal;
+import datawave.security.authorization.DatawaveUser;
+import datawave.security.authorization.SubjectIssuerDNPair;
+import datawave.test.MacTestUtil;
+import datawave.util.TableName;
+import datawave.webservice.query.cache.RunningQueryTimingImpl;
+import datawave.webservice.query.exception.QueryException;
+import datawave.webservice.query.runner.RunningQuery;
+
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class IntermediateResultsQueryTest extends AbstractQueryTest {
+
+    private static final Logger log = LoggerFactory.getLogger(IntermediateResultsQueryTest.class);
+
+    private static final Authorizations auths = new Authorizations("ALL");
+    protected static AccumuloClient client = null;
+    protected static TableOperations tops = null;
+
+    protected static final String PASSWORD = "password";
+    protected static MiniAccumuloCluster mac;
+
+    @TempDir
+    public static Path folder;
+
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
+
+    @Autowired
+    @Qualifier("CountQuery")
+    protected CountingShardQueryLogic countingLogic;
+
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    private int completePageCount = 0;
+    private int expectedCompletePageCount = 0;
+
+    private int completePageSize = 0;
+    private int expectedCompletePageSize = 0;
+
+    private int intermediatePageCount = 0;
+    private int expectedMinimumIntermediatePages = 0;
+
+    // slow event aggregation to trigger short circuit timeouts
+    private final int iterationDelayMS = 100;
+
+    // default timing values
+    private final long maxCallMsDefault = 60 * 60 * 1000;
+    private final long pageSizeShortCircuitCheckTimeMsDefault = 30 * 60 * 1000;
+    private final long pageShortCircuitTimeoutMsDefault = 58 * 60 * 1000;
+    private final int maxLongRunningTimeoutRetriesDefault = 3;
+
+    // override timing values
+    private long maxCallMsOverride = 0;
+    private long pageSizeShortCircuitCheckTimeMsOverride = 0;
+    private long pageShortCircuitTimeoutMsOverride = 0;
+    private int maxLongRunningTimeoutRetriesOverride = 0;
+
+    // higher order variables required by the RunningQuery
+    private final SubjectIssuerDNPair userDN = SubjectIssuerDNPair.of("userDn", "issuerDn");
+    private final DatawaveUser user = new DatawaveUser(userDN, DatawaveUser.UserType.USER, Sets.newHashSet(auths.toString().split(",")), null, null, -1L);
+    private final DatawavePrincipal datawavePrincipal = new DatawavePrincipal((Collections.singleton(user)));
+
+    @Override
+    protected void extraConfigurations() {
+
+    }
+
+    @Override
+    protected void extraAssertions() {
+        log.info("expected {} intermediate pages and got {}", expectedMinimumIntermediatePages, intermediatePageCount);
+        assertTrue(intermediatePageCount >= expectedMinimumIntermediatePages);
+
+        assertEquals(expectedCompletePageCount, completePageCount, "expected page count: " + expectedCompletePageCount + " but got " + completePageCount);
+        assertEquals(expectedCompletePageSize, completePageSize, "expected page size: " + expectedCompletePageSize + " but got " + completePageSize);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        boolean useMAC = false;
+        if (useMAC) {
+            MiniAccumuloConfig cfg = new MiniAccumuloConfig(folder.toFile(), PASSWORD);
+            cfg.setNumTservers(1);
+            mac = new MiniAccumuloCluster(cfg);
+            mac.start();
+            client = mac.createAccumuloClient("root", new PasswordToken(PASSWORD));
+        } else {
+            InMemoryInstance instance = new InMemoryInstance(IntermediateResultsQueryTest.class.getName());
+            client = new InMemoryAccumuloClient("root", instance);
+        }
+
+        ShapesIngest.writeData(client, ShapesIngest.RangeType.SHARD);
+        IndexIngestUtil ingestUtil = new IndexIngestUtil();
+        Authorizations auths = new Authorizations("ALL");
+        ingestUtil.write(client, auths);
+
+        tops = client.tableOperations();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+        setClientForTest(client);
+        givenDate("20240201", "20240209");
+        configureLogic(logic);
+        configureLogic(countingLogic);
+    }
+
+    private void configureLogic(ShardQueryLogic logic) {
+        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        Preconditions.checkNotNull(hadoopConfig);
+        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
+
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toUri().toString());
+        logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
+        logic.setMaxFieldIndexRangeSplit(1); // keep things simple
+
+        // every test also exercises hit terms
+        givenParameter(QueryParameters.HIT_LIST, "true");
+        logic.setHitList(true);
+
+        logic.setCollapseUids(false); // index table will either have uids or not
+
+        logic.setQueryExecutionForPageTimeout(1);
+        logic.setMaxEvaluationPipelines(1);
+        logic.setMaxPipelineCachedResults(0);
+        logic.setIvaratorCacheBufferSize(0);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        super.afterEach();
+        resetState();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        if (mac != null) {
+            mac.stop();
+        }
+    }
+
+    private void resetState() {
+        // reset override state
+        maxCallMsOverride = 0;
+        pageSizeShortCircuitCheckTimeMsOverride = 0;
+        pageShortCircuitTimeoutMsOverride = 0;
+        maxLongRunningTimeoutRetriesOverride = 0;
+
+        // reset state for page count, page size, and intermediate page count
+
+        completePageCount = 0;
+        expectedCompletePageCount = 0;
+
+        completePageSize = 0;
+        expectedCompletePageSize = 0;
+
+        intermediatePageCount = 0;
+        expectedMinimumIntermediatePages = 0;
+    }
+
+    /**
+     * This test does not require iteration across multiple index tables
+     *
+     * @return a single index table name
+     */
+    protected List<String> getIndexTableNames() {
+        return List.of(TableName.SHARD_INDEX);
+    }
+
+    @Override
+    protected void executeQuery(ShardQueryLogic logic) throws Exception {
+        try {
+            results.clear();
+
+            logic.setQueryExecutionForPageTimeout(1);
+
+            RunningQueryTimingImpl timing = getQueryTiming();
+            RunningQuery runningQuery = new RunningQuery(null, client, AccumuloConnectionFactory.Priority.NORMAL, logic, getSettings(), "", datawavePrincipal,
+                            timing, null, new QueryMetricFactoryImpl());
+
+            while (true) {
+                ResultsPage<?> page = runningQuery.next();
+                log.info("status: {} size: {}", page.getStatus(), page.getResults().size());
+                switch (page.getStatus()) {
+                    case PARTIAL:
+                        intermediatePageCount++;
+                        break;
+                    case COMPLETE:
+                        completePageCount++;
+                        completePageSize += page.getResults().size();
+                        break;
+                    case NONE:
+                    default:
+                        break;
+                }
+                if (page.getStatus().equals(ResultsPage.Status.NONE)) {
+                    break;
+                }
+            }
+        } finally {
+            logic.close();
+            log.info("query retrieved {} results", results.size());
+        }
+    }
+
+    /**
+     * Create a {@link RunningQueryTimingImpl} using default values, or their overrides if configured
+     *
+     * @return query timing
+     */
+    private RunningQueryTimingImpl getQueryTiming() {
+        return new RunningQueryTimingImpl(getMaxCallMs(), getPageSizeShortCircuitCheckMs(), getPageShortCircuitTimeoutMs(), getMaxLongRunningTimeoutRetries());
+    }
+
+    private long getMaxCallMs() {
+        if (maxCallMsOverride > 0) {
+            return maxCallMsOverride;
+        }
+        return maxCallMsDefault;
+    }
+
+    private long getPageSizeShortCircuitCheckMs() {
+        if (pageSizeShortCircuitCheckTimeMsOverride > 0) {
+            return pageSizeShortCircuitCheckTimeMsOverride;
+        }
+        return pageSizeShortCircuitCheckTimeMsDefault;
+    }
+
+    private long getPageShortCircuitTimeoutMs() {
+        if (pageShortCircuitTimeoutMsOverride > 0) {
+            return pageShortCircuitTimeoutMsOverride;
+        }
+        return pageShortCircuitTimeoutMsDefault;
+    }
+
+    private int getMaxLongRunningTimeoutRetries() {
+        if (maxLongRunningTimeoutRetriesOverride > 0) {
+            return maxLongRunningTimeoutRetriesOverride;
+        }
+        return maxLongRunningTimeoutRetriesDefault;
+    }
+
+    private void givenMaxCallMs(int maxCallMs) {
+        this.maxCallMsOverride = maxCallMs;
+    }
+
+    private void givenPageSizeShortCircuitCheckMs(int pageSizeShortCircuitCheckMs) {
+        this.pageSizeShortCircuitCheckTimeMsOverride = pageSizeShortCircuitCheckMs;
+    }
+
+    private void givenPageShortCircuitTimeoutMs(int pageShortCircuitTimeoutMs) {
+        this.pageShortCircuitTimeoutMsOverride = pageShortCircuitTimeoutMs;
+    }
+
+    private void givenMaxLongRunningTimeoutRetries(int maxLongRunningTimeoutRetries) {
+        this.maxLongRunningTimeoutRetriesOverride = maxLongRunningTimeoutRetries;
+    }
+
+    private void expectCompletePageSize(int completePageSize) {
+        this.expectedCompletePageSize = completePageSize;
+    }
+
+    private void expectMinimumIntermediatePages(int numMinimumIntermediatePages) {
+        this.expectedMinimumIntermediatePages = numMinimumIntermediatePages;
+    }
+
+    private void expectCompletePageCount(int completePageCount) {
+        this.expectedCompletePageCount = completePageCount;
+    }
+
+    /**
+     * Add a {@link datawave.test.iter.DelayIterator} to the shard table with a default timeout of {@link #iterationDelayMS}
+     */
+    protected void addDelayIterator() {
+        addDelayIterator(iterationDelayMS);
+    }
+
+    /**
+     * Add a {@link datawave.test.iter.DelayIterator} to the shard table with the provided timeout
+     *
+     * @param delay
+     *            the delay in milliseconds
+     */
+    protected void addDelayIterator(int delay) {
+        Map<String,String> properties = new HashMap<>();
+        properties.put("table.iterator.scan.delay", "1,datawave.test.iter.DelayIterator");
+        properties.put("table.iterator.scan.delay.opt.delay", String.valueOf(delay));
+        MacTestUtil.addPropertiesAndWait(tops, TableName.SHARD, properties);
+    }
+
+    /**
+     * Remove the {@link datawave.test.iter.DelayIterator} from the shard table
+     */
+    protected void removeDelayIterator() {
+        Set<String> properties = new HashSet<>();
+        properties.add("table.iterator.scan.delay");
+        properties.add("table.iterator.scan.delay.opt.delay");
+        MacTestUtil.removePropertiesAndWait(tops, TableName.SHARD, properties);
+    }
+
+    @Test
+    public void testLongRunningEventQuery() throws Exception {
+        try {
+            addDelayIterator();
+            givenParameter(QueryParameters.GROUP_FIELDS, "SHAPE,TYPE");
+            givenParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "10");
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectCompletePageCount(1);
+            expectCompletePageSize(6);
+            planAndExecuteQuery();
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    /**
+     * A single timeout retry and a max call time of 1 ms will trigger a query timeout exception
+     */
+    @Test
+    public void testLongRunningEventQuery_maxCallMs() {
+        try {
+            addDelayIterator();
+            givenParameter(QueryParameters.GROUP_FIELDS, "SHAPE,TYPE");
+            givenParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "10");
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            givenMaxCallMs(1);
+            givenMaxLongRunningTimeoutRetries(1);
+            assertThrows(QueryException.class, this::planAndExecuteQuery);
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testLongRunningEventQuery_shortCircuitOnPageSize() throws Exception {
+        int originalMaxPageSize = logic.getMaxPageSize();
+        try {
+            addDelayIterator();
+            givenParameter(QueryParameters.GROUP_FIELDS, "SHAPE,TYPE");
+            givenParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "10");
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            givenPageSizeShortCircuitCheckMs(1);
+            logic.setMaxPageSize(2); // six results, two per page, should be three pages
+            expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectCompletePageCount(3);
+            expectCompletePageSize(6);
+            planAndExecuteQuery();
+        } finally {
+            logic.setMaxPageSize(originalMaxPageSize);
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testLongRunningEventQuery_shortCircuitOnNextTimeout() throws Exception {
+        try {
+            addDelayIterator();
+            givenParameter(QueryParameters.GROUP_FIELDS, "SHAPE,TYPE");
+            givenParameter(QueryParameters.GROUP_FIELDS_BATCH_SIZE, "10");
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            givenPageShortCircuitTimeoutMs(1_000);
+            givenMaxLongRunningTimeoutRetries(10); // need more than default of three
+            expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectCompletePageCount(1);
+            expectCompletePageSize(6);
+            planAndExecuteQuery();
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testLongRunningCountQuery() throws Exception {
+        givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        countingLogic.setPageWaitTimeMillis(10_000);
+        expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+        expectCompletePageCount(1);
+        expectCompletePageSize(1);
+        planAndExecuteQuery(countingLogic);
+    }
+
+    /**
+     * A single timeout retry and a max call time of 1 ms will trigger a query timeout exception
+     */
+    @Test
+    public void testLongRunningCountQuery_maxCallMs() {
+        try {
+            addDelayIterator();
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            givenMaxCallMs(1); // absurdly small next timeout
+            givenMaxLongRunningTimeoutRetries(1); // only retry once
+            countingLogic.setPageWaitTimeMillis(750); // configure wait time
+            assertThrows(QueryException.class, () -> planAndExecuteQuery(countingLogic));
+            // note: this code path will cause the batch scanner to throw exceptions as the query logic
+            // is forcibly torn down
+        } finally {
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testLongRunningCountQuery_shortCircuitOnPageSize() throws Exception {
+        int originalMaxPageSize = countingLogic.getMaxPageSize();
+        try {
+            addDelayIterator();
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            givenPageSizeShortCircuitCheckMs(1);
+            givenMaxLongRunningTimeoutRetries(10); // need more than default of three
+            countingLogic.setMaxPageSize(2); // six results, two per page, should be three pages
+            countingLogic.setPageWaitTimeMillis(750); // configure wait time
+            expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectCompletePageCount(1);
+            expectCompletePageSize(1);
+            expectMinimumIntermediatePages(5);
+            planAndExecuteQuery(countingLogic);
+        } finally {
+            countingLogic.setMaxPageSize(originalMaxPageSize);
+            removeDelayIterator();
+        }
+    }
+
+    @Test
+    public void testLongRunningCountQuery_shortCircuitOnNextTimeout() throws Exception {
+        try {
+            addDelayIterator();
+            givenQuery("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            givenPageShortCircuitTimeoutMs(1_000);
+            givenMaxLongRunningTimeoutRetries(10); // need more than default of three
+            countingLogic.setPageWaitTimeMillis(750); // configure await time
+            expectPlan("SHAPE == 'triangle' || SHAPE == 'square' || SHAPE == 'pentagon' || SHAPE == 'hexagon' || SHAPE == 'octagon'");
+            expectCompletePageCount(1);
+            expectCompletePageSize(1);
+            expectMinimumIntermediatePages(5);
+            planAndExecuteQuery(countingLogic);
+        } finally {
+            removeDelayIterator();
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
+++ b/warehouse/query-core/src/test/java/datawave/query/testframework/AbstractFunctionalQuery.java
@@ -278,6 +278,9 @@ public abstract class AbstractFunctionalQuery implements QueryLogicTestHarness.T
         try {
             this.logic = (ShardQueryLogic) (logicFactory.getQueryLogic("EventQuery", principal));
             this.countLogic = (CountingShardQueryLogic) (logicFactory.getQueryLogic("CountQuery", principal));
+            // this test is fundamentally broken because it does not handle intermediate results, which are now
+            // supported by the CountQuery
+            this.countLogic.setPageWaitTimeMillis(3600000);
         } catch (CloneNotSupportedException | QueryException e) {
             throw new RuntimeException("Unable to create query logics", e);
         }

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -702,12 +702,20 @@
         <property name="extractors" ref="tagCloudExtractors" />
     </bean>
 
-    <!-- Query Logic that returns returnd document keywords -->
+    <!-- Query Logic that returns document keywords -->
     <bean id="KeywordQuery" parent="baseQueryLogic" scope="prototype"  class="datawave.query.tables.keyword.KeywordQueryLogic">
         <property name="tableName" value="shard" />
         <property name="maxResults" value="-1" />
         <property name="maxWork" value="-1" />
         <property name="auditType" value="NONE" />
         <property name="logicDescription" value="Query that returns keywords from content" />
+    </bean>
+
+    <bean id="CountQuery" parent="BaseEventQuery" scope="prototype" class="datawave.query.tables.CountingShardQueryLogic">
+        <property name="logicDescription" value="Executes an EventQuery but returns a count of matching events"/>
+        <property name="collapseUids" value="true"/>
+        <property name="useDocumentScheduler" value="false" />
+        <!-- default timeout of one hour -->
+        <property name="pageWaitTimeMillis" value="3600000"/>
     </bean>
 </beans>


### PR DESCRIPTION
- refactored CountAggregatingIterator to perform aggregation in a separate thread
- CountQuery will return intermediate results until aggregation is complete
- added IntermediateResultsQueryTest to exercise various conditions for returning an intermediate page for both the EventQuery and the CountQuery