### PR TITLE
Add TermFrequencyContextTest

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
@@ -177,8 +177,8 @@ public abstract class ContentFunctionEvaluator {
                         TermFrequencyList.Zone zone = new TermFrequencyList.Zone(field, true, eventId);
                         Collection<TermWeightPosition> offsets = tfList.fetchOffsets().get(zone);
                         // if no offsets, but we are explicitly looking for this field (i.e. not unfielded), then check for a non-content expansion zone
-                        // TODO: there is a bug that drops hits. The fix is to replace '(fields != null && fields.contains(field))' with 'isRelevantField(field)'
-                        if (offsets.isEmpty() && (fields != null && fields.contains(field))) {
+                        // fields in the TF column may have a context hash which necessitates isRelevantField() to get a correct match
+                        if (offsets.isEmpty() && isRelevantField(field)) {
                             zone = new TermFrequencyList.Zone(field, false, eventId);
                             offsets = tfList.fetchOffsets().get(zone);
                         }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/functions/ContentFunctionEvaluator.java
@@ -177,6 +177,7 @@ public abstract class ContentFunctionEvaluator {
                         TermFrequencyList.Zone zone = new TermFrequencyList.Zone(field, true, eventId);
                         Collection<TermWeightPosition> offsets = tfList.fetchOffsets().get(zone);
                         // if no offsets, but we are explicitly looking for this field (i.e. not unfielded), then check for a non-content expansion zone
+                        // TODO: there is a bug that drops hits. The fix is to replace '(fields != null && fields.contains(field))' with 'isRelevantField(field)'
                         if (offsets.isEmpty() && (fields != null && fields.contains(field))) {
                             zone = new TermFrequencyList.Zone(field, false, eventId);
                             offsets = tfList.fetchOffsets().get(zone);

--- a/warehouse/query-core/src/test/java/datawave/query/TermFrequencyContextIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TermFrequencyContextIT.java
@@ -20,7 +20,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.LcType;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.AbstractIngest;
 import datawave.query.util.AbstractQueryTest;
@@ -85,18 +85,19 @@ public class TermFrequencyContextIT extends AbstractQueryTest {
         client = new InMemoryAccumuloClient("", i);
 
         ingest = new AbstractIngest(client, auths);
-        ingest.registerField("TF", new LcNoDiacriticsType());
+        ingest.registerField("TF", new LcType());
         ingest.registerColumns("TF", List.of("i", "tf"));
 
-        ingest.registerField("ID", new LcNoDiacriticsType());
+        ingest.registerField("ID", new LcType());
         ingest.registerColumns("ID", List.of("i", "e"));
 
-        // mark ID (and only ID) as a content-expansion field, i.e. a field eligible for unfielded content:phrase() queries.
+        // mark TOK (and only TOK) as a content-expansion field, i.e. a field eligible for unfielded content:phrase() queries.
         // this mirrors real deployments where content expansion fields are explicitly curated, so TF is *not* a content
         // expansion field. this matters because TermOffsetPopulator only writes a TF-column entry with
         // contentExpansionField=true when the field is (or is unconfigured and therefore defaults to) a content expansion
         // field; otherwise it writes contentExpansionField=false.
-        ingest.registerColumns("ID", List.of("content"));
+        ingest.registerField("TOK", new LcType());
+        ingest.registerColumns("TOK", List.of("content"));
 
         // simple event
         ingest.writeFV(1, "ID", "1");

--- a/warehouse/query-core/src/test/java/datawave/query/TermFrequencyContextIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TermFrequencyContextIT.java
@@ -91,6 +91,13 @@ public class TermFrequencyContextIT extends AbstractQueryTest {
         ingest.registerField("ID", new LcNoDiacriticsType());
         ingest.registerColumns("ID", List.of("i", "e"));
 
+        // mark ID (and only ID) as a content-expansion field, i.e. a field eligible for unfielded content:phrase() queries.
+        // this mirrors real deployments where content expansion fields are explicitly curated, so TF is *not* a content
+        // expansion field. this matters because TermOffsetPopulator only writes a TF-column entry with
+        // contentExpansionField=true when the field is (or is unconfigured and therefore defaults to) a content expansion
+        // field; otherwise it writes contentExpansionField=false.
+        ingest.registerColumns("ID", List.of("content"));
+
         // simple event
         ingest.writeFV(1, "ID", "1");
 

--- a/warehouse/query-core/src/test/java/datawave/query/TermFrequencyContextIT.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TermFrequencyContextIT.java
@@ -1,0 +1,173 @@
+package datawave.query;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.util.AbstractIngest;
+import datawave.query.util.AbstractQueryTest;
+import datawave.table.constants.TableName;
+
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class TermFrequencyContextIT extends AbstractQueryTest {
+
+    private static final Logger log = LoggerFactory.getLogger(TermFrequencyContextIT.class);
+
+    @TempDir
+    public static Path folder;
+
+    private static final Authorizations auths = new Authorizations("ALL");
+
+    protected static AccumuloClient client = null;
+
+    protected static AbstractIngest ingest = null;
+
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
+
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    @Override
+    protected List<String> getIndexTableNames() {
+        return List.of(TableName.SHARD_INDEX);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+
+        InMemoryInstance i = new InMemoryInstance(TermFrequencyContextIT.class.getName());
+        client = new InMemoryAccumuloClient("", i);
+
+        ingest = new AbstractIngest(client, auths);
+        ingest.registerField("TF", new LcNoDiacriticsType());
+        ingest.registerColumns("TF", List.of("i", "tf"));
+
+        ingest.registerField("ID", new LcNoDiacriticsType());
+        ingest.registerColumns("ID", List.of("i", "e"));
+
+        // simple event
+        ingest.writeFV(1, "ID", "1");
+
+        // simple phrase
+        ingest.writeFV(2, "ID", "2");
+        ingest.writeTokenized(2, "TF", "see spot run");
+
+        // phrase with context
+        ingest.writeFV(3, "ID", "3");
+        ingest.writeTokenized(3, "TF.123", "we go to the park");
+        ingest.writeTokenized(3, "TF.456", "we go to the ocean");
+        ingest.writeTokenized(3, "TF.789", "we go to the playground");
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        setClientForTest(client);
+    }
+
+    @Test
+    public void printTables() {
+        ingest.printTable(TableName.METADATA);
+        ingest.printTable(TableName.SHARD_INDEX, ingest.uid(3));
+        ingest.printTable(TableName.SHARD, ingest.uid(3));
+    }
+
+    @Test
+    public void testSimpleIdQuery() throws Exception {
+        givenDate(ingest.getDate());
+        givenQuery("ID == '1'");
+        expectPlan("ID == '1'");
+        expectResultCount(1);
+        planAndExecuteQuery();
+    }
+
+    @Test
+    public void testSeeSpotRun() throws Exception {
+        givenDate(ingest.getDate());
+        givenQuery("content:phrase(TF, termOffsetMap, 'spot', 'run')");
+        expectPlan("content:phrase(TF, termOffsetMap, 'spot', 'run') && TF == 'spot' && TF == 'run'");
+        expectResultCount(1);
+        planAndExecuteQuery();
+    }
+
+    @Test
+    public void testSpotWithContext() throws Exception {
+        givenDate(ingest.getDate());
+        givenQuery("content:phrase(TF, termOffsetMap, 'spot', 'run')");
+        expectPlan("content:phrase(TF, termOffsetMap, 'spot', 'run') && TF == 'spot' && TF == 'run'");
+        expectResultCount(1);
+        planAndExecuteQuery();
+    }
+
+    @Test
+    public void testToThePark() throws Exception {
+        givenDate(ingest.getDate());
+        givenQuery("content:phrase(TF, termOffsetMap, 'to', 'the', 'park')");
+        expectPlan("content:phrase(TF, termOffsetMap, 'to', 'the', 'park') && TF == 'to' && TF == 'the' && TF == 'park'");
+        expectResultCount(1);
+        planAndExecuteQuery();
+    }
+
+    @Test
+    public void testToTheOcean() throws Exception {
+        givenDate(ingest.getDate());
+        givenQuery("content:phrase(TF, termOffsetMap, 'to', 'the', 'ocean')");
+        expectPlan("content:phrase(TF, termOffsetMap, 'to', 'the', 'ocean') && TF == 'to' && TF == 'the' && TF == 'ocean'");
+        expectResultCount(1);
+        planAndExecuteQuery();
+    }
+
+    @Test
+    public void testToThePlayGround() throws Exception {
+        givenDate(ingest.getDate());
+        givenQuery("content:phrase(TF, termOffsetMap, 'to', 'the', 'playground')");
+        expectPlan("content:phrase(TF, termOffsetMap, 'to', 'the', 'playground') && TF == 'to' && TF == 'the' && TF == 'playground'");
+        expectResultCount(1);
+        planAndExecuteQuery();
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
@@ -93,6 +93,10 @@ public class AbstractIngest {
     }
 
     public void registerColumns(String field, List<String> columns) {
+        registerColumns(field, DATATYPE, columns);
+    }
+
+    public void registerColumns(String field, String datatype, List<String> columns) {
         try (BatchWriter bw = client.createBatchWriter(METADATA)) {
             Mutation m = new Mutation(field);
             for (String column : columns) {
@@ -103,7 +107,7 @@ public class AbstractIngest {
                     case "tf":
                     case "content":
                         fieldColumns.putAll(field, columns);
-                        m.put(column, DATATYPE, EMPTY_VALUE);
+                        m.put(column, datatype, EMPTY_VALUE);
                         break;
                     case "t":
                         // ignore

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
@@ -101,6 +101,7 @@ public class AbstractIngest {
                     case "ri":
                     case "e":
                     case "tf":
+                    case "content":
                         fieldColumns.putAll(field, columns);
                         m.put(column, DATATYPE, EMPTY_VALUE);
                         break;

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
@@ -1,0 +1,301 @@
+package datawave.query.util;
+
+import static datawave.table.constants.TableName.METADATA;
+import static datawave.table.constants.TableName.SHARD;
+import static datawave.table.constants.TableName.SHARD_INDEX;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.SecurityOperations;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import datawave.data.type.Type;
+import datawave.ingest.protobuf.TermWeight;
+import datawave.ingest.protobuf.Uid;
+import datawave.query.jexl.JexlASTHelper;
+import datawave.table.hash.UID;
+import datawave.test.MacTestUtil;
+import datawave.util.time.DateHelper;
+
+/**
+ * Simple ingest utility for writing fields and values to the big three tables
+ */
+public class AbstractIngest {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractIngest.class);
+
+    private final AccumuloClient client;
+    private final Authorizations auths;
+    private final TableOperations tops;
+
+    private final Multimap<String,String> fieldColumns = ArrayListMultimap.create();
+    private final Map<String,Type<?>> normalizers = new HashMap<>();
+
+    // default values
+    private static final String DATE = "20260708";
+    private static final String ROW = DATE + "_0";
+    private static final String DATATYPE = "datatype-a";
+    private static final Long TIMESTAMP = DateHelper.parse(DATE).getTime();
+    private static final Value EMPTY_VALUE = new Value();
+
+    public AbstractIngest(AccumuloClient client, Authorizations auths) throws AccumuloException, AccumuloSecurityException {
+        this.client = client;
+        this.auths = auths;
+        this.tops = client.tableOperations();
+
+        MacTestUtil.createOrRecreate(tops, METADATA);
+        MacTestUtil.createOrRecreate(tops, SHARD_INDEX);
+        MacTestUtil.createOrRecreate(tops, SHARD);
+
+        SecurityOperations sops = client.securityOperations();
+        sops.changeUserAuthorizations("root", auths);
+    }
+
+    /**
+     * Registers a field and it's normalizer. For now fields can have at most one normalizer.
+     *
+     * @param field
+     *            the field
+     * @param normalizer
+     *            the normalizer
+     */
+    public void registerField(String field, Type<?> normalizer) {
+        try (BatchWriter bw = client.createBatchWriter(METADATA)) {
+            normalizers.put(field, normalizer);
+            Mutation m = new Mutation(field);
+            m.put("t", DATATYPE + "\0" + normalizer.getClass().getName(), EMPTY_VALUE);
+            bw.addMutation(m);
+        } catch (TableNotFoundException | MutationsRejectedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void registerColumns(String field, List<String> columns) {
+        try (BatchWriter bw = client.createBatchWriter(METADATA)) {
+            Mutation m = new Mutation(field);
+            for (String column : columns) {
+                switch (column) {
+                    case "i":
+                    case "ri":
+                    case "e":
+                    case "tf":
+                        fieldColumns.putAll(field, columns);
+                        m.put(column, DATATYPE, EMPTY_VALUE);
+                        break;
+                    case "t":
+                        // ignore
+                        break;
+                    default:
+                        throw new RuntimeException("Unsupported metadata column: " + column);
+                }
+            }
+            bw.addMutation(m);
+        } catch (TableNotFoundException | MutationsRejectedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void writeFV(int eventId, String field, String value) {
+        String uid = uid(eventId);
+        String normalizedValue = getNormalizedValue(field, value);
+
+        writeShardIndex(uid, field, normalizedValue);
+        writeFieldIndex(uid, field, normalizedValue);
+        writeEvent(uid, field, value);
+    }
+
+    public void writeTokenized(int eventId, String field, String phrase) {
+        String uid = uid(eventId);
+        String[] tokens = phrase.split(" ");
+        String[] normalizedTokens = Arrays.stream(tokens).map(token -> getNormalizedValue(field, token)).toArray(String[]::new);
+        String baseField = JexlASTHelper.deconstructIdentifier(field);
+
+        writeShardIndex(uid, baseField, normalizedTokens);
+        writeFieldIndex(uid, baseField, normalizedTokens);
+        // persist context for the TF column
+        writeTermFrequency(uid, field, normalizedTokens);
+    }
+
+    private void writeShardIndex(String uid, String field, String... values) {
+        if (fieldColumns.containsEntry(field, "i")) {
+            try (BatchWriter bw = client.createBatchWriter(SHARD_INDEX)) {
+                for (String value : values) {
+                    Mutation m = new Mutation(value);
+                    Text cf = new Text(field);
+                    Text cq = new Text(ROW + "\0" + DATATYPE);
+                    ColumnVisibility cv = new ColumnVisibility(auths.iterator().next());
+                    m.put(cf, cq, cv, TIMESTAMP, getValue(uid));
+                    bw.addMutation(m);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void writeFieldIndex(String uid, String field, String... values) {
+        if (fieldColumns.containsEntry(field, "i")) {
+            try (BatchWriter bw = client.createBatchWriter(SHARD)) {
+                Mutation m = new Mutation(ROW);
+                Text cf = new Text("fi\0" + field);
+                for (String value : values) {
+                    Text cq = new Text(value + "\0" + DATATYPE + "\0" + uid);
+                    ColumnVisibility cv = new ColumnVisibility(auths.iterator().next());
+                    m.put(cf, cq, cv, TIMESTAMP, EMPTY_VALUE);
+                }
+                bw.addMutation(m);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void writeEvent(String uid, String field, String value) {
+        if (fieldColumns.containsEntry(field, "e")) {
+            try (BatchWriter bw = client.createBatchWriter(SHARD)) {
+                Mutation m = new Mutation(ROW);
+                Text cf = new Text(DATATYPE + "\0" + uid);
+                Text cq = new Text(field + "\0" + value);
+                ColumnVisibility cv = new ColumnVisibility(auths.iterator().next());
+                m.put(cf, cq, cv, TIMESTAMP, EMPTY_VALUE);
+                bw.addMutation(m);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void writeTermFrequency(String uid, String field, String... values) {
+        String baseField = JexlASTHelper.deconstructIdentifier(field);
+        if (fieldColumns.containsEntry(baseField, "i") && fieldColumns.containsEntry(baseField, "tf")) {
+            try (BatchWriter bw = client.createBatchWriter(SHARD)) {
+                Mutation m = new Mutation(ROW);
+                Text cf = new Text("tf");
+                for (int i = 0; i < values.length; i++) {
+                    String value = values[i];
+                    Text cq = new Text(DATATYPE + "\0" + uid + "\0" + value + "\0" + field);
+                    ColumnVisibility cv = new ColumnVisibility(auths.iterator().next());
+
+                    TermWeight.Info info = TermWeight.Info.newBuilder().addTermOffset(i).build();
+                    Value termFrequencyValue = new Value(info.toByteArray());
+                    m.put(cf, cq, cv, TIMESTAMP, termFrequencyValue);
+                }
+                bw.addMutation(m);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Generate a {@link datawave.table.hash.HashUID} for the given integer event id
+     *
+     * @param id
+     *            the event id
+     * @return the uid for the event
+     */
+    public String uid(int id) {
+        return UID.builder().newId(String.valueOf(id).getBytes(), (Date) null).toString();
+    }
+
+    /**
+     * Normalize the value using a preregistered {@link Type}.
+     *
+     * @param field
+     *            the field
+     * @param value
+     *            the value
+     * @return the normalized value
+     */
+    private String getNormalizedValue(String field, String value) {
+        String baseField = JexlASTHelper.deconstructIdentifier(field);
+        Type<?> normalizer = normalizers.get(baseField);
+        if (normalizer == null) {
+            throw new RuntimeException("Did not find normalizer registered for field " + baseField);
+        }
+
+        return normalizer.normalize(value);
+    }
+
+    private Value getValue(String uid) {
+        Uid.List.Builder builder = Uid.List.newBuilder();
+        builder.setIGNORE(false);
+        builder.setCOUNT(1L);
+        builder.addUID(uid);
+        return new Value(builder.build().toByteArray());
+    }
+
+    /**
+     * Debugging utility that prints an entire table
+     *
+     * @param name
+     *            the table name
+     */
+    public void printTable(String name) {
+        try (Scanner scanner = client.createScanner(name, auths)) {
+            log.info("=== {} ===", name);
+            for (Map.Entry<Key,Value> entry : scanner) {
+                log.info("k: {} v: {}", entry.getKey(), entry.getValue());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Debugging utility that prints an entire table, filtered to keys that contain the provided 'target' parameter
+     * <p>
+     * For example, prints all keys that match an event's uid
+     *
+     * @param name
+     *            the table name
+     * @param target
+     *            the filter target
+     */
+    public void printTable(String name, String target) {
+        try (Scanner scanner = client.createScanner(name, auths)) {
+            log.info("=== {} ===", name);
+            log.info("filter: {}", target);
+            for (Map.Entry<Key,Value> entry : scanner) {
+                String key = entry.getKey().toString();
+                if (name.equals(SHARD_INDEX)) {
+                    Uid.List docIds = Uid.List.parseFrom(entry.getValue().get());
+                    List<String> uids = docIds.getUIDList();
+                    if (uids.contains(target)) {
+                        log.info("k: {} v: {}", key, entry.getValue());
+                    }
+                } else if (key.contains(target)) {
+                    log.info("k: {} v: {}", key, entry.getValue());
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getDate() {
+        return DATE;
+    }
+}


### PR DESCRIPTION
Add test for TermFrequency keys with context. 

Added simple AbstractIngest class to help with declarative ingest when you need tightly scoped data.