### PR TITLE
Ensures that process-resources has required props

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -153,6 +153,18 @@
                         <goal>push</goal>
                     </goals>
                 </goalsList>
+                <!-- Always load properties for resource filtering -->
+                <goalsList artifactId="read-properties">
+                    <goals>
+                        <goal>read-properties</goal>
+                    </goals>
+                </goalsList>
+                <!-- Always load the rpm version for resource filtering -->
+                <goalsList artifactId="rpm-maven-plugin">
+                    <goals>
+                        <goal>version</goal>
+                    </goals>
+                </goalsList>
                 <!-- Always run resource copying and processing for proper configuration -->
                 <goalsList artifactId="maven-resources-plugin">
                     <goals>


### PR DESCRIPTION
Ensures that the `process-resources` gaol of `maven-resources-plugin` always has the correct properties loaded when rendering files.

This fixes an issue where files generated with a populated build-cache still had placeholders inside them instead of the correct property values from `process-resources`. 