### PR TITLE
Fix invalid Accumulo range caused by end date set before begin date in query planning

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -2286,13 +2286,18 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             if (config.getNoExpansionIfCurrentDateTypes().contains(dateType)) {
                 // only remap the end date if the user did not specify today's date
                 if (!DateUtils.isSameDay(new Date(), config.getEndDate())) {
+                    Date remappedEndDate = dateIndexData.getEndDate();
+                    if (remappedEndDate.before(config.getBeginDate())) {
+                        throw new NoResultsException("Remapped end date " + remappedEndDate + " is before begin date " + config.getBeginDate()
+                                        + " for date type " + dateType);
+                    }
                     // now lets update the query parameters with the correct end date
                     log.info("Remapped " + dateType + " dates [" + config.getBeginDate() + "," + config.getEndDate() + "] to EVENT dates "
-                                    + config.getBeginDate() + "," + dateIndexData.getEndDate());
+                                    + config.getBeginDate() + "," + remappedEndDate);
 
                     // reset the dates in the configuration, no need to reset them in
                     // the Query settings object
-                    config.setEndDate(dateIndexData.getEndDate());
+                    config.setEndDate(remappedEndDate);
                 } else {
                     log.info("No Remapped dates for " + dateType + " because " + config.getEndDate() + " is today");
                 }
@@ -2324,18 +2329,14 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (config.getBeginDateCap() > 0) {
             long minStartTime = System.currentTimeMillis() - config.getBeginDateCap();
             if (config.getBeginDate().getTime() < minStartTime) {
-                if (config.isFailOutsideValidDateRange() && config.getEndDate().getTime() < minStartTime) {
-                    throw new DatawaveQueryException("This requested date range is outside of range of data on this system");
-                } else {
-                    config.setBeginDate(new Date(minStartTime));
-                    log.info("Resetting begin date to the beginDateCap: " + config.getBeginDate());
-                    if (config.getEndDate().getTime() < minStartTime) {
-                        // setting the end date to the same as the begin date will result in no ranges being created (@see
-                        // GenericQueryConfiguration.canRunQuery())
-                        config.setEndDate(new Date(minStartTime - 1));
-                        log.info("Resetting end date to the beginDateCap: " + config.getEndDate());
+                if (config.getEndDate().getTime() < minStartTime) {
+                    if (config.isFailOutsideValidDateRange()) {
+                        throw new DatawaveQueryException("This requested date range is outside of range of data on this system");
                     }
+                    throw new NoResultsException("Both begin and end dates are outside the valid date range cap");
                 }
+                config.setBeginDate(new Date(minStartTime));
+                log.info("Resetting begin date to the beginDateCap: " + config.getBeginDate());
             }
         }
     }

--- a/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
@@ -2,6 +2,7 @@ package datawave.query.planner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -25,6 +26,7 @@ import datawave.query.common.grouping.GroupFields;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.DatawaveQueryException;
+import datawave.query.exceptions.NoResultsException;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.DateIndexHelper;
@@ -211,6 +213,27 @@ class DefaultQueryPlannerTest {
             assertEquals(DateIndexUtil.getEndDate("20241010"), config.getEndDate());
         }
 
+        /**
+         * Verify that when the date type is in noExpansionIfCurrentDateTypes and the query end date is not today, but the remapped shard end date falls before
+         * the query begin date, a NoResultsException is thrown rather than creating an invalid date range.
+         */
+        @Test
+        void testParamDateTypeMarkedForNoExpansionRemappedEndDateBeforeBeginDate() throws Exception {
+            queryTree = JexlASTHelper.parseJexlQuery("FOO == 'bar'");
+            config.setDefaultDateTypeName("EVENT");
+            config.setNoExpansionIfCurrentDateTypes(Set.of("SPECIAL_EVENT"));
+            // Query begin date is 2024-01-01; end date is not today
+            Date beginDate = DateHelper.parse("20240101");
+            config.setBeginDate(beginDate);
+            config.setEndDate(DateHelper.parse("20240131"));
+            settings.addParameter(QueryParameters.DATE_RANGE_TYPE, "SPECIAL_EVENT");
+            // Date index shard dates are all in December 2023 — entirely before the query begin date
+            dateIndexHelper.addEntry("20231201", "SPECIAL_EVENT", "wiki", "FOO", "20231201_shard");
+            dateIndexHelper.addEntry("20231215", "SPECIAL_EVENT", "wiki", "FOO", "20231215_shard");
+
+            assertThrows(NoResultsException.class, this::addDateFilters);
+        }
+
         private ASTJexlScript addDateFilters() throws TableNotFoundException, DatawaveQueryException {
             return planner.addDateFilters(queryTree, null, null, dateIndexHelper, config, settings);
         }
@@ -285,6 +308,86 @@ class DefaultQueryPlannerTest {
 
             assertThrows(DatawaveFatalQueryException.class, () -> planner.validateGroupFields(groupFields),
                             "The following group-by fields are not date fields and cannot be used with temporal truncation: ROLE");
+        }
+    }
+
+    /**
+     * Contains tests for {@link DefaultQueryPlanner#capDateRange(ShardQueryConfiguration)}
+     */
+    @Nested
+    class CapDateRangeTests {
+
+        private static final long THIRTY_DAYS_MS = 30L * 24 * 60 * 60 * 1000;
+
+        private DefaultQueryPlanner planner;
+        private ShardQueryConfiguration config;
+
+        @BeforeEach
+        void setUp() {
+            planner = new DefaultQueryPlanner();
+            config = new ShardQueryConfiguration();
+        }
+
+        /**
+         * Verify that when both begin and end dates are before the cap and failOutsideValidDateRange is false, a NoResultsException is thrown rather than
+         * setting endDate before beginDate.
+         */
+        @Test
+        void testBothDatesBeforeCapSoftFailThrowsNoResults() {
+            config.setBeginDateCap(THIRTY_DAYS_MS);
+            config.setFailOutsideValidDateRange(false);
+            config.setBeginDate(new Date(System.currentTimeMillis() - 60 * 24 * 60 * 60 * 1000L)); // 60 days ago
+            config.setEndDate(new Date(System.currentTimeMillis() - 45 * 24 * 60 * 60 * 1000L)); // 45 days ago
+
+            assertThrows(NoResultsException.class, () -> planner.capDateRange(config));
+        }
+
+        /**
+         * Verify that when both begin and end dates are before the cap and failOutsideValidDateRange is true, a DatawaveQueryException is thrown.
+         */
+        @Test
+        void testBothDatesBeforeCapHardFailThrowsQueryException() {
+            config.setBeginDateCap(THIRTY_DAYS_MS);
+            config.setFailOutsideValidDateRange(true);
+            config.setBeginDate(new Date(System.currentTimeMillis() - 60 * 24 * 60 * 60 * 1000L));
+            config.setEndDate(new Date(System.currentTimeMillis() - 45 * 24 * 60 * 60 * 1000L));
+
+            assertThrows(DatawaveQueryException.class, () -> planner.capDateRange(config));
+        }
+
+        /**
+         * Verify that when only the begin date is before the cap (end date is within range), beginDate is capped and endDate is unchanged.
+         */
+        @Test
+        void testOnlyBeginDateBeforeCapUpdatesBeginDate() throws DatawaveQueryException {
+            config.setBeginDateCap(THIRTY_DAYS_MS);
+            config.setFailOutsideValidDateRange(false);
+            long minStartTime = System.currentTimeMillis() - THIRTY_DAYS_MS;
+            config.setBeginDate(new Date(minStartTime - 1000)); // just before cap
+            Date endDate = new Date(); // now — well within cap
+            config.setEndDate(endDate);
+
+            planner.capDateRange(config);
+
+            assertTrue(!config.getEndDate().before(config.getBeginDate()), "endDate must not be before beginDate after cap");
+            assertEquals(endDate, config.getEndDate(), "endDate should be unchanged");
+        }
+
+        /**
+         * Verify that when both dates are within the cap, neither date is modified.
+         */
+        @Test
+        void testDatesWithinCapAreUnchanged() throws DatawaveQueryException {
+            config.setBeginDateCap(THIRTY_DAYS_MS);
+            Date beginDate = new Date(System.currentTimeMillis() - 10 * 24 * 60 * 60 * 1000L); // 10 days ago
+            Date endDate = new Date();
+            config.setBeginDate(beginDate);
+            config.setEndDate(endDate);
+
+            planner.capDateRange(config);
+
+            assertEquals(beginDate, config.getBeginDate());
+            assertEquals(endDate, config.getEndDate());
         }
     }
 }


### PR DESCRIPTION
## Summary

- `capDateRange` was advancing `beginDate` to `minStartTime` and setting `endDate` to `minStartTime - 1` (one millisecond earlier) when both query dates fell outside the begin-date cap. This produced `endDate < beginDate`, which RangeStream passed directly to Accumulo's `Range` constructor, causing an invalid range error.
- `addDateFilters` was setting `endDate` to the date-index-remapped shard end date without checking whether that value preceded the query's `beginDate`. When the mapped shard dates were entirely before the user's begin date, this produced the same invalid range.
- Both sites now throw `NoResultsException` instead, which is caught in `process()` and returns an empty iterator — the correct "no data in this range" outcome without corrupting config state.

## Test plan

- [x] `DefaultQueryPlannerTest$CapDateRangeTests` — 4 new tests covering: both dates before cap (soft fail → `NoResultsException`, hard fail → `DatawaveQueryException`), only begin date before cap (begin date updated, end date unchanged), both dates within cap (no change)
- [x] `DefaultQueryPlannerTest$DateFilterTests.testParamDateTypeMarkedForNoExpansionRemappedEndDateBeforeBeginDate` — verifies `addDateFilters` throws `NoResultsException` when the remapped shard end date falls before the query begin date
- [x] Run `mvn -pl warehouse/query-core test -Dtest=DefaultQueryPlannerTest -DskipITs` — all 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)