### PR TITLE
Enforce static imports for JUnit5 assertions

### DIFF
--- a/core/utils/metadata-utils/src/test/java/datawave/iterators/FrequencyMetadataAggregatorTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/iterators/FrequencyMetadataAggregatorTest.java
@@ -6,6 +6,7 @@ import static datawave.data.ColumnFamilyConstants.COLF_F;
 import static datawave.data.ColumnFamilyConstants.COLF_I;
 import static datawave.data.ColumnFamilyConstants.COLF_RI;
 import static datawave.query.util.TestUtils.createDateFrequencyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -33,7 +34,6 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -655,7 +655,7 @@ public class FrequencyMetadataAggregatorTest {
         List<Map.Entry<Key,Value>> expectedSorted = new ArrayList(expected);
         expectedSorted.sort(Map.Entry.comparingByKey());
 
-        Assertions.assertEquals(expectedSorted, actual, getDiffs(expectedSorted, actual));
+        assertEquals(expectedSorted, actual, getDiffs(expectedSorted, actual));
     }
 
     private Scanner createScanner() throws TableNotFoundException {
@@ -697,7 +697,7 @@ public class FrequencyMetadataAggregatorTest {
         List<Map.Entry<Key,Value>> expectedSorted = new ArrayList(expected);
         expectedSorted.sort(Map.Entry.comparingByKey());
 
-        Assertions.assertEquals(expectedSorted, actual, getDiffs(expectedSorted, actual));
+        assertEquals(expectedSorted, actual, getDiffs(expectedSorted, actual));
     }
 
     private String getDiffs(List<Map.Entry<Key,Value>> expected, List<Map.Entry<Key,Value>> actual) {

--- a/core/utils/metadata-utils/src/test/java/datawave/query/model/FieldMappingTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/model/FieldMappingTest.java
@@ -1,9 +1,11 @@
 package datawave.query.model;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Collections;
 
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 
 public class FieldMappingTest {
 
@@ -12,7 +14,7 @@ public class FieldMappingTest {
      */
     @Test
     public void testForwardMappingWithPlainFieldName() {
-        Assertions.assertDoesNotThrow(() -> new FieldMapping("datatype", "DB_NAME", "FIELD_NAME", Direction.FORWARD, "ALL", Collections.emptySet()));
+        assertDoesNotThrow(() -> new FieldMapping("datatype", "DB_NAME", "FIELD_NAME", Direction.FORWARD, "ALL", Collections.emptySet()));
     }
 
     /**
@@ -20,8 +22,7 @@ public class FieldMappingTest {
      */
     @Test
     public void testForwardMappingWithInvalidPatternFieldName() {
-        Assertions.assertThrows(IllegalArgumentException.class,
-                        () -> new FieldMapping("datatype", "[\\]", "FIELD_NAME", Direction.FORWARD, "ALL", Collections.emptySet()),
+        assertThrows(IllegalArgumentException.class, () -> new FieldMapping("datatype", "[\\]", "FIELD_NAME", Direction.FORWARD, "ALL", Collections.emptySet()),
                         "Invalid regex pattern supplied for field name: [\\]");
     }
 
@@ -30,6 +31,6 @@ public class FieldMappingTest {
      */
     @Test
     public void testForwardMappingWithValidPatternFieldName() {
-        Assertions.assertDoesNotThrow(() -> new FieldMapping("datatype", "DB_NAME.*", "FIELD_NAME", Direction.FORWARD, "ALL", Collections.emptySet()));
+        assertDoesNotThrow(() -> new FieldMapping("datatype", "DB_NAME.*", "FIELD_NAME", Direction.FORWARD, "ALL", Collections.emptySet()));
     }
 }

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/IndexFieldHoleTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/IndexFieldHoleTest.java
@@ -4,6 +4,8 @@ import static datawave.data.ColumnFamilyConstants.COLF_F;
 import static datawave.query.util.TestUtils.createDateFrequencyMap;
 import static datawave.query.util.TestUtils.createRangedDateFrequencyMap;
 import static org.apache.accumulo.core.iterators.LongCombiner.VAR_LEN_ENCODER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +38,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -192,7 +193,7 @@ class IndexFieldHoleTest {
 
             HashMap<String,Long> actual = helper.getCountsByFieldInDayWithTypes(new AbstractMap.SimpleEntry<>("NAME", "20200110"));
 
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
 
         /**
@@ -216,7 +217,7 @@ class IndexFieldHoleTest {
 
             HashMap<String,Long> actual = helper.getCountsByFieldInDayWithTypes(new AbstractMap.SimpleEntry<>("NAME", "20200102"));
 
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
 
         /**
@@ -246,7 +247,7 @@ class IndexFieldHoleTest {
 
             HashMap<String,Long> actual = helper.getCountsByFieldInDayWithTypes(new AbstractMap.SimpleEntry<>("NAME", "20200102"));
 
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
     }
 
@@ -346,7 +347,7 @@ class IndexFieldHoleTest {
 
             // Verify that no index holes were found.
             Map<String,Map<String,IndexFieldHole>> IndexFieldHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertTrue(IndexFieldHoles.isEmpty());
+            assertTrue(IndexFieldHoles.isEmpty());
         }
 
         /**
@@ -364,7 +365,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -383,7 +384,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -402,7 +403,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200103")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -423,7 +424,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200103")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -442,7 +443,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -463,7 +464,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -485,7 +486,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200109")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -507,7 +508,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -529,7 +530,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -551,7 +552,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         @ParameterizedTest
@@ -569,7 +570,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -603,7 +604,7 @@ class IndexFieldHoleTest {
                     createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -625,7 +626,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -648,7 +649,7 @@ class IndexFieldHoleTest {
                                             dateRange("20200114", "20200116"),
                                             dateRange("20200119", "20200120")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -675,7 +676,7 @@ class IndexFieldHoleTest {
                                             dateRange("20200114", "20200116"),
                                             dateRange("20200119", "20200120")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -696,7 +697,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -718,7 +719,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -738,7 +739,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200112")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -760,7 +761,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200112")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -783,7 +784,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
                             createIndexFieldHole("URI", "maze", dateRange("20200216", "20200328")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -810,7 +811,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
                             createIndexFieldHole("URI", "maze", dateRange("20200216", "20200328")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -848,7 +849,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -894,7 +895,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -937,7 +938,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -982,7 +983,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1025,7 +1026,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
                             createIndexFieldHole("NAME", "csv", dateRange("20200110", "20200110"), dateRange("20200113", "20200113")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1077,7 +1078,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1146,7 +1147,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200122", "20200122")),
                             createIndexFieldHole("ZETA", "csv", dateRange("20200122", "20200122")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1215,7 +1216,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
                             createIndexFieldHole("ZETA", "csv", dateRange("20200122", "20200122")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
     }
 
@@ -1249,7 +1250,7 @@ class IndexFieldHoleTest {
 
             // Verify that no index holes were found.
             Map<String,Map<String,IndexFieldHole>> IndexFieldHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertTrue(IndexFieldHoles.isEmpty());
+            assertTrue(IndexFieldHoles.isEmpty());
         }
 
         /**
@@ -1267,7 +1268,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1286,7 +1287,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1305,7 +1306,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200103")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1325,7 +1326,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200103")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1344,7 +1345,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1364,7 +1365,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1386,7 +1387,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200109")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1408,7 +1409,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1430,7 +1431,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1452,7 +1453,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         @ParameterizedTest
@@ -1470,7 +1471,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1489,7 +1490,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1509,7 +1510,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1529,7 +1530,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1550,7 +1551,7 @@ class IndexFieldHoleTest {
                                             dateRange("20200114", "20200116"),
                                             dateRange("20200119", "20200120")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1572,7 +1573,7 @@ class IndexFieldHoleTest {
                                             dateRange("20200114", "20200116"),
                                             dateRange("20200119", "20200120")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1593,7 +1594,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1614,7 +1615,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1632,7 +1633,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200112")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1651,7 +1652,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200112")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1674,7 +1675,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
                             createIndexFieldHole("URI", "maze", dateRange("20200216", "20200328")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1701,7 +1702,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
                             createIndexFieldHole("URI", "maze", dateRange("20200216", "20200328")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1734,7 +1735,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1770,7 +1771,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1806,7 +1807,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1844,7 +1845,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1880,7 +1881,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
                             createIndexFieldHole("NAME", "csv", dateRange("20200110", "20200110"), dateRange("20200113", "20200113")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1921,7 +1922,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -1975,7 +1976,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200122", "20200122")),
                             createIndexFieldHole("ZETA", "csv", dateRange("20200122", "20200122")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2029,7 +2030,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
                             createIndexFieldHole("ZETA", "csv", dateRange("20200122", "20200122")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
     }
 
@@ -2065,7 +2066,7 @@ class IndexFieldHoleTest {
 
             // Verify that no index holes were found.
             Map<String,Map<String,IndexFieldHole>> IndexFieldHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertTrue(IndexFieldHoles.isEmpty());
+            assertTrue(IndexFieldHoles.isEmpty());
         }
 
         /**
@@ -2084,7 +2085,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2104,7 +2105,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2124,7 +2125,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200103")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2145,7 +2146,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200103")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2164,7 +2165,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2185,7 +2186,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2207,7 +2208,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200101", "20200109")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2229,7 +2230,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2251,7 +2252,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2273,7 +2274,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         @ParameterizedTest
@@ -2291,7 +2292,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2311,7 +2312,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2332,7 +2333,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2354,7 +2355,7 @@ class IndexFieldHoleTest {
             // @formatter:on
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200106")));
             // @formatter:off
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2378,7 +2379,7 @@ class IndexFieldHoleTest {
                                             dateRange("20200114", "20200116"),
                                             dateRange("20200119", "20200120")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2403,7 +2404,7 @@ class IndexFieldHoleTest {
                                             dateRange("20200114", "20200116"),
                                             dateRange("20200119", "20200120")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2424,7 +2425,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2446,7 +2447,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200105")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2466,7 +2467,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200112")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2486,7 +2487,7 @@ class IndexFieldHoleTest {
             Map<String,Map<String,IndexFieldHole>> expected = createIndexFieldHoleMap(
                             createIndexFieldHole("NAME", "wiki", dateRange("20200104", "20200112")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2509,7 +2510,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
                             createIndexFieldHole("URI", "maze", dateRange("20200216", "20200328")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2536,7 +2537,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
                             createIndexFieldHole("URI", "maze", dateRange("20200216", "20200328")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2572,7 +2573,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2609,7 +2610,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2646,7 +2647,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2685,7 +2686,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2722,7 +2723,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
                             createIndexFieldHole("NAME", "csv", dateRange("20200110", "20200110"), dateRange("20200113", "20200113")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2766,7 +2767,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
                                             dateRange("20200316", "20200316")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2824,7 +2825,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("EVENT_DATE", "wiki", dateRange("20200122", "20200122")),
                             createIndexFieldHole("ZETA", "csv", dateRange("20200122", "20200122")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
 
         /**
@@ -2880,7 +2881,7 @@ class IndexFieldHoleTest {
                             createIndexFieldHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
                             createIndexFieldHole("ZETA", "csv", dateRange("20200122", "20200122")));
             // @formatter:on
-            Assertions.assertEquals(expected, IndexFieldHoles);
+            assertEquals(expected, IndexFieldHoles);
         }
     }
 }

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -4,6 +4,9 @@ import static datawave.data.ColumnFamilyConstants.COLF_F;
 import static datawave.data.ColumnFamilyConstants.COLF_H;
 import static datawave.query.util.TestUtils.createDateFrequencyMap;
 import static org.apache.accumulo.core.iterators.LongCombiner.VAR_LEN_ENCODER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +31,6 @@ import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -137,9 +139,9 @@ public class MetadataHelperTest {
 
             writeMutations();
 
-            Assertions.assertEquals(Collections.singleton("rowA"), helper.getAllFields(Collections.singleton("dataTypeA")));
-            Assertions.assertEquals(Collections.singleton("rowA"), helper.getAllFields(null));
-            Assertions.assertEquals(Collections.singleton("rowA"), helper.getAllFields(Collections.emptySet()));
+            assertEquals(Collections.singleton("rowA"), helper.getAllFields(Collections.singleton("dataTypeA")));
+            assertEquals(Collections.singleton("rowA"), helper.getAllFields(null));
+            assertEquals(Collections.singleton("rowA"), helper.getAllFields(Collections.emptySet()));
         }
 
         @Test
@@ -149,9 +151,9 @@ public class MetadataHelperTest {
 
             writeMutations();
 
-            Assertions.assertEquals(Collections.singleton("rowB"), helper.getAllFields(Collections.singleton("dataTypeB")));
-            Assertions.assertEquals(Sets.newHashSet("rowA", "rowB"), helper.getAllFields(null));
-            Assertions.assertEquals(Sets.newHashSet("rowA", "rowB"), helper.getAllFields(Collections.emptySet()));
+            assertEquals(Collections.singleton("rowB"), helper.getAllFields(Collections.singleton("dataTypeB")));
+            assertEquals(Sets.newHashSet("rowA", "rowB"), helper.getAllFields(null));
+            assertEquals(Sets.newHashSet("rowA", "rowB"), helper.getAllFields(Collections.emptySet()));
         }
 
         @Test
@@ -162,9 +164,9 @@ public class MetadataHelperTest {
 
             writeMutations();
 
-            Assertions.assertEquals(Collections.singleton("rowB"), helper.getAllFields(Collections.singleton("dataTypeB")));
-            Assertions.assertEquals(Sets.newHashSet("rowA", "rowB", "rowC"), helper.getAllFields(null));
-            Assertions.assertEquals(Sets.newHashSet("rowA", "rowB", "rowC"), helper.getAllFields(Collections.emptySet()));
+            assertEquals(Collections.singleton("rowB"), helper.getAllFields(Collections.singleton("dataTypeB")));
+            assertEquals(Sets.newHashSet("rowA", "rowB", "rowC"), helper.getAllFields(null));
+            assertEquals(Sets.newHashSet("rowA", "rowB", "rowC"), helper.getAllFields(Collections.emptySet()));
         }
     }
 
@@ -189,8 +191,8 @@ public class MetadataHelperTest {
 
             writeMutations();
 
-            Assertions.assertEquals(24L, helper.getCardinalityForField("NAME", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
-            Assertions.assertEquals(12L, helper.getCardinalityForField("NAME", "wiki", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
+            assertEquals(24L, helper.getCardinalityForField("NAME", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
+            assertEquals(12L, helper.getCardinalityForField("NAME", "wiki", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
         }
 
         /**
@@ -215,8 +217,8 @@ public class MetadataHelperTest {
                                                                                                                                                // match.
             writeMutations();
 
-            Assertions.assertEquals(33L, helper.getCardinalityForField("NAME", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
-            Assertions.assertEquals(12L, helper.getCardinalityForField("NAME", "wiki", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
+            assertEquals(33L, helper.getCardinalityForField("NAME", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
+            assertEquals(12L, helper.getCardinalityForField("NAME", "wiki", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
         }
 
         /**
@@ -242,8 +244,8 @@ public class MetadataHelperTest {
             givenNonAggregatedFrequencyRows("EVENT_DATE", COLF_F, "maze", "20200101", "20200120", 6L);
             writeMutations();
 
-            Assertions.assertEquals(51L, helper.getCardinalityForField("NAME", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
-            Assertions.assertEquals(21L, helper.getCardinalityForField("NAME", "wiki", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
+            assertEquals(51L, helper.getCardinalityForField("NAME", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
+            assertEquals(21L, helper.getCardinalityForField("NAME", "wiki", DateHelper.parse("20200104"), DateHelper.parse("20200115")));
         }
     }
 
@@ -274,7 +276,7 @@ public class MetadataHelperTest {
 
             HashMap<String,Long> actual = helper.getCountsByFieldInDayWithTypes("NAME", "20200110", accumuloClient, null);
 
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
 
         /**
@@ -298,7 +300,7 @@ public class MetadataHelperTest {
 
             HashMap<String,Long> actual = helper.getCountsByFieldInDayWithTypes("NAME", "20200102", accumuloClient, null);
 
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
 
         /**
@@ -329,7 +331,7 @@ public class MetadataHelperTest {
 
             HashMap<String,Long> actual = helper.getCountsByFieldInDayWithTypes("NAME", "20200102", accumuloClient, null);
 
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
     }
 
@@ -353,8 +355,8 @@ public class MetadataHelperTest {
             givenNonAggregatedFrequencyRows("EVENT_DATE", COLF_F, "maze", "20200101", "20200120", 6L);
             writeMutations();
 
-            Assertions.assertEquals(DateHelper.parse("20200101"), helper.getEarliestOccurrenceOfFieldWithType("NAME", null, accumuloClient, null));
-            Assertions.assertEquals(DateHelper.parse("20200105"), helper.getEarliestOccurrenceOfFieldWithType("NAME", "maze", accumuloClient, null));
+            assertEquals(DateHelper.parse("20200101"), helper.getEarliestOccurrenceOfFieldWithType("NAME", null, accumuloClient, null));
+            assertEquals(DateHelper.parse("20200105"), helper.getEarliestOccurrenceOfFieldWithType("NAME", "maze", accumuloClient, null));
         }
 
         /**
@@ -371,8 +373,8 @@ public class MetadataHelperTest {
             givenAggregatedFrequencyRow("EVENT_DATE", COLF_F, "maze", createDateFrequencyMap("20200101", 2L, "20200102", 3L, "20200103", 4L));
             writeMutations();
 
-            Assertions.assertEquals(DateHelper.parse("20200101"), helper.getEarliestOccurrenceOfFieldWithType("NAME", null, accumuloClient, null));
-            Assertions.assertEquals(DateHelper.parse("20200102"), helper.getEarliestOccurrenceOfFieldWithType("NAME", "maze", accumuloClient, null));
+            assertEquals(DateHelper.parse("20200101"), helper.getEarliestOccurrenceOfFieldWithType("NAME", null, accumuloClient, null));
+            assertEquals(DateHelper.parse("20200102"), helper.getEarliestOccurrenceOfFieldWithType("NAME", "maze", accumuloClient, null));
         }
 
         /**
@@ -395,8 +397,8 @@ public class MetadataHelperTest {
             givenNonAggregatedFrequencyRows("EVENT_DATE", COLF_F, "maze", "20200101", "20200120", 6L);
             writeMutations();
 
-            Assertions.assertEquals(DateHelper.parse("20200101"), helper.getEarliestOccurrenceOfFieldWithType("NAME", null, accumuloClient, null));
-            Assertions.assertEquals(DateHelper.parse("20200103"), helper.getEarliestOccurrenceOfFieldWithType("NAME", "maze", accumuloClient, null));
+            assertEquals(DateHelper.parse("20200101"), helper.getEarliestOccurrenceOfFieldWithType("NAME", null, accumuloClient, null));
+            assertEquals(DateHelper.parse("20200103"), helper.getEarliestOccurrenceOfFieldWithType("NAME", "maze", accumuloClient, null));
         }
     }
 
@@ -410,10 +412,10 @@ public class MetadataHelperTest {
         givenHiddenField("EVENT_DATE", "maze");
         writeMutations();
 
-        Assertions.assertTrue(helper.getHiddenFields(Set.of("csv")).contains("NAME"));
-        Assertions.assertTrue(helper.getHiddenFields(Set.of()).contains("EVENT_DATE"));
-        Assertions.assertFalse(helper.getHiddenFields(Set.of("foo")).contains("NAME"));
-        Assertions.assertFalse(helper.getHiddenFields(Set.of()).contains("FOO"));
+        assertTrue(helper.getHiddenFields(Set.of("csv")).contains("NAME"));
+        assertTrue(helper.getHiddenFields(Set.of()).contains("EVENT_DATE"));
+        assertFalse(helper.getHiddenFields(Set.of("foo")).contains("NAME"));
+        assertFalse(helper.getHiddenFields(Set.of()).contains("FOO"));
     }
 
     /**
@@ -436,17 +438,17 @@ public class MetadataHelperTest {
             writeMutations();
 
             // No DataTypes
-            Assertions.assertEquals(Collections.emptySet(), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Collections.emptySet(), "20200101",
+            assertEquals(Collections.emptySet(), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Collections.emptySet(), "20200101",
                             "20200120", Collections.emptySet()));
             // Using DataTypes
-            Assertions.assertEquals(Set.of("EVENT_DATE"),
+            assertEquals(Set.of("EVENT_DATE"),
                             helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("data"), "20200101", "20200120", Collections.emptySet()));
             // Fictitious field
-            Assertions.assertEquals(Set.of("FOO"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE", "FOO"),
-                            Set.of("wiki", "data", "csv", "maze"), "20200101", "20200120", Collections.emptySet()));
+            assertEquals(Set.of("FOO"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE", "FOO"), Set.of("wiki", "data", "csv", "maze"),
+                            "20200101", "20200120", Collections.emptySet()));
             // Missing because of date range
-            Assertions.assertEquals(Set.of("NAME", "EVENT_DATE"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("wiki", "data"),
-                            "20190101", "20191231", Collections.emptySet()));
+            assertEquals(Set.of("NAME", "EVENT_DATE"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("wiki", "data"), "20190101",
+                            "20191231", Collections.emptySet()));
         }
 
         /**
@@ -464,17 +466,17 @@ public class MetadataHelperTest {
             writeMutations();
 
             // No DataTypes
-            Assertions.assertEquals(Collections.emptySet(), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Collections.emptySet(), "20200101",
+            assertEquals(Collections.emptySet(), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Collections.emptySet(), "20200101",
                             "20200120", Collections.emptySet()));
             // Using DataTypes
-            Assertions.assertEquals(Set.of("EVENT_DATE"),
+            assertEquals(Set.of("EVENT_DATE"),
                             helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("data"), "20200101", "20200120", Collections.emptySet()));
             // Fictitious field
-            Assertions.assertEquals(Set.of("FOO"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE", "FOO"),
-                            Set.of("wiki", "data", "csv", "maze"), "20200101", "20200120", Collections.emptySet()));
+            assertEquals(Set.of("FOO"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE", "FOO"), Set.of("wiki", "data", "csv", "maze"),
+                            "20200101", "20200120", Collections.emptySet()));
             // Missing because of date range
-            Assertions.assertEquals(Set.of("NAME", "EVENT_DATE"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("wiki", "data"),
-                            "20190101", "20191231", Collections.emptySet()));
+            assertEquals(Set.of("NAME", "EVENT_DATE"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("wiki", "data"), "20190101",
+                            "20191231", Collections.emptySet()));
         }
 
         /**
@@ -498,17 +500,17 @@ public class MetadataHelperTest {
             writeMutations();
 
             // No DataTypes
-            Assertions.assertEquals(Collections.emptySet(), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Collections.emptySet(), "20200101",
+            assertEquals(Collections.emptySet(), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Collections.emptySet(), "20200101",
                             "20200120", Collections.emptySet()));
             // Using DataTypes
-            Assertions.assertEquals(Set.of("EVENT_DATE"),
+            assertEquals(Set.of("EVENT_DATE"),
                             helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("data"), "20200101", "20200120", Collections.emptySet()));
             // Fictitious field
-            Assertions.assertEquals(Set.of("FOO"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE", "FOO"),
-                            Set.of("wiki", "data", "csv", "maze"), "20200101", "20200120", Collections.emptySet()));
+            assertEquals(Set.of("FOO"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE", "FOO"), Set.of("wiki", "data", "csv", "maze"),
+                            "20200101", "20200120", Collections.emptySet()));
             // Missing because of date range
-            Assertions.assertEquals(Set.of("NAME", "EVENT_DATE"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("wiki", "data"),
-                            "20190101", "20191231", Collections.emptySet()));
+            assertEquals(Set.of("NAME", "EVENT_DATE"), helper.getMissingFieldsInDateRange(Set.of("NAME", "EVENT_DATE"), Set.of("wiki", "data"), "20190101",
+                            "20191231", Collections.emptySet()));
         }
     }
 }

--- a/core/utils/type-utils/src/test/java/datawave/data/normalizer/NumberNormalizerTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/normalizer/NumberNormalizerTest.java
@@ -2,6 +2,7 @@ package datawave.data.normalizer;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -10,7 +11,6 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class NumberNormalizerTest {
@@ -92,14 +92,14 @@ public class NumberNormalizerTest {
     }
 
     private void assertNormalizeResult(String input, String expected) {
-        assertEquals(normalizer.normalize(input), expected);
+        assertEquals(expected, normalizer.normalize(input));
     }
 
     private void assertComparativelyConsecutive(String... values) {
         for (int i = 0; i < values.length - 1; i++) {
             int compare = values[i].compareTo(values[i + 1]);
             if (compare > 0) {
-                Assertions.fail("Expected values to be consecutive, but encountered " + values[i] + " which is greater than " + values[i + 1]);
+                fail("Expected values to be consecutive, but encountered " + values[i] + " which is greater than " + values[i + 1]);
             }
         }
     }

--- a/core/utils/type-utils/src/test/java/datawave/data/type/ListTypeTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/data/type/ListTypeTest.java
@@ -1,9 +1,10 @@
 package datawave.data.type;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.util.Assert;
 
@@ -44,10 +45,7 @@ public class ListTypeTest {
         String str = "3,2,1,banana";
 
         NumberListType nt = new NumberListType();
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            nt.normalizeToMany(str);
-        });
-
+        assertThrows(IllegalArgumentException.class, () -> nt.normalizeToMany(str));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1905,6 +1905,22 @@
                                 <fail>true</fail>
                             </configuration>
                         </execution>
+                        <execution>
+                            <id>enforce-junit-conventions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <phase>process-sources</phase>
+                            <configuration>
+                                <rules>
+                                    <restrictImports>
+                                        <!-- Do not allow qualified static access in code, i.e. Assertions.assertEquals -->
+                                        <reason>Use static imports for JUnit assertions</reason>
+                                        <bannedImport>org.junit.jupiter.api.Assertions</bannedImport>
+                                    </restrictImports>
+                                </rules>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1869,6 +1869,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.5.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>de.skuzzle.enforcer</groupId>
+                            <artifactId>restrict-imports-enforcer-rule</artifactId>
+                            <version>2.6.1</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>enforce-maven</id>

--- a/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
+++ b/warehouse/accumulo-extensions/src/test/java/datawave/ingest/table/balancer/ShardRendezvousHostBalancerTest.java
@@ -25,9 +25,6 @@ import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.TableId;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.dataImpl.KeyExtent;
@@ -44,7 +41,6 @@ import org.apache.hadoop.io.Text;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 
 import com.google.common.base.Preconditions;
 
@@ -58,9 +54,9 @@ public class ShardRendezvousHostBalancerTest {
             tservers.add(tsi);
         }
 
-        public void removeTservers(Predicate<TabletServerId> tserverPedicate) {
-            tservers.removeIf(tserverPedicate);
-            tabletLocs.values().removeIf(tserverPedicate);
+        public void removeTServers(Predicate<TabletServerId> tserverPredicate) {
+            tservers.removeIf(tserverPredicate);
+            tabletLocs.values().removeIf(tserverPredicate);
 
         }
 
@@ -117,8 +113,8 @@ public class ShardRendezvousHostBalancerTest {
         }
     }
 
-    private AtomicReference<LocalDate> today = new AtomicReference<>();
-    private List<TabletId> tablets = new ArrayList<>();
+    private final AtomicReference<LocalDate> today = new AtomicReference<>();
+    private final List<TabletId> tablets = new ArrayList<>();
     private final TableId tableId = TableId.of("1");
     private final TestTServers testTServers = new TestTServers();
     private final Map<String,String> tableProps = new TreeMap<>();
@@ -243,13 +239,13 @@ public class ShardRendezvousHostBalancerTest {
 
         // nothing changed so should not migrate anything
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
-        Assertions.assertEquals(0, migrations.size());
+        assertEquals(0, migrations.size());
 
         // move forward by one day, should cause tablets to move
         today.set(parseDay("20010131"));
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
         // should migrate all shards in a single day
-        Assertions.assertEquals(31, migrations.size());
+        assertEquals(31, migrations.size());
         testTServers.applyMigrations(migrations);
         // The first set of tservers should loose a day
         shardStats = ShardStats.compute(filter("host0000.*", testTServers.getLocationProvider()));
@@ -281,7 +277,7 @@ public class ShardRendezvousHostBalancerTest {
         // remove a tablet server for case where there are more shards per day than tservers
         var tabletsOnH09 = testTServers.getLocationProvider().values().stream().filter(tabletServerId -> tabletServerId.getHost().equals("host00009")).count();
         assertTrue(tabletsOnH09 > 0);
-        testTServers.removeTservers(tabletServerId -> tabletServerId.getHost().equals("host00009"));
+        testTServers.removeTServers(tabletServerId -> tabletServerId.getHost().equals("host00009"));
         migrations.clear();
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
         // balancing will not migrate unassigned tablet, so this should be a noop
@@ -308,7 +304,7 @@ public class ShardRendezvousHostBalancerTest {
         // remove a tablet server for case where there are more tservers than shards per day
         var tabletsOnH19 = testTServers.getLocationProvider().values().stream().filter(tabletServerId -> tabletServerId.getHost().equals("host00019")).count();
         assertTrue(tabletsOnH19 > 0);
-        testTServers.removeTservers(tabletServerId -> tabletServerId.getHost().equals("host00019"));
+        testTServers.removeTServers(tabletServerId -> tabletServerId.getHost().equals("host00019"));
         migrations.clear();
         balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations));
         // balancing will not migrate unassigned tablet, so this should be a noop
@@ -445,9 +441,9 @@ public class ShardRendezvousHostBalancerTest {
 
         tableProps.clear();
 
-        Assertions.assertThrows(IllegalStateException.class,
+        assertThrows(IllegalStateException.class,
                         () -> balancer.getAssignments(new TestAssignmentParams(testTServers.getCurrent(), testTServers.getUnassigned(tablets), aout)));
-        Assertions.assertThrows(IllegalStateException.class, () -> balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations)));
+        assertThrows(IllegalStateException.class, () -> balancer.balance(new TestBalanceParams(testTServers.getCurrent(), Set.of(), migrations)));
 
         // set the config and it should start working
         tableProps.put("table.custom.volume.tier.names", "t1,t2");
@@ -595,7 +591,7 @@ public class ShardRendezvousHostBalancerTest {
         generateTabletServers(0, 29, 3).forEach(testTServers::addTServer);
         generateTabletServers(30, 3, 1).forEach(testTServers::addTServer);
 
-        // Configure a tier for really old data
+        // Configure a tier for much older data
         tableProps.put("table.custom.volume.tier.names", "t1,t2,t3");
         tableProps.put("table.custom.volume.tiered.t1.days.back", "0");
         tableProps.put("table.custom.volume.tiered.t1.tservers", "host0000.*");
@@ -617,7 +613,7 @@ public class ShardRendezvousHostBalancerTest {
         shardStats.check(20, 31, 10, 3);
         shardStats = ShardStats.compute(filter("host000[12].*", testTServers.getLocationProvider()));
         shardStats.check(10, 31, 19, 3);
-        // The three bad tablets should all group into the tier for really old data
+        // The three bad tablets should all group into the tier for much older data
         shardStats = ShardStats.compute(filter("host0003.*", testTServers.getLocationProvider()));
         shardStats.check(1, 3, 3, 1);
 
@@ -745,7 +741,7 @@ public class ShardRendezvousHostBalancerTest {
         assertEquals(Map.of(), filter(regex, testTServers.getLocationProvider()));
         // check the regex used above
         assertEquals(2, testTServers.getCurrent().keySet().stream().filter(tabletServerId -> tabletServerId.getHost().matches(regex)).count());
-        assertEquals(502, testTServers.getCurrent().keySet().size());
+        assertEquals(502, testTServers.getCurrent().size());
 
         // Add 98 host with 1 tserver. For the 31 shards per day the should now partition as round(500/600*31)=26 and round(100/600*31)=5.
         generateTabletServers(202, 98, 1).forEach(testTServers::addTServer);
@@ -889,7 +885,7 @@ public class ShardRendezvousHostBalancerTest {
     private static class MyBalancerEnvironment implements BalancerEnvironment {
         private final TableId tableId;
         private final List<TabletId> tablets;
-        private final TestTServers testTServers;;
+        private final TestTServers testTServers;
         private final Map<String,String> tableProps;
 
         public MyBalancerEnvironment(TableId tableId, List<TabletId> tablets, TestTServers testTServers, Map<String,String> tableProps) {
@@ -908,24 +904,24 @@ public class ShardRendezvousHostBalancerTest {
         public Configuration getConfiguration(TableId tableId) {
             Configuration mock = EasyMock.mock(ServiceEnvironment.Configuration.class);
             EasyMock.expect(mock.get(EasyMock.anyString())).andAnswer(() -> tableProps.get((String) EasyMock.getCurrentArgument(0))).anyTimes();
-            EasyMock.expect(mock.getTableCustom(EasyMock.anyString()))
-                            .andAnswer(() -> tableProps.get("table.custom." + (String) EasyMock.getCurrentArgument(0))).anyTimes();
+            EasyMock.expect(mock.getTableCustom(EasyMock.anyString())).andAnswer(() -> tableProps.get("table.custom." + EasyMock.getCurrentArgument(0)))
+                            .anyTimes();
             EasyMock.replay(mock);
             return mock;
         }
 
         @Override
-        public String getTableName(TableId tableId) throws TableNotFoundException {
+        public String getTableName(TableId tableId) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public <T> T instantiate(String className, Class<T> base) throws Exception {
+        public <T> T instantiate(String className, Class<T> base) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public <T> T instantiate(TableId tableId, String className, Class<T> base) throws Exception {
+        public <T> T instantiate(TableId tableId, String className, Class<T> base) {
             throw new UnsupportedOperationException();
         }
 
@@ -949,8 +945,7 @@ public class ShardRendezvousHostBalancerTest {
         }
 
         @Override
-        public List<TabletStatistics> listOnlineTabletsForTable(TabletServerId tabletServerId, TableId tableId)
-                        throws AccumuloException, AccumuloSecurityException {
+        public List<TabletStatistics> listOnlineTabletsForTable(TabletServerId tabletServerId, TableId tableId) {
             throw new UnsupportedOperationException();
         }
 

--- a/warehouse/core/src/test/java/datawave/ingest/data/config/ConfigurationHelperTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/data/config/ConfigurationHelperTest.java
@@ -1,10 +1,14 @@
 package datawave.ingest.data.config;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Objects;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class ConfigurationHelperTest {
@@ -16,7 +20,7 @@ class ConfigurationHelperTest {
     void testGetIncrementalInstancesWithNoMatchFound() {
         Configuration conf = new Configuration();
         List<TestInterface> actual = ConfigurationHelper.getIndexedInstances(conf, "test.instance", TestInterface.class, 1);
-        Assertions.assertTrue(actual.isEmpty());
+        assertTrue(actual.isEmpty());
     }
 
     /**
@@ -34,7 +38,7 @@ class ConfigurationHelperTest {
 
         List<TestInterface> expected = List.of(new ValidImpl("FOO"), new ValidImpl("BAR"), new ValidImpl("HAT"));
         List<TestInterface> actual = ConfigurationHelper.getIndexedInstances(conf, "test.instance", TestInterface.class, 1);
-        Assertions.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     /**
@@ -54,7 +58,7 @@ class ConfigurationHelperTest {
 
         List<TestInterface> expected = List.of(new ValidImpl("HAT"), new ValidImpl("BOT"));
         List<TestInterface> actual = ConfigurationHelper.getIndexedInstances(conf, "test.instance", TestInterface.class, 3);
-        Assertions.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     /**
@@ -66,9 +70,9 @@ class ConfigurationHelperTest {
         conf.set("test.instance.1", String.class.getName());
         conf.set("test.instance.1.name", "BAR");
 
-        RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+        RuntimeException exception = assertThrows(RuntimeException.class,
                         () -> ConfigurationHelper.getIndexedInstances(conf, "test.instance", TestInterface.class, 1));
-        Assertions.assertEquals("class java.lang.String cannot be cast to interface datawave.ingest.data.config.ConfigurationHelperTest$TestInterface",
+        assertEquals("class java.lang.String cannot be cast to interface datawave.ingest.data.config.ConfigurationHelperTest$TestInterface",
                         exception.getMessage());
     }
 
@@ -82,11 +86,11 @@ class ConfigurationHelperTest {
         conf.set("test.instance.1", MissingConstructorImpl.class.getName());
         conf.set("test.instance.1.name", "FOO");
 
-        RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+        RuntimeException exception = assertThrows(RuntimeException.class,
                         () -> ConfigurationHelper.getIndexedInstances(conf, "test.instance", TestInterface.class, 1));
-        Assertions.assertEquals("Failed to invoke constructor MissingConstructorImpl(class org.apache.hadoop.conf.Configuration, class java.lang.String)",
+        assertEquals("Failed to invoke constructor MissingConstructorImpl(class org.apache.hadoop.conf.Configuration, class java.lang.String)",
                         exception.getMessage());
-        Assertions.assertInstanceOf(NoSuchMethodException.class, exception.getCause());
+        assertInstanceOf(NoSuchMethodException.class, exception.getCause());
     }
 
     /**

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/ErrorShardedIngestHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/ErrorShardedIngestHelperTest.java
@@ -1,9 +1,12 @@
 package datawave.ingest.data.config.ingest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.TestBaseIngestHelper;
@@ -27,21 +30,21 @@ class ErrorShardedIngestHelperTest {
         ErrorShardedIngestHelper helper = new ErrorShardedIngestHelper();
         helper.setup(config);
 
-        Assertions.assertEquals(Set.of("FOO", "BAR", "HAT"), helper.getIndexedFields());
-        Assertions.assertFalse(helper.hasIndexDisallowlist());
+        assertEquals(Set.of("FOO", "BAR", "HAT"), helper.getIndexedFields());
+        assertFalse(helper.hasIndexDisallowlist());
 
         // The fields FOO, BAR, and HAT should be considered indexed fields.
-        Assertions.assertTrue(helper.isIndexedField("FOO"));
-        Assertions.assertTrue(helper.isIndexedField("BAR"));
-        Assertions.assertTrue(helper.isIndexedField("HAT"));
+        assertTrue(helper.isIndexedField("FOO"));
+        assertTrue(helper.isIndexedField("BAR"));
+        assertTrue(helper.isIndexedField("HAT"));
 
-        Assertions.assertEquals(Set.of("APPLE", "BANANA", "KIWI"), helper.getReverseIndexedFields());
-        Assertions.assertFalse(helper.hasReverseIndexDisallowlist());
+        assertEquals(Set.of("APPLE", "BANANA", "KIWI"), helper.getReverseIndexedFields());
+        assertFalse(helper.hasReverseIndexDisallowlist());
 
         // The fields APPLE, BANANA, and KIWI should be considered reverse indexed fields.
-        Assertions.assertTrue(helper.isReverseIndexedField("APPLE"));
-        Assertions.assertTrue(helper.isReverseIndexedField("BANANA"));
-        Assertions.assertTrue(helper.isReverseIndexedField("KIWI"));
+        assertTrue(helper.isReverseIndexedField("APPLE"));
+        assertTrue(helper.isReverseIndexedField("BANANA"));
+        assertTrue(helper.isReverseIndexedField("KIWI"));
     }
 
     /**
@@ -56,22 +59,22 @@ class ErrorShardedIngestHelperTest {
         ErrorShardedIngestHelper helper = new ErrorShardedIngestHelper();
         helper.setup(config);
 
-        Assertions.assertEquals(Set.of("FOO", "BAR", "HAT"), helper.getIndexedFields());
-        Assertions.assertTrue(helper.hasIndexDisallowlist());
+        assertEquals(Set.of("FOO", "BAR", "HAT"), helper.getIndexedFields());
+        assertTrue(helper.hasIndexDisallowlist());
 
         // Although getIndexedFields() will return FOO, BAR, and HAT, they should not be considered indexed fields due to the disallow list. Verify this as a
         // sanity check.
-        Assertions.assertFalse(helper.isIndexedField("FOO"));
-        Assertions.assertFalse(helper.isIndexedField("BAR"));
-        Assertions.assertFalse(helper.isIndexedField("HAT"));
+        assertFalse(helper.isIndexedField("FOO"));
+        assertFalse(helper.isIndexedField("BAR"));
+        assertFalse(helper.isIndexedField("HAT"));
 
-        Assertions.assertEquals(Set.of("APPLE", "BANANA", "KIWI"), helper.getReverseIndexedFields());
-        Assertions.assertTrue(helper.hasReverseIndexDisallowlist());
+        assertEquals(Set.of("APPLE", "BANANA", "KIWI"), helper.getReverseIndexedFields());
+        assertTrue(helper.hasReverseIndexDisallowlist());
 
         // Repeat the sanity check for APPLE, BANANA, and KIWI as reverse indexed fields.
-        Assertions.assertFalse(helper.isReverseIndexedField("APPLE"));
-        Assertions.assertFalse(helper.isReverseIndexedField("BANANA"));
-        Assertions.assertFalse(helper.isReverseIndexedField("KIWI"));
+        assertFalse(helper.isReverseIndexedField("APPLE"));
+        assertFalse(helper.isReverseIndexedField("BANANA"));
+        assertFalse(helper.isReverseIndexedField("KIWI"));
     }
 
     private Configuration getBaseConfig() {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardIdFactoryTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardIdFactoryTest.java
@@ -1,7 +1,8 @@
 package datawave.ingest.mapreduce.handler.shard;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.hadoop.conf.Configuration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,10 +17,10 @@ import datawave.util.time.DateHelper;
 
 class ShardIdFactoryTest {
 
-    private String uid = "1.2.3";
-    private String date = "20240115";
-    private String dataType = "csva";
-    private int numShards = 10;
+    private final String uid = "1.2.3";
+    private final String date = "20240115";
+    private final String dataType = "csva";
+    private final int numShards = 10;
 
     private Configuration conf;
 
@@ -43,7 +44,7 @@ class ShardIdFactoryTest {
     void testGetShardIdWithNoGenerators() {
         RawRecordContainer event = createEvent(uid, date, dataType);
         String shardId = new ShardIdFactory(conf).getShardId(event);
-        Assertions.assertEquals("20240115_2", shardId);
+        assertEquals("20240115_2", shardId);
     }
 
     /**
@@ -62,7 +63,7 @@ class ShardIdFactoryTest {
 
         RawRecordContainer event = createEvent(uid, date, dataType);
         String shardId = new ShardIdFactory(conf).getShardId(event);
-        Assertions.assertEquals("20240115_2", shardId);
+        assertEquals("20240115_2", shardId);
     }
 
     /**
@@ -81,7 +82,7 @@ class ShardIdFactoryTest {
 
         RawRecordContainer event = createEvent(uid, date, dataType);
         String shardId = new ShardIdFactory(conf).getShardId(event);
-        Assertions.assertEquals("20240115_10", shardId);
+        assertEquals("20240115_10", shardId);
     }
 
     /**
@@ -100,7 +101,7 @@ class ShardIdFactoryTest {
 
         RawRecordContainer event = createEvent(uid, date, dataType);
         String shardId = new ShardIdFactory(conf).getShardId(event);
-        Assertions.assertEquals("20240115_20", shardId);
+        assertEquals("20240115_20", shardId);
     }
 
     @Test
@@ -113,7 +114,7 @@ class ShardIdFactoryTest {
 
         String actualShardId = new ShardIdFactory(conf).getShardId(event);
 
-        Assertions.assertEquals(expectedShardId, actualShardId);
+        assertEquals(expectedShardId, actualShardId);
     }
 
     private RawRecordContainer createEvent(String uid, String date, String dataType) {
@@ -129,7 +130,7 @@ class ShardIdFactoryTest {
     }
 
     public static class EventWithShardId extends RawRecordContainerImpl {
-        private String shardId;
+        private final String shardId;
 
         public EventWithShardId(String shardId) {
             this.shardId = shardId;

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShiftOnDayTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShiftOnDayTest.java
@@ -1,11 +1,16 @@
 package datawave.ingest.mapreduce.handler.shard;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Date;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -51,9 +56,9 @@ class ShiftOnDayTest {
         void testAllNullAttributes() {
             ShiftOnDay generator = init();
 
-            Assertions.assertTrue(generator.getDataTypes().isEmpty());
-            Assertions.assertNull(generator.getBegin());
-            Assertions.assertNull(generator.getEnd());
+            assertTrue(generator.getDataTypes().isEmpty());
+            assertNull(generator.getBegin());
+            assertNull(generator.getEnd());
         }
 
         /**
@@ -67,9 +72,9 @@ class ShiftOnDayTest {
 
             ShiftOnDay generator = init();
 
-            Assertions.assertEquals(Set.of("a", "b", "c"), generator.getDataTypes());
-            Assertions.assertEquals(DateHelper.parse("20240115"), generator.getBegin());
-            Assertions.assertEquals(DateHelper.parse("20240120"), generator.getEnd());
+            assertEquals(Set.of("a", "b", "c"), generator.getDataTypes());
+            assertEquals(DateHelper.parse("20240115"), generator.getBegin());
+            assertEquals(DateHelper.parse("20240120"), generator.getEnd());
         }
 
         /**
@@ -80,8 +85,8 @@ class ShiftOnDayTest {
             this.begin = DateHelper.parse("20240115");
             this.end = DateHelper.parse("19990120");
 
-            IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, this::init);
-            Assertions.assertEquals("End date must be after begin date", exception.getMessage());
+            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, this::init);
+            assertEquals("End date must be after begin date", exception.getMessage());
         }
     }
 
@@ -133,7 +138,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, null, null);
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -146,7 +151,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(Set.of("wiki", "tv", "text"), null, null);
 
-        Assertions.assertFalse(generator.isApplicable(record));
+        assertFalse(generator.isApplicable(record));
     }
 
     /**
@@ -159,7 +164,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(Set.of("wiki", "tv", CSV), null, null);
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -172,7 +177,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, DateHelper.parse("20200101"), null);
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -185,7 +190,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, DateHelper.parse("20200101"), null);
 
-        Assertions.assertFalse(generator.isApplicable(record));
+        assertFalse(generator.isApplicable(record));
     }
 
     /**
@@ -198,7 +203,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, null, DateHelper.parse("20240111"));
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -211,7 +216,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, null, DateHelper.parse("20200101"));
 
-        Assertions.assertFalse(generator.isApplicable(record));
+        assertFalse(generator.isApplicable(record));
     }
 
     /**
@@ -224,7 +229,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, DateHelper.parse("20200101"), DateHelper.parse("20240101"));
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -236,7 +241,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, DateHelper.parse("20200101"), DateHelper.parse("20240101"));
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -248,7 +253,7 @@ class ShiftOnDayTest {
 
         ShiftOnDay generator = new ShiftOnDay(null, DateHelper.parse("20200101"), DateHelper.parse("20240101"));
 
-        Assertions.assertTrue(generator.isApplicable(record));
+        assertTrue(generator.isApplicable(record));
     }
 
     /**
@@ -259,7 +264,7 @@ class ShiftOnDayTest {
         RawRecordContainer record = createRecord("20240101");
         ShiftOnDay shiftOnDay = new ShiftOnDay(null, null, null);
         String shardId = shiftOnDay.getShardId(record, "20240101_2", 10);
-        Assertions.assertEquals("20240101_12", shardId);
+        assertEquals("20240101_12", shardId);
     }
 
     private RawRecordContainer createRecord(String dateStr) {

--- a/warehouse/query-core/src/test/java/datawave/next/DocIdQueryIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/DocIdQueryIteratorTest.java
@@ -1,5 +1,7 @@
 package datawave.next;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -7,7 +9,6 @@ import java.util.Set;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -110,7 +111,7 @@ public class DocIdQueryIteratorTest extends FieldIndexDataTestUtil {
                 iter.next();
             }
         } catch (Exception e) {
-            Assertions.fail("Saw exception", e);
+            fail("Saw exception", e);
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/attributes/TemporalGranularityTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/attributes/TemporalGranularityTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.util.AssertionErrors.assertFalse;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -130,8 +129,7 @@ public class TemporalGranularityTest {
     @Test
     public void testSerialization() throws JsonProcessingException {
         for (TemporalGranularity granularity : TemporalGranularity.values()) {
-            Assertions.assertEquals("\"" + granularity.getName() + "\"", objectMapper.writeValueAsString(granularity),
-                            "Incorrect serialization of " + granularity);
+            assertEquals("\"" + granularity.getName() + "\"", objectMapper.writeValueAsString(granularity), "Incorrect serialization of " + granularity);
         }
     }
 
@@ -141,7 +139,7 @@ public class TemporalGranularityTest {
     @Test
     public void testDeserialization() throws JsonProcessingException {
         for (TemporalGranularity granularity : TemporalGranularity.values()) {
-            Assertions.assertEquals(granularity, objectMapper.readValue("\"" + granularity.getName() + "\"", TemporalGranularity.class),
+            assertEquals(granularity, objectMapper.readValue("\"" + granularity.getName() + "\"", TemporalGranularity.class),
                             "Incorrect deserialization of " + granularity);
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/common/grouping/GroupingAttributeTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/common/grouping/GroupingAttributeTest.java
@@ -1,9 +1,11 @@
 package datawave.query.common.grouping;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import java.math.BigDecimal;
 
 import org.apache.accumulo.core.data.Key;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.data.type.LcNoDiacriticsListType;
@@ -17,7 +19,7 @@ class GroupingAttributeTest {
         GroupingAttribute<BigDecimal> attr1 = new GroupingAttribute<>(new NumberType("123"), new Key("FOO.1"), true);
         GroupingAttribute<BigDecimal> attr2 = new GroupingAttribute<>(new NumberType("123"), new Key("FOO.1"), true);
 
-        Assertions.assertEquals(attr1, attr2);
+        assertEquals(attr1, attr2);
     }
 
     @Test
@@ -25,7 +27,7 @@ class GroupingAttributeTest {
         GroupingAttribute<BigDecimal> attr1 = new GroupingAttribute<>(new NumberType("123"), new Key("FOO.1"), true);
         GroupingAttribute<BigDecimal> attr2 = new GroupingAttribute<>(new NumberType("456"), new Key("FOO.1"), true);
 
-        Assertions.assertNotEquals(attr1, attr2);
+        assertNotEquals(attr1, attr2);
     }
 
     @Test
@@ -33,7 +35,7 @@ class GroupingAttributeTest {
         GroupingAttribute<BigDecimal> attr1 = new GroupingAttribute<>(new NumberType("123"), new Key("FOO.1"), true);
         GroupingAttribute<BigDecimal> attr2 = new GroupingAttribute<>(new NumberType("123"), new Key("BAR.1"), true);
 
-        Assertions.assertNotEquals(attr1, attr2);
+        assertNotEquals(attr1, attr2);
     }
 
     @Test
@@ -41,7 +43,6 @@ class GroupingAttributeTest {
         GroupingAttribute<BigDecimal> attr1 = new GroupingAttribute<>(new NumberType("123"), new Key("FOO.1"), true);
         GroupingAttribute<BigDecimal> attr2 = new GroupingAttribute<>(new LcNoDiacriticsListType("123"), new Key("BAR.1"), true);
 
-        Assertions.assertEquals(attr1.hashCode(), attr2.hashCode());
-
+        assertEquals(attr1.hashCode(), attr2.hashCode());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/util/LuceneQueryGeneratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/util/LuceneQueryGeneratorTest.java
@@ -1,6 +1,7 @@
 package datawave.query.jexl.util;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.Set;
@@ -8,7 +9,6 @@ import java.util.Set;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -127,7 +127,7 @@ class LuceneQueryGeneratorTest {
             ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery(parsed);
             assertTrue(validator.isValid(script));
         } catch (Exception e) {
-            Assertions.fail("Failed to validate query: " + query);
+            fail("Failed to validate query: " + query);
             throw new RuntimeException(e);
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldsWithNumericRangeValuesVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldsWithNumericRangeValuesVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.jexl.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -7,7 +9,6 @@ import java.util.Set;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -220,7 +221,7 @@ class FieldsWithNumericRangeValuesVisitorTest {
             PrintingVisitor.printQuery(script);
         }
         Set<String> actual = FieldsWithNumericRangeValuesVisitor.getFields(script);
-        Assertions.assertEquals(expectedFields, actual);
+        assertEquals(expectedFields, actual);
     }
 
     private void assertLuceneResult() throws ParseException {
@@ -240,7 +241,7 @@ class FieldsWithNumericRangeValuesVisitorTest {
 
             // Visitor under test
             Set<String> actual = FieldsWithNumericRangeValuesVisitor.getFields(jexlScript);
-            Assertions.assertEquals(expectedFields, actual, "Lucene: " + luceneQuery + "  JEXL: " + jexl);
+            assertEquals(expectedFields, actual, "Lucene: " + luceneQuery + "  JEXL: " + jexl);
         } catch (datawave.query.language.parser.ParseException e) {
             throw new RuntimeException(e);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldsWithNumericValuesVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/FieldsWithNumericValuesVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.jexl.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -7,7 +9,6 @@ import java.util.Set;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.apache.commons.jexl3.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -100,6 +101,6 @@ class FieldsWithNumericValuesVisitorTest {
     private void assertResult() throws ParseException {
         ASTJexlScript script = JexlASTHelper.parseJexlQuery(query);
         Set<String> actual = FieldsWithNumericValuesVisitor.getFields(script);
-        Assertions.assertEquals(expectedFields, actual);
+        assertEquals(expectedFields, actual);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/language/functions/jexl/GroupByTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/language/functions/jexl/GroupByTest.java
@@ -1,9 +1,9 @@
 package datawave.query.language.functions.jexl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
@@ -55,10 +55,10 @@ class GroupByTest {
                         exception.getMessage());
         Throwable childCause = exception.getCause();
         // Verify that the original exception was not swallowed, and is present in the stack trace.
-        Assertions.assertInstanceOf(BadRequestQueryException.class, childCause);
+        assertInstanceOf(BadRequestQueryException.class, childCause);
         Throwable grandchildCause = childCause.getCause();
-        Assertions.assertInstanceOf(IllegalArgumentException.class, grandchildCause);
-        Assertions.assertEquals("No TemporalGranularity exists with the name BAD_TRANSFORMER", grandchildCause.getMessage());
+        assertInstanceOf(IllegalArgumentException.class, grandchildCause);
+        assertEquals("No TemporalGranularity exists with the name BAD_TRANSFORMER", grandchildCause.getMessage());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/AmbiguousUnfieldedTermsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/AmbiguousUnfieldedTermsVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.lucene.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,7 +11,6 @@ import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
 import org.apache.lucene.queryparser.flexible.core.parser.SyntaxParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -265,6 +266,6 @@ class AmbiguousUnfieldedTermsVisitorTest {
         // Compare the lists via their query strings.
         List<String> actualStrs = actual.stream().map(node -> node.toQueryString(escapedSyntax).toString()).collect(Collectors.toList());
         List<String> expectedStrs = expectedNodes.stream().map(node -> node.toQueryString(escapedSyntax).toString()).collect(Collectors.toList());
-        Assertions.assertEquals(expectedStrs, actualStrs);
+        assertEquals(expectedStrs, actualStrs);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/GroupedInterpretationVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/GroupedInterpretationVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.lucene.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,7 +11,6 @@ import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.EscapeQuerySyntax;
 import org.apache.lucene.queryparser.flexible.core.parser.SyntaxParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.query.language.parser.lucene.AccumuloSyntaxParser;
@@ -220,6 +221,6 @@ class GroupedInterpretationVisitorTest {
         // Compare the lists via their query strings.
         List<String> actualStrs = actual.stream().map(node -> node.toQueryString(escapedSyntax).toString()).collect(Collectors.toList());
         List<String> expectedStrs = expectedNodes.stream().map(node -> node.toQueryString(escapedSyntax).toString()).collect(Collectors.toList());
-        Assertions.assertEquals(expectedStrs, actualStrs);
+        assertEquals(expectedStrs, actualStrs);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/InvalidIncludeExcludeArgsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/InvalidIncludeExcludeArgsVisitorTest.java
@@ -3,6 +3,7 @@ package datawave.query.lucene.visitors;
 import static datawave.query.lucene.visitors.InvalidIncludeExcludeArgsVisitor.REASON.NO_ARGS_AFTER_BOOLEAN;
 import static datawave.query.lucene.visitors.InvalidIncludeExcludeArgsVisitor.REASON.UNEVEN_ARGS;
 import static datawave.query.lucene.visitors.InvalidIncludeExcludeArgsVisitor.REASON.UNEVEN_ARGS_AFTER_BOOLEAN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,7 +12,6 @@ import org.apache.lucene.queryparser.flexible.core.QueryNodeParseException;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.SyntaxParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -240,6 +240,6 @@ public class InvalidIncludeExcludeArgsVisitorTest {
     private void assertResult() throws QueryNodeParseException {
         QueryNode queryNode = parser.parse(query, "");
         List<InvalidIncludeExcludeArgsVisitor.InvalidFunction> actual = InvalidIncludeExcludeArgsVisitor.check(queryNode);
-        Assertions.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/InvalidQuoteVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/InvalidQuoteVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.lucene.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,7 +10,6 @@ import org.apache.lucene.queryparser.flexible.core.QueryNodeParseException;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.SyntaxParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.query.language.parser.lucene.AccumuloSyntaxParser;
@@ -132,6 +133,6 @@ public class InvalidQuoteVisitorTest {
         List<String> actualStrings = actual.stream().map(LuceneQueryStringBuildingVisitor::build).collect(Collectors.toList());
         List<String> expectedStrings = expected.stream().map(LuceneQueryStringBuildingVisitor::build).collect(Collectors.toList());
         // Compare the query strings.
-        Assertions.assertEquals(expectedStrings, actualStrings);
+        assertEquals(expectedStrings, actualStrings);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/UnescapedWildcardsInQuotedPhrasesVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/UnescapedWildcardsInQuotedPhrasesVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.lucene.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -9,7 +11,6 @@ import org.apache.lucene.queryparser.flexible.core.QueryNodeParseException;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.SyntaxParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.query.language.parser.lucene.AccumuloSyntaxParser;
@@ -91,6 +92,6 @@ class UnescapedWildcardsInQuotedPhrasesVisitorTest {
                         .collect(Collectors.toList());
         // @formatter:on
 
-        Assertions.assertEquals(expectedPhrases, actual);
+        assertEquals(expectedPhrases, actual);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/UnfieldedTermsVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/lucene/visitors/UnfieldedTermsVisitorTest.java
@@ -1,5 +1,7 @@
 package datawave.query.lucene.visitors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,7 +9,6 @@ import org.apache.lucene.queryparser.flexible.core.QueryNodeParseException;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.core.parser.SyntaxParser;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.query.language.parser.lucene.AccumuloSyntaxParser;
@@ -66,6 +67,6 @@ class UnfieldedTermsVisitorTest {
     private void assertResult() throws QueryNodeParseException {
         QueryNode node = parser.parse(query, "");
         List<String> actual = UnfieldedTermsVisitor.check(node);
-        Assertions.assertEquals(expectedTerms, actual);
+        assertEquals(expectedTerms, actual);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
@@ -1,12 +1,14 @@
 package datawave.query.planner;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Set;
 
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -76,8 +78,8 @@ class DefaultQueryPlannerTest {
 
             // no hints or date filter required in this case
             JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertEquals(beginDate, config.getBeginDate());
-            Assertions.assertEquals(endDate, config.getEndDate());
+            assertEquals(beginDate, config.getBeginDate());
+            assertEquals(endDate, config.getEndDate());
         }
 
         /**
@@ -105,9 +107,9 @@ class DefaultQueryPlannerTest {
             JexlNodeAssert.assertThat(actual).isEqualTo(
                             "(FOO == 'bar') && filter:betweenDates(FOO, '" + filterFormat.format(beginDate) + "', '" + filterFormat.format(endDate) + "')");
             // begin date is not pushed farther back
-            Assertions.assertEquals(DateIndexUtil.getBeginDate("20241001"), config.getBeginDate());
+            assertEquals(DateIndexUtil.getBeginDate("20241001"), config.getBeginDate());
             // end date not pushed farther back either
-            Assertions.assertEquals(endDate, config.getEndDate());
+            assertEquals(endDate, config.getEndDate());
         }
 
         /**
@@ -129,8 +131,8 @@ class DefaultQueryPlannerTest {
 
             // no hints or date filter required in this case
             JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertEquals(beginDate, config.getBeginDate());
-            Assertions.assertEquals(endDate, config.getEndDate());
+            assertEquals(beginDate, config.getBeginDate());
+            assertEquals(endDate, config.getEndDate());
         }
 
         /**
@@ -155,8 +157,8 @@ class DefaultQueryPlannerTest {
             JexlNodeAssert.assertThat(actual).hasExactQueryString(
                             "(FOO == 'bar') && filter:betweenDates(FOO, '" + filterFormat.format(beginDate) + "', '" + filterFormat.format(endDate) + "')");
             // only the end date is adjusted
-            Assertions.assertEquals(beginDate, config.getBeginDate());
-            Assertions.assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
+            assertEquals(beginDate, config.getBeginDate());
+            assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
         }
 
         /**
@@ -178,8 +180,8 @@ class DefaultQueryPlannerTest {
 
             // no hints or date filter required in this case
             JexlNodeAssert.assertThat(actual).isEqualTo("FOO == 'bar'");
-            Assertions.assertEquals(beginDate, config.getBeginDate());
-            Assertions.assertEquals(endDate, config.getEndDate());
+            assertEquals(beginDate, config.getBeginDate());
+            assertEquals(endDate, config.getEndDate());
         }
 
         /**
@@ -205,8 +207,8 @@ class DefaultQueryPlannerTest {
             // hints and date filter used in this case
             JexlNodeAssert.assertThat(actual).hasExactQueryString(
                             "(FOO == 'bar') && filter:betweenDates(FOO, '" + filterFormat.format(beginDate) + "', '" + filterFormat.format(endDate) + "')");
-            Assertions.assertEquals(DateIndexUtil.getBeginDate("20241010"), config.getBeginDate());
-            Assertions.assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
+            assertEquals(DateIndexUtil.getBeginDate("20241010"), config.getBeginDate());
+            assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
         }
 
         private ASTJexlScript addDateFilters() throws TableNotFoundException, DatawaveQueryException {
@@ -248,7 +250,7 @@ class DefaultQueryPlannerTest {
             uniqueFields.put("ROLE", TemporalGranularity.TRUNCATE_TEMPORAL_TO_DAY);
             uniqueFields.put("HIRE_DATE", TemporalGranularity.TRUNCATE_TEMPORAL_TO_DAY);
 
-            Assertions.assertThrows(DatawaveFatalQueryException.class, () -> planner.validateUniqueFields(uniqueFields),
+            assertThrows(DatawaveFatalQueryException.class, () -> planner.validateUniqueFields(uniqueFields),
                             "The following unique fields are not date fields and cannot be used with UNIQUE_BY_X: ROLE");
         }
 
@@ -281,7 +283,7 @@ class DefaultQueryPlannerTest {
 
             GroupFields groupFields = GroupFields.from("NAME,ROLE[DAY],HIRE_DATE[DAY]");
 
-            Assertions.assertThrows(DatawaveFatalQueryException.class, () -> planner.validateGroupFields(groupFields),
+            assertThrows(DatawaveFatalQueryException.class, () -> planner.validateGroupFields(groupFields),
                             "The following group-by fields are not date fields and cannot be used with temporal truncation: ROLE");
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/QueryValidationResultTransformerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/QueryValidationResultTransformerTest.java
@@ -1,10 +1,11 @@
 package datawave.query.transformer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import datawave.query.rules.QueryRuleResult;
@@ -168,6 +169,6 @@ class QueryValidationResultTransformerTest {
 
     private void assertResult() {
         QueryValidationResponse actual = transformer.transform(result);
-        Assertions.assertEquals(expectedResponse, actual);
+        assertEquals(expectedResponse, actual);
     }
 }

--- a/web-services/common/src/test/java/datawave/configuration/spring/ThreadSafeClassPathXmlApplicationContextTest.java
+++ b/web-services/common/src/test/java/datawave/configuration/spring/ThreadSafeClassPathXmlApplicationContextTest.java
@@ -1,5 +1,10 @@
 package datawave.configuration.spring;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Locale;
@@ -12,7 +17,6 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.IMocksControl;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -563,14 +567,14 @@ class ThreadSafeClassPathXmlApplicationContextTest extends EasyMockSupport {
         replayAll();
 
         // Call the method under test and assert that it throws a RuntimeException.
-        Exception exception = Assertions.assertThrows(RuntimeException.class, () -> threadSafeContext.getResources("locationPattern"));
+        Exception exception = assertThrows(RuntimeException.class, () -> threadSafeContext.getResources("locationPattern"));
 
         verifyAll();
 
         // Assert the exception is not suppressed and the cause is the original exception.
         Throwable cause = exception.getCause();
-        Assertions.assertInstanceOf(IOException.class, cause);
-        Assertions.assertEquals("test exception", cause.getMessage());
+        assertInstanceOf(IOException.class, cause);
+        assertEquals("test exception", cause.getMessage());
     }
 
     /**
@@ -664,7 +668,7 @@ class ThreadSafeClassPathXmlApplicationContextTest extends EasyMockSupport {
 
         replayAll();
         T actual = methodUnderTest.get();
-        Assertions.assertSame(expected, actual);
+        assertSame(expected, actual);
 
         // Verify the order of method calls and that the read lock was obtained and released.
         verifyAll();


### PR DESCRIPTION
Do not allow qualified usages of JUnit5 Assertions class (i.e., enforce static imports)