### PR TITLE
address race conditions in RemoteEventQueryLogicIT

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicIT.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
@@ -190,7 +192,7 @@ public class RemoteEventQueryLogicIT {
                 if (t1.getState() == Thread.State.WAITING || t2.getState() == Thread.State.WAITING) {
                     done = true;
                 }
-                t1.join(100);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
                 // no-op
             }
@@ -224,8 +226,11 @@ public class RemoteEventQueryLogicIT {
 
         // create two threads that both access the forever handler
         // execute this in a thread so it can be interrupted
+        CountDownLatch exceptionLatch = new CountDownLatch(1);
         RemoteQueryServiceTestUtil.QueryRunnable r1 = new RemoteQueryServiceTestUtil.QueryRunnable(logic);
+        r1.setExceptionLatch(exceptionLatch);
         RemoteQueryServiceTestUtil.QueryRunnable r2 = new RemoteQueryServiceTestUtil.QueryRunnable(logic);
+        r2.setExceptionLatch(exceptionLatch);
 
         // start both threads
         Thread t1 = new Thread(r1);
@@ -234,12 +239,10 @@ public class RemoteEventQueryLogicIT {
         t2.start();
 
         // wait until the exception is caught
-        while (!r1.isCaught().get() && !r2.isCaught().get()) {
-            try {
-                t1.join(100);
-            } catch (InterruptedException e) {
-                // no-op
-            }
+        try {
+            assertTrue("Timed out waiting for connection pool timeout", exceptionLatch.await(35, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            throw new AssertionError("Interrupted while waiting for connection pool timeout", e);
         }
 
         assertFalse(r1.isSetup().get());

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RemoteQueryServiceTestUtil.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RemoteQueryServiceTestUtil.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ws.rs.core.MediaType;
@@ -239,6 +240,7 @@ public class RemoteQueryServiceTestUtil extends RemoteServiceUtil {
 
         private boolean planTest = false;
         private String plan;
+        private CountDownLatch exceptionLatch;
 
         public QueryRunnable(QueryLogic logic) {
             this(logic, null);
@@ -293,8 +295,11 @@ public class RemoteQueryServiceTestUtil extends RemoteServiceUtil {
                     assertEquals(expectedCount, events.size());
                 }
             } catch (Exception e) {
-                caught.set(true);
                 exception = e;
+                caught.set(true);
+                if (exceptionLatch != null) {
+                    exceptionLatch.countDown();
+                }
                 return;
             }
 
@@ -314,6 +319,10 @@ public class RemoteQueryServiceTestUtil extends RemoteServiceUtil {
 
         public Exception getException() {
             return exception;
+        }
+
+        public void setExceptionLatch(CountDownLatch latch) {
+            this.exceptionLatch = latch;
         }
 
         public void setPlanTest(boolean planTest) {


### PR DESCRIPTION
Use Thread.sleep instead of t1.join to ensure we wait the desired time  
Use CountDownLatch to reliably check for the exception case