### PR TITLE
Always look for checkstyle.xml in project root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1814,7 +1814,8 @@
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.6.0</version>
                     <configuration>
-                        <configLocation>checkstyle.xml</configLocation>
+                        <!-- Use multiModuleProjectDirectory to prevent child modules form looking inside their own sub-folders for checkstyle.xml. -->
+                        <configLocation>${maven.multiModuleProjectDirectory}/checkstyle.xml</configLocation>
                         <failsOnError>true</failsOnError>
                         <failOnViolation>false</failOnViolation>
                         <consoleOutput>true</consoleOutput>


### PR DESCRIPTION
Prefix the checkstyle.xml path with the property `${maven.multiModuleProjectDirectory}`. This will prevent child modules from looking inside their own sub-folders for checkstyle.xml. This will allow us to build child modules from within their root folders without maven complaining about not being able to find the checkstyle.xml.