### PR TITLE
fix RemoteEventQueryLogicIT flaky test

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RemoteEventQueryLogicIT.java
@@ -220,7 +220,10 @@ public class RemoteEventQueryLogicIT {
         remoteConfig.setConnectionPoolTimeout(1);
 
         // patch in the forever handler which will block until its unlocked
-        HttpHandler foreverHandler = new ForeverHandler(handlerInterrupt);
+        // use an arrival latch to ensure the first request occupies the connection before the second thread starts
+        CountDownLatch arrivalLatch = new CountDownLatch(1);
+        ForeverHandler foreverHandler = new ForeverHandler(handlerInterrupt);
+        foreverHandler.setArrivalLatch(arrivalLatch);
 
         testUtil.updateRoute("/DataWave/Query/" + DEFAULT_REMOTE_LOGIC + "/create", foreverHandler);
 
@@ -232,9 +235,17 @@ public class RemoteEventQueryLogicIT {
         RemoteQueryServiceTestUtil.QueryRunnable r2 = new RemoteQueryServiceTestUtil.QueryRunnable(logic);
         r2.setExceptionLatch(exceptionLatch);
 
-        // start both threads
+        // start the first thread and wait for it to acquire the single connection
         Thread t1 = new Thread(r1);
         t1.start();
+
+        try {
+            assertTrue("Timed out waiting for first request to arrive", arrivalLatch.await(35, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            throw new AssertionError("Interrupted while waiting for first request to arrive", e);
+        }
+
+        // now start the second thread which will find the pool exhausted
         Thread t2 = new Thread(r2);
         t2.start();
 
@@ -248,11 +259,10 @@ public class RemoteEventQueryLogicIT {
         assertFalse(r1.isSetup().get());
         assertFalse(r2.isSetup().get());
 
-        // only one thread had an exception
-        assertFalse(r1.isCaught().get() && r2.isCaught().get());
-        assertTrue(r1.getException() != null || r2.getException() != null);
-        assertTrue(r1.getException() == null || r1.getException() instanceof RemoteTimeoutQueryException);
-        assertTrue(r2.getException() == null || r2.getException() instanceof RemoteTimeoutQueryException);
+        // only the second thread should have an exception
+        assertFalse(r1.isCaught().get());
+        assertTrue(r2.isCaught().get());
+        assertTrue(r2.getException() instanceof RemoteTimeoutQueryException);
     }
 
     @Test

--- a/web-services/common/src/test/java/datawave/webservice/common/remote/RemoteServiceUtil.java
+++ b/web-services/common/src/test/java/datawave/webservice/common/remote/RemoteServiceUtil.java
@@ -4,6 +4,7 @@ import static java.lang.Thread.sleep;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.sun.net.httpserver.HttpExchange;
@@ -70,13 +71,21 @@ public class RemoteServiceUtil {
 
     public static class ForeverHandler implements HttpHandler {
         private final AtomicBoolean interrupt;
+        private volatile CountDownLatch arrivalLatch;
 
         public ForeverHandler(AtomicBoolean interrupt) {
             this.interrupt = interrupt;
         }
 
+        public void setArrivalLatch(CountDownLatch arrivalLatch) {
+            this.arrivalLatch = arrivalLatch;
+        }
+
         @Override
         public void handle(HttpExchange exchange) throws IOException {
+            if (arrivalLatch != null) {
+                arrivalLatch.countDown();
+            }
             while (true) {
                 try {
                     sleep(50);


### PR DESCRIPTION
**Issue:**

testConnectionPoolTimeout starts both threads simultaneously, but with a 1ms pool timeout, there's no guarantee that thread 1 has actually acquired the single connection before thread 2 tries. If both threads race to the pool before either establishes a connection, the expected timeout may never occur.

**The Fix:**

signal when the ForeverHandler has received a request (proving the connection is occupied), then start the second thread.

**What Changed:**

1. ForeverHandler — added an optional arrivalLatch that counts down when handle() is entered, signaling that a request has arrived and the connection is occupied.
2. testConnectionPoolTimeout — instead of starting both threads simultaneously and hoping for the right scheduling, it now:
    - Starts thread 1 and waits for the arrivalLatch (proving thread 1 holds the single connection)
    - Only then starts thread 2, which deterministically finds the pool exhausted and gets the 1ms timeout
    - Asserts specifically that thread 2 (not thread 1) got the exception

The existing ForeverHandler usages are unaffected since arrivalLatch defaults to null.