### PR TITLE
ScanBuilders support Set of Authorizations

### DIFF
--- a/core/utils/accumulo-utils/src/main/java/datawave/scan/BatchScannerBuilder.java
+++ b/core/utils/accumulo-utils/src/main/java/datawave/scan/BatchScannerBuilder.java
@@ -1,10 +1,17 @@
 package datawave.scan;
 
+import java.util.Iterator;
+
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.security.Authorizations;
 
 import com.google.common.base.Preconditions;
+
+import datawave.security.util.AuthorizationsMinimizer;
+import datawave.security.util.ScannerHelper;
+import datawave.webservice.common.connection.BatchScannerDelegate;
 
 /**
  * The builder <b>must</b> specify the AccumuloClient, the table name, and the authorizations
@@ -64,17 +71,21 @@ public class BatchScannerBuilder extends ScanBuilder<BatchScannerBuilder> {
         Preconditions.checkNotNull(authorizations, "Authorizations must be set");
 
         try {
-            BatchScanner scanner = client.createBatchScanner(tableName, authorizations, numQueryThreads);
+            // the first auth set is used to create the scanner, additional auths are added to the iterator stack
+            Iterator<Authorizations> iter = AuthorizationsMinimizer.minimize(authorizations).iterator();
+            BatchScanner scanner = client.createBatchScanner(tableName, iter.next(), numQueryThreads);
+            BatchScannerDelegate delegate = new BatchScannerDelegate(scanner);
+            ScannerHelper.addVisibilityFilters(iter, delegate);
 
             if (consistencyLevel != null) {
-                scanner.setConsistencyLevel(consistencyLevel);
+                delegate.setConsistencyLevel(consistencyLevel);
             }
 
             if (!executionHints.isEmpty()) {
-                scanner.setExecutionHints(executionHints);
+                delegate.setExecutionHints(executionHints);
             }
 
-            return scanner;
+            return delegate;
         } catch (TableNotFoundException e) {
             throw new RuntimeException("Could not create scanner", e);
         }

--- a/core/utils/accumulo-utils/src/main/java/datawave/scan/ScanBuilder.java
+++ b/core/utils/accumulo-utils/src/main/java/datawave/scan/ScanBuilder.java
@@ -2,7 +2,9 @@ package datawave.scan;
 
 import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -14,6 +16,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
+
+import datawave.security.util.AuthorizationsMinimizer;
+import datawave.security.util.ScannerHelper;
 
 /**
  * Builder that contains the core logic for building implementations of a {@link ScannerBase}, specifically {@link Scanner} or {@link BatchScanner}
@@ -36,7 +41,7 @@ public abstract class ScanBuilder<B> {
     // required variables
     protected final AccumuloClient client;
     protected String tableName;
-    protected Authorizations authorizations;
+    protected Collection<Authorizations> authorizations;
 
     // optional variables
     protected ScannerBase.ConsistencyLevel consistencyLevel;
@@ -84,6 +89,20 @@ public abstract class ScanBuilder<B> {
      * @return this builder
      */
     public B setAuthorizations(Authorizations authorizations) {
+        this.authorizations = List.of(authorizations);
+        return self();
+    }
+
+    /**
+     * Set the collection {@link Authorizations} for the scanner
+     * <p>
+     * See {@link ScannerHelper} and {@link AuthorizationsMinimizer} for details.
+     *
+     * @param authorizations
+     *            the authorizations
+     * @return this builder
+     */
+    public B setAuthorizations(Collection<Authorizations> authorizations) {
         this.authorizations = authorizations;
         return self();
     }
@@ -182,7 +201,7 @@ public abstract class ScanBuilder<B> {
      *
      * @return the authorizations
      */
-    public Authorizations getAuthorizations() {
+    public Collection<Authorizations> getAuthorizations() {
         return authorizations;
     }
 

--- a/core/utils/accumulo-utils/src/main/java/datawave/scan/ScannerBuilder.java
+++ b/core/utils/accumulo-utils/src/main/java/datawave/scan/ScannerBuilder.java
@@ -1,10 +1,17 @@
 package datawave.scan;
 
+import java.util.Iterator;
+
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.security.Authorizations;
 
 import com.google.common.base.Preconditions;
+
+import datawave.security.util.AuthorizationsMinimizer;
+import datawave.security.util.ScannerHelper;
+import datawave.webservice.common.connection.ScannerDelegate;
 
 /**
  * The builder <b>must</b> specify the AccumuloClient, the table name, and the authorizations
@@ -49,17 +56,21 @@ public class ScannerBuilder extends ScanBuilder<ScannerBuilder> {
         Preconditions.checkNotNull(authorizations, "Authorizations must be set");
 
         try {
-            Scanner scanner = client.createScanner(tableName, authorizations);
+            // the first auth set is used to create the scanner, additional auths are added to the iterator stack
+            Iterator<Authorizations> iter = AuthorizationsMinimizer.minimize(authorizations).iterator();
+            Scanner scanner = client.createScanner(tableName, iter.next());
+            ScannerDelegate delegate = new ScannerDelegate(scanner);
+            ScannerHelper.addVisibilityFilters(iter, delegate);
 
             if (consistencyLevel != null) {
-                scanner.setConsistencyLevel(consistencyLevel);
+                delegate.setConsistencyLevel(consistencyLevel);
             }
 
             if (!executionHints.isEmpty()) {
-                scanner.setExecutionHints(executionHints);
+                delegate.setExecutionHints(executionHints);
             }
 
-            return scanner;
+            return delegate;
         } catch (TableNotFoundException e) {
             throw new RuntimeException("ScannerBuilder could not create scanner", e);
         }

--- a/core/utils/accumulo-utils/src/main/java/datawave/security/util/ScannerHelper.java
+++ b/core/utils/accumulo-utils/src/main/java/datawave/security/util/ScannerHelper.java
@@ -56,7 +56,7 @@ public class ScannerHelper {
         return batchDeleter;
     }
 
-    protected static void addVisibilityFilters(Iterator<Authorizations> iter, ScannerBase scanner) {
+    public static void addVisibilityFilters(Iterator<Authorizations> iter, ScannerBase scanner) {
         for (int priority = 10; iter.hasNext(); priority++) {
             IteratorSetting cfg = new IteratorSetting(priority, ConfigurableVisibilityFilter.class);
             cfg.setName("visibilityFilter" + priority);

--- a/core/utils/accumulo-utils/src/test/java/datawave/scan/BatchScannerBuilderTest.java
+++ b/core/utils/accumulo-utils/src/test/java/datawave/scan/BatchScannerBuilderTest.java
@@ -4,6 +4,7 @@ import static org.apache.accumulo.core.client.ScannerBase.ConsistencyLevel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class BatchScannerBuilderTest {
 
     private static AccumuloClient client;
     private static final String tableName = "shard";
-    private static final Authorizations auths = new Authorizations("VIZ-A");
+    private static final Collection<Authorizations> auths = List.of(new Authorizations("VIZ-A"));
     private final Range range = Range.exact("row");
 
     private static final Long ts = System.currentTimeMillis();

--- a/core/utils/accumulo-utils/src/test/java/datawave/scan/ScannerBuilderTest.java
+++ b/core/utils/accumulo-utils/src/test/java/datawave/scan/ScannerBuilderTest.java
@@ -3,6 +3,8 @@ package datawave.scan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.accumulo.core.client.AccumuloClient;
@@ -27,11 +29,14 @@ public class ScannerBuilderTest {
 
     private static AccumuloClient client;
     private static final String tableName = "shard";
-    private final Authorizations auths = new Authorizations("VIZ-A");
+
+    private final Authorizations authSetA = new Authorizations("VIZ-A", "VIZ-B");
+    private final Authorizations authSetB = new Authorizations("VIZ-B", "VIZ-C");
+    private final Collection<Authorizations> auths = List.of(authSetA, authSetB);
     private final Range range = Range.exact("row");
 
     private static final Long ts = System.currentTimeMillis();
-    private static final Key key = new Key("row", "cf", "cq", "VIZ-A", ts);
+    private static final Key key = new Key("row", "cf", "cq", "VIZ-B", ts);
     private static final Value EMPTY_VALUE = new Value();
 
     @BeforeAll


### PR DESCRIPTION
- ScanBuilders now support a set of authorizations, 
- ScannerHelper is used to set multiple visibility filters
- delegate scanners are used to enforce visibility filters