### PR TITLE
Add dependency mapreduce query

### DIFF
--- a/microservices/services/mapreduce-query/service/pom.xml
+++ b/microservices/services/mapreduce-query/service/pom.xml
@@ -71,6 +71,11 @@
             </dependency>
             <dependency>
                 <groupId>gov.nsa.datawave.microservice</groupId>
+                <artifactId>mapreduce-query-core-job</artifactId>
+                <version>${version.datawave.mapreduce-query-core-job}</version>
+            </dependency>
+            <dependency>
+                <groupId>gov.nsa.datawave.microservice</groupId>
                 <artifactId>spring-boot-starter-datawave</artifactId>
                 <version>${version.datawave.starter}</version>
             </dependency>


### PR DESCRIPTION
This dependency was already included in plugins section. Not having it in this section causes version:update-properties to miss it. 