### PR TITLE
Switches from Jgit to using Native Git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1722,8 +1722,9 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>9.0.1</version>
+                    <version>9.2.0</version>
                     <configuration>
+                        <useNativeGit>true</useNativeGit>
                         <dotGitDirectory>${maven.multiModuleProjectDirectory}/.git</dotGitDirectory>
                         <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
                         <generateGitPropertiesFile>true</generateGitPropertiesFile>


### PR DESCRIPTION
Updates the git-commit-id-maven-plugin version to 9.2.0 and switches it from using JGit to native git.

This reduces the git.properties generation step time from ~65 seconds to ~20 seconds.