### PR TITLE
Specify UTF-8 explicitly at ingest String.getBytes() sites

### DIFF
--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityTokenizingFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ColumnVisibilityTokenizingFilter.java
@@ -1,12 +1,14 @@
 package datawave.iterators.filter;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
 import datawave.iterators.filter.ageoff.FilterOptions;
 
 public class ColumnVisibilityTokenizingFilter extends TokenizingFilterBase {
-    private static final byte[] CV_DELIMITERS = "&|()".getBytes();
+    private static final byte[] CV_DELIMITERS = "&|()".getBytes(StandardCharsets.UTF_8);
 
     @Override
     public byte[] getKeyField(Key k, Value V) {

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/EdgeColumnQualifierTokenFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/EdgeColumnQualifierTokenFilter.java
@@ -1,5 +1,7 @@
 package datawave.iterators.filter;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 
@@ -7,7 +9,7 @@ import datawave.iterators.filter.ageoff.FilterOptions;
 
 public class EdgeColumnQualifierTokenFilter extends TokenizingFilterBase {
 
-    private static final byte[] CV_DELIMITERS = "/".getBytes();
+    private static final byte[] CV_DELIMITERS = "/".getBytes(StandardCharsets.UTF_8);
 
     @Override
     public byte[] getKeyField(Key k, Value V) {

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenFilterBase.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenFilterBase.java
@@ -1,5 +1,6 @@
 package datawave.iterators.filter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import org.apache.accumulo.core.data.Key;
@@ -26,7 +27,7 @@ public abstract class TokenFilterBase extends AppliedRule {
 
     // These are the possible delimiters in a column visibility exception for the double quote. NOTE, this is fragile
     // but currently there is no way to get this list out of the accumulo ColumnVisibility class.
-    private static final byte[] DELIMITERS = "|&()".getBytes();
+    private static final byte[] DELIMITERS = "|&()".getBytes(StandardCharsets.UTF_8);
 
     /**
      * This method is to be implemented by sub-classes of this class. It should return the tokens that needs to be tested against a test token for the instance
@@ -124,7 +125,7 @@ public abstract class TokenFilterBase extends AppliedRule {
             String[] patternStrs = options.getOption(AgeOffConfigParams.MATCHPATTERN).split(",");
             patternBytes = new byte[patternStrs.length][];
             for (int i = 0; i < patternStrs.length; i++) {
-                patternBytes[i] = patternStrs[i].trim().getBytes();
+                patternBytes[i] = patternStrs[i].trim().getBytes(StandardCharsets.UTF_8);
             }
         }
         ruleApplied = false;

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenSpecParser.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenSpecParser.java
@@ -1,5 +1,6 @@
 package datawave.iterators.filter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -192,7 +193,7 @@ public abstract class TokenSpecParser<B extends TokenSpecParser> {
                     ttl = parseTtl(ParseTokenType.EQUALS);
                 }
                 try {
-                    builder.addToken(tokenStr.getBytes(), ttl);
+                    builder.addToken(tokenStr.getBytes(StandardCharsets.UTF_8), ttl);
                 } catch (IllegalArgumentException ex) {
                     throw error(ex.getMessage(), initialToken.offset, ex);
                 }

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenizingFilterBase.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/TokenizingFilterBase.java
@@ -1,5 +1,6 @@
 package datawave.iterators.filter;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import org.apache.accumulo.core.data.Key;
@@ -72,7 +73,7 @@ public abstract class TokenizingFilterBase extends AppliedRule {
         if (delimiters == null) {
             throw new IllegalArgumentException("A set of delimiters must be specified");
         }
-        return delimiters.getBytes();
+        return delimiters.getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ageoff/DataTypeAgeOffFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ageoff/DataTypeAgeOffFilter.java
@@ -1,5 +1,6 @@
 package datawave.iterators.filter.ageoff;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -264,7 +265,7 @@ public class DataTypeAgeOffFilter extends AppliedRule {
         if (null != dataTypeOption) {
             String[] dataTypeArray = dataTypeOption.split(",");
             for (String dt : dataTypeArray)
-                dataTypes.add(new ArrayByteSequence(dt.trim().getBytes()));
+                dataTypes.add(new ArrayByteSequence(dt.trim().getBytes(StandardCharsets.UTF_8)));
         }
 
         isIndextable = false;

--- a/warehouse/age-off/src/main/java/datawave/iterators/filter/ageoff/FieldAgeOffFilter.java
+++ b/warehouse/age-off/src/main/java/datawave/iterators/filter/ageoff/FieldAgeOffFilter.java
@@ -1,5 +1,6 @@
 package datawave.iterators.filter.ageoff;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -254,13 +255,13 @@ public class FieldAgeOffFilter extends AppliedRule {
         if (null != fieldsTypeOption) {
             String[] fieldsArray = fieldsTypeOption.split(",");
             for (String dt : fieldsArray)
-                fields.add(new ArrayByteSequence(dt.trim().getBytes()));
+                fields.add(new ArrayByteSequence(dt.trim().getBytes(StandardCharsets.UTF_8)));
         }
 
         for (String optionKey : options.options.keySet()) {
             if (optionKey.startsWith(OPTION_PREFIX)) {
                 String anotherField = optionKey.substring(OPTION_PREFIX.length(), optionKey.indexOf('.', OPTION_PREFIX.length() + 1));
-                fields.add(new ArrayByteSequence(anotherField.trim().getBytes()));
+                fields.add(new ArrayByteSequence(anotherField.trim().getBytes(StandardCharsets.UTF_8)));
             }
         }
 

--- a/warehouse/core/src/main/java/datawave/edge/util/EdgeKey.java
+++ b/warehouse/core/src/main/java/datawave/edge/util/EdgeKey.java
@@ -1,6 +1,7 @@
 package datawave.edge.util;
 
 import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -482,7 +483,7 @@ public class EdgeKey {
 
     private static final String STATS_COLF = "STATS";
 
-    static final byte[] STATS_BYTES = STATS_COLF.getBytes();
+    static final byte[] STATS_BYTES = STATS_COLF.getBytes(StandardCharsets.UTF_8);
 
     private static final int SOURCE_INDEX = 0;
     private static final int SINK_INDEX = 1;

--- a/warehouse/core/src/main/java/datawave/ingest/data/config/ingest/AccumuloHelper.java
+++ b/warehouse/core/src/main/java/datawave/ingest/data/config/ingest/AccumuloHelper.java
@@ -1,5 +1,6 @@
 package datawave.ingest.data.config.ingest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -32,7 +33,7 @@ public class AccumuloHelper {
 
     public void setup(Configuration config) throws IllegalArgumentException {
         username = ConfigurationHelper.isNull(config, USERNAME, String.class);
-        byte[] pw = Base64.decodeBase64(ConfigurationHelper.isNull(config, PASSWORD, String.class).getBytes());
+        byte[] pw = Base64.decodeBase64(ConfigurationHelper.isNull(config, PASSWORD, String.class).getBytes(StandardCharsets.UTF_8));
         password = new PasswordToken(pw);
         instanceName = ConfigurationHelper.isNull(config, INSTANCE_NAME, String.class);
         zooKeepers = ConfigurationHelper.isNull(config, ZOOKEEPERS, String.class);
@@ -97,7 +98,7 @@ public class AccumuloHelper {
     }
 
     public static byte[] getPassword(Configuration conf) {
-        return Base64.decodeBase64(ConfigurationHelper.isNull(conf, PASSWORD, String.class).getBytes());
+        return Base64.decodeBase64(ConfigurationHelper.isNull(conf, PASSWORD, String.class).getBytes(StandardCharsets.UTF_8));
     }
 
     public static String getInstanceName(Configuration conf) {

--- a/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileSystemWatcher.java
+++ b/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileSystemWatcher.java
@@ -2,6 +2,7 @@ package datawave.ingest.util.cache.watch;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -47,7 +48,7 @@ public abstract class FileSystemWatcher<V> extends Reloadable<V> {
         FileChecksum checksum = fs.getFileChecksum(filePath);
 
         if (null == checksum) {
-            return "".getBytes();
+            return "".getBytes(StandardCharsets.UTF_8);
         } else
             return checksum.getBytes();
     }

--- a/warehouse/core/src/main/java/datawave/mr/bulk/BulkInputFormat.java
+++ b/warehouse/core/src/main/java/datawave/mr/bulk/BulkInputFormat.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -568,8 +569,9 @@ public class BulkInputFormat extends InputFormat<Key,Value> {
         Set<Pair<Text,Text>> columns = new HashSet<>();
         for (String col : conf.getStringCollection(COLUMNS)) {
             int idx = col.indexOf(':');
-            Text cf = new Text(idx < 0 ? Base64.decodeBase64(col.getBytes()) : Base64.decodeBase64(col.substring(0, idx).getBytes()));
-            Text cq = idx < 0 ? null : new Text(Base64.decodeBase64(col.substring(idx + 1).getBytes()));
+            Text cf = new Text(idx < 0 ? Base64.decodeBase64(col.getBytes(StandardCharsets.UTF_8))
+                            : Base64.decodeBase64(col.substring(0, idx).getBytes(StandardCharsets.UTF_8)));
+            Text cq = idx < 0 ? null : new Text(Base64.decodeBase64(col.substring(idx + 1).getBytes(StandardCharsets.UTF_8)));
             columns.add(Pair.of(cf, cq));
         }
         return columns;
@@ -663,7 +665,7 @@ public class BulkInputFormat extends InputFormat<Key,Value> {
         } else {
             String passwd = conf.get(PASSWORD);
             if (null != passwd)
-                return passwd.getBytes();
+                return passwd.getBytes(StandardCharsets.UTF_8);
             else
                 return null;
         }

--- a/warehouse/ingest-annotation/src/main/java/datawave/ingest/annotation/mapreduce/handler/AnnotationHelper.java
+++ b/warehouse/ingest-annotation/src/main/java/datawave/ingest/annotation/mapreduce/handler/AnnotationHelper.java
@@ -2,6 +2,7 @@ package datawave.ingest.annotation.mapreduce.handler;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystemNotFoundException;
 import java.util.Date;
 import java.util.Iterator;
@@ -234,7 +235,7 @@ public class AnnotationHelper {
     }
 
     public Annotation buildAnnotation(byte[] jsonInBytes, RawRecordContainer event) throws InvalidProtocolBufferException, SaxonApiException {
-        return buildAnnotation(jsonInBytes, event.getShardId().getBytes(), event.getId(), event.getVisibility().flatten(), event);
+        return buildAnnotation(jsonInBytes, event.getShardId().getBytes(StandardCharsets.UTF_8), event.getId(), event.getVisibility().flatten(), event);
     }
 
     /**

--- a/warehouse/ingest-annotation/src/main/java/datawave/ingest/annotation/mapreduce/input/SimpleAnnotationRecordReader.java
+++ b/warehouse/ingest-annotation/src/main/java/datawave/ingest/annotation/mapreduce/input/SimpleAnnotationRecordReader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import org.apache.commons.collections4.IteratorUtils;
@@ -141,7 +142,7 @@ public class SimpleAnnotationRecordReader extends AbstractEventRecordReader<Byte
     @Override
     public BytesWritable getCurrentValue() throws IOException, InterruptedException {
         if (currentJsonString != null) {
-            return new BytesWritable(currentJsonString.getBytes());
+            return new BytesWritable(currentJsonString.getBytes(StandardCharsets.UTF_8));
         } else {
             return null;
         }
@@ -155,7 +156,7 @@ public class SimpleAnnotationRecordReader extends AbstractEventRecordReader<Byte
             event.setTimestamp(this.inputDate);
         }
 
-        event.setRawData(currentJsonString.getBytes());
+        event.setRawData(currentJsonString.getBytes(StandardCharsets.UTF_8));
 
         if (!event.isTimestampSet()) {
             event.setTimestamp(System.currentTimeMillis());

--- a/warehouse/ingest-configuration/src/main/java/datawave/ingest/config/MimeDecoderImpl.java
+++ b/warehouse/ingest-configuration/src/main/java/datawave/ingest/config/MimeDecoderImpl.java
@@ -1,6 +1,7 @@
 package datawave.ingest.config;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.mail.internet.MimeUtility;
 
@@ -8,7 +9,7 @@ public class MimeDecoderImpl implements MimeDecoder {
 
     @Override
     public byte[] decode(byte[] b) throws UnsupportedEncodingException {
-        return MimeUtility.decodeText(new String(b, "iso-8859-1")).getBytes();
+        return MimeUtility.decodeText(new String(b, "iso-8859-1")).getBytes(StandardCharsets.UTF_8);
     }
 
 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/OptionsParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/OptionsParser.java
@@ -1,5 +1,7 @@
 package datawave.ingest;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.hadoop.conf.Configuration;
 
 import datawave.ingest.config.TableConfigCache;
@@ -39,7 +41,7 @@ public class OptionsParser {
             } else if (args[i].equals(USER_FLAG) || args[i].equals(USER_FLAG_2)) {
                 AccumuloHelper.setUsername(conf, args[++i]);
             } else if (args[i].equals(PASSWORD_FLAG) || args[i].equals(PASSWORD_FLAG_2)) {
-                AccumuloHelper.setPassword(conf, PasswordConverter.parseArg(args[++i]).getBytes());
+                AccumuloHelper.setPassword(conf, PasswordConverter.parseArg(args[++i]).getBytes(StandardCharsets.UTF_8));
             } else if (args[i].equals(ACC_CACHE_DIR_FLAG)) {
                 conf.set(TableConfigCache.ACCUMULO_CONFIG_CACHE_PATH_PROPERTY, args[++i]);
             } else if (args[i].equals(CONFIG_DIR_FLAG)) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/DataTypeOverrideHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/DataTypeOverrideHelper.java
@@ -1,5 +1,6 @@
 package datawave.ingest.data.config;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -166,9 +167,9 @@ public class DataTypeOverrideHelper extends DataTypeHelperImpl {
             for (int i = 2; i < uidParts.length; i++) {
                 extra.append(UIDConstants.DEFAULT_SEPARATOR).append(uidParts[i]);
             }
-            return builder.newId(uidParts[0].getBytes(), time, extra.toString());
+            return builder.newId(uidParts[0].getBytes(StandardCharsets.UTF_8), time, extra.toString());
         } else {
-            return builder.newId(id.getBytes(), time);
+            return builder.newId(id.getBytes(StandardCharsets.UTF_8), time);
         }
     }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/AbstractEventRecordReader.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/AbstractEventRecordReader.java
@@ -1,6 +1,7 @@
 package datawave.ingest.input.reader;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -213,7 +214,7 @@ public abstract class AbstractEventRecordReader<K> extends RecordReader<LongWrit
             builder.append(value);
         }
 
-        return uidBuilder.newId(builder.toString().getBytes(), event.getTimeForUID());
+        return uidBuilder.newId(builder.toString().getBytes(StandardCharsets.UTF_8), event.getTimeForUID());
     }
 
     /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorDataTypeHandler.java
@@ -2,6 +2,7 @@ package datawave.ingest.mapreduce.handler.error;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 
@@ -305,7 +306,8 @@ public class ErrorDataTypeHandler<KEYIN,KEYOUT,VALUEOUT> implements ExtendedData
      */
     private Key createKey(String row, Text colf, Text colq, byte[] vis, long ts) {
         // Note: we can never reverse ingest from the error table
-        return new Key(row.getBytes(), colf.toString().getBytes(), colq.toString().getBytes(), vis, ts, false);
+        return new Key(row.getBytes(StandardCharsets.UTF_8), colf.toString().getBytes(StandardCharsets.UTF_8), colq.toString().getBytes(StandardCharsets.UTF_8),
+                        vis, ts, false);
     }
 
     /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/facet/HashTableFunction.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/facet/HashTableFunction.java
@@ -1,6 +1,7 @@
 package datawave.ingest.mapreduce.handler.facet;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
 import javax.annotation.Nullable;
@@ -32,7 +33,7 @@ import datawave.ingest.mapreduce.job.writer.ContextWriter;
 public class HashTableFunction<KEYIN,KEYOUT,VALUEOUT> implements Function<Collection<NormalizedContentInterface>,Collection<NormalizedContentInterface>> {
 
     public static final String FIELD_APPEND = ".hash";
-    public static final byte[] FIELD_APPEND_BYTES = FIELD_APPEND.getBytes();
+    public static final byte[] FIELD_APPEND_BYTES = FIELD_APPEND.getBytes(StandardCharsets.UTF_8);
     private static final byte[] EMPTY_BYTES = new byte[] {};
     private static final Value EMPTY_VALUE = new Value(EMPTY_BYTES);
 
@@ -96,13 +97,13 @@ public class HashTableFunction<KEYIN,KEYOUT,VALUEOUT> implements Function<Collec
 
             for (NormalizedContentInterface nci : input) {
                 hasher.putUnencodedChars(nci.getIndexedFieldValue());
-                byte[] indexedValue = nci.getIndexedFieldValue().getBytes();
+                byte[] indexedValue = nci.getIndexedFieldValue().getBytes(StandardCharsets.UTF_8);
                 // key maintains a reference to hashBytes, so it is properly updated by the time it is written
                 map.put(new BulkIngestKey(outputTable, new Key(hashBytes, indexedValue, EMPTY_BYTES, EMPTY_BYTES, timestamp, false, false)), EMPTY_VALUE);
             }
 
             final String hash = hasher.hash().toString();
-            final byte[] hashStringBytes = hash.getBytes();
+            final byte[] hashStringBytes = hash.getBytes(StandardCharsets.UTF_8);
             System.arraycopy(hashStringBytes, 0, hashBytes, 0, hashBytes.length);
 
             try {
@@ -135,7 +136,7 @@ public class HashTableFunction<KEYIN,KEYOUT,VALUEOUT> implements Function<Collec
      * @return true if the field name ends with the FIELD_APPEND_BYTES suffix.
      */
     public static boolean isReduced(NormalizedContentInterface pivotTypes) {
-        final byte[] fieldNameBytes = pivotTypes.getIndexedFieldName().getBytes();
+        final byte[] fieldNameBytes = pivotTypes.getIndexedFieldName().getBytes(StandardCharsets.UTF_8);
         if (fieldNameBytes.length > FIELD_APPEND_BYTES.length) {
             // @formatter:off
             final int cmp = WritableComparator.compareBytes(

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardIdFactory.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardIdFactory.java
@@ -1,5 +1,6 @@
 package datawave.ingest.mapreduce.handler.shard;
 
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -32,7 +33,7 @@ public class ShardIdFactory {
      * @return Shard id
      */
     public byte[] getShardIdBytes(RawRecordContainer record) {
-        return getShardId(record).getBytes();
+        return getShardId(record).getBytes(StandardCharsets.UTF_8);
     }
 
     /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -1,5 +1,6 @@
 package datawave.ingest.mapreduce.handler.shard;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -859,13 +860,13 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     }
                 }
                 // Create a key for the masked field value with the masked visibility.
-                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(), colf, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(StandardCharsets.UTF_8), colf, colq, maskedVisibility, event.getTimestamp(), false);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, indexValue);
             }
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, indexValue);
             }
@@ -885,7 +886,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, indexValue);
         }
@@ -1597,7 +1598,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // Dont create index entries for empty values
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
                 // Create a key for the masked field value with the masked visibility
-                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(), colf, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(StandardCharsets.UTF_8), colf, colq, maskedVisibility, event.getTimestamp(), false);
 
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, val);
@@ -1605,7 +1606,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, val);
             }
@@ -1628,7 +1629,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, val);
 
@@ -1669,8 +1670,8 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         Text colf = new Text(directionColFam);
         Text colq = new Text(fieldName);
 
-        Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), false);
-        Value val = new Value("".getBytes());
+        Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, visibility, event.getTimestamp(), false);
+        Value val = new Value("".getBytes(StandardCharsets.UTF_8));
 
         BulkIngestKey bKey = new BulkIngestKey(tableName, k);
         values.put(bKey, val);
@@ -1718,12 +1719,12 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             Text colf = new Text(directionColFam);
             Text colq = new Text(fieldName);
 
-            Value val = new Value("".getBytes());
+            Value val = new Value("".getBytes(StandardCharsets.UTF_8));
 
             // Dont create index entries for empty values
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
                 // Create a key for the masked field value with the masked visibility
-                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(), colf, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(StandardCharsets.UTF_8), colf, colq, maskedVisibility, event.getTimestamp(), false);
 
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, val);
@@ -1731,7 +1732,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, val);
             }
@@ -1741,7 +1742,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             Text colq = new Text(fieldName);
             // TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
 
-            Value val = new Value("".getBytes());
+            Value val = new Value("".getBytes(StandardCharsets.UTF_8));
 
             /**
              * For values that are not being masked, we use the "unmaskedValue" and the masked visibility e.g. release the value as it was in the event at the
@@ -1753,7 +1754,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = this.createIndexKey(fieldValue.getBytes(StandardCharsets.UTF_8), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, val);
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/summary/MetricsSummaryDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/summary/MetricsSummaryDataTypeHandler.java
@@ -1,5 +1,6 @@
 package datawave.ingest.mapreduce.handler.summary;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,7 +55,7 @@ public class MetricsSummaryDataTypeHandler<KEYIN> extends SummaryDataTypeHandler
 
     // constants
     private static final int EXPECTED_VALUES_PER_KEY = 1;
-    public static final Value INCREMENT_ONE_VALUE = new Value("1".getBytes());
+    public static final Value INCREMENT_ONE_VALUE = new Value("1".getBytes(StandardCharsets.UTF_8));
 
     private HandlerDelegate delegate = new HandlerDelegate();
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandler.java
@@ -2,6 +2,7 @@ package datawave.ingest.mapreduce.handler.tokenize;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -604,7 +605,7 @@ public abstract class ContentIndexingColumnBasedHandler<KEYIN> extends AbstractC
                         .append(nfv.getIndexedFieldName());
 
         BulkIngestKey bKey = new BulkIngestKey(new Text(this.getShardTableName()), new Key(shardId, ColumnFamilyConstants.TERM_FREQUENCY_TEXT.getBytes(),
-                        colq.toString().getBytes(), visibility, event.getTimestamp(), helper.getDeleteMode()));
+                        colq.toString().getBytes(StandardCharsets.UTF_8), visibility, event.getTimestamp(), helper.getDeleteMode()));
 
         values.put(bKey, value);
     }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ExtendedContentIndexingColumnBasedHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ExtendedContentIndexingColumnBasedHandler.java
@@ -2,6 +2,7 @@ package datawave.ingest.mapreduce.handler.tokenize;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -353,8 +354,8 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
             TermAndZone indexedTermAndZone = new TermAndZone(nfv.getIndexedFieldValue(), nfv.getIndexedFieldName());
 
             org.apache.hadoop.util.bloom.Key alreadySeen = null;
-            if ((alreadyIndexedTerms != null) && alreadyIndexedTerms
-                            .membershipTest(alreadySeen = new org.apache.hadoop.util.bloom.Key(indexedTermAndZone.getToken().getBytes()))) {
+            if ((alreadyIndexedTerms != null) && alreadyIndexedTerms.membershipTest(
+                            alreadySeen = new org.apache.hadoop.util.bloom.Key(indexedTermAndZone.getToken().getBytes(StandardCharsets.UTF_8)))) {
                 if (log.isDebugEnabled()) {
                     log.debug("Not creating index mutations for {} as we've already created mutations for it.", termAndZone);
                 }
@@ -806,7 +807,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
                         .append(nfv.getIndexedFieldName());
 
         BulkIngestKey bKey = new BulkIngestKey(new Text(this.getShardTableName()), new Key(shardId, ColumnFamilyConstants.TERM_FREQUENCY_TEXT.getBytes(),
-                        colq.toString().getBytes(), visibility, event.getTimestamp(), deleteMode));
+                        colq.toString().getBytes(StandardCharsets.UTF_8), visibility, event.getTimestamp(), deleteMode));
 
         contextWriter.write(bKey, value, context);
     }
@@ -851,7 +852,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
         Text colq = new Text(shardId);
         TextUtil.textAppend(colq, this.eventDataTypeName, replacedMalformedUTF8);
 
-        Key k = this.createIndexKey(nFV.getIndexedFieldValue().getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+        Key k = this.createIndexKey(nFV.getIndexedFieldValue().getBytes(StandardCharsets.UTF_8), colf, colq, visibility, event.getTimestamp(), deleteMode);
 
         // Create a UID object for the Value
         Value val = createUidArray(eventUid, deleteMode);
@@ -862,7 +863,8 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
         if (getBitSetIndexEnabled()) {
             String shard = new String(shardId);
             String cq = shard.substring(0, 8) + '\u0000' + event.getDataType().outputName();
-            Key key = new Key(nFV.getEventFieldValue().getBytes(), nFV.getEventFieldName().getBytes(), cq.getBytes(), visibility, event.getTimestamp());
+            Key key = new Key(nFV.getEventFieldValue().getBytes(StandardCharsets.UTF_8), nFV.getEventFieldName().getBytes(StandardCharsets.UTF_8),
+                            cq.getBytes(StandardCharsets.UTF_8), visibility, event.getTimestamp());
             Value value = getValueForBitsetIndex(shard);
             BulkIngestKey bik = new BulkIngestKey(getShardBitsetIndexTableName(), key);
             contextWriter.write(bik, value, context);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/IngestJob.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -630,7 +631,7 @@ public class IngestJob implements Tool {
                 userName = args[++i];
                 AccumuloHelper.setUsername(conf, userName);
             } else if (args[i].equals("-pass")) {
-                password = PasswordConverter.parseArg(args[++i]).getBytes();
+                password = PasswordConverter.parseArg(args[++i]).getBytes(StandardCharsets.UTF_8);
                 AccumuloHelper.setPassword(conf, password);
             } else if (args[i].equals("-flagFile")) {
                 flagFile = args[++i];

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SplitsFile.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SplitsFile.java
@@ -3,6 +3,7 @@ package datawave.ingest.mapreduce.job;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,7 +135,7 @@ public class SplitsFile {
      */
     private static boolean shardsExistForDate(Map<Text,String> locations, String datePrefix, int expectedNumberOfShards) {
         int count = 0;
-        byte[] prefixBytes = datePrefix.getBytes();
+        byte[] prefixBytes = datePrefix.getBytes(StandardCharsets.UTF_8);
         for (Text key : locations.keySet()) {
             if (prefixMatches(prefixBytes, key.getBytes(), key.getLength())) {
                 count++;
@@ -157,7 +158,7 @@ public class SplitsFile {
         boolean dateIsBalanced = true;
 
         Map<String,MutableInt> tabletsSeenForDate = new HashMap<>();
-        byte[] prefixBytes = datePrefix.getBytes();
+        byte[] prefixBytes = datePrefix.getBytes(StandardCharsets.UTF_8);
 
         for (Map.Entry<Text,String> entry : locations.entrySet()) {
             Text key = entry.getKey();

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/TableSplitsCache.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/TableSplitsCache.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -287,8 +288,8 @@ public class TableSplitsCache extends BaseHdfsFileCacheUtil {
     @VisibleForTesting
     public void writeLocations(PrintStream out, String table, List<Text> splits, Map<Text,String> splitLocations) {
         for (Text split : splits) {
-            out.println(tableCacheIds.get(table) + this.delimiter + new String(Base64.encodeBase64(split.toString().trim().getBytes())) + "\t"
-                            + splitLocations.get(split));
+            out.println(tableCacheIds.get(table) + this.delimiter + new String(Base64.encodeBase64(split.toString().trim().getBytes(StandardCharsets.UTF_8)))
+                            + "\t" + splitLocations.get(split));
         }
     }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reindex/RepartitionerJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reindex/RepartitionerJob.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
@@ -81,7 +82,7 @@ public class RepartitionerJob implements Tool {
 
         // configure the accumulo helper
         AccumuloHelper.setInstanceName(configuration, jobConfig.instance);
-        AccumuloHelper.setPassword(configuration, getPassword().getBytes());
+        AccumuloHelper.setPassword(configuration, getPassword().getBytes(StandardCharsets.UTF_8));
         AccumuloHelper.setUsername(configuration, jobConfig.username);
         AccumuloHelper.setZooKeepers(configuration, jobConfig.zookeepers);
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reindex/ShardReindexJob.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reindex/ShardReindexJob.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -195,7 +196,7 @@ public class ShardReindexJob implements Tool {
 
         // setup the accumulo helper
         AccumuloHelper.setInstanceName(configuration, jobConfig.instance);
-        AccumuloHelper.setPassword(configuration, getPassword().getBytes());
+        AccumuloHelper.setPassword(configuration, getPassword().getBytes(StandardCharsets.UTF_8));
         AccumuloHelper.setUsername(configuration, jobConfig.username);
         AccumuloHelper.setZooKeepers(configuration, jobConfig.zookeepers);
         // TODO convert to this?

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/util/AccumuloUtil.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/util/AccumuloUtil.java
@@ -1,5 +1,6 @@
 package datawave.ingest.mapreduce.job.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -64,7 +65,7 @@ public class AccumuloUtil {
         AccumuloHelper.setInstanceName(config, instanceName);
         AccumuloHelper.setZooKeepers(config, zookeepers);
         AccumuloHelper.setUsername(config, username);
-        AccumuloHelper.setPassword(config, password.getBytes());
+        AccumuloHelper.setPassword(config, password.getBytes(StandardCharsets.UTF_8));
         if (clientPropertiesPath != null) {
             AccumuloHelper.setClientPropertiesPath(config, clientPropertiesPath);
         }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedDayIndexKeyParser.java
@@ -1,5 +1,6 @@
 package datawave.ingest.table.aggregator.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 
 import org.apache.accumulo.core.data.Key;
@@ -35,9 +36,9 @@ public class ShardedDayIndexKeyParser extends AbstractIndexKeyParser {
         }
 
         // use a byte array constructor to avoid expensive parsing of the ColumnVisibility
-        byte[] row = (getDate() + NULL_CHAR + getValue()).getBytes();
-        byte[] cf = getField().getBytes();
-        byte[] cq = getDatatype().getBytes();
+        byte[] row = (getDate() + NULL_CHAR + getValue()).getBytes(StandardCharsets.UTF_8);
+        byte[] cf = getField().getBytes(StandardCharsets.UTF_8);
+        byte[] cq = getDatatype().getBytes(StandardCharsets.UTF_8);
         byte[] cv = key.getColumnVisibilityData().toArray();
         return new Key(row, cf, cq, cv, key.getTimestamp());
     }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedYearIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/ShardedYearIndexKeyParser.java
@@ -1,5 +1,6 @@
 package datawave.ingest.table.aggregator.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 import java.util.Calendar;
 
@@ -18,9 +19,9 @@ public class ShardedYearIndexKeyParser extends AbstractIndexKeyParser {
 
         // use a byte array constructor to avoid expensive parsing of the ColumnVisibility
         String year = getYear();
-        byte[] row = (year + NULL_CHAR + getValue()).getBytes();
-        byte[] cf = getField().getBytes();
-        byte[] cq = getDatatype().getBytes();
+        byte[] row = (year + NULL_CHAR + getValue()).getBytes(StandardCharsets.UTF_8);
+        byte[] cf = getField().getBytes(StandardCharsets.UTF_8);
+        byte[] cq = getDatatype().getBytes(StandardCharsets.UTF_8);
         byte[] cv = key.getColumnVisibilityData().toArray();
         return new Key(row, cf, cq, cv, key.getTimestamp());
     }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/TruncatedIndexKeyParser.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/util/TruncatedIndexKeyParser.java
@@ -1,5 +1,6 @@
 package datawave.ingest.table.aggregator.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.BitSet;
 
 import org.apache.accumulo.core.data.Key;
@@ -31,9 +32,9 @@ public class TruncatedIndexKeyParser extends AbstractIndexKeyParser {
         if (isStandardKey()) {
             // might want to snag the delete flag as well in the future
             // use a byte array constructor to avoid expensive parsing of the ColumnVisibility
-            byte[] row = getValue().getBytes();
-            byte[] cf = getField().getBytes();
-            byte[] cq = (getDate() + NULL_CHAR + getDatatype()).getBytes();
+            byte[] row = getValue().getBytes(StandardCharsets.UTF_8);
+            byte[] cf = getField().getBytes(StandardCharsets.UTF_8);
+            byte[] cq = (getDate() + NULL_CHAR + getDatatype()).getBytes(StandardCharsets.UTF_8);
             byte[] cv = key.getColumnVisibilityData().toArray();
             return new Key(row, cf, cq, cv, key.getTimestamp());
         } else {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/AccumuloCliOptions.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/AccumuloCliOptions.java
@@ -1,5 +1,7 @@
 package datawave.ingest.util;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
@@ -78,7 +80,7 @@ public class AccumuloCliOptions {
 
     public void setAccumuloConfiguration(Configuration conf) {
         AccumuloHelper.setUsername(conf, cl.getOptionValue("u"));
-        AccumuloHelper.setPassword(conf, PasswordConverter.parseArg(cl.getOptionValue("p")).getBytes());
+        AccumuloHelper.setPassword(conf, PasswordConverter.parseArg(cl.getOptionValue("p")).getBytes(StandardCharsets.UTF_8));
         AccumuloHelper.setInstanceName(conf, cl.getOptionValue("i"));
         AccumuloHelper.setZooKeepers(conf, cl.getOptionValue("zk"));
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateEdgeKeyVersionCache.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateEdgeKeyVersionCache.java
@@ -1,5 +1,6 @@
 package datawave.ingest.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import org.apache.commons.codec.binary.Base64;
@@ -57,7 +58,7 @@ public class GenerateEdgeKeyVersionCache {
                         printUsageAndExit();
                     } else {
                         username = toolArgs[i];
-                        password = PasswordConverter.parseArg(toolArgs[i + 1]).getBytes();
+                        password = PasswordConverter.parseArg(toolArgs[i + 1]).getBytes(StandardCharsets.UTF_8);
                         tableName = toolArgs[i + 2];
                         // skip over args
                         i += 3;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateShardSplits.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateShardSplits.java
@@ -1,5 +1,6 @@
 package datawave.ingest.util;
 
+import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -163,7 +164,7 @@ public class GenerateShardSplits {
                     printUsageAndExit();
                 } else {
                     username = args[i];
-                    password = PasswordConverter.parseArg(args[i + 1]).getBytes();
+                    password = PasswordConverter.parseArg(args[i + 1]).getBytes(StandardCharsets.UTF_8);
                     tableName = args[i + 2];
                     // skip over args
                     i += 3;

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/Identity.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/Identity.java
@@ -1,5 +1,6 @@
 package datawave.ingest.util;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 import org.apache.log4j.Logger;
@@ -64,14 +65,14 @@ public class Identity {
     }
 
     public void updateId(String value) {
-        md.update(value.getBytes());
+        md.update(value.getBytes(StandardCharsets.UTF_8));
     }
 
     public void updateId(String[] value) {
         sb.setLength(0);
         for (int i = 0; i < value.length; i++)
             sb.append(value[i]);
-        md.update(sb.toString().getBytes());
+        md.update(sb.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     public byte[] getDigest(byte esc) {
@@ -104,7 +105,7 @@ public class Identity {
 
     public String getId(String message) {
         clearId();
-        updateId(message.getBytes());
+        updateId(message.getBytes(StandardCharsets.UTF_8));
         return getId();
     }
 

--- a/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/iterators/PropogatingIterator.java
@@ -1,6 +1,7 @@
 package datawave.iterators;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -331,7 +332,7 @@ public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, O
                         log.debug("Default aggregator is " + propAgg.getClass());
                     defaultAgg = propAgg;
                 } else {
-                    aggMap.put(new ArrayByteSequence(familyOption.getKey().getBytes()), propAgg);
+                    aggMap.put(new ArrayByteSequence(familyOption.getKey().getBytes(StandardCharsets.UTF_8)), propAgg);
                 }
             }
         }

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMaker.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagMaker.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -562,7 +563,7 @@ public class FlagMaker implements Runnable, Observer, SizeValidator {
                 }
             }
 
-            flagOS.write(sb.toString().getBytes());
+            flagOS.write(sb.toString().getBytes(StandardCharsets.UTF_8));
         }
 
         return f;

--- a/warehouse/ingest-csv/src/main/java/datawave/ingest/csv/mr/input/CSVReaderBase.java
+++ b/warehouse/ingest-csv/src/main/java/datawave/ingest/csv/mr/input/CSVReaderBase.java
@@ -1,6 +1,7 @@
 package datawave.ingest.csv.mr.input;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -186,7 +187,7 @@ public class CSVReaderBase extends LongLineEventRecordReader implements EventRec
         // decorate with additional data (used by overriding classes)
         decorateEvent();
 
-        event.setRawData(rawEventRecordStr.getBytes());
+        event.setRawData(rawEventRecordStr.getBytes(StandardCharsets.UTF_8));
 
         // Check to see if we need to override the UID. The use case for this is that some of the hashes are "enrichment" and the same
         // values will be loaded over and over again. By default, the UID is calculated on the raw byte[]

--- a/warehouse/ingest-json/src/main/java/datawave/ingest/json/mr/input/JsonRecordReader.java
+++ b/warehouse/ingest-json/src/main/java/datawave/ingest/json/mr/input/JsonRecordReader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -92,7 +93,7 @@ public class JsonRecordReader extends AbstractEventRecordReader<BytesWritable> {
     @Override
     public BytesWritable getCurrentValue() {
         if (currentJsonObj != null) {
-            return new BytesWritable(currentJsonObj.toString().getBytes());
+            return new BytesWritable(currentJsonObj.toString().getBytes(StandardCharsets.UTF_8));
         } else {
             return null;
         }
@@ -226,7 +227,7 @@ public class JsonRecordReader extends AbstractEventRecordReader<BytesWritable> {
 
         decorateEvent();
 
-        event.setRawData(currentJsonObj.toString().getBytes());
+        event.setRawData(currentJsonObj.toString().getBytes(StandardCharsets.UTF_8));
 
         if (!event.isTimestampSet()) {
             event.setTimestamp(System.currentTimeMillis());

--- a/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaDataTypeHandler.java
+++ b/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaDataTypeHandler.java
@@ -3,6 +3,7 @@ package datawave.ingest.wikipedia;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -224,7 +225,7 @@ public class WikipediaDataTypeHandler<KEYIN,KEYOUT,VALUEOUT> extends ExtendedCon
 
                 // Create the full content record
                 if (!content.isEmpty()) {
-                    createContentRecord(event, contextWriter, context, reporter, colf, visibility, this.shardId, content.getBytes());
+                    createContentRecord(event, contextWriter, context, reporter, colf, visibility, this.shardId, content.getBytes(StandardCharsets.UTF_8));
 
                     norm = new NormalizedFieldAndValue(contentPresenceFieldName, "true");
                     byte[] fieldVisibility = getVisibility(event, norm);

--- a/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaRecordReader.java
+++ b/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaRecordReader.java
@@ -4,6 +4,7 @@ import static datawave.ingest.input.reader.LineReader.Properties.LONGLINE_NEWLIN
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Date;
@@ -242,7 +243,7 @@ public class WikipediaRecordReader extends AggregatingRecordReader {
             this.parser.reset();
             String data = rawPageText.toString().trim();
 
-            event.setRawData(data.getBytes());
+            event.setRawData(data.getBytes(StandardCharsets.UTF_8));
 
             try {
                 StringReader reader = new StringReader(data);
@@ -257,7 +258,7 @@ public class WikipediaRecordReader extends AggregatingRecordReader {
             updateEventDate(event);
 
             if (event instanceof Configurable) {
-                event.setId(UID.builder(((Configurable) event).getConf()).newId(data.getBytes(), event.getTimeForUID()));
+                event.setId(UID.builder(((Configurable) event).getConf()).newId(data.getBytes(StandardCharsets.UTF_8), event.getTimeForUID()));
             } else {
                 event.generateId(null);
             }

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/FileByteSummaryLoader.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/FileByteSummaryLoader.java
@@ -1,6 +1,7 @@
 package datawave.metrics.analytic;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Properties;
@@ -66,7 +67,7 @@ public class FileByteSummaryLoader extends Configured implements Tool {
         }
 
         private Value makeValue(String value) {
-            return new Value(value.getBytes());
+            return new Value(value.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/IngestMetricsSummaryLoader.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/IngestMetricsSummaryLoader.java
@@ -3,6 +3,7 @@ package datawave.metrics.analytic;
 import static datawave.metrics.analytic.MetricsDailySummaryReducer.WeightedPair;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -213,7 +214,7 @@ public class IngestMetricsSummaryLoader extends Configured implements Tool {
         }
 
         private Value makeValue(String value) {
-            return new Value(value.getBytes());
+            return new Value(value.getBytes(StandardCharsets.UTF_8));
         }
 
         private Value makeValue(long value) {

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/MetricsDailySummaryReducer.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/MetricsDailySummaryReducer.java
@@ -3,6 +3,7 @@ package datawave.metrics.analytic;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -72,7 +73,7 @@ public class MetricsDailySummaryReducer extends Reducer<Key,Value,Text,Mutation>
 
         ColumnVisibility columnVisibility = new ColumnVisibility(key.getColumnVisibility());
         Mutation m = new Mutation(key.getRow());
-        m.put(key.getColumnFamily(), key.getColumnQualifier(), columnVisibility, new Value(sum.getReport().getBytes()));
+        m.put(key.getColumnFamily(), key.getColumnQualifier(), columnVisibility, new Value(sum.getReport().getBytes(StandardCharsets.UTF_8)));
         return m;
     }
 
@@ -110,13 +111,13 @@ public class MetricsDailySummaryReducer extends Reducer<Key,Value,Text,Mutation>
         ColumnVisibility columnVisibility = new ColumnVisibility(key.getColumnVisibility());
         Text columnFamily = key.getColumnFamily();
         Mutation m = new Mutation(key.getRow());
-        m.put(columnFamily, MIN_TEXT, columnVisibility, new Value(Long.toString(min).getBytes()));
-        m.put(columnFamily, MAX_TEXT, columnVisibility, new Value(Long.toString(max).getBytes()));
-        m.put(columnFamily, AVERAGE_TEXT, columnVisibility, new Value(average.getBytes()));
+        m.put(columnFamily, MIN_TEXT, columnVisibility, new Value(Long.toString(min).getBytes(StandardCharsets.UTF_8)));
+        m.put(columnFamily, MAX_TEXT, columnVisibility, new Value(Long.toString(max).getBytes(StandardCharsets.UTF_8)));
+        m.put(columnFamily, AVERAGE_TEXT, columnVisibility, new Value(average.getBytes(StandardCharsets.UTF_8)));
         if (numLongs <= MAX_MEDIAN_COUNT) {
             Collections.sort(longs);
             String median = "" + longs.get(longs.size() / 2);
-            m.put(columnFamily, MEDIAN_TEXT, columnVisibility, new Value(median.getBytes()));
+            m.put(columnFamily, MEDIAN_TEXT, columnVisibility, new Value(median.getBytes(StandardCharsets.UTF_8)));
         }
         return m;
     }
@@ -160,13 +161,13 @@ public class MetricsDailySummaryReducer extends Reducer<Key,Value,Text,Mutation>
         ColumnVisibility columnVisibility = new ColumnVisibility(key.getColumnVisibility());
         Text columnFamily = key.getColumnFamily();
         Mutation m = new Mutation(key.getRow());
-        m.put(columnFamily, MIN_TEXT, columnVisibility, new Value(Long.toString(min).getBytes()));
-        m.put(columnFamily, MAX_TEXT, columnVisibility, new Value(Long.toString(max).getBytes()));
-        m.put(columnFamily, AVERAGE_TEXT, columnVisibility, new Value(average.getBytes()));
+        m.put(columnFamily, MIN_TEXT, columnVisibility, new Value(Long.toString(min).getBytes(StandardCharsets.UTF_8)));
+        m.put(columnFamily, MAX_TEXT, columnVisibility, new Value(Long.toString(max).getBytes(StandardCharsets.UTF_8)));
+        m.put(columnFamily, AVERAGE_TEXT, columnVisibility, new Value(average.getBytes(StandardCharsets.UTF_8)));
         if (numPairs <= MAX_MEDIAN_COUNT) {
             Collections.sort(pairs);
             String median = "" + pairs.get(pairs.size() / 2).getValue();
-            m.put(columnFamily, MEDIAN_TEXT, columnVisibility, new Value(median.getBytes()));
+            m.put(columnFamily, MEDIAN_TEXT, columnVisibility, new Value(median.getBytes(StandardCharsets.UTF_8)));
 
             // Figure out the position in the list where the sum of the weights up to that point is
             // at the 95% percentile. We'll then take the value at that position. Go through the
@@ -179,7 +180,7 @@ public class MetricsDailySummaryReducer extends Reducer<Key,Value,Text,Mutation>
                 positionWeight -= pair.getWeight();
                 if (positionWeight < percentileWeight) { // this pair's weight contribution took us to or over the 95th percentile weight...
                     String percentile = "" + pair.getValue();
-                    m.put(columnFamily, PERCENTILE_TEXT, columnVisibility, new Value(percentile.getBytes()));
+                    m.put(columnFamily, PERCENTILE_TEXT, columnVisibility, new Value(percentile.getBytes(StandardCharsets.UTF_8)));
                     break;
                 }
             }

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/QueryMetricsSummaryLoader.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/analytic/QueryMetricsSummaryLoader.java
@@ -1,6 +1,7 @@
 package datawave.metrics.analytic;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -234,7 +235,7 @@ public class QueryMetricsSummaryLoader extends Configured implements Tool {
         }
 
         private Value makeValue(String value) {
-            return new Value(value.getBytes());
+            return new Value(value.getBytes(StandardCharsets.UTF_8));
         }
 
         private Value makeValue(long value) {

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/iterators/EventCountIterator.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/iterators/EventCountIterator.java
@@ -1,5 +1,6 @@
 package datawave.metrics.iterators;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,7 +52,7 @@ public class EventCountIterator extends RowIterator {
         }
         row.clear();
         Key newKey = new Key(timestamp, new Text(Long.toString(count)), WritableUtil.EmptyText);
-        row.put(newKey, new Value(collectionToCsv(jobIds).getBytes()));
+        row.put(newKey, new Value(collectionToCsv(jobIds).getBytes(StandardCharsets.UTF_8)));
     }
 
     private String collectionToCsv(Collection<String> cs) {

--- a/warehouse/metrics-core/src/main/java/datawave/metrics/iterators/JsonCountersIterator.java
+++ b/warehouse/metrics-core/src/main/java/datawave/metrics/iterators/JsonCountersIterator.java
@@ -3,6 +3,7 @@ package datawave.metrics.iterators;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.accumulo.core.data.Key;
@@ -76,7 +77,7 @@ public class JsonCountersIterator extends WrappingIterator implements OptionDesc
                 Counters counters = new Counters();
                 counters.readFields(ByteStreams.newDataInput(topValue.get()));
                 String json = gson.toJson(counters);
-                return new Value(json.getBytes());
+                return new Value(json.getBytes(StandardCharsets.UTF_8));
             } catch (IOException e) {
                 log.debug("Unable to parse value for key " + getTopKey() + " as a counters", e);
                 return topValue;


### PR DESCRIPTION

Closes #3596

Pins the charset on the ingest encode path: `String.getBytes()` ->
`getBytes(StandardCharsets.UTF_8)` across the warehouse ingest modules. Only
`String` receivers are touched; Hadoop `Text` / Accumulo `Value` / HyperLogLog
sites are left as-is.

96 call sites across 49 files. No functional change beyond fixing the charset.