### PR TITLE
fix: EdgeDictionaryImplTest

### DIFF
--- a/microservices/services/dictionary/service/src/test/java/datawave/microservice/dictionary/edge/EdgeDictionaryImplTest.java
+++ b/microservices/services/dictionary/service/src/test/java/datawave/microservice/dictionary/edge/EdgeDictionaryImplTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -38,6 +39,7 @@ import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.data.ColumnFamilyConstants;
 import datawave.metadata.protobuf.EdgeMetadata.MetadataValue;
+import datawave.security.authorization.JWTTokenHandler;
 import datawave.webservice.dictionary.edge.DefaultEdgeDictionary;
 import datawave.webservice.dictionary.edge.DefaultMetadata;
 import datawave.webservice.dictionary.edge.EventField;
@@ -64,6 +66,9 @@ public class EdgeDictionaryImplTest {
 
     SetMultimap<Key,Value> edgeMetadataRows;
     Method transformResultsMethod;
+
+    @MockBean
+    private JWTTokenHandler jwtTokenHandler;
 
     @Autowired
     private EdgeDictionary<DefaultEdgeDictionary,DefaultMetadata> impl;


### PR DESCRIPTION
mock `JWTTokenHandler` bean to work with newer versions of datawave