### PR TITLE
Migrate core/tables SnowflakeUIDTest from JUnit4 to JUnit5

### DIFF
--- a/core/tables/src/test/java/datawave/table/hash/SnowflakeUIDTest.java
+++ b/core/tables/src/test/java/datawave/table/hash/SnowflakeUIDTest.java
@@ -1,10 +1,10 @@
 package datawave.table.hash;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -18,8 +18,8 @@ import java.util.Date;
 
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SnowflakeUIDTest {
 
@@ -29,7 +29,7 @@ public class SnowflakeUIDTest {
     private final String data2 = "20100831: the quick brown fox jumped over the lazy dog";
     private final Configuration conf = new Configuration();
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         conf.set(UIDConstants.CONFIG_UID_TYPE_KEY, SnowflakeUID.class.getSimpleName());
         conf.set(UIDConstants.CONFIG_MACHINE_ID_KEY, "" + SnowflakeUID.MAX_MACHINE_ID);
@@ -527,7 +527,7 @@ public class SnowflakeUIDTest {
             storedTimestamp = expectedTimestamp;
 
             assertEquals(myMachineId, uid.getMachineId());
-            assertTrue("Not initialized", ZkSnowflakeCache.isInitialized());
+            assertTrue(ZkSnowflakeCache.isInitialized(), "Not initialized");
             assertEquals(expectedTimestamp, uid.getTimestamp());
             assertEquals(expectedSequence, uid.getSequenceId());
             assertEquals(storedTimestamp, ZkSnowflakeCache.getLastCachedTid((BigInteger.valueOf(uid.getMachineId()))));


### PR DESCRIPTION
## Summary
- Migrates `SnowflakeUIDTest` in `core/tables` from JUnit4 to JUnit5
- Replaces `org.junit.*` imports with `org.junit.jupiter.api.*` equivalents
- Renames `@Before` → `@BeforeEach`
- Fixes `assertTrue(String, boolean)` argument order to JUnit5 convention (`boolean, String`)

## Test plan
- [x] `core/tables` module builds clean: `mvn clean install -T1.0C -Dmaven.build.cache.enabled=false`
- [x] All 47 tests pass (13 in `SnowflakeUIDTest`, 34 in remaining test classes)
- [x] No JUnit4 imports remain in `core/tables`

🤖 Generated with [Claude Code](https://claude.com/claude-code)