### PR TITLE
Refactor Ivarator directory validation

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
@@ -1,8 +1,15 @@
 package datawave.query.iterator.ivarator;
 
+import java.io.IOException;
+
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FsStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IvaratorCacheDir {
+
+    private static final Logger log = LoggerFactory.getLogger(IvaratorCacheDir.class);
 
     final protected IvaratorCacheDirConfig config;
 
@@ -24,6 +31,26 @@ public class IvaratorCacheDir {
 
     public FileSystem getFs() {
         return fs;
+    }
+
+    public boolean validateFS() {
+        FsStatus fsStatus = null;
+        try {
+            fsStatus = getFs().getStatus();
+        } catch (IOException e) {
+            log.warn("Unable to determine status of the filesystem: {}", getFs());
+        }
+
+        // determine whether this fs is a good candidate
+        if (fsStatus != null) {
+            long availableStorageMiB = fsStatus.getRemaining() / 0x100000L;
+            double availableStoragePercent = (double) fsStatus.getRemaining() / fsStatus.getCapacity();
+
+            // if we are using less than our storage limit, the cache dir is valid
+            return availableStorageMiB >= config.getMinAvailableStorageMiB() && availableStoragePercent >= config.getMinAvailableStoragePercent();
+        }
+
+        return false;
     }
 
     public String getPathURI() {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
@@ -20,6 +20,12 @@ public class IvaratorCacheDir {
     // the path for caching ivarator output for this query
     final protected String pathURI;
 
+    public IvaratorCacheDir() {
+        this.config = null;
+        this.fs = null;
+        this.pathURI = "/";
+    }
+
     public IvaratorCacheDir(IvaratorCacheDirConfig config, FileSystem fs, String pathURI) {
         this.config = config;
         this.fs = fs;
@@ -40,6 +46,7 @@ public class IvaratorCacheDir {
             return getFs().getStatus(path);
         } catch (IOException e) {
             log.warn("Unable to determine status of the filesystem: {}", getFs());
+            log.warn("Exception : {}", e.getMessage());
         }
         return null;
     }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
@@ -65,7 +65,8 @@ public class IvaratorCacheDir {
         }
 
         long availableStorageMiB = fsStatus.getRemaining() / 0x100000L;
-        double availableStoragePercent = (double) fsStatus.getRemaining() / fsStatus.getCapacity();
+        // Using the RawLocalFileSystem for unit tests will return zero remaining/capacity
+        double availableStoragePercent = (double) fsStatus.getRemaining() / Math.max(1, fsStatus.getCapacity());
 
         if (log.isTraceEnabled()) {
             log.trace("availableStorageMiB: {}", availableStorageMiB);

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/ivarator/IvaratorCacheDir.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FsStatus;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,24 +34,39 @@ public class IvaratorCacheDir {
         return fs;
     }
 
-    public boolean validateFS() {
-        FsStatus fsStatus = null;
+    public FsStatus getFsStatus() {
         try {
-            fsStatus = getFs().getStatus();
+            Path path = new Path(pathURI);
+            return getFs().getStatus(path);
         } catch (IOException e) {
             log.warn("Unable to determine status of the filesystem: {}", getFs());
         }
+        return null;
+    }
 
+    public boolean validateFS() {
         // determine whether this fs is a good candidate
-        if (fsStatus != null) {
-            long availableStorageMiB = fsStatus.getRemaining() / 0x100000L;
-            double availableStoragePercent = (double) fsStatus.getRemaining() / fsStatus.getCapacity();
+        FsStatus fsStatus = getFsStatus();
 
-            // if we are using less than our storage limit, the cache dir is valid
-            return availableStorageMiB >= config.getMinAvailableStorageMiB() && availableStoragePercent >= config.getMinAvailableStoragePercent();
+        if (fsStatus == null) {
+            return false;
         }
 
-        return false;
+        if (log.isTraceEnabled()) {
+            log.trace("remaining: {}", fsStatus.getRemaining());
+            log.trace("capacity: {}", fsStatus.getCapacity());
+        }
+
+        long availableStorageMiB = fsStatus.getRemaining() / 0x100000L;
+        double availableStoragePercent = (double) fsStatus.getRemaining() / fsStatus.getCapacity();
+
+        if (log.isTraceEnabled()) {
+            log.trace("availableStorageMiB: {}", availableStorageMiB);
+            log.trace("availableStoragePercent: {}", availableStoragePercent);
+        }
+
+        // if we are using less than our storage limit, the cache dir is valid
+        return availableStorageMiB >= config.getMinAvailableStorageMiB() && availableStoragePercent >= config.getMinAvailableStoragePercent();
     }
 
     public String getPathURI() {

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedmap/HdfsBackedSortedMap.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedmap/HdfsBackedSortedMap.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FsStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 
@@ -159,24 +158,7 @@ public class HdfsBackedSortedMap<K,V> extends BufferedFileBackedSortedMap<K,V> {
         }
 
         public boolean isValid() {
-            FsStatus fsStatus = null;
-            try {
-                fsStatus = ivaratorCacheDir.getFs().getStatus();
-            } catch (IOException e) {
-                log.warn("Unable to determine status of the filesystem: " + ivaratorCacheDir.getFs());
-            }
-
-            // determine whether this fs is a good candidate
-            if (fsStatus != null) {
-                long availableStorageMiB = fsStatus.getRemaining() / 0x100000L;
-                double availableStoragePercent = (double) fsStatus.getRemaining() / fsStatus.getCapacity();
-
-                // if we are using less than our storage limit, the cache dir is valid
-                return availableStorageMiB >= ivaratorCacheDir.getConfig().getMinAvailableStorageMiB()
-                                && availableStoragePercent >= ivaratorCacheDir.getConfig().getMinAvailableStoragePercent();
-            }
-
-            return false;
+            return ivaratorCacheDir.validateFS();
         }
 
         @Override

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/HdfsBackedSortedSet.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/HdfsBackedSortedSet.java
@@ -11,7 +11,6 @@ import java.util.SortedSet;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FsStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 
@@ -191,24 +190,7 @@ public class HdfsBackedSortedSet<E> extends BufferedFileBackedSortedSet<E> imple
         }
 
         public boolean isValid() {
-            FsStatus fsStatus = null;
-            try {
-                fsStatus = ivaratorCacheDir.getFs().getStatus();
-            } catch (IOException e) {
-                log.warn("Unable to determine status of the filesystem: " + ivaratorCacheDir.getFs());
-            }
-
-            // determine whether this fs is a good candidate
-            if (fsStatus != null) {
-                long availableStorageMiB = fsStatus.getRemaining() / 0x100000L;
-                double availableStoragePercent = (double) fsStatus.getRemaining() / fsStatus.getCapacity();
-
-                // if we are using less than our storage limit, the cache dir is valid
-                return availableStorageMiB >= ivaratorCacheDir.getConfig().getMinAvailableStorageMiB()
-                                && availableStoragePercent >= ivaratorCacheDir.getConfig().getMinAvailableStoragePercent();
-            }
-
-            return false;
+            return ivaratorCacheDir.validateFS();
         }
 
         @Override

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/ivarator/IvaratorCacheDirTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/ivarator/IvaratorCacheDirTest.java
@@ -1,0 +1,34 @@
+package datawave.query.iterator.ivarator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class IvaratorCacheDirTest {
+
+    @TempDir
+    public Path tempDir;
+
+    @Test
+    public void testDirectoryValidation() throws Exception {
+
+        File dir = new File(tempDir.toUri());
+        IvaratorCacheDirConfig config = new IvaratorCacheDirConfig(dir.toURI().toString());
+
+        FileSystem fs = new LocalFileSystem();
+        fs.initialize(dir.toURI(), new Configuration());
+
+        String pathURI = dir.getPath();
+        IvaratorCacheDir cacheDir = new IvaratorCacheDir(config, fs, pathURI);
+
+        boolean valid = cacheDir.validateFS();
+        assertTrue(valid);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/ivarator/IvaratorCacheDirTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/ivarator/IvaratorCacheDirTest.java
@@ -1,8 +1,12 @@
 package datawave.query.iterator.ivarator;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 
 import org.apache.hadoop.conf.Configuration;
@@ -30,5 +34,18 @@ public class IvaratorCacheDirTest {
 
         boolean valid = cacheDir.validateFS();
         assertTrue(valid);
+    }
+
+    @Test
+    public void testExceptionOnGetFsStatus() {
+        IvaratorCacheDir cacheDir = spy(IvaratorCacheDir.class);
+
+        // bypass strict method signature enforcement
+        doAnswer(invocation -> {
+            throw new IOException("no such FS");
+        }).when(cacheDir).getFs();
+
+        Exception e = assertThrows(IOException.class, cacheDir::getFsStatus);
+        assertTrue(e.getMessage().contains("no such FS"));
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformMostRecentTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/UniqueTransformMostRecentTest.java
@@ -1,5 +1,7 @@
 package datawave.query.transformer;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -30,6 +32,7 @@ public class UniqueTransformMostRecentTest extends UniqueTransformTest {
 
         // setup the hadoop configuration
         URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        assertNotNull("hadoop config cannot be null", hadoopConfig);
         logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
 
         // setup a directory for cache results

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedSortedMapTest.java
@@ -88,22 +88,29 @@ public abstract class BufferedFileBackedSortedMapTest<K,V> {
             sortedOrder[i * 2] = sortedTemplate[i] + sortedTemplate.length;
             sortedOrder[i * 2 + 1] = sortedTemplate[i];
         }
-        map = new datawave.query.util.sortedmap.BufferedFileBackedSortedMap.Builder().withComparator(getComparator()).withRewriteStrategy(getRewriteStrategy())
-                        .withBufferPersistThreshold(5).withMaxOpenFiles(7).withNumRetries(2).withHandlerFactories(
-                                        Collections.singletonList(new datawave.query.util.sortedmap.BufferedFileBackedSortedMap.SortedMapFileHandlerFactory() {
-                                            @Override
-                                            public FileSortedMap.SortedMapFileHandler createHandler() throws IOException {
-                                                datawave.query.util.sortedmap.SortedMapTempFileHandler fileHandler = new datawave.query.util.sortedmap.SortedMapTempFileHandler();
-                                                tempFileHandlers.add(fileHandler);
-                                                return fileHandler;
-                                            }
-
-                                            @Override
-                                            public boolean isValid() {
-                                                return true;
-                                            }
-                                        }))
-                        .withMapFactory(getFactory()).build();
+        //  @formatter:off
+        map = new BufferedFileBackedSortedMap.Builder()
+                .withComparator(getComparator())
+                .withRewriteStrategy(getRewriteStrategy())
+                .withBufferPersistThreshold(5)
+                .withMaxOpenFiles(7)
+                .withNumRetries(2)
+                .withHandlerFactories(
+                        Collections.singletonList(new BufferedFileBackedSortedMap.SortedMapFileHandlerFactory() {
+                            @Override
+                            public FileSortedMap.SortedMapFileHandler createHandler() throws IOException {
+                                SortedMapTempFileHandler fileHandler = new SortedMapTempFileHandler();
+                                tempFileHandlers.add(fileHandler);
+                                return fileHandler;
+                            }
+                            @Override
+                            public boolean isValid() {
+                                return true;
+                            }
+                        }))
+                .withMapFactory(getFactory())
+                .build();
+        //  @formatter:on
 
         // adding in the data map multiple times to create underlying files with duplicate values making the
         // MergeSortIterator's job a little tougher...

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedSortedMapTest.java
@@ -23,7 +23,6 @@ import java.util.TreeMap;
 
 import org.apache.commons.collections.keyvalue.UnmodifiableMapEntry;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -158,7 +157,7 @@ public abstract class BufferedFileBackedSortedMapTest<K,V> {
 
     private void tryDelete(File file) {
         if (file.exists()) {
-            Assert.assertTrue("Failed to delete file " + file, file.delete());
+            assertTrue("Failed to delete file " + file, file.delete());
         }
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/HdfsBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/HdfsBackedSortedMapTest.java
@@ -1,10 +1,12 @@
 package datawave.query.util.sortedmap;
 
 import java.io.File;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -18,8 +20,7 @@ import org.junit.rules.TemporaryFolder;
 
 import datawave.query.iterator.ivarator.IvaratorCacheDir;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
-import datawave.query.util.sortedset.FileSortedSet;
-import datawave.query.util.sortedset.HdfsBackedSortedSet;
+import datawave.query.util.sortedset.FileSortedSet.PersistOptions;
 
 public class HdfsBackedSortedMapTest {
 
@@ -41,8 +42,8 @@ public class HdfsBackedSortedMapTest {
 
         FsStatus fsStatus = fs.getStatus();
 
-        // set the min remaining MB to something which will cause the 'small' directiory to be skipped
-        long minRemainingMB = (fsStatus.getRemaining() / 0x100000L) + 4096l;
+        // set the min remaining MB to something which will cause the 'small' directory to be skipped
+        long minRemainingMB = (fsStatus.getRemaining() / 0x100000L) + 4096L;
 
         List<IvaratorCacheDir> ivaratorCacheDirs = new ArrayList<>();
         ivaratorCacheDirs
@@ -53,21 +54,21 @@ public class HdfsBackedSortedMapTest {
 
         // @formatter:off
         @SuppressWarnings("unchecked")
-        datawave.query.util.sortedset.HdfsBackedSortedSet<String> sortedSet = (datawave.query.util.sortedset.HdfsBackedSortedSet<String>) datawave.query.util.sortedset.HdfsBackedSortedSet.builder()
+        HdfsBackedSortedMap<String, String> sortedMap = (HdfsBackedSortedMap<String, String>) HdfsBackedSortedMap.builder()
                 .withIvaratorCacheDirs(ivaratorCacheDirs)
                 .withUniqueSubPath(uniquePath)
                 .withMaxOpenFiles(9999)
                 .withNumRetries(2)
-                .withPersistOptions(new datawave.query.util.sortedset.FileSortedSet.PersistOptions())
+                .withPersistOptions(new PersistOptions())
                 .build();
         // @formatter:on
 
         // Add an entry to the sorted set
         String someTestString = "some test string";
-        sortedSet.add(someTestString);
+        sortedMap.put("key", someTestString);
 
         // persist the sorted set
-        sortedSet.persist();
+        sortedMap.persist();
 
         Path smallPath = new Path(smallDir.toURI().toString());
         Path smallSubPath = new Path(smallPath, uniquePath);
@@ -81,22 +82,22 @@ public class HdfsBackedSortedMapTest {
 
         FileStatus[] fileStatuses = fs.listStatus(largeSubPath);
         Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedSet"));
+        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // Now make sure reloading an ivarator cache dir works
         // @formatter:off
         @SuppressWarnings("unchecked")
-        datawave.query.util.sortedset.HdfsBackedSortedSet<String> reloadedSortedSet = (datawave.query.util.sortedset.HdfsBackedSortedSet<String>) datawave.query.util.sortedset.HdfsBackedSortedSet.builder()
+        HdfsBackedSortedMap<String, String> reloadedSortedMap = (HdfsBackedSortedMap<String, String>) HdfsBackedSortedMap.builder()
                 .withIvaratorCacheDirs(ivaratorCacheDirs)
                 .withUniqueSubPath(uniquePath)
                 .withMaxOpenFiles(9999)
                 .withNumRetries(2)
-                .withPersistOptions(new datawave.query.util.sortedset.FileSortedSet.PersistOptions())
+                .withPersistOptions(new PersistOptions())
                 .build();
         // @formatter:on
 
-        Assert.assertEquals(1, reloadedSortedSet.size());
-        Assert.assertEquals(someTestString, reloadedSortedSet.first());
+        Assert.assertEquals(1, reloadedSortedMap.size());
+        Assert.assertEquals(someTestString, reloadedSortedMap.get("key"));
     }
 
     @Test
@@ -130,39 +131,39 @@ public class HdfsBackedSortedMapTest {
 
         // @formatter:off
         @SuppressWarnings("unchecked")
-        datawave.query.util.sortedset.HdfsBackedSortedSet<String> firstSortedSet = (datawave.query.util.sortedset.HdfsBackedSortedSet<String>) datawave.query.util.sortedset.HdfsBackedSortedSet.builder()
+        HdfsBackedSortedMap<String, String> firstSortedMap = (HdfsBackedSortedMap<String, String>) HdfsBackedSortedMap.builder()
                 .withIvaratorCacheDirs(Collections.singletonList(ivaratorCacheDirs.get(0)))
                 .withUniqueSubPath(uniquePath)
                 .withMaxOpenFiles(9999)
                 .withNumRetries(2)
-                .withPersistOptions(new datawave.query.util.sortedset.FileSortedSet.PersistOptions())
+                .withPersistOptions(new PersistOptions())
                 .build();
         // @formatter:on
 
         // Add an entry to the first sorted set
         String someTestString = "some test string";
-        firstSortedSet.add(someTestString);
+        firstSortedMap.put("key1", someTestString);
 
         // persist the sorted set
-        firstSortedSet.persist();
+        firstSortedMap.persist();
 
         // @formatter:off
         @SuppressWarnings("unchecked")
-        datawave.query.util.sortedset.HdfsBackedSortedSet<String> thirdSortedSet = (datawave.query.util.sortedset.HdfsBackedSortedSet<String>) datawave.query.util.sortedset.HdfsBackedSortedSet.builder()
+        HdfsBackedSortedMap<String, String> thirdSortedMap = (HdfsBackedSortedMap<String, String>) HdfsBackedSortedMap.builder()
                 .withIvaratorCacheDirs(Collections.singletonList(ivaratorCacheDirs.get(2)))
                 .withUniqueSubPath(uniquePath)
                 .withMaxOpenFiles(9999)
                 .withNumRetries(2)
-                .withPersistOptions(new datawave.query.util.sortedset.FileSortedSet.PersistOptions())
+                .withPersistOptions(new PersistOptions())
                 .build();
         // @formatter:on
 
         // Add an entry to the third sorted set
         String anotherTestString = "another test string";
-        thirdSortedSet.add(anotherTestString);
+        thirdSortedMap.put("key2", anotherTestString);
 
         // persist the sorted set
-        thirdSortedSet.persist();
+        thirdSortedMap.persist();
 
         // ensure that data was written to the first and third folders
         Assert.assertTrue(fs.exists(subPaths[0]));
@@ -175,43 +176,43 @@ public class HdfsBackedSortedMapTest {
         // ensure that 1 file was written to the first folder
         FileStatus[] fileStatuses = fs.listStatus(subPaths[0]);
         Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedSet"));
+        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // ensure that 1 file was written to the third folder
         fileStatuses = fs.listStatus(subPaths[2]);
         Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedSet"));
+        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // Now make sure reloading an ivarator cache dir works, and set maxOpenFiles to 1 so that we compact during the next persist
         // @formatter:off
         @SuppressWarnings("unchecked")
-        datawave.query.util.sortedset.HdfsBackedSortedSet<String> reloadedSortedSet = (datawave.query.util.sortedset.HdfsBackedSortedSet<String>) datawave.query.util.sortedset.HdfsBackedSortedSet.builder()
+        HdfsBackedSortedMap<String, String> reloadedSortedMap = (HdfsBackedSortedMap<String, String>) HdfsBackedSortedMap.builder()
                 .withIvaratorCacheDirs(ivaratorCacheDirs)
                 .withUniqueSubPath(uniquePath)
                 .withMaxOpenFiles(1)
                 .withNumRetries(2)
-                .withPersistOptions(new datawave.query.util.sortedset.FileSortedSet.PersistOptions())
+                .withPersistOptions(new PersistOptions())
                 .build();
         // @formatter:on
 
         // Ensure that we have 2 entries total
-        Assert.assertEquals(2, reloadedSortedSet.size());
+        Assert.assertEquals(2, reloadedSortedMap.size());
 
         // This is what we expect to be loaded by the set
-        List<String> results = new ArrayList<>();
-        results.add(someTestString);
-        results.add(anotherTestString);
+        List<Map.Entry<String,String>> results = new ArrayList<>();
+        results.add(new AbstractMap.SimpleEntry<>("key1", someTestString));
+        results.add(new AbstractMap.SimpleEntry<>("key2", anotherTestString));
 
         // for each result we find, remove it from the results list and ensure that the list is empty when we're done
-        reloadedSortedSet.iterator().forEachRemaining(results::remove);
+        reloadedSortedMap.entrySet().forEach(results::remove);
         Assert.assertTrue(results.isEmpty());
 
         // Finally, add an entry to the reloaded sorted set
         String lastTestString = "last test string";
-        reloadedSortedSet.add(lastTestString);
+        reloadedSortedMap.put("key3", lastTestString);
 
         // persist the sorted set (this should cause a compaction down to 1 file)
-        reloadedSortedSet.persist();
+        reloadedSortedMap.persist();
 
         // ensure that data was not written to the second folder
         Assert.assertFalse(fs.exists(subPaths[1]));
@@ -224,31 +225,31 @@ public class HdfsBackedSortedMapTest {
         // ensure that all data exists in the first folder
         fileStatuses = fs.listStatus(subPaths[0]);
         Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedSet"));
+        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // Finally, make sure that the compacted data can be reloaded
         // @formatter:off
         @SuppressWarnings("unchecked")
-        datawave.query.util.sortedset.HdfsBackedSortedSet<String> compactedSortedSet = (datawave.query.util.sortedset.HdfsBackedSortedSet<String>) HdfsBackedSortedSet.builder()
+        HdfsBackedSortedMap<String, String> compactedSortedMap = (HdfsBackedSortedMap<String, String>) HdfsBackedSortedMap.builder()
                 .withIvaratorCacheDirs(ivaratorCacheDirs)
                 .withUniqueSubPath(uniquePath)
                 .withMaxOpenFiles(9999)
                 .withNumRetries(2)
-                .withPersistOptions(new FileSortedSet.PersistOptions())
+                .withPersistOptions(new PersistOptions())
                 .build();
         // @formatter:on
 
         // Ensure that we have 3 entries total
-        Assert.assertEquals(3, compactedSortedSet.size());
+        Assert.assertEquals(3, compactedSortedMap.size());
 
         // This is what we expect to be loaded by the set
         results.clear();
-        results.add(someTestString);
-        results.add(anotherTestString);
-        results.add(lastTestString);
+        results.add(new AbstractMap.SimpleEntry<>("key1", someTestString));
+        results.add(new AbstractMap.SimpleEntry<>("key2", anotherTestString));
+        results.add(new AbstractMap.SimpleEntry<>("key3", lastTestString));
 
         // for each result we find, remove it from the results list and ensure that the list is empty when we're done
-        compactedSortedSet.iterator().forEachRemaining(results::remove);
+        compactedSortedMap.entrySet().forEach(results::remove);
         Assert.assertTrue(results.isEmpty());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/HdfsBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/HdfsBackedSortedMapTest.java
@@ -1,5 +1,9 @@
 package datawave.query.util.sortedmap;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -13,7 +17,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FsStatus;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -32,10 +35,10 @@ public class HdfsBackedSortedMapTest {
         File tempDir = temporaryFolder.newFolder();
 
         File smallDir = new File(tempDir, "small");
-        Assert.assertTrue(smallDir.mkdirs());
+        assertTrue(smallDir.mkdirs());
 
         File largeDir = new File(tempDir, "large");
-        Assert.assertTrue(largeDir.mkdirs());
+        assertTrue(largeDir.mkdirs());
 
         LocalFileSystem fs = new LocalFileSystem();
         fs.initialize(tempDir.toURI(), new Configuration());
@@ -76,13 +79,13 @@ public class HdfsBackedSortedMapTest {
         Path largeSubPath = new Path(largePath, uniquePath);
 
         // ensure that data was written to the large folder, not the small folder
-        Assert.assertFalse(fs.exists(smallSubPath));
-        Assert.assertEquals(0, fs.listStatus(smallPath).length);
-        Assert.assertTrue(fs.exists(largeSubPath));
+        assertFalse(fs.exists(smallSubPath));
+        assertEquals(0, fs.listStatus(smallPath).length);
+        assertTrue(fs.exists(largeSubPath));
 
         FileStatus[] fileStatuses = fs.listStatus(largeSubPath);
-        Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
+        assertEquals(1, fileStatuses.length);
+        assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // Now make sure reloading an ivarator cache dir works
         // @formatter:off
@@ -96,8 +99,8 @@ public class HdfsBackedSortedMapTest {
                 .build();
         // @formatter:on
 
-        Assert.assertEquals(1, reloadedSortedMap.size());
-        Assert.assertEquals(someTestString, reloadedSortedMap.get("key"));
+        assertEquals(1, reloadedSortedMap.size());
+        assertEquals(someTestString, reloadedSortedMap.get("key"));
     }
 
     @Test
@@ -107,7 +110,7 @@ public class HdfsBackedSortedMapTest {
         File[] dirs = new File[] {new File(tempDir, "first"), new File(tempDir, "second"), new File(tempDir, "third")};
 
         for (File dir : dirs)
-            Assert.assertTrue(dir.mkdirs());
+            assertTrue(dir.mkdirs());
 
         String uniquePath = "blah";
 
@@ -166,22 +169,22 @@ public class HdfsBackedSortedMapTest {
         thirdSortedMap.persist();
 
         // ensure that data was written to the first and third folders
-        Assert.assertTrue(fs.exists(subPaths[0]));
-        Assert.assertTrue(fs.exists(subPaths[2]));
+        assertTrue(fs.exists(subPaths[0]));
+        assertTrue(fs.exists(subPaths[2]));
 
         // ensure that data was not written to the second folder
-        Assert.assertFalse(fs.exists(subPaths[1]));
-        Assert.assertEquals(0, fs.listStatus(paths[1]).length);
+        assertFalse(fs.exists(subPaths[1]));
+        assertEquals(0, fs.listStatus(paths[1]).length);
 
         // ensure that 1 file was written to the first folder
         FileStatus[] fileStatuses = fs.listStatus(subPaths[0]);
-        Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
+        assertEquals(1, fileStatuses.length);
+        assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // ensure that 1 file was written to the third folder
         fileStatuses = fs.listStatus(subPaths[2]);
-        Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
+        assertEquals(1, fileStatuses.length);
+        assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // Now make sure reloading an ivarator cache dir works, and set maxOpenFiles to 1 so that we compact during the next persist
         // @formatter:off
@@ -196,7 +199,7 @@ public class HdfsBackedSortedMapTest {
         // @formatter:on
 
         // Ensure that we have 2 entries total
-        Assert.assertEquals(2, reloadedSortedMap.size());
+        assertEquals(2, reloadedSortedMap.size());
 
         // This is what we expect to be loaded by the set
         List<Map.Entry<String,String>> results = new ArrayList<>();
@@ -205,7 +208,7 @@ public class HdfsBackedSortedMapTest {
 
         // for each result we find, remove it from the results list and ensure that the list is empty when we're done
         reloadedSortedMap.entrySet().forEach(results::remove);
-        Assert.assertTrue(results.isEmpty());
+        assertTrue(results.isEmpty());
 
         // Finally, add an entry to the reloaded sorted set
         String lastTestString = "last test string";
@@ -215,17 +218,17 @@ public class HdfsBackedSortedMapTest {
         reloadedSortedMap.persist();
 
         // ensure that data was not written to the second folder
-        Assert.assertFalse(fs.exists(subPaths[1]));
-        Assert.assertEquals(0, fs.listStatus(paths[1]).length);
+        assertFalse(fs.exists(subPaths[1]));
+        assertEquals(0, fs.listStatus(paths[1]).length);
 
         // ensure that while the folder still exists, data no longer exists for the third folder
-        Assert.assertTrue(fs.exists(subPaths[2]));
-        Assert.assertEquals(0, fs.listStatus(subPaths[2]).length);
+        assertTrue(fs.exists(subPaths[2]));
+        assertEquals(0, fs.listStatus(subPaths[2]).length);
 
         // ensure that all data exists in the first folder
         fileStatuses = fs.listStatus(subPaths[0]);
-        Assert.assertEquals(1, fileStatuses.length);
-        Assert.assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
+        assertEquals(1, fileStatuses.length);
+        assertTrue(fileStatuses[0].getPath().getName().startsWith("SortedMap"));
 
         // Finally, make sure that the compacted data can be reloaded
         // @formatter:off
@@ -240,7 +243,7 @@ public class HdfsBackedSortedMapTest {
         // @formatter:on
 
         // Ensure that we have 3 entries total
-        Assert.assertEquals(3, compactedSortedMap.size());
+        assertEquals(3, compactedSortedMap.size());
 
         // This is what we expect to be loaded by the set
         results.clear();
@@ -250,6 +253,6 @@ public class HdfsBackedSortedMapTest {
 
         // for each result we find, remove it from the results list and ensure that the list is empty when we're done
         compactedSortedMap.entrySet().forEach(results::remove);
-        Assert.assertTrue(results.isEmpty());
+        assertTrue(results.isEmpty());
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/HdfsBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/HdfsBackedSortedMapTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -203,8 +202,8 @@ public class HdfsBackedSortedMapTest {
 
         // This is what we expect to be loaded by the set
         List<Map.Entry<String,String>> results = new ArrayList<>();
-        results.add(new AbstractMap.SimpleEntry<>("key1", someTestString));
-        results.add(new AbstractMap.SimpleEntry<>("key2", anotherTestString));
+        results.add(Map.entry("key1", someTestString));
+        results.add(Map.entry("key2", anotherTestString));
 
         // for each result we find, remove it from the results list and ensure that the list is empty when we're done
         reloadedSortedMap.entrySet().forEach(results::remove);
@@ -247,9 +246,9 @@ public class HdfsBackedSortedMapTest {
 
         // This is what we expect to be loaded by the set
         results.clear();
-        results.add(new AbstractMap.SimpleEntry<>("key1", someTestString));
-        results.add(new AbstractMap.SimpleEntry<>("key2", anotherTestString));
-        results.add(new AbstractMap.SimpleEntry<>("key3", lastTestString));
+        results.add(Map.entry("key1", someTestString));
+        results.add(Map.entry("key2", anotherTestString));
+        results.add(Map.entry("key3", lastTestString));
 
         // for each result we find, remove it from the results list and ensure that the list is empty when we're done
         compactedSortedMap.entrySet().forEach(results::remove);

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/MultiMapBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/MultiMapBackedSortedMapTest.java
@@ -21,7 +21,6 @@ import java.util.TreeMap;
 
 import org.apache.commons.collections.keyvalue.UnmodifiableMapEntry;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -143,7 +142,7 @@ public abstract class MultiMapBackedSortedMapTest<K,V> {
 
     private void tryDelete(File file) {
         if (file.exists()) {
-            Assert.assertTrue("Failed to delete file " + file, file.delete());
+            assertTrue("Failed to delete file " + file, file.delete());
         }
     }
 


### PR DESCRIPTION
- BufferedFileBackedSortedMapTest now tests a Map instead of a Set
- tests now prefer static imports
- duplicate directory validation logic now lives in IvaratorCacheDir
- updated FsStatus constructor to one that accepts a path