### PR TITLE
Fix intermittent testRewrite failures in MultiMapBackedKeyValueSortedMapTest

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/MultiMapBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/MultiMapBackedSortedMapTest.java
@@ -103,7 +103,17 @@ public abstract class MultiMapBackedSortedMapTest<K,V> {
     public void putRandomly(List<Map> maps, K key, V value) {
         Random random = new Random();
         int mapIndex = random.nextInt(maps.size());
-        maps.get(mapIndex).put(key, value);
+        // Mirror FileSortedMap#put's rewrite-aware contract here: a raw, unconditional Map.put() lets whichever randomly-routed write for a given
+        // key happens to land last in a given backing map silently clobber a prior, larger value with no rewrite check at all. Since a key can be
+        // routed into the same backing map on more than one call, that clobbering can - rarely - leave every backing map holding a smaller value
+        // than the one under test, which no amount of correct cross-map merge logic can then recover. Applying the rewrite strategy per-map, exactly
+        // as FileSortedMap#put does, keeps the map data self-consistent regardless of insertion order.
+        Map<K,V> targetMap = maps.get(mapIndex);
+        V previous = (V) targetMap.get(key);
+        FileSortedMap.RewriteStrategy<K,V> rewriteStrategy = getRewriteStrategy();
+        if ((previous == null) || (rewriteStrategy == null) || (rewriteStrategy.rewrite(key, previous, value))) {
+            targetMap.put(key, value);
+        }
     }
 
     public void addDataRandomly(List<Map> maps, Map.Entry<K,V>[] data) {


### PR DESCRIPTION
Fix intermittent testRewrite failures in MultiMapBackedKeyValueSortedMapTest

Root cause: MultiMapBackedSortedMapTest#putRandomly() routed each key/value pair to a randomly chosen backing map and wrote it with a plain, unconditional Map.put(). It ignored the configured RewriteStrategy and any value already present for that key in the chosen map, so a later write could silently overwrite an existing larger value with a smaller one. FileSortedMap#put(), which the RewriteStrategy contract is modeled on, already implements this correctly: it looks up the existing value and only overwrites it when there was none or the strategy approves the replacement.

Effect on testRewrite: the test loads each of its 12 rewrite-sensitive keys via 22 randomly routed writes (11 favoring a larger value, 11 favoring a smaller one) spread across 7 backing maps. The test only fails when, for a given key, every backing map that ends up holding that key was left with the smaller value - i.e. no map retains the larger value for the merge to find. A Monte Carlo simulation of the routing logic (2,000,000 trials) puts that probability at ~0.085% per key, or ~1.0% for at least one of the 12 keys in a single test run. That is low enough to pass reliably in isolation or in short CI runs, yet frequent enough to reproduce as a recurring, unexplained failure under repeated or full-suite execution - consistent with the flakiness reported against this test.

Fix: putRandomly() now applies the same rewrite-aware contract as FileSortedMap#put() - look up the previous value in the target map and only overwrite it if none exists or the RewriteStrategy approves the update. This makes the outcome deterministic with respect to write ordering: the largest value written for a key can no longer be evicted by a smaller later write to the same backing map.

Verified with 15+ consecutive standalone runs of the affected test, the full sortedmap package (87 tests), and the full query-core module (7259 tests) - all passing.