### PR TITLE
Make Annotation SegmentValue score field explicitly optional

### DIFF
--- a/core/annotation/pom.xml
+++ b/core/annotation/pom.xml
@@ -65,6 +65,17 @@
                     <excludePackageNames>datawave.annotation.protobuf.*</excludePackageNames>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protoSourceRoot>${project.basedir}/src/main/protobuf</protoSourceRoot>
+                    <outputDirectory>${project.build.sourceDirectory}</outputDirectory>
+                    <clearOutputDirectory>false</clearOutputDirectory>
+                    <protocArtifact>com.google.protobuf:protoc:${version.protobuf}:exe:linux-x86_64</protocArtifact>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/annotation/src/main/java/datawave/annotation/protobuf/v1/AnnotationV1.java
+++ b/core/annotation/src/main/java/datawave/annotation/protobuf/v1/AnnotationV1.java
@@ -47,39 +47,41 @@ public final class AnnotationV1 {
     static {
         java.lang.String[] descriptorData = {"\n\022AnnotationV1.proto\022\037datawave.annotatio"
                         + "n.protobuf.v1\",\n\005Point\022\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002"
-                        + " \001(\005\022\r\n\005label\030\003 \001(\t\"\302\001\n\014SegmentValue\022\021\n\t"
-                        + "valueHash\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\022\r\n\005score\030"
-                        + "\003 \001(\002\022O\n\textension\030\004 \003(\0132<.datawave.anno" + "tation.protobuf.v1.SegmentValue.Extensio"
-                        + "nEntry\0320\n\016ExtensionEntry\022\013\n\003key\030\001 \001(\t\022\r\n"
-                        + "\005value\030\002 \001(\t:\0028\001\"\322\001\n\017SegmentBoundary\022C\n\014"
-                        + "boundaryType\030\001 \001(\0162-.datawave.annotation" + ".protobuf.v1.BoundaryType\022\022\n\005start\030\025 \001(\005"
-                        + "H\000\210\001\001\022\020\n\003end\030\026 \001(\005H\001\210\001\001\0226\n\006points\030\027 \003(\0132"
-                        + "&.datawave.annotation.protobuf.v1.PointB"
-                        + "\010\n\006_startB\006\n\004_endJ\004\010\002\020\024J\004\010\030\0203\"\242\002\n\007Segmen"
-                        + "t\022\023\n\013segmentHash\030\001 \001(\t\022B\n\010boundary\030\002 \001(\013" + "20.datawave.annotation.protobuf.v1.Segme"
-                        + "ntBoundary\022=\n\006values\030\003 \003(\0132-.datawave.an" + "notation.protobuf.v1.SegmentValue\022H\n\010met"
-                        + "adata\0302 \003(\01326.datawave.annotation.protob" + "uf.v1.Segment.MetadataEntry\032/\n\rMetadataE"
-                        + "ntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001J\004\010\004"
-                        + "\0202\"\261\003\n\nAnnotation\022\r\n\005shard\030\001 \001(\t\022\020\n\010data"
-                        + "Type\030\002 \001(\t\022\013\n\003uid\030\003 \001(\t\022\024\n\014annotationId\030"
-                        + "\004 \001(\t\022\022\n\ndocumentId\030\005 \001(\t\022\026\n\016annotationT"
-                        + "ype\030\006 \001(\t\022\032\n\022analyticSourceHash\030\007 \001(\t\022F\n"
-                        + "\006source\030\010 \001(\01321.datawave.annotation.prot" + "obuf.v1.AnnotationSourceH\000\210\001\001\022:\n\010segment"
-                        + "s\030\024 \003(\0132(.datawave.annotation.protobuf.v" + "1.Segment\022K\n\010metadata\0302 \003(\01329.datawave.a"
-                        + "nnotation.protobuf.v1.Annotation.Metadat" + "aEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005"
-                        + "value\030\002 \001(\t:\0028\001B\t\n\007_sourceJ\004\010\t\020\024J\004\010\025\0202\"\200"
-                        + "\003\n\020AnnotationSource\022\024\n\014analyticHash\030\001 \001("
-                        + "\t\022\032\n\022analyticSourceHash\030\002 \001(\t\022\016\n\006engine\030"
-                        + "\003 \001(\t\022\r\n\005model\030\004 \001(\t\022[\n\rconfiguration\030\005 " + "\003(\0132D.datawave.annotation.protobuf.v1.An"
-                        + "notationSource.ConfigurationEntry\022Q\n\010met" + "adata\0302 \003(\0132?.datawave.annotation.protob"
-                        + "uf.v1.AnnotationSource.MetadataEntry\0324\n\022" + "ConfigurationEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value"
-                        + "\030\002 \001(\t:\0028\001\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t"
-                        + "\022\r\n\005value\030\002 \001(\t:\0028\001J\004\010\006\0202\"`\n\013SegmentList"
-                        + "\022:\n\010segments\030\001 \003(\0132(.datawave.annotation" + ".protobuf.v1.Segment\022\025\n\rnextPageToken\030\002 "
-                        + "\001(\t\"i\n\016AnnotationList\022@\n\013annotations\030\001 \003" + "(\0132+.datawave.annotation.protobuf.v1.Ann"
-                        + "otation\022\025\n\rnextPageToken\030\002 \001(\t*O\n\014Bounda"
-                        + "ryType\022\013\n\007UNKNOWN\020\000\022\007\n\003ALL\020\001\022\n\n\006POINTS\020\002"
-                        + "\022\016\n\nTIME_MILLI\020\003\022\r\n\tTEXT_CHAR\020\004B#\n\037dataw" + "ave.annotation.protobuf.v1P\001b\006proto3"};
+                        + " \001(\005\022\r\n\005label\030\003 \001(\t\"\321\001\n\014SegmentValue\022\021\n\t"
+                        + "valueHash\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\022\022\n\005score\030"
+                        + "\003 \001(\002H\000\210\001\001\022O\n\textension\030\004 \003(\0132<.datawave" + ".annotation.protobuf.v1.SegmentValue.Ext"
+                        + "ensionEntry\0320\n\016ExtensionEntry\022\013\n\003key\030\001 \001"
+                        + "(\t\022\r\n\005value\030\002 \001(\t:\0028\001B\010\n\006_score\"\322\001\n\017Segm"
+                        + "entBoundary\022C\n\014boundaryType\030\001 \001(\0162-.data" + "wave.annotation.protobuf.v1.BoundaryType"
+                        + "\022\022\n\005start\030\025 \001(\005H\000\210\001\001\022\020\n\003end\030\026 \001(\005H\001\210\001\001\0226"
+                        + "\n\006points\030\027 \003(\0132&.datawave.annotation.pro"
+                        + "tobuf.v1.PointB\010\n\006_startB\006\n\004_endJ\004\010\002\020\024J\004"
+                        + "\010\030\0203\"\242\002\n\007Segment\022\023\n\013segmentHash\030\001 \001(\t\022B\n"
+                        + "\010boundary\030\002 \001(\01320.datawave.annotation.pr" + "otobuf.v1.SegmentBoundary\022=\n\006values\030\003 \003("
+                        + "\0132-.datawave.annotation.protobuf.v1.Segm" + "entValue\022H\n\010metadata\0302 \003(\01326.datawave.an"
+                        + "notation.protobuf.v1.Segment.MetadataEnt" + "ry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005valu"
+                        + "e\030\002 \001(\t:\0028\001J\004\010\004\0202\"\261\003\n\nAnnotation\022\r\n\005shar"
+                        + "d\030\001 \001(\t\022\020\n\010dataType\030\002 \001(\t\022\013\n\003uid\030\003 \001(\t\022\024"
+                        + "\n\014annotationId\030\004 \001(\t\022\022\n\ndocumentId\030\005 \001(\t"
+                        + "\022\026\n\016annotationType\030\006 \001(\t\022\032\n\022analyticSour"
+                        + "ceHash\030\007 \001(\t\022F\n\006source\030\010 \001(\01321.datawave." + "annotation.protobuf.v1.AnnotationSourceH"
+                        + "\000\210\001\001\022:\n\010segments\030\024 \003(\0132(.datawave.annota" + "tion.protobuf.v1.Segment\022K\n\010metadata\0302 \003"
+                        + "(\01329.datawave.annotation.protobuf.v1.Ann" + "otation.MetadataEntry\032/\n\rMetadataEntry\022\013"
+                        + "\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001B\t\n\007_sourc"
+                        + "eJ\004\010\t\020\024J\004\010\025\0202\"\200\003\n\020AnnotationSource\022\024\n\014an"
+                        + "alyticHash\030\001 \001(\t\022\032\n\022analyticSourceHash\030\002"
+                        + " \001(\t\022\016\n\006engine\030\003 \001(\t\022\r\n\005model\030\004 \001(\t\022[\n\rc"
+                        + "onfiguration\030\005 \003(\0132D.datawave.annotation" + ".protobuf.v1.AnnotationSource.Configurat"
+                        + "ionEntry\022Q\n\010metadata\0302 \003(\0132?.datawave.an" + "notation.protobuf.v1.AnnotationSource.Me"
+                        + "tadataEntry\0324\n\022ConfigurationEntry\022\013\n\003key"
+                        + "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\032/\n\rMetadataEnt"
+                        + "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001J\004\010\006\0202"
+                        + "\"`\n\013SegmentList\022:\n\010segments\030\001 \003(\0132(.data" + "wave.annotation.protobuf.v1.Segment\022\025\n\rn"
+                        + "extPageToken\030\002 \001(\t\"i\n\016AnnotationList\022@\n\013" + "annotations\030\001 \003(\0132+.datawave.annotation."
+                        + "protobuf.v1.Annotation\022\025\n\rnextPageToken\030"
+                        + "\002 \001(\t*O\n\014BoundaryType\022\013\n\007UNKNOWN\020\000\022\007\n\003AL"
+                        + "L\020\001\022\n\n\006POINTS\020\002\022\016\n\nTIME_MILLI\020\003\022\r\n\tTEXT_"
+                        + "CHAR\020\004B#\n\037datawave.annotation.protobuf.v" + "1P\001b\006proto3"};
         descriptor = com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(descriptorData,
                         new com.google.protobuf.Descriptors.FileDescriptor[] {});
         internal_static_datawave_annotation_protobuf_v1_Point_descriptor = getDescriptor().getMessageTypes().get(0);
@@ -88,7 +90,7 @@ public final class AnnotationV1 {
         internal_static_datawave_annotation_protobuf_v1_SegmentValue_descriptor = getDescriptor().getMessageTypes().get(1);
         internal_static_datawave_annotation_protobuf_v1_SegmentValue_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
                         internal_static_datawave_annotation_protobuf_v1_SegmentValue_descriptor,
-                        new java.lang.String[] {"ValueHash", "Value", "Score", "Extension",});
+                        new java.lang.String[] {"ValueHash", "Value", "Score", "Extension", "Score",});
         internal_static_datawave_annotation_protobuf_v1_SegmentValue_ExtensionEntry_descriptor = internal_static_datawave_annotation_protobuf_v1_SegmentValue_descriptor
                         .getNestedTypes().get(0);
         internal_static_datawave_annotation_protobuf_v1_SegmentValue_ExtensionEntry_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(

--- a/core/annotation/src/main/java/datawave/annotation/protobuf/v1/SegmentValue.java
+++ b/core/annotation/src/main/java/datawave/annotation/protobuf/v1/SegmentValue.java
@@ -58,6 +58,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
                                         datawave.annotation.protobuf.v1.SegmentValue.Builder.class);
     }
 
+    private int bitField0_;
     public static final int VALUEHASH_FIELD_NUMBER = 1;
     private volatile java.lang.Object valueHash_;
 
@@ -152,6 +153,20 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
 
     public static final int SCORE_FIELD_NUMBER = 3;
     private float score_;
+
+    /**
+     * <pre>
+     * e.g., confidence
+     * </pre>
+     *
+     * <code>float score = 3;</code>
+     *
+     * @return Whether the score field is set.
+     */
+    @java.lang.Override
+    public boolean hasScore() {
+        return ((bitField0_ & 0x00000001) != 0);
+    }
 
     /**
      * <pre>
@@ -285,7 +300,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
         if (!getValueBytes().isEmpty()) {
             com.google.protobuf.GeneratedMessageV3.writeString(output, 2, value_);
         }
-        if (score_ != 0F) {
+        if (((bitField0_ & 0x00000001) != 0)) {
             output.writeFloat(3, score_);
         }
         com.google.protobuf.GeneratedMessageV3.serializeStringMapTo(output, internalGetExtension(), ExtensionDefaultEntryHolder.defaultEntry, 4);
@@ -305,7 +320,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
         if (!getValueBytes().isEmpty()) {
             size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, value_);
         }
-        if (score_ != 0F) {
+        if (((bitField0_ & 0x00000001) != 0)) {
             size += com.google.protobuf.CodedOutputStream.computeFloatSize(3, score_);
         }
         for (java.util.Map.Entry<java.lang.String,java.lang.String> entry : internalGetExtension().getMap().entrySet()) {
@@ -332,8 +347,12 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
             return false;
         if (!getValue().equals(other.getValue()))
             return false;
-        if (java.lang.Float.floatToIntBits(getScore()) != java.lang.Float.floatToIntBits(other.getScore()))
+        if (hasScore() != other.hasScore())
             return false;
+        if (hasScore()) {
+            if (java.lang.Float.floatToIntBits(getScore()) != java.lang.Float.floatToIntBits(other.getScore()))
+                return false;
+        }
         if (!internalGetExtension().equals(other.internalGetExtension()))
             return false;
         if (!getUnknownFields().equals(other.getUnknownFields()))
@@ -352,8 +371,10 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
         hash = (53 * hash) + getValueHash().hashCode();
         hash = (37 * hash) + VALUE_FIELD_NUMBER;
         hash = (53 * hash) + getValue().hashCode();
-        hash = (37 * hash) + SCORE_FIELD_NUMBER;
-        hash = (53 * hash) + java.lang.Float.floatToIntBits(getScore());
+        if (hasScore()) {
+            hash = (37 * hash) + SCORE_FIELD_NUMBER;
+            hash = (53 * hash) + java.lang.Float.floatToIntBits(getScore());
+        }
         if (!internalGetExtension().getMap().isEmpty()) {
             hash = (37 * hash) + EXTENSION_FIELD_NUMBER;
             hash = (53 * hash) + internalGetExtension().hashCode();
@@ -501,7 +522,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
             value_ = "";
 
             score_ = 0F;
-
+            bitField0_ = (bitField0_ & ~0x00000001);
             internalGetMutableExtension().clear();
             return this;
         }
@@ -529,11 +550,16 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
         public datawave.annotation.protobuf.v1.SegmentValue buildPartial() {
             datawave.annotation.protobuf.v1.SegmentValue result = new datawave.annotation.protobuf.v1.SegmentValue(this);
             int from_bitField0_ = bitField0_;
+            int to_bitField0_ = 0;
             result.valueHash_ = valueHash_;
             result.value_ = value_;
-            result.score_ = score_;
+            if (((from_bitField0_ & 0x00000001) != 0)) {
+                result.score_ = score_;
+                to_bitField0_ |= 0x00000001;
+            }
             result.extension_ = internalGetExtension();
             result.extension_.makeImmutable();
+            result.bitField0_ = to_bitField0_;
             onBuilt();
             return result;
         }
@@ -589,7 +615,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
                 value_ = other.value_;
                 onChanged();
             }
-            if (other.getScore() != 0F) {
+            if (other.hasScore()) {
                 setScore(other.getScore());
             }
             internalGetMutableExtension().mergeFrom(other.internalGetExtension());
@@ -629,7 +655,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
                         } // case 18
                         case 29: {
                             score_ = input.readFloat();
-
+                            bitField0_ |= 0x00000001;
                             break;
                         } // case 29
                         case 34: {
@@ -869,6 +895,20 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
          *
          * <code>float score = 3;</code>
          *
+         * @return Whether the score field is set.
+         */
+        @java.lang.Override
+        public boolean hasScore() {
+            return ((bitField0_ & 0x00000001) != 0);
+        }
+
+        /**
+         * <pre>
+         * e.g., confidence
+         * </pre>
+         *
+         * <code>float score = 3;</code>
+         *
          * @return The score.
          */
         @java.lang.Override
@@ -888,7 +928,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
          * @return This builder for chaining.
          */
         public Builder setScore(float value) {
-
+            bitField0_ |= 0x00000001;
             score_ = value;
             onChanged();
             return this;
@@ -904,7 +944,7 @@ public final class SegmentValue extends com.google.protobuf.GeneratedMessageV3 i
          * @return This builder for chaining.
          */
         public Builder clearScore() {
-
+            bitField0_ = (bitField0_ & ~0x00000001);
             score_ = 0F;
             onChanged();
             return this;

--- a/core/annotation/src/main/java/datawave/annotation/protobuf/v1/SegmentValueOrBuilder.java
+++ b/core/annotation/src/main/java/datawave/annotation/protobuf/v1/SegmentValueOrBuilder.java
@@ -58,6 +58,17 @@ public interface SegmentValueOrBuilder extends
      *
      * <code>float score = 3;</code>
      *
+     * @return Whether the score field is set.
+     */
+    boolean hasScore();
+
+    /**
+     * <pre>
+     * e.g., confidence
+     * </pre>
+     *
+     * <code>float score = 3;</code>
+     *
      * @return The score.
      */
     float getScore();

--- a/core/annotation/src/main/protobuf/AnnotationV1.proto
+++ b/core/annotation/src/main/protobuf/AnnotationV1.proto
@@ -19,7 +19,7 @@ message Point { int32 x = 1; int32 y = 2; string label = 3; } // annotations on 
 message SegmentValue {
     string valueHash = 1; // the 32-bit value hash used for grouping.
     string value = 2; // e.g., label
-    float score = 3; // e.g., confidence
+    optional float score = 3; // e.g., confidence
     map<string,string> extension = 4; // type-specific data
 }
 

--- a/core/annotation/src/main/protobuf/README.md
+++ b/core/annotation/src/main/protobuf/README.md
@@ -31,3 +31,13 @@ git clone git@github.com:pubg/protoc-gen-jsonschema.git
 cd protoc-gen-jsonschema
 go install github.com/pubg/protoc-gen-jsonschema
 ```
+
+## Optional: build via Maven
+
+When you need to regenerate `AnnotationV1.proto` Java sources, run the protobuf plugin that is configured in `core/annotation/pom.xml`. It compiles the `.proto` definitions with the same protobuf toolchain referenced in the Maven build and writes the generated Java directly into `core/annotation/src/main/java/datawave/annotation/protobuf/v1`:
+
+```bash
+mvn -pl core/annotation protobuf:compile
+```
+
+Generated files stay alongside the checked-in sources and no additional source-path configuration is required.

--- a/core/annotation/src/test/java/datawave/annotation/protobuf/v1/SegmentValueCompatibilityTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/protobuf/v1/SegmentValueCompatibilityTest.java
@@ -1,0 +1,45 @@
+package datawave.annotation.protobuf.v1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.annotation.util.v1.AnnotationUtils;
+
+public class SegmentValueCompatibilityTest {
+
+    @Test
+    public void testLegacyZeroScoreDeserializationWithOptionalScore() throws Exception {
+        // Serialized before `score` was explicitly optional, both methods produce same output:
+        // SegmentValue segmentValue = SegmentValue.newBuilder().setValue("horse").setScore(0.0f).build();
+        // SegmentValue segmentValue = SegmentValue.newBuilder().setValue("horse").build();
+        // segmentValue = AnnotationUtils.injectSegmentValueHash(segmentValue);
+        // String legacySegmentValueBase64 = Base64.getEncoder().encodeToString(segmentValue.toByteArray());
+        final String legacySegmentValueBase64 = "Cgg3N0JGQjVCNxIFaG9yc2U=";
+        final String legacySegmentValueHash = "77BFB5B7";
+
+        SegmentValue segmentValue = SegmentValue.parseFrom(Base64.getDecoder().decode(legacySegmentValueBase64));
+        segmentValue = AnnotationUtils.injectSegmentValueHash(segmentValue);
+
+        // Without presence bit a 0.0 value will always deserialize as not having a score.
+        assertEquals("horse", segmentValue.getValue());
+        assertEquals(0.0f, segmentValue.getScore(), 0.0f);
+        assertEquals(legacySegmentValueHash, segmentValue.getValueHash());
+        assertFalse(segmentValue.hasScore());
+
+        // With the score explicitly optional we can distinguish between 0.0 values being explicitly set or not
+        SegmentValue segmentValueWithOutPresence = SegmentValue.newBuilder().setValue("horse").build();
+        segmentValueWithOutPresence = AnnotationUtils.injectSegmentValueHash(segmentValueWithOutPresence);
+        assertFalse(segmentValueWithOutPresence.hasScore());
+        assertEquals(legacySegmentValueHash, segmentValueWithOutPresence.getValueHash());
+
+        SegmentValue segmentValueWithPresence = SegmentValue.newBuilder().setValue("horse").setScore(0.0f).build();
+        segmentValueWithPresence = AnnotationUtils.injectSegmentValueHash(segmentValueWithPresence);
+        assertTrue(segmentValueWithPresence.hasScore());
+        assertEquals(legacySegmentValueHash, segmentValueWithPresence.getValueHash());
+    }
+}

--- a/core/annotation/src/test/java/datawave/annotation/protobuf/v1/SegmentValueCompatibilityTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/protobuf/v1/SegmentValueCompatibilityTest.java
@@ -13,12 +13,21 @@ import datawave.annotation.util.v1.AnnotationUtils;
 public class SegmentValueCompatibilityTest {
 
     @Test
+    /**
+     * {@code legacySegmentValueBase64} is the Base64-encoded protobuf binary produced by the previous version, where the {@code score} field in
+     * {@code SegmentValue} was not explicitly declared {@code optional}.
+     *
+     * <p>
+     * The following two statements produced the same serialized output because the default score value {@code 0.0f} was not written to the protobuf:
+     *
+     * <pre>{@code
+     * SegmentValue segmentValue = SegmentValue.newBuilder().setValue("horse").setScore(0.0f).build();
+     * SegmentValue segmentValue = SegmentValue.newBuilder().setValue("horse").build();
+     * segmentValue = AnnotationUtils.injectSegmentValueHash(segmentValue);
+     * String legacySegmentValueBase64 = Base64.getEncoder().encodeToString(segmentValue.toByteArray());
+     * }</pre>
+     */
     public void testLegacyZeroScoreDeserializationWithOptionalScore() throws Exception {
-        // Serialized before `score` was explicitly optional, both methods produce same output:
-        // SegmentValue segmentValue = SegmentValue.newBuilder().setValue("horse").setScore(0.0f).build();
-        // SegmentValue segmentValue = SegmentValue.newBuilder().setValue("horse").build();
-        // segmentValue = AnnotationUtils.injectSegmentValueHash(segmentValue);
-        // String legacySegmentValueBase64 = Base64.getEncoder().encodeToString(segmentValue.toByteArray());
         final String legacySegmentValueBase64 = "Cgg3N0JGQjVCNxIFaG9yc2U=";
         final String legacySegmentValueHash = "77BFB5B7";
 

--- a/core/annotation/src/test/java/datawave/annotation/util/v1/JacksonJsonSerializationTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/util/v1/JacksonJsonSerializationTest.java
@@ -1,6 +1,7 @@
 package datawave.annotation.util.v1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileInputStream;
@@ -9,6 +10,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -18,12 +20,15 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.IteratorUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
@@ -32,6 +37,7 @@ import com.google.protobuf.util.JsonFormat;
 
 import datawave.annotation.protobuf.v1.Annotation;
 import datawave.annotation.protobuf.v1.AnnotationList;
+import datawave.annotation.protobuf.v1.SegmentValue;
 import datawave.annotation.test.v1.AnnotationAssertions;
 import datawave.annotation.test.v1.AnnotationTestDataUtil;
 
@@ -125,6 +131,28 @@ public class JacksonJsonSerializationTest {
     }
 
     @Test
+    @ResourceLock(value = "annotation_baseline", mode = ResourceAccessMode.READ)
+    public void testProtobufDeserializationListBaselineWithZeroScore() throws Exception {
+        JsonFormat.Parser parser = AnnotationJsonUtils.getParser();
+        AnnotationList parsed = parseAnnotationListWithBaselineSegmentValueMutations(true, false, parser);
+        SegmentValue value = parsed.getAnnotations(0).getSegments(0).getValues(0);
+
+        assertEquals(0.0f, value.getScore(), 0.0f);
+        assertTrue(value.hasScore());
+    }
+
+    @Test
+    @ResourceLock(value = "annotation_baseline", mode = ResourceAccessMode.READ)
+    public void testProtobufDeserializationListBaselineWithMissingScore() throws Exception {
+        JsonFormat.Parser parser = AnnotationJsonUtils.getParser();
+        AnnotationList parsed = parseAnnotationListWithBaselineSegmentValueMutations(false, true, parser);
+        SegmentValue value = parsed.getAnnotations(0).getSegments(0).getValues(1);
+
+        assertEquals(0.0f, value.getScore(), 0.0f);
+        assertFalse(value.hasScore());
+    }
+
+    @Test
     @ResourceLock("annotation_baseline_ndjson")
     public void testProtobufSerializationBaselineNdJson() throws Exception {
         JsonFormat.Printer printer = AnnotationJsonUtils.getPrinter();
@@ -178,5 +206,23 @@ public class JacksonJsonSerializationTest {
         }
         assertEquals(36, parsedAnnotations.size());
         // TODO more validation
+    }
+
+    private AnnotationList parseAnnotationListWithBaselineSegmentValueMutations(boolean setFirstScoreToZero, boolean removeSecondScore,
+                    JsonFormat.Parser parser) throws Exception {
+        Path p = Path.of("src/test/resources/annotation_baseline.json");
+        ObjectNode root = (ObjectNode) objectMapper.readTree(Files.readString(p));
+        ArrayNode values = root.withArray("annotations").get(0).withArray("segments").get(0).withArray("values");
+
+        if (setFirstScoreToZero) {
+            ((ObjectNode) values.get(0)).put("score", 0.0);
+        }
+        if (removeSecondScore) {
+            ((ObjectNode) values.get(1)).remove("score");
+        }
+
+        AnnotationList.Builder builder = AnnotationList.newBuilder();
+        parser.merge(objectMapper.writeValueAsString(root), builder);
+        return builder.build();
     }
 }


### PR DESCRIPTION
**Updates**:

- Makes the score field in Annotation SegmentValue objects explicitly optional to allow value presence checking.
- Adds maven plugin definition to provide option for manually building Java source from .proto files. This was tested to confirm it generates the same output as using the existing method described in the protobuf README.md

**More Details**:

Currently the Annotation SegmentValue is defined with an implicitly optional score field. When a field is 'implicitly' optional it behaves differently from an explicitly optional field in that it doesn't track whether the field's value was explicitly set. In the case the field is 0.0 then it is not serialized to protobuf output. 

When deserialized there is no way to determine if the field was explicitly set to 0.0 or if it defaulted to 0.0 since it was not present in the protobuf. Explicitly setting the field to 'optional' adds presence bits for the score field and allows code to distinguish between the two. 

This enhancement will be used for defining Annotations which purpose is to describe a state-change from a previous annotation state whereby a SegmentValue with a missing score implies the score should be unset from the previous state (versus setting to zero which has a different meaning).



