### PR TITLE
Quick fix to TermFrequencyIteraor and ContentFunctionEvaluator to address failures

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/core/iterators/TermFrequencyIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/core/iterators/TermFrequencyIterator.java
@@ -198,9 +198,12 @@ public class TermFrequencyIterator extends WrappingIterator {
                 topKey = k;
                 topValue = source.getTopValue();
                 break;
-            } else if (!uidMatches() || shouldSeekByValue() || shouldSeekByCount(count)) {
-                seekToNext(k);
-                count = 0; // reset count
+            //@formatter:off
+            // we believe that seekToNext may be calculating an incorrect range when tf grouping contexts are used.
+            //} else if (!uidMatches() || shouldSeekByValue() || shouldSeekByCount(count)) {
+            //    seekToNext(k);
+            //    count = 0; // reset count
+            //@formatter:on
             } else {
                 source.next();
                 count++;

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
@@ -177,7 +177,7 @@ public abstract class ContentFunctionEvaluator {
                         TermFrequencyList.Zone zone = new TermFrequencyList.Zone(field, true, eventId);
                         Collection<TermWeightPosition> offsets = tfList.fetchOffsets().get(zone);
                         // if no offsets, but we are explicitly looking for this field (i.e. not unfielded), then check for a non-content expansion zone
-                        if (offsets.isEmpty() && (fields != null && fields.contains(field))) {
+                        if (offsets.isEmpty() && (isRelevantField(field))) {
                             zone = new TermFrequencyList.Zone(field, false, eventId);
                             offsets = tfList.fetchOffsets().get(zone);
                         }


### PR DESCRIPTION
Patch added to downstream as a workaround for observed hit failures, capturing here as a baseline in support of further investigation.

This manifested itself as missing hits when content contexts were enabled at ingest. It appears to be related to incomplete evaluation of tf entries for a fielded phrase query (e.g., BODY:"cat dog") when multiple instances of BODY with different contexts exist in a single document. The hit failures manifested only when a data type filter was enabled, so minimally modify existing integration tests to exercise this path when attempting to reproduce.

Note: prior to #3487, the null vs. empty semantics for the fields list in `ContentFunctionEvaluator` were poorly defined, so it's worth investigating this as a root cause.