### PR TITLE
Ingest configuration field config helper support

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/config/IngestConfiguration.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/config/IngestConfiguration.java
@@ -1,15 +1,29 @@
 package datawave.ingest.config;
 
+import static datawave.ingest.data.config.FieldConfigHelperConstants.FIELD_CONFIG_FILE;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
+import datawave.ingest.data.config.FieldConfigHelper;
 import datawave.ingest.data.config.MarkingsHelper;
 import datawave.ingest.data.config.MaskedFieldHelper;
+import datawave.ingest.data.config.XMLFieldConfigHelper;
+import datawave.ingest.data.config.ingest.BaseIngestHelper;
 import datawave.ingest.metadata.RawRecordMetadata;
 
 public interface IngestConfiguration {
+
+    default FieldConfigHelper getFieldConfigHelper(Configuration config, Type dataType, BaseIngestHelper helper) {
+        String typeName = dataType.typeName();
+        String fieldConfigFile = config.get(typeName + FIELD_CONFIG_FILE);
+        if (fieldConfigFile == null) {
+            return null;
+        }
+        return XMLFieldConfigHelper.load(fieldConfigFile, helper);
+    }
 
     MarkingsHelper getMarkingsHelper(Configuration config, Type dataType);
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldConfigHelper.java
@@ -1,6 +1,8 @@
 package datawave.ingest.data.config;
 
 public interface FieldConfigHelper {
+    String describeSource();
+
     boolean isStoredField(String fieldName);
 
     boolean isIndexedField(String fieldName);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldConfigHelperConstants.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldConfigHelperConstants.java
@@ -1,0 +1,5 @@
+package datawave.ingest.data.config;
+
+public class FieldConfigHelperConstants {
+    public static final String FIELD_CONFIG_FILE = ".data.category.field.config.file";
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/XMLFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/XMLFieldConfigHelper.java
@@ -40,6 +40,7 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     private boolean noMatchReverseTokenized = false;
     private String noMatchFieldType = null;
 
+    private final String configSource;
     private final Map<String,FieldInfo> knownFields = new HashMap<>();
     private TreeMap<Matcher,String> patterns = new TreeMap<>(new BaseIngestHelper.MatcherComparator());
 
@@ -72,7 +73,7 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
         try (InputStream in = getAsStream(fieldConfigFile)) {
             if (in != null) {
                 log.info("Loading field configuration from configuration file: {}", fieldConfigFile);
-                return new XMLFieldConfigHelper(in, baseIngestHelper);
+                return new XMLFieldConfigHelper(in, baseIngestHelper, fieldConfigFile);
             } else {
                 throw new IllegalArgumentException("Field config file '" + fieldConfigFile + "' not found!");
             }
@@ -108,6 +109,12 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     }
 
     public XMLFieldConfigHelper(InputStream in, BaseIngestHelper helper) throws ParserConfigurationException, SAXException, IOException {
+        this(in, helper, null);
+    }
+
+    public XMLFieldConfigHelper(InputStream in, BaseIngestHelper helper, String source) throws ParserConfigurationException, SAXException, IOException {
+        this.configSource = source;
+
         final FieldConfigHandler handler = new FieldConfigHandler(this, helper);
         SAXParser parser = parserFactory.newSAXParser();
         parser.parse(in, handler);
@@ -118,6 +125,11 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     public boolean addKnownField(String fieldName, FieldInfo info) {
         // must track the fields we've seen so we can properly apply default rules.
         return (knownFields.put(fieldName, info) == null);
+    }
+
+    @Override
+    public String describeSource() {
+        return configSource;
     }
 
     public boolean addKnownFieldPattern(String fieldName, FieldInfo info, Matcher pattern) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -35,11 +35,11 @@ import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.DataTypeHelperImpl;
 import datawave.ingest.data.config.FieldConfigHelper;
+import datawave.ingest.data.config.FieldConfigHelperConstants;
 import datawave.ingest.data.config.MarkingsHelper;
 import datawave.ingest.data.config.MaskedFieldHelper;
 import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.ingest.data.config.NormalizedFieldAndValue;
-import datawave.ingest.data.config.XMLFieldConfigHelper;
 
 /**
  * Specialization of the Helper type that validates the configuration for Ingest purposes. These helper classes also have the logic to parse the field names and
@@ -136,7 +136,10 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
      */
     public static final String FIELD_FAILED_NORMALIZATION_POLICY = ".data.field.normalization.failure.policy";
 
-    public static final String FIELD_CONFIG_FILE = ".data.category.field.config.file";
+    /**
+     * Backwards compatible property. Duplicated from the field config helper constants.
+     */
+    public static final String FIELD_CONFIG_FILE = FieldConfigHelperConstants.FIELD_CONFIG_FILE;
 
     private static final String PROPERTY_MALFORMED = " property malformed: ";
     private static final Logger log = LoggerFactory.getLogger(BaseIngestHelper.class);
@@ -253,12 +256,9 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         String configProperty = null;
 
         // Load the field helper, which takes precedence over the individual field configurations
-        final String fieldConfigFile = config.get(this.getType().typeName() + FIELD_CONFIG_FILE);
-        if (fieldConfigFile != null) {
-            if (log.isDebugEnabled()) {
-                log.debug("Field config file {} specified for: {}", fieldConfigFile, this.getType().typeName() + FIELD_CONFIG_FILE);
-            }
-            this.fieldConfigHelper = XMLFieldConfigHelper.load(fieldConfigFile, this);
+        this.fieldConfigHelper = ingestConfiguration.getFieldConfigHelper(config, getType(), this);
+        if (this.fieldConfigHelper != null && log.isDebugEnabled()) {
+            log.debug("Field config specified: {}", this.fieldConfigHelper.describeSource());
         }
 
         // Process the indexed fields


### PR DESCRIPTION
* Supports adjusting the field config helper implementation or creation behavior.
* Introduced a default field config helper on the IngestConfiguration interface.
* Implemented default interface method for backwards compatibility.