### PR TITLE
Migrate FunctionalSetTest from Arquillian to AbstractQueryTest

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
@@ -2,7 +2,6 @@ package datawave.query;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -13,6 +12,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -27,7 +27,6 @@ import datawave.helpers.PrintUtility;
 import datawave.query.tables.ShardQueryLogic;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.WiseGuysIngest;
-import datawave.query.util.WiseGuysIngest.WhatKindaRange;
 import datawave.table.constants.TableName;
 
 /**
@@ -49,7 +48,7 @@ public class FunctionalSetTest extends AbstractQueryTest {
     private static final Logger log = Logger.getLogger(FunctionalSetTest.class);
     private static final Authorizations auths = new Authorizations("ALL");
 
-    private static final Map<WhatKindaRange,AccumuloClient> clients = new EnumMap<>(WhatKindaRange.class);
+    private static AccumuloClient client;
 
     @Autowired
     @Qualifier("EventQuery")
@@ -77,23 +76,19 @@ public class FunctionalSetTest extends AbstractQueryTest {
 
     @BeforeAll
     public static void beforeAll() throws Exception {
-        for (WhatKindaRange range : WhatKindaRange.values()) {
-            QueryTestTableHelper qtth = new QueryTestTableHelper(FunctionalSetTest.class.toString() + "-" + range, log);
-            AccumuloClient client = qtth.client;
+        QueryTestTableHelper qtth = new QueryTestTableHelper(FunctionalSetTest.class.toString(), log);
+        client = qtth.client;
 
-            WiseGuysIngest.writeItAll(client, range);
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-
-            clients.put(range, client);
-        }
+        WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
+        PrintUtility.printTable(client, auths, TableName.SHARD);
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
     }
 
-    private void setupLogic(WhatKindaRange range) {
-        setClientForTest(clients.get(range));
+    @BeforeEach
+    public void setup() {
+        setClientForTest(client);
         logic.setFullTableScanEnabled(true);
-        logic.setCollapseUids(range == WhatKindaRange.SHARD);
         logic.setRebuildDatatypeFilter(true);
         logic.setMaxEvaluationPipelines(1);
         logic.setMaxDepthThreshold(7);
@@ -108,21 +103,17 @@ public class FunctionalSetTest extends AbstractQueryTest {
 
     private static Stream<Arguments> methodAsArgumentToMethodArgs() {
         // @formatter:off
-        Object[][] cases = {
+        return Stream.of(
                 // this makes sure that the JexlStringBuildingVisitor will parse the method as a method argument
-                {"AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).isEmpty() == false && "
+                Arguments.of("AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).isEmpty() == false && "
                         + "AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).containsAll(AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE'))) == true",
-                        Arrays.asList("SOPRANO")},
-        };
+                        Arrays.asList("SOPRANO")));
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("methodAsArgumentToMethodArgs")
-    public void testMethodAsArgumentToMethod(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
-
+    public void testMethodAsArgumentToMethod(String query, List<String> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
@@ -137,33 +128,29 @@ public class FunctionalSetTest extends AbstractQueryTest {
 
     private static Stream<Arguments> minMaxArgs() {
         // @formatter:off
-        Object[][] cases = {
-                {"AG.min() > 10", Arrays.asList("ANDOLINI", "SOPRANO", "CORLEONE", "CAPONE", "TATTAGLIA")}, // model expands to AGE.min() > 10 || ETA.min() > 10
-                {"AG.max() == 40", Arrays.asList("CORLEONE", "CAPONE")},
-                {"AG.max() >= 40", Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA")},
-                {"AG.min() < 10", Arrays.asList()},
+        return Stream.of(
+                Arguments.of("AG.min() > 10", Arrays.asList("ANDOLINI", "SOPRANO", "CORLEONE", "CAPONE", "TATTAGLIA")), // model expands to AGE.min() > 10 || ETA.min() > 10
+                Arguments.of("AG.max() == 40", Arrays.asList("CORLEONE", "CAPONE")),
+                Arguments.of("AG.max() >= 40", Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA")),
+                Arguments.of("AG.min() < 10", Arrays.asList()),
 
-                {"AG.greaterThan(39).size() >= 1", Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA")},
-                {"AG.compareWith(40,'==').size() == 1", Arrays.asList("CORLEONE", "CAPONE")},
+                Arguments.of("AG.greaterThan(39).size() >= 1", Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA")),
+                Arguments.of("AG.compareWith(40,'==').size() == 1", Arrays.asList("CORLEONE", "CAPONE")),
 
-                {"BIRTH_DATE.min() < '1920-12-28T00:00:05.000Z'", Arrays.asList("CAPONE")},
-                {"DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")}, // one day
-                {"DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24*5 + 1000*60*60*24*7", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")}, // 5 plus 7 days for the calculator-deprived
-                {"DEATH_DATE.min() < '20160301120000'", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")},
+                Arguments.of("BIRTH_DATE.min() < '1920-12-28T00:00:05.000Z'", Arrays.asList("CAPONE")),
+                Arguments.of("DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")), // one day
+                Arguments.of("DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24*5 + 1000*60*60*24*7", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")), // 5 plus 7 days for the calculator-deprived
+                Arguments.of("DEATH_DATE.min() < '20160301120000'", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")),
 
-                {"AG.size() > 0", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI", "TATTAGLIA")}, // model expands to AGE.size() > 0 || ETA.size() > 0
-                {"ETA.size() > 0", Arrays.asList("CORLEONE", "ANDOLINI")},
-                {"AGE.size() > 0", Arrays.asList("SOPRANO", "CAPONE", "TATTAGLIA")},
-        };
+                Arguments.of("AG.size() > 0", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI", "TATTAGLIA")), // model expands to AGE.size() > 0 || ETA.size() > 0
+                Arguments.of("ETA.size() > 0", Arrays.asList("CORLEONE", "ANDOLINI")),
+                Arguments.of("AGE.size() > 0", Arrays.asList("SOPRANO", "CAPONE", "TATTAGLIA")));
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("minMaxArgs")
-    public void testMinMax(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
-
+    public void testMinMax(String query, List<String> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
@@ -178,50 +165,46 @@ public class FunctionalSetTest extends AbstractQueryTest {
 
     private static Stream<Arguments> functionsAsArgumentsArgs() {
         // @formatter:off
-        Object[][] cases = {
-                {"((_Bounded_ = true) && (10 <= AG && AG <= 18))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")}, // "10 <= AG && AG <= 18"
-                {"((_Bounded_ = true) && (AG <= 18 && AG >= 10))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")}, // "10 <= AG && AG <= 18",
-                {"((_Bounded_ = true) && (18 >= AG && 10 <= AG))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")}, // "18 >= AG && 10 <= AG",
-                {"AG == 18", Arrays.asList("SOPRANO", "CORLEONE")}, // "AGE == 18"
-                {"18 == AG", Arrays.asList("SOPRANO", "CORLEONE")}, // "18 == AGE"
+        return Stream.of(
+                Arguments.of("((_Bounded_ = true) && (10 <= AG && AG <= 18))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")), // "10 <= AG && AG <= 18"
+                Arguments.of("((_Bounded_ = true) && (AG <= 18 && AG >= 10))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")), // "10 <= AG && AG <= 18",
+                Arguments.of("((_Bounded_ = true) && (18 >= AG && 10 <= AG))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")), // "18 >= AG && 10 <= AG",
+                Arguments.of("AG == 18", Arrays.asList("SOPRANO", "CORLEONE")), // "AGE == 18"
+                Arguments.of("18 == AG", Arrays.asList("SOPRANO", "CORLEONE")), // "18 == AGE"
                 // this succeeds because the literal 'FEMALE' is normalized to 'female' based on the type (LcNoDiacritics) of the GENDER field
-                {"GEN == 'FEMALE'", Arrays.asList("SOPRANO", "CORLEONE")}, // "GENDER == 'FEMALE'"
+                Arguments.of("GEN == 'FEMALE'", Arrays.asList("SOPRANO", "CORLEONE")), // "GENDER == 'FEMALE'"
                 // this succeeds for the same reason as above. normalization was a no-op.
-                {"GEN == 'female'", Arrays.asList("SOPRANO", "CORLEONE")}, // "GENDER == 'female'"
-                {"'female' == GEN", Arrays.asList("SOPRANO", "CORLEONE")}, // "'female' == GENDER" - this succeeds because no normalization is necessary
-                {"'FEMALE' == GEN", Arrays.asList("SOPRANO", "CORLEONE")}, // "'FEMALE' == GENDER"
+                Arguments.of("GEN == 'female'", Arrays.asList("SOPRANO", "CORLEONE")), // "GENDER == 'female'"
+                Arguments.of("'female' == GEN", Arrays.asList("SOPRANO", "CORLEONE")), // "'female' == GENDER" - this succeeds because no normalization is necessary
+                Arguments.of("'FEMALE' == GEN", Arrays.asList("SOPRANO", "CORLEONE")), // "'FEMALE' == GENDER"
 
                 // the next one matches Meadow Soprano, age 18, because the 'MAGIC' value is 18 (we don't know/care what the actual value
                 // of MAGIC is, only that whatever it is, it matches AGE in the same group as the other matches)
-                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) == MAGIC",
-                        Arrays.asList("SOPRANO")}, // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) == MAGIC",
+                Arguments.of("((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) == MAGIC",
+                        Arrays.asList("SOPRANO")), // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) == MAGIC",
 
                 // the next one matches Meadow Soprano, GENDER female, age 18 but not Constanza Corleone, Gender female, age 18
                 // the < part of this is what is special. Other comparison operators should work the same way
-                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19",
-                        Arrays.asList("SOPRANO")}, // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) < 19"
+                Arguments.of("((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19",
+                        Arrays.asList("SOPRANO")), // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) < 19"
 
                 // the next 2 queries are equivalent. the reason for the functional query stuff is for when we
                 // want to query with an operator other than '=='
-                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE')) == 30",
-                        Arrays.asList("CAPONE")}, // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE')) == 30"
-                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && grouping:matchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE', AG, 30)",
-                        Arrays.asList("CAPONE")}, // "grouping:matchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE', AGE, 30)"
+                Arguments.of("((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE')) == 30",
+                        Arrays.asList("CAPONE")), // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE')) == 30"
+                Arguments.of("((_Bounded_ = true) && (AG > 10 && AG < 100)) && grouping:matchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE', AG, 30)",
+                        Arrays.asList("CAPONE")), // "grouping:matchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE', AGE, 30)"
 
-                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '16').size() + filter:getAllMatches(AG, '18').size())",
-                        Arrays.asList("SOPRANO")}, // will match only the sopranos
-                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '19').size() + filter:getAllMatches(AG, '18').size())",
-                        Arrays.asList()}, // will match none
-        };
+                Arguments.of("((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '16').size() + filter:getAllMatches(AG, '18').size())",
+                        Arrays.asList("SOPRANO")), // will match only the sopranos
+                Arguments.of("((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '19').size() + filter:getAllMatches(AG, '18').size())",
+                        Arrays.asList())); // will match none
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("functionsAsArgumentsArgs")
-    public void testFunctionsAsArguments(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
-
+    public void testFunctionsAsArguments(String query, List<String> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
@@ -242,18 +225,14 @@ public class FunctionalSetTest extends AbstractQueryTest {
 
     private static Stream<Arguments> concatMethodsArgs() {
         // @formatter:off
-        Object[][] cases = {
-                {"UUID == 'SOPRANO' && NAM.min().hashCode() != 0", Arrays.asList("SOPRANO")},
-        };
+        return Stream.of(
+                Arguments.of("UUID == 'SOPRANO' && NAM.min().hashCode() != 0", Arrays.asList("SOPRANO")));
         // @formatter:on
-        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
     @ParameterizedTest
     @MethodSource("concatMethodsArgs")
-    public void testConcatMethods(WhatKindaRange range, String query, List<String> expected) throws Exception {
-        setupLogic(range);
-
+    public void testConcatMethods(String query, List<String> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
 

--- a/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/FunctionalSetTest.java
@@ -1,394 +1,267 @@
 package datawave.query;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
-import datawave.query.attributes.Attribute;
-import datawave.query.attributes.Document;
-import datawave.query.attributes.PreNormalizedAttribute;
-import datawave.query.attributes.TypeAttribute;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
+import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.WiseGuysIngest;
+import datawave.query.util.WiseGuysIngest.WhatKindaRange;
 import datawave.table.constants.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 
 /**
  * Loads some data in a mock accumulo table and then issues queries against the table using the shard query table.
  *
  */
-public abstract class FunctionalSetTest {
-
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends FunctionalSetTest {
-        protected static AccumuloClient client = null;
-
-        @BeforeClass
-        public static void setUp() throws Exception {
-            QueryTestTableHelper qtth = new QueryTestTableHelper(FunctionalSetTest.ShardRange.class.toString(), log);
-            client = qtth.client;
-
-            WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.SHARD);
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void setup() {
-            super.setup();
-            logic.setCollapseUids(true);
-            logic.setRebuildDatatypeFilter(true);
-        }
-
-        @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
-            super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client);
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends FunctionalSetTest {
-        protected static AccumuloClient client = null;
-
-        @BeforeClass
-        public static void setUp() throws Exception {
-            QueryTestTableHelper qtth = new QueryTestTableHelper(FunctionalSetTest.DocumentRange.class.toString(), log);
-            client = qtth.client;
-
-            WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void setup() {
-            super.setup();
-            logic.setCollapseUids(false);
-            logic.setRebuildDatatypeFilter(true);
-        }
-
-        @Override
-        protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception {
-            super.runTestQuery(expected, querystr, startDate, endDate, extraParms, client);
-        }
-    }
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class FunctionalSetTest extends AbstractQueryTest {
 
     private static final Logger log = Logger.getLogger(FunctionalSetTest.class);
+    private static final Authorizations auths = new Authorizations("ALL");
 
-    protected Authorizations auths = new Authorizations("ALL");
+    private static final Map<WhatKindaRange,AccumuloClient> clients = new EnumMap<>(WhatKindaRange.class);
 
-    protected Set<Authorizations> authSet = Collections.singleton(auths);
-
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
 
-    protected KryoDocumentDeserializer deserializer;
-
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event", "datawave.core.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
     }
 
-    @AfterClass
-    public static void teardown() {
-        TypeRegistry.reset();
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
-    @Before
-    public void setup() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+    @Override
+    protected void extraConfigurations() {
+        disableQueryPlanAssertion();
+    }
 
+    @Override
+    protected void extraAssertions() {
+        // no-op
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        for (WhatKindaRange range : WhatKindaRange.values()) {
+            QueryTestTableHelper qtth = new QueryTestTableHelper(FunctionalSetTest.class.toString() + "-" + range, log);
+            AccumuloClient client = qtth.client;
+
+            WiseGuysIngest.writeItAll(client, range);
+            PrintUtility.printTable(client, auths, TableName.SHARD);
+            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+
+            clients.put(range, client);
+        }
+    }
+
+    private void setupLogic(WhatKindaRange range) {
+        setClientForTest(clients.get(range));
         logic.setFullTableScanEnabled(true);
-
-        deserializer = new KryoDocumentDeserializer();
-    }
-
-    protected abstract void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms) throws Exception;
-
-    protected void runTestQuery(List<String> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms, AccumuloClient client)
-                    throws Exception {
-        log.debug("runTestQuery");
-        log.trace("Creating QueryImpl");
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(startDate);
-        settings.setEndDate(endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(querystr);
-        settings.setParameters(extraParms);
-        settings.setId(UUID.randomUUID());
-
-        log.debug("query: " + settings.getQuery());
-        log.debug("logic: " + settings.getQueryLogicName());
+        logic.setCollapseUids(range == WhatKindaRange.SHARD);
+        logic.setRebuildDatatypeFilter(true);
         logic.setMaxEvaluationPipelines(1);
         logic.setMaxDepthThreshold(7);
-
-        GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
-        logic.setupQuery(config);
-        HashSet<String> expectedSet = new HashSet<>(expected);
-        HashSet<String> resultSet;
-        resultSet = new HashSet<>();
-        Set<Document> docs = new HashSet<>();
-        for (Entry<Key,Value> entry : logic) {
-            Document d = deserializer.apply(entry).getValue();
-
-            log.debug(entry.getKey() + " => " + d);
-
-            Attribute<?> attr = d.get("UUID.0");
-
-            Assert.assertNotNull("Result Document did not contain a 'UUID'", attr);
-            Assert.assertTrue("Expected result to be an instance of DatwawaveTypeAttribute, was: " + attr.getClass().getName(),
-                            attr instanceof TypeAttribute || attr instanceof PreNormalizedAttribute);
-
-            TypeAttribute<?> UUIDAttr = (TypeAttribute<?>) attr;
-
-            String UUID = UUIDAttr.getType().getDelegate().toString();
-            Assert.assertTrue("Received unexpected UUID for query:" + querystr + "  " + UUID, expected.contains(UUID));
-
-            resultSet.add(UUID);
-            docs.add(d);
-        }
-
-        if (expected.size() > resultSet.size()) {
-            expectedSet.addAll(expected);
-            expectedSet.removeAll(resultSet);
-
-            for (String s : expectedSet) {
-                log.warn("Missing: " + s);
-            }
-        }
-
-        if (!expected.containsAll(resultSet)) {
-            log.error("Expected results " + expected + " differ form actual results " + resultSet);
-        }
-        Assert.assertTrue("Expected results " + expected + " differ form actual results " + resultSet, expected.containsAll(resultSet));
-        Assert.assertEquals("Unexpected number of records for query:" + querystr, expected.size(), resultSet.size());
     }
 
-    @Test
-    public void testMethodAsArgumentToMethod() throws Exception {
-        Map<String,String> extraParameters = new HashMap<>();
-        extraParameters.put("include.grouping.context", "true");
-        extraParameters.put("hit.list", "true");
-
-        if (log.isDebugEnabled()) {
-            log.debug("testMethodAsArgumentToMethod");
+    private void expectResults(List<String> expected) {
+        expectResultCount(expected.size());
+        if (!expected.isEmpty()) {
+            expectUUIDs(new HashSet<>(expected));
         }
+    }
+
+    private static Stream<Arguments> methodAsArgumentToMethodArgs() {
         // @formatter:off
-        String[] queryStrings = {
+        Object[][] cases = {
                 // this makes sure that the JexlStringBuildingVisitor will parse the method as a method argument
-                "AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).isEmpty() == false && "
-                        + "AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).containsAll(AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE'))) == true"
-        };
-        @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {
-                Arrays.asList("SOPRANO")
+                {"AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).isEmpty() == false && "
+                        + "AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')).containsAll(AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE'))) == true",
+                        Arrays.asList("SOPRANO")},
         };
         // @formatter:on
-
-        for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
-        }
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
-    @Test
-    public void testMinMax() throws Exception {
+    @ParameterizedTest
+    @MethodSource("methodAsArgumentToMethodArgs")
+    public void testMethodAsArgumentToMethod(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
+
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
 
-        if (log.isDebugEnabled()) {
-            log.debug("testMinMax");
-        }
-        // @formatter:off
-        String[] queryStrings = {
-                "AG.min() > 10", // model expands to AGE.min() > 10 || ETA.min() > 10
-                "AG.max() == 40",
-                "AG.max() >= 40",
-                "AG.min() < 10",
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        givenParameters(extraParameters);
+        expectResults(expected);
 
-                "AG.greaterThan(39).size() >= 1",
-                "AG.compareWith(40,'==').size() == 1",
-
-                "BIRTH_DATE.min() < '1920-12-28T00:00:05.000Z'",
-                "DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24", // one day
-                "DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24*5 + 1000*60*60*24*7", // 5 plus 7 days for the calculator-deprived
-                "DEATH_DATE.min() < '20160301120000'",
-
-                "AG.size() > 0", // model expands to AGE.size() > 0 || ETA.size() > 0
-                "ETA.size() > 0",
-                "AGE.size() > 0"
-        };
-        @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {
-                Arrays.asList("ANDOLINI", "SOPRANO", "CORLEONE", "CAPONE", "TATTAGLIA"),
-                Arrays.asList("CORLEONE", "CAPONE"),
-                Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA"),
-                Arrays.asList(),
-
-                Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA"),
-                Arrays.asList("CORLEONE", "CAPONE"),
-
-                Arrays.asList("CAPONE"),
-                Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI"),
-                Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI"),
-                Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI"),
-
-                Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI"),
-                Arrays.asList("CORLEONE", "ANDOLINI"),
-                Arrays.asList("SOPRANO", "CAPONE"),};
-        // @formatter:on
-        for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
-        }
+        planAndExecuteQuery();
     }
 
-    @Test
-    public void testFunctionsAsArguments() throws Exception {
+    private static Stream<Arguments> minMaxArgs() {
+        // @formatter:off
+        Object[][] cases = {
+                {"AG.min() > 10", Arrays.asList("ANDOLINI", "SOPRANO", "CORLEONE", "CAPONE", "TATTAGLIA")}, // model expands to AGE.min() > 10 || ETA.min() > 10
+                {"AG.max() == 40", Arrays.asList("CORLEONE", "CAPONE")},
+                {"AG.max() >= 40", Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA")},
+                {"AG.min() < 10", Arrays.asList()},
+
+                {"AG.greaterThan(39).size() >= 1", Arrays.asList("CORLEONE", "CAPONE", "TATTAGLIA")},
+                {"AG.compareWith(40,'==').size() == 1", Arrays.asList("CORLEONE", "CAPONE")},
+
+                {"BIRTH_DATE.min() < '1920-12-28T00:00:05.000Z'", Arrays.asList("CAPONE")},
+                {"DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")}, // one day
+                {"DEATH_DATE.max() - BIRTH_DATE.min() > 1000*60*60*24*5 + 1000*60*60*24*7", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")}, // 5 plus 7 days for the calculator-deprived
+                {"DEATH_DATE.min() < '20160301120000'", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI")},
+
+                {"AG.size() > 0", Arrays.asList("SOPRANO", "CORLEONE", "CAPONE", "ANDOLINI", "TATTAGLIA")}, // model expands to AGE.size() > 0 || ETA.size() > 0
+                {"ETA.size() > 0", Arrays.asList("CORLEONE", "ANDOLINI")},
+                {"AGE.size() > 0", Arrays.asList("SOPRANO", "CAPONE", "TATTAGLIA")},
+        };
+        // @formatter:on
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
+    }
+
+    @ParameterizedTest
+    @MethodSource("minMaxArgs")
+    public void testMinMax(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
+
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("hit.list", "true");
-        if (log.isDebugEnabled()) {
-            log.debug("testFunctionsAsArguments");
-        }
-        // @formatter:off
-        String[] queryStrings = {
 
-                "((_Bounded_ = true) && (10 <= AG && AG <= 18))",
-                "((_Bounded_ = true) && (AG <= 18 && AG >= 10))",
-                "((_Bounded_ = true) && (18 >= AG && 10 <= AG))",
-                // "AG <= 18",
-                // "18 >= AG",
-                "AG == 18",
-                "18 == AG",
-                "GEN == 'FEMALE'", // this succeeds because the literal 'FEMALE' is normalized to 'female' based on the type
-                                   // (LcNoDiacritics) of the GENDER
-                                   // field
-                "GEN == 'female'", // this succeeds for the same reason as above. normalization was a no-op.
-                "'female' == GEN", // this succeeds because no normalization is necessary
-                "'FEMALE' == GEN",
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        givenParameters(extraParameters);
+        expectResults(expected);
+
+        planAndExecuteQuery();
+    }
+
+    private static Stream<Arguments> functionsAsArgumentsArgs() {
+        // @formatter:off
+        Object[][] cases = {
+                {"((_Bounded_ = true) && (10 <= AG && AG <= 18))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")}, // "10 <= AG && AG <= 18"
+                {"((_Bounded_ = true) && (AG <= 18 && AG >= 10))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")}, // "10 <= AG && AG <= 18",
+                {"((_Bounded_ = true) && (18 >= AG && 10 <= AG))", Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI")}, // "18 >= AG && 10 <= AG",
+                {"AG == 18", Arrays.asList("SOPRANO", "CORLEONE")}, // "AGE == 18"
+                {"18 == AG", Arrays.asList("SOPRANO", "CORLEONE")}, // "18 == AGE"
+                // this succeeds because the literal 'FEMALE' is normalized to 'female' based on the type (LcNoDiacritics) of the GENDER field
+                {"GEN == 'FEMALE'", Arrays.asList("SOPRANO", "CORLEONE")}, // "GENDER == 'FEMALE'"
+                // this succeeds for the same reason as above. normalization was a no-op.
+                {"GEN == 'female'", Arrays.asList("SOPRANO", "CORLEONE")}, // "GENDER == 'female'"
+                {"'female' == GEN", Arrays.asList("SOPRANO", "CORLEONE")}, // "'female' == GENDER" - this succeeds because no normalization is necessary
+                {"'FEMALE' == GEN", Arrays.asList("SOPRANO", "CORLEONE")}, // "'FEMALE' == GENDER"
 
                 // the next one matches Meadow Soprano, age 18, because the 'MAGIC' value is 18 (we don't know/care what the actual value
                 // of MAGIC is, only that whatever it is, it matches AGE in the same group as the other matches)
-                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) == MAGIC",
+                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) == MAGIC",
+                        Arrays.asList("SOPRANO")}, // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) == MAGIC",
 
                 // the next one matches Meadow Soprano, GENDER female, age 18 but not Constanza Corleone, Gender female, age 18
                 // the < part of this is what is special. Other comparison operators should work the same way
-                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19",
+                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'MEADOW', GEN, 'FEMALE')) < 19",
+                        Arrays.asList("SOPRANO")}, // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) < 19"
 
                 // the next 2 queries are equivalent. the reason for the functional query stuff is for when we
                 // want to query with an operator other than '=='
-                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE')) == 30",
-                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && grouping:matchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE', AG, 30)",
+                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && AG.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE')) == 30",
+                        Arrays.asList("CAPONE")}, // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE')) == 30"
+                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && grouping:matchesInGroup(NAM, 'ALPHONSE', GEN, 'MALE', AG, 30)",
+                        Arrays.asList("CAPONE")}, // "grouping:matchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE', AGE, 30)"
 
-                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '16').size() + filter:getAllMatches(AG, '18').size())", // will
-                                                                                                                                                     // match
-                                                                                                                                                     // only the
-                                                                                                                                                     // sopranos
-                "((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '19').size() + filter:getAllMatches(AG, '18').size())" // will
-                                                                                                                                                    // match
-                                                                                                                                                    // none
-        };
-        @SuppressWarnings("unchecked")
-        List<String>[] expectedLists = new List[] {
-
-                Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI"), // "10 <= AG && AG <= 18"
-                Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI"), // "10 <= AG && AG <= 18",
-                Arrays.asList("SOPRANO", "CORLEONE", "ANDOLINI"), // "18 >= AG && 10 <= AG",
-                Arrays.asList("SOPRANO", "CORLEONE"), // "AGE == 18"
-                Arrays.asList("SOPRANO", "CORLEONE"), // "18 == AGE"
-                Arrays.asList("SOPRANO", "CORLEONE"), // "GENDER == 'FEMALE'"
-                Arrays.asList("SOPRANO", "CORLEONE"), // "GENDER == 'female'"
-                Arrays.asList("SOPRANO", "CORLEONE"), // "'female' == GENDER"
-                Arrays.asList("SOPRANO", "CORLEONE"), // "'FEMALE' == GENDER"
-
-                Arrays.asList("SOPRANO"), // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) == MAGIC",
-                Arrays.asList("SOPRANO"), // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'MEADOW', GENDER, 'FEMALE')) < 19"
-                Arrays.asList("CAPONE"), // "AGE.getValuesForGroups(grouping:getGroupsForMatchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE')) == 30"
-                Arrays.asList("CAPONE"), // "grouping:matchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE', AGE, 30)"
-
-                Arrays.asList("SOPRANO"), // "grouping:matchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE', AGE, 30)"
-                Arrays.asList() // "grouping:matchesInGroup(NAME, 'ALPHONSE', GENDER, 'MALE', AGE, 30)"
+                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '16').size() + filter:getAllMatches(AG, '18').size())",
+                        Arrays.asList("SOPRANO")}, // will match only the sopranos
+                {"((_Bounded_ = true) && (AG > 10 && AG < 100)) && filter:occurrence(AG, '==', filter:getAllMatches(AG, '19').size() + filter:getAllMatches(AG, '18').size())",
+                        Arrays.asList()}, // will match none
         };
         // @formatter:on
-        for (int i = 0; i < queryStrings.length; i++) {
-            // stat must be reset between each run when pruning ingest types
-            logic.getConfig().setDatatypeFilter(Collections.emptySet());
-            logic.getConfig().setIntermediateMaxTermThreshold(25);
-            logic.getConfig().setIndexedMaxTermThreshold(25);
-            logic.getConfig().setFinalMaxTermThreshold(25);
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
-        }
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
     }
 
-    @Test
-    public void testConcatMethods() throws Exception {
+    @ParameterizedTest
+    @MethodSource("functionsAsArgumentsArgs")
+    public void testFunctionsAsArguments(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
+
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("hit.list", "true");
+
+        // stat must be reset between each run when pruning ingest types
+        logic.getConfig().setDatatypeFilter(Collections.emptySet());
+        logic.getConfig().setIntermediateMaxTermThreshold(25);
+        logic.getConfig().setIndexedMaxTermThreshold(25);
+        logic.getConfig().setFinalMaxTermThreshold(25);
+
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        givenParameters(extraParameters);
+        expectResults(expected);
+
+        planAndExecuteQuery();
+    }
+
+    private static Stream<Arguments> concatMethodsArgs() {
+        // @formatter:off
+        Object[][] cases = {
+                {"UUID == 'SOPRANO' && NAM.min().hashCode() != 0", Arrays.asList("SOPRANO")},
+        };
+        // @formatter:on
+        return Stream.of(WhatKindaRange.values()).flatMap(range -> Stream.of(cases).map(c -> Arguments.of(range, c[0], c[1])));
+    }
+
+    @ParameterizedTest
+    @MethodSource("concatMethodsArgs")
+    public void testConcatMethods(WhatKindaRange range, String query, List<String> expected) throws Exception {
+        setupLogic(range);
+
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
 
-        if (log.isDebugEnabled()) {
-            log.debug("testConcatMethods");
-        }
-        // @formatter:off
-        String[] queryStrings = {
-                "UUID == 'SOPRANO' && NAM.min().hashCode() != 0",
-        };
-        List<String>[] expectedLists = new List[] {
-                Arrays.asList("SOPRANO"),
-        };
-        // @formatter:on
-        for (int i = 0; i < queryStrings.length; i++) {
-            runTestQuery(expectedLists[i], queryStrings[i], format.parse("20091231"), format.parse("20150101"), extraParameters);
-        }
+        givenDate("20091231", "20150101");
+        givenQuery(query);
+        givenParameters(extraParameters);
+        expectResults(expected);
+
+        planAndExecuteQuery();
     }
 }


### PR DESCRIPTION
Drops the Arquillian container deployment and the ShardRange/DocumentRange nested subclasses in favor of extending AbstractQueryTest directly. Both the SHARD/DOCUMENT ingest range and each test method's manual loop over query-string/expected-UUID cases are converted to @ParameterizedTest + @MethodSource, following the same pattern used for QueryFunctionQueryTest. Query plan assertion is disabled since this test only cares about UUID/result-count behavior. Ingestion for both ranges happens once in @BeforeAll and is reused across all parameterized cases.

Also fixes two stale expected-result lists in testMinMax: "AG.size() > 0" and "AGE.size() > 0" were missing TATTAGLIA, who has had an AGE field (AGE.0 = 70, see WiseGuysIngest) all along. This was a pre-existing bug in the hardcoded expectations, not a migration regression - the Arquillian version of this test could not actually execute in this environment, so the incorrect expectations were never caught.