### PR TITLE
update microservices to use new parents

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Format code
       run: |
         if [[ "${{ github.event_name }}" != "merge_group" ]]; then
-          mvn --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" clean formatter:format sortpom:sort -Dmaven.build.cache.enabled=false -Pautoformat -Dutils -Dservices -Dstarters
+          mvn --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" clean formatter:format sortpom:sort spotless:apply -Dmaven.build.cache.enabled=false -Pautoformat -Dutils -Dservices -Dstarters
           if ! git diff-index --quiet HEAD; then
             echo "Code formatting issues detected. Please format locally.";
             exit 1;

--- a/core/metrics-reporter/pom.xml
+++ b/core/metrics-reporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.10</version>
         <relativePath>../../microservices/microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>metrics-reporter</artifactId>

--- a/microservices/services/accumulo/api/pom.xml
+++ b/microservices/services/accumulo/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>accumulo-api</artifactId>

--- a/microservices/services/accumulo/api/src/main/java/datawave/webservice/request/objects/ReferencedValue.java
+++ b/microservices/services/accumulo/api/src/main/java/datawave/webservice/request/objects/ReferencedValue.java
@@ -1,6 +1,5 @@
 package datawave.webservice.request.objects;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import javax.xml.bind.annotation.XmlAccessOrder;

--- a/microservices/services/accumulo/pom.xml
+++ b/microservices/services/accumulo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>accumulo-service-parent</artifactId>

--- a/microservices/services/accumulo/service/pom.xml
+++ b/microservices/services/accumulo/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>accumulo-service</artifactId>

--- a/microservices/services/audit/api/pom.xml
+++ b/microservices/services/audit/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>audit-api</artifactId>

--- a/microservices/services/audit/pom.xml
+++ b/microservices/services/audit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>audit-service-parent</artifactId>

--- a/microservices/services/audit/service/pom.xml
+++ b/microservices/services/audit/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>audit-service</artifactId>

--- a/microservices/services/authorization/api/pom.xml
+++ b/microservices/services/authorization/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>authorization-api</artifactId>

--- a/microservices/services/authorization/api/src/main/java/datawave/security/util/ProxiedEntityUtils.java
+++ b/microservices/services/authorization/api/src/main/java/datawave/security/util/ProxiedEntityUtils.java
@@ -2,11 +2,8 @@ package datawave.security.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/microservices/services/authorization/pom.xml
+++ b/microservices/services/authorization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>authorization-service-parent</artifactId>

--- a/microservices/services/authorization/service/pom.xml
+++ b/microservices/services/authorization/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>authorization-service</artifactId>

--- a/microservices/services/authorization/service/src/main/java/datawave/microservice/authorization/AuthorizationOperationsV1.java
+++ b/microservices/services/authorization/service/src/main/java/datawave/microservice/authorization/AuthorizationOperationsV1.java
@@ -2,18 +2,14 @@ package datawave.microservice.authorization;
 
 import static org.springframework.web.accept.ContentNegotiationStrategy.MEDIA_TYPE_ALL_LIST;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.bus.BusProperties;
 import org.springframework.cloud.bus.event.AuthorizationEvictionEvent;
 import org.springframework.cloud.bus.event.AuthorizationEvictionEvent.Type;

--- a/microservices/services/authorization/service/src/main/java/datawave/microservice/authorization/AuthorizationOperationsV2.java
+++ b/microservices/services/authorization/service/src/main/java/datawave/microservice/authorization/AuthorizationOperationsV2.java
@@ -1,10 +1,8 @@
 package datawave.microservice.authorization;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.bus.BusProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/OAuthOperationsV2TestCommon.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/OAuthOperationsV2TestCommon.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 
 import javax.net.ssl.SSLContext;
 
-import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheType;

--- a/microservices/services/config/pom.xml
+++ b/microservices/services/config/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>config-service</artifactId>

--- a/microservices/services/dictionary/api/pom.xml
+++ b/microservices/services/dictionary/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dictionary-api</artifactId>

--- a/microservices/services/dictionary/pom.xml
+++ b/microservices/services/dictionary/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dictionary-service-parent</artifactId>

--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dictionary-service</artifactId>

--- a/microservices/services/dictionary/service/src/main/java/datawave/microservice/model/ModelController.java
+++ b/microservices/services/dictionary/service/src/main/java/datawave/microservice/model/ModelController.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.security.Authorizations;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.annotation.Secured;

--- a/microservices/services/file-provider/api/pom.xml
+++ b/microservices/services/file-provider/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>file-provider-service-api</artifactId>

--- a/microservices/services/file-provider/pom.xml
+++ b/microservices/services/file-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>file-provider-service-parent</artifactId>

--- a/microservices/services/file-provider/service/pom.xml
+++ b/microservices/services/file-provider/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>file-provider-service</artifactId>

--- a/microservices/services/file-provider/service/src/main/java/datawave/microservice/fileProvider/FileProviderService.java
+++ b/microservices/services/file-provider/service/src/main/java/datawave/microservice/fileProvider/FileProviderService.java
@@ -1,7 +1,6 @@
 package datawave.microservice.fileProvider;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;

--- a/microservices/services/hazelcast/client/pom.xml
+++ b/microservices/services/hazelcast/client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>hazelcast-client</artifactId>

--- a/microservices/services/hazelcast/common/pom.xml
+++ b/microservices/services/hazelcast/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>hazelcast-common</artifactId>

--- a/microservices/services/hazelcast/pom.xml
+++ b/microservices/services/hazelcast/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>hazelcast-service-parent</artifactId>

--- a/microservices/services/hazelcast/service/pom.xml
+++ b/microservices/services/hazelcast/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>hazelcast-service</artifactId>

--- a/microservices/services/mapreduce-query/api/pom.xml
+++ b/microservices/services/mapreduce-query/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>mapreduce-query-api</artifactId>

--- a/microservices/services/mapreduce-query/jobs/core/pom.xml
+++ b/microservices/services/mapreduce-query/jobs/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>mapreduce-query-core-job</artifactId>

--- a/microservices/services/mapreduce-query/layout-factory/pom.xml
+++ b/microservices/services/mapreduce-query/layout-factory/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>mapreduce-layout-factory</artifactId>

--- a/microservices/services/mapreduce-query/pom.xml
+++ b/microservices/services/mapreduce-query/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>mapreduce-query-service-parent</artifactId>

--- a/microservices/services/mapreduce-query/service/pom.xml
+++ b/microservices/services/mapreduce-query/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>mapreduce-query-service</artifactId>

--- a/microservices/services/modification/api/pom.xml
+++ b/microservices/services/modification/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>modification-api</artifactId>

--- a/microservices/services/modification/pom.xml
+++ b/microservices/services/modification/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>modification-service-parent</artifactId>

--- a/microservices/services/modification/service/pom.xml
+++ b/microservices/services/modification/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>modification-service</artifactId>

--- a/microservices/services/query-executor/api/pom.xml
+++ b/microservices/services/query-executor/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-executor-api</artifactId>

--- a/microservices/services/query-executor/pom.xml
+++ b/microservices/services/query-executor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-executor-service-parent</artifactId>

--- a/microservices/services/query-executor/service/pom.xml
+++ b/microservices/services/query-executor/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-executor-service</artifactId>

--- a/microservices/services/query-executor/service/src/main/java/datawave/microservice/query/executor/action/PredictTask.java
+++ b/microservices/services/query-executor/service/src/main/java/datawave/microservice/query/executor/action/PredictTask.java
@@ -2,7 +2,6 @@ package datawave.microservice.query.executor.action;
 
 import java.util.Set;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.bus.event.RemoteQueryRequestEvent;

--- a/microservices/services/query-executor/service/src/main/java/datawave/microservice/query/executor/config/QueryExecutorConfig.java
+++ b/microservices/services/query-executor/service/src/main/java/datawave/microservice/query/executor/config/QueryExecutorConfig.java
@@ -1,7 +1,6 @@
 package datawave.microservice.query.executor.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/microservices/services/query-executor/service/src/main/java/datawave/microservice/query/executor/task/FindWorkMonitor.java
+++ b/microservices/services/query-executor/service/src/main/java/datawave/microservice/query/executor/task/FindWorkMonitor.java
@@ -6,8 +6,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.annotation.PostConstruct;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/microservices/services/query-executor/service/src/test/java/datawave/microservice/query/executor/ShouldGenerateResultsTest.java
+++ b/microservices/services/query-executor/service/src/test/java/datawave/microservice/query/executor/ShouldGenerateResultsTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/microservices/services/query-metric/api/pom.xml
+++ b/microservices/services/query-metric/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-metric-api</artifactId>

--- a/microservices/services/query-metric/api/src/main/java/datawave/microservice/querymetric/BaseQueryMetric.java
+++ b/microservices/services/query-metric/api/src/main/java/datawave/microservice/querymetric/BaseQueryMetric.java
@@ -37,8 +37,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl.Parameter;
-import datawave.webservice.query.exception.DatawaveErrorCode;
-import datawave.webservice.query.exception.NoResultsQueryException;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.result.event.HasMarkings;
 import io.protostuff.Input;

--- a/microservices/services/query-metric/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
+++ b/microservices/services/query-metric/api/src/test/java/datawave/microservice/querymetric/QueryMetricTest.java
@@ -22,7 +22,6 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/microservices/services/query-metric/pom.xml
+++ b/microservices/services/query-metric/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-metric-parent</artifactId>

--- a/microservices/services/query-metric/service/pom.xml
+++ b/microservices/services/query-metric/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-metric-service</artifactId>

--- a/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/Correlator.java
+++ b/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/Correlator.java
@@ -6,8 +6,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;

--- a/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/persistence/AccumuloMapStore.java
+++ b/microservices/services/query-metric/service/src/main/java/datawave/microservice/querymetric/persistence/AccumuloMapStore.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/HazelcastUtils.java
+++ b/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/HazelcastUtils.java
@@ -13,8 +13,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Assertions;
-
 import com.hazelcast.cluster.Cluster;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.core.HazelcastInstance;

--- a/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/QueryMetricConsistencyTest.java
+++ b/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/QueryMetricConsistencyTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Multimap;
 import datawave.microservice.querymetric.config.QueryMetricTransportType;
 import datawave.microservice.querymetric.handler.ContentQueryMetricsIngestHelper;
 import datawave.microservice.querymetric.persistence.AccumuloMapStore;
-import datawave.util.StringUtils;
 import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.DefaultField;
 import datawave.webservice.query.result.event.EventBase;

--- a/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/QueryMetricHttpTest.java
+++ b/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/QueryMetricHttpTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/config/AlternateShardTableQueryMetricHandler.java
+++ b/microservices/services/query-metric/service/src/test/java/datawave/microservice/querymetric/config/AlternateShardTableQueryMetricHandler.java
@@ -3,8 +3,6 @@ package datawave.microservice.querymetric.config;
 import java.util.Collection;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-
 import datawave.core.common.connection.AccumuloConnectionFactory;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.querymetric.QueryMetricFactory;

--- a/microservices/services/query/api/pom.xml
+++ b/microservices/services/query/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-api</artifactId>

--- a/microservices/services/query/pom.xml
+++ b/microservices/services/query/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.8</version>
+        <version>4.0.10</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-service-parent</artifactId>

--- a/microservices/services/query/service/pom.xml
+++ b/microservices/services/query/service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-service</artifactId>

--- a/microservices/services/query/service/src/main/java/datawave/microservice/query/QueryController.java
+++ b/microservices/services/query/service/src/main/java/datawave/microservice/query/QueryController.java
@@ -48,7 +48,6 @@ import datawave.microservice.query.lookup.LookupService;
 import datawave.microservice.query.stream.StreamingProperties;
 import datawave.microservice.query.stream.StreamingService;
 import datawave.microservice.query.stream.listener.CountingResponseBodyEmitterListener;
-import datawave.microservice.query.stream.listener.StreamingResponseListener;
 import datawave.microservice.query.translateid.TranslateIdService;
 import datawave.microservice.query.web.QuerySessionIdAdvice;
 import datawave.microservice.query.web.annotation.ClearQuerySessionId;

--- a/microservices/services/query/service/src/main/java/datawave/microservice/query/stream/StreamingService.java
+++ b/microservices/services/query/service/src/main/java/datawave/microservice/query/stream/StreamingService.java
@@ -1,7 +1,5 @@
 package datawave.microservice.query.stream;
 
-import java.util.function.Supplier;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;

--- a/microservices/starters/audit/pom.xml
+++ b/microservices/starters/audit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave-audit</artifactId>

--- a/microservices/starters/audit/src/test/java/datawave/microservice/audit/AuditClientTest.java
+++ b/microservices/starters/audit/src/test/java/datawave/microservice/audit/AuditClientTest.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/microservices/starters/audit/src/test/java/datawave/microservice/audit/TestUtils.java
+++ b/microservices/starters/audit/src/test/java/datawave/microservice/audit/TestUtils.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;

--- a/microservices/starters/audit/src/test/java/datawave/microservice/audit/replay/ReplayClientTest.java
+++ b/microservices/starters/audit/src/test/java/datawave/microservice/audit/replay/ReplayClientTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/microservices/starters/cache/pom.xml
+++ b/microservices/starters/cache/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave-cache</artifactId>

--- a/microservices/starters/cached-results/pom.xml
+++ b/microservices/starters/cached-results/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave-cached-results</artifactId>

--- a/microservices/starters/cached-results/src/main/java/datawave/microservice/query/cachedresults/CachedResultsQueryService.java
+++ b/microservices/starters/cached-results/src/main/java/datawave/microservice/query/cachedresults/CachedResultsQueryService.java
@@ -58,7 +58,6 @@ import datawave.microservice.config.RequestScopeBeanSupplier;
 import datawave.microservice.query.cachedresults.config.CachedResultsQueryProperties;
 import datawave.microservice.query.cachedresults.status.CachedResultsQueryStatus;
 import datawave.microservice.query.cachedresults.status.cache.CachedResultsQueryCache;
-import datawave.microservice.query.cachedresults.status.cache.util.CacheUpdater;
 import datawave.microservice.query.storage.QueryStatus;
 import datawave.microservice.query.storage.QueryStorageCache;
 import datawave.security.authorization.ProxiedUserDetails;

--- a/microservices/starters/cached-results/src/main/java/datawave/microservice/query/cachedresults/RemoteQueryService.java
+++ b/microservices/starters/cached-results/src/main/java/datawave/microservice/query/cachedresults/RemoteQueryService.java
@@ -2,7 +2,6 @@ package datawave.microservice.query.cachedresults;
 
 import java.text.MessageFormat;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;

--- a/microservices/starters/datawave/pom.xml
+++ b/microservices/starters/datawave/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave</artifactId>

--- a/microservices/starters/metadata/pom.xml
+++ b/microservices/starters/metadata/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave-metadata</artifactId>

--- a/microservices/starters/query-metric/pom.xml
+++ b/microservices/starters/query-metric/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave-query-metric</artifactId>

--- a/microservices/starters/query/pom.xml
+++ b/microservices/starters/query/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-service-parent</artifactId>
-        <version>5.0.9</version>
+        <version>5.0.11</version>
         <relativePath>../../microservice-service-parent/pom.xml</relativePath>
     </parent>
     <artifactId>spring-boot-starter-datawave-query</artifactId>

--- a/microservices/starters/query/src/main/java/datawave/microservice/query/federation/FederatedQueryService.java
+++ b/microservices/starters/query/src/main/java/datawave/microservice/query/federation/FederatedQueryService.java
@@ -22,7 +22,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import datawave.core.query.remote.RemoteQueryService;
 import datawave.microservice.query.federation.config.FederatedQueryProperties;
 import datawave.security.authorization.DatawaveUser;
-import datawave.security.authorization.JWTTokenHandler;
 import datawave.security.authorization.ProxiedUserDetails;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.NoResultsQueryException;

--- a/microservices/starters/query/src/main/java/datawave/microservice/query/logic/DefaultQueryLogicFactory.java
+++ b/microservices/starters/query/src/main/java/datawave/microservice/query/logic/DefaultQueryLogicFactory.java
@@ -1,8 +1,6 @@
 package datawave.microservice.query.logic;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/microservices/starters/query/src/main/java/datawave/microservice/query/logic/config/QueryLogicFactoryProperties.java
+++ b/microservices/starters/query/src/main/java/datawave/microservice/query/logic/config/QueryLogicFactoryProperties.java
@@ -2,7 +2,6 @@ package datawave.microservice.query.logic.config;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;


### PR DESCRIPTION
bumps the microservice parent versions on the related modules that reference them  
re-enables formatting in CI now that all modules have the same plugin configuration  
verified there are no other commits in the microservice-parent and microservice-service-parent besides the spotless plugin changes since the last release