### PR TITLE
Migrate ColumnFamilyConstants to core/tables

### DIFF
--- a/core/tables/src/main/java/datawave/table/constants/MetadataColumnFamilyConstants.java
+++ b/core/tables/src/main/java/datawave/table/constants/MetadataColumnFamilyConstants.java
@@ -1,12 +1,11 @@
-package datawave.data;
+package datawave.table.constants;
 
 import org.apache.hadoop.io.Text;
 
 /**
- *
+ * Reserved ColumnFamily names for the DatawaveMetadata table
  */
-@Deprecated(forRemoval = true, since = "7.40.0")
-public interface ColumnFamilyConstants {
+public interface MetadataColumnFamilyConstants {
     /**
      * A colf of 'e' denotes event fields (shard table)
      */

--- a/core/tables/src/test/java/datawave/table/constants/MetadataColumnFamilyConstantsTest.java
+++ b/core/tables/src/test/java/datawave/table/constants/MetadataColumnFamilyConstantsTest.java
@@ -1,0 +1,45 @@
+package datawave.table.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.hadoop.io.Text;
+import org.junit.jupiter.api.Test;
+
+public class MetadataColumnFamilyConstantsTest {
+
+    @Test
+    public void verifyNoConstantsChanged() {
+        assertConstant(MetadataColumnFamilyConstants.COLF_E, "e");
+        assertConstant(MetadataColumnFamilyConstants.COLF_EXP, "exp");
+        assertConstant(MetadataColumnFamilyConstants.COLF_CONTENT, "content");
+        assertConstant(MetadataColumnFamilyConstants.COLF_I, "i");
+        assertConstant(MetadataColumnFamilyConstants.COLF_RI, "ri");
+        assertConstant(MetadataColumnFamilyConstants.COLF_F, "f");
+        assertConstant(MetadataColumnFamilyConstants.COLF_TF, "tf");
+        assertConstant(MetadataColumnFamilyConstants.COLF_N, "n");
+        assertConstant(MetadataColumnFamilyConstants.COLF_T, "t");
+        assertConstant(MetadataColumnFamilyConstants.COLF_DESC, "desc");
+        assertConstant(MetadataColumnFamilyConstants.COLF_EDGE, "edge");
+        assertConstant(MetadataColumnFamilyConstants.COLF_H, "h");
+        assertConstant(MetadataColumnFamilyConstants.COLF_CI, "ci");
+        assertConstant(MetadataColumnFamilyConstants.COLF_CITD, "citd");
+        assertConstant(MetadataColumnFamilyConstants.COLF_CISEP, "cisep");
+        assertConstant(MetadataColumnFamilyConstants.COLF_COUNT, "count");
+        assertConstant(MetadataColumnFamilyConstants.COLF_VERSION, "version");
+        assertConstant(MetadataColumnFamilyConstants.COLF_VI, "vi");
+        assertConstant(MetadataColumnFamilyConstants.COLF_WCD, "wcd");
+    }
+
+    /**
+     * Verify the constant has not changed
+     *
+     * @param actual
+     *            the actual column family constant
+     * @param expected
+     *            the expected constant
+     */
+    private void assertConstant(Text actual, String expected) {
+        assertEquals(new Text(expected), actual, "Did not expect constant to change: " + actual);
+    }
+
+}


### PR DESCRIPTION
Copy ColumnFamilyConstants to MetadataColumnFamilyConstants, deprecate old