### PR TITLE
Adding Column Expand Capability to Data Dictionary v2

### DIFF
--- a/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
+++ b/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
@@ -56,13 +56,15 @@
   text-align: center;
 }
 
+/* This allows text overflow and wrapping (for long descriptions) */
 .q-table th,
 .q-table td {
-  white-space: nowrap !important;    /* don’t wrap text */
-  overflow: hidden !important;       /* hide overflowing content */
-  text-overflow: clip !important;    /* don’t add ellipsis, just cut */
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: clip !important;
 }
 
+/* Styles for the resizable column handle and the hovering effect */
 .resize-handle {
   cursor: col-resize;
   width: 6px;
@@ -74,9 +76,8 @@
   z-index: 10;
 }
 
-/* show something on hover */
 .resize-handle:hover {
-  background-color: rgba(0, 188, 212, 0.5); /* bright blue on hover */
+  background-color: rgba(0, 188, 212, 0.5);
 }
 
 ::-webkit-scrollbar {

--- a/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
+++ b/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
@@ -61,7 +61,6 @@
   white-space: nowrap !important;    /* don’t wrap text */
   overflow: hidden !important;       /* hide overflowing content */
   text-overflow: clip !important;    /* don’t add ellipsis, just cut */
-  min-width: 0 !important;           /* allow zero width */
 }
 
 .resize-handle {
@@ -108,6 +107,7 @@
 /* Sets a fixed height for the table container */
 .datawave-dictionary-sticky-sass {
   height: 310px;
+  overflow-y: auto;
 }
 
 /* Applies a blur effect to the first row's headers for a frosted look */

--- a/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
+++ b/microservices/services/dictionary/service/src/main/frontend/src/css/app.css
@@ -56,6 +56,30 @@
   text-align: center;
 }
 
+.q-table th,
+.q-table td {
+  white-space: nowrap !important;    /* don’t wrap text */
+  overflow: hidden !important;       /* hide overflowing content */
+  text-overflow: clip !important;    /* don’t add ellipsis, just cut */
+  min-width: 0 !important;           /* allow zero width */
+}
+
+.resize-handle {
+  cursor: col-resize;
+  width: 6px;
+  height: 100%;
+  position: absolute;
+  right: 0;
+  top: 0;
+  background-color: rgba(0, 188, 212, 0.3);
+  z-index: 10;
+}
+
+/* show something on hover */
+.resize-handle:hover {
+  background-color: rgba(0, 188, 212, 0.5); /* bright blue on hover */
+}
+
 ::-webkit-scrollbar {
     height: 12px;
     width: 14px;

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
@@ -29,6 +29,7 @@ export const columns: QTableProps['columns'] = [
     field: 'fieldName',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Internal FieldName',
@@ -36,6 +37,7 @@ export const columns: QTableProps['columns'] = [
     field: 'internalFieldName',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Data Type',
@@ -43,6 +45,7 @@ export const columns: QTableProps['columns'] = [
     field: 'dataType',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Index Only',
@@ -50,6 +53,7 @@ export const columns: QTableProps['columns'] = [
     field: 'indexOnly',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Forward Index',
@@ -57,6 +61,7 @@ export const columns: QTableProps['columns'] = [
     field: 'forwardIndexed',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Reverse Index',
@@ -64,6 +69,7 @@ export const columns: QTableProps['columns'] = [
     field: 'reverseIndexed',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Normalized',
@@ -71,6 +77,7 @@ export const columns: QTableProps['columns'] = [
     field: 'normalized',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Types',
@@ -78,6 +85,7 @@ export const columns: QTableProps['columns'] = [
     field: 'Types',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Tokenized',
@@ -85,13 +93,15 @@ export const columns: QTableProps['columns'] = [
     field: 'tokenized',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Description',
     name: 'Descriptions',
     field: 'Descriptions',
-    align: 'center',
+    align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
   {
     label: 'Last Updated',
@@ -99,5 +109,6 @@ export const columns: QTableProps['columns'] = [
     field: 'lastUpdated',
     align: 'left',
     sortable: false,
+    style: 'max-width: 0px;'
   },
 ];

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
@@ -29,7 +29,6 @@ export const columns: QTableProps['columns'] = [
     field: 'fieldName',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Internal FieldName',
@@ -37,7 +36,6 @@ export const columns: QTableProps['columns'] = [
     field: 'internalFieldName',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Data Type',
@@ -45,7 +43,6 @@ export const columns: QTableProps['columns'] = [
     field: 'dataType',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Index Only',
@@ -53,7 +50,6 @@ export const columns: QTableProps['columns'] = [
     field: 'indexOnly',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Forward Index',
@@ -61,7 +57,6 @@ export const columns: QTableProps['columns'] = [
     field: 'forwardIndexed',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Reverse Index',
@@ -69,7 +64,6 @@ export const columns: QTableProps['columns'] = [
     field: 'reverseIndexed',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Normalized',
@@ -77,7 +71,6 @@ export const columns: QTableProps['columns'] = [
     field: 'normalized',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Types',
@@ -85,7 +78,6 @@ export const columns: QTableProps['columns'] = [
     field: 'Types',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Tokenized',
@@ -93,7 +85,6 @@ export const columns: QTableProps['columns'] = [
     field: 'tokenized',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Description',
@@ -101,7 +92,6 @@ export const columns: QTableProps['columns'] = [
     field: 'Descriptions',
     align: 'center',
     sortable: false,
-    style: 'max-width: 0px;',
   },
   {
     label: 'Last Updated',
@@ -109,6 +99,5 @@ export const columns: QTableProps['columns'] = [
     field: 'lastUpdated',
     align: 'left',
     sortable: false,
-    style: 'max-width: 0px;',
   },
 ];

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/components.ts
@@ -29,7 +29,7 @@ export const columns: QTableProps['columns'] = [
     field: 'fieldName',
     align: 'left',
     sortable: false,
-    style: 'max-width: 275px; min-width: 275px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Internal FieldName',
@@ -37,7 +37,7 @@ export const columns: QTableProps['columns'] = [
     field: 'internalFieldName',
     align: 'left',
     sortable: false,
-    style: 'max-width: 275px; min-width: 275px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Data Type',
@@ -45,7 +45,7 @@ export const columns: QTableProps['columns'] = [
     field: 'dataType',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Index Only',
@@ -53,7 +53,7 @@ export const columns: QTableProps['columns'] = [
     field: 'indexOnly',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Forward Index',
@@ -61,7 +61,7 @@ export const columns: QTableProps['columns'] = [
     field: 'forwardIndexed',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Reverse Index',
@@ -69,7 +69,7 @@ export const columns: QTableProps['columns'] = [
     field: 'reverseIndexed',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Normalized',
@@ -77,7 +77,7 @@ export const columns: QTableProps['columns'] = [
     field: 'normalized',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Types',
@@ -85,7 +85,7 @@ export const columns: QTableProps['columns'] = [
     field: 'Types',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Tokenized',
@@ -93,7 +93,7 @@ export const columns: QTableProps['columns'] = [
     field: 'tokenized',
     align: 'left',
     sortable: false,
-    style: 'max-width: 100px; min-width: 100px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Description',
@@ -101,7 +101,7 @@ export const columns: QTableProps['columns'] = [
     field: 'Descriptions',
     align: 'center',
     sortable: false,
-    style: 'max-width: 200px; min-width: 200px',
+    style: 'max-width: 0px;',
   },
   {
     label: 'Last Updated',
@@ -109,6 +109,6 @@ export const columns: QTableProps['columns'] = [
     field: 'lastUpdated',
     align: 'left',
     sortable: false,
-    style: 'max-width: 125px; min-width: 125px',
+    style: 'max-width: 0px;',
   },
 ];

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -55,28 +55,12 @@ export function parseVal(colName: string, colValue: any, colDataTypeCount?: any)
   }
 }
 
-// Produces the max substring for the table, adds '...' if above 34 chars.
+// Catches undefined values and returns an empty string to prevent 'undefined' from rendering in the DOM.
 export function maxSubstring(str: any, colName: any): any {
   if (str === undefined) {
     return;
   }
 
-  // switch (colName) {
-  //   case 'fieldName':
-  //   case 'internalFieldName':
-  //     return str.length > 32 ? str.substring(0, 30) + ' ...' : str;
-  //   case 'Types':
-  //     // Types is offset by 2 to prevent overlapping in 'Tokenized' Column
-  //     return str.length > 14 ? str.substring(0, 9) + ' ...' : str;
-  //   case 'Descriptions':
-  //     return str.length > 24 ? str.substring(0, 22) + ' ...' : str;
-  //   case 'CopyPaste':
-  //     return str.length > 42 ? str.substring(0, 40) + ' ...' : str;
-  //   case 'dataType':
-  //     return str.length > 12 ? str.substring(0, 10) + ' ...' : str;
-  //   default:
-  //     return str;
-  // }
   return str;
 }
 

--- a/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
+++ b/microservices/services/dictionary/service/src/main/frontend/src/functions/formatters.ts
@@ -61,22 +61,23 @@ export function maxSubstring(str: any, colName: any): any {
     return;
   }
 
-  switch (colName) {
-    case 'fieldName':
-    case 'internalFieldName':
-      return str.length > 32 ? str.substring(0, 30) + ' ...' : str;
-    case 'Types':
-      // Types is offset by 2 to prevent overlapping in 'Tokenized' Column
-      return str.length > 14 ? str.substring(0, 9) + ' ...' : str;
-    case 'Descriptions':
-      return str.length > 24 ? str.substring(0, 22) + ' ...' : str;
-    case 'CopyPaste':
-      return str.length > 42 ? str.substring(0, 40) + ' ...' : str;
-    case 'dataType':
-      return str.length > 12 ? str.substring(0, 10) + ' ...' : str;
-    default:
-      return str;
-  }
+  // switch (colName) {
+  //   case 'fieldName':
+  //   case 'internalFieldName':
+  //     return str.length > 32 ? str.substring(0, 30) + ' ...' : str;
+  //   case 'Types':
+  //     // Types is offset by 2 to prevent overlapping in 'Tokenized' Column
+  //     return str.length > 14 ? str.substring(0, 9) + ' ...' : str;
+  //   case 'Descriptions':
+  //     return str.length > 24 ? str.substring(0, 22) + ' ...' : str;
+  //   case 'CopyPaste':
+  //     return str.length > 42 ? str.substring(0, 40) + ' ...' : str;
+  //   case 'dataType':
+  //     return str.length > 12 ? str.substring(0, 10) + ' ...' : str;
+  //   default:
+  //     return str;
+  // }
+  return str;
 }
 
 // Defines how the expandability is parsed on the table.

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -47,6 +47,8 @@
         dense
         style="font-size: smaller; height: 100%; width: 100%;"
         class="datawave-dictionary-sticky-sass dark"
+        sticky-header
+        table-style="table-layout: fixed; width: 100%;"
         :rows-per-page-options="[]"
       >
         <template v-slot:top-left>
@@ -94,6 +96,7 @@
               v-for="col in props.cols"
               :key="col.name"
               :props="props"
+              :style="{ width: colWidths[col.name] + 'px', position: 'relative' }"
             >
               <div class="tooltip-wrapper row items-center no-wrap">
                 <span class="q-mr-xs">
@@ -171,6 +174,10 @@
                   </q-btn>
                 </template>
               </div>
+                <div
+                  class="resize-handle"
+                  @mousedown.stop.prevent="startResizing(col.name, $event)"
+                />
             </q-th>
           </q-tr>
         </template>
@@ -287,6 +294,9 @@ const paginationFront = ref({
   rowsPerPage: 200,
   sortBy: 'fieldName',
 });
+const resizingCol = ref<string | null>(null);
+const startX = ref(0);
+const colWidths = ref<Record<string, number>>({});
 
 // API - Defines all the Nececssary API calls for the user, and filters.
 // Note that to run the endpoint in DEV mode, you must build the project at least once first.
@@ -362,6 +372,14 @@ onMounted(() => {
 
   if (changeFilter.value) {
     queryTable();
+  }
+
+  if (columns) {
+    columns.forEach(col => {
+      if (col.name) {
+        colWidths.value[col.name] = 150;
+      }
+    });
   }
 });
 
@@ -455,6 +473,39 @@ async function queryTable(priorDays?: any) {
 // Query 2 - Awaits for the user to change or add something.
 function waitUp() {
   filter.value = changeFilter.value;
+}
+
+function startResizing(colName: string, evt: MouseEvent) {
+  resizingCol.value = colName;
+  startX.value = evt.pageX;
+
+  document.addEventListener('mousemove', handleResize);
+  document.addEventListener('mouseup', stopResizing);
+}
+
+function handleResize(evt: MouseEvent) {
+  if (!resizingCol.value) return;
+  const diff = evt.pageX - startX.value;
+  startX.value = evt.pageX;
+
+  const allCols = Object.keys(colWidths.value);
+  const dragged = resizingCol.value;
+  const otherCols = allCols.filter(c => c !== dragged);
+
+  colWidths.value[dragged] += diff;
+  otherCols.forEach(c => {
+    colWidths.value[c] -= diff / otherCols.length;
+    if (colWidths.value[c] < 0) colWidths.value[c] = 0;
+  });
+
+  // force update so sticky header adjusts
+  table.value?.refresh();
+}
+
+function stopResizing() {
+  document.removeEventListener('mousemove', handleResize);
+  document.removeEventListener('mouseup', stopResizing);
+  resizingCol.value = null;
 }
 
 // Customization - Sets the Dark Mode Toggle for the User.

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -500,7 +500,7 @@ function handleResize(evt: MouseEvent) {
   const totalDiff = evt.pageX - startX.value;
 
   // apply directly (no accumulation lag)
-  colWidths.value[dragged] = initialWidth.value + totalDiff * 2;
+  colWidths.value[dragged] = initialWidth.value + totalDiff;
 
   // clamp so it doesn’t collapse
   if (colWidths.value[dragged] < 20) {

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -475,9 +475,13 @@ function waitUp() {
   filter.value = changeFilter.value;
 }
 
+const initialWidth = ref(0);
 function startResizing(colName: string, evt: MouseEvent) {
   resizingCol.value = colName;
   startX.value = evt.pageX;
+
+  // store initial width of this column
+  initialWidth.value = colWidths.value[colName];
 
   document.addEventListener('mousemove', handleResize);
   document.addEventListener('mouseup', stopResizing);
@@ -485,20 +489,20 @@ function startResizing(colName: string, evt: MouseEvent) {
 
 function handleResize(evt: MouseEvent) {
   if (!resizingCol.value) return;
-  const diff = evt.pageX - startX.value;
-  startX.value = evt.pageX;
 
-  const allCols = Object.keys(colWidths.value);
   const dragged = resizingCol.value;
-  const otherCols = allCols.filter(c => c !== dragged);
 
-  colWidths.value[dragged] += diff;
-  otherCols.forEach(c => {
-    colWidths.value[c] -= diff / otherCols.length;
-    if (colWidths.value[c] < 0) colWidths.value[c] = 0;
-  });
+  // TOTAL distance from where drag started
+  const totalDiff = evt.pageX - startX.value;
 
-  // force update so sticky header adjusts
+  // apply directly (no accumulation lag)
+  colWidths.value[dragged] = initialWidth.value + totalDiff * 2;
+
+  // clamp so it doesn’t collapse
+  if (colWidths.value[dragged] < 20) {
+    colWidths.value[dragged] = 20;
+  }
+
   table.value?.refresh();
 }
 

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -100,7 +100,6 @@
                 width: colWidths[col.name] + 'px',
                 minWidth: colWidths[col.name] + 'px',
                 maxWidth: colWidths[col.name] + 'px',
-                position: 'relative'
                 }"
             >
               <div class="tooltip-wrapper row items-center no-wrap">

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -96,7 +96,12 @@
               v-for="col in props.cols"
               :key="col.name"
               :props="props"
-              :style="{ width: colWidths[col.name] + 'px', position: 'relative' }"
+              :style="{
+                width: colWidths[col.name] + 'px',
+                minWidth: colWidths[col.name] + 'px',
+                maxWidth: colWidths[col.name] + 'px',
+                position: 'relative'
+                }"
             >
               <div class="tooltip-wrapper row items-center no-wrap">
                 <span class="q-mr-xs">

--- a/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/microservices/services/dictionary/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -294,10 +294,7 @@ const system = ref<System>();
 const helpMenu = ref<Menu>();
 const search = ref('');
 let rows: QTableProps['rows'] = [];
-const paginationFront = ref({
-  rowsPerPage: 200,
-  sortBy: 'fieldName',
-});
+const paginationFront = ref({ rowsPerPage: 200, sortBy: 'fieldName', });
 const resizingCol = ref<string | null>(null);
 const startX = ref(0);
 const colWidths = ref<Record<string, number>>({});
@@ -479,37 +476,45 @@ function waitUp() {
   filter.value = changeFilter.value;
 }
 
+// Resizing Logic - Handles the column resizing by tracking mouse movements and adjusting column widths.
 const initialWidth = ref(0);
 function startResizing(colName: string, evt: MouseEvent) {
+  // 1 - Set the column being resized and the initial mouse position
   resizingCol.value = colName;
   startX.value = evt.pageX;
 
-  // store initial width of this column
+  // 2 - Store the initial width of the column being resized
   initialWidth.value = colWidths.value[colName];
 
+  // 3 - Add event listeners to track mouse movement and when the user releases the mouse button
   document.addEventListener('mousemove', handleResize);
   document.addEventListener('mouseup', stopResizing);
 }
 
+// Resizing Handler - This function is called whenever the mouse moves while resizing a column.
 function handleResize(evt: MouseEvent) {
   if (!resizingCol.value) return;
 
+  // 1 - Determines which column is being dragged
   const dragged = resizingCol.value;
 
-  // TOTAL distance from where drag started
+  // 2 - Calculate how far the mouse has moved from the initial position
+  // Quick Note: This can be multiplied by a factor (e.g. 0.5 or 2) to slow down or increase the resizing speed.
   const totalDiff = evt.pageX - startX.value;
 
-  // apply directly (no accumulation lag)
+  // 3 - Update the width of dragged column based on initial width (no accumulation lag)
   colWidths.value[dragged] = initialWidth.value + totalDiff;
 
-  // clamp so it doesn’t collapse
+  // 4 - Clamp the column width to a minimum value (e.g. 20px) to prevent it from becoming too small
   if (colWidths.value[dragged] < 20) {
     colWidths.value[dragged] = 20;
   }
 
+  // 5 - Trigger a refresh of the table to apply the new column widths
   table.value?.refresh();
 }
 
+// Stop Resizing - Called when the user releases the mouse button (they have finished resizing the column).
 function stopResizing() {
   document.removeEventListener('mousemove', handleResize);
   document.removeEventListener('mouseup', stopResizing);


### PR DESCRIPTION
This PR introduces column resizing to the Data Dictionary table, making it easier to adjust field widths and view more data at once. Tooltips were added previously and continue to support smaller screen resolutions by displaying full values when content is cut off.

This improves usability and makes it easier to work with larger or more detailed datasets without feeling constrained by the table layout.