### PR TITLE
Move TableName constants to core/tables

### DIFF
--- a/core/tables/src/main/java/datawave/table/constants/TableName.java
+++ b/core/tables/src/main/java/datawave/table/constants/TableName.java
@@ -1,9 +1,8 @@
-package datawave.util;
+package datawave.table.constants;
 
 /**
  * Class that contains default table names
  */
-@Deprecated(forRemoval = true, since = "7.40.0")
 public final class TableName {
 
     public static final String DATE_INDEX = "dateIndex";

--- a/core/tables/src/test/java/datawave/table/constants/TableNameTest.java
+++ b/core/tables/src/test/java/datawave/table/constants/TableNameTest.java
@@ -1,0 +1,36 @@
+package datawave.table.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TableNameTest {
+
+    @Test
+    public void testVerifyConstants() {
+        verifyConstant(TableName.DATE_INDEX, "dateIndex");
+        verifyConstant(TableName.EDGE, "edge");
+        verifyConstant(TableName.ERROR_SHARD, "errorShard");
+        verifyConstant(TableName.INDEX_STATS, "shardIndexStats");
+        verifyConstant(TableName.LOAD_DATES, "LoadDates");
+        verifyConstant(TableName.METADATA, "DatawaveMetadata");
+        verifyConstant(TableName.SHARD, "shard");
+        verifyConstant(TableName.SHARD_INDEX, "shardIndex");
+        verifyConstant(TableName.SHARD_RINDEX, "shardReverseIndex");
+        verifyConstant(TableName.TRUNCATED_SHARD_INDEX, "truncatedShardIndex");
+        verifyConstant(TableName.SHARD_YEAR_INDEX, "shardYearIndex");
+        verifyConstant(TableName.SHARD_DAY_INDEX, "shardDayIndex");
+    }
+
+    /**
+     * Verify the constant did not change
+     *
+     * @param constant
+     *            the constant
+     * @param expected
+     *            the expected value
+     */
+    private void verifyConstant(String constant, String expected) {
+        assertEquals(expected, constant, "Constant changed unexpectedly");
+    }
+}


### PR DESCRIPTION
Copy TableName from warehouse/core to core/tables, deprecate old