### PR TITLE
Migrate CompositeIndexTest to AbstractQueryTest

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
@@ -2,30 +2,24 @@ package datawave.query.planner;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import static datawave.microservice.query.QueryParameters.QUERY_AUTHORIZATIONS;
-import static datawave.microservice.query.QueryParameters.QUERY_BEGIN;
-import static datawave.microservice.query.QueryParameters.QUERY_END;
-import static datawave.microservice.query.QueryParameters.QUERY_EXPIRATION;
-import static datawave.microservice.query.QueryParameters.QUERY_LOGIC_NAME;
-import static datawave.microservice.query.QueryParameters.QUERY_NAME;
-import static datawave.microservice.query.QueryParameters.QUERY_PERSISTENCE;
-import static datawave.microservice.query.QueryParameters.QUERY_STRING;
 import static datawave.query.testframework.RawDataManager.JEXL_AND_OP;
 import static datawave.query.testframework.RawDataManager.JEXL_OR_OP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -40,26 +34,22 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.configuration.spring.SpringBean;
 import datawave.core.query.configuration.QueryData;
 import datawave.data.ColumnFamilyConstants;
 import datawave.data.type.GeometryType;
@@ -80,28 +70,30 @@ import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.partition.BalancedShardPartitioner;
 import datawave.ingest.table.config.ShardTableConfigHelper;
 import datawave.ingest.table.config.TableConfigHelper;
-import datawave.microservice.query.DefaultQueryParameters;
-import datawave.microservice.query.Query;
 import datawave.microservice.query.QueryImpl;
-import datawave.microservice.query.QueryParameters;
 import datawave.policy.IngestPolicyEnforcer;
 import datawave.query.composite.CompositeMetadataHelper;
 import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.DefaultEdgeEventQueryLogic;
 import datawave.query.testframework.MockStatusReporter;
+import datawave.query.util.AbstractQueryTest;
 import datawave.table.constants.TableName;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.webservice.query.result.event.DefaultEvent;
 import datawave.webservice.query.result.event.DefaultField;
 
-@RunWith(Arquillian.class)
-public class CompositeIndexTest {
-
-    @ClassRule
-    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class CompositeIndexTest extends AbstractQueryTest {
 
     private static final int NUM_SHARDS = 3;
     private static final String DATA_TYPE_NAME = "wkt";
@@ -111,6 +103,7 @@ public class CompositeIndexTest {
     private static final String WKT_BYTE_LENGTH_FIELD = "WKT_BYTE_LENGTH";
 
     private static final String AUTHS = "ALL";
+    private static final Authorizations auths = new Authorizations(AUTHS);
 
     private static final String formatPattern = "yyyyMMdd HHmmss.SSS";
     private static final SimpleDateFormat formatter = new SimpleDateFormat(formatPattern);
@@ -120,9 +113,6 @@ public class CompositeIndexTest {
 
     private static final String BEGIN_DATE = "20000101 000000.000";
     private static final String END_DATE = "20020101 000000.000";
-
-    private static final String USER = "testcorp";
-    private static final String USER_DN = "cn=test.testcorp.com, ou=datawave, ou=development, o=testcorp, c=us";
 
     private static final Configuration conf = new Configuration();
 
@@ -188,30 +178,96 @@ public class CompositeIndexTest {
             TimeUnit.DAYS.toMillis(90)};
     // @formatter:on
 
-    @Inject
-    @SpringBean(name = "EventQuery")
-    ShardQueryLogic logic;
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
 
-    private static InMemoryInstance instance;
-
+    private static AccumuloClient clientForTest;
     private static List<IvaratorCacheDirConfig> ivaratorCacheDirConfigs;
-
     private static final IndexIngestUtil ingestUtil = new IndexIngestUtil();
 
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "datawave.webservice.query.result.event",
-                                        "datawave.core.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
+    private ShardQueryLogic currentLogic;
+    private List<DefaultEvent> events = new ArrayList<>();
+    private int expectedEventCount = -1;
+
+    @Override
+    public ShardQueryLogic getLogic() {
+        return currentLogic;
     }
 
-    @BeforeClass
-    public static void setupClass() throws Exception {
+    @Override
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    @Override
+    protected void extraConfigurations() {
+        disableQueryPlanAssertion();
+    }
+
+    @Override
+    protected QueryImpl getSettings() throws Exception {
+        QueryImpl settings = new QueryImpl();
+        settings.setBeginDate(formatter.parse(BEGIN_DATE));
+        settings.setEndDate(formatter.parse(END_DATE));
+        settings.setPagesize(Integer.MAX_VALUE);
+        settings.setQueryAuthorizations(getAuths().serialize());
+        settings.setQuery(getQuery());
+        settings.setParameters(getParameters());
+        settings.setId(UUID.randomUUID());
+        return settings;
+    }
+
+    @Override
+    protected void executeQuery(ShardQueryLogic logic) throws Exception {
+        try {
+            Iterator<?> iter = logic.getTransformIterator(logic.getConfig().getQuery());
+            events = new ArrayList<>();
+            while (iter.hasNext()) {
+                events.add((DefaultEvent) iter.next());
+            }
+        } finally {
+            logic.close();
+        }
+    }
+
+    @Override
+    protected void extraAssertions() {
+        assertEquals(expectedEventCount, events.size());
+
+        List<String> wktList = new ArrayList<>();
+        wktList.addAll(Arrays.asList(wktLegacyData));
+        wktList.addAll(Arrays.asList(wktCompositeData));
+
+        List<Integer> wktByteLengthList = new ArrayList<>();
+        wktByteLengthList.addAll(Arrays.asList(wktByteLengthLegacyData));
+        wktByteLengthList.addAll(Arrays.asList(wktByteLengthCompositeData));
+
+        for (DefaultEvent event : events) {
+            String wkt = null;
+            Integer wktByteLength = null;
+
+            for (DefaultField field : event.getFields()) {
+                if (field.getName().equals(GEO_FIELD))
+                    wkt = field.getValueString();
+                else if (field.getName().equals(WKT_BYTE_LENGTH_FIELD))
+                    wktByteLength = Integer.parseInt(field.getValueString());
+            }
+
+            // shouldn't get back a null wktByteLength
+            assertNotNull(wktByteLength);
+
+            // ensure that this is one of the ingested events
+            assertTrue(wktList.remove(wkt));
+            assertTrue(wktByteLengthList.remove(wktByteLength));
+        }
+
+        assertEquals(wktLegacyData.length + wktCompositeData.length - expectedEventCount, wktList.size());
+        assertEquals(wktByteLengthLegacyData.length + wktByteLengthCompositeData.length - expectedEventCount, wktByteLengthList.size());
+    }
+
+    @BeforeAll
+    public static void setupClass(@TempDir Path tempDir) throws Exception {
         System.setProperty("subject.dn.pattern", "(?:^|,)\\s*OU\\s*=\\s*My Department\\s*(?:,|$)");
 
         setupConfiguration(conf);
@@ -285,13 +341,16 @@ public class CompositeIndexTest {
         keyValues.put(new BulkIngestKey(new Text(TableName.METADATA), tdKey), new Value());
 
         // write these values to their respective tables
-        instance = new InMemoryInstance();
+        InMemoryInstance instance = new InMemoryInstance();
         AccumuloClient client = new InMemoryAccumuloClient("root", instance);
         client.securityOperations().changeUserAuthorizations("root", new Authorizations(AUTHS));
 
         writeKeyValues(client, keyValues);
+        clientForTest = client;
 
-        ivaratorCacheDirConfigs = Collections.singletonList(new IvaratorCacheDirConfig(temporaryFolder.newFolder().toURI().toString()));
+        Path ivaratorDir = tempDir.resolve("ivarator");
+        Files.createDirectories(ivaratorDir);
+        ivaratorCacheDirConfigs = Collections.singletonList(new IvaratorCacheDirConfig(ivaratorDir.toUri().toString()));
 
         ingestUtil.write(client, new Authorizations(AUTHS));
     }
@@ -352,6 +411,14 @@ public class CompositeIndexTest {
         }
     }
 
+    private void runGeoQuery(ShardQueryLogic queryLogic, String query, int expectedCount) throws Exception {
+        setClientForTest(clientForTest);
+        currentLogic = queryLogic;
+        this.expectedEventCount = expectedCount;
+        givenQuery(query);
+        planAndExecuteQuery();
+    }
+
     @Test
     public void compositeWithoutIvaratorTest() throws Exception {
         // @formatter:off
@@ -363,101 +430,37 @@ public class CompositeIndexTest {
                 "((_Bounded_ = true) && (" + WKT_BYTE_LENGTH_FIELD + " >= 0" + JEXL_AND_OP + WKT_BYTE_LENGTH_FIELD + " < 80))";
         // @formatter:on
 
-        ShardQueryLogic logic = getShardQueryLogic(false);
-        logic.setIntermediateMaxTermThreshold(50);
-        logic.setIndexedMaxTermThreshold(50);
-        logic.setFinalMaxTermThreshold(50);
+        ShardQueryLogic rangeLogic = getShardQueryLogic(false);
+        rangeLogic.setIntermediateMaxTermThreshold(50);
+        rangeLogic.setIndexedMaxTermThreshold(50);
+        rangeLogic.setFinalMaxTermThreshold(50);
 
-        if (!logic.isUseDocumentScheduler()) {
-            List<QueryData> queries = getQueryRanges(logic, query, false);
-            if (logic.isUseShardedIndex()) {
-                Assert.assertEquals(17, queries.size());
+        if (!rangeLogic.isUseDocumentScheduler()) {
+            List<QueryData> queries = getQueryRanges(rangeLogic, query);
+            if (rangeLogic.isUseShardedIndex()) {
+                assertEquals(17, queries.size());
             } else {
-                Assert.assertEquals(10, queries.size());
+                assertEquals(10, queries.size());
             }
         }
 
-        List<DefaultEvent> events = getQueryResults(logic, query, false);
-        Assert.assertEquals(9, events.size());
-
-        List<String> wktList = new ArrayList<>();
-        wktList.addAll(Arrays.asList(wktLegacyData));
-        wktList.addAll(Arrays.asList(wktCompositeData));
-
-        List<Integer> wktByteLengthList = new ArrayList<>();
-        wktByteLengthList.addAll(Arrays.asList(wktByteLengthLegacyData));
-        wktByteLengthList.addAll(Arrays.asList(wktByteLengthCompositeData));
-
-        for (DefaultEvent event : events) {
-            String wkt = null;
-            Integer wktByteLength = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD))
-                    wkt = field.getValueString();
-                else if (field.getName().equals(WKT_BYTE_LENGTH_FIELD))
-                    wktByteLength = Integer.parseInt(field.getValueString());
-            }
-
-            // shouldn't get back a null wktByteLength
-            Assert.assertNotNull(wktByteLength);
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(wktList.remove(wkt));
-            Assert.assertTrue(wktByteLengthList.remove(wktByteLength));
-        }
-
-        Assert.assertEquals(3, wktList.size());
-        Assert.assertEquals(3, wktByteLengthList.size());
-
-        Assert.assertEquals(9, events.size());
+        runGeoQuery(rangeLogic, query, 9);
     }
 
     // the bounded range is fixed by the QueryPropertyMarkerSourceConsolidator
     // if ASTValidation is enabled the query will fail on the first visitor, InvertSwappedNodes
-    @Ignore
+    @Disabled
     @Test
     public void testRecordOfIncorrectQueryStringWorking() throws Exception {
         // original "((_Bounded_ = true) && (GEO >= '0500aa' && GEO <= '050355'))";
         String query = "(((_Bounded_ = true) && GEO >= '0500aa' && GEO <= '050355'))";
-        if (!logic.isUseDocumentScheduler()) {
-            List<QueryData> queries = getQueryRanges(query, false);
-            Assert.assertEquals(1, queries.size());
+        ShardQueryLogic rangeLogic = getShardQueryLogic(false);
+        if (!rangeLogic.isUseDocumentScheduler()) {
+            List<QueryData> queries = getQueryRanges(rangeLogic, query);
+            assertEquals(1, queries.size());
         }
 
-        List<DefaultEvent> events = getQueryResults(query, false);
-        Assert.assertEquals(1, events.size());
-
-        List<String> wktList = new ArrayList<>();
-        wktList.addAll(Arrays.asList(wktLegacyData));
-        wktList.addAll(Arrays.asList(wktCompositeData));
-
-        List<Integer> wktByteLengthList = new ArrayList<>();
-        wktByteLengthList.addAll(Arrays.asList(wktByteLengthLegacyData));
-        wktByteLengthList.addAll(Arrays.asList(wktByteLengthCompositeData));
-
-        for (DefaultEvent event : events) {
-            String wkt = null;
-            Integer wktByteLength = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD))
-                    wkt = field.getValueString();
-                else if (field.getName().equals(WKT_BYTE_LENGTH_FIELD))
-                    wktByteLength = Integer.parseInt(field.getValueString());
-            }
-
-            // shouldn't get back a null wktByteLength
-            Assert.assertNotNull(wktByteLength);
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(wktList.remove(wkt));
-            Assert.assertTrue(wktByteLengthList.remove(wktByteLength));
-        }
-
-        Assert.assertEquals(11, wktList.size());
-        Assert.assertEquals(11, wktByteLengthList.size());
-        Assert.assertEquals(1, events.size());
+        runGeoQuery(rangeLogic, query, 1);
     }
 
     @Test
@@ -471,152 +474,57 @@ public class CompositeIndexTest {
                 "((_Bounded_ = true) && (" + WKT_BYTE_LENGTH_FIELD + " >= 0" + JEXL_AND_OP + WKT_BYTE_LENGTH_FIELD + " < 80))";
         // @formatter:on
 
-        if (!logic.isUseDocumentScheduler()) {
-            List<QueryData> queries = getQueryRanges(query, true);
-            Assert.assertEquals(2196, queries.size());
+        ShardQueryLogic rangeLogic = getShardQueryLogic(true);
+        if (!rangeLogic.isUseDocumentScheduler()) {
+            List<QueryData> queries = getQueryRanges(rangeLogic, query);
+            assertEquals(2196, queries.size());
         }
 
-        List<DefaultEvent> events = getQueryResults(query, true);
-        Assert.assertEquals(9, events.size());
-
-        List<String> wktList = new ArrayList<>();
-        wktList.addAll(Arrays.asList(wktLegacyData));
-        wktList.addAll(Arrays.asList(wktCompositeData));
-
-        List<Integer> wktByteLengthList = new ArrayList<>();
-        wktByteLengthList.addAll(Arrays.asList(wktByteLengthLegacyData));
-        wktByteLengthList.addAll(Arrays.asList(wktByteLengthCompositeData));
-
-        for (DefaultEvent event : events) {
-            String wkt = null;
-            Integer wktByteLength = null;
-
-            for (DefaultField field : event.getFields()) {
-                if (field.getName().equals(GEO_FIELD))
-                    wkt = field.getValueString();
-                else if (field.getName().equals(WKT_BYTE_LENGTH_FIELD))
-                    wktByteLength = Integer.parseInt(field.getValueString());
-            }
-
-            // shouldn't get back a null wktByteLength
-            Assert.assertNotNull(wktByteLength);
-
-            // ensure that this is one of the ingested events
-            Assert.assertTrue(wktList.remove(wkt));
-            Assert.assertTrue(wktByteLengthList.remove(wktByteLength));
-        }
-
-        Assert.assertEquals(3, wktList.size());
-        Assert.assertEquals(3, wktByteLengthList.size());
-
-        Assert.assertEquals(9, events.size());
+        runGeoQuery(rangeLogic, query, 9);
     }
 
-    private List<QueryData> getQueryRanges(String queryString, boolean useIvarator) throws Exception {
-        ShardQueryLogic logic = getShardQueryLogic(useIvarator);
-        return getQueryRanges(logic, queryString, useIvarator);
-    }
+    private List<QueryData> getQueryRanges(ShardQueryLogic rangeLogic, String queryString) throws Exception {
+        QueryImpl query = new QueryImpl();
+        query.setBeginDate(formatter.parse(BEGIN_DATE));
+        query.setEndDate(formatter.parse(END_DATE));
+        query.setPagesize(Integer.MAX_VALUE);
+        query.setQueryAuthorizations(auths.serialize());
+        query.setQuery(queryString);
+        query.setId(UUID.randomUUID());
 
-    private List<QueryData> getQueryRanges(ShardQueryLogic logic, String queryString, boolean useIvarator) throws Exception {
-        Iterator iter = getQueryRangesIterator(queryString, logic);
+        ShardQueryConfiguration config = ShardQueryConfiguration.create(rangeLogic, query);
+
+        rangeLogic.initialize(config, clientForTest, query, Collections.singleton(auths));
+        rangeLogic.setupQuery(config);
+
         List<QueryData> queryData = new ArrayList<>();
+        Iterator<QueryData> iter = config.getQueriesIter();
         while (iter.hasNext()) {
-            queryData.add((QueryData) iter.next());
+            queryData.add(iter.next());
         }
         return queryData;
     }
 
-    private List<DefaultEvent> getQueryResults(String queryString, boolean useIvarator) throws Exception {
-        ShardQueryLogic logic = getShardQueryLogic(useIvarator);
-        return getQueryResults(logic, queryString, useIvarator);
-    }
-
-    private List<DefaultEvent> getQueryResults(ShardQueryLogic logic, String queryString, boolean useIvarator) throws Exception {
-        Iterator iter = getResultsIterator(queryString, logic);
-        List<DefaultEvent> events = new ArrayList<>();
-        while (iter.hasNext())
-            events.add((DefaultEvent) iter.next());
-        return events;
-    }
-
-    private Iterator getQueryRangesIterator(String queryString, ShardQueryLogic logic) throws Exception {
-        MultivaluedMap<String,String> params = new MultivaluedMapImpl<>();
-        params.putSingle(QUERY_STRING, queryString);
-        params.putSingle(QUERY_NAME, "geoQuery");
-        params.putSingle(QUERY_LOGIC_NAME, "EventQueryLogic");
-        params.putSingle(QUERY_PERSISTENCE, "PERSISTENT");
-        params.putSingle(QUERY_AUTHORIZATIONS, AUTHS);
-        params.putSingle(QUERY_EXPIRATION, "20200101 000000.000");
-        params.putSingle(QUERY_BEGIN, BEGIN_DATE);
-        params.putSingle(QUERY_END, END_DATE);
-
-        QueryParameters queryParams = new DefaultQueryParameters();
-        queryParams.validate(params);
-
-        Set<Authorizations> auths = new HashSet<>();
-        auths.add(new Authorizations(AUTHS));
-
-        Query query = new QueryImpl();
-        query.initialize(USER, Arrays.asList(USER_DN), null, queryParams, null);
-
-        ShardQueryConfiguration config = ShardQueryConfiguration.create(logic, query);
-
-        logic.initialize(config, new InMemoryAccumuloClient("root", instance), query, auths);
-
-        logic.setupQuery(config);
-
-        return config.getQueriesIter();
-    }
-
-    private Iterator getResultsIterator(String queryString, ShardQueryLogic logic) throws Exception {
-        MultivaluedMap<String,String> params = new MultivaluedMapImpl<>();
-        params.putSingle(QUERY_STRING, queryString);
-        params.putSingle(QUERY_NAME, "geoQuery");
-        params.putSingle(QUERY_LOGIC_NAME, "EventQueryLogic");
-        params.putSingle(QUERY_PERSISTENCE, "PERSISTENT");
-        params.putSingle(QUERY_AUTHORIZATIONS, AUTHS);
-        params.putSingle(QUERY_EXPIRATION, "20200101 000000.000");
-        params.putSingle(QUERY_BEGIN, BEGIN_DATE);
-        params.putSingle(QUERY_END, END_DATE);
-
-        QueryParameters queryParams = new DefaultQueryParameters();
-        queryParams.validate(params);
-
-        Set<Authorizations> auths = new HashSet<>();
-        auths.add(new Authorizations(AUTHS));
-
-        Query query = new QueryImpl();
-        query.initialize(USER, Arrays.asList(USER_DN), null, queryParams, null);
-
-        ShardQueryConfiguration config = ShardQueryConfiguration.create(logic, query);
-
-        logic.initialize(config, new InMemoryAccumuloClient("root", instance), query, auths);
-
-        logic.setupQuery(config);
-
-        return logic.getTransformIterator(query);
-    }
-
     private ShardQueryLogic getShardQueryLogic(boolean useIvarator) {
-        ShardQueryLogic logic = new ShardQueryLogic(this.logic);
+        ShardQueryLogic clonedLogic = new ShardQueryLogic(this.logic);
 
         // increase the depth threshold
-        logic.setMaxDepthThreshold(20);
-        logic.setInitialMaxTermThreshold(15);
-        logic.setIntermediateMaxTermThreshold(15);
-        logic.setFinalMaxTermThreshold(15);
+        clonedLogic.setMaxDepthThreshold(20);
+        clonedLogic.setInitialMaxTermThreshold(15);
+        clonedLogic.setIntermediateMaxTermThreshold(15);
+        clonedLogic.setFinalMaxTermThreshold(15);
 
         // set the pushdown threshold really high to avoid collapsing uids into shards (overrides setCollapseUids if #terms is greater than this threshold)
-        ((DefaultQueryPlanner) (logic.getQueryPlanner())).setPushdownThreshold(1000000);
+        ((DefaultQueryPlanner) (clonedLogic.getQueryPlanner())).setPushdownThreshold(1000000);
 
         URL hdfsSiteConfig = this.getClass().getResource("/testhadoop.config");
-        logic.setHdfsSiteConfigURLs(hdfsSiteConfig.toExternalForm());
-        logic.setIvaratorCacheDirConfigs(ivaratorCacheDirConfigs);
+        clonedLogic.setHdfsSiteConfigURLs(hdfsSiteConfig.toExternalForm());
+        clonedLogic.setIvaratorCacheDirConfigs(ivaratorCacheDirConfigs);
 
         if (useIvarator)
-            setupIvarator(logic);
+            setupIvarator(clonedLogic);
 
-        return logic;
+        return clonedLogic;
     }
 
     private void setupIvarator(ShardQueryLogic logic) {


### PR DESCRIPTION
Same shape as the ContentFunctionQueryTest/ExceededOrThresholdMarkerJexlNodeTest family: clones a per-test ShardQueryLogic to vary term-threshold and ivarator settings, executeQuery()/getSettings() overridden for DefaultEvent results and the fixed date format, and getQueryRanges() kept self-contained since it inspects planned QueryData ranges rather than execution results.

runGeoQuery() takes the already-configured ShardQueryLogic instance directly (rather than rebuilding one internally) so that threshold overrides applied before the getQueryRanges() call (e.g. compositeWithoutIvaratorTest's raised term thresholds) are preserved for the actual query execution too, matching the original's reuse of a single logic instance across both calls.

@Ignore -> @Disabled for the one pre-existing disabled test. Ingest already called IndexIngestUtil with a single fixed dataset, so no ingest changes needed. All active tests pass (1 correctly skipped).