### PR TITLE
Add ClockIterator

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/test/iter/ClockIterator.java
+++ b/warehouse/query-core/src/test/java/datawave/test/iter/ClockIterator.java
@@ -1,0 +1,146 @@
+package datawave.test.iter;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+
+/**
+ * An iterator that advances an internal clock on next and seek calls by a specified amount.
+ * <p>
+ * See {@link ClockIteratorTest} for instrumentation examples.
+ */
+public class ClockIterator implements SortedKeyValueIterator<Key,Value>, OptionDescriber {
+
+    public static final String ADVANCE_ON_NEXT = "advanceOnNext";
+    public static final String ADVANCE_ON_SEEK = "advanceOnSeek";
+    public static final String ADVANCE_ON_BOTH = "advanceOnBoth";
+    public static final String ADVANCE_AMOUNT = "advanceAmount";
+
+    private Key tk;
+    private Value tv;
+
+    private SortedKeyValueIterator<Key,Value> source;
+
+    private boolean advanceOnNext;
+    private boolean advanceOnSeek;
+    private boolean advanceOnBoth;
+    private long advanceAmount;
+
+    // this cannot be final despite what your IDE may say.
+    private static Clock clock = Clock.systemUTC();
+
+    /**
+     * Advance the lock by the {@link #advanceAmount}
+     */
+    private void advanceClock() {
+        long current = clock.millis();
+        when(clock.millis()).thenReturn(current + advanceAmount);
+    }
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        this.source = source;
+        validateOptions(options);
+    }
+
+    @Override
+    public boolean hasTop() {
+        return tk != null;
+    }
+
+    @Override
+    public void next() throws IOException {
+        if (advanceOnNext || advanceOnBoth) {
+            advanceClock();
+        }
+        tk = null;
+        tv = null;
+        if (source.hasTop()) {
+            tk = source.getTopKey();
+            tv = source.getTopValue();
+            source.next();
+        }
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        if (advanceOnSeek || advanceOnBoth) {
+            advanceClock();
+        }
+        source.seek(range, columnFamilies, inclusive);
+        next();
+    }
+
+    @Override
+    public Key getTopKey() {
+        return tk;
+    }
+
+    @Override
+    public Value getTopValue() {
+        return tv;
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+        ClockIterator copy = new ClockIterator();
+        copy.source = source.deepCopy(env);
+        copy.advanceOnNext = advanceOnNext;
+        copy.advanceOnSeek = advanceOnSeek;
+        copy.advanceOnBoth = advanceOnBoth;
+        copy.advanceAmount = advanceAmount;
+        return copy;
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+        IteratorOptions options = new IteratorOptions(getClass().getName(), "An iterator that advances a mock clock", null, null);
+        options.addNamedOption(ADVANCE_ON_NEXT, "Flag to advance the clock on every next call");
+        options.addNamedOption(ADVANCE_ON_SEEK, "Flag to advance the clock on every seek call");
+        options.addNamedOption(ADVANCE_ON_BOTH, "Flag to advance the clock on every next and seek call");
+        options.addNamedOption(ADVANCE_AMOUNT, "The number of milliseconds the clock is advanced");
+        return options;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        String option = options.get(ADVANCE_ON_NEXT);
+        if (option != null) {
+            advanceOnNext = Boolean.parseBoolean(option);
+        }
+
+        option = options.get(ADVANCE_ON_SEEK);
+        if (option != null) {
+            advanceOnSeek = Boolean.parseBoolean(option);
+        }
+
+        option = options.get(ADVANCE_ON_BOTH);
+        if (option != null) {
+            advanceOnBoth = Boolean.parseBoolean(option);
+        }
+
+        if (!(advanceOnNext || advanceOnSeek || advanceOnBoth)) {
+            throw new IllegalStateException("At least one advance option must be specified");
+        }
+
+        option = options.get(ADVANCE_AMOUNT);
+        if (option == null) {
+            throw new IllegalStateException("ADVANCE_AMOUNT option must be specified");
+        } else {
+            advanceAmount = Long.parseLong(option);
+        }
+
+        return true;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/test/iter/ClockIteratorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/iter/ClockIteratorTest.java
@@ -1,0 +1,145 @@
+package datawave.test.iter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iteratorsImpl.system.SortedMapIterator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Demonstrates how to use {@link org.springframework.test.util.ReflectionTestUtils} to inject a {@link java.time.Clock} into the {@link ClockIterator} using
+ * Mockito.
+ */
+public class ClockIteratorTest {
+
+    private static final Value EMPTY_VALUE = new Value();
+
+    private final Map<String,String> options = new HashMap<>();
+
+    private final Clock clock = Mockito.mock(Clock.class);
+
+    @BeforeEach
+    public void beforeEach() {
+        options.clear();
+
+        // inject the mock clock and set initial time
+        ReflectionTestUtils.setField(ClockIterator.class, "clock", clock);
+        when(clock.millis()).thenReturn(0L);
+    }
+
+    private void givenAdvanceOnNext() {
+        options.put(ClockIterator.ADVANCE_ON_NEXT, "true");
+    }
+
+    private void givenAdvanceOnSeek() {
+        options.put(ClockIterator.ADVANCE_ON_SEEK, "true");
+    }
+
+    private void givenAdvanceOnBoth() {
+        options.put(ClockIterator.ADVANCE_ON_BOTH, "true");
+    }
+
+    private void givenAdvanceAmount() {
+        options.put(ClockIterator.ADVANCE_AMOUNT, "100");
+    }
+
+    @Test
+    public void testNoAdvanceOptionSet() {
+        Exception e = assertThrows(IllegalStateException.class, this::getIter);
+        String expected = "At least one advance option must be specified";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    public void testAdvanceOptionSetButNoAdvanceAmount() {
+        givenAdvanceOnNext();
+        Exception e = assertThrows(IllegalStateException.class, this::getIter);
+        String expected = "ADVANCE_AMOUNT option must be specified";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    public void testAdvanceOnNext() throws Exception {
+        givenAdvanceOnNext();
+        givenAdvanceAmount();
+        assertEquals(0L, clock.millis());
+        driveIterator();
+        // 100ms per next call. One next call per element + one next call to determine no next element
+        assertEquals(1100L, clock.millis());
+    }
+
+    @Test
+    public void testAdvanceOnSeek() throws Exception {
+        givenAdvanceOnSeek();
+        givenAdvanceAmount();
+
+        assertEquals(0L, clock.millis());
+        driveIterator();
+        // 100ms per seek call, seek only called once at the start
+        assertEquals(100L, clock.millis());
+    }
+
+    @Test
+    public void testAdvanceOnBoth() throws Exception {
+        givenAdvanceOnBoth();
+        givenAdvanceAmount();
+
+        assertEquals(0L, clock.millis());
+        driveIterator();
+        // 100ms per next and seek. Eleven next calls + one seek call.
+        assertEquals(1200L, clock.millis());
+    }
+
+    @Test
+    public void testAdvanceOnSeekAndAdvanceOnNext() throws Exception {
+        givenAdvanceOnNext();
+        givenAdvanceOnSeek();
+        givenAdvanceAmount();
+
+        assertEquals(0L, clock.millis());
+        driveIterator();
+        // 100ms per next and seek. Eleven next calls + one seek call.
+        assertEquals(1200L, clock.millis());
+    }
+
+    private void driveIterator() throws Exception {
+        SortedKeyValueIterator<Key,Value> iter = getIter();
+        while (iter.hasTop()) {
+            assertNotNull(iter.getTopKey());
+            assertNotNull(iter.getTopValue());
+            iter.next();
+        }
+        assertFalse(iter.hasTop());
+    }
+
+    private SortedKeyValueIterator<Key,Value> getIter() throws Exception {
+        TreeMap<Key,Value> data = new TreeMap<>();
+        for (int i = 0; i < 10; i++) {
+            data.put(new Key("row-" + i), EMPTY_VALUE);
+        }
+
+        SortedKeyValueIterator<Key,Value> source = new SortedMapIterator(data);
+
+        ClockIterator clockIterator = new ClockIterator();
+        clockIterator.init(source, options, new TestIteratorEnv());
+        clockIterator.seek(new Range(), Collections.emptySet(), false);
+        return clockIterator;
+    }
+
+}


### PR DESCRIPTION
This iterator advances an internal clock by a specified amount. The clock may be advanced on seek calls, next calls, or both.

Intended for use with JUnit5, Spring ReflectionTestUtils, and Mockito. Using these libraries a single clock can be constructed for a test and advanced, allowing for deterministic testing of clock-based operations.