### PR TITLE
Migrate QueryFunctionQueryTest from Arquillian to AbstractQueryTest

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/QueryFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryFunctionQueryTest.java
@@ -2,7 +2,6 @@ package datawave.query;
 
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -13,6 +12,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,7 +29,6 @@ import datawave.query.jexl.functions.QueryFunctions;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.WiseGuysIngest;
-import datawave.query.util.WiseGuysIngest.WhatKindaRange;
 import datawave.table.constants.TableName;
 
 /**
@@ -56,7 +55,7 @@ public class QueryFunctionQueryTest extends AbstractQueryTest {
     private static final Logger log = Logger.getLogger(QueryFunctionQueryTest.class);
     private static final Authorizations auths = new Authorizations("ALL");
 
-    private static final Map<WhatKindaRange,AccumuloClient> clients = new EnumMap<>(WhatKindaRange.class);
+    private static AccumuloClient client;
 
     @Autowired
     @Qualifier("EventQuery")
@@ -84,25 +83,21 @@ public class QueryFunctionQueryTest extends AbstractQueryTest {
 
     @BeforeAll
     public static void beforeAll(@TempDir Path tempDir) throws Exception {
-        for (WhatKindaRange range : WhatKindaRange.values()) {
-            System.setProperty("type.metadata.dir", tempDir.toFile().getCanonicalPath() + "/" + range.name());
+        System.setProperty("type.metadata.dir", tempDir.toFile().getCanonicalPath());
 
-            QueryTestTableHelper qtth = new QueryTestTableHelper(QueryFunctionQueryTest.class.toString() + "-" + range, log);
-            AccumuloClient client = qtth.client;
+        QueryTestTableHelper qtth = new QueryTestTableHelper(QueryFunctionQueryTest.class.toString(), log);
+        client = qtth.client;
 
-            WiseGuysIngest.writeItAll(client, range);
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-
-            clients.put(range, client);
-        }
+        WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
+        PrintUtility.printTable(client, auths, TableName.SHARD);
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
+        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
     }
 
-    private void setupLogic(WhatKindaRange range) {
-        setClientForTest(clients.get(range));
-        eventQueryLogic.setCollapseUids(range == WhatKindaRange.SHARD);
+    @BeforeEach
+    public void setup() {
+        setClientForTest(client);
         eventQueryLogic.setMaxEvaluationPipelines(1);
     }
 
@@ -115,28 +110,25 @@ public class QueryFunctionQueryTest extends AbstractQueryTest {
 
     private static Stream<Arguments> phraseFunctionsWithHashesArgs() {
         // @formatter:off
-        Object[][] cases = {
+        return Stream.of(
                 // this is added to the new tfs added with dot notation check if they can even be queried
-                {"QUOTE == 'never' && QUOTE == 'refuse'", List.of("CORLEONE")},
+                Arguments.of("QUOTE == 'never' && QUOTE == 'refuse'", List.of("CORLEONE")),
                 // check if a content phrase across these same dot notation fields can get a hit
-                {"content:phrase(termOffsetMap, 'i', 'never', 'refuse') && QUOTE == 'i' && QUOTE == 'never' && QUOTE == 'refuse'", List.of("CORLEONE")},
+                Arguments.of("content:phrase(termOffsetMap, 'i', 'never', 'refuse') && QUOTE == 'i' && QUOTE == 'never' && QUOTE == 'refuse'", List.of("CORLEONE")),
                 // check that there is no cross contamination between the dot notation tfs and normal tfs
-                {"content:phrase(termOffsetMap, 'gonna', 'refuse') && QUOTE == 'gonna' && QUOTE == 'refuse'", Collections.emptyList()},
+                Arguments.of("content:phrase(termOffsetMap, 'gonna', 'refuse') && QUOTE == 'gonna' && QUOTE == 'refuse'", Collections.emptyList()),
                 // check that if no tf set with dot notation satisfies a query it will be short circuited in tf eval
-                {"content:phrase(termOffsetMap, 'never', 'offer') && QUOTE == 'never' && QUOTE == 'offer'", Collections.emptyList()},
+                Arguments.of("content:phrase(termOffsetMap, 'never', 'offer') && QUOTE == 'never' && QUOTE == 'offer'", Collections.emptyList()),
                 // verify tfs from another section of the query don't help this resolve
-                {"content:phrase(QUOTE, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(PHILOSOPHY, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'", List.of("CORLEONE")},
+                Arguments.of("content:phrase(QUOTE, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(PHILOSOPHY, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'", List.of("CORLEONE")),
                 // invert the targets
-                {"content:phrase(PHILOSOPHY, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(QUOTE, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'", Collections.emptyList()},
-        };
+                Arguments.of("content:phrase(PHILOSOPHY, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(QUOTE, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'", Collections.emptyList()));
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("phraseFunctionsWithHashesArgs")
-    public void testPhraseFunctionsWithHashes(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
+    public void testPhraseFunctionsWithHashes(String query, List<String> expected) throws Exception {
         eventQueryLogic.setInitialMaxTermThreshold(20);
         eventQueryLogic.setIntermediateMaxTermThreshold(20);
         eventQueryLogic.setFinalMaxTermThreshold(20);
@@ -150,20 +142,16 @@ public class QueryFunctionQueryTest extends AbstractQueryTest {
 
     private static Stream<Arguments> includeTextArgs() {
         // @formatter:off
-        Object[][] cases = {
-                {"UUID == 'corleone' && f:includeText(GENERE, 'FEMALE')", List.of("CORLEONE")},
-                {"UUID == 'corleone' && f:includeText(GENERE, 'male')", Collections.emptyList()}, //  misses because includeText is case-sensitive
-                {"UUID == 'corleone' && f:includeText(NUMBER, '25')", List.of("CORLEONE")},
-        };
+        return Stream.of(
+                Arguments.of("UUID == 'corleone' && f:includeText(GENERE, 'FEMALE')", List.of("CORLEONE")),
+                Arguments.of("UUID == 'corleone' && f:includeText(GENERE, 'male')", Collections.emptyList()), //  misses because includeText is case-sensitive
+                Arguments.of("UUID == 'corleone' && f:includeText(NUMBER, '25')", List.of("CORLEONE")));
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("includeTextArgs")
-    public void testIncludeText(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
-
+    public void testIncludeText(String query, List<String> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("hit.list", "true");
 
@@ -177,21 +165,17 @@ public class QueryFunctionQueryTest extends AbstractQueryTest {
 
     private static Stream<Arguments> matchRegexArgs() {
         // @formatter:off
-        Object[][] cases = {
-                {"UUID == 'corleone' && f:matchRegex(GENERE, '.*MALE')", List.of("CORLEONE")},
-                {"UUID == 'corleone' && f:matchRegex(GENERE, '.*male')", List.of("CORLEONE")},
-                {"UUID == 'corleone' && f:matchRegex(NUMBER, '2.*')", List.of("CORLEONE")},
-                {"UUID == 'corleone' && f:matchRegex(GENERE, '[A-Z]+')", List.of("CORLEONE")},
-        };
+        return Stream.of(
+                Arguments.of("UUID == 'corleone' && f:matchRegex(GENERE, '.*MALE')", List.of("CORLEONE")),
+                Arguments.of("UUID == 'corleone' && f:matchRegex(GENERE, '.*male')", List.of("CORLEONE")),
+                Arguments.of("UUID == 'corleone' && f:matchRegex(NUMBER, '2.*')", List.of("CORLEONE")),
+                Arguments.of("UUID == 'corleone' && f:matchRegex(GENERE, '[A-Z]+')", List.of("CORLEONE")));
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("matchRegexArgs")
-    public void testMatchRegex(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
-
+    public void testMatchRegex(String query, List<String> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("hit.list", "true");
 

--- a/warehouse/query-core/src/test/java/datawave/query/QueryFunctionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/QueryFunctionQueryTest.java
@@ -1,56 +1,36 @@
 package datawave.query;
 
-import java.io.File;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.attributes.Attribute;
-import datawave.query.attributes.Document;
-import datawave.query.attributes.PreNormalizedAttribute;
-import datawave.query.attributes.TypeAttribute;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.jexl.functions.QueryFunctions;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.WiseGuysIngest;
+import datawave.query.util.WiseGuysIngest.WhatKindaRange;
 import datawave.table.constants.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * Integration test for {@link QueryFunctions}.
@@ -61,285 +41,165 @@ import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
  * <li>{@link QueryFunctions#MATCH_REGEX}</li>
  * </ul>
  */
-public abstract class QueryFunctionQueryTest {
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class QueryFunctionQueryTest extends AbstractQueryTest {
 
-    @ClassRule
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private static final Logger log = Logger.getLogger(QueryFunctionQueryTest.class);
+    private static final Authorizations auths = new Authorizations("ALL");
 
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends QueryFunctionQueryTest {
-        protected static AccumuloClient client = null;
+    private static final Map<WhatKindaRange,AccumuloClient> clients = new EnumMap<>(WhatKindaRange.class);
 
-        @BeforeClass
-        public static void setUp() throws Exception {
-            // this will get property substituted into the TypeMetadataBridgeContext.xml file
-            // for the injection test (when this unit test is first created)
-            File tempDir = temporaryFolder.newFolder("TempDirForCompositeFunctionsTestShardRange");
-            System.setProperty("type.metadata.dir", tempDir.getCanonicalPath());
-
-            QueryTestTableHelper qtth = new QueryTestTableHelper(QueryFunctionQueryTest.ShardRange.class.toString(), log);
-            client = qtth.client;
-
-            WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.SHARD);
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void setup() {
-            super.setup();
-            eventQueryLogic.setCollapseUids(true);
-        }
-
-        @AfterClass
-        public static void teardown() {
-            TypeRegistry.reset();
-        }
-
-        @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
-            super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client, eventQueryLogic);
-        }
-
-        @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms, ShardQueryLogic logic)
-                        throws Exception {
-            super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client, logic);
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends QueryFunctionQueryTest {
-        protected static AccumuloClient client = null;
-
-        @BeforeClass
-        public static void setUp() throws Exception {
-            // this will get property substituted into the TypeMetadataBridgeContext.xml file
-            // for the injection test (when this unit test is first created)
-            File tempDir = temporaryFolder.newFolder("TempDirForCompositeFunctionsTestDocumentRange");
-            System.setProperty("type.metadata.dir", tempDir.getCanonicalPath());
-
-            QueryTestTableHelper qtth = new QueryTestTableHelper(QueryFunctionQueryTest.DocumentRange.class.toString(), log);
-            client = qtth.client;
-
-            WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void setup() {
-            super.setup();
-            eventQueryLogic.setCollapseUids(false);
-        }
-
-        @AfterClass
-        public static void teardown() {
-            TypeRegistry.reset();
-        }
-
-        @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
-            super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client, eventQueryLogic);
-        }
-
-        @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms, ShardQueryLogic logic)
-                        throws Exception {
-            super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client, logic);
-        }
-    }
-
-    private static final Logger log = Logger.getLogger(CompositeFunctionsTest.class);
-
-    protected Authorizations auths = new Authorizations("ALL");
-
-    private final Set<Authorizations> authSet = Collections.singleton(auths);
-
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic eventQueryLogic;
 
-    private KryoDocumentDeserializer deserializer;
-
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-
-    @Deployment
-    public static JavaArchive createDeployment() {
-
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event", "datawave.core.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    @Override
+    public ShardQueryLogic getLogic() {
+        return eventQueryLogic;
     }
 
-    @Before
-    public void setup() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-        deserializer = new KryoDocumentDeserializer();
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
-    protected abstract void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception;
-
-    protected abstract void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms,
-                    ShardQueryLogic logic) throws Exception;
-
-    protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms, AccumuloClient client,
-                    ShardQueryLogic logic) throws Exception {
-        log.debug("runTestQuery");
-        log.trace("Creating QueryImpl");
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(startDate);
-        settings.setEndDate(endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(querystr);
-        settings.setParameters(extraParms);
-        settings.setId(UUID.randomUUID());
-
-        log.debug("query: " + settings.getQuery());
-        log.debug("logic: " + settings.getQueryLogicName());
-        logic.setMaxEvaluationPipelines(1);
-
-        GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
-        logic.setupQuery(config);
-
-        HashSet<String> expectedSet = new HashSet<>(expected);
-        HashSet<String> resultSet;
-        resultSet = new HashSet<>();
-        Set<Document> docs = new HashSet<>();
-        for (Entry<Key,Value> entry : logic) {
-            Document d = deserializer.apply(entry).getValue();
-
-            log.debug(entry.getKey() + " => " + d);
-
-            Attribute<?> attr = d.get("UUID");
-            if (attr == null) {
-                attr = d.get("UUID.0");
-            }
-
-            Assert.assertNotNull("Result Document did not contain a 'UUID'", attr);
-            Assert.assertTrue("Expected result to be an instance of DatwawaveTypeAttribute, was: " + attr.getClass().getName(),
-                            attr instanceof TypeAttribute || attr instanceof PreNormalizedAttribute);
-
-            TypeAttribute<?> UUIDAttr = (TypeAttribute<?>) attr;
-
-            String UUID = UUIDAttr.getType().getDelegate().toString();
-            Assert.assertTrue("Received unexpected UUID: " + UUID, expected.contains(UUID));
-
-            resultSet.add(UUID);
-            docs.add(d);
-        }
-
-        if (expected.size() > resultSet.size()) {
-            expectedSet.addAll(expected);
-            expectedSet.removeAll(resultSet);
-
-            for (String s : expectedSet) {
-                log.warn("Missing: " + s);
-            }
-        }
-
-        if (!expected.containsAll(resultSet)) {
-            log.error("Expected results " + expected + " differ form actual results " + resultSet);
-        }
-        Assert.assertTrue("Expected results " + expected + " differ form actual results " + resultSet, expected.containsAll(resultSet));
-        Assert.assertEquals("Unexpected number of records", expected.size(), resultSet.size());
+    @Override
+    protected void extraConfigurations() {
+        disableQueryPlanAssertion();
     }
 
-    @Test
-    public void testPhraseFunctionsWithHashes() throws Exception {
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    @BeforeAll
+    public static void beforeAll(@TempDir Path tempDir) throws Exception {
+        for (WhatKindaRange range : WhatKindaRange.values()) {
+            System.setProperty("type.metadata.dir", tempDir.toFile().getCanonicalPath() + "/" + range.name());
+
+            QueryTestTableHelper qtth = new QueryTestTableHelper(QueryFunctionQueryTest.class.toString() + "-" + range, log);
+            AccumuloClient client = qtth.client;
+
+            WiseGuysIngest.writeItAll(client, range);
+            PrintUtility.printTable(client, auths, TableName.SHARD);
+            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+            PrintUtility.printTable(client, auths, QueryTestTableHelper.METADATA_TABLE_NAME);
+            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+
+            clients.put(range, client);
+        }
+    }
+
+    private void setupLogic(WhatKindaRange range) {
+        setClientForTest(clients.get(range));
+        eventQueryLogic.setCollapseUids(range == WhatKindaRange.SHARD);
+        eventQueryLogic.setMaxEvaluationPipelines(1);
+    }
+
+    private void expectResults(List<String> expected) {
+        expectResultCount(expected.size());
+        if (!expected.isEmpty()) {
+            expectUUIDs(new HashSet<>(expected));
+        }
+    }
+
+    private static Stream<Arguments> phraseFunctionsWithHashesArgs() {
         // @formatter:off
-        String[] queryStrings = {
+        Object[][] cases = {
                 // this is added to the new tfs added with dot notation check if they can even be queried
-                "QUOTE == 'never' && QUOTE == 'refuse'",
+                {"QUOTE == 'never' && QUOTE == 'refuse'", List.of("CORLEONE")},
                 // check if a content phrase across these same dot notation fields can get a hit
-                "content:phrase(termOffsetMap, 'i', 'never', 'refuse') && QUOTE == 'i' && QUOTE == 'never' && QUOTE == 'refuse'",
+                {"content:phrase(termOffsetMap, 'i', 'never', 'refuse') && QUOTE == 'i' && QUOTE == 'never' && QUOTE == 'refuse'", List.of("CORLEONE")},
                 // check that there is no cross contamination between the dot notation tfs and normal tfs
-                "content:phrase(termOffsetMap, 'gonna', 'refuse') && QUOTE == 'gonna' && QUOTE == 'refuse'",
+                {"content:phrase(termOffsetMap, 'gonna', 'refuse') && QUOTE == 'gonna' && QUOTE == 'refuse'", Collections.emptyList()},
                 // check that if no tf set with dot notation satisfies a query it will be short circuited in tf eval
-                "content:phrase(termOffsetMap, 'never', 'offer') && QUOTE == 'never' && QUOTE == 'offer'",
+                {"content:phrase(termOffsetMap, 'never', 'offer') && QUOTE == 'never' && QUOTE == 'offer'", Collections.emptyList()},
                 // verify tfs from another section of the query don't help this resolve
-                "content:phrase(QUOTE, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(PHILOSOPHY, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'",
+                {"content:phrase(QUOTE, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(PHILOSOPHY, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'", List.of("CORLEONE")},
                 // invert the targets
-                "content:phrase(PHILOSOPHY, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(QUOTE, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'",
-        };
-
-        List<String>[] expected = new List[] {
-                List.of("CORLEONE"),
-                List.of("CORLEONE"),
-                Collections.emptyList(),
-                Collections.emptyList(),
-                List.of("CORLEONE"),
-                Collections.emptyList(),
+                {"content:phrase(PHILOSOPHY, termOffsetMap, 'never', 'refuse') && QUOTE == 'never' && QUOTE == 'refuse' && content:phrase(QUOTE, termOffsetMap, 'absolute', 'power') && PHILOSOPHY == 'absolute' && PHILOSOPHY == 'power'", Collections.emptyList()},
         };
         // @formatter:on
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
+    }
+
+    @ParameterizedTest
+    @MethodSource("phraseFunctionsWithHashesArgs")
+    public void testPhraseFunctionsWithHashes(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
         eventQueryLogic.setInitialMaxTermThreshold(20);
         eventQueryLogic.setIntermediateMaxTermThreshold(20);
         eventQueryLogic.setFinalMaxTermThreshold(20);
 
-        for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expected[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), Collections.emptyMap());
-        }
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        expectResults(expected);
+
+        planAndExecuteQuery();
     }
 
-    @Test
-    public void testIncludeText() throws Exception {
+    private static Stream<Arguments> includeTextArgs() {
+        // @formatter:off
+        Object[][] cases = {
+                {"UUID == 'corleone' && f:includeText(GENERE, 'FEMALE')", List.of("CORLEONE")},
+                {"UUID == 'corleone' && f:includeText(GENERE, 'male')", Collections.emptyList()}, //  misses because includeText is case-sensitive
+                {"UUID == 'corleone' && f:includeText(NUMBER, '25')", List.of("CORLEONE")},
+        };
+        // @formatter:on
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
+    }
+
+    @ParameterizedTest
+    @MethodSource("includeTextArgs")
+    public void testIncludeText(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
+
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("hit.list", "true");
 
-        // @formatter:off
-        String[] queryStrings = {
-                        "UUID == 'corleone' && f:includeText(GENERE, 'FEMALE')",
-                        "UUID == 'corleone' && f:includeText(GENERE, 'male')",
-                        "UUID == 'corleone' && f:includeText(NUMBER, '25')",
-        };
-        @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {
-                        List.of("CORLEONE"),
-                        List.of(),   //  misses because includeText is case-sensitive
-                        List.of("CORLEONE"),
-        };
-        // @formatter:on
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        givenParameters(extraParameters);
+        expectResults(expected);
 
-        for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
-        }
+        planAndExecuteQuery();
     }
 
-    @Test
-    public void testMatchRegex() throws Exception {
+    private static Stream<Arguments> matchRegexArgs() {
+        // @formatter:off
+        Object[][] cases = {
+                {"UUID == 'corleone' && f:matchRegex(GENERE, '.*MALE')", List.of("CORLEONE")},
+                {"UUID == 'corleone' && f:matchRegex(GENERE, '.*male')", List.of("CORLEONE")},
+                {"UUID == 'corleone' && f:matchRegex(NUMBER, '2.*')", List.of("CORLEONE")},
+                {"UUID == 'corleone' && f:matchRegex(GENERE, '[A-Z]+')", List.of("CORLEONE")},
+        };
+        // @formatter:on
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
+    }
+
+    @ParameterizedTest
+    @MethodSource("matchRegexArgs")
+    public void testMatchRegex(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
+
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("hit.list", "true");
 
-        // @formatter:off
-        String[] queryStrings = {
-                        "UUID == 'corleone' && f:matchRegex(GENERE, '.*MALE')",
-                        "UUID == 'corleone' && f:matchRegex(GENERE, '.*male')",
-                        "UUID == 'corleone' && f:matchRegex(NUMBER, '2.*')",
-                        "UUID == 'corleone' && f:matchRegex(GENERE, '[A-Z]+')",
-        };
-        @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {
-                        List.of("CORLEONE"),
-                        List.of("CORLEONE"),
-                        List.of("CORLEONE"),
-                        List.of("CORLEONE"),
-        };
-        // @formatter:on
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        givenParameters(extraParameters);
+        expectResults(expected);
 
-        for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
-        }
+        planAndExecuteQuery();
     }
 }


### PR DESCRIPTION
Drops the Arquillian container deployment and the ShardRange/DocumentRange nested subclasses in favor of extending AbstractQueryTest directly. Both the SHARD/DOCUMENT ingest range and the per-test query-string/expected-UUID cases are converted to @ParameterizedTest + @MethodSource, since the subclasses only differed in ingest range and collapseUids, and each test method previously looped over multiple query variants manually. Query plan assertion is disabled since this test only cares about UUID/result-count behavior, not the planned query string. Ingestion for both ranges happens once in @BeforeAll and is reused across all parameterized cases.