### PR TITLE
Add builders for all ScannerSession implementations

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/AnyFieldScannerBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/AnyFieldScannerBuilder.java
@@ -1,0 +1,85 @@
+package datawave.query.tables;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+
+import com.google.common.base.Preconditions;
+
+import datawave.query.tables.stats.ScanSessionStats;
+
+/**
+ * Builder for the {@link AnyFieldScanner}
+ * <p>
+ * This is virtually identical to the {@link ScannerSessionBuilder} but per-instance builders are better for clarity.
+ */
+public class AnyFieldScannerBuilder extends SessionBuilder<AnyFieldScannerBuilder> {
+
+    /**
+     * Static access enforces AccumuloClient requirement
+     *
+     * @param client
+     *            the AccumuloClient
+     * @return a new instance of a scanner session builder
+     */
+    public static AnyFieldScannerBuilder create(AccumuloClient client) {
+        return new AnyFieldScannerBuilder(client);
+    }
+
+    /**
+     * Private constructor to enforce static access
+     *
+     * @param client
+     *            the AccumuloClient
+     */
+    private AnyFieldScannerBuilder(AccumuloClient client) {
+        super(client);
+    }
+
+    /**
+     * Build the {@link AnyFieldScanner}
+     *
+     * @return the AnyFieldScanner
+     */
+    @Override
+    public AnyFieldScanner build() {
+        try {
+            Preconditions.checkArgument(resourceQueueSize > 0, "ResourceQueueSize must be greater than 0");
+            ResourceQueue resourceQueue = new ResourceQueue(resourceQueueSize, client);
+
+            Preconditions.checkNotNull(tableName, "TableName must be set");
+            Preconditions.checkNotNull(authorizations, "Authorizations must be set");
+            Preconditions.checkNotNull(query, "Query must be set");
+            Preconditions.checkArgument(resultQueueSize > 0, "ResultQueueSize must be greater than 0");
+            ScannerSession scannerSession = new ScannerSession(tableName, authorizations, resourceQueue, resultQueueSize, query);
+
+            AnyFieldScanner session = AnyFieldScanner.class.getConstructor(ScannerSession.class).newInstance(scannerSession);
+
+            if (statsEnabled) {
+                session.applyStats(new ScanSessionStats());
+            }
+
+            if (consistencyLevel != null) {
+                session.getOptions().setConsistencyLevel(consistencyLevel);
+            }
+
+            if (!executionHints.isEmpty()) {
+                session.getOptions().setExecutionHints(executionHints);
+            }
+
+            return session;
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException("Could not create BatchScannerSession", e);
+        }
+    }
+
+    /**
+     * Allow child-specific methods to be picked up by the builder
+     *
+     * @return this builder
+     */
+    @Override
+    protected AnyFieldScannerBuilder self() {
+        return this;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/BatchScannerSessionBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/BatchScannerSessionBuilder.java
@@ -1,0 +1,111 @@
+package datawave.query.tables;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+
+import com.google.common.base.Preconditions;
+
+import datawave.query.tables.stats.ScanSessionStats;
+
+/**
+ * Builder for a {@link BatchScannerSession}
+ */
+public class BatchScannerSessionBuilder extends SessionBuilder<BatchScannerSessionBuilder> {
+
+    private static final int DEFAULT_THREAD_COUNT = 5;
+    private int numQueryThreads = DEFAULT_THREAD_COUNT;
+
+    /**
+     * Static access enforces AccumuloClient requirement
+     *
+     * @param client
+     *            the AccumuloClient
+     * @return a new instance of a scanner session builder
+     */
+    public static BatchScannerSessionBuilder create(AccumuloClient client) {
+        return new BatchScannerSessionBuilder(client);
+    }
+
+    /**
+     * Private constructor to enforce static access
+     *
+     * @param client
+     *            the AccumuloClient
+     */
+    private BatchScannerSessionBuilder(AccumuloClient client) {
+        super(client);
+    }
+
+    /**
+     * Set the number of query threads
+     *
+     * @param numQueryThreads
+     *            the number of query threads
+     * @return this builder
+     */
+    public BatchScannerSessionBuilder setNumQueryThreads(int numQueryThreads) {
+        this.numQueryThreads = numQueryThreads;
+        return this;
+    }
+
+    /**
+     * Get the number of query threads
+     *
+     * @return the number of query threads
+     */
+    public int getNumQueryThreads() {
+        return numQueryThreads;
+    }
+
+    /**
+     * Build the {@link BatchScannerSession}
+     *
+     * @return the BatchScannerSession
+     */
+    @Override
+    public BatchScannerSession build() {
+        try {
+            Preconditions.checkArgument(resourceQueueSize > 0, "ResourceQueueSize must be greater than 0");
+            ResourceQueue resourceQueue = new ResourceQueue(resourceQueueSize, client);
+
+            Preconditions.checkNotNull(tableName, "TableName must be set");
+            Preconditions.checkNotNull(authorizations, "Authorizations must be set");
+            Preconditions.checkNotNull(query, "Query must be set");
+            Preconditions.checkArgument(resultQueueSize > 0, "ResultQueueSize must be greater than 0");
+            ScannerSession scannerSession = new ScannerSession(tableName, authorizations, resourceQueue, resultQueueSize, query);
+
+            //  @formatter:off
+            BatchScannerSession session = BatchScannerSession.class.getConstructor(ScannerSession.class)
+                    .newInstance(scannerSession)
+                    .setThreads(numQueryThreads);
+            //  @formatter:on
+
+            if (statsEnabled) {
+                session.applyStats(new ScanSessionStats());
+            }
+
+            if (consistencyLevel != null) {
+                session.getOptions().setConsistencyLevel(consistencyLevel);
+            }
+
+            if (!executionHints.isEmpty()) {
+                session.getOptions().setExecutionHints(executionHints);
+            }
+
+            return session;
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException("Could not create BatchScannerSession", e);
+        }
+    }
+
+    /**
+     * Allow child-specific methods to be picked up by the builder
+     *
+     * @return this builder
+     */
+    @Override
+    protected BatchScannerSessionBuilder self() {
+        return this;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScannerBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/RangeStreamScannerBuilder.java
@@ -1,0 +1,106 @@
+package datawave.query.tables;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.core.query.configuration.GenericQueryConfiguration;
+import datawave.query.tables.stats.ScanSessionStats;
+
+/**
+ * Builder for a {@link RangeStreamScanner}
+ */
+public class RangeStreamScannerBuilder extends SessionBuilder<RangeStreamScannerBuilder> {
+
+    private static final Logger log = LoggerFactory.getLogger(RangeStreamScannerBuilder.class);
+
+    private GenericQueryConfiguration config;
+
+    /**
+     * Static access enforces AccumuloClient requirement
+     *
+     * @param client
+     *            the AccumuloClient
+     * @return a new instance of a scanner session builder
+     */
+    public static RangeStreamScannerBuilder create(AccumuloClient client) {
+        return new RangeStreamScannerBuilder(client);
+    }
+
+    /**
+     * Private constructor to enforce static access
+     *
+     * @param client
+     *            the AccumuloClient
+     */
+    private RangeStreamScannerBuilder(AccumuloClient client) {
+        super(client);
+    }
+
+    /**
+     * Set the {@link GenericQueryConfiguration}. This method can be removed once the RangeStreamScanner uses a builder instead of the ScannerFactory.
+     *
+     * @param config
+     *            the query config
+     * @return this builder
+     */
+    public RangeStreamScannerBuilder setConfig(GenericQueryConfiguration config) {
+        this.config = config;
+        return this;
+    }
+
+    /**
+     * Build the {@link RangeStreamScanner}
+     *
+     * @return the scanner
+     */
+    @Override
+    public RangeStreamScanner build() {
+        try {
+            Preconditions.checkArgument(resourceQueueSize > 0, "ResourceQueueSize must be greater than 0");
+            ResourceQueue resourceQueue = new ResourceQueue(resourceQueueSize, client);
+
+            Preconditions.checkNotNull(tableName, "TableName must be set");
+            Preconditions.checkNotNull(authorizations, "Authorizations must be set");
+            Preconditions.checkNotNull(query, "Query must be set");
+            Preconditions.checkArgument(resultQueueSize > 0, "ResultQueueSize must be greater than 0");
+            ScannerSession scannerSession = new ScannerSession(tableName, authorizations, resourceQueue, resultQueueSize, query);
+            if (statsEnabled) {
+                scannerSession.applyStats(new ScanSessionStats());
+            }
+
+            RangeStreamScanner session = RangeStreamScanner.class.getConstructor(ScannerSession.class).newInstance(scannerSession);
+
+            if (consistencyLevel != null) {
+                session.getOptions().setConsistencyLevel(consistencyLevel);
+            }
+
+            if (!executionHints.isEmpty()) {
+                session.getOptions().setExecutionHints(executionHints);
+            }
+
+            // the RangeStreamScanner can use a builder instead of the scanner factory
+            Preconditions.checkNotNull(config, "GenericQueryConfiguration must be set");
+            ScannerFactory scannerFactory = new ScannerFactory(config);
+            session.setScannerFactory(scannerFactory);
+
+            return session;
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            throw new RuntimeException("Could not create BatchScannerSession", e);
+        }
+    }
+
+    /**
+     * Allow child-specific methods to be picked up by the builder
+     *
+     * @return this builder
+     */
+    @Override
+    protected RangeStreamScannerBuilder self() {
+        return this;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ScanSessionManager.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ScanSessionManager.java
@@ -1,0 +1,64 @@
+package datawave.query.tables;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import datawave.query.scan.ScanManager;
+
+/**
+ * An extension of {@link ScanManager} that also tracks {@link ScannerSession} instances in addition to {@link org.apache.accumulo.core.client.Scanner} and
+ * {@link org.apache.accumulo.core.client.BatchScanner}
+ */
+public class ScanSessionManager extends ScanManager {
+
+    private static final Logger log = LoggerFactory.getLogger(ScanSessionManager.class);
+
+    protected final Set<ScannerSession> sessionInstances = Collections.synchronizedSet(new HashSet<>());
+
+    public ScanSessionManager() {
+        // empty constructor
+    }
+
+    /**
+     * Adds a {@link ScannerSession}
+     *
+     * @param scanner
+     *            a ScannerSession instance
+     */
+    public void addScanner(ScannerSession scanner) {
+        log.trace("Adding scanner {}", scanner);
+        this.sessionInstances.add(scanner);
+    }
+
+    /**
+     * Closes a {@link ScannerSession} if it is tracked
+     *
+     * @param scanner
+     *            a ScannerSession
+     */
+    public void close(ScannerSession scanner) {
+        if (sessionInstances.remove(scanner)) {
+            scanner.close();
+            log.debug("Closed scanner: {}", scanner);
+        } else {
+            log.warn("ScannerManager was asked to close untracked scanner session: {}", scanner);
+        }
+    }
+
+    /**
+     * Closes all scanners tracked by the {@link ScanSessionManager}
+     */
+    public void close() {
+        log.trace("ScannerManager asked to close all tracked scanners");
+        super.close();
+
+        for (ScannerSession scanner : new HashSet<>(sessionInstances)) {
+            close(scanner);
+        }
+    }
+
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ScannerSessionBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ScannerSessionBuilder.java
@@ -1,0 +1,83 @@
+package datawave.query.tables;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.query.tables.stats.ScanSessionStats;
+
+/**
+ * Builder for a {@link ScannerSession}
+ */
+public class ScannerSessionBuilder extends SessionBuilder<ScannerSessionBuilder> {
+
+    private static final Logger log = LoggerFactory.getLogger(ScannerSessionBuilder.class);
+
+    /**
+     * Static access enforces AccumuloClient requirement
+     *
+     * @param client
+     *            the AccumuloClient
+     * @return a new instance of a scanner session builder
+     */
+    public static ScannerSessionBuilder create(AccumuloClient client) {
+        return new ScannerSessionBuilder(client);
+    }
+
+    /**
+     * Private constructor to enforce static access
+     *
+     * @param client
+     *            the AccumuloClient
+     */
+    private ScannerSessionBuilder(AccumuloClient client) {
+        super(client);
+    }
+
+    /**
+     * Allow child-specific methods to be picked up by the builder
+     *
+     * @return this builder
+     */
+    @Override
+    protected ScannerSessionBuilder self() {
+        return this;
+    }
+
+    /**
+     * Build the {@link ScannerSession}
+     *
+     * @return the scanner
+     */
+    @Override
+    public ScannerSession build() {
+        Preconditions.checkNotNull(tableName, "TableName must be set");
+        Preconditions.checkNotNull(authorizations, "Authorizations must be set");
+        Preconditions.checkArgument(resourceQueueSize > 0, "ResourceQueueSize must be greater than 0");
+        ResourceQueue resourceQueue = new ResourceQueue(resourceQueueSize, client);
+
+        if (log.isTraceEnabled()) {
+            log.trace("Creating ScannerSession for {}", tableName);
+        }
+
+        Preconditions.checkArgument(resultQueueSize > 0, "ResultQueueSize must be greater than 0");
+        Preconditions.checkNotNull(query, "Query must be set");
+        ScannerSession session = new ScannerSession(tableName, authorizations, resourceQueue, resultQueueSize, query);
+
+        if (statsEnabled) {
+            session.applyStats(new ScanSessionStats());
+        }
+
+        if (consistencyLevel != null) {
+            session.getOptions().setConsistencyLevel(consistencyLevel);
+        }
+
+        if (!executionHints.isEmpty()) {
+            session.getOptions().setExecutionHints(executionHints);
+        }
+
+        return session;
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/tables/SessionBuilder.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/SessionBuilder.java
@@ -1,0 +1,278 @@
+package datawave.query.tables;
+
+import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.security.Authorizations;
+
+import com.google.common.base.Preconditions;
+
+import datawave.microservice.query.Query;
+
+/**
+ * Base builder for {@link ScannerSession} and associated classes
+ */
+public abstract class SessionBuilder<B> {
+
+    protected final AccumuloClient client;
+    protected String tableName;
+    protected Set<Authorizations> authorizations;
+
+    protected boolean statsEnabled = false;
+
+    private static final int DEFAULT_RESOURCE_QUEUE_SIZE = 100;
+    private static final int DEFAULT_RESULT_QUEUE_SIZE = 1_000;
+
+    protected int resourceQueueSize = DEFAULT_RESOURCE_QUEUE_SIZE;
+    protected int resultQueueSize = DEFAULT_RESULT_QUEUE_SIZE;
+
+    protected Query query;
+
+    protected ConsistencyLevel consistencyLevel;
+
+    private static final String SCAN_TYPE_KEY = "scan_type";
+    private static final String PRIORITY_KEY = "priority";
+
+    protected final Map<String,String> executionHints = new HashMap<>();
+
+    /**
+     * Constructor that enforces a non-null AccumuloClient argument
+     *
+     * @param client
+     *            the AccumuloClient
+     */
+    protected SessionBuilder(AccumuloClient client) {
+        Preconditions.checkNotNull(client, "AccumuloClient must be set");
+        this.client = client;
+    }
+
+    /**
+     * Create the ScannerSession implementation
+     *
+     * @return the scanner session
+     */
+    abstract ScannerSession build();
+
+    /**
+     * Forcing children to implement this method allows child-specific methods to be picked up
+     *
+     * @return this builder
+     */
+    protected abstract B self();
+
+    /**
+     * Set the table name for the scanner session
+     *
+     * @param tableName
+     *            the table name
+     * @return this builder
+     */
+    public B setTableName(String tableName) {
+        this.tableName = tableName;
+        return self();
+    }
+
+    /**
+     * Set the authorization set for the scanner session
+     *
+     * @param authorizations
+     *            the set of authorizations
+     * @return this builder
+     */
+    public B setAuthorizations(Set<Authorizations> authorizations) {
+        this.authorizations = authorizations;
+        return self();
+    }
+
+    /**
+     * Set whether {@link datawave.query.tables.stats.ScanSessionStats} will be gathered
+     *
+     * @param statsEnabled
+     *            flag for gathering stats
+     * @return this builder
+     */
+    public B setStatsEnabled(boolean statsEnabled) {
+        this.statsEnabled = statsEnabled;
+        return self();
+    }
+
+    /**
+     * Set the internal queue size for the {@link ResourceQueue}
+     *
+     * @param resourceQueueSize
+     *            the size of the resource queue
+     * @return this builder
+     */
+    public B setResourceQueueSize(int resourceQueueSize) {
+        this.resourceQueueSize = resourceQueueSize;
+        return self();
+    }
+
+    /**
+     * Set the size of the result queue.
+     * <p>
+     * <b>NOTE:</b> some implementations are not actually threaded, so it is possible to enter a deadlock state if the number of elements exceeds the size of
+     * the result queue. See {@link RangeStreamScanner}
+     *
+     * @param resultQueueSize
+     *            the size of the result queue
+     * @return this builder
+     */
+    public B setResultQueueSize(int resultQueueSize) {
+        this.resultQueueSize = resultQueueSize;
+        return self();
+    }
+
+    /**
+     * Set the Query
+     *
+     * @param query
+     *            the query
+     * @return this builder
+     */
+    public B setQuery(Query query) {
+        this.query = query;
+        return self();
+    }
+
+    /**
+     * Set the {@link ConsistencyLevel} via an instance.
+     * <p>
+     * See {@link ConsistencyLevel#values()} for permitted values.
+     * <ul>
+     * <li>IMMEDIATE routes the scan to a tablet server</li>
+     * <li>EVENTUAL routes the scan to a scan server</li>
+     * </ul>
+     *
+     * @param consistencyLevel
+     *            the consistency level of the scanner
+     * @return this builder
+     */
+    public B setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
+        return self();
+    }
+
+    /**
+     * Set the {@link ConsistencyLevel} via a string.
+     * <p>
+     * See {@link ConsistencyLevel#values()} for permitted values.
+     * <ul>
+     * <li>IMMEDIATE routes the scan to a tablet server</li>
+     * <li>EVENTUAL routes the scan to a scan server</li>
+     * </ul>
+     *
+     * @param consistencyLevel
+     *            the consistency level of the scanner
+     * @return this builder
+     */
+    public B setConsistencyLevel(String consistencyLevel) {
+        this.consistencyLevel = ConsistencyLevel.valueOf(consistencyLevel);
+        return self();
+    }
+
+    /**
+     * Set the scan type on the execution hints. This is used to route the scan to specific executor pools.
+     * <p>
+     * See {@link ScannerBase#setExecutionHints(Map)} for details.
+     *
+     * @param scanType
+     *            the scan type
+     * @return this builder
+     */
+    public B setScanType(String scanType) {
+        executionHints.put(SCAN_TYPE_KEY, scanType);
+        return self();
+    }
+
+    /**
+     * Set a scan priority to the execution hints. This allows a scan to be executed given a relative priority.
+     * <p>
+     * See {@link ScannerBase#setExecutionHints(Map)} for details.
+     *
+     * @param scanPriority
+     *            an integer priority
+     * @return this builder
+     */
+    public B setScanPriority(int scanPriority) {
+        executionHints.put(PRIORITY_KEY, Integer.toString(scanPriority));
+        return self();
+    }
+
+    /**
+     * Get the table name
+     *
+     * @return the table name
+     */
+    public String getTableName() {
+        return tableName;
+    }
+
+    /**
+     * Get the set of authorizations
+     *
+     * @return the authorizations
+     */
+    public Set<Authorizations> getAuthorizations() {
+        return authorizations;
+    }
+
+    /**
+     * Get the stats enabled flag
+     *
+     * @return the stats enabled flag
+     */
+    public boolean isStatsEnabled() {
+        return statsEnabled;
+    }
+
+    /**
+     * Get the size of the resource queue
+     *
+     * @return the size of the resource queue
+     */
+    public int getResourceQueueSize() {
+        return resourceQueueSize;
+    }
+
+    /**
+     * Get the size of the result queue
+     *
+     * @return the size of the result queue
+     */
+    public int getResultQueueSize() {
+        return resultQueueSize;
+    }
+
+    /**
+     * Get the Query
+     *
+     * @return the query
+     */
+    public Query getQuery() {
+        return query;
+    }
+
+    /**
+     * Get the consistency level
+     *
+     * @return the consistency level
+     */
+    public ConsistencyLevel getConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    /**
+     * Get the map of execution hints
+     *
+     * @return the execution hints
+     */
+    public Map<String,String> getExecutionHints() {
+        return executionHints;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/AnyFieldScannerBuilderTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/AnyFieldScannerBuilderTest.java
@@ -1,0 +1,285 @@
+package datawave.query.tables;
+
+import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
+public class AnyFieldScannerBuilderTest implements BaseScannerSessionTest<AnyFieldScannerBuilder> {
+
+    private static final InMemoryInstance instance = new InMemoryInstance(AnyFieldScannerBuilderTest.class.getName());
+
+    private static AccumuloClient client;
+    private static final String tableName = "shard";
+    private final Set<Authorizations> authorizations = Set.of(new Authorizations("VIZ-A", "VIZ-B", "VIZ-C"));
+
+    private static Range range;
+
+    private static final Long ts = System.currentTimeMillis();
+    private static final Key key = new Key("row", "cf", "cq", "VIZ-A", ts);
+    private static final Value EMPTY_VALUE = new Value();
+
+    private final Query query = new QueryImpl();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        client = new InMemoryAccumuloClient("user", instance);
+
+        TableOperations tops = client.tableOperations();
+
+        // create or recreate the table
+        if (tops.exists(tableName)) {
+            tops.delete(tableName);
+        }
+        tops.create(tableName);
+
+        try (BatchWriter bw = client.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), EMPTY_VALUE);
+            bw.addMutation(m);
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        this.query.setUncaughtExceptionHandler(new QueryUncaughtExceptionHandler());
+
+        Key start = new Key(key.getRow());
+        Key stop = start.followingKey(PartialKey.ROW);
+        range = new Range(start, true, stop, false);
+    }
+
+    @Test
+    @Override
+    public void testClientNotSet() {
+        Exception e = assertThrows(NullPointerException.class, () -> AnyFieldScannerBuilder.create(null));
+        String expected = "AccumuloClient must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNameNotSet() {
+        AnyFieldScannerBuilder builder = AnyFieldScannerBuilder.create(client);
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "TableName must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testAuthorizationsNotSet() {
+        //  @formatter:off
+        AnyFieldScannerBuilder builder = AnyFieldScannerBuilder.create(client)
+                .setTableName(tableName);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Authorizations must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResourceQueueSize() {
+        AnyFieldScannerBuilder builder = create().setResourceQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResourceQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResultQueueSize() {
+        AnyFieldScannerBuilder builder = create().setResultQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResultQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testQueryNotSet() {
+        //  @formatter:off
+        AnyFieldScannerBuilder builder = AnyFieldScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Query must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNotFound() {
+        //  @formatter:off
+        AnyFieldScannerBuilder builder = AnyFieldScannerBuilder.create(client)
+                .setTableName("NotFound")
+                .setAuthorizations(authorizations)
+                .setQuery(new QueryImpl());
+        //  @formatter:on
+        Exception e = assertThrows(RuntimeException.class, () -> buildAndScan(builder));
+        String expected = "org.apache.accumulo.core.client.TableNotFoundException: Table NotFound (Id=NotFound) does not exist (no such table)";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testOptionalParameterDefaultValues() {
+        //  @formatter:off
+        AnyFieldScannerBuilder builder = AnyFieldScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+        buildAndScan(builder);
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+
+        assertEquals(100, builder.getResourceQueueSize());
+        assertEquals(1000, builder.getResultQueueSize());
+
+        assertNull(builder.getConsistencyLevel());
+        assertTrue(builder.getExecutionHints().isEmpty());
+    }
+
+    @Test
+    public void testConsistencyLevelImmediate() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.IMMEDIATE);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventual() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelImmediateViaString() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setConsistencyLevel("IMMEDIATE");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventualViaString() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setConsistencyLevel("EVENTUAL");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testIncorrectConsistencyLevel() {
+        AnyFieldScannerBuilder builder = create();
+        Exception e = assertThrows(IllegalArgumentException.class, () -> builder.setConsistencyLevel("LAZY"));
+        String expected = "No enum constant org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel.LAZY";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testScanType() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+    }
+
+    @Test
+    @Override
+    public void testScanPriority() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testScanTypeAndScanPriority() {
+        AnyFieldScannerBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testStatsEnabled() {
+        AnyFieldScannerBuilder builder = create().setStatsEnabled(true);
+        buildAndScan(builder);
+        assertTrue(builder.isStatsEnabled());
+    }
+
+    /**
+     * Create a AnyFieldScannerBuilder with the minimum required options
+     *
+     * @return the builder
+     */
+    @Override
+    public AnyFieldScannerBuilder create() {
+        //  @formatter:off
+        return AnyFieldScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+    }
+
+    /**
+     * Run the scanner and assert several variables
+     *
+     * @param builder
+     *            the builder
+     */
+    private void buildAndScan(AnyFieldScannerBuilder builder) {
+        AnyFieldScanner scanner = builder.build();
+        scanner.setRanges(List.of(range));
+
+        assertTrue(scanner.hasNext());
+        assertNotNull(scanner.next());
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/BaseScannerSessionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/BaseScannerSessionTest.java
@@ -1,0 +1,103 @@
+package datawave.query.tables;
+
+import org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
+
+import datawave.microservice.query.Query;
+
+/**
+ * Interface for {@link ScannerSessionBuilder} tests, ensures that every implementation gets the same set of core tests
+ */
+public interface BaseScannerSessionTest<T> {
+
+    /**
+     * Verify an exception with appropriate message is thrown when a null client is passed to the builder
+     */
+    void testClientNotSet();
+
+    /**
+     * Verify an exception with appropriate message is thrown when a null table name is passed to the builder
+     */
+    void testTableNameNotSet();
+
+    /**
+     * Verify an exception with appropriate message is thrown when a null authorization set is passed to the builder
+     */
+    void testAuthorizationsNotSet();
+
+    /**
+     * Verify an exception with appropriate message is thrown when a zero size resource queue is specified
+     */
+    void testInvalidResourceQueueSize();
+
+    /**
+     * Verify an exception with appropriate message is thrown when a zero size result queue is specified
+     */
+    void testInvalidResultQueueSize();
+
+    /**
+     * Verify an exception with appropriate message is thrown when a null {@link Query} is passed to the builder
+     */
+    void testQueryNotSet();
+
+    /**
+     * Verify an exception with appropriate message is thrown when an invalid table name is passed to the builder
+     */
+    void testTableNotFound();
+
+    /**
+     * Verify default values for optional parameters
+     */
+    void testOptionalParameterDefaultValues();
+
+    /**
+     * Verify that the builder sets {@link ConsistencyLevel#IMMEDIATE}
+     */
+    void testConsistencyLevelImmediate();
+
+    /**
+     * Verify that the builder sets {@link ConsistencyLevel#EVENTUAL}
+     */
+    void testConsistencyLevelEventual();
+
+    /**
+     * Verify that the builder sets {@link ConsistencyLevel#IMMEDIATE} via the String value
+     */
+    void testConsistencyLevelImmediateViaString();
+
+    /**
+     * Verify that the builder sets {@link ConsistencyLevel#IMMEDIATE} via the String value
+     */
+    void testConsistencyLevelEventualViaString();
+
+    /**
+     * Verify that the builder throws an exception when an invalid {@link ConsistencyLevel} is provided
+     */
+    void testIncorrectConsistencyLevel();
+
+    /**
+     * Verify that the builder sets the <code>scan_type</code> execution hint
+     */
+    void testScanType();
+
+    /**
+     * Verify that the builder sets the <code>priority</code> execution hint
+     */
+    void testScanPriority();
+
+    /**
+     * Verify that the builder sets the <code>scan_type</code> and <code>priority</code> execution hint
+     */
+    void testScanTypeAndScanPriority();
+
+    /**
+     * Verify that the builder can enable stats
+     */
+    void testStatsEnabled();
+
+    /**
+     * Create a builder with the minimum required options
+     *
+     * @return a builder
+     */
+    T create();
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/BatchScannerSessionBuilderTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/BatchScannerSessionBuilderTest.java
@@ -1,0 +1,298 @@
+package datawave.query.tables;
+
+import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.VersioningIterator;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.query.configuration.QueryData;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.tables.async.ScannerChunk;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
+public class BatchScannerSessionBuilderTest implements BaseScannerSessionTest<BatchScannerSessionBuilder> {
+
+    private static final InMemoryInstance instance = new InMemoryInstance(BatchScannerSessionBuilderTest.class.getName());
+
+    private static AccumuloClient client;
+    private static final String tableName = "shard";
+    private final Set<Authorizations> authorizations = Set.of(new Authorizations("VIZ-A", "VIZ-B", "VIZ-C"));
+
+    private static final Long ts = System.currentTimeMillis();
+    private static final Key key = new Key("row", "cf", "cq", "VIZ-A", ts);
+    private static final Value EMPTY_VALUE = new Value();
+
+    private final Query query = new QueryImpl();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        client = new InMemoryAccumuloClient("user", instance);
+
+        TableOperations tops = client.tableOperations();
+
+        // create or recreate the table
+        if (tops.exists(tableName)) {
+            tops.delete(tableName);
+        }
+        tops.create(tableName);
+
+        try (BatchWriter bw = client.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), EMPTY_VALUE);
+            bw.addMutation(m);
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        this.query.setUncaughtExceptionHandler(new QueryUncaughtExceptionHandler());
+    }
+
+    @Test
+    @Override
+    public void testClientNotSet() {
+        Exception e = assertThrows(NullPointerException.class, () -> BatchScannerSessionBuilder.create(null));
+        String expected = "AccumuloClient must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNameNotSet() {
+        BatchScannerSessionBuilder builder = BatchScannerSessionBuilder.create(client);
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "TableName must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testAuthorizationsNotSet() {
+        //  @formatter:off
+        BatchScannerSessionBuilder builder = BatchScannerSessionBuilder.create(client)
+                .setTableName(tableName);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Authorizations must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResourceQueueSize() {
+        BatchScannerSessionBuilder builder = create().setResourceQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResourceQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResultQueueSize() {
+        BatchScannerSessionBuilder builder = create().setResultQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResultQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testQueryNotSet() {
+        //  @formatter:off
+        BatchScannerSessionBuilder builder = BatchScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Query must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNotFound() {
+        //  @formatter:off
+        BatchScannerSessionBuilder builder = BatchScannerSessionBuilder.create(client)
+                .setTableName("NotFound")
+                .setAuthorizations(authorizations)
+                .setQuery(new QueryImpl());
+        //  @formatter:on
+        Exception e = assertThrows(RuntimeException.class, () -> buildAndScan(builder));
+        String expected = "org.apache.accumulo.core.client.TableNotFoundException: Table NotFound (Id=NotFound) does not exist (no such table)";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testOptionalParameterDefaultValues() {
+        //  @formatter:off
+        BatchScannerSessionBuilder builder = BatchScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+        buildAndScan(builder);
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+
+        assertEquals(100, builder.getResourceQueueSize());
+        assertEquals(1000, builder.getResultQueueSize());
+
+        assertNull(builder.getConsistencyLevel());
+        assertTrue(builder.getExecutionHints().isEmpty());
+
+        assertEquals(5, builder.getNumQueryThreads());
+    }
+
+    @Test
+    public void testConsistencyLevelImmediate() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.IMMEDIATE);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventual() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelImmediateViaString() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel("IMMEDIATE");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventualViaString() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel("EVENTUAL");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testIncorrectConsistencyLevel() {
+        BatchScannerSessionBuilder builder = create();
+        Exception e = assertThrows(IllegalArgumentException.class, () -> builder.setConsistencyLevel("LAZY"));
+        String expected = "No enum constant org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel.LAZY";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testScanType() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+    }
+
+    @Test
+    @Override
+    public void testScanPriority() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testScanTypeAndScanPriority() {
+        BatchScannerSessionBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testStatsEnabled() {
+        BatchScannerSessionBuilder builder = create().setStatsEnabled(true);
+        buildAndScan(builder);
+        assertTrue(builder.isStatsEnabled());
+    }
+
+    /**
+     * Create a BatchScannerSessionBuilder with the minimum required options
+     *
+     * @return the builder
+     */
+    @Override
+    public BatchScannerSessionBuilder create() {
+        //  @formatter:off
+        return BatchScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+    }
+
+    /**
+     * Run the scanner and assert several variables
+     *
+     * @param builder
+     *            the builder
+     */
+    private void buildAndScan(BatchScannerSessionBuilder builder) {
+        BatchScannerSession scanner = builder.build();
+        scanner.setChunkIter(List.of(createScannerChunk()).iterator());
+
+        assertTrue(scanner.hasNext());
+        assertNotNull(scanner.next());
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+    }
+
+    private List<ScannerChunk> createScannerChunk() {
+        Key start = new Key(key.getRow());
+        Key stop = start.followingKey(PartialKey.ROW);
+        Range range = new Range(start, true, stop, false);
+
+        IteratorSetting settings = new IteratorSetting(1, "VersioningIterator", VersioningIterator.class);
+        QueryData queryData = new QueryData("tableName", "FOO == 'bar'", List.of(range), Collections.emptySet(), List.of(settings));
+
+        ScannerChunk chunk = new ScannerChunk(new SessionOptions(), List.of(range), queryData);
+        return List.of(chunk);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerBuilderTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerBuilderTest.java
@@ -1,0 +1,298 @@
+package datawave.query.tables;
+
+import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.query.configuration.GenericQueryConfiguration;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
+public class RangeStreamScannerBuilderTest implements BaseScannerSessionTest<RangeStreamScannerBuilder> {
+    private static final InMemoryInstance instance = new InMemoryInstance(RangeStreamScannerBuilderTest.class.getName());
+
+    private static AccumuloClient client;
+    private static final String tableName = "shard";
+    private final Set<Authorizations> authorizations = Set.of(new Authorizations("VIZ-A", "VIZ-B", "VIZ-C"));
+
+    private static Range range;
+
+    private static final Long ts = System.currentTimeMillis();
+    private static final Key key = new Key("row", "cf", "cq", "VIZ-A", ts);
+    private static final Value EMPTY_VALUE = new Value();
+
+    private final Query query = new QueryImpl();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        client = new InMemoryAccumuloClient("user", instance);
+
+        TableOperations tops = client.tableOperations();
+
+        // create or recreate the table
+        if (tops.exists(tableName)) {
+            tops.delete(tableName);
+        }
+        tops.create(tableName);
+
+        try (BatchWriter bw = client.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), EMPTY_VALUE);
+            bw.addMutation(m);
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        this.query.setUncaughtExceptionHandler(new QueryUncaughtExceptionHandler());
+
+        Key start = new Key(key.getRow());
+        Key stop = start.followingKey(PartialKey.ROW);
+        range = new Range(start, true, stop, false);
+    }
+
+    @Test
+    @Override
+    public void testClientNotSet() {
+        Exception e = assertThrows(NullPointerException.class, () -> RangeStreamScannerBuilder.create(null));
+        String expected = "AccumuloClient must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNameNotSet() {
+        RangeStreamScannerBuilder builder = RangeStreamScannerBuilder.create(client);
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "TableName must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testAuthorizationsNotSet() {
+        //  @formatter:off
+        RangeStreamScannerBuilder builder = RangeStreamScannerBuilder.create(client)
+                .setTableName(tableName);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Authorizations must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResourceQueueSize() {
+        RangeStreamScannerBuilder builder = create().setResourceQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResourceQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResultQueueSize() {
+        RangeStreamScannerBuilder builder = create().setResultQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResultQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testQueryNotSet() {
+        //  @formatter:off
+        RangeStreamScannerBuilder builder = RangeStreamScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Query must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNotFound() {
+        //  @formatter:off
+        RangeStreamScannerBuilder builder = RangeStreamScannerBuilder.create(client)
+                .setTableName("NotFound")
+                .setAuthorizations(authorizations)
+                .setQuery(query)
+                .setConfig(getConfig());
+        //  @formatter:on
+        Exception e = assertThrows(RuntimeException.class, () -> buildAndScan(builder));
+        String expected = "java.util.concurrent.ExecutionException: org.apache.accumulo.core.client.TableNotFoundException: Table NotFound (Id=NotFound) does not exist (no such table)";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testOptionalParameterDefaultValues() {
+        //  @formatter:off
+        RangeStreamScannerBuilder builder = RangeStreamScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query)
+                .setConfig(getConfig());
+        //  @formatter:on
+        buildAndScan(builder);
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+
+        assertEquals(100, builder.getResourceQueueSize());
+        assertEquals(1000, builder.getResultQueueSize());
+
+        assertNull(builder.getConsistencyLevel());
+        assertTrue(builder.getExecutionHints().isEmpty());
+    }
+
+    @Test
+    public void testConsistencyLevelImmediate() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.IMMEDIATE);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventual() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelImmediateViaString() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setConsistencyLevel("IMMEDIATE");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventualViaString() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setConsistencyLevel("EVENTUAL");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testIncorrectConsistencyLevel() {
+        RangeStreamScannerBuilder builder = create();
+        Exception e = assertThrows(IllegalArgumentException.class, () -> builder.setConsistencyLevel("LAZY"));
+        String expected = "No enum constant org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel.LAZY";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testScanType() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+    }
+
+    @Test
+    @Override
+    public void testScanPriority() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testScanTypeAndScanPriority() {
+        RangeStreamScannerBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testStatsEnabled() {
+        RangeStreamScannerBuilder builder = create().setStatsEnabled(true);
+        buildAndScan(builder);
+        assertTrue(builder.isStatsEnabled());
+    }
+
+    /**
+     * Create a RangeStreamScannerBuilder with the minimum required options
+     *
+     * @return the builder
+     */
+    @Override
+    public RangeStreamScannerBuilder create() {
+        //  @formatter:off
+        return RangeStreamScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query)
+                .setConfig(getConfig());
+        //  @formatter:on
+    }
+
+    private GenericQueryConfiguration getConfig() {
+        GenericQueryConfiguration config = new GenericQueryConfiguration();
+        config.setClient(client);
+        config.setTableName(tableName);
+        config.setAuthorizations(authorizations);
+        config.setQuery(query);
+        // not adding table based consistency levels or execution hints
+        return config;
+    }
+
+    /**
+     * Run the scanner and assert several variables
+     *
+     * @param builder
+     *            the builder
+     */
+    private void buildAndScan(RangeStreamScannerBuilder builder) {
+        ScannerSession scanner = builder.build();
+        scanner.setRanges(List.of(range));
+
+        assertTrue(scanner.hasNext());
+        assertNotNull(scanner.next());
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ScanSessionManagerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ScanSessionManagerTest.java
@@ -1,0 +1,357 @@
+package datawave.query.tables;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.ScannerBase;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.VersioningIterator;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.query.configuration.GenericQueryConfiguration;
+import datawave.core.query.configuration.QueryData;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.scan.BatchScannerBuilder;
+import datawave.query.scan.ScannerBuilder;
+import datawave.query.tables.async.ScannerChunk;
+import datawave.util.TableName;
+
+public class ScanSessionManagerTest {
+
+    private static final InMemoryInstance instance = new InMemoryInstance(ScanSessionManagerTest.class.getSimpleName());
+    private static AccumuloClient client;
+
+    private final String tableName = TableName.SHARD;
+    private final Set<Authorizations> auths = Collections.singleton(new Authorizations("a", "b", "c"));
+    private final Query query = new QueryImpl();
+
+    private ScanSessionManagerForTests manager;
+
+    @BeforeAll
+    public static void setup() throws AccumuloSecurityException, AccumuloException, TableExistsException, TableNotFoundException {
+        client = new InMemoryAccumuloClient("user", instance);
+        client.tableOperations().create(TableName.SHARD);
+
+        try (BatchWriter writer = client.createBatchWriter(TableName.SHARD)) {
+            Mutation m = new Mutation("row");
+            m.put("cf", "cq", new Value());
+            m.put("cf2", "cq2", new Value());
+            m.put("cf3", "cq3", new Value());
+            writer.addMutation(m);
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        manager = new ScanSessionManagerForTests();
+    }
+
+    @Test
+    public void testManageScanner() {
+        Scanner scanner = createScanner();
+        manager.addScanner(scanner);
+        advanceScanner(scanner);
+        manager.close(scanner);
+        assertManagerState();
+    }
+
+    @Test
+    public void testManageBatchScanner() {
+        BatchScanner scanner = createBatchScanner();
+        manager.addScanner(scanner);
+        advanceScanner(scanner);
+        manager.close(scanner);
+        assertManagerState();
+    }
+
+    @Test
+    public void testManageScannerSession() {
+        ScannerSession scanner = createScannerSession();
+        manager.addScanner(scanner);
+        advanceScanner(scanner);
+        manager.close(scanner);
+        assertFalse(scanner.isRunning());
+        assertManagerState();
+    }
+
+    @Test
+    public void testManageAnyFieldScanner() {
+        ScannerSession scanner = createAnyFieldScanner();
+        manager.addScanner(scanner);
+        advanceScanner(scanner);
+        manager.close(scanner);
+        assertFalse(scanner.isRunning());
+        assertManagerState();
+    }
+
+    @Test
+    public void testManageBatchScannerSession() {
+        BatchScannerSession scanner = createBatchScannerSession();
+        manager.addScanner(scanner);
+        advanceScanner(scanner);
+        manager.close(scanner);
+        assertFalse(scanner.isRunning());
+        assertManagerState();
+    }
+
+    @Test
+    public void testManageRangeStreamScanner() {
+        ScannerSession scanner = createRangeStreamScanner();
+        manager.addScanner(scanner);
+        advanceScanner(scanner);
+
+        manager.close(scanner);
+        assertFalse(scanner.isRunning());
+        assertManagerState();
+    }
+
+    @Test
+    public void testManageMultipleScanners() {
+        Scanner scanner = createScanner();
+        BatchScanner batchScanner = createBatchScanner();
+        ScannerSession scannerSession = createScannerSession();
+
+        manager.addScanner(scanner);
+        manager.addScanner(batchScanner);
+        manager.addScanner(scannerSession);
+
+        advanceScanner(scanner);
+        advanceScanner(batchScanner);
+        advanceScanner(scannerSession);
+
+        manager.close(scanner);
+        manager.close(batchScanner);
+        manager.close(scannerSession);
+
+        assertManagerState();
+    }
+
+    @Test
+    public void testCloseMultipleScannersOneAtATime() {
+        Scanner scanner = createScanner();
+        BatchScanner batchScanner = createBatchScanner();
+        ScannerSession scannerSession = createScannerSession();
+        ScannerSession anyFieldScanner = createAnyFieldScanner();
+        ScannerSession batchScannerSession = createBatchScannerSession();
+        ScannerSession rangeStreamScanner = createRangeStreamScanner();
+
+        manager.addScanner(scanner);
+        manager.addScanner(batchScanner);
+        manager.addScanner(scannerSession);
+        manager.addScanner(anyFieldScanner);
+        manager.addScanner(batchScannerSession);
+        manager.addScanner(rangeStreamScanner);
+
+        advanceScanner(scanner);
+        advanceScanner(batchScanner);
+        advanceScanner(scannerSession);
+        advanceScanner(anyFieldScanner);
+        advanceScanner(batchScannerSession);
+        advanceScanner(rangeStreamScanner);
+
+        manager.close(scanner);
+        manager.close(batchScanner);
+        manager.close(scannerSession);
+        manager.close(anyFieldScanner);
+        manager.close(batchScannerSession);
+        manager.close(rangeStreamScanner);
+
+        assertManagerState();
+    }
+
+    @Test
+    public void testCloseMultipleScannersAllAtOnce() {
+        Scanner scanner = createScanner();
+        BatchScanner batchScanner = createBatchScanner();
+        ScannerSession scannerSession = createScannerSession();
+        ScannerSession anyFieldScanner = createAnyFieldScanner();
+        ScannerSession batchScannerSession = createBatchScannerSession();
+        ScannerSession rangeStreamScanner = createRangeStreamScanner();
+
+        manager.addScanner(scanner);
+        manager.addScanner(batchScanner);
+        manager.addScanner(scannerSession);
+        manager.addScanner(anyFieldScanner);
+        manager.addScanner(batchScannerSession);
+        manager.addScanner(rangeStreamScanner);
+
+        advanceScanner(scanner);
+        advanceScanner(batchScanner);
+        advanceScanner(scannerSession);
+        advanceScanner(anyFieldScanner);
+        advanceScanner(batchScannerSession);
+        advanceScanner(rangeStreamScanner);
+
+        // close all scanners at once
+        manager.close();
+        assertManagerState();
+    }
+
+    private void advanceScanner(Scanner scanner) {
+        scanner.setRange(new Range());
+        var iter = scanner.iterator();
+        assertTrue(iter.hasNext());
+        assertNotNull(iter.next());
+    }
+
+    private void advanceScanner(BatchScanner scanner) {
+        scanner.setRanges(Collections.singleton(new Range()));
+        var iter = scanner.iterator();
+        assertTrue(iter.hasNext());
+        assertNotNull(iter.next());
+    }
+
+    private void advanceScanner(ScannerSession scanner) {
+        scanner.setRanges(Collections.singleton(new Range()));
+        assertTrue(scanner.hasNext());
+        scanner.next();
+    }
+
+    private void assertManagerState() {
+        assertNotNull(manager);
+        assertEquals(manager.getAdded(), manager.getClosed());
+    }
+
+    private Scanner createScanner() {
+        //  @formatter:off
+        return ScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(auths.iterator().next())
+                .build();
+        //  @formatter:on
+    }
+
+    private BatchScanner createBatchScanner() {
+        //  @formatter:off
+        return BatchScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(auths.iterator().next())
+                .build();
+        //  @formatter:on
+    }
+
+    private ScannerSession createScannerSession() {
+        //  @formatter:off
+        return ScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(auths)
+                .setQuery(query)
+                .build();
+        //  @formatter:on
+    }
+
+    private ScannerSession createAnyFieldScanner() {
+        //  @formatter:off
+        return AnyFieldScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(auths)
+                .setQuery(query)
+                .build();
+        //  @formatter:on
+    }
+
+    private BatchScannerSession createBatchScannerSession() {
+        //  @formatter:off
+        BatchScannerSession session = BatchScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(auths)
+                .setQuery(query)
+                .build();
+        //  @formatter:on
+        session.setChunkIter(List.of(createScannerChunk()).iterator());
+        return session;
+    }
+
+    private List<ScannerChunk> createScannerChunk() {
+        SessionOptions options = new SessionOptions();
+
+        Range range = new Range();
+
+        IteratorSetting settings = new IteratorSetting(1, "VersioningIterator", VersioningIterator.class);
+        QueryData queryData = new QueryData("tableName", "FOO == 'bar'", List.of(range), Collections.emptySet(), List.of(settings));
+
+        ScannerChunk chunk = new ScannerChunk(options, List.of(range), queryData);
+        return List.of(chunk);
+    }
+
+    private RangeStreamScanner createRangeStreamScanner() {
+        //  @formatter:off
+        return RangeStreamScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(auths)
+                .setQuery(query)
+                .setConfig(getConfig())
+                .build();
+        //  @formatter:on
+    }
+
+    private GenericQueryConfiguration getConfig() {
+        GenericQueryConfiguration config = new GenericQueryConfiguration();
+        config.setClient(client);
+        config.setTableName(tableName);
+        config.setAuthorizations(auths);
+        config.setQuery(new QueryImpl());
+        // not adding table based consistency levels or execution hints
+        return config;
+    }
+
+    private static class ScanSessionManagerForTests extends ScanSessionManager {
+        private int added = 0;
+        private int closed = 0;
+
+        public void addScanner(ScannerBase scanner) {
+            added++;
+            super.addScanner(scanner);
+        }
+
+        public void addScanner(ScannerSession scanner) {
+            added++;
+            super.addScanner(scanner);
+        }
+
+        public void close(ScannerBase scanner) {
+            if (baseInstances.contains(scanner)) {
+                closed++;
+                super.close(scanner);
+            }
+        }
+
+        public void close(ScannerSession scanner) {
+            if (sessionInstances.contains(scanner)) {
+                closed++;
+                super.close(scanner);
+            }
+        }
+
+        public int getAdded() {
+            return added;
+        }
+
+        public int getClosed() {
+            return closed;
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionBuilderTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionBuilderTest.java
@@ -1,0 +1,285 @@
+package datawave.query.tables;
+
+import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
+public class ScannerSessionBuilderTest implements BaseScannerSessionTest<ScannerSessionBuilder> {
+
+    private static final InMemoryInstance instance = new InMemoryInstance(ScannerSessionBuilderTest.class.getName());
+
+    private static AccumuloClient client;
+    private static final String tableName = "shard";
+    private final Set<Authorizations> authorizations = Set.of(new Authorizations("VIZ-A", "VIZ-B", "VIZ-C"));
+
+    private static Range range;
+
+    private static final Long ts = System.currentTimeMillis();
+    private static final Key key = new Key("row", "cf", "cq", "VIZ-A", ts);
+    private static final Value EMPTY_VALUE = new Value();
+
+    private final Query query = new QueryImpl();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        client = new InMemoryAccumuloClient("user", instance);
+
+        TableOperations tops = client.tableOperations();
+
+        // create or recreate the table
+        if (tops.exists(tableName)) {
+            tops.delete(tableName);
+        }
+        tops.create(tableName);
+
+        try (BatchWriter bw = client.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), EMPTY_VALUE);
+            bw.addMutation(m);
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        this.query.setUncaughtExceptionHandler(new QueryUncaughtExceptionHandler());
+
+        Key start = new Key(key.getRow());
+        Key stop = start.followingKey(PartialKey.ROW);
+        range = new Range(start, true, stop, false);
+    }
+
+    @Test
+    @Override
+    public void testClientNotSet() {
+        Exception e = assertThrows(NullPointerException.class, () -> ScannerSessionBuilder.create(null));
+        String expected = "AccumuloClient must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNameNotSet() {
+        ScannerSessionBuilder builder = ScannerSessionBuilder.create(client);
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "TableName must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testAuthorizationsNotSet() {
+        //  @formatter:off
+        ScannerSessionBuilder builder = ScannerSessionBuilder.create(client)
+                .setTableName(tableName);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Authorizations must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResourceQueueSize() {
+        ScannerSessionBuilder builder = create().setResourceQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResourceQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testInvalidResultQueueSize() {
+        ScannerSessionBuilder builder = create().setResultQueueSize(0);
+        Exception e = assertThrows(IllegalArgumentException.class, () -> buildAndScan(builder));
+        String expected = "ResultQueueSize must be greater than 0";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testQueryNotSet() {
+        //  @formatter:off
+        ScannerSessionBuilder builder = ScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations);
+        //  @formatter:on
+        Exception e = assertThrows(NullPointerException.class, () -> buildAndScan(builder));
+        String expected = "Query must be set";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testTableNotFound() {
+        //  @formatter:off
+        ScannerSessionBuilder builder = ScannerSessionBuilder.create(client)
+                .setTableName("NotFound")
+                .setAuthorizations(authorizations)
+                .setQuery(new QueryImpl());
+        //  @formatter:on
+        Exception e = assertThrows(RuntimeException.class, () -> buildAndScan(builder));
+        String expected = "org.apache.accumulo.core.client.TableNotFoundException: Table NotFound (Id=NotFound) does not exist (no such table)";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testOptionalParameterDefaultValues() {
+        //  @formatter:off
+        ScannerSessionBuilder builder = ScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+        buildAndScan(builder);
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+
+        assertEquals(100, builder.getResourceQueueSize());
+        assertEquals(1000, builder.getResultQueueSize());
+
+        assertNull(builder.getConsistencyLevel());
+        assertTrue(builder.getExecutionHints().isEmpty());
+    }
+
+    @Test
+    public void testConsistencyLevelImmediate() {
+        ScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.IMMEDIATE);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventual() {
+        ScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel(ConsistencyLevel.EVENTUAL);
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelImmediateViaString() {
+        ScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel("IMMEDIATE");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.IMMEDIATE, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testConsistencyLevelEventualViaString() {
+        ScannerSessionBuilder builder = create();
+        builder.setConsistencyLevel("EVENTUAL");
+        buildAndScan(builder);
+        assertEquals(ConsistencyLevel.EVENTUAL, builder.getConsistencyLevel());
+    }
+
+    @Test
+    @Override
+    public void testIncorrectConsistencyLevel() {
+        ScannerSessionBuilder builder = create();
+        Exception e = assertThrows(IllegalArgumentException.class, () -> builder.setConsistencyLevel("LAZY"));
+        String expected = "No enum constant org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel.LAZY";
+        assertEquals(expected, e.getMessage());
+    }
+
+    @Test
+    @Override
+    public void testScanType() {
+        ScannerSessionBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+    }
+
+    @Test
+    @Override
+    public void testScanPriority() {
+        ScannerSessionBuilder builder = create();
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testScanTypeAndScanPriority() {
+        ScannerSessionBuilder builder = create();
+        builder.setScanType("executor-pool-a");
+        builder.setScanPriority(10);
+        buildAndScan(builder);
+        assertEquals("executor-pool-a", builder.getExecutionHints().get("scan_type"));
+        assertEquals("10", builder.getExecutionHints().get("priority"));
+    }
+
+    @Test
+    @Override
+    public void testStatsEnabled() {
+        ScannerSessionBuilder builder = create().setStatsEnabled(true);
+        buildAndScan(builder);
+        assertTrue(builder.isStatsEnabled());
+    }
+
+    /**
+     * Create a ScannerSessionBuilder with the minimum required options
+     *
+     * @return the builder
+     */
+    @Override
+    public ScannerSessionBuilder create() {
+        //  @formatter:off
+        return ScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+    }
+
+    /**
+     * Run the scanner and assert several variables
+     *
+     * @param builder
+     *            the builder
+     */
+    private void buildAndScan(ScannerSessionBuilder builder) {
+        ScannerSession scanner = builder.build();
+        scanner.setRanges(List.of(range));
+
+        assertTrue(scanner.hasNext());
+        assertNotNull(scanner.next());
+
+        assertEquals(tableName, builder.getTableName());
+        assertEquals(authorizations, builder.getAuthorizations());
+        assertEquals(query, builder.getQuery());
+    }
+}


### PR DESCRIPTION
Add builders for all ScannerSession implementations

BaseScannerSessionTest documents common test cases and is implemented by tests for scanner session, batch scanner session, range stream scanner and any field scanner builders.

Add ScanSessionManager that tracks scanner sessions for later close operations. Using a ScanSessionManager in conjunction wiht a ScanSessionBuilder allows for removal of the ScannerFactory.