### PR TITLE
Fix DocumentScheduler dropping results with native document retrieval

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIterator.java
@@ -98,7 +98,10 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
     }
 
     /**
-     * Aggregates the next candidate if one exists
+     * Aggregates candidates, in order, until one matches the query or the candidate list is exhausted.
+     * <p>
+     * A single candidate that fails to match must not be mistaken for the iterator being done: {@code hasTop()} reports done only once {@code tk} is null AND
+     * there are no more candidates left to try, so this must keep advancing through the remaining candidates on a miss rather than trying just one.
      *
      * @throws IOException
      *             if something goes wrong
@@ -106,8 +109,7 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
     private void aggregateNextCandidate() throws IOException {
         tk = null;
         tv = null;
-        // aggregate document
-        if (!candidates.isEmpty()) {
+        while (tk == null && !candidates.isEmpty()) {
             String nextCandidate = candidates.remove(0);
             aggregateCandidate(nextCandidate);
         }
@@ -224,7 +226,9 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
                 Text cf = new Text("fi\0" + field);
                 Text cq = new Text(value + "\0" + candidate);
                 Key start = new Key(range.getStartKey().getRow(), cf, cq);
-                Range range = new Range(start, true, start.followingKey(PartialKey.ROW_COLFAM), false);
+                // bound the range to just this exact (field, value, candidate) entry - stopping at the next column
+                // family (ROW_COLFAM) would sweep in unrelated entries for other values/documents sharing this field
+                Range range = new Range(start, true, start.followingKey(PartialKey.ROW_COLFAM_COLQUAL), false);
                 ranges.add(range);
             }
         }
@@ -259,7 +263,10 @@ public class DocumentIterator extends DocumentIteratorOptions implements SortedK
             for (String value : termFrequencyFieldValues.get(field)) {
                 Text cq = new Text(candidate + "\0" + value + "\0" + field);
                 Key start = new Key(range.getStartKey().getRow(), cf, cq);
-                Range range = new Range(start, true, start.followingKey(PartialKey.ROW_COLFAM), false);
+                // bound the range to just this exact (candidate, value, field) entry - the "tf" column family is
+                // shared by the entire row, so stopping at the next column family (ROW_COLFAM) would sweep in
+                // unrelated term frequency entries for other documents/fields/values
+                Range range = new Range(start, true, start.followingKey(PartialKey.ROW_COLFAM_COLQUAL), false);
                 ranges.add(range);
             }
         }

--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/IndexOnlyFragmentVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/IndexOnlyFragmentVisitor.java
@@ -13,8 +13,9 @@ import datawave.query.jexl.visitors.BaseVisitor;
 /**
  * Visitor that collects the index only and tokenized field-value pairs required for document evaluation
  * <p>
- * Note: it is possible and even likely that some tokenized fields are also index only. However, in this context the sets of index only and tokenized fields are
- * fully exclusive, i.e., there is no duplication between sets.
+ * Note: a field can be both index only and tokenized at the same time (e.g. an index-only field that is also tokenized for {@code content:phrase} support). A
+ * term against such a field must be collected into both sets, since {@link DocumentIterator#collectIndexOnlyFragments} and
+ * {@link DocumentIterator#collectTermFrequencyFragments} each populate a different part of the document required for evaluation.
  */
 public class IndexOnlyFragmentVisitor extends BaseVisitor {
 
@@ -46,7 +47,8 @@ public class IndexOnlyFragmentVisitor extends BaseVisitor {
 
         if (tokenizedFields != null && tokenizedFields.contains(field)) {
             tokenizedFieldValues.put(field, String.valueOf(literal));
-        } else if (indexOnlyFields != null && indexOnlyFields.contains(field)) {
+        }
+        if (indexOnlyFields != null && indexOnlyFields.contains(field)) {
             indexOnlyFieldValues.put(field, String.valueOf(literal));
         }
 


### PR DESCRIPTION
Three bugs in the non-iterator document retrieval path caused matching results to be silently dropped: IndexOnlyFragmentVisitor mishandled fields that are both index-only and tokenized, DocumentIterator's per-value seeks were bounded too loosely (ROW_COLFAM instead of ROW_COLFAM_COLQUAL) and could attribute another document's FI/TF entry to the wrong document, and aggregateNextCandidate gave up on a whole batch after the first non-matching candidate instead of trying the rest.