### PR TITLE
Add EmptyTreeChecker and integrate into QueryOptionsFromQueryVisitor

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitor.java
@@ -30,6 +30,7 @@ import datawave.query.attributes.UniqueFields;
 import datawave.query.common.grouping.GroupFields;
 import datawave.query.jexl.functions.QueryFunctions;
 import datawave.query.language.functions.jexl.GroupByDate;
+import datawave.query.util.EmptyTreeChecker;
 
 /**
  * Visits the query tree and extracts the parameters from any options functions present and adds them to the provided data {@link Map}. Any options function
@@ -107,10 +108,16 @@ public class QueryOptionsFromQueryVisitor extends RebuildingVisitor {
                     QueryFunctions.RENAME_FUNCTION);
     // @formatter:on
 
+    private QueryOptionsFromQueryVisitor() {
+        // enforce static access
+    }
+
     @SuppressWarnings("unchecked")
     public static <T extends JexlNode> T collect(T node, Object data) {
         QueryOptionsFromQueryVisitor visitor = new QueryOptionsFromQueryVisitor();
-        return (T) node.jjtAccept(visitor, data);
+        T result = (T) node.jjtAccept(visitor, data);
+        EmptyTreeChecker.check(result);
+        return result;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/util/EmptyTreeChecker.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/EmptyTreeChecker.java
@@ -1,0 +1,35 @@
+package datawave.query.util;
+
+import org.apache.commons.jexl3.parser.JexlNode;
+
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.visitors.QueryOptionsFromQueryVisitor;
+
+/**
+ * A utility class that contains logic for empty query tree checks. This utility should be used by visitors that modify the query tree
+ * <p>
+ * One use case is the {@link QueryOptionsFromQueryVisitor} which removes function nodes. If a query contains only function nodes the resulting query tree will
+ * be empty.
+ */
+public class EmptyTreeChecker {
+
+    private EmptyTreeChecker() {
+        // enforce static access
+    }
+
+    /**
+     * Check if the provided JexlNode is null or empty. The JexlNode should be the root of the query tree.
+     *
+     * @param node
+     *            the root node
+     */
+    public static void check(JexlNode node) {
+        if (node == null) {
+            throw new DatawaveFatalQueryException("QueryTree was null");
+        }
+
+        if (node.jjtGetNumChildren() == 0) {
+            throw new DatawaveFatalQueryException("QueryTree was empty");
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/QueryOptionsFromQueryVisitorTest.java
@@ -2,6 +2,7 @@ package datawave.query.jexl.visitors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,6 +14,7 @@ import org.apache.log4j.Logger;
 import org.junit.Test;
 
 import datawave.query.QueryParameters;
+import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.jexl.JexlASTHelper;
 
 public class QueryOptionsFromQueryVisitorTest {
@@ -24,11 +26,11 @@ public class QueryOptionsFromQueryVisitorTest {
     @Test
     public void testOptionsFunction() throws ParseException {
         // Verify that an empty options function adds no parameters.
-        assertResult("f:options()", "");
+        assertResult("f:options()");
         assertTrue(optionsMap.isEmpty());
 
         // Verify any specified options are added as separate parameters.
-        assertResult("f:options('include.grouping.context','true','hit.list','true','limit.fields','FOO_1_BAR=3,FOO_1=2')", "");
+        assertResult("f:options('include.grouping.context','true','hit.list','true','limit.fields','FOO_1_BAR=3,FOO_1=2')");
         assertOption("include.grouping.context", "true");
         assertOption("hit.list", "true");
         assertOption("limit.fields", "FOO_1_BAR=3,FOO_1=2");
@@ -37,171 +39,171 @@ public class QueryOptionsFromQueryVisitorTest {
     @Test
     public void testRenameFunction() throws ParseException {
         // Verify that an empty rename function results in an empty parameter value.
-        assertResult("f:rename()", "");
-        assertOption(QueryParameters.RENAME_FIELDS, "");
+        assertResult("f:rename()");
+        assertOption(QueryParameters.RENAME_FIELDS);
 
-        assertResult("f:rename('field1=field2','field3=field4')", "");
+        assertResult("f:rename('field1=field2','field3=field4')");
         assertOption(QueryParameters.RENAME_FIELDS, "field1=field2,field3=field4");
     }
 
     @Test
     public void testGroupByFunction() throws ParseException {
         // Verify that an empty groupby function results in an empty parameter value.
-        assertResult("f:groupby()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify that fields of no specified granularity are added with the default ALL granularity.
-        assertResult("f:groupby('field1','field2','field3')", "");
+        assertResult("f:groupby('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL],FIELD2[ALL],FIELD3[ALL])");
 
         // Verify that fields with DAY granularity are added as such.
-        assertResult("f:groupby('field1[DAY]','field2[DAY]','field3[DAY]')", "");
+        assertResult("f:groupby('field1[DAY]','field2[DAY]','field3[DAY]')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[DAY],FIELD2[DAY],FIELD3[DAY])");
 
         // Verify that fields with HOUR granularity are added as such.
-        assertResult("f:groupby('field1[HOUR]','field2[HOUR]','field3[HOUR]')", "");
+        assertResult("f:groupby('field1[HOUR]','field2[HOUR]','field3[HOUR]')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[HOUR],FIELD2[HOUR],FIELD3[HOUR])");
 
         // Verify that fields with MINUTE granularity are added as such.
-        assertResult("f:groupby('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')", "");
+        assertResult("f:groupby('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[MINUTE],FIELD2[MINUTE],FIELD3[MINUTE])");
 
         // Verify that fields from multiple groupby functions are merged together.
-        assertResult("f:groupby('field1','field2') AND f:groupby('field2[DAY]','field3[DAY]') AND f:groupby('field4')", "");
+        assertResult("f:groupby('field1','field2') AND f:groupby('field2[DAY]','field3[DAY]') AND f:groupby('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL],FIELD2[ALL,DAY],FIELD3[DAY],FIELD4[ALL])");
 
         // Verify more complex fields with multiple granularity levels are merged together.
-        assertResult("f:groupby('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')", "");
+        assertResult("f:groupby('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[DAY],FIELD2[DAY,HOUR],FIELD3[HOUR,MINUTE],FIELD4[ALL,MINUTE],FIELD5[ALL])");
 
         // Lucene will parse comma-delimited granularity levels into separate strings. Ensure it still parses correctly.
-        assertResult("f:groupby('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')", "");
+        assertResult("f:groupby('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[DAY],FIELD2[DAY,HOUR],FIELD3[HOUR,MINUTE],FIELD4[ALL,MINUTE],FIELD5[ALL])");
     }
 
     @Test
     public void testSumFunction() throws ParseException {
-        assertResult("f:sum()", "");
-        assertOption(QueryParameters.SUM_FIELDS, "");
+        assertResult("f:sum()");
+        assertOption(QueryParameters.SUM_FIELDS);
 
-        assertResult("f:sum(FIELD)", "");
+        assertResult("f:sum(FIELD)");
         assertOption(QueryParameters.SUM_FIELDS, "FIELD");
 
-        assertResult("f:sum(FIELD_A, FIELD_B)", "");
+        assertResult("f:sum(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.SUM_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testCountFunction() throws ParseException {
-        assertResult("f:count()", "");
-        assertOption(QueryParameters.COUNT_FIELDS, "");
+        assertResult("f:count()");
+        assertOption(QueryParameters.COUNT_FIELDS);
 
-        assertResult("f:count(FIELD)", "");
+        assertResult("f:count(FIELD)");
         assertOption(QueryParameters.COUNT_FIELDS, "FIELD");
 
-        assertResult("f:count(FIELD_A, FIELD_B)", "");
+        assertResult("f:count(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.COUNT_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testMinFunction() throws ParseException {
-        assertResult("f:min()", "");
-        assertOption(QueryParameters.MIN_FIELDS, "");
+        assertResult("f:min()");
+        assertOption(QueryParameters.MIN_FIELDS);
 
-        assertResult("f:min(FIELD)", "");
+        assertResult("f:min(FIELD)");
         assertOption(QueryParameters.MIN_FIELDS, "FIELD");
 
-        assertResult("f:min(FIELD_A, FIELD_B)", "");
+        assertResult("f:min(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.MIN_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testMaxFunction() throws ParseException {
-        assertResult("f:max()", "");
-        assertOption(QueryParameters.MAX_FIELDS, "");
+        assertResult("f:max()");
+        assertOption(QueryParameters.MAX_FIELDS);
 
-        assertResult("f:max(FIELD)", "");
+        assertResult("f:max(FIELD)");
         assertOption(QueryParameters.MAX_FIELDS, "FIELD");
 
-        assertResult("f:max(FIELD_A, FIELD_B)", "");
+        assertResult("f:max(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.MAX_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testAverageFunction() throws ParseException {
-        assertResult("f:average()", "");
-        assertOption(QueryParameters.AVERAGE_FIELDS, "");
+        assertResult("f:average()");
+        assertOption(QueryParameters.AVERAGE_FIELDS);
 
-        assertResult("f:average(FIELD)", "");
+        assertResult("f:average(FIELD)");
         assertOption(QueryParameters.AVERAGE_FIELDS, "FIELD");
 
-        assertResult("f:average(FIELD_A, FIELD_B)", "");
+        assertResult("f:average(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.AVERAGE_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testStrictFunction() throws ParseException {
-        assertResult("f:strict()", "");
-        assertOption(QueryParameters.STRICT_FIELDS, "");
+        assertResult("f:strict()");
+        assertOption(QueryParameters.STRICT_FIELDS);
 
-        assertResult("f:strict(FIELD)", "");
+        assertResult("f:strict(FIELD)");
         assertOption(QueryParameters.STRICT_FIELDS, "FIELD");
 
-        assertResult("f:strict(FIELD_A, FIELD_B)", "");
+        assertResult("f:strict(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.STRICT_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testLenientFunction() throws ParseException {
-        assertResult("f:lenient()", "");
-        assertOption(QueryParameters.LENIENT_FIELDS, "");
+        assertResult("f:lenient()");
+        assertOption(QueryParameters.LENIENT_FIELDS);
 
-        assertResult("f:lenient(FIELD)", "");
+        assertResult("f:lenient(FIELD)");
         assertOption(QueryParameters.LENIENT_FIELDS, "FIELD");
 
-        assertResult("f:lenient(FIELD_A, FIELD_B)", "");
+        assertResult("f:lenient(FIELD_A, FIELD_B)");
         assertOption(QueryParameters.LENIENT_FIELDS, "FIELD_A,FIELD_B");
     }
 
     @Test
     public void testUniqueFunction() throws ParseException {
         // Verify an empty function results in an empty parameter value.
-        assertResult("f:unique_by_day()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_day()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Verify that fields of no specified granularity are added with the default ALL granularity.
-        assertResult("f:unique('field1','field2','field3')", "");
+        assertResult("f:unique('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL],FIELD2[ALL],FIELD3[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Verify that fields with DAY granularity are added as such.
-        assertResult("f:unique('field1[DAY]','field2[DAY]','field3[DAY]')", "");
+        assertResult("f:unique('field1[DAY]','field2[DAY]','field3[DAY]')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY],FIELD3[DAY]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Verify that fields with HOUR granularity are added as such.
-        assertResult("f:unique('field1[HOUR]','field2[HOUR]','field3[HOUR]')", "");
+        assertResult("f:unique('field1[HOUR]','field2[HOUR]','field3[HOUR]')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[HOUR],FIELD2[HOUR],FIELD3[HOUR]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Verify that fields with MINUTE granularity are added as such.
-        assertResult("f:unique('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')", "");
+        assertResult("f:unique('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[MINUTE],FIELD2[MINUTE],FIELD3[MINUTE]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Verify that fields from multiple unique functions are merged together.
-        assertResult("f:unique('field1','field2') AND f:unique('field2[DAY]','field3[DAY]') AND f:unique('field4')", "");
+        assertResult("f:unique('field1','field2') AND f:unique('field2[DAY]','field3[DAY]') AND f:unique('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL],FIELD2[ALL,DAY],FIELD3[DAY],FIELD4[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Verify more complex fields with multiple granularity levels are merged together.
-        assertResult("f:unique('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')", "");
+        assertResult("f:unique('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY,HOUR],FIELD3[HOUR,MINUTE],FIELD4[ALL,MINUTE],FIELD5[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
 
         // Lucene will parse comma-delimited granularity levels into separate strings. Ensure it still parses correctly.
-        assertResult("f:unique('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')", "");
+        assertResult("f:unique('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY,HOUR],FIELD3[HOUR,MINUTE],FIELD4[ALL,MINUTE],FIELD5[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, null);
     }
@@ -209,42 +211,42 @@ public class QueryOptionsFromQueryVisitorTest {
     @Test
     public void testMostRecentUniqueFunction() throws ParseException {
         // Verify an empty function results in an empty parameter value.
-        assertResult("f:most_recent_unique_by_day()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:most_recent_unique_by_day()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Verify that fields of no specified granularity are added with the default ALL granularity.
-        assertResult("f:most_recent_unique('field1','field2','field3')", "");
+        assertResult("f:most_recent_unique('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL],FIELD2[ALL],FIELD3[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Verify that fields with DAY granularity are added as such.
-        assertResult("f:most_recent_unique('field1[DAY]','field2[DAY]','field3[DAY]')", "");
+        assertResult("f:most_recent_unique('field1[DAY]','field2[DAY]','field3[DAY]')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY],FIELD3[DAY]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Verify that fields with HOUR granularity are added as such.
-        assertResult("f:most_recent_unique('field1[HOUR]','field2[HOUR]','field3[HOUR]')", "");
+        assertResult("f:most_recent_unique('field1[HOUR]','field2[HOUR]','field3[HOUR]')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[HOUR],FIELD2[HOUR],FIELD3[HOUR]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Verify that fields with MINUTE granularity are added as such.
-        assertResult("f:most_recent_unique('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')", "");
+        assertResult("f:most_recent_unique('field1[MINUTE]','field2[MINUTE]','field3[MINUTE]')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[MINUTE],FIELD2[MINUTE],FIELD3[MINUTE]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Verify that fields from multiple unique functions are merged together.
-        assertResult("f:most_recent_unique('field1','field2') AND f:unique('field2[DAY]','field3[DAY]') AND f:unique('field4')", "");
+        assertResult("f:most_recent_unique('field1','field2') AND f:unique('field2[DAY]','field3[DAY]') AND f:unique('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL],FIELD2[ALL,DAY],FIELD3[DAY],FIELD4[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Verify more complex fields with multiple granularity levels are merged together.
-        assertResult("f:most_recent_unique('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')", "");
+        assertResult("f:most_recent_unique('field1[DAY]','field2[DAY,HOUR]','field3[HOUR,MINUTE]','field4[ALL,MINUTE]','field5')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY,HOUR],FIELD3[HOUR,MINUTE],FIELD4[ALL,MINUTE],FIELD5[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
 
         // Lucene will parse comma-delimited granularity levels into separate strings. Ensure it still parses correctly.
-        assertResult("f:most_recent_unique('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')", "");
+        assertResult("f:most_recent_unique('field1[DAY]','field2[DAY','HOUR]','field3[HOUR','MINUTE]','field4[ALL','MINUTE]','field5')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY,HOUR],FIELD3[HOUR,MINUTE],FIELD4[ALL,MINUTE],FIELD5[ALL]");
         assertOption(QueryParameters.MOST_RECENT_UNIQUE, "true");
     }
@@ -252,120 +254,120 @@ public class QueryOptionsFromQueryVisitorTest {
     @Test
     public void testUniqueByDay() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_day()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_day()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the DAY granularity.
-        assertResult("f:unique_by_day('field1','field2','field3')", "");
+        assertResult("f:unique_by_day('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[DAY],FIELD2[DAY],FIELD3[DAY]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[HOUR]') AND f:unique_by_day('field1','field2','field3') AND f:unique_by_day('field4')", "");
+        assertResult("f:unique('field1','field2[HOUR]') AND f:unique_by_day('field1','field2','field3') AND f:unique_by_day('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,DAY],FIELD2[DAY,HOUR],FIELD3[DAY],FIELD4[DAY]");
     }
 
     @Test
     public void testUniqueByHour() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_hour()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_hour()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:unique_by_hour('field1','field2','field3')", "");
+        assertResult("f:unique_by_hour('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[HOUR],FIELD2[HOUR],FIELD3[HOUR]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_hour('field1','field2','field3') AND f:unique_by_hour('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_hour('field1','field2','field3') AND f:unique_by_hour('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,HOUR],FIELD2[DAY,HOUR],FIELD3[HOUR],FIELD4[HOUR]");
     }
 
     @Test
     public void testUniqueByMonth() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_month()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_month()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:unique_by_month('field1','field2','field3')", "");
+        assertResult("f:unique_by_month('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[MONTH],FIELD2[MONTH],FIELD3[MONTH]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_month('field1','field2','field3') AND f:unique_by_month('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_month('field1','field2','field3') AND f:unique_by_month('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,MONTH],FIELD2[DAY,MONTH],FIELD3[MONTH],FIELD4[MONTH]");
     }
 
     @Test
     public void testUniqueBySecond() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_second()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_second()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:unique_by_second('field1','field2','field3')", "");
+        assertResult("f:unique_by_second('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[SECOND],FIELD2[SECOND],FIELD3[SECOND]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_second('field1','field2','field3') AND f:unique_by_second('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_second('field1','field2','field3') AND f:unique_by_second('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,SECOND],FIELD2[DAY,SECOND],FIELD3[SECOND],FIELD4[SECOND]");
     }
 
     @Test
     public void testUniqueByMillisecond() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_millisecond()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_millisecond()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:unique_by_millisecond('field1','field2','field3')", "");
+        assertResult("f:unique_by_millisecond('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[MILLISECOND],FIELD2[MILLISECOND],FIELD3[MILLISECOND]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_millisecond('field1','field2','field3') AND f:unique_by_millisecond('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_millisecond('field1','field2','field3') AND f:unique_by_millisecond('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,MILLISECOND],FIELD2[DAY,MILLISECOND],FIELD3[MILLISECOND],FIELD4[MILLISECOND]");
     }
 
     @Test
     public void testUniqueByYear() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_year()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_year()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the MINUTE granularity.
-        assertResult("f:unique_by_year('field1','field2','field3')", "");
+        assertResult("f:unique_by_year('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[YEAR],FIELD2[YEAR],FIELD3[YEAR]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_year('field1','field2','field3') AND f:unique_by_year('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_year('field1','field2','field3') AND f:unique_by_year('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,YEAR],FIELD2[DAY,YEAR],FIELD3[YEAR],FIELD4[YEAR]");
     }
 
     @Test
     public void testUniqueByMinute() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_minute()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_minute()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the MINUTE granularity.
-        assertResult("f:unique_by_minute('field1','field2','field3')", "");
+        assertResult("f:unique_by_minute('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[MINUTE],FIELD2[MINUTE],FIELD3[MINUTE]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_minute('field1','field2','field3') AND f:unique_by_minute('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_minute('field1','field2','field3') AND f:unique_by_minute('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,MINUTE],FIELD2[DAY,MINUTE],FIELD3[MINUTE],FIELD4[MINUTE]");
     }
 
     @Test
     public void testUniqueByTenth() throws ParseException {
         // Verify an empty function results in an empty unique parameter.
-        assertResult("f:unique_by_tenth_of_hour()", "");
-        assertOption(QueryParameters.UNIQUE_FIELDS, "");
+        assertResult("f:unique_by_tenth_of_hour()");
+        assertOption(QueryParameters.UNIQUE_FIELDS);
 
         // Verify fields are added with the MINUTE granularity.
-        assertResult("f:unique_by_tenth_of_hour('field1','field2','field3')", "");
+        assertResult("f:unique_by_tenth_of_hour('field1','field2','field3')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[TENTH_OF_HOUR],FIELD2[TENTH_OF_HOUR],FIELD3[TENTH_OF_HOUR]");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_tenth_of_hour('field1','field2','field3') AND f:unique_by_tenth_of_hour('field4')", "");
+        assertResult("f:unique('field1','field2[DAY]') AND f:unique_by_tenth_of_hour('field1','field2','field3') AND f:unique_by_tenth_of_hour('field4')");
         assertOption(QueryParameters.UNIQUE_FIELDS, "FIELD1[ALL,TENTH_OF_HOUR],FIELD2[DAY,TENTH_OF_HOUR],FIELD3[TENTH_OF_HOUR],FIELD4[TENTH_OF_HOUR]");
     }
 
@@ -395,127 +397,172 @@ public class QueryOptionsFromQueryVisitorTest {
     @Test
     public void testGroupByDay() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_day()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_day()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the DAY granularity.
-        assertResult("f:groupby_day('field1','field2','field3')", "");
+        assertResult("f:groupby_day('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[DAY],FIELD2[DAY],FIELD3[DAY])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[HOUR]') AND f:groupby_day('field1','field2','field3') AND f:groupby_day('field4')", "");
+        assertResult("f:groupby('field1','field2[HOUR]') AND f:groupby_day('field1','field2','field3') AND f:groupby_day('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,DAY],FIELD2[DAY,HOUR],FIELD3[DAY],FIELD4[DAY])");
     }
 
     @Test
     public void testGroupByHour() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_hour()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_hour()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:groupby_hour('field1','field2','field3')", "");
+        assertResult("f:groupby_hour('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[HOUR],FIELD2[HOUR],FIELD3[HOUR])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_hour('field1','field2','field3') AND f:groupby_hour('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_hour('field1','field2','field3') AND f:groupby_hour('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,HOUR],FIELD2[DAY,HOUR],FIELD3[HOUR],FIELD4[HOUR])");
     }
 
     @Test
     public void testGroupByMonth() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_month()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_month()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:groupby_month('field1','field2','field3')", "");
+        assertResult("f:groupby_month('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[MONTH],FIELD2[MONTH],FIELD3[MONTH])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_month('field1','field2','field3') AND f:groupby_month('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_month('field1','field2','field3') AND f:groupby_month('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,MONTH],FIELD2[DAY,MONTH],FIELD3[MONTH],FIELD4[MONTH])");
     }
 
     @Test
     public void testGroupBySecond() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_second()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_second()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:groupby_second('field1','field2','field3')", "");
+        assertResult("f:groupby_second('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[SECOND],FIELD2[SECOND],FIELD3[SECOND])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_second('field1','field2','field3') AND f:groupby_second('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_second('field1','field2','field3') AND f:groupby_second('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,SECOND],FIELD2[DAY,SECOND],FIELD3[SECOND],FIELD4[SECOND])");
     }
 
     @Test
     public void testGroupByMillisecond() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_millisecond()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_millisecond()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the HOUR granularity.
-        assertResult("f:groupby_millisecond('field1','field2','field3')", "");
+        assertResult("f:groupby_millisecond('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[MILLISECOND],FIELD2[MILLISECOND],FIELD3[MILLISECOND])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_millisecond('field1','field2','field3') AND f:groupby_millisecond('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_millisecond('field1','field2','field3') AND f:groupby_millisecond('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,MILLISECOND],FIELD2[DAY,MILLISECOND],FIELD3[MILLISECOND],FIELD4[MILLISECOND])");
     }
 
     @Test
     public void testGroupByYear() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_year()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_year()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the MINUTE granularity.
-        assertResult("f:groupby_year('field1','field2','field3')", "");
+        assertResult("f:groupby_year('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[YEAR],FIELD2[YEAR],FIELD3[YEAR])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_year('field1','field2','field3') AND f:groupby_year('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_year('field1','field2','field3') AND f:groupby_year('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,YEAR],FIELD2[DAY,YEAR],FIELD3[YEAR],FIELD4[YEAR])");
     }
 
     @Test
     public void testGroupByMinute() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_minute()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_minute()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the MINUTE granularity.
-        assertResult("f:groupby_minute('field1','field2','field3')", "");
+        assertResult("f:groupby_minute('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[MINUTE],FIELD2[MINUTE],FIELD3[MINUTE])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_minute('field1','field2','field3') AND f:groupby_minute('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_minute('field1','field2','field3') AND f:groupby_minute('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,MINUTE],FIELD2[DAY,MINUTE],FIELD3[MINUTE],FIELD4[MINUTE])");
     }
 
     @Test
     public void testGroupByTenth() throws ParseException {
         // Verify an empty function results in an empty groupby parameter.
-        assertResult("f:groupby_tenth_of_hour()", "");
-        assertOption(QueryParameters.GROUP_FIELDS, "");
+        assertResult("f:groupby_tenth_of_hour()");
+        assertOption(QueryParameters.GROUP_FIELDS);
 
         // Verify fields are added with the MINUTE granularity.
-        assertResult("f:groupby_tenth_of_hour('field1','field2','field3')", "");
+        assertResult("f:groupby_tenth_of_hour('field1','field2','field3')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[TENTH_OF_HOUR],FIELD2[TENTH_OF_HOUR],FIELD3[TENTH_OF_HOUR])");
 
         // Verify fields from multiple functions are merged.
-        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_tenth_of_hour('field1','field2','field3') AND f:groupby_tenth_of_hour('field4')", "");
+        assertResult("f:groupby('field1','field2[DAY]') AND f:groupby_tenth_of_hour('field1','field2','field3') AND f:groupby_tenth_of_hour('field4')");
         assertOption(QueryParameters.GROUP_FIELDS, "GROUP(FIELD1[ALL,TENTH_OF_HOUR],FIELD2[DAY,TENTH_OF_HOUR],FIELD3[TENTH_OF_HOUR],FIELD4[TENTH_OF_HOUR])");
     }
 
+    /**
+     * Assert an option with an empty value
+     *
+     * @param option
+     *            the option name
+     */
+    private void assertOption(String option) {
+        assertOption(option, "");
+    }
+
+    /**
+     * Assert an option key and value
+     *
+     * @param option
+     *            the option key
+     * @param value
+     *            the option value
+     */
     private void assertOption(String option, String value) {
         assertEquals(value, optionsMap.get(option));
     }
 
+    /**
+     * Assert a query with union and intersection operator
+     *
+     * @param original
+     *            the original query string
+     * @throws ParseException
+     *             if the query fails to parse
+     */
+    private void assertResult(String original) throws ParseException {
+        String anchor = "FOO == 'bar'";
+        assertResult(anchor + " || " + original, anchor);
+        assertResult(anchor + " && " + original, anchor);
+        // a query composed of only functions results in an empty query tree which will triggers
+        // an exception during the empty tree check
+        assertThrows(DatawaveFatalQueryException.class, () -> assertResult(original, ""));
+    }
+
+    /**
+     * Assert that after option parsing the resulting query tree matches the expectation
+     *
+     * @param original
+     *            the original query string
+     * @param expected
+     *            the expected query string
+     * @throws ParseException
+     *             if the query fails to parse
+     */
     private void assertResult(String original, String expected) throws ParseException {
         optionsMap.clear();
 

--- a/warehouse/query-core/src/test/java/datawave/query/util/EmptyTreeCheckerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/EmptyTreeCheckerTest.java
@@ -1,0 +1,66 @@
+package datawave.query.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.commons.jexl3.parser.ASTEQNode;
+import org.apache.commons.jexl3.parser.ASTJexlScript;
+import org.apache.commons.jexl3.parser.ASTReferenceExpression;
+import org.apache.commons.jexl3.parser.JexlNode;
+import org.apache.commons.jexl3.parser.JexlNodes;
+import org.apache.commons.jexl3.parser.ParseException;
+import org.apache.commons.jexl3.parser.ParserTreeConstants;
+import org.junit.jupiter.api.Test;
+
+import datawave.query.exceptions.DatawaveFatalQueryException;
+import datawave.query.jexl.JexlASTHelper;
+
+public class EmptyTreeCheckerTest {
+
+    /**
+     * Root node is non-null and has children
+     */
+    @Test
+    public void testValidTree() {
+        JexlNode node = parse("FOO == 'bar'");
+        assertValid(node);
+
+        node = parse("(FOO == 'bar' || FOO == 'baz')");
+        assertValid(node);
+    }
+
+    /**
+     * Root nodes either have no children or are null
+     */
+    @Test
+    public void testInvalidTree() {
+        ASTJexlScript script = new ASTJexlScript(ParserTreeConstants.JJTJEXLSCRIPT);
+        assertInvalid(script);
+
+        ASTReferenceExpression referenceExpression = JexlNodes.makeRefExp();
+        assertInvalid(referenceExpression);
+
+        JexlNode eq = new ASTEQNode(ParserTreeConstants.JJTEQNODE);
+        assertInvalid(eq);
+
+        assertInvalid(null);
+    }
+
+    private void assertValid(JexlNode node) {
+        assertDoesNotThrow(() -> EmptyTreeChecker.check(node));
+    }
+
+    private void assertInvalid(JexlNode node) {
+        assertThrows(DatawaveFatalQueryException.class, () -> EmptyTreeChecker.check(node));
+    }
+
+    private JexlNode parse(String query) {
+        try {
+            return JexlASTHelper.parseAndFlattenJexlQuery(query);
+        } catch (ParseException e) {
+            fail("bad query: " + query);
+            throw new RuntimeException("bad query");
+        }
+    }
+}


### PR DESCRIPTION
EmptyTreeChecker is a static utility that determines "emptiness" via a null check or a zero children check. This is important when you have a query composed entirely of functions, or any visitor that has the potential to prune all children from the root node.

The QueryOptionsFromQueryVisitor test cases were updated to now include only functions, intersections and unions. 