### PR TITLE
Alternate fix for hit excerpts on grouped term-frequency field names

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
@@ -43,6 +43,7 @@ import datawave.query.attributes.ExcerptFields;
 import datawave.query.attributes.ValueTuple;
 import datawave.query.function.JexlEvaluation;
 import datawave.query.iterator.logic.TermFrequencyExcerptIterator;
+import datawave.query.jexl.JexlASTHelper;
 import datawave.query.postprocessing.tf.PhraseIndexes;
 import datawave.query.postprocessing.tf.PhraseOffset;
 
@@ -123,14 +124,14 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
             for (Attribute<?> attr : hitList.getAttributes()) {
                 ValueTuple hitTuple = attributeToHitTuple(attr);
                 // if this is for a requested excerpt field
-                if (excerptFields.containsField(hitTuple.getFieldName())) {
+                if (getMatchingExcerptField(hitTuple.getFieldName(), excerptFields) != null) {
                     // get the offset, preferring offsets that overlap with existing phrases for this field/eventId
-                    TermWeightPosition pos = getOffset(hitTuple, phraseIndexes);
-                    if (pos != null) {
+                    HitOffset hitOffset = getOffset(hitTuple, phraseIndexes);
+                    if (hitOffset != null) {
                         // add the term as a phrase as defined in the term weight position. Note that this will collapse with any overlapping phrases already in
                         // the list.
-                        allPhraseIndexes.addIndexTriplet(String.valueOf(hitTuple.getFieldName()), keyToEventId(attr.getMetadata()), pos.getLowOffset(),
-                                        pos.getOffset());
+                        allPhraseIndexes.addIndexTriplet(hitOffset.getField(), keyToEventId(attr.getMetadata()), hitOffset.getPosition().getLowOffset(),
+                                        hitOffset.getPosition().getOffset());
                     }
                     // save the hit term for later call-out
                     Collections.addAll(hitTermValues, ((String) hitTuple.getValue()).split(Constants.SPACE));
@@ -143,15 +144,16 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
 
     /**
      * Get the term weight position (offset) for the specified hit term. This will return an offset overlapping a phrase in the existing phrase index map first.
-     * Otherwise, the first position will be returned.
+     * Otherwise, the first position will be returned. The returned {@link HitOffset} also carries the concrete term-frequency field that was used to resolve
+     * the offset so that excerpt generation can remain scoped to the matched content context.
      *
      * @param hitTuple
      *            The hit term tuple
      * @param phraseIndexes
      *            The phrase indexes
-     * @return The TermWeightPosition for the given hit term
+     * @return the concrete field and offset for the given hit term
      */
-    private TermWeightPosition getOffset(ValueTuple hitTuple, PhraseIndexes phraseIndexes) {
+    private HitOffset getOffset(ValueTuple hitTuple, PhraseIndexes phraseIndexes) {
         Key docKey = hitTuple.getSource().getMetadata();
         // if we do not know the source document key, then we cannot find the term offset
         if (docKey == null) {
@@ -186,7 +188,7 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
                     pos = position.build();
                 }
 
-                return pos;
+                return new HitOffset(fieldName, pos);
             }
 
         } catch (InvalidProtocolBufferException e) {
@@ -328,7 +330,7 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
                 excerptIteratorOptions.put(END_OFFSET, String.valueOf(expandedEnd));
 
                 if (log.isDebugEnabled()) {
-                    log.debug("size of excerpt requested: {}", excerptFields.getOffset(field) * 2);
+                    log.debug("size of excerpt requested: {}", getExcerptOffset(field) * 2);
                     log.debug("original range is ({},{}) and the expanded range is ({},{})", start, end, expandedStart, expandedEnd);
                 }
             }
@@ -337,7 +339,7 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
                 // set all of our options for the iterator
                 excerptIterator.init(source, excerptIteratorOptions, env);
                 excerptIterator.setHitTermsList(hitTermValues);
-                excerptIterator.setDirection(excerptFields.getDirection(field).toUpperCase().trim());
+                excerptIterator.setDirection(getExcerptDirection(field).toUpperCase().trim());
                 excerptIterator.setOrigHalfSize(origHalfSize);
                 // if this is the second attempt, we want the iterator to trim the excerpt down to the size we want.
                 // (remember we run the iterator with an expanded range the second time so we can potentially have a bigger excerpt than needed even after
@@ -404,11 +406,12 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
      */
     private static PhraseIndexes getOffsetPhraseIndexes(PhraseIndexes phraseIndexes, ExcerptFields excerptFields) {
         PhraseIndexes offsetPhraseIndexes = new PhraseIndexes();
-        for (String field : excerptFields.getFields()) {
+        for (String field : phraseIndexes.getFields()) {
             // Filter out phrases that are not in desired fields.
-            Collection<PhraseOffset> indexes = phraseIndexes.getPhraseOffsets(field);
+            String excerptField = getMatchingExcerptField(field, excerptFields);
+            Collection<PhraseOffset> indexes = excerptField == null ? null : phraseIndexes.getPhraseOffsets(field);
             if (indexes != null) {
-                int offset = excerptFields.getOffset(field);
+                int offset = excerptFields.getOffset(excerptField);
                 // Ensure the offset is modified to encompass the target excerpt range.
                 for (PhraseOffset indexPair : indexes) {
                     String eventId = indexPair.getEventId();
@@ -419,6 +422,38 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
             }
         }
         return offsetPhraseIndexes;
+    }
+
+    private int getExcerptOffset(String field) {
+        return excerptFields.getOffset(getMatchingExcerptField(field, excerptFields));
+    }
+
+    private String getExcerptDirection(String field) {
+        return excerptFields.getDirection(getMatchingExcerptField(field, excerptFields));
+    }
+
+    /**
+     * Return the configured excerpt field that should be used for the given concrete phrase-index field. The concrete field may include grouping/context
+     * notation, while the excerpt configuration may only specify the base field.
+     *
+     * @param field
+     *            a concrete phrase-index or term-frequency field
+     * @param excerptFields
+     *            the configured excerpt fields
+     * @return the matching configured excerpt field, or null if no match exists
+     */
+    private static String getMatchingExcerptField(String field, ExcerptFields excerptFields) {
+        if (excerptFields.containsField(field)) {
+            return field;
+        }
+
+        for (String excerptField : excerptFields.getFields()) {
+            if (JexlASTHelper.isGroupedFieldMatch(excerptField, field)) {
+                return excerptField;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -526,6 +561,28 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
         @Override
         public int hashCode() {
             return Objects.hash(excerptWithScores, excerptWithoutScores, excerptOneBest, source);
+        }
+    }
+
+    /**
+     * Holds the concrete term-frequency field and position selected for a hit term. The field is preserved separately from the requested excerpt field so that
+     * later excerpt scans do not merge sibling content contexts such as {@code QUOTE} and {@code QUOTE.hash1}.
+     */
+    private static class HitOffset {
+        private final String field;
+        private final TermWeightPosition position;
+
+        public HitOffset(String field, TermWeightPosition position) {
+            this.field = field;
+            this.position = position;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public TermWeightPosition getPosition() {
+            return position;
         }
     }
 

--- a/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
+++ b/warehouse/query-core/src/main/java/datawave/query/transformer/ExcerptTransform.java
@@ -109,6 +109,8 @@ public class ExcerptTransform extends DocumentTransform.DefaultDocumentTransform
      * @return the phrase indexes
      */
     private PhraseIndexes getPhraseIndexes(Document document) {
+        // Clear hit terms from the previously transformed document before collecting terms for this one.
+        hitTermValues.clear();
         PhraseIndexes phraseIndexes = null;
         PhraseIndexes allPhraseIndexes = new PhraseIndexes();
         // first lets find all the phrase indexes that came from phrase functions

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/ExcerptTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/ExcerptTransformTest.java
@@ -290,6 +290,44 @@ public class ExcerptTransformTest extends EasyMockSupport {
     }
 
     /**
+     * Verify that hit terms collected for one document do not leak into excerpts generated for a later document.
+     */
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void testHitTermsClearedBetweenDocuments() throws IOException {
+        givenExcerptField("BODY", 2);
+
+        Key metadata = new Key("shard", "dt\u0000uid");
+        Document firstDocument = mock(Document.class);
+        expect(firstDocument.isToKeep()).andReturn(true);
+        expect(firstDocument.containsKey(ExcerptTransform.PHRASE_INDEXES_ATTRIBUTE)).andReturn(false);
+        expect(firstDocument.containsKey(JexlEvaluation.HIT_TERM_FIELD)).andReturn(true);
+        Attribute firstHitTerms = new Attributes(Collections.singletonList(new Content("BODY:first", metadata, true)), true);
+        expect(firstDocument.get(JexlEvaluation.HIT_TERM_FIELD)).andReturn(firstHitTerms);
+        givenMatchingTermFrequencies("BODY", new int[][] {{2, 2}}, "first");
+        givenMatchingPhrase("BODY", 0, 4, "the [first] document excerpt", List.of("first"));
+        firstDocument.put(eq(ExcerptTransform.HIT_EXCERPT), isA(Attributes.class));
+
+        PhraseIndexes secondPhraseIndexes = new PhraseIndexes();
+        secondPhraseIndexes.addIndexTriplet("BODY", EVENT_ID, 4, 4);
+        Document secondDocument = mock(Document.class);
+        expect(secondDocument.isToKeep()).andReturn(true);
+        expect(secondDocument.containsKey(ExcerptTransform.PHRASE_INDEXES_ATTRIBUTE)).andReturn(true);
+        Attribute phraseIndexAttribute = new Content(secondPhraseIndexes.toString(), metadata, false);
+        expect(secondDocument.get(ExcerptTransform.PHRASE_INDEXES_ATTRIBUTE)).andReturn(phraseIndexAttribute);
+        expect(secondDocument.containsKey(JexlEvaluation.HIT_TERM_FIELD)).andReturn(false);
+        givenMatchingPhrase("BODY", 2, 6, "the second document excerpt", Collections.emptyList());
+        secondDocument.put(eq(ExcerptTransform.HIT_EXCERPT), isA(Attributes.class));
+
+        initTransform();
+        replayAll();
+
+        excerptTransform.apply(new AbstractMap.SimpleEntry<>(new Key(), firstDocument));
+        excerptTransform.apply(new AbstractMap.SimpleEntry<>(new Key(), secondDocument));
+        verifyAll();
+    }
+
+    /**
      * Verify that when a start index is less than the specified excerpt offset, that the excerpt start defaults to 0.
      */
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/ExcerptTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/ExcerptTransformTest.java
@@ -238,6 +238,58 @@ public class ExcerptTransformTest extends EasyMockSupport {
     }
 
     /**
+     * Verify that a grouped phrase index can be excerpted when the base field is requested.
+     */
+    @Test
+    public void testGroupedPhraseIndexUsesBaseExcerptField() throws IOException {
+        givenExcerptField("BODY", 2);
+        givenPhraseIndex("BODY.hash1", 10, 14);
+
+        givenMockDocument();
+        givenMatchingPhrase("BODY.hash1", 8, 16, "the quick brown fox jumped over the lazy dog", Collections.emptyList());
+
+        Capture<Attributes> capturedArg = Capture.newInstance();
+        document.put(eq(ExcerptTransform.HIT_EXCERPT), and(capture(capturedArg), isA(Attributes.class)));
+
+        initTransform();
+        replayAll();
+
+        applyTransform();
+        verifyAll();
+
+        Attributes arg = capturedArg.getValue();
+        assertEquals(1, arg.size());
+        String excerpt = arg.getAttributes().iterator().next().getData().toString();
+        assertEquals("the quick brown fox jumped over the lazy dog", excerpt);
+    }
+
+    /**
+     * Verify that a grouped hit term drives excerpt generation using the concrete grouped field while still using base field excerpt options.
+     */
+    @Test
+    public void testGroupedHitTermUsesGroupedFieldForExcerpt() throws IOException {
+        givenExcerptField("BODY", 2);
+
+        givenMockDocumentWithHitTerm("BODY.hash1", "word");
+        givenMatchingTermFrequencies("BODY.hash1", new int[][] {{24, 24}}, "word");
+        givenMatchingPhrase("BODY.hash1", 22, 26, "and the [word] from bird", List.of("word"));
+
+        Capture<Attributes> capturedArg = Capture.newInstance();
+        document.put(eq(ExcerptTransform.HIT_EXCERPT), and(capture(capturedArg), isA(Attributes.class)));
+
+        initTransform();
+        replayAll();
+
+        applyTransform();
+        verifyAll();
+
+        Attributes arg = capturedArg.getValue();
+        assertEquals(1, arg.size());
+        String excerpt = arg.getAttributes().iterator().next().getData().toString();
+        assertEquals("and the [word] from bird", excerpt);
+    }
+
+    /**
      * Verify that when a start index is less than the specified excerpt offset, that the excerpt start defaults to 0.
      */
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/transformer/ExcerptTransformTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/transformer/ExcerptTransformTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -322,8 +321,8 @@ public class ExcerptTransformTest extends EasyMockSupport {
         initTransform();
         replayAll();
 
-        excerptTransform.apply(new AbstractMap.SimpleEntry<>(new Key(), firstDocument));
-        excerptTransform.apply(new AbstractMap.SimpleEntry<>(new Key(), secondDocument));
+        excerptTransform.apply(Map.entry(new Key(), firstDocument));
+        excerptTransform.apply(Map.entry(new Key(), secondDocument));
         verifyAll();
     }
 
@@ -433,7 +432,7 @@ public class ExcerptTransformTest extends EasyMockSupport {
     }
 
     private Map.Entry<Key,Document> getDocumentEntry() {
-        return new AbstractMap.SimpleEntry<>(new Key(), document);
+        return Map.entry(new Key(), document);
     }
 
     private void givenExcerptField(String field, int offset) {


### PR DESCRIPTION
#3647 proposes some changes to the hit excerpt code to account for omitted hit excerpts when content contexts are in play. We ran into some issues with that fix pulling in term positions from outside contexts. After some analysis, it was discovered that we weren't properly passing the specific hit context for matched terms. This change addresses that issue and omits some of the changes in #3647 that exacerbated the issue.

This fix also omits #3647's migration from EasyMock, which should be potentially considered for a future PR.