### PR TITLE
inherit annotation source visibility from annotation for display

### DIFF
--- a/core/annotation/src/main/java/datawave/annotation/util/v1/AnnotationUtils.java
+++ b/core/annotation/src/main/java/datawave/annotation/util/v1/AnnotationUtils.java
@@ -16,6 +16,7 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 
+import datawave.annotation.data.transform.VisibilityTransformer;
 import datawave.annotation.protobuf.v1.Annotation;
 import datawave.annotation.protobuf.v1.AnnotationSource;
 import datawave.annotation.protobuf.v1.Point;
@@ -28,7 +29,23 @@ public class AnnotationUtils {
     public static final String UPDATE_REFERENCE = "updates";
 
     public static Annotation injectAnnotationSource(Annotation a, AnnotationSource as) {
-        return a.toBuilder().clearSource().setSource(as).clearAnalyticSourceHash().setAnalyticSourceHash(as.getAnalyticSourceHash()).build();
+        return injectAnnotationSource(a, as, false, null);
+    }
+
+    public static Annotation injectAnnotationSource(Annotation a, AnnotationSource as, boolean inheritVisibility, VisibilityTransformer visibilityTransformer) {
+        AnnotationSource asForInjection = as;
+
+        if (inheritVisibility && visibilityTransformer != null) {
+            // building new AnnotationSource from result but overriding the visibility
+            AnnotationSource.Builder newSourceBuilder = AnnotationSource.newBuilder(as);
+            for (String metadataFieldForVisibility : visibilityTransformer.getMetadataFields()) {
+                newSourceBuilder.putMetadata(metadataFieldForVisibility, a.getMetadataMap().get(metadataFieldForVisibility));
+            }
+            asForInjection = newSourceBuilder.build();
+        }
+
+        return a.toBuilder().clearSource().setSource(asForInjection).clearAnalyticSourceHash().setAnalyticSourceHash(asForInjection.getAnalyticSourceHash())
+                        .build();
     }
 
     /**

--- a/core/annotation/src/test/java/datawave/annotation/test/v1/AnnotationTestDataUtil.java
+++ b/core/annotation/src/test/java/datawave/annotation/test/v1/AnnotationTestDataUtil.java
@@ -29,12 +29,16 @@ public class AnnotationTestDataUtil {
     public static final String VISIBILITY = "PUBLIC";
 
     public static AnnotationSource generateTestAnnotationSource() {
+        return generateTestAnnotationSource(VISIBILITY);
+    }
+
+    public static AnnotationSource generateTestAnnotationSource(String visibility) {
         //@formatter:off
         return AnnotationSource.newBuilder()
                 .setEngine("inline v6")
                 .setModel("GR Supra")
                 .setPlatform("toyota")
-                .putMetadata("visibility", VISIBILITY)
+                .putMetadata("visibility", visibility)
                 .putMetadata("created_date",CREATED_DATE)
                 .putConfiguration("octane","99")
                 .putConfiguration("model_year", "2025")

--- a/core/annotation/src/test/java/datawave/annotation/util/v1/AnnotationUtilsTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/util/v1/AnnotationUtilsTest.java
@@ -1,0 +1,38 @@
+package datawave.annotation.util.v1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.annotation.data.transform.DefaultVisibilityTransformer;
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.AnnotationSource;
+import datawave.annotation.test.v1.AnnotationTestDataUtil;
+
+public class AnnotationUtilsTest {
+    @Test
+    public void testInjectAnnotationSourceWithVisibilityInheritanceFeature() throws Exception {
+        // annotation is built with PUBLIC visibility only
+        Annotation a = AnnotationTestDataUtil.generateTestAnnotation();
+
+        // generating annotation source which two combined visibilities to test the inherit feature
+        AnnotationSource as = AnnotationTestDataUtil.generateTestAnnotationSource("(PRIVATE|PUBLIC)");
+
+        // with inherit feature enabled, annotation source should only have the one from annotation
+        AnnotationSource asWithInheritedVisibility = AnnotationTestDataUtil.generateTestAnnotationSource("PUBLIC");
+
+        //@formatter:off
+        assertEquals(
+                AnnotationUtils.injectAnnotationSource(a, as).getSource(),
+                as);
+
+        assertEquals(
+                AnnotationUtils.injectAnnotationSource(a, as, false, new DefaultVisibilityTransformer()).getSource(),
+                as);
+
+        assertEquals(
+                AnnotationUtils.injectAnnotationSource(a, as, true, new DefaultVisibilityTransformer()).getSource(),
+                asWithInheritedVisibility);
+        //@formatter:on
+    }
+}


### PR DESCRIPTION
just adding the feature to AnnotationUtils class. there will be another changes to wire it in AnnotationManagerBean class