### PR TITLE
Fix timeout in QueryExecutorTest

### DIFF
--- a/microservices/services/query-executor/service/src/test/java/datawave/microservice/query/executor/QueryExecutorTest.java
+++ b/microservices/services/query-executor/service/src/test/java/datawave/microservice/query/executor/QueryExecutorTest.java
@@ -515,7 +515,7 @@ public abstract class QueryExecutorTest {
         // get a result
         startTime = System.currentTimeMillis();
         Result result = null;
-        while (result == null && (System.currentTimeMillis() - startTime) < TimeUnit.SECONDS.toMillis(10000)) {
+        while (result == null && (System.currentTimeMillis() - startTime) < TimeUnit.SECONDS.toMillis(10)) {
             result = listener.receive(100, TimeUnit.MILLISECONDS);
             checkFailed(key.getQueryId());
         }


### PR DESCRIPTION
testCheckpointableDiscoveryQuery now only waits for 10 seconds instead of 10K seconds