### PR TITLE
task/add-values-only-as-optional Added values.only as optional parameter

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/discovery/DiscoveryLogic.java
@@ -678,6 +678,7 @@ public class DiscoveryLogic extends ShardIndexQueryTable {
         Set<String> params = super.getOptionalQueryParameters();
         params.add(SEPARATE_COUNTS_BY_COLVIS);
         params.add(SUM_COUNTS);
+        params.add(VALUES_ONLY);
         return params;
     }
 


### PR DESCRIPTION
Add values.only as an optional parameter for the Query Logic documentation page.