### PR TITLE
Updated the RunningQuery to use an injected ExecutorService.

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/LongRunningQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/LongRunningQueryTest.java
@@ -13,10 +13,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,6 +62,7 @@ public class LongRunningQueryTest {
     private static final Logger log = Logger.getLogger(LongRunningQueryTest.class);
     private static AccumuloClient client = null;
     private ShardQueryLogic logic;
+    private ExecutorService executor;
 
     @Before
     public void setup() throws Exception {
@@ -89,6 +93,16 @@ public class LongRunningQueryTest {
         logic.setCacheModel(false);
         logic.setMaxPipelineCachedResults(0);
         logic.setIvaratorCacheBufferSize(0);
+
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void after() {
+        if (executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
     }
 
     /**
@@ -132,6 +146,7 @@ public class LongRunningQueryTest {
         RunningQueryTimingImpl timing = new RunningQueryTimingImpl(conf, 1);
         RunningQuery runningQuery = new RunningQuery(null, client, AccumuloConnectionFactory.Priority.NORMAL, logic, query, "", datawavePrincipal, timing, null,
                         new QueryMetricFactoryImpl());
+        runningQuery.setExecutor(executor);
         List<ResultsPage> pages = new ArrayList<>();
 
         ResultsPage page = runningQuery.next();
@@ -194,6 +209,7 @@ public class LongRunningQueryTest {
         RunningQueryTimingImpl timing = new RunningQueryTimingImpl(conf, 1);
         RunningQuery runningQuery = new RunningQuery(null, client, AccumuloConnectionFactory.Priority.NORMAL, logic, query, "", datawavePrincipal, timing, null,
                         new QueryMetricFactoryImpl());
+        runningQuery.setExecutor(executor);
         List<ResultsPage> pages = new ArrayList<>();
         ResultsPage page = runningQuery.next();
         Thread.sleep(15);
@@ -248,6 +264,7 @@ public class LongRunningQueryTest {
 
         RunningQuery runningQuery = new RunningQuery(null, client, AccumuloConnectionFactory.Priority.NORMAL, logic, query, "", datawavePrincipal, null, null,
                         new QueryMetricFactoryImpl());
+        runningQuery.setExecutor(executor);
         List<ResultsPage> pages = new ArrayList<>();
 
         ResultsPage page = runningQuery.next();
@@ -306,6 +323,7 @@ public class LongRunningQueryTest {
 
         RunningQuery runningQuery = new RunningQuery(null, client, AccumuloConnectionFactory.Priority.NORMAL, logic, query, "", datawavePrincipal, null, null,
                         new QueryMetricFactoryImpl());
+        runningQuery.setExecutor(executor);
         List<ResultsPage> pages = new ArrayList<>();
 
         ResultsPage page = runningQuery.next();

--- a/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedResultsBean.java
+++ b/web-services/cached-results/src/main/java/datawave/webservice/results/cached/CachedResultsBean.java
@@ -44,6 +44,7 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
+import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.inject.Inject;
 import javax.interceptor.Interceptors;
 import javax.sql.DataSource;
@@ -190,6 +191,9 @@ public class CachedResultsBean {
 
     @Resource(lookup = "java:jboss/datasources/CachedResultsDS")
     protected DataSource ds;
+
+    @Resource
+    private ManagedExecutorService executor;
 
     @Inject
     private QueryCache runningQueryCache;
@@ -479,6 +483,7 @@ public class CachedResultsBean {
                 try {
                     query = new RunningQuery(null, null, logic.getConnectionPriority(), logic, q, q.getQueryAuthorizations(), p,
                                     new RunningQueryTimingImpl(queryExpirationConf, q.getPageTimeout()), predictor, userOperationsBean, metricFactory);
+                    query.setExecutor(executor);
                     query.setActiveCall(true);
                     // queryMetric was duplicated from the original earlier
                     query.setMetric(queryMetric);
@@ -2146,6 +2151,7 @@ public class CachedResultsBean {
                 AccumuloConnectionFactory.Priority priority = logic.getConnectionPriority();
                 query = new RunningQuery(metrics, null, priority, logic, q, q.getQueryAuthorizations(), p,
                                 new RunningQueryTimingImpl(queryExpirationConf, q.getPageTimeout()), predictor, userOperationsBean, metricFactory);
+                query.setExecutor(executor);
                 query.setActiveCall(true);
                 // Put in the cache by id and name, we will have two copies that reference the same object
                 runningQueryCache.put(q.getId().toString(), query);

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/QueryExecutorBean.java
@@ -660,6 +660,7 @@ public class QueryExecutorBean implements QueryExecutor {
 
             rq = new RunningQuery(metrics, null, priority, qd.logic, q, qp.getAuths(), qd.p,
                             new RunningQueryTimingImpl(queryExpirationConf, qp.getPageTimeout()), this.predictor, this.userOperationsBean, this.metricFactory);
+            rq.setExecutor(executor);
             rq.setActiveCall(true);
             rq.getMetric().setProxyServers(qd.proxyServers);
             queryCache.put(q.getId().toString(), rq);
@@ -778,6 +779,7 @@ public class QueryExecutorBean implements QueryExecutor {
             qlCache.add(q.getId().toString(), qd.userid, qd.logic, client);
             rq = new RunningQuery(metrics, null, priority, qd.logic, q, qp.getAuths(), qd.p,
                             new RunningQueryTimingImpl(queryExpirationConf, qp.getPageTimeout()), this.predictor, this.userOperationsBean, this.metricFactory);
+            rq.setExecutor(executor);
             rq.setActiveCall(true);
             rq.getMetric().setProxyServers(qd.proxyServers);
             rq.setClient(client);
@@ -1144,6 +1146,7 @@ public class QueryExecutorBean implements QueryExecutor {
             AccumuloConnectionFactory.Priority priority = logic.getConnectionPriority();
             RunningQuery query = new RunningQuery(metrics, null, priority, logic, q, q.getQueryAuthorizations(), p,
                             new RunningQueryTimingImpl(queryExpirationConf, qp.getPageTimeout()), this.predictor, this.userOperationsBean, this.metricFactory);
+            query.setExecutor(executor);
             results.add(query);
             // Put in the cache by id if its not already in the cache.
             if (!queryCache.containsKey(q.getId().toString()))
@@ -1182,6 +1185,7 @@ public class QueryExecutorBean implements QueryExecutor {
                 query = new RunningQuery(metrics, null, priority, logic, q, q.getQueryAuthorizations(), principal,
                                 new RunningQueryTimingImpl(queryExpirationConf, qp.getPageTimeout()), this.predictor, this.userOperationsBean,
                                 this.metricFactory);
+                query.setExecutor(executor);
                 // Put in the cache by id and name, we will have two copies that reference the same object
                 queryCache.put(q.getId().toString(), query);
             }
@@ -1217,6 +1221,7 @@ public class QueryExecutorBean implements QueryExecutor {
             final AccumuloConnectionFactory.Priority priority = logic.getConnectionPriority();
             query = RunningQuery.createQueryWithAuthorizations(metrics, null, priority, logic, q, auths,
                             new RunningQueryTimingImpl(queryExpirationConf, qp.getPageTimeout()), this.predictor, this.metricFactory);
+            query.setExecutor(executor);
 
             // Put in the cache by id and name, we will have two copies that reference the same object
             queryCache.put(q.getId().toString(), query);

--- a/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/runner/RunningQuery.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -66,9 +65,9 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
     private Query settings = null;
     private long numResults = 0;
     private long lastPageNumber = 0;
-    private transient TransformIterator iter = null;
+    private volatile transient TransformIterator iter = null;
     private Set<Authorizations> calculatedAuths = null;
-    private boolean finished = false;
+    private volatile boolean finished = false;
     private volatile boolean canceled = false;
     private transient QueryMetricsBean queryMetrics = null;
     private transient RunningQueryTiming timing = null;
@@ -142,7 +141,6 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
                                         : userOperations.getRemoteUser((DatawavePrincipal) principal);
         this.calculatedAuths = WSAuthorizationsUtil.getDowngradedAuthorizations(methodAuths, overallPrincipal, queryPrincipal);
         this.timing = timing;
-        this.executor = Executors.newSingleThreadExecutor();
         this.predictor = predictor;
         // set the metric information
         this.getMetric().populate(this.settings);
@@ -328,7 +326,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
      *             if there is a timeout
      */
     private boolean hasNext(long pageStartTime) throws TimeoutException {
-        if (useResultsThread) {
+        if (useResultsThread && executor != null) {
             synchronized (hasNext) {
                 if (hasNext.get() == 0 && running.get() && !this.finished && !this.canceled) {
                     long timeout = (timing != null ? Math.max(1, (timing.getPageShortCircuitTimeoutMs() - (System.currentTimeMillis() - pageStartTime)))
@@ -379,7 +377,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
      *             if there is a timeout
      */
     private Object getNext(long pageStartTime) throws TimeoutException {
-        if (useResultsThread) {
+        if (useResultsThread && executor != null) {
             synchronized (gotNext) {
                 if (gotNext.get() == 0 && running.get() && !this.finished && !this.canceled) {
                     long timeout = (timing != null ? Math.max(1, (timing.getPageShortCircuitTimeoutMs() - (System.currentTimeMillis() - pageStartTime)))
@@ -422,7 +420,6 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
             }
             future = null;
         }
-        executor.shutdown();
     }
 
     /**
@@ -452,7 +449,7 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
             testForUncaughtException(resultList.size());
 
             // start up the results thread if needed
-            if (useResultsThread && future == null && !this.canceled && !this.finished) {
+            if (useResultsThread && future == null && executor != null && !this.canceled && !this.finished) {
                 running.set(true);
                 future = executor.submit(() -> getResultsThread());
             }
@@ -814,6 +811,14 @@ public class RunningQuery extends AbstractRunningQuery implements Runnable {
                 throw new QueryException(handler.getThrowable());
             }
         }
+    }
+
+    public ExecutorService getExecutor() {
+        return executor;
+    }
+
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
     }
 
 }

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -18,12 +18,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.functors.NOPTransformer;
 import org.apache.commons.collections4.iterators.TransformIterator;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,12 +80,23 @@ public class ExtendedRunningQueryTest {
     @Mock
     TransformIterator transformIterator;
 
+    private ExecutorService executor;
+
     private Transformer transformer = NOPTransformer.nopTransformer();
 
     @Before
     public void setup() {
         System.setProperty(DnUtils.NPE_OU_PROPERTY, "iamnotaperson");
         System.setProperty("dw.metadatahelper.all.auths", "A,B,C,D");
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void after() {
+        if (executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
     }
 
     @Test
@@ -191,6 +205,7 @@ public class ExtendedRunningQueryTest {
         PowerMock.replayAll();
         RunningQuery subject = new RunningQuery(this.client, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
                         new QueryMetricFactoryImpl());
+        subject.setExecutor(executor);
 
         ResultsPage result1 = subject.next();
         String result2 = subject.toString();
@@ -206,7 +221,6 @@ public class ExtendedRunningQueryTest {
         assertNotNull("Expected a non-null toString() representation", result2);
 
         assertSame("Expected lifecycle to be results", QueryMetric.Lifecycle.RESULTS, subject.getMetric().getLifecycle());
-
     }
 
     @Test
@@ -279,6 +293,7 @@ public class ExtendedRunningQueryTest {
         PowerMock.replayAll();
         RunningQuery subject = new RunningQuery(this.client, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
                         new RunningQueryTimingImpl(3600, 1200, 3500, 10), new QueryMetricFactoryImpl());
+        subject.setExecutor(executor);
 
         ResultsPage result1 = subject.next();
         String result2 = subject.toString();
@@ -294,7 +309,6 @@ public class ExtendedRunningQueryTest {
         assertNotNull("Expected a non-null toString() representation", result2);
 
         assertSame("Expected lifecycle to be results", QueryMetric.Lifecycle.RESULTS, subject.getMetric().getLifecycle());
-
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -371,6 +385,7 @@ public class ExtendedRunningQueryTest {
         PowerMock.replayAll();
         RunningQuery subject = new RunningQuery(this.client, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
                         new QueryMetricFactoryImpl());
+        subject.setExecutor(executor);
 
         ResultsPage result1 = subject.next();
 
@@ -444,6 +459,7 @@ public class ExtendedRunningQueryTest {
         PowerMock.replayAll();
         RunningQuery subject = new RunningQuery(this.queryMetrics, this.client, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
                         new QueryMetricFactoryImpl());
+        subject.setExecutor(executor);
         subject.cancel();
         boolean result1 = subject.isCanceled();
         ResultsPage result2 = subject.next();
@@ -504,6 +520,7 @@ public class ExtendedRunningQueryTest {
         PowerMock.replayAll();
         RunningQuery subject = new RunningQuery(this.queryMetrics, this.client, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
                         new QueryMetricFactoryImpl());
+        subject.setExecutor(executor);
         subject.closeConnection(this.connectionFactory);
         QueryMetric.Lifecycle status = subject.getMetric().getLifecycle();
         PowerMock.verifyAll();
@@ -588,6 +605,7 @@ public class ExtendedRunningQueryTest {
         PowerMock.replayAll();
         RunningQuery subject = new RunningQuery(this.client, Priority.NORMAL, this.queryLogic, this.query, methodAuths, principal,
                         new QueryMetricFactoryImpl());
+        subject.setExecutor(executor);
 
         ResultsPage result1 = subject.next();
 


### PR DESCRIPTION
Updated the QueryExecutorBean amongst other clases to set the ExecutorService on the RunningQuery as the ManagedExecutorService. The ManagerExecutorService will handle passing the roles onto the threads which allows query logics to make calls to other EJBs as needed.