### PR TITLE
Fix CI bug for compose jobs

### DIFF
--- a/.github/workflows/compose-coordinator.yml
+++ b/.github/workflows/compose-coordinator.yml
@@ -2,6 +2,10 @@ name: Compose Coordinator
 
 on:
   workflow_call:
+    outputs:
+      compose-check-result:
+        description: 'The result of the compose check gate job'
+        value: ${{ jobs.compose-check-jobs.outputs.status }}
 
 jobs:
   call-compose-tests:
@@ -18,14 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs: [call-compose-tests, call-compose-tests-with-snapshots]
+    outputs:
+      status: ${{ steps.check.outputs.status }}
     steps:
       - name: Status message
         run: |
              echo "compose-tests: ${{ needs.call-compose-tests.result }}"
              echo "compose-tests-with-snapshots: ${{ needs.call-compose-tests-with-snapshots.result }}"
       - name: Checks that at least one of the compose jobs ran successfully
-        if: ${{ !contains(needs.*.result, 'success') }}
-        uses: actions/github-script@v6
-        with:
-          script: |
-            core.setFailed('Neither compose jobs passed');
+        id: check
+        run: |
+          if [[ "${{ needs.call-compose-tests.result }}" == "success" || "${{ needs.call-compose-tests-with-snapshots.result }}" == "success" ]]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.call-compose-tests.result }}" == "cancelled" && "${{ needs.call-compose-tests-with-snapshots.result }}" == "cancelled" ]]; then
+            echo "status=cancelled" >> $GITHUB_OUTPUT
+            echo "Compose jobs were cancelled"
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "Neither compose jobs passed"
+            exit 1
+          fi

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -173,7 +173,7 @@ jobs:
     - name: Report result
       if: needs.check-changes.outputs.should_run_compose == 'true'
       run: |
-        if [[ "${{ needs.call-compose-tests.result }}" == "success" ]]; then
+        if [[ "${{ needs.call-compose-tests.outputs.compose-check-result }}" == "success" ]]; then
           echo "✓ Compose checks passed"
           exit 0
         else


### PR DESCRIPTION
Here's what changed and why:

Root cause: When a reusable workflow is called via workflow_call, the caller sees the overall workflow result as failure if any job in it fails — even if the gate job (compose-check-jobs) succeeds. So when one compose test fails but the other passes, the coordinator's gate correctly succeeds, but required-checks.yml sees needs.call-compose-tests.result == 'failure'.

Fix (two files):

1. compose-coordinator.yml — Added a workflow_call output (compose-check-result) that exposes the gate job's explicit status. The gate job now sets a status output to success when at least one test passed (before potentially exiting with failure when neither passed). Also replaced the actions/github-script step with a bash conditional for consistency.
2. required-checks.yml — Changed compose-check-jobs to check needs.call-compose-tests.outputs.compose-check-result instead of needs.call-compose-tests.result, so it reads the gate's actual determination rather than the overall workflow result.