### PR TITLE
specify version of log4j dependency in spotbugs and spring-boot plugins in configcheck, parent poms

### DIFF
--- a/microservices/configcheck/pom.xml
+++ b/microservices/configcheck/pom.xml
@@ -266,6 +266,11 @@
                 </configuration>
                 <dependencies>
                     <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-to-slf4j</artifactId>
+                        <version>${version.log4j}</version>
+                    </dependency>
+                    <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-sink-api</artifactId>
                         <version>2.0.0</version>

--- a/microservices/microservice-parent/pom.xml
+++ b/microservices/microservice-parent/pom.xml
@@ -322,6 +322,11 @@
                     </configuration>
                     <dependencies>
                         <dependency>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-to-slf4j</artifactId>
+                            <version>${version.log4j}</version>
+                        </dependency>
+                        <dependency>
                             <groupId>org.apache.maven.doxia</groupId>
                             <artifactId>doxia-sink-api</artifactId>
                             <version>2.0.0</version>

--- a/microservices/microservice-service-parent/pom.xml
+++ b/microservices/microservice-service-parent/pom.xml
@@ -293,6 +293,13 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${version.spring.boot}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-slf4j2-impl</artifactId>
+                            <version>${version.log4j}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>generate-build-info</id>

--- a/microservices/services/mapreduce-query/jobs/core/pom.xml
+++ b/microservices/services/mapreduce-query/jobs/core/pom.xml
@@ -131,6 +131,11 @@
                         <artifactId>mapreduce-layout-factory</artifactId>
                         <version>${version.datawave.mapreduce-layout-factory}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j2-impl</artifactId>
+                        <version>${version.log4j}</version>
+                    </dependency>
                 </dependencies>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1695,6 +1695,11 @@
                     </configuration>
                     <dependencies>
                         <dependency>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-to-slf4j</artifactId>
+                            <version>${version.log4j}</version>
+                        </dependency>
+                        <dependency>
                             <groupId>org.apache.maven.doxia</groupId>
                             <artifactId>doxia-sink-api</artifactId>
                             <version>2.0.0</version>


### PR DESCRIPTION
specify version of log4j dependency in spotbugs and spring-boot plugins in configcheck, parent poms

these plugins otherwise specify their own versions of log4j which get downloaded when they are executed