### PR TITLE
Update ingest-core UID class references to core/tables

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/config/RawRecordContainerImpl.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/config/RawRecordContainerImpl.java
@@ -28,8 +28,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.protobuf.ByteString;
 
-import datawave.data.hash.UID;
-import datawave.data.hash.UIDBuilder;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
@@ -38,6 +36,8 @@ import datawave.ingest.data.config.ingest.IgnorableErrorHelperInterface;
 import datawave.ingest.protobuf.RawRecordContainer.Data;
 import datawave.marking.AccessExpressionMarkings;
 import datawave.marking.Markings;
+import datawave.table.hash.UID;
+import datawave.table.hash.UIDBuilder;
 import datawave.util.CompositeTimestamp;
 
 public class RawRecordContainerImpl implements Writable, Configurable, RawRecordContainer {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/RawRecordContainer.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/RawRecordContainer.java
@@ -7,8 +7,8 @@ import java.util.Date;
 
 import org.apache.accumulo.core.security.ColumnVisibility;
 
-import datawave.data.hash.UID;
 import datawave.marking.Markings;
+import datawave.table.hash.UID;
 import datawave.util.CompositeTimestamp;
 
 /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/DataTypeOverrideHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/DataTypeOverrideHelper.java
@@ -8,12 +8,12 @@ import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 
-import datawave.data.hash.UID;
-import datawave.data.hash.UIDBuilder;
-import datawave.data.hash.UIDConstants;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
 import datawave.ingest.input.reader.event.RecordFilter;
+import datawave.table.hash.UID;
+import datawave.table.hash.UIDBuilder;
+import datawave.table.hash.UIDConstants;
 import datawave.util.StringUtils;
 
 /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/hash/StringUID.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/hash/StringUID.java
@@ -2,10 +2,10 @@ package datawave.ingest.data.hash;
 
 import com.google.common.base.Objects;
 
-import datawave.data.hash.HashUID;
-import datawave.data.hash.SnowflakeUID;
-import datawave.data.hash.UID;
-import datawave.data.hash.UIDConstants;
+import datawave.table.hash.HashUID;
+import datawave.table.hash.SnowflakeUID;
+import datawave.table.hash.UID;
+import datawave.table.hash.UIDConstants;
 import datawave.util.StringUtils;
 
 /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/tokenize/TokenizationHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/tokenize/TokenizationHelper.java
@@ -10,9 +10,9 @@ import org.apache.lucene.analysis.CharArraySet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import datawave.data.hash.HashUID;
-import datawave.data.hash.UID;
 import datawave.ingest.data.config.DataTypeHelper;
+import datawave.table.hash.HashUID;
+import datawave.table.hash.UID;
 import datawave.util.ObjectFactory;
 
 public class TokenizationHelper {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/AbstractEventRecordReader.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/AbstractEventRecordReader.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
-import datawave.data.hash.UID;
-import datawave.data.hash.UIDBuilder;
 import datawave.data.normalizer.DateNormalizer;
 import datawave.ingest.config.IngestConfiguration;
 import datawave.ingest.config.IngestConfigurationFactory;
@@ -36,6 +34,8 @@ import datawave.ingest.data.config.DataTypeHelperImpl;
 import datawave.ingest.data.config.MarkingsHelper;
 import datawave.policy.IngestPolicyEnforcer;
 import datawave.policy.Policy;
+import datawave.table.hash.UID;
+import datawave.table.hash.UIDBuilder;
 
 public abstract class AbstractEventRecordReader<K> extends RecordReader<LongWritable,K> implements EventRecordReader {
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/event/EventSequenceFileRecordReader.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/input/reader/event/EventSequenceFileRecordReader.java
@@ -2,9 +2,9 @@ package datawave.ingest.input.reader.event;
 
 import org.apache.hadoop.mapreduce.lib.input.SequenceFileRecordReader;
 
-import datawave.data.hash.UID;
 import datawave.ingest.data.RawDataErrorNames;
 import datawave.ingest.data.RawRecordContainer;
+import datawave.table.hash.UID;
 
 /**
  * Reads Event objects from a sequence file. Users of this class need to be aware that the Event object may not have validated and may contain errors.

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/atom/AtomErrorDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/atom/AtomErrorDataTypeHandler.java
@@ -17,7 +17,6 @@ import org.apache.hadoop.mapreduce.TaskInputOutputContext;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.ingest.config.IngestConfigurationFactory;
 import datawave.ingest.data.RawDataErrorNames;
 import datawave.ingest.data.RawRecordContainer;
@@ -31,6 +30,7 @@ import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.writer.ContextWriter;
 import datawave.marking.MarkingFunctions;
 import datawave.marking.Markings;
+import datawave.table.hash.UID;
 
 /**
  * This class differs from the parent in that when it sees a field name of ERROR it creates a category name using the field name and value.

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorDataTypeHandler.java
@@ -21,8 +21,6 @@ import org.apache.log4j.Logger;
 
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
-import datawave.data.hash.UIDBuilder;
 import datawave.ingest.config.IngestConfiguration;
 import datawave.ingest.config.IngestConfigurationFactory;
 import datawave.ingest.data.RawDataErrorNames;
@@ -38,6 +36,8 @@ import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.writer.ContextWriter;
 import datawave.ingest.metadata.RawRecordMetadata;
 import datawave.marking.MarkingFunctions;
+import datawave.table.hash.UID;
+import datawave.table.hash.UIDBuilder;
 import datawave.util.TextUtil;
 import datawave.util.time.DateHelper;
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorShardedDataTypeHandler.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.ingest.config.IngestConfiguration;
 import datawave.ingest.config.IngestConfigurationFactory;
 import datawave.ingest.data.RawDataErrorNames;
@@ -45,6 +44,7 @@ import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.writer.ContextWriter;
 import datawave.table.constants.ColumnFamilyConstants;
+import datawave.table.hash.UID;
 
 /**
  * Handler that take events with processing errors or fatal errors and dumps them into a processing error table. This table will be used for subsequent

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reindex/ShardReindexMapper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/reindex/ShardReindexMapper.java
@@ -44,7 +44,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.HashUID;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
@@ -62,6 +61,7 @@ import datawave.ingest.mapreduce.job.writer.ContextWriter;
 import datawave.ingest.mapreduce.partition.MultiTableRangePartitioner;
 import datawave.ingest.metadata.EventMetadata;
 import datawave.ingest.protobuf.Uid;
+import datawave.table.hash.HashUID;
 
 public class ShardReindexMapper extends Mapper<Key,Value,BulkIngestKey,Value> {
     private static final String CLASS_NAME = ShardReindexMapper.class.getName();

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/TruncatedIndexConversionIterator.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/aggregator/TruncatedIndexConversionIterator.java
@@ -15,7 +15,7 @@ import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import datawave.ingest.table.aggregator.util.TruncatedIndexKeyParser;
+import datawave.table.key.parser.TruncatedIndexKeyParser;
 
 /**
  * This iterator can transform a global index table to a truncated index where the shard number becomes an index in a bitset

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/RawRecordContainerImplTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/RawRecordContainerImplTest.java
@@ -18,10 +18,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.Before;
 import org.junit.Test;
 
-import datawave.data.hash.UID;
 import datawave.ingest.config.IngestConfigurationFactory;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.config.MarkingsHelper;
+import datawave.table.hash.UID;
 
 public class RawRecordContainerImplTest {
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/EventMapperTest.java
@@ -30,7 +30,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
-import datawave.data.hash.UIDConstants;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
@@ -41,6 +40,7 @@ import datawave.ingest.mapreduce.job.metrics.Metric;
 import datawave.ingest.mapreduce.job.metrics.MetricsConfiguration;
 import datawave.ingest.mapreduce.job.metrics.TestEventCountMetricsReceiver;
 import datawave.ingest.mapreduce.job.writer.ContextWriter;
+import datawave.table.hash.UIDConstants;
 
 public class EventMapperTest {
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/SimpleRawRecord.java
@@ -14,14 +14,14 @@ import org.apache.accumulo.access.AccessExpression;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.hadoop.io.Writable;
 
-import datawave.data.hash.HashUID;
-import datawave.data.hash.UID;
-import datawave.data.hash.UIDBuilder;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
 import datawave.marking.AccessExpressionMarkings;
 import datawave.marking.Markings;
+import datawave.table.hash.HashUID;
+import datawave.table.hash.UID;
+import datawave.table.hash.UIDBuilder;
 import datawave.util.CompositeTimestamp;
 
 /**

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDeleteModeTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDeleteModeTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.data.normalizer.DateNormalizer;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
@@ -53,6 +52,7 @@ import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.writer.ContextWriter;
 import datawave.ingest.time.Now;
 import datawave.metadata.protobuf.EdgeMetadata;
+import datawave.table.hash.UID;
 import datawave.util.time.DateHelper;
 
 public class ProtobufEdgeDeleteModeTest {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDeletePreconditionTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDeletePreconditionTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
@@ -32,6 +31,7 @@ import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.ingest.data.config.ingest.FakeIngestHelper;
 import datawave.ingest.mapreduce.SimpleDataTypeHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
+import datawave.table.hash.UID;
 
 public class ProtobufEdgeDeletePreconditionTest {
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDirectionTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgeDirectionTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
@@ -34,6 +33,7 @@ import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.ingest.data.config.ingest.FakeIngestHelper;
 import datawave.ingest.mapreduce.SimpleDataTypeHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
+import datawave.table.hash.UID;
 
 public class ProtobufEdgeDirectionTest {
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgePreconditionTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/edge/ProtobufEdgePreconditionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
@@ -37,6 +36,7 @@ import datawave.ingest.data.config.ingest.FakeIngestHelper;
 import datawave.ingest.mapreduce.SimpleDataTypeHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.time.Now;
+import datawave.table.hash.UID;
 import datawave.util.time.DateHelper;
 
 public class ProtobufEdgePreconditionTest {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/facet/FacetHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/facet/FacetHandlerTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.UID;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
@@ -52,6 +51,7 @@ import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.writer.AbstractContextWriter;
 import datawave.ingest.test.StandaloneStatusReporter;
 import datawave.ingest.test.StandaloneTaskAttemptContext;
+import datawave.table.hash.UID;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardIdFactoryTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardIdFactoryTest.java
@@ -6,13 +6,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import datawave.data.hash.HashUID;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.RawRecordContainerImplTest;
 import datawave.ingest.data.Type;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.ingest.CSVIngestHelper;
+import datawave.table.hash.HashUID;
 import datawave.util.time.DateHelper;
 
 class ShardIdFactoryTest {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandlerTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
-import datawave.data.hash.HashUID;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.Type;
@@ -40,6 +39,7 @@ import datawave.ingest.table.config.TableConfigHelper;
 import datawave.policy.IngestPolicyEnforcer;
 import datawave.query.model.Direction;
 import datawave.table.constants.TableName;
+import datawave.table.hash.HashUID;
 import datawave.util.CompositeTimestamp;
 
 public class ShardedDataTypeHandlerTest {

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandlerTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
-import datawave.data.hash.UID;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberType;
 import datawave.ingest.config.RawRecordContainerImpl;
@@ -42,6 +41,7 @@ import datawave.ingest.data.tokenize.TokenizationHelper;
 import datawave.ingest.input.reader.EventRecordReader;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.policy.IngestPolicyEnforcer;
+import datawave.table.hash.UID;
 
 public class ContentIndexingColumnBasedHandlerTest {
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/CBMutationOutputFormatterTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/CBMutationOutputFormatterTest.java
@@ -24,10 +24,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import datawave.common.test.logging.TestLogCollector;
-import datawave.data.hash.UID;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.ingest.AccumuloHelper;
 import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
+import datawave.table.hash.UID;
 
 public class CBMutationOutputFormatterTest {
 

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/reindex/ShardReindexMapperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/job/reindex/ShardReindexMapperTest.java
@@ -61,7 +61,6 @@ import org.junit.Test;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 
-import datawave.data.hash.HashUID;
 import datawave.data.type.NoOpType;
 import datawave.ingest.config.RawRecordContainerImpl;
 import datawave.ingest.data.RawRecordContainer;
@@ -77,6 +76,7 @@ import datawave.ingest.protobuf.TermWeight;
 import datawave.iterators.FrequencyMetadataAggregator;
 import datawave.query.iterator.SortedListKeyValueIterator;
 import datawave.query.model.DateFrequencyMap;
+import datawave.table.hash.HashUID;
 import datawave.util.accumulo.RFileUtil;
 
 public class ShardReindexMapperTest extends EasyMockSupport {


### PR DESCRIPTION
Points ingest-core imports at the migrated datawave.table.hash.* and datawave.table.key.parser.* classes instead of the deprecated datawave.data.hash.* and datawave.ingest.table.aggregator.util.* originals. Deprecated classes and their dedicated tests are left in place.