### PR TITLE
use Google Cloud Maven Central Mirror

### DIFF
--- a/.github/workflows/build-accumulo.yml
+++ b/.github/workflows/build-accumulo.yml
@@ -47,7 +47,30 @@ jobs:
         repository: ${{ github.event.inputs.accumuloRepo }}
         path: accumulo
         ref: ${{ github.event.inputs.accumuloBranch }}
-
+    - name: Configure Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <servers>
+         <server>
+           <id>github-datawave</id>
+           <username>${env.GITHUB_USERNAME}</username>
+           <password>${env.GITHUB_PASSWORD}</password>
+         </server>
+        </servers>
+        <mirrors>
+         <mirror>
+           <id>google-maven-central</id>
+           <name>Google Cloud Maven Central Mirror</name>
+           <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+           <mirrorOf>central</mirrorOf>
+         </mirror>
+        </mirrors>
+        </settings>
+        EOF
     - name: Set up JDK ${{env.ACCUMULO_JAVA_VERSION}}
       uses: actions/setup-java@v5
       with:
@@ -63,30 +86,6 @@ jobs:
         java-version: ${{env.DATAWAVE_JAVA_VERSION}}
         cache: 'maven'
         overwrite-settings: false
-    - name: Configure Maven Central mirror
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml <<'EOF'
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-            <server>
-              <id>github-datawave</id>
-              <username>${env.GITHUB_USERNAME}</username>
-              <password>${env.GITHUB_PASSWORD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>google-maven-central</id>
-              <name>Google Cloud Maven Central Mirror</name>
-              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
     - run: echo "DATAWAVE_JAVA=$JAVA_HOME" >> $GITHUB_ENV
     - name: Get Accumulo Version
       id: get-accumulo-version

--- a/.github/workflows/build-accumulo.yml
+++ b/.github/workflows/build-accumulo.yml
@@ -54,7 +54,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.ACCUMULO_JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
+        overwrite-settings: false
     - run: echo "ACCUMULO_JAVA=$JAVA_HOME" >> $GITHUB_ENV
     - name: Set up JDK ${{env.DATAWAVE_JAVA_VERSION}}
       uses: actions/setup-java@v5
@@ -62,10 +62,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.DATAWAVE_JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
-        # username and password are the env variables names that maven will use
-        server-username: GITHUB_USERNAME
-        server-password: GITHUB_PASSWORD
+        overwrite-settings: false
     - name: Configure Maven Central mirror
       run: |
         mkdir -p ~/.m2
@@ -73,6 +70,13 @@ jobs:
         <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github-datawave</id>
+              <username>${env.GITHUB_USERNAME}</username>
+              <password>${env.GITHUB_PASSWORD}</password>
+            </server>
+          </servers>
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/.github/workflows/build-accumulo.yml
+++ b/.github/workflows/build-accumulo.yml
@@ -66,6 +66,23 @@ jobs:
         # username and password are the env variables names that maven will use
         server-username: GITHUB_USERNAME
         server-password: GITHUB_PASSWORD
+    - name: Configure Maven Central mirror
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>google-maven-central</id>
+              <name>Google Cloud Maven Central Mirror</name>
+              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF
     - run: echo "DATAWAVE_JAVA=$JAVA_HOME" >> $GITHUB_ENV
     - name: Get Accumulo Version
       id: get-accumulo-version

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -30,6 +30,23 @@ jobs:
         # username and password are the env variables names that maven will use
         server-username: GITHUB_USERNAME
         server-password: GITHUB_PASSWORD
+    - name: Configure Maven Central mirror
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>google-maven-central</id>
+              <name>Google Cloud Maven Central Mirror</name>
+              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF
     - name: Extract branch name
       shell: bash
       run: |

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -20,6 +20,30 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
+    - name: Configure Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <servers>
+         <server>
+           <id>github-datawave</id>
+           <username>${env.GITHUB_USERNAME}</username>
+           <password>${env.GITHUB_PASSWORD}</password>
+         </server>
+        </servers>
+        <mirrors>
+         <mirror>
+           <id>google-maven-central</id>
+           <name>Google Cloud Maven Central Mirror</name>
+           <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+           <mirrorOf>central</mirrorOf>
+         </mirror>
+        </mirrors>
+        </settings>
+        EOF
     - name: Set up JDK ${{env.JAVA_VERSION}}
       uses: actions/setup-java@v5
       with:
@@ -27,30 +51,6 @@ jobs:
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
         overwrite-settings: false
-    - name: Configure Maven Central mirror
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml <<'EOF'
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-            <server>
-              <id>github-datawave</id>
-              <username>${env.GITHUB_USERNAME}</username>
-              <password>${env.GITHUB_PASSWORD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>google-maven-central</id>
-              <name>Google Cloud Maven Central Mirror</name>
-              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
     - name: Extract branch name
       shell: bash
       run: |

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -26,10 +26,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
-        # username and password are the env variables names that maven will use
-        server-username: GITHUB_USERNAME
-        server-password: GITHUB_PASSWORD
+        overwrite-settings: false
     - name: Configure Maven Central mirror
       run: |
         mkdir -p ~/.m2
@@ -37,6 +34,13 @@ jobs:
         <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github-datawave</id>
+              <username>${env.GITHUB_USERNAME}</username>
+              <password>${env.GITHUB_PASSWORD}</password>
+            </server>
+          </servers>
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -58,13 +58,7 @@ jobs:
       - uses: ./.github/actions/free-space
         with:
           tool-cache: false
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v5
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-          overwrite-settings: false
-      - name: Configure Maven Central mirror
+      - name: Configure Maven Settings
         run: |
           mkdir -p ~/.m2
           cat > ~/.m2/settings.xml <<'EOF'
@@ -88,6 +82,12 @@ jobs:
           </mirrors>
           </settings>
           EOF
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+          overwrite-settings: false
       - uses: actions/cache@v4
         if: ${{ !inputs.allow-snapshots }}
         with:

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -67,6 +67,23 @@ jobs:
         # username and password are the env variables names that maven will use
           server-username: GITHUB_USERNAME
           server-password: GITHUB_PASSWORD
+      - name: Configure Maven Central mirror
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'EOF'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+           <mirror>
+             <id>google-maven-central</id>
+             <name>Google Cloud Maven Central Mirror</name>
+             <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+             <mirrorOf>central</mirrorOf>
+           </mirror>
+          </mirrors>
+          </settings>
+          EOF
       - uses: actions/cache@v4
         if: ${{ !inputs.allow-snapshots }}
         with:

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -63,10 +63,7 @@ jobs:
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
-          server-id: github-datawave
-        # username and password are the env variables names that maven will use
-          server-username: GITHUB_USERNAME
-          server-password: GITHUB_PASSWORD
+          overwrite-settings: false
       - name: Configure Maven Central mirror
         run: |
           mkdir -p ~/.m2
@@ -74,6 +71,13 @@ jobs:
           <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+           <server>
+             <id>github-datawave</id>
+             <username>${env.GITHUB_USERNAME}</username>
+             <password>${env.GITHUB_PASSWORD}</password>
+           </server>
+          </servers>
           <mirrors>
            <mirror>
              <id>google-maven-central</id>

--- a/.github/workflows/datawave-tests.yml
+++ b/.github/workflows/datawave-tests.yml
@@ -51,6 +51,30 @@ jobs:
     - uses: ./.github/actions/free-space
       with:
         tool-cache: false
+    - name: Configure Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <servers>
+         <server>
+           <id>github-datawave</id>
+           <username>${env.GITHUB_USERNAME}</username>
+           <password>${env.GITHUB_PASSWORD}</password>
+         </server>
+        </servers>
+        <mirrors>
+         <mirror>
+           <id>google-maven-central</id>
+           <name>Google Cloud Maven Central Mirror</name>
+           <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+           <mirrorOf>central</mirrorOf>
+         </mirror>
+        </mirrors>
+        </settings>
+        EOF
     - name: Set up JDK ${{env.JAVA_VERSION}}
       uses: actions/setup-java@v5
       with:
@@ -58,30 +82,6 @@ jobs:
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
         overwrite-settings: false
-    - name: Configure Maven Central mirror
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml <<'EOF'
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-            <server>
-              <id>github-datawave</id>
-              <username>${env.GITHUB_USERNAME}</username>
-              <password>${env.GITHUB_PASSWORD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>google-maven-central</id>
-              <name>Google Cloud Maven Central Mirror</name>
-              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
     - name: Build and Run Unit Tests
       run: |
           mvn --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples,assemble,spotbugs  ${{ needs.configure-runner.outputs.cache_settings }} -Ddeploy -Ddist -T1C clean install -Dsurefire.rerunFailingTestsCount=3 -Dutils -DskipITs -DskipFormat

--- a/.github/workflows/datawave-tests.yml
+++ b/.github/workflows/datawave-tests.yml
@@ -61,6 +61,23 @@ jobs:
         # username and password are the env variables names that maven will use
         server-username: GITHUB_USERNAME
         server-password: GITHUB_PASSWORD
+    - name: Configure Maven Central mirror
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>google-maven-central</id>
+              <name>Google Cloud Maven Central Mirror</name>
+              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF
     - name: Build and Run Unit Tests
       run: |
           mvn --show-version --batch-mode --errors --no-transfer-progress "-Dstyle.color=always" -Pexamples,assemble,spotbugs  ${{ needs.configure-runner.outputs.cache_settings }} -Ddeploy -Ddist -T1C clean install -Dsurefire.rerunFailingTestsCount=3 -Dutils -DskipITs -DskipFormat

--- a/.github/workflows/datawave-tests.yml
+++ b/.github/workflows/datawave-tests.yml
@@ -57,10 +57,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
-        # username and password are the env variables names that maven will use
-        server-username: GITHUB_USERNAME
-        server-password: GITHUB_PASSWORD
+        overwrite-settings: false
     - name: Configure Maven Central mirror
       run: |
         mkdir -p ~/.m2
@@ -68,6 +65,13 @@ jobs:
         <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github-datawave</id>
+              <username>${env.GITHUB_USERNAME}</username>
+              <password>${env.GITHUB_PASSWORD}</password>
+            </server>
+          </servers>
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/.github/workflows/deploy-datawave.yml
+++ b/.github/workflows/deploy-datawave.yml
@@ -42,6 +42,30 @@ jobs:
     - uses: ./.github/actions/free-space
       with:
         tool-cache: false
+    - name: Configure Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <servers>
+         <server>
+           <id>github-datawave</id>
+           <username>${env.GITHUB_USERNAME}</username>
+           <password>${env.GITHUB_PASSWORD}</password>
+         </server>
+        </servers>
+        <mirrors>
+         <mirror>
+           <id>google-maven-central</id>
+           <name>Google Cloud Maven Central Mirror</name>
+           <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+           <mirrorOf>central</mirrorOf>
+         </mirror>
+        </mirrors>
+        </settings>
+        EOF
     - name: Set up JDK ${{env.JAVA_VERSION}}
       uses: actions/setup-java@v5
       with:
@@ -49,30 +73,6 @@ jobs:
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
         overwrite-settings: false
-    - name: Configure Maven Central mirror
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml <<'EOF'
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-            <server>
-              <id>github-datawave</id>
-              <username>${env.GITHUB_USERNAME}</username>
-              <password>${env.GITHUB_PASSWORD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>google-maven-central</id>
-              <name>Google Cloud Maven Central Mirror</name>
-              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
     - name: Build and Push DataWave web/ingest images and packages
       run: |
         docker info

--- a/.github/workflows/deploy-datawave.yml
+++ b/.github/workflows/deploy-datawave.yml
@@ -48,10 +48,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
-        # username and password are the env variables names that maven will use
-        server-username: GITHUB_USERNAME
-        server-password: GITHUB_PASSWORD
+        overwrite-settings: false
     - name: Configure Maven Central mirror
       run: |
         mkdir -p ~/.m2
@@ -59,6 +56,13 @@ jobs:
         <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github-datawave</id>
+              <username>${env.GITHUB_USERNAME}</username>
+              <password>${env.GITHUB_PASSWORD}</password>
+            </server>
+          </servers>
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/.github/workflows/deploy-datawave.yml
+++ b/.github/workflows/deploy-datawave.yml
@@ -52,6 +52,23 @@ jobs:
         # username and password are the env variables names that maven will use
         server-username: GITHUB_USERNAME
         server-password: GITHUB_PASSWORD
+    - name: Configure Maven Central mirror
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>google-maven-central</id>
+              <name>Google Cloud Maven Central Mirror</name>
+              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF
     - name: Build and Push DataWave web/ingest images and packages
       run: |
         docker info

--- a/.github/workflows/microservice-release.yml
+++ b/.github/workflows/microservice-release.yml
@@ -107,6 +107,30 @@ jobs:
     - name: Fast-forward to branch tip
       run: git pull --ff-only
 
+    - name: Configure Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <servers>
+         <server>
+           <id>github-datawave</id>
+           <username>${env.GITHUB_USERNAME}</username>
+           <password>${env.GITHUB_PASSWORD}</password>
+         </server>
+        </servers>
+        <mirrors>
+         <mirror>
+           <id>google-maven-central</id>
+           <name>Google Cloud Maven Central Mirror</name>
+           <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+           <mirrorOf>central</mirrorOf>
+         </mirror>
+        </mirrors>
+        </settings>
+        EOF
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
@@ -114,30 +138,6 @@ jobs:
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
         overwrite-settings: false
-    - name: Configure Maven Central mirror
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml <<'EOF'
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-            <server>
-              <id>github-datawave</id>
-              <username>${env.GITHUB_USERNAME}</username>
-              <password>${env.GITHUB_PASSWORD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>google-maven-central</id>
-              <name>Google Cloud Maven Central Mirror</name>
-              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
     - name: Log in to the Container registry
       uses: docker/login-action@v4
       with:

--- a/.github/workflows/microservice-release.yml
+++ b/.github/workflows/microservice-release.yml
@@ -113,10 +113,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
-        # username and password are the env variables names that maven will use
-        server-username: GITHUB_USERNAME
-        server-password: GITHUB_PASSWORD
+        overwrite-settings: false
     - name: Configure Maven Central mirror
       run: |
         mkdir -p ~/.m2
@@ -124,6 +121,13 @@ jobs:
         <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github-datawave</id>
+              <username>${env.GITHUB_USERNAME}</username>
+              <password>${env.GITHUB_PASSWORD}</password>
+            </server>
+          </servers>
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/.github/workflows/microservice-release.yml
+++ b/.github/workflows/microservice-release.yml
@@ -117,6 +117,23 @@ jobs:
         # username and password are the env variables names that maven will use
         server-username: GITHUB_USERNAME
         server-password: GITHUB_PASSWORD
+    - name: Configure Maven Central mirror
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>google-maven-central</id>
+              <name>Google Cloud Maven Central Mirror</name>
+              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF
     - name: Log in to the Container registry
       uses: docker/login-action@v4
       with:

--- a/.github/workflows/microservice-tests.yml
+++ b/.github/workflows/microservice-tests.yml
@@ -51,6 +51,30 @@ jobs:
     - uses: ./.github/actions/free-space
       with:
         tool-cache: false
+    - name: Configure Maven Settings
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+        <servers>
+         <server>
+           <id>github-datawave</id>
+           <username>${env.GITHUB_USERNAME}</username>
+           <password>${env.GITHUB_PASSWORD}</password>
+         </server>
+        </servers>
+        <mirrors>
+         <mirror>
+           <id>google-maven-central</id>
+           <name>Google Cloud Maven Central Mirror</name>
+           <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+           <mirrorOf>central</mirrorOf>
+         </mirror>
+        </mirrors>
+        </settings>
+        EOF
     - name: Set up JDK ${{env.JAVA_VERSION}}
       uses: actions/setup-java@v5
       with:
@@ -58,30 +82,6 @@ jobs:
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
         overwrite-settings: false
-    - name: Configure Maven Central mirror
-      run: |
-        mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml <<'EOF'
-        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-          <servers>
-            <server>
-              <id>github-datawave</id>
-              <username>${env.GITHUB_USERNAME}</username>
-              <password>${env.GITHUB_PASSWORD}</password>
-            </server>
-          </servers>
-          <mirrors>
-            <mirror>
-              <id>google-maven-central</id>
-              <name>Google Cloud Maven Central Mirror</name>
-              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-        EOF
     - name: Build and Run Unit Tests
       run: |
         cd microservices

--- a/.github/workflows/microservice-tests.yml
+++ b/.github/workflows/microservice-tests.yml
@@ -57,10 +57,7 @@ jobs:
         distribution: ${{env.JAVA_DISTRIBUTION}}
         java-version: ${{env.JAVA_VERSION}}
         cache: 'maven'
-        server-id: github-datawave
-        # username and password are the env variables names that maven will use
-        server-username: GITHUB_USERNAME
-        server-password: GITHUB_PASSWORD
+        overwrite-settings: false
     - name: Configure Maven Central mirror
       run: |
         mkdir -p ~/.m2
@@ -68,6 +65,13 @@ jobs:
         <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <servers>
+            <server>
+              <id>github-datawave</id>
+              <username>${env.GITHUB_USERNAME}</username>
+              <password>${env.GITHUB_PASSWORD}</password>
+            </server>
+          </servers>
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/.github/workflows/microservice-tests.yml
+++ b/.github/workflows/microservice-tests.yml
@@ -61,6 +61,23 @@ jobs:
         # username and password are the env variables names that maven will use
         server-username: GITHUB_USERNAME
         server-password: GITHUB_PASSWORD
+    - name: Configure Maven Central mirror
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml <<'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>google-maven-central</id>
+              <name>Google Cloud Maven Central Mirror</name>
+              <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+              <mirrorOf>central</mirrorOf>
+            </mirror>
+          </mirrors>
+        </settings>
+        EOF
     - name: Build and Run Unit Tests
       run: |
         cd microservices

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <version.thrift>0.17.0</version.thrift>
         <version.weld>3.1.1.Final</version.weld>
         <version.weld-se>3.1.1.Final</version.weld-se>
-        <!-- Different version of weld for tests since the Arquillian embedded EE container needs an older version. -->
+        <!-- Different version of weld for tests since the Arquillian embedded EE container needs an older version. TEST -->
         <version.weld-test>2.3.5.Final</version.weld-test>
         <version.wildfly>17.0.1.Final</version.wildfly>
         <version.woodstox-core>5.4.0</version.woodstox-core>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <version.thrift>0.17.0</version.thrift>
         <version.weld>3.1.1.Final</version.weld>
         <version.weld-se>3.1.1.Final</version.weld-se>
-        <!-- Different version of weld for tests since the Arquillian embedded EE container needs an older version. TEST -->
+        <!-- Different version of weld for tests since the Arquillian embedded EE container needs an older version. -->
         <version.weld-test>2.3.5.Final</version.weld-test>
         <version.wildfly>17.0.1.Final</version.wildfly>
         <version.woodstox-core>5.4.0</version.woodstox-core>


### PR DESCRIPTION
addresses HTTP 429 Too Many Requests errors seen in CI jobs recently  
`actions/setup-java` will skip creating settings.xml  
`Skipping generation /home/ec2-user/.m2/settings.xml because file already exists and overwriting is not required`