### PR TITLE
fix flaky tests

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IndexExpansionQueryTest.java
@@ -447,9 +447,16 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedRegexNPERandom() {
         try {
+            disableQueryPlanAssertion();
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random NPE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -495,9 +502,16 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedRegexITEOnRandom() {
         try {
+            disableQueryPlanAssertion();
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random ITE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeIOExceptionIterator();
         }
@@ -507,9 +521,16 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedRegexIIEOnRandom() {
         try {
+            disableQueryPlanAssertion();
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("_ANYFIELD_ =~ 'a.*'");
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random IIE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -696,9 +717,17 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedLiteralNPERandom() {
         try {
+            disableQueryPlanAssertion();
             addRuntimeExceptionIterator(NullPointerException.class.getName(), "NPE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+                // if we get here, the random NPE didn't fire -- that's acceptable
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random NPE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -744,9 +773,16 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedLiteralITEOnRandom() {
         try {
+            disableQueryPlanAssertion();
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random ITE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeIOExceptionIterator();
         }
@@ -756,9 +792,16 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
     @Test
     public void testUnfieldedLiteralIIEOnRandom() {
         try {
+            disableQueryPlanAssertion();
             addRuntimeExceptionIterator(IterationInterruptedException.class.getName(), "IIE for test", "random");
             givenQuery("_ANYFIELD_ == 'a1b2c3'");
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random IIE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeRuntimeExceptionIterator();
         }
@@ -789,10 +832,16 @@ public class IndexExpansionQueryTest extends AbstractQueryTest {
             SortedSet<String> prefixes = new TreeSet<>(Set.of("aa", "ab", "ac", "ad", "ae"));
             String query = buildUnfieldedRegexQuery(prefixes);
 
+            disableQueryPlanAssertion();
             addIOExceptionIterator(IteratorTimeoutException.class.getName(), "random");
             givenQuery(query);
-            expectPlan(null); // no plan expected
-            assertThrows(DatawaveFatalQueryException.class, this::planAndExecuteQuery);
+            try {
+                planAndExecuteQuery();
+            } catch (DatawaveFatalQueryException e) {
+                // expected when the random ITE fires during index expansion
+            } catch (Exception e) {
+                throw new AssertionError("Expected either success or DatawaveFatalQueryException, but got: " + e.getClass().getName(), e);
+            }
         } finally {
             removeIOExceptionIterator();
         }

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterConcurrencyTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterConcurrencyTest.java
@@ -54,7 +54,7 @@ class QueryLimiterConcurrencyTest {
     //
     // This number represents maximum amount of time allowed to elapse between extra queries that should not have been created to the last valid query that
     // is expected to be a valid creation. A certain fudge factor is required for testing simultaneous query creations.
-    private static final long SIMULTANEOUS_QUERY_CREATION_ALLOWANCE = 100L;
+    private static final long SIMULTANEOUS_QUERY_CREATION_ALLOWANCE = 250L;
 
     // Set this to true to print the attempt results for debugging purposes.
     private static final boolean printAttempts = true;

--- a/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/runner/ExtendedRunningQueryTest.java
@@ -320,8 +320,10 @@ public class ExtendedRunningQueryTest {
         when(this.queryLogic.isLongRunningQuery()).thenReturn(false);
         when(this.queryLogic.getResultLimit(eq(this.query))).thenReturn(maxResults);
 
-        when(this.transformIterator.hasNext()).thenReturn(true);
-        when(this.transformIterator.next()).thenReturn(new Object(), "resultObject1", "resultObject2", "resultObject3", "resultObject4", "resultObject5");
+        List<Object> resultObjects = Arrays.asList(new Object(), "resultObject1", "resultObject2", "resultObject3", "resultObject4", "resultObject5");
+        when(this.transformIterator.hasNext()).thenReturn(true, true, true, true, true, true, false);
+        when(this.transformIterator.next()).thenReturn(resultObjects.get(0), resultObjects.get(1), resultObjects.get(2), resultObjects.get(3),
+                        resultObjects.get(4), resultObjects.get(5));
 
         when(this.transformIterator.getTransformer()).thenReturn(transformer);
 


### PR DESCRIPTION
**IndexExpansionQueryTest.java**
- Due to the random nature of these tests the DatawaveFatalQueryException is not always thrown

**QueryLimiterConcurrencyTest.java**
- query creation time allowance is too short when running tests concurrently (100L -> 250L)

**ExtendedRunningQueryTest.java**
- resolves race condition by explicitly setting the list of boolean return values for the hasNext mock