### PR TITLE
Feature/banned dependencies

### DIFF
--- a/core/in-memory-accumulo/pom.xml
+++ b/core/in-memory-accumulo/pom.xml
@@ -241,6 +241,8 @@
                                             <exclude>log4j:log4j</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>ch.qos.logback:logback-classic</exclude>
+                                            <!-- exclude all versions of log4j before version.log4j -->
+                                            <exclude>org.apache.logging.log4j:*:(,${version.log4j})</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/microservices/microservice-parent/pom.xml
+++ b/microservices/microservice-parent/pom.xml
@@ -608,6 +608,8 @@
                                         <exclude>org.slf4j:slf4j-reload4j</exclude>
                                         <exclude>org.slf4j:slf4j-log4j12</exclude>
                                         <exclude>joda-time:joda-time</exclude>
+                                        <!-- exclude all versions of log4j before version.log4j -->
+                                        <exclude>org.apache.logging.log4j:*:(,${version.log4j})</exclude>
                                         <!-- spring boot microservices do not use 1.x versions of junit -->
                                         <exclude>junit:junit</exclude>
                                     </excludes>

--- a/microservices/microservice-parent/pom.xml
+++ b/microservices/microservice-parent/pom.xml
@@ -591,6 +591,35 @@
                             <fail>true</fail>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- spring boot microservices do not use 1.x versions of log4j -->
+                                        <exclude>log4j:log4j</exclude>
+                                        <!-- spring boot microservices do not use the following slf4j binders -->
+                                        <exclude>ch.qos.reload4j:reload4j</exclude>
+                                        <exclude>ch.qos.logback:logback-classic</exclude>
+                                        <exclude>org.slf4j:slf4j-reload4j</exclude>
+                                        <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                        <exclude>joda-time:joda-time</exclude>
+                                        <!-- spring boot microservices do not use 1.x versions of junit -->
+                                        <exclude>junit:junit</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <!-- some spring boot microservices include test dependencies which use 1.x versions of junit -->
+                                        <include>junit:junit:*:*:test</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/microservices/microservice-service-parent/pom.xml
+++ b/microservices/microservice-service-parent/pom.xml
@@ -207,32 +207,6 @@
                                 <fail>true</fail>
                             </configuration>
                         </execution>
-                        <execution>
-                            <id>enforce-banned-dependencies</id>
-                            <goals>
-                                <goal>enforce</goal>
-                            </goals>
-                            <configuration>
-                                <rules>
-                                    <bannedDependencies>
-                                        <excludes>
-                                            <!-- spring boot microservices do not use the following slf4j binders -->
-                                            <exclude>ch.qos.reload4j:reload4j</exclude>
-                                            <exclude>org.slf4j:slf4j-reload4j</exclude>
-                                            <!-- spring boot microservices do not use 1.x versions of log4j -->
-                                            <exclude>log4j:log4j</exclude>
-                                            <!-- spring boot microservices do not use 1.x versions of junit -->
-                                            <exclude>junit:junit</exclude>
-                                        </excludes>
-                                        <includes>
-                                            <!-- some spring boot microservices include test dependencies which use 1.x versions of junit -->
-                                            <include>junit:junit:*:*:test</include>
-                                        </includes>
-                                    </bannedDependencies>
-                                </rules>
-                                <fail>true</fail>
-                            </configuration>
-                        </execution>
                     </executions>
                 </plugin>
                 <plugin>

--- a/microservices/services/accumulo/service/pom.xml
+++ b/microservices/services/accumulo/service/pom.xml
@@ -171,6 +171,12 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${version.zookeeper}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1915,6 +1915,8 @@
                                             <exclude>org.slf4j:slf4j-reload4j</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>joda-time:joda-time</exclude>
+                                            <!-- exclude all versions of log4j before version.log4j -->
+                                            <exclude>org.apache.logging.log4j:*:(,${version.log4j})</exclude>
                                         </excludes>
                                     </bannedDependencies>
                                 </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -1910,6 +1910,8 @@
                                             <exclude>log4j:log4j</exclude>
                                             <exclude>ch.qos.reload4j:reload4j</exclude>
                                             <exclude>ch.qos.logback:logback-classic</exclude>
+                                            <!-- exclude all versions of log4j before version.log4j -->
+                                            <exclude>org.apache.logging.log4j:*:(,${version.log4j})</exclude>
                                             <exclude>org.slf4j:slf4j-reload4j</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>joda-time:joda-time</exclude>

--- a/web-services/pom.xml
+++ b/web-services/pom.xml
@@ -618,24 +618,6 @@
                             <fail>true</fail>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>enforce-banned-dependencies</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>log4j:log4j</exclude>
-                                        <exclude>org.slf4j:slf4j-log4j12</exclude>
-                                    </excludes>
-                                    <includes />
-                                </bannedDependencies>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
the banned dependencies in web-service/pom.xml were a subset of those in pom.xml and were overriding them
enforce trhe currently specified log4j version using banned dependencies (of prior version)

 