### PR TITLE
Migrate UniqueTest from Arquillian to AbstractQueryTest

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/UniqueTest.java
@@ -1,54 +1,45 @@
 package datawave.query;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.net.URL;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TimeZone;
-import java.util.UUID;
-
-import javax.inject.Inject;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.commons.collections4.iterators.TransformIterator;
 import org.apache.log4j.Logger;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.collect.Sets;
 
-import datawave.configuration.spring.SpringBean;
-import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.core.query.iterator.DatawaveTransformIterator;
 import datawave.helpers.PrintUtility;
-import datawave.ingest.data.TypeRegistry;
-import datawave.microservice.query.QueryImpl;
 import datawave.query.exceptions.InvalidQueryException;
-import datawave.query.function.deserializer.KryoDocumentDeserializer;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.transformer.DocumentTransformer;
+import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.WiseGuysIngest;
 import datawave.table.constants.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.webservice.query.result.event.EventBase;
 import datawave.webservice.result.BaseQueryResponse;
 import datawave.webservice.result.DefaultEventQueryResponse;
@@ -57,170 +48,75 @@ import datawave.webservice.result.DefaultEventQueryResponse;
  * Applies uniqueness to queries
  *
  */
-public abstract class UniqueTest {
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class UniqueTest extends AbstractQueryTest {
 
     private static final Logger log = Logger.getLogger(UniqueTest.class);
+    private static final Authorizations auths = new Authorizations("ALL");
 
-    @RunWith(Arquillian.class)
-    public static class ShardRange extends UniqueTest {
-        protected static AccumuloClient client = null;
-        private static Authorizations auths = new Authorizations("ALL");
+    private static AccumuloClient client;
 
-        @BeforeClass
-        public static void setUp() throws Exception {
-
-            // testing tear downs but without consistency, because when we tear it down then we loose the ongoing bloom filter and subsequently the rebuild will
-            // start returning
-            // different keys.
-            QueryTestTableHelper qtth = new QueryTestTableHelper(ShardRange.class.toString(), log,
-                            RebuildingScannerTestHelper.TEARDOWN.EVERY_OTHER_SANS_CONSISTENCY, RebuildingScannerTestHelper.INTERRUPT.EVERY_OTHER);
-            client = qtth.client;
-
-            WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void setup() {
-            super.setup();
-            logic.setCollapseUids(true);
-        }
-
-        @Override
-        protected void runTestQueryWithUniqueness(Set<Set<String>> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
-                        throws Exception {
-            super.runTestQueryWithUniqueness(expected, querystr, startDate, endDate, extraParms, client);
-        }
-    }
-
-    @RunWith(Arquillian.class)
-    public static class DocumentRange extends UniqueTest {
-        protected static AccumuloClient client = null;
-        private static Authorizations auths = new Authorizations("ALL");
-
-        @BeforeClass
-        public static void setUp() throws Exception {
-
-            // testing tear downs but without consistency, because when we tear it down then we loose the ongoing bloom filter and subsequently the rebuild will
-            // start returning
-            // different keys.
-            QueryTestTableHelper qtth = new QueryTestTableHelper(DocumentRange.class.toString(), log,
-                            RebuildingScannerTestHelper.TEARDOWN.EVERY_OTHER_SANS_CONSISTENCY, RebuildingScannerTestHelper.INTERRUPT.EVERY_OTHER);
-            client = qtth.client;
-
-            WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
-            Authorizations auths = new Authorizations("ALL");
-            PrintUtility.printTable(client, auths, TableName.SHARD);
-            PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
-            PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
-        }
-
-        @Before
-        public void setup() {
-            super.setup();
-            logic.setCollapseUids(false);
-        }
-
-        @Override
-        protected void runTestQueryWithUniqueness(Set<Set<String>> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
-                        throws Exception {
-            super.runTestQueryWithUniqueness(expected, querystr, startDate, endDate, extraParms, client);
-        }
-    }
-
-    protected Authorizations auths = new Authorizations("ALL");
-
-    protected Set<Authorizations> authSet = Collections.singleton(auths);
-
-    @Inject
-    @SpringBean(name = "EventQuery")
+    @Autowired
+    @Qualifier("EventQuery")
     protected ShardQueryLogic logic;
 
-    protected KryoDocumentDeserializer deserializer;
+    private Set<Set<String>> expectedGroups;
+    private List<EventBase> events;
 
-    private final DateFormat format = new SimpleDateFormat("yyyyMMdd");
-
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "org.jboss.logging",
-                                        "datawave.webservice.query.result.event", "datawave.core.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
     }
 
-    @AfterClass
-    public static void teardown() {
-        TypeRegistry.reset();
+    @Override
+    public Authorizations getAuths() {
+        return auths;
     }
 
-    @Before
-    public void setup() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
-
-        logic.setFullTableScanEnabled(true);
-        // setup the hadoop configuration
-        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
-        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
-
-        logic.setQueryExecutionForPageTimeout(300000000000000L);
-        deserializer = new KryoDocumentDeserializer();
+    @Override
+    protected void extraConfigurations() {
+        disableQueryPlanAssertion();
     }
 
-    protected abstract void runTestQueryWithUniqueness(Set<Set<String>> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms)
-                    throws Exception;
-
-    protected void runTestQueryWithUniqueness(Set<Set<String>> expected, String querystr, Date startDate, Date endDate, Map<String,String> extraParms,
-                    AccumuloClient client) throws Exception {
-        log.debug("runTestQueryWithUniqueness");
-
-        QueryImpl settings = new QueryImpl();
-        settings.setBeginDate(startDate);
-        settings.setEndDate(endDate);
-        settings.setPagesize(Integer.MAX_VALUE);
-        settings.setQueryAuthorizations(auths.serialize());
-        settings.setQuery(querystr);
-        settings.setParameters(extraParms);
-        settings.setId(UUID.randomUUID());
-
-        log.debug("query: " + settings.getQuery());
-        log.debug("logic: " + settings.getQueryLogicName());
-
-        GenericQueryConfiguration config = logic.initialize(client, settings, authSet);
-        logic.setupQuery(config);
-
-        DocumentTransformer transformer = (DocumentTransformer) (logic.getTransformer(settings));
-        TransformIterator iter = new DatawaveTransformIterator(logic.iterator(), transformer);
-        List<Object> eventList = new ArrayList<>();
-        while (iter.hasNext()) {
-            Object o = iter.next();
-            if (o != null) {
-                eventList.add(o);
+    @Override
+    protected void executeQuery(ShardQueryLogic logic) throws Exception {
+        try {
+            DocumentTransformer transformer = (DocumentTransformer) (logic.getTransformer(logic.getConfig().getQuery()));
+            TransformIterator iter = new DatawaveTransformIterator(logic.iterator(), transformer);
+            List<Object> eventList = new ArrayList<>();
+            while (iter.hasNext()) {
+                Object o = iter.next();
+                if (o != null) {
+                    eventList.add(o);
+                }
             }
+
+            BaseQueryResponse response = transformer.createResponse(eventList);
+            assertTrue(response instanceof DefaultEventQueryResponse);
+            this.events = ((DefaultEventQueryResponse) response).getEvents();
+        } finally {
+            logic.close();
         }
+    }
 
-        BaseQueryResponse response = transformer.createResponse(eventList);
+    @Override
+    protected void extraAssertions() {
+        // planAndExecuteQuery() invokes extraAssertions() once per index table variant, so check
+        // against a local copy rather than destructively consuming the shared expectedGroups set.
+        Set<Set<String>> remaining = new HashSet<>(expectedGroups);
 
-        // un-comment to look at the json output
-        // ObjectMapper mapper = new ObjectMapper();
-        // mapper.enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME);
-        // mapper.writeValue(new File("/tmp/grouped2.json"), response);
-
-        Assert.assertTrue(response instanceof DefaultEventQueryResponse);
-        DefaultEventQueryResponse eventQueryResponse = (DefaultEventQueryResponse) response;
-
-        // copy expected set to avoid modifying parameter passed in
-        expected = new HashSet<>(expected);
-
-        for (EventBase event : eventQueryResponse.getEvents()) {
+        for (EventBase event : events) {
             boolean found = false;
-            for (Iterator<Set<String>> it = expected.iterator(); it.hasNext();) {
+            for (Iterator<Set<String>> it = remaining.iterator(); it.hasNext();) {
                 Set<String> expectedSet = it.next();
 
                 if (expectedSet.contains(event.getMetadata().getInternalId())) {
@@ -229,131 +125,141 @@ public abstract class UniqueTest {
                     break;
                 }
             }
-            Assert.assertTrue("Failed to find " + event.getMetadata().getInternalId() + " in expected results", found);
+            assertTrue(found, "Failed to find " + event.getMetadata().getInternalId() + " in expected results");
         }
-        Assert.assertTrue("Failed to find all expected results.  Missing " + expected, expected.isEmpty());
+        assertTrue(remaining.isEmpty(), "Failed to find all expected results.  Missing " + remaining);
     }
 
-    @Test
-    public void testUniqueness() throws Exception {
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        // testing tear downs but without consistency, because when we tear it down then we lose the ongoing bloom filter and subsequently the rebuild
+        // will start returning different keys.
+        QueryTestTableHelper qtth = new QueryTestTableHelper(UniqueTest.class.toString(), log,
+                        RebuildingScannerTestHelper.TEARDOWN.EVERY_OTHER_SANS_CONSISTENCY, RebuildingScannerTestHelper.INTERRUPT.EVERY_OTHER);
+        client = qtth.client;
+
+        WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
+        PrintUtility.printTable(client, auths, TableName.SHARD);
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+    }
+
+    @BeforeEach
+    public void setup() {
+        setClientForTest(client);
+        logic.setFullTableScanEnabled(true);
+
+        // setup the hadoop configuration
+        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
+
+        logic.setQueryExecutionForPageTimeout(300000000000000L);
+    }
+
+    private void runTestQueryWithUniqueness(Set<Set<String>> expected, String querystr, Map<String,String> extraParms) throws Exception {
+        this.expectedGroups = expected;
+
+        givenDate("20091231", "20150101");
+        givenQuery(querystr);
+        givenParameters(extraParms);
+
+        planAndExecuteQuery();
+    }
+
+    private static Stream<Arguments> uniquenessArgs() {
+        // @formatter:off
+        return Stream.of(
+                Arguments.of("DEATH_DATE,$MAGIC", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID))),
+                Arguments.of("$DEATH_DATE,BIRTH_DATE", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("death_date,birth_date", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID))));
+        // @formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("uniquenessArgs")
+    public void testUniqueness(String uniqueFields, Set<Set<String>> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
-
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
+        extraParameters.put("unique.fields", uniqueFields);
 
         String queryString = "UUID =~ '^[CS].*'";
 
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        expected.clear();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        extraParameters.put("unique.fields", "$DEATH_DATE,BIRTH_DATE");
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        expected.clear();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        extraParameters.put("unique.fields", "death_date,birth_date");
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
     }
 
     @Test
     public void testUniquenessWithMissingField() throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
-
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
+        extraParameters.put("unique.fields", "NUMBER");
 
         String queryString = "UUID =~ '^[CS].*'";
 
-        Set<Set<String>> expected = new HashSet<>();
         // both capone and corleone contain NUMBER:25, only one document is expected to be returned
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID, WiseGuysIngest.corleoneUID));
         // soprano uid -1kfeoq.-80b5fs.r0262j does NOT contain a NUMBER field
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        extraParameters.put("unique.fields", "NUMBER");
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+        Set<Set<String>> expected = Set.of(Sets.newHashSet(WiseGuysIngest.caponeUID, WiseGuysIngest.corleoneUID), Sets.newHashSet(WiseGuysIngest.sopranoUID));
+
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
     }
 
-    @Test
-    public void testUniquenessUsingFunction() throws Exception {
+    private static Stream<Arguments> uniquenessUsingFunctionArgs() {
+        // @formatter:off
+        return Stream.of(
+                Arguments.of("UUID =~ '^[CS].*' && f:unique($DEATH_DATE,MAGIC)",
+                        Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID))),
+                Arguments.of("UUID =~ '^[CS].*' && f:unique('DEATH_DATE','$BIRTH_DATE')", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID),
+                        Sets.newHashSet(WiseGuysIngest.corleoneUID), Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("UUID =~ '^[CS].*' && f:unique('death_date','$birth_date')", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID),
+                        Sets.newHashSet(WiseGuysIngest.corleoneUID), Sets.newHashSet(WiseGuysIngest.caponeUID))));
+        // @formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("uniquenessUsingFunctionArgs")
+    public void testUniquenessUsingFunction(String queryString, Set<Set<String>> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
 
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
-
-        String queryString = "UUID =~ '^[CS].*' && f:unique($DEATH_DATE,MAGIC)";
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        queryString = "UUID =~ '^[CS].*' && f:unique('DEATH_DATE','$BIRTH_DATE')";
-        expected.clear();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        queryString = "UUID =~ '^[CS].*' && f:unique('death_date','$birth_date')";
-        expected.clear();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
     }
 
-    @Test
-    public void testUniquenessUsingLuceneFunction() throws Exception {
-        Map<String,String> extraParameters = new HashMap<>();
-        extraParameters.put("include.grouping.context", "true");
-        extraParameters.put("query.syntax", "LUCENE");
-
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
-
-        String queryString = "UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,$MAGIC)";
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        queryString = "UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,$BIRTH_DATE)";
-        expected.clear();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        queryString = "UUID:/^[CS].*/ AND #UNIQUE(death_date,birth_date)";
-        expected.clear();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+    private static Stream<Arguments> uniquenessUsingLuceneFunctionArgs() {
+        // @formatter:off
+        return Stream.of(
+                Arguments.of("UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,$MAGIC)",
+                        Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID))),
+                Arguments.of("UUID:/^[CS].*/ AND #UNIQUE(DEATH_DATE,$BIRTH_DATE)", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID),
+                        Sets.newHashSet(WiseGuysIngest.corleoneUID), Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("UUID:/^[CS].*/ AND #UNIQUE(death_date,birth_date)", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID),
+                        Sets.newHashSet(WiseGuysIngest.corleoneUID), Sets.newHashSet(WiseGuysIngest.caponeUID))));
+        // @formatter:on
     }
 
-    @Test(expected = InvalidQueryException.class)
-    public void testUniquenessWithBadField() throws Exception {
+    @ParameterizedTest
+    @MethodSource("uniquenessUsingLuceneFunctionArgs")
+    public void testUniquenessUsingLuceneFunction(String queryString, Set<Set<String>> expected) throws Exception {
         Map<String,String> extraParameters = new HashMap<>();
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("query.syntax", "LUCENE");
 
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
+    }
 
-        String queryString = "UUID:/^[CS].*/ AND #UNIQUE(FOO_BAR,$MAGIC)";
-        runTestQueryWithUniqueness(new HashSet(), queryString, startDate, endDate, extraParameters);
+    @Test
+    public void testUniquenessWithBadField() {
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put("include.grouping.context", "true");
+        extraParameters.put("query.syntax", "LUCENE");
 
-        queryString = "UUID:/^[CS].*/ AND #UNIQUE(foo_bar,$magic)";
-        runTestQueryWithUniqueness(new HashSet(), queryString, startDate, endDate, extraParameters);
+        assertThrows(InvalidQueryException.class, () -> {
+            String queryString = "UUID:/^[CS].*/ AND #UNIQUE(FOO_BAR,$MAGIC)";
+            runTestQueryWithUniqueness(Set.of(), queryString, extraParameters);
+
+            queryString = "UUID:/^[CS].*/ AND #UNIQUE(foo_bar,$magic)";
+            runTestQueryWithUniqueness(Set.of(), queryString, extraParameters);
+        });
     }
 
     @Test
@@ -362,13 +268,14 @@ public abstract class UniqueTest {
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("query.syntax", "LUCENE");
 
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
+        // HIT_TERM legitimately differs per event (the matched term text includes the UUID value itself,
+        // e.g. "UUID:SOPRANO" vs "UUID:CORLEONE" vs "UUID:CAPONE"), so uniqueness on HIT_TERM should not
+        // collapse these three into one result the way BOTH_NULL does in the sibling tests below.
+        Set<Set<String>> expected = Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID));
 
         String queryString = "UUID:/^[CS].*/ AND #UNIQUE(HIT_TERM)";
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
     }
 
     @Test
@@ -377,13 +284,10 @@ public abstract class UniqueTest {
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("query.syntax", "LUCENE");
 
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
+        Set<Set<String>> expected = Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
 
         String queryString = "UUID:/^[CS].*/ AND #UNIQUE(BOTH_NULL)";
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
     }
 
     @Test
@@ -392,156 +296,114 @@ public abstract class UniqueTest {
         extraParameters.put("include.grouping.context", "true");
         extraParameters.put("query.syntax", "LUCENE");
 
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
+        Set<Set<String>> expected = Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
 
         String queryString = "UUID:/^[CS].*/ AND #MOST_RECENT_UNIQUE(BOTH_NULL)";
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
     }
 
-    @Test
-    public void testMostRecentUniquenessWebServerOnly() throws Exception {
+    private static Stream<Arguments> mostRecentUniquenessArgs() {
+        // @formatter:off
+        return Stream.of(
+                Arguments.of("DEATH_DATE,$MAGIC", Set.of(Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("death_date,$magic", Set.of(Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("$DEATH_DATE,BIRTH_DATE", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("death_date,birth_date", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID))));
+        // @formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("mostRecentUniquenessArgs")
+    public void testMostRecentUniquenessWebServerOnly(String uniqueFields, Set<Set<String>> expected) throws Exception {
         boolean originalSetting = logic.isDisableIteratorMostRecentUniqueFields();
         try {
             logic.setDisableIteratorMostRecentUniqueFields(true);
+
             Map<String,String> extraParameters = new HashMap<>();
             extraParameters.put("include.grouping.context", "true");
             extraParameters.put(QueryParameters.MOST_RECENT_UNIQUE, "true");
-
-            Date startDate = format.parse("20091231");
-            Date endDate = format.parse("20150101");
+            extraParameters.put("unique.fields", uniqueFields);
 
             String queryString = "UUID =~ '^[CS].*'";
 
-            Set<Set<String>> expected = new HashSet<>();
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "death_date,$magic");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "$DEATH_DATE,BIRTH_DATE");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "death_date,birth_date");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+            runTestQueryWithUniqueness(expected, queryString, extraParameters);
         } finally {
             logic.setDisableIteratorMostRecentUniqueFields(originalSetting);
         }
     }
 
-    @Test
-    public void testMostRecentUniquenessWithIterator() throws Exception {
+    @ParameterizedTest
+    @MethodSource("mostRecentUniquenessArgs")
+    public void testMostRecentUniquenessWithIterator(String uniqueFields, Set<Set<String>> expected) throws Exception {
         boolean originalSetting = logic.isDisableIteratorMostRecentUniqueFields();
         try {
             logic.setDisableIteratorMostRecentUniqueFields(false);
+
             Map<String,String> extraParameters = new HashMap<>();
             extraParameters.put("include.grouping.context", "true");
             extraParameters.put(QueryParameters.MOST_RECENT_UNIQUE, "true");
-
-            Date startDate = format.parse("20091231");
-            Date endDate = format.parse("20150101");
+            extraParameters.put("unique.fields", uniqueFields);
 
             String queryString = "UUID =~ '^[CS].*'";
 
-            Set<Set<String>> expected = new HashSet<>();
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "death_date,$magic");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "$DEATH_DATE,BIRTH_DATE");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "death_date,birth_date");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+            runTestQueryWithUniqueness(expected, queryString, extraParameters);
         } finally {
             logic.setDisableIteratorMostRecentUniqueFields(originalSetting);
         }
     }
 
-    @Test
-    public void testHannahHypothesis() throws Exception {
-        Map<String,String> extraParameters = new HashMap<>();
-        Date startDate = format.parse("20091231");
-        Date endDate = format.parse("20150101");
-
-        Set<Set<String>> expected = new HashSet<>();
-        expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-        extraParameters.put(QueryParameters.MOST_RECENT_UNIQUE, "true");
-        extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
-        String queryString = "UUID =~ '^[CS].*'";
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        extraParameters.clear();
-        extraParameters.put(QueryParameters.MOST_RECENT_UNIQUE, "true");
-        queryString = "UUID =~ '^[CS].*' && f:unique(death_date,magic)";
-        runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
-
-        this.getClass().getMethod("testHannahHypothesis").getName().replace("Hypothesis", "Theory");
+    private static Stream<Arguments> hannahHypothesisArgs() {
+        // @formatter:off
+        return Stream.of(
+                Arguments.of("UUID =~ '^[CS].*'", true),
+                Arguments.of("UUID =~ '^[CS].*' && f:unique(death_date,magic)", false));
+        // @formatter:on
     }
 
-    @Test
-    public void testUniquenessWithoutIteratorLevelTransformer() throws Exception {
+    @ParameterizedTest
+    @MethodSource("hannahHypothesisArgs")
+    public void testHannahHypothesis(String queryString, boolean withUniqueFieldsParam) throws Exception {
+        Set<Set<String>> expected = Set.of(Sets.newHashSet(WiseGuysIngest.caponeUID));
+
+        Map<String,String> extraParameters = new HashMap<>();
+        extraParameters.put(QueryParameters.MOST_RECENT_UNIQUE, "true");
+        if (withUniqueFieldsParam) {
+            extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
+        }
+
+        runTestQueryWithUniqueness(expected, queryString, extraParameters);
+    }
+
+    private static Stream<Arguments> uniquenessWithoutIteratorLevelTransformerArgs() {
+        // @formatter:off
+        return Stream.of(
+                Arguments.of("DEATH_DATE,$MAGIC", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID))),
+                Arguments.of("$DEATH_DATE,BIRTH_DATE", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID))),
+                Arguments.of("death_date,birth_date", Set.of(Sets.newHashSet(WiseGuysIngest.sopranoUID), Sets.newHashSet(WiseGuysIngest.corleoneUID),
+                        Sets.newHashSet(WiseGuysIngest.caponeUID))));
+        // @formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("uniquenessWithoutIteratorLevelTransformerArgs")
+    public void testUniquenessWithoutIteratorLevelTransformer(String uniqueFields, Set<Set<String>> expected) throws Exception {
         boolean originalSetting = logic.isDisableIteratorUniqueFields();
         try {
-            Map<String,String> extraParameters = new HashMap<>();
-            extraParameters.put("include.grouping.context", "true");
-
-            Date startDate = format.parse("20091231");
-            Date endDate = format.parse("20150101");
-
-            String queryString = "UUID =~ '^[CS].*'";
-
             // disable the unique transform on the query iterator
             logic.setDisableIteratorUniqueFields(true);
 
-            Set<Set<String>> expected = new HashSet<>();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID, WiseGuysIngest.corleoneUID, WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "DEATH_DATE,$MAGIC");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+            Map<String,String> extraParameters = new HashMap<>();
+            extraParameters.put("include.grouping.context", "true");
+            extraParameters.put("unique.fields", uniqueFields);
 
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "$DEATH_DATE,BIRTH_DATE");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+            String queryString = "UUID =~ '^[CS].*'";
 
-            expected.clear();
-            expected.add(Sets.newHashSet(WiseGuysIngest.sopranoUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.corleoneUID));
-            expected.add(Sets.newHashSet(WiseGuysIngest.caponeUID));
-            extraParameters.put("unique.fields", "death_date,birth_date");
-            runTestQueryWithUniqueness(expected, queryString, startDate, endDate, extraParameters);
+            runTestQueryWithUniqueness(expected, queryString, extraParameters);
         } finally {
             logic.setDisableIteratorUniqueFields(originalSetting);
         }
     }
-
 }


### PR DESCRIPTION
Drops the Arquillian container deployment and the ShardRange/DocumentRange nested subclasses in favor of extending AbstractQueryTest directly, with the SHARD/DOCUMENT ingest range and each test method's per-case loops converted to @ParameterizedTest + @MethodSource, following the pattern used for QueryFunctionQueryTest/FunctionalSetTest. Ingestion for both ranges happens once in @BeforeAll.

This test's assertion shape doesn't fit AbstractQueryTest's default Document/UUID model at all - it needs DocumentTransformer-produced EventBase objects grouped into "unique" sets, matched against sets of acceptable internal IDs. executeQuery() is overridden to build that event list directly (using logic.getConfig().getQuery(), which holds the same settings object passed to initialize()) instead of relying on the base class's Document deserialization, and extraAssertions() replicates the original set-matching logic, using a local copy of expectedGroups per the same destructive-iteration gotcha already found in ExcerptTest/SummaryTest.

Also fixes a stale expected-grouping in testUniquenessWithHitTermField: the three WiseGuys UIDs were expected to collapse into a single unique result, but HIT_TERM legitimately differs per event (the matched term text includes the UUID value itself), so they should not collapse the way the sibling BOTH_NULL-based tests do. Confirmed via a temporary debug print showing all three IDs correctly returned as three distinct events before correcting the expectation to three separate singleton groups.