### PR TITLE
Allow additional API calls on authorization service without checking allowedCallers filter

### DIFF
--- a/microservices/services/authorization/service/src/main/java/datawave/microservice/authorization/config/AuthorizationAllowedCallersFilter.java
+++ b/microservices/services/authorization/service/src/main/java/datawave/microservice/authorization/config/AuthorizationAllowedCallersFilter.java
@@ -1,7 +1,8 @@
 package datawave.microservice.authorization.config;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -13,7 +14,16 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import datawave.microservice.config.security.AllowedCallersFilter;
 
 public class AuthorizationAllowedCallersFilter extends AllowedCallersFilter {
-    private static final Pattern oauthPattern = Pattern.compile("/v\\d*/oauth/.*");
+    private static final Set<String> allowAllUsersPaths = new LinkedHashSet<>();
+
+    static {
+        allowAllUsersPaths.add("/oauth");
+        allowAllUsersPaths.add("/listEffectiveAuthorizations");
+    }
+
+    public static void addAllowAllUsersPath(String path) {
+        allowAllUsersPaths.add(path);
+    }
 
     public AuthorizationAllowedCallersFilter(DatawaveSecurityProperties securityProperties, AuthenticationEntryPoint authenticationEntryPoint) {
         super(securityProperties, authenticationEntryPoint);
@@ -32,6 +42,17 @@ public class AuthorizationAllowedCallersFilter extends AllowedCallersFilter {
     }
 
     public static boolean enforceAllowedCallersForRequest(HttpServletRequest httpServletRequest) {
-        return !oauthPattern.matcher(httpServletRequest.getServletPath()).matches();
+        String requestPath = httpServletRequest.getServletPath();
+        if (requestPath.matches("/v\\d*/.*")) {
+            // find second / to remove the /v1, /v2, etc. from the start of the path
+            int x = requestPath.indexOf("/", 1);
+            requestPath = requestPath.substring(x);
+        }
+        for (String allowedPath : allowAllUsersPaths) {
+            if (requestPath.startsWith(allowedPath)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizationTestUtils.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizationTestUtils.java
@@ -48,10 +48,10 @@ public class AuthorizationTestUtils {
         UriComponents uri = UriComponentsBuilder.newInstance().scheme(scheme).host("localhost").port(webServicePort).path(path).query(query).build();
         RequestEntity requestEntity = createRequestEntity(null, authUser, HttpMethod.GET, uri);
         ResponseEntity<String> entity = restTemplate.exchange(requestEntity, String.class);
-        assertEquals(HttpStatus.OK, entity.getStatusCode(), "Authorizaed admin request to " + uri + " did not return a 200.");
+        assertEquals(HttpStatus.OK, entity.getStatusCode(), "Authorized admin request to " + uri + " did not return a 200.");
     }
 
-    public void testAuthorizeMethodFailure(DatawaveUserDetails unauthUser, String path, boolean useTrustedHeader, boolean useJWT) throws Exception {
+    public void testNotAllowedMethodFailure(DatawaveUserDetails unauthUser, String path, boolean useTrustedHeader, boolean useJWT) throws Exception {
         UriComponents uri = UriComponentsBuilder.newInstance().scheme(scheme).host("localhost").port(webServicePort).path(path).build();
         try {
             RequestEntity requestEntity;
@@ -69,7 +69,7 @@ public class AuthorizationTestUtils {
         }
     }
 
-    public void testAuthorizeMethodSuccess(DatawaveUserDetails authUser, String path, boolean useTrustedHeader, boolean useJWT) throws Exception {
+    public void testAllowedMethodSuccess(DatawaveUserDetails authUser, String path, boolean useTrustedHeader, boolean useJWT) throws Exception {
         UriComponents uri = UriComponentsBuilder.newInstance().scheme(scheme).host("localhost").port(webServicePort).path(path).build();
         RequestEntity requestEntity;
         DatawaveUserDetails trustedHeaderUser = useTrustedHeader ? authUser : null;
@@ -79,7 +79,7 @@ public class AuthorizationTestUtils {
             requestEntity = createRequestEntity(trustedHeaderUser, null, HttpMethod.GET, uri);
         }
         ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode(), "Authorized request to " + uri + " did not return a 200.");
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode(), "Allowed request to " + uri + " did not return a 200.");
     }
 
     public <T> RequestEntity<T> createRequestEntity(DatawaveUserDetails trustedUser, DatawaveUserDetails jwtUser, HttpMethod method, UriComponents uri) {

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpTest.java
@@ -90,8 +90,8 @@ public class AuthorizeHttpTest {
     @Test
     public void testAuthorizeNotAllowedCallerTrustedHeader() throws Exception {
         // Use trusted header to authenticate to ProxiedEntityX509Filter
-        testUtils.testAuthorizeMethodFailure(notAllowedCaller, "/authorization/v1/authorize", true, false);
-        testUtils.testAuthorizeMethodFailure(notAllowedCaller, "/authorization/v2/authorize", true, false);
+        testUtils.testNotAllowedMethodFailure(notAllowedCaller, "/authorization/v1/authorize", true, false);
+        testUtils.testNotAllowedMethodFailure(notAllowedCaller, "/authorization/v2/authorize", true, false);
     }
 
     @Test
@@ -99,34 +99,34 @@ public class AuthorizeHttpTest {
         // Use JWT to authenticate to JWTAuthenticationFilter
         // Since user is already authenticated, ProxiedEntityX509Filter does not
         // authenticate and trustedHeaders are ignored
-        testUtils.testAuthorizeMethodSuccess(allowedCaller, "/authorization/v1/authorize", true, true);
-        testUtils.testAuthorizeMethodSuccess(allowedCaller, "/authorization/v2/authorize", true, true);
+        testUtils.testAllowedMethodSuccess(allowedCaller, "/authorization/v1/authorize", true, true);
+        testUtils.testAllowedMethodSuccess(allowedCaller, "/authorization/v2/authorize", true, true);
 
         // Use JWT to authenticate to JWTAuthenticationFilter
         // Since user is already authenticated, ProxiedEntityX509Filter does not
         // authenticate and trustedHeaders are ignored
         // allowedCaller is not enforced when accessing using JWT
-        testUtils.testAuthorizeMethodSuccess(notAllowedCaller, "/authorization/v1/authorize", true, true);
-        testUtils.testAuthorizeMethodSuccess(notAllowedCaller, "/authorization/v2/authorize", true, true);
+        testUtils.testAllowedMethodSuccess(notAllowedCaller, "/authorization/v1/authorize", true, true);
+        testUtils.testAllowedMethodSuccess(notAllowedCaller, "/authorization/v2/authorize", true, true);
     }
 
     @Test
     public void testAuthorizeJWT() throws Exception {
         // Use JWT to authenticate to JWTAuthenticationFilter
-        testUtils.testAuthorizeMethodSuccess(allowedCaller, "/authorization/v1/authorize", false, true);
-        testUtils.testAuthorizeMethodSuccess(allowedCaller, "/authorization/v2/authorize", false, true);
+        testUtils.testAllowedMethodSuccess(allowedCaller, "/authorization/v1/authorize", false, true);
+        testUtils.testAllowedMethodSuccess(allowedCaller, "/authorization/v2/authorize", false, true);
 
         // Use JWT to authenticate to JWTAuthenticationFilter
         // allowedCaller is not enforced when accessing using JWT
-        testUtils.testAuthorizeMethodSuccess(notAllowedCaller, "/authorization/v1/authorize", false, true);
-        testUtils.testAuthorizeMethodSuccess(notAllowedCaller, "/authorization/v2/authorize", false, true);
+        testUtils.testAllowedMethodSuccess(notAllowedCaller, "/authorization/v1/authorize", false, true);
+        testUtils.testAllowedMethodSuccess(notAllowedCaller, "/authorization/v2/authorize", false, true);
     }
 
     @Test
     public void testAuthorizeAllowedCallerTrustedHeader() throws Exception {
         // Use trusted header to authenticate to ProxiedEntityX509Filter
-        testUtils.testAuthorizeMethodSuccess(allowedCaller, "/authorization/v1/authorize", true, false);
-        testUtils.testAuthorizeMethodSuccess(allowedCaller, "/authorization/v2/authorize", true, false);
+        testUtils.testAllowedMethodSuccess(allowedCaller, "/authorization/v1/authorize", true, false);
+        testUtils.testAllowedMethodSuccess(allowedCaller, "/authorization/v2/authorize", true, false);
     }
 
     @Test

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsAllowedCallerTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsAllowedCallerTest.java
@@ -65,8 +65,8 @@ public class AuthorizeHttpsAllowedCallerTest {
         // X509 certificate used for identity
         // passes AllowedCallersFilter because configured certificate is in allowedCallers list
         // passes AuthorizationProxiedEntityX509Filter because configured certificate is in allowedCallers list
-        testUtils.testAuthorizeMethodSuccess(null, "/authorization/v1/authorize", false, false);
-        testUtils.testAuthorizeMethodSuccess(null, "/authorization/v2/authorize", false, false);
+        testUtils.testAllowedMethodSuccess(null, "/authorization/v1/authorize", false, false);
+        testUtils.testAllowedMethodSuccess(null, "/authorization/v2/authorize", false, false);
     }
 
     @ImportAutoConfiguration({RefreshAutoConfiguration.class})

--- a/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsNotAllowedCallerTest.java
+++ b/microservices/services/authorization/service/src/test/java/datawave/microservice/authorization/AuthorizeHttpsNotAllowedCallerTest.java
@@ -66,8 +66,16 @@ public class AuthorizeHttpsNotAllowedCallerTest {
     public void testAuthorizeMethodSecurityWithNotAllowedCaller() throws Exception {
         // X509 certificate used for identity
         // fails AllowedCallersFilter because configured certificate is not in allowedCallers list
-        testUtils.testAuthorizeMethodFailure(null, "/authorization/v1/authorize", false, false);
-        testUtils.testAuthorizeMethodFailure(null, "/authorization/v2/authorize", false, false);
+        testUtils.testNotAllowedMethodFailure(null, "/authorization/v1/authorize", false, false);
+        testUtils.testNotAllowedMethodFailure(null, "/authorization/v2/authorize", false, false);
+    }
+
+    @Test
+    public void testAllowedCallWithNotAllowedCaller() throws Exception {
+        // X509 certificate used for identity
+        // passes AllowedCallersFilter because request paths bypass the allowedCallers list
+        testUtils.testAllowedMethodSuccess(null, "/authorization/v1/listEffectiveAuthorizations", false, false);
+        testUtils.testAllowedMethodSuccess(null, "/authorization/v2/listEffectiveAuthorizations", false, false);
     }
 
     @ImportAutoConfiguration({RefreshAutoConfiguration.class})


### PR DESCRIPTION
Allow additional API calls on authorization service without checking allowedCallers filter
Normal users should be able to call /listEffectiveAuthorizations