### PR TITLE
Migrate MixedGeoAndGeoWaveTest to AbstractQueryTest framework

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -115,7 +115,7 @@ public class ColorsTest extends AbstractQueryTest {
         Preconditions.checkNotNull(hadoopConfig);
         logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
 
-        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toFile().toString());
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toUri().toString());
         logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
 
         logic.setMaxFieldIndexRangeSplit(1); // keep things simple

--- a/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/MixedGeoAndGeoWaveTest.java
@@ -1,696 +1,260 @@
 package datawave.query;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import static datawave.microservice.query.QueryParameters.QUERY_AUTHORIZATIONS;
-import static datawave.microservice.query.QueryParameters.QUERY_BEGIN;
-import static datawave.microservice.query.QueryParameters.QUERY_END;
-import static datawave.microservice.query.QueryParameters.QUERY_EXPIRATION;
-import static datawave.microservice.query.QueryParameters.QUERY_LOGIC_NAME;
-import static datawave.microservice.query.QueryParameters.QUERY_NAME;
-import static datawave.microservice.query.QueryParameters.QUERY_PERSISTENCE;
-import static datawave.microservice.query.QueryParameters.QUERY_STRING;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.BEGIN_DATE;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.END_DATE;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.GEO_5;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.GEO_6;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.GEO_FIELD;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.POINT_4;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.POINT_FIELD;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.POLY_POINT_FIELD;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.geoData;
+import static datawave.query.util.MixedGeoAndGeoWaveIngest.pointData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URL;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import javax.inject.Inject;
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.BatchWriter;
-import org.apache.accumulo.core.client.BatchWriterConfig;
-import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapreduce.TaskAttemptID;
-import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.util.GeometricShapeFactory;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.configuration.spring.SpringBean;
-import datawave.data.type.GeoType;
-import datawave.data.type.PointType;
-import datawave.ingest.config.RawRecordContainerImpl;
-import datawave.ingest.data.RawRecordContainer;
-import datawave.ingest.data.Type;
-import datawave.ingest.data.TypeRegistry;
-import datawave.ingest.data.config.DataTypeHelper;
-import datawave.ingest.data.config.NormalizedContentInterface;
-import datawave.ingest.data.config.NormalizedFieldAndValue;
-import datawave.ingest.data.config.ingest.BaseIngestHelper;
-import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
-import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
-import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
-import datawave.ingest.mapreduce.job.BulkIngestKey;
-import datawave.ingest.mapreduce.partition.BalancedShardPartitioner;
-import datawave.ingest.table.config.ShardTableConfigHelper;
-import datawave.ingest.table.config.TableConfigHelper;
-import datawave.microservice.query.DefaultQueryParameters;
-import datawave.microservice.query.Query;
-import datawave.microservice.query.QueryImpl;
-import datawave.policy.IngestPolicyEnforcer;
-import datawave.query.config.ShardQueryConfiguration;
+import datawave.query.attributes.Attribute;
+import datawave.query.attributes.Attributes;
+import datawave.query.attributes.Document;
 import datawave.query.exceptions.InvalidQueryException;
-import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.model.QueryModel;
 import datawave.query.planner.DefaultQueryPlanner;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
-import datawave.query.testframework.MockStatusReporter;
-import datawave.util.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
-import datawave.webservice.query.result.event.DefaultEvent;
-import datawave.webservice.query.result.event.DefaultField;
+import datawave.query.util.AbstractQueryTest;
+import datawave.query.util.MixedGeoAndGeoWaveIngest;
+import datawave.query.util.TestIndexTableNames;
 
-@RunWith(Arquillian.class)
-public class MixedGeoAndGeoWaveTest {
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class MixedGeoAndGeoWaveTest extends AbstractQueryTest {
 
-    @ClassRule
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private static final Logger log = LoggerFactory.getLogger(MixedGeoAndGeoWaveTest.class);
 
     private static final int NUM_CIRCLE_POINTS = 60;
-    private static final int NUM_SHARDS = 3;
-    private static final String DATA_TYPE_NAME = "MixedGeo";
-    private static final String INGEST_HELPER_CLASS = TestIngestHelper.class.getName();
-
-    private static final String GEO_FIELD = "GEO";
-    private static final String POINT_FIELD = "POINT";
-    private static final String POLY_POINT_FIELD = "POLY_POINT";
 
     private static final String AUTHS = "ALL";
+    private static final Authorizations auths = new Authorizations(AUTHS);
 
-    private static final String formatPattern = "yyyyMMdd HHmmss.SSS";
-    private static final SimpleDateFormat formatter = new SimpleDateFormat(formatPattern);
+    @TempDir
+    public static Path folder;
 
-    private static final String BEGIN_DATE = "20000101 000000.000";
-    private static final String MID_DATE = "20010101 000000.000";
-    private static final String END_DATE = "20020101 000000.000";
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
 
-    private static final String USER = "testcorp";
-    private static final String USER_DN = "cn=test.testcorp.com, ou=datawave, ou=development, o=testcorp, c=us";
+    private static AccumuloClient client;
 
-    private static final Configuration conf = new Configuration();
+    // special asserts for this test
+    private final Set<String> expectedGeoValues = new HashSet<>();
 
-    private static final String GEO_1 = "0_0";
-    private static final String GEO_2 = "3_0";
-    private static final String GEO_3 = "2_0";
-    private static final String GEO_4 = "1_0";
-    private static final String GEO_5 = "1_1";
-    private static final String GEO_6 = "2_1";
-
-    private static final String POINT_1 = "POINT (2 2)";
-    private static final String POINT_2 = "POINT (2 1)";
-    private static final String POINT_3 = "POINT (2 3)";
-    private static final String POINT_4 = "POINT (1 3)";
-    private static final String POINT_5 = "POINT (2 0)";
-    private static final String POINT_6 = "POINT (1 0)";
-
-    private static final String POLY_1 = "POLYGON((-4 -4, 0 -4, 0 0, -4 0, -4 -4))";
-    private static final String POLY_2 = "POLYGON((0 -4, 4 -4, 4 0, -4 0, 0 -4))";
-    private static final String POLY_3 = "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))";
-    private static final String POLY_4 = "POLYGON((-4 0, 0 0, 0 4, -4 4, -4 0))";
-    private static final String POLY_5 = "POLYGON((-2 -2, 2 -2, 2 2, -2 2, -2 -2))";
-
-    // @formatter:off
-    private static final String[] geoData = {
-            GEO_1,
-            GEO_2,
-            GEO_3,
-            GEO_4,
-            GEO_5,
-            GEO_6};
-    // @formatter:on
-
-    // @formatter:off
-    private static final String[] pointData = {
-            POINT_1,
-            POINT_2,
-            POINT_3,
-            POINT_4,
-            POINT_5,
-            POINT_6};
-    // @formatter:on
-
-    // @formatter:off
-    private static final String[] polyData = {
-            POLY_1,
-            POLY_2,
-            POLY_3,
-            POLY_4,
-            POLY_5};
-    // @formatter:on
-
-    @Inject
-    @SpringBean(name = "EventQuery")
-    ShardQueryLogic logic;
-
-    private static InMemoryInstance instance;
-
-    private static List<IvaratorCacheDirConfig> ivaratorCacheDirConfigs;
-
-    private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
-
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "datawave.webservice.query.result.event",
-                                        "datawave.core.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
-    }
-
-    @BeforeClass
-    public static void setupClass() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
         System.setProperty("subject.dn.pattern", "(?:^|,)\\s*OU\\s*=\\s*My Department\\s*(?:,|$)");
 
-        instance = new InMemoryInstance();
+        InMemoryInstance instance = new InMemoryInstance();
+        client = new InMemoryAccumuloClient("root", instance);
 
-        int recNum = 1;
+        SecurityOperations sops = client.securityOperations();
+        sops.changeUserAuthorizations("root", auths);
 
-        setupConfiguration(conf);
-        recNum = ingestData(conf, GEO_FIELD, geoData, recNum, BEGIN_DATE);
-        recNum = ingestData(conf, POINT_FIELD, pointData, recNum, MID_DATE);
-        ingestData(conf, POLY_POINT_FIELD, polyData, recNum, MID_DATE);
-
-        ivaratorCacheDirConfigs = Collections.singletonList(new IvaratorCacheDirConfig(temporaryFolder.newFolder().toURI().toString()));
+        MixedGeoAndGeoWaveIngest.write(client, auths);
+        log.debug("Data written");
     }
 
-    public static int ingestData(Configuration conf, String fieldName, String[] data, int startRecNum, String ingestDate) throws Exception {
-        AbstractColumnBasedHandler<Text> dataTypeHandler = new AbstractColumnBasedHandler<>();
-        dataTypeHandler.setup(new TaskAttemptContextImpl(conf, new TaskAttemptID()));
-
-        TestIngestHelper ingestHelper = new TestIngestHelper();
-        ingestHelper.setup(conf);
-
-        // create and process events with WKT data
-        RawRecordContainer record = new RawRecordContainerImpl();
-        Multimap<BulkIngestKey,Value> keyValues = HashMultimap.create();
-        int recNum = startRecNum;
-
-        for (int i = 0; i < data.length; i++) {
-            record.clear();
-            record.setDataType(new Type(DATA_TYPE_NAME, TestIngestHelper.class, (Class) null, (String[]) null, 1, (String[]) null));
-            record.setRawFileName("geodata_" + recNum + ".dat");
-            record.setRawRecordNumber(recNum++);
-            record.setTimestamp(formatter.parse(ingestDate).getTime());
-            record.setRawData((fieldName + data[i]).getBytes(UTF_8));
-            record.generateId(null);
-            record.setVisibility(new ColumnVisibility(AUTHS));
-
-            final Multimap<String,NormalizedContentInterface> fields = LinkedListMultimap.create();
-            for (Map.Entry<String,NormalizedContentInterface> entry : ingestHelper.getEventFields(record).entries())
-                if (entry.getValue().getError() == null)
-                    fields.put(entry.getKey(), entry.getValue());
-
-            Multimap<BulkIngestKey,Value> kvPairs = dataTypeHandler.processBulk(new Text(), record, fields, new MockStatusReporter());
-
-            keyValues.putAll(kvPairs);
-
-            dataTypeHandler.getMetadata().addEvent(ingestHelper, record, fields);
-        }
-        keyValues.putAll(dataTypeHandler.getMetadata().getBulkMetadata());
-
-        // write these values to their respective tables
-        AccumuloClient client = new InMemoryAccumuloClient("root", instance);
-        client.securityOperations().changeUserAuthorizations("root", new Authorizations(AUTHS));
-
-        writeKeyValues(client, keyValues);
-
-        ingestUtil.write(client, new Authorizations(AUTHS));
-
-        return recNum;
-    }
-
-    public static void setupConfiguration(Configuration conf) {
-        conf.clear();
-
-        conf.set(DATA_TYPE_NAME + BaseIngestHelper.INDEX_FIELDS, GEO_FIELD + "," + POINT_FIELD + "," + POLY_POINT_FIELD);
-        conf.set(DATA_TYPE_NAME + "." + GEO_FIELD + BaseIngestHelper.FIELD_TYPE, GeoType.class.getName());
-        conf.set(DATA_TYPE_NAME + "." + POINT_FIELD + BaseIngestHelper.FIELD_TYPE, PointType.class.getName());
-        conf.set(DATA_TYPE_NAME + "." + POLY_POINT_FIELD + BaseIngestHelper.FIELD_TYPE, PointType.class.getName());
-
-        conf.set(DATA_TYPE_NAME + DataTypeHelper.Properties.INGEST_POLICY_ENFORCER_CLASS, IngestPolicyEnforcer.NoOpIngestPolicyEnforcer.class.getName());
-        conf.set(DataTypeHelper.Properties.DATA_NAME, DATA_TYPE_NAME);
-        conf.set(TypeRegistry.INGEST_DATA_TYPES, DATA_TYPE_NAME);
-        conf.set(DATA_TYPE_NAME + TypeRegistry.INGEST_HELPER, INGEST_HELPER_CLASS);
-
-        conf.set(ShardedDataTypeHandler.METADATA_TABLE_NAME, TableName.METADATA);
-        conf.set(ShardedDataTypeHandler.NUM_SHARDS, Integer.toString(NUM_SHARDS));
-        conf.set(ShardedDataTypeHandler.SHARDED_TNAMES, TableName.SHARD + "," + TableName.ERROR_SHARD);
-        conf.set(ShardedDataTypeHandler.SHARD_TNAME, TableName.SHARD);
-        conf.set(ShardedDataTypeHandler.SHARD_LPRIORITY, "30");
-        conf.set(TableName.SHARD + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
-        conf.set(ShardedDataTypeHandler.SHARD_GIDX_TNAME, TableName.SHARD_INDEX);
-        conf.set(ShardedDataTypeHandler.SHARD_GIDX_LPRIORITY, "30");
-        conf.set(TableName.SHARD_INDEX + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
-        conf.set(ShardedDataTypeHandler.SHARD_GRIDX_TNAME, TableName.SHARD_RINDEX);
-        conf.set(ShardedDataTypeHandler.SHARD_GRIDX_LPRIORITY, "30");
-        conf.set(TableName.SHARD_RINDEX + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
-        conf.set(ShardTableConfigHelper.MARKINGS_SETUP_ITERATOR_ENABLED, "false");
-        conf.set(ShardTableConfigHelper.MARKINGS_SETUP_ITERATOR_CONFIG, "");
-        conf.set("partitioner.category.shardedTables", BalancedShardPartitioner.class.getName());
-        conf.set("partitioner.category.member." + TableName.SHARD, "shardedTables");
-    }
-
-    private static void writeKeyValues(AccumuloClient client, Multimap<BulkIngestKey,Value> keyValues) throws Exception {
-        final TableOperations tops = client.tableOperations();
-        final Set<BulkIngestKey> biKeys = keyValues.keySet();
-
-        Set<String> loadedShards = new HashSet<>();
-
-        for (final BulkIngestKey biKey : biKeys) {
-            final String tableName = biKey.getTableName().toString();
-            if (!tops.exists(tableName))
-                tops.create(tableName);
-
-            final BatchWriter writer = client.createBatchWriter(tableName, new BatchWriterConfig());
-            for (final Value val : keyValues.get(biKey)) {
-                final Mutation mutation = new Mutation(biKey.getKey().getRow());
-                mutation.put(biKey.getKey().getColumnFamily(), biKey.getKey().getColumnQualifier(), biKey.getKey().getColumnVisibilityParsed(),
-                                biKey.getKey().getTimestamp(), val);
-                writer.addMutation(mutation);
-                if (biKey.getTableName().toString().equals("shard")) {
-                    loadedShards.add(biKey.getKey().getRow().toString());
-                }
-            }
-            writer.close();
-        }
-
-        try (BatchWriter bw = client.createBatchWriter(TableName.METADATA)) {
-            Mutation m = new Mutation("num_shards");
-            m.put("ns", "20000101_" + NUM_SHARDS, new Value());
-            bw.addMutation(m);
-        }
+    @BeforeEach
+    public void beforeEach() {
+        setClientForTest(client);
+        givenDate(BEGIN_DATE, END_DATE);
     }
 
     @Test
-    public void withinSmallBoundingBoxTest() throws Exception {
-        String query = "geo:within_bounding_box(" + GEO_FIELD + ", '2_0.5', '10_1.5')";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(2, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(GEO_6, POINT_4));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testWithinSmallBoundingBox() throws Exception {
+        givenQuery("geo:within_bounding_box(" + GEO_FIELD + ", '2_0.5', '10_1.5')");
+        expectPlan("(GEO == '019821..0000000000' && geo:within_bounding_box(GEO, '019820..0500000000', '110801..0500000000')) || (POINT == '1f200398c60112ee03' && geowave:intersects(POINT, 'POLYGON ((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))'))");
+        expectGeoValues(GEO_6, POINT_4);
+        expectResultCount(2);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void intersectsSmallBoundingBoxTest() throws Exception {
-        String query = "geowave:intersects(" + GEO_FIELD + ", 'POLYGON((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))')";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(2, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(GEO_6, POINT_4));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testIntersectsSmallBoundingBox() throws Exception {
+        givenQuery("geowave:intersects(" + GEO_FIELD + ", 'POLYGON((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))')");
+        expectPlan("(GEO == '019821..0000000000' && geowave:intersects(GEO, 'POLYGON((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))')) || (POINT == '1f200398c60112ee03' && geowave:intersects(POINT, 'POLYGON((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))'))");
+        expectGeoValues(GEO_6, POINT_4);
+        expectResultCount(2);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void withinSmallBoundingBoxEvaluationOnlyTest() throws Exception {
-        String query = "geo:within_bounding_box(" + GEO_FIELD + ", '2_0.5', '10_1.5') && ((_Eval_ = true) && geo:within_bounding_box(" + GEO_FIELD
-                        + ", '2_0.5', '10_1.5'))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(2, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(GEO_6, POINT_4));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testWithinSmallBoundingBoxEvaluationOnly() throws Exception {
+        givenQuery("geo:within_bounding_box(" + GEO_FIELD + ", '2_0.5', '10_1.5') && ((_Eval_ = true) && geo:within_bounding_box(" + GEO_FIELD
+                        + ", '2_0.5', '10_1.5'))");
+        expectPlan("((GEO == '019821..0000000000' && geo:within_bounding_box(GEO, '019820..0500000000', '110801..0500000000')) || (POINT == '1f200398c60112ee03' && geowave:intersects(POINT, 'POLYGON ((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))'))) && ((_Eval_ = true) && (geo:within_bounding_box(GEO, '019820..0500000000', '110801..0500000000') || geowave:intersects(POINT, 'POLYGON ((0.5 2, 1.5 2, 1.5 10, 0.5 10, 0.5 2))')))");
+        expectGeoValues(GEO_6, POINT_4);
+        expectResultCount(2);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void intersectsSmallBoundingBoxEvaluationOnlyTest() throws Exception {
-        String query = "geowave:intersects(" + GEO_FIELD + ", 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))') && ((_Eval_ = true) && geowave:intersects("
-                        + GEO_FIELD + ", 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))'))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(2, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(GEO_6, POINT_4));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testIntersectsSmallBoundingBoxEvaluationOnly() throws Exception {
+        givenQuery("geowave:intersects(" + GEO_FIELD + ", 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))') && ((_Eval_ = true) && geowave:intersects("
+                        + GEO_FIELD + ", 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))'))");
+        expectPlan("((GEO == '019821..0000000000' && geowave:intersects(GEO, 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))')) || (POINT == '1f200398c60112ee03' && geowave:intersects(POINT, 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))'))) && ((_Eval_ = true) && (geowave:intersects(GEO, 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))') || geowave:intersects(POINT, 'POLYGON((0.5 2, 0.5 10, 1.5 10, 1.5 2, 0.5 2))')))");
+        expectGeoValues(GEO_6, POINT_4);
+        expectResultCount(2);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void withinLargeBoundingBoxTest() throws Exception {
-        String query = "geo:within_bounding_box(" + GEO_FIELD + ", '-90_-180', '90_180')";
+    public void testWithinLargeBoundingBox() throws Exception {
+        givenQuery("geo:within_bounding_box(" + GEO_FIELD + ", '-90_-180', '90_180')");
+        expectPlan("(geo:within_bounding_box(GEO, '000000..0000000000', '138600..0000000000') && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '000000..0000000000' && GEO <= '030700..0000000000')))) || (geowave:intersects(POINT, 'POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1c00000000000000' && POINT <= '1f23ffffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f31ffffffffffffff' && POINT <= '1f37ffffffffffffff')))))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
+    }
 
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
+    // this test takes forever to execute and teardown. Maybe a threadpool timeout?
+    @Test
+    public void testIntersectsLargeBoundingBoxTest() throws Exception {
+        givenQuery("geowave:intersects(" + GEO_FIELD + ", 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))')");
+        expectPlan("(geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '000000..0000000000' && GEO <= '030700..0000000000')))) || (geowave:intersects(POINT, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1c00000000000000' && POINT <= '1f23ffffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f31ffffffffffffff' && POINT <= '1f37ffffffffffffff')))))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
+    }
 
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
+    // this test takes forever to execute and teardown. Maybe a threadpool timeout?
+    @Test
+    public void testWithinLargeBoundingBoxEvaluationOnly() throws Exception {
+        givenQuery("geo:within_bounding_box(" + GEO_FIELD + ", '-90_-180', '90_180') && ((_Eval_ = true) && geo:within_bounding_box(" + GEO_FIELD
+                        + ", '-90_-180', '90_180'))");
+        expectPlan("((geo:within_bounding_box(GEO, '000000..0000000000', '138600..0000000000') && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '000000..0000000000' && GEO <= '030700..0000000000')))) || (geowave:intersects(POINT, 'POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1c00000000000000' && POINT <= '1f23ffffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f31ffffffffffffff' && POINT <= '1f37ffffffffffffff')))))) && ((_Eval_ = true) && (geo:within_bounding_box(GEO, '000000..0000000000', '138600..0000000000') || geowave:intersects(POINT, 'POLYGON ((-180 -90, 180 -90, 180 90, -180 90, -180 -90))')))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
+    }
 
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    // this test takes forever to execute and teardown. Maybe a threadpool timeout?
+    @Test
+    public void testIntersectsLargeBoundingBoxEvaluationOnly() throws Exception {
+        givenQuery("geowave:intersects(" + GEO_FIELD + ", 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && ((_Eval_ = true) && geowave:intersects("
+                        + GEO_FIELD + ", 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))'))");
+        expectPlan("((geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '000000..0000000000' && GEO <= '030700..0000000000')))) || (geowave:intersects(POINT, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1c00000000000000' && POINT <= '1f23ffffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f31ffffffffffffff' && POINT <= '1f37ffffffffffffff')))))) && ((_Eval_ = true) && (geowave:intersects(GEO, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') || geowave:intersects(POINT, 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))')))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void intersectsLargeBoundingBoxTest() throws Exception {
-        String query = "geowave:intersects(" + GEO_FIELD + ", 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))')";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testWithinLargeCircle() throws Exception {
+        givenQuery("geo:within_circle(" + GEO_FIELD + ", '0_0', 90)");
+        expectPlan("(geo:within_circle(GEO, '019800..0000000000', 90) && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '011200..0000000000' && GEO <= '020300..0000000000')))) || (geowave:intersects(POINT, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1fffffffffffffff' && POINT <= '1f227fffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f3400000000000000' && POINT <= '1f37bfffffffffffff')))))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void withinLargeBoundingBoxEvaluationOnlyTest() throws Exception {
-        String query = "geo:within_bounding_box(" + GEO_FIELD + ", '-90_-180', '90_180') && ((_Eval_ = true) && geo:within_bounding_box(" + GEO_FIELD
-                        + ", '-90_-180', '90_180'))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testIntersectsLargeCircle() throws Exception {
+        givenQuery("geowave:intersects(" + GEO_FIELD + ", '" + createCircle(0, 0, 90).toText() + "')");
+        expectPlan("(geowave:intersects(GEO, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '011200..0000000000' && GEO <= '020300..0000000000')))) || (geowave:intersects(POINT, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1fffffffffffffff' && POINT <= '1f227fffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f3400000000000000' && POINT <= '1f37bfffffffffffff')))))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void intersectsLargeBoundingBoxEvaluationOnlyTest() throws Exception {
-        String query = "geowave:intersects(" + GEO_FIELD
-                        + ", 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))') && ((_Eval_ = true) && geowave:intersects(" + GEO_FIELD
-                        + ", 'POLYGON((-180 -90, 180 -90, 180 90, -180 90, -180 -90))'))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testWithinLargeCircleEvaluationOnly() throws Exception {
+        givenQuery("geo:within_circle(" + GEO_FIELD + ", '0_0', 90) && ((_Eval_ = true) && geo:within_circle(" + GEO_FIELD + ", '0_0', 90))");
+        expectPlan("((geo:within_circle(GEO, '019800..0000000000', 90) && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '011200..0000000000' && GEO <= '020300..0000000000')))) || (geowave:intersects(POINT, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1fffffffffffffff' && POINT <= '1f227fffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f3400000000000000' && POINT <= '1f37bfffffffffffff')))))) && ((_Eval_ = true) && (geo:within_circle(GEO, '019800..0000000000', 90) || geowave:intersects(POINT, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))')))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void withinLargeCircleTest() throws Exception {
-        String query = "geo:within_circle(" + GEO_FIELD + ", '0_0', 90)";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testIntersectsLargeCircleEvaluationOnly() throws Exception {
+        givenQuery("geowave:intersects(" + GEO_FIELD + ", '" + createCircle(0, 0, 90).toText() + "') && ((_Eval_ = true) && geowave:intersects(" + GEO_FIELD
+                        + ", '" + createCircle(0, 0, 90).toText() + "'))");
+        expectPlan("((geowave:intersects(GEO, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') && ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '011200..0000000000' && GEO <= '020300..0000000000')))) || (geowave:intersects(POINT, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f1fffffffffffffff' && POINT <= '1f227fffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f3400000000000000' && POINT <= '1f37bfffffffffffff')))))) && ((_Eval_ = true) && (geowave:intersects(GEO, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))') || geowave:intersects(POINT, 'POLYGON ((90 0, 89.5069705831446 9.40756169408881, 88.03328406604251 18.712052173598337, 85.59508646656381 27.811529493745265, 82.21909118783408 36.60629787682201, 77.94228634059948 44.99999999999999, 72.81152949374527 52.90067270632258, 66.88303429296549 60.22175457229723, 60.22175457229724 66.88303429296548, 52.90067270632258 72.81152949374527, 45.00000000000001 77.94228634059948, 36.60629787682203 82.21909118783408, 27.81152949374527 85.59508646656381, 18.71205217359835 88.0332840660425, 9.40756169408883 89.5069705831446, 0.0000000000000055 90, -9.4075616940888 89.50697058314461, -18.71205217359832 88.03328406604251, -27.81152949374526 85.59508646656383, -36.606297876822005 82.21909118783408, -44.99999999999998 77.94228634059948, -52.900672706322574 72.81152949374527, -60.221754572297215 66.8830342929655, -66.88303429296546 60.22175457229725, -72.81152949374525 52.900672706322595, -77.94228634059947 45.00000000000003, -82.21909118783407 36.60629787682204, -85.59508646656381 27.811529493745276, -88.0332840660425 18.712052173598376, -89.5069705831446 9.407561694088836, -90 0.000000000000011, -89.50697058314461 -9.407561694088775, -88.03328406604251 -18.712052173598316, -85.59508646656383 -27.811529493745255, -82.2190911878341 -36.60629787682198, -77.9422863405995 -44.99999999999997, -72.81152949374528 -52.900672706322574, -66.88303429296552 -60.221754572297215, -60.221754572297264 -66.88303429296546, -52.900672706322595 -72.81152949374525, -45.00000000000004 -77.94228634059945, -36.606297876822076 -82.21909118783405, -27.81152949374528 -85.59508646656381, -18.71205217359838 -88.0332840660425, -9.407561694088882 -89.5069705831446, -0.0000000000000165 -90, 9.407561694088768 -89.50697058314461, 18.71205217359827 -88.03328406604253, 27.81152949374525 -85.59508646656383, 36.606297876821976 -82.2190911878341, 44.99999999999994 -77.94228634059951, 52.90067270632256 -72.81152949374528, 60.2217545722972 -66.88303429296552, 66.88303429296543 -60.22175457229729, 72.81152949374525 -52.9006727063226, 77.94228634059945 -45.00000000000004, 82.21909118783405 -36.60629787682208, 85.59508646656381 -27.811529493745287, 88.0332840660425 -18.712052173598387, 89.5069705831446 -9.407561694088887, 90 0))')))");
+        expectGeoValues(pointData);
+        expectGeoValues(geoData);
+        expectResultCount(12);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void intersectsLargeCircleTest() throws Exception {
-        String query = "geowave:intersects(" + GEO_FIELD + ", '" + createCircle(0, 0, 90).toText() + "')";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testWithinLargeBoundingBoxAcrossAntimeridian() throws Exception {
+        givenQuery("geo:within_bounding_box(" + GEO_FIELD + ", '-90_0.01', '90_-0.01')");
+        expectPlan("(geo:within_bounding_box(GEO, '010800..0001000000', '118709..0909000000') && (((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '000000..0000000000' && GEO <= '020000..0000000000'))) || ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '010800..0001000000' && GEO <= '030700..0000000000'))))) || (geowave:intersects(POINT, 'GEOMETRYCOLLECTION (POLYGON ((0.01 -90, 180 -90, 180 90, 0.01 90, 0.01 -90)), POLYGON ((-180 -90, -0.01 -90, -0.01 90, -180 90, -180 -90)))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f2000000000000000' && POINT <= '1f23ffffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f31ffffffffffffff' && POINT <= '1f37ffffffffffffff')))))");
+        expectGeoValues(pointData);
+        expectGeoValues(GEO_5, GEO_6);
+        expectResultCount(8);
+        planAndExecuteQuery();
     }
 
     @Test
-    public void withinLargeCircleEvaluationOnlyTest() throws Exception {
-        String query = "geo:within_circle(" + GEO_FIELD + ", '0_0', 90) && ((_Eval_ = true) && geo:within_circle(" + GEO_FIELD + ", '0_0', 90))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
-    }
-
-    @Test
-    public void intersectsLargeCircleEvaluationOnlyTest() throws Exception {
-        String query = "geowave:intersects(" + GEO_FIELD + ", '" + createCircle(0, 0, 90).toText() + "') && ((_Eval_ = true) && geowave:intersects(" + GEO_FIELD
-                        + ", '" + createCircle(0, 0, 90).toText() + "'))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(12, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(geoData));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
-    }
-
-    @Test
-    public void withinLargeBoundingBoxAcrossAntimeridianTest() throws Exception {
-        String query = "geo:within_bounding_box(" + GEO_FIELD + ", '-90_0.01', '90_-0.01')";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(8, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(GEO_5, GEO_6));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
-    }
-
-    @Test
-    public void withinLargeBoundingBoxAcrossAntimeridianEvaluationOnlyTest() throws Exception {
-        String query = "geo:within_bounding_box(" + GEO_FIELD + ", '-90_0.01', '90_-0.01') && ((_Eval_ = true) && geo:within_bounding_box(" + GEO_FIELD
-                        + ", '-90_0.01', '90_-0.01'))";
-
-        List<DefaultEvent> events = getQueryResults(query);
-        Assert.assertEquals(8, events.size());
-
-        List<String> geoList = new ArrayList<>();
-        geoList.addAll(Arrays.asList(pointData));
-        geoList.addAll(Arrays.asList(GEO_5, GEO_6));
-
-        for (DefaultEvent event : events) {
-            String geo = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD) || field.getName().equals(POINT_FIELD))
-                    geo = field.getValueString();
-            }
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(geoList.remove(geo));
-        }
-
-        Assert.assertEquals(0, geoList.size());
+    public void testWithinLargeBoundingBoxAcrossAntimeridianEvaluationOnly() throws Exception {
+        givenQuery("geo:within_bounding_box(" + GEO_FIELD + ", '-90_0.01', '90_-0.01') && ((_Eval_ = true) && geo:within_bounding_box(" + GEO_FIELD
+                        + ", '-90_0.01', '90_-0.01'))");
+        expectPlan("((geo:within_bounding_box(GEO, '010800..0001000000', '118709..0909000000') && (((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '000000..0000000000' && GEO <= '020000..0000000000'))) || ((_Value_ = true) && ((_Bounded_ = true) && (GEO >= '010800..0001000000' && GEO <= '030700..0000000000'))))) || (geowave:intersects(POINT, 'GEOMETRYCOLLECTION (POLYGON ((0.01 -90, 180 -90, 180 90, 0.01 90, 0.01 -90)), POLYGON ((-180 -90, -0.01 -90, -0.01 90, -180 90, -180 -90)))') && (((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f2000000000000000' && POINT <= '1f23ffffffffffffff'))) || ((_Value_ = true) && ((_Bounded_ = true) && (POINT >= '1f31ffffffffffffff' && POINT <= '1f37ffffffffffffff')))))) && ((_Eval_ = true) && (geo:within_bounding_box(GEO, '010800..0001000000', '118709..0909000000') || geowave:intersects(POINT, 'GEOMETRYCOLLECTION (POLYGON ((0.01 -90, 180 -90, 180 90, 0.01 90, 0.01 -90)), POLYGON ((-180 -90, -0.01 -90, -0.01 90, -180 90, -180 -90)))')))");
+        expectGeoValues(pointData);
+        expectGeoValues(GEO_5, GEO_6);
+        expectResultCount(8);
+        planAndExecuteQuery();
     }
 
     // Note: Trying to ingest non-point WKT as PointType will not work. PointType can only be used for POINT wkt
-    @Test(expected = InvalidQueryException.class)
-    public void polyPointTest() throws Exception {
-        String query = "geo:within_bounding_box(" + POLY_POINT_FIELD + ", '-1_-1', '1_1')";
-        getQueryResults(query);
+    @Test
+    public void testPolyPoint() {
+        givenQuery("geo:within_bounding_box(" + POLY_POINT_FIELD + ", '-1_-1', '1_1')");
+        assertThrows(InvalidQueryException.class, this::planAndExecuteQuery);
     }
 
     private Polygon createCircle(double lon, double lat, double radius) {
@@ -701,91 +265,88 @@ public class MixedGeoAndGeoWaveTest {
         return shapeFactory.createCircle();
     }
 
-    private List<DefaultEvent> getQueryResults(String queryString) throws Exception {
-        ShardQueryLogic logic = getShardQueryLogic();
-
-        Iterator iter = getResultsIterator(queryString, logic);
-        List<DefaultEvent> events = new ArrayList<>();
-        while (iter.hasNext())
-            events.add((DefaultEvent) iter.next());
-        return events;
-    }
-
-    private Iterator getResultsIterator(String queryString, ShardQueryLogic logic) throws Exception {
-        MultivaluedMap<String,String> params = new MultivaluedMapImpl<>();
-        params.putSingle(QUERY_LOGIC_NAME, "EventQuery");
-        params.putSingle(QUERY_STRING, queryString);
-        params.putSingle(QUERY_NAME, "geoQuery");
-        params.putSingle(QUERY_PERSISTENCE, "PERSISTENT");
-        params.putSingle(QUERY_AUTHORIZATIONS, AUTHS);
-        params.putSingle(QUERY_EXPIRATION, "20200101 000000.000");
-        params.putSingle(QUERY_BEGIN, BEGIN_DATE);
-        params.putSingle(QUERY_END, END_DATE);
-
-        datawave.microservice.query.QueryParameters queryParams = new DefaultQueryParameters();
-        queryParams.validate(params);
-
-        Set<Authorizations> auths = new HashSet<>();
-        auths.add(new Authorizations(AUTHS));
-
-        Query query = new QueryImpl();
-        query.initialize(USER, Arrays.asList(USER_DN), null, queryParams, null);
-
-        ShardQueryConfiguration config = ShardQueryConfiguration.create(logic, query);
-
-        QueryModel queryModel = new QueryModel();
-        queryModel.addTermToModel(GEO_FIELD, GEO_FIELD);
-        queryModel.addTermToModel(GEO_FIELD, POINT_FIELD);
-        config.setQueryModel(queryModel);
-
-        logic.initialize(config, new InMemoryAccumuloClient("root", instance), query, auths);
-
-        logic.setupQuery(config);
-
-        return logic.getTransformIterator(query);
-    }
-
-    private ShardQueryLogic getShardQueryLogic() {
-        ShardQueryLogic logic = new ShardQueryLogic(this.logic);
-
-        // increase the depth threshold
-        logic.setMaxDepthThreshold(20);
-
-        // set the pushdown threshold really high to avoid collapsing uids into shards (overrides setCollapseUids if #terms is greater than this threshold)
-        ((DefaultQueryPlanner) (logic.getQueryPlanner())).setPushdownThreshold(1000000);
-
-        URL hdfsSiteConfig = this.getClass().getResource("/testhadoop.config");
-        logic.setHdfsSiteConfigURLs(hdfsSiteConfig.toExternalForm());
-
-        setupIvarator(logic);
-
-        return logic;
-    }
-
     private void setupIvarator(ShardQueryLogic logic) {
         // Set these to ensure ivarator runs
         logic.setMaxUnfieldedExpansionThreshold(1);
         logic.setMaxValueExpansionThreshold(1);
         logic.setIvaratorCacheScanPersistThreshold(1);
-        logic.setIvaratorCacheDirConfigs(ivaratorCacheDirConfigs);
+        logic.setMaxFieldIndexRangeSplit(1);
+
+        URL hdfsSiteConfig = this.getClass().getResource("/testhadoop.config");
+        assertNotNull(hdfsSiteConfig);
+        logic.setHdfsSiteConfigURLs(hdfsSiteConfig.toExternalForm());
+
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(folder.toUri().toString());
+        logic.setIvaratorCacheDirConfigs(Collections.singletonList(config));
     }
 
-    public static class TestIngestHelper extends ContentBaseIngestHelper {
-        @Override
-        public Multimap<String,NormalizedContentInterface> getEventFields(RawRecordContainer record) {
-            Multimap<String,NormalizedContentInterface> eventFields = HashMultimap.create();
-            String rawData = new String(record.getRawData());
-            String prefix = null;
-            if (rawData.startsWith(GEO_FIELD)) {
-                prefix = GEO_FIELD;
-            } else if (rawData.startsWith(POINT_FIELD)) {
-                prefix = POINT_FIELD;
-            } else if (rawData.startsWith(POLY_POINT_FIELD)) {
-                prefix = POLY_POINT_FIELD;
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    /**
+     * Only execute against a single index table due to the expense of cleaning up ivarator temp directories
+     *
+     * @return a singleton that is the basic shard index table name
+     */
+    @Override
+    protected List<String> getIndexTableNames() {
+        return List.of(TestIndexTableNames.NO_UID_INDEX);
+    }
+
+    @Override
+    protected void extraConfigurations() {
+        // change this to be an update to the datawave metadata
+        QueryModel queryModel = new QueryModel();
+        queryModel.addTermToModel(GEO_FIELD, GEO_FIELD);
+        queryModel.addTermToModel(GEO_FIELD, POINT_FIELD);
+        getLogic().setQueryModel(queryModel);
+
+        // increase the depth threshold
+        getLogic().setMaxDepthThreshold(20);
+
+        // set the pushdown threshold really high to avoid collapsing uids into shards (overrides setCollapseUids if #terms is greater than this threshold)
+        ((DefaultQueryPlanner) (getLogic().getQueryPlanner())).setPushdownThreshold(1000000);
+
+        setupIvarator(getLogic());
+    }
+
+    @Override
+    protected void extraAssertions() {
+        Set<String> foundGeoValues = new HashSet<>();
+        for (Document result : results) {
+            if (result.containsKey(GEO_FIELD)) {
+                foundGeoValues.addAll(getValuesForAttribute(result.get(GEO_FIELD)));
             }
-            NormalizedContentInterface geo_nci = new NormalizedFieldAndValue(prefix, rawData.substring(prefix.length()));
-            eventFields.put(prefix, geo_nci);
-            return normalizeMap(eventFields);
+            if (result.containsKey(POINT_FIELD)) {
+                foundGeoValues.addAll(getValuesForAttribute(result.get(POINT_FIELD)));
+            }
+        }
+
+        assertEquals(expectedGeoValues, foundGeoValues);
+    }
+
+    private void expectGeoValues(String... fields) {
+        this.expectedGeoValues.addAll(Arrays.asList(fields));
+    }
+
+    private Set<String> getValuesForAttribute(Attribute<?> attr) {
+        if (attr instanceof Attributes) {
+            Attributes attrs = (Attributes) attr;
+            Set<String> values = new HashSet<>();
+            for (Attribute<?> a : attrs.getAttributes()) {
+                values.add(a.getData().toString());
+            }
+            return values;
+        } else {
+            return Set.of(attr.getData().toString());
         }
     }
+
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/MixedGeoAndGeoWaveIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MixedGeoAndGeoWaveIngest.java
@@ -1,0 +1,283 @@
+package datawave.query.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.text.SimpleDateFormat;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+
+import datawave.data.type.GeoType;
+import datawave.data.type.PointType;
+import datawave.ingest.config.RawRecordContainerImpl;
+import datawave.ingest.data.RawRecordContainer;
+import datawave.ingest.data.Type;
+import datawave.ingest.data.TypeRegistry;
+import datawave.ingest.data.config.DataTypeHelper;
+import datawave.ingest.data.config.NormalizedContentInterface;
+import datawave.ingest.data.config.NormalizedFieldAndValue;
+import datawave.ingest.data.config.ingest.BaseIngestHelper;
+import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
+import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
+import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
+import datawave.ingest.mapreduce.job.BulkIngestKey;
+import datawave.ingest.mapreduce.partition.BalancedShardPartitioner;
+import datawave.ingest.table.config.ShardTableConfigHelper;
+import datawave.ingest.table.config.TableConfigHelper;
+import datawave.policy.IngestPolicyEnforcer;
+import datawave.query.index.day.IndexIngestUtil;
+import datawave.query.testframework.MockStatusReporter;
+import datawave.util.TableName;
+
+/**
+ * Write tests data for the {@link datawave.query.MixedGeoAndGeoWaveTest}
+ */
+public class MixedGeoAndGeoWaveIngest {
+
+    private static final Logger log = LoggerFactory.getLogger(MixedGeoAndGeoWaveIngest.class);
+
+    private static final int NUM_SHARDS = 1;
+    private static final String DATA_TYPE_NAME = "MixedGeo";
+    private static final String INGEST_HELPER_CLASS = TestIngestHelper.class.getName();
+
+    public static final String GEO_FIELD = "GEO";
+    public static final String POINT_FIELD = "POINT";
+    public static final String POLY_POINT_FIELD = "POLY_POINT";
+
+    private static final String formatPattern = "yyyyMMdd HHmmss.SSS";
+    private static final SimpleDateFormat formatter = new SimpleDateFormat(formatPattern);
+
+    public static final String BEGIN_DATE = "20000101 000000.000";
+    private static final String MID_DATE = "20010101 000000.000";
+    public static final String END_DATE = "20020101 000000.000";
+
+    public static final String GEO_1 = "0_0";
+    public static final String GEO_2 = "3_0";
+    public static final String GEO_3 = "2_0";
+    public static final String GEO_4 = "1_0";
+    public static final String GEO_5 = "1_1";
+    public static final String GEO_6 = "2_1";
+
+    public static final String POINT_1 = "POINT (2 2)";
+    public static final String POINT_2 = "POINT (2 1)";
+    public static final String POINT_3 = "POINT (2 3)";
+    public static final String POINT_4 = "POINT (1 3)";
+    public static final String POINT_5 = "POINT (2 0)";
+    public static final String POINT_6 = "POINT (1 0)";
+
+    public static final String POLY_1 = "POLYGON((-4 -4, 0 -4, 0 0, -4 0, -4 -4))";
+    public static final String POLY_2 = "POLYGON((0 -4, 4 -4, 4 0, -4 0, 0 -4))";
+    public static final String POLY_3 = "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0))";
+    public static final String POLY_4 = "POLYGON((-4 0, 0 0, 0 4, -4 4, -4 0))";
+    public static final String POLY_5 = "POLYGON((-2 -2, 2 -2, 2 2, -2 2, -2 -2))";
+
+    // @formatter:off
+    public static final String[] geoData = {
+            GEO_1,
+            GEO_2,
+            GEO_3,
+            GEO_4,
+            GEO_5,
+            GEO_6};
+    // @formatter:on
+
+    // @formatter:off
+    public static final String[] pointData = {
+            POINT_1,
+            POINT_2,
+            POINT_3,
+            POINT_4,
+            POINT_5,
+            POINT_6};
+    // @formatter:on
+
+    // @formatter:off
+    public static final String[] polyData = {
+            POLY_1,
+            POLY_2,
+            POLY_3,
+            POLY_4,
+            POLY_5};
+    // @formatter:on
+
+    private static final String AUTHS = "ALL";
+
+    private static final Configuration conf = new Configuration();
+
+    private MixedGeoAndGeoWaveIngest() {
+        // enforce static access
+    }
+
+    public static void write(AccumuloClient client, Authorizations auths) throws Exception {
+        setupConfiguration(conf);
+
+        int recNum = 0;
+        recNum = ingestData(client, GEO_FIELD, geoData, recNum, BEGIN_DATE);
+        recNum = ingestData(client, POINT_FIELD, pointData, recNum, MID_DATE);
+        recNum = ingestData(client, POLY_POINT_FIELD, polyData, recNum, MID_DATE);
+
+        log.info("Ingested {} records", recNum);
+
+        // write model fields
+        try (BatchWriter bw = client.createBatchWriter(TableName.METADATA)) {
+            Mutation m = new Mutation(GEO_FIELD);
+            m.put("DATAWAVE", GEO_FIELD + "\0forward", "ALL");
+            m.put("DATAWAVE", POINT_FIELD + "\0forward", "ALL");
+            bw.addMutation(m);
+        }
+
+        IndexIngestUtil ingestUtil = new IndexIngestUtil();
+        ingestUtil.write(client, auths);
+    }
+
+    public static int ingestData(AccumuloClient client, String fieldName, String[] data, int startRecNum, String ingestDate) throws Exception {
+        AbstractColumnBasedHandler<Text> dataTypeHandler = new AbstractColumnBasedHandler<>();
+        dataTypeHandler.setup(new TaskAttemptContextImpl(conf, new TaskAttemptID()));
+
+        TestIngestHelper ingestHelper = new TestIngestHelper();
+        ingestHelper.setup(conf);
+
+        // create and process events with WKT data
+        RawRecordContainer record = new RawRecordContainerImpl();
+        Multimap<BulkIngestKey,Value> keyValues = HashMultimap.create();
+        int recNum = startRecNum;
+
+        for (String datum : data) {
+            record.clear();
+            record.setDataType(new Type(DATA_TYPE_NAME, TestIngestHelper.class, null, null, 1, null));
+            record.setRawFileName("geodata_" + recNum + ".dat");
+            record.setRawRecordNumber(recNum++);
+            record.setTimestamp(formatter.parse(ingestDate).getTime());
+            record.setRawData((fieldName + datum).getBytes(UTF_8));
+            record.generateId(null);
+            record.setVisibility(new ColumnVisibility(AUTHS));
+
+            final Multimap<String,NormalizedContentInterface> fields = LinkedListMultimap.create();
+            for (Map.Entry<String,NormalizedContentInterface> entry : ingestHelper.getEventFields(record).entries()) {
+                if (entry.getValue().getError() == null) {
+                    fields.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            Multimap<BulkIngestKey,Value> kvPairs = dataTypeHandler.processBulk(new Text(), record, fields, new MockStatusReporter());
+
+            keyValues.putAll(kvPairs);
+
+            dataTypeHandler.getMetadata().addEvent(ingestHelper, record, fields);
+        }
+        keyValues.putAll(dataTypeHandler.getMetadata().getBulkMetadata());
+
+        writeKeyValues(client, keyValues);
+        return recNum;
+    }
+
+    private static void writeKeyValues(AccumuloClient client, Multimap<BulkIngestKey,Value> keyValues) throws Exception {
+        final TableOperations tops = client.tableOperations();
+        final Set<BulkIngestKey> biKeys = keyValues.keySet();
+
+        Set<String> loadedShards = new HashSet<>();
+
+        for (final BulkIngestKey biKey : biKeys) {
+            final String tableName = biKey.getTableName().toString();
+            if (!tops.exists(tableName))
+                tops.create(tableName);
+
+            try (BatchWriter bw = client.createBatchWriter(tableName, new BatchWriterConfig())) {
+                for (final Value val : keyValues.get(biKey)) {
+                    Key key = biKey.getKey();
+                    final Mutation m = new Mutation(key.getRow());
+                    m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), val);
+                    bw.addMutation(m);
+
+                    if (biKey.getTableName().toString().equals("shard")) {
+                        loadedShards.add(key.getRow().toString());
+                    }
+                }
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Loaded data into {} shards", loadedShards.size());
+        }
+
+        try (BatchWriter bw = client.createBatchWriter(TableName.METADATA)) {
+            Mutation m = new Mutation("num_shards");
+            m.put("ns", "20000101_" + NUM_SHARDS, new Value());
+            bw.addMutation(m);
+        }
+    }
+
+    public static void setupConfiguration(Configuration conf) {
+        conf.clear();
+
+        conf.set(DATA_TYPE_NAME + BaseIngestHelper.INDEX_FIELDS, GEO_FIELD + "," + POINT_FIELD + "," + POLY_POINT_FIELD);
+        conf.set(DATA_TYPE_NAME + "." + GEO_FIELD + BaseIngestHelper.FIELD_TYPE, GeoType.class.getName());
+        conf.set(DATA_TYPE_NAME + "." + POINT_FIELD + BaseIngestHelper.FIELD_TYPE, PointType.class.getName());
+        conf.set(DATA_TYPE_NAME + "." + POLY_POINT_FIELD + BaseIngestHelper.FIELD_TYPE, PointType.class.getName());
+
+        conf.set(DATA_TYPE_NAME + DataTypeHelper.Properties.INGEST_POLICY_ENFORCER_CLASS, IngestPolicyEnforcer.NoOpIngestPolicyEnforcer.class.getName());
+        conf.set(DataTypeHelper.Properties.DATA_NAME, DATA_TYPE_NAME);
+        conf.set(TypeRegistry.INGEST_DATA_TYPES, DATA_TYPE_NAME);
+        conf.set(DATA_TYPE_NAME + TypeRegistry.INGEST_HELPER, INGEST_HELPER_CLASS);
+
+        conf.set(ShardedDataTypeHandler.METADATA_TABLE_NAME, TableName.METADATA);
+        conf.set(ShardedDataTypeHandler.NUM_SHARDS, Integer.toString(NUM_SHARDS));
+        conf.set(ShardedDataTypeHandler.SHARDED_TNAMES, TableName.SHARD + "," + TableName.ERROR_SHARD);
+        conf.set(ShardedDataTypeHandler.SHARD_TNAME, TableName.SHARD);
+        conf.set(ShardedDataTypeHandler.SHARD_LPRIORITY, "30");
+        conf.set(TableName.SHARD + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
+        conf.set(ShardedDataTypeHandler.SHARD_GIDX_TNAME, TableName.SHARD_INDEX);
+        conf.set(ShardedDataTypeHandler.SHARD_GIDX_LPRIORITY, "30");
+        conf.set(TableName.SHARD_INDEX + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
+        conf.set(ShardedDataTypeHandler.SHARD_GRIDX_TNAME, TableName.SHARD_RINDEX);
+        conf.set(ShardedDataTypeHandler.SHARD_GRIDX_LPRIORITY, "30");
+        conf.set(TableName.SHARD_RINDEX + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
+        conf.set(ShardTableConfigHelper.MARKINGS_SETUP_ITERATOR_ENABLED, "false");
+        conf.set(ShardTableConfigHelper.MARKINGS_SETUP_ITERATOR_CONFIG, "");
+        conf.set("partitioner.category.shardedTables", BalancedShardPartitioner.class.getName());
+        conf.set("partitioner.category.member." + TableName.SHARD, "shardedTables");
+    }
+
+    public static class TestIngestHelper extends ContentBaseIngestHelper {
+        @Override
+        public Multimap<String,NormalizedContentInterface> getEventFields(RawRecordContainer record) {
+            Multimap<String,NormalizedContentInterface> eventFields = HashMultimap.create();
+            String rawData = new String(record.getRawData());
+            String prefix = null;
+            if (rawData.startsWith(GEO_FIELD)) {
+                prefix = GEO_FIELD;
+            } else if (rawData.startsWith(POINT_FIELD)) {
+                prefix = POINT_FIELD;
+            } else if (rawData.startsWith(POLY_POINT_FIELD)) {
+                prefix = POLY_POINT_FIELD;
+            }
+
+            assertNotNull(prefix);
+            NormalizedContentInterface geo_nci = new NormalizedFieldAndValue(prefix, rawData.substring(prefix.length()));
+            eventFields.put(prefix, geo_nci);
+            return normalizeMap(eventFields);
+        }
+    }
+}


### PR DESCRIPTION
Extract ingest code from MixedGeoAndGeoWaveTest to utility class

Reduced number of shards from three to one and increased test execution speed by a factor of three. A significant amount of the runtime is spent cleaning up temporary folders from ivarators.