### PR TITLE
Fix TLDTermFrequencyEventDataQueryFilter to recognize grouped TF fields

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilter.java
@@ -52,13 +52,37 @@ public class TLDTermFrequencyEventDataQueryFilter implements EventDataQueryFilte
     @Override
     public boolean keep(Key k) {
         DatawaveKey key = new DatawaveKey(k);
-        return (!isRootPointer.test(k) || indexOnlyFields.contains(key.getFieldName())) && fieldMatches(k);
+        return (!isRootPointer.test(k) || containsField(indexOnlyFields, key.getFieldName())) && fieldMatches(k);
     }
 
     private boolean fieldMatches(Key key) {
         DatawaveKey parser = new DatawaveKey(key);
         String fieldName = JexlASTHelper.deconstructIdentifier(parser.getFieldName());
-        return fields.contains(fieldName);
+        return containsField(fields, fieldName);
+    }
+
+    /**
+     * Return whether the given set of (un-grouped) field names contains the candidate field, accepting both exact matches and grouped/content-context variants
+     * of a field in the set, e.g. {@code QUOTE} in the set matching a candidate of {@code QUOTE.1234}.
+     *
+     * @param fieldNames
+     *            a set of field names, expected to not carry grouping/content-context notation
+     * @param candidateField
+     *            the field to check, which may carry grouping/content-context notation
+     * @return true if the candidate field is present in, or a grouped variant of a field in, the given set
+     */
+    private static boolean containsField(Set<String> fieldNames, String candidateField) {
+        if (fieldNames.contains(candidateField)) {
+            return true;
+        }
+
+        for (String fieldName : fieldNames) {
+            if (JexlASTHelper.isGroupedFieldMatch(fieldName, candidateField)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilterTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/TLDTermFrequencyEventDataQueryFilterTest.java
@@ -20,6 +20,15 @@ public class TLDTermFrequencyEventDataQueryFilterTest {
     private final Key childField2 = new Key("row", "fi\0FIELD2", "value\0datatype\0d8zay2.-3pnndm.-anolok.33");
     private final Key childField3 = new Key("row", "fi\0FIELD3", "value\0datatype\0d8zay2.-3pnndm.-anolok.45");
 
+    // grouped/content-context-hashed instances of the same fields, e.g. as written for a tokenized content field with
+    // content-context hashing enabled. The hash notation is only ever present on the term-frequency field name itself;
+    // indexOnlyFields/fields are always configured with base (un-grouped) field names by TLDIndexBuildingVisitor.
+    private final Key tldField1Grouped = new Key("row", "fi\0FIELD1.hash1", "value\0datatype\0d8zay2.-3pnndm.-anolok");
+    private final Key tldField3Grouped = new Key("row", "fi\0FIELD3.hash1", "value\0datatype\0d8zay2.-3pnndm.-anolok");
+
+    private final Key childField1Grouped = new Key("row", "fi\0FIELD1.hash2", "value\0datatype\0d8zay2.-3pnndm.-anolok.23");
+    private final Key childField3Grouped = new Key("row", "fi\0FIELD3.hash2", "value\0datatype\0d8zay2.-3pnndm.-anolok.45");
+
     @Test
     public void testTLDTermFrequencyEventDataQueryFilter() {
         Set<String> indexOnlyFields = Sets.newHashSet("FIELD1", "FIELD2");
@@ -34,6 +43,27 @@ public class TLDTermFrequencyEventDataQueryFilterTest {
         assertTrue(filter.keep(childField1));
         assertFalse(filter.keep(childField2));
         assertFalse(filter.keep(childField3));
+    }
+
+    /**
+     * A grouped/content-context instance of a requested field (e.g. {@code FIELD1.hash1}) must be recognized as satisfying a request for its base field
+     * ({@code FIELD1}), the same as an un-grouped instance would be -- both for a root (tld) key, where {@code keep()} additionally requires the field to be
+     * found in {@code indexOnlyFields}, and for a child key.
+     */
+    @Test
+    public void testTLDTermFrequencyEventDataQueryFilterWithGroupedFieldNames() {
+        Set<String> indexOnlyFields = Sets.newHashSet("FIELD1", "FIELD2");
+        TLDTermFrequencyEventDataQueryFilter filter = new TLDTermFrequencyEventDataQueryFilter(indexOnlyFields, Set.of("FIELD1"));
+
+        // a grouped instance of the requested, index-only root field is kept, exactly as the un-grouped instance is
+        assertTrue(filter.keep(tldField1Grouped));
+        // a grouped instance of a field that was not requested is still not kept
+        assertFalse(filter.keep(tldField3Grouped));
+
+        // a grouped instance of the requested field is kept on a child key too
+        assertTrue(filter.keep(childField1Grouped));
+        // a grouped instance of a field that was not requested is still not kept on a child key
+        assertFalse(filter.keep(childField3Grouped));
     }
 
 }


### PR DESCRIPTION
keep() and fieldMatches() compared the full grouped/content-context term-frequency field name (e.g. QUOTE.hash1) against un-grouped requested-field sets with an exact match, so any field written with grouping notation was always dropped from TLD query results even when explicitly requested.