### PR TITLE
Update require-labels.yml

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const requiredLabels = ["Integration Tested", "no-downstream-affects", "cherry-pick"];
+            const requiredLabels = ["Integration Tested", "no-downstream-effects", "cherry-pick"];
             const labels = context.payload.pull_request.labels.map(label => label.name);
 
             const hasRequired = requiredLabels.some(l => labels.includes(l));


### PR DESCRIPTION
The label 'no-downstream-affects' was deleted in favor of the more grammatically correctly and aesthetically pleasing label 'no-downstream-effects'.

This commit updates our required-labels.yml to reflect this change.