### PR TITLE
Allow snapshot compose job to fail without red X or failure email

### DIFF
--- a/.github/workflows/compose-coordinator.yml
+++ b/.github/workflows/compose-coordinator.yml
@@ -14,6 +14,7 @@ jobs:
       allow-snapshots: false
     secrets: inherit
   call-compose-tests-with-snapshots:
+    continue-on-error: true
     uses: ./.github/workflows/compose-tests.yml
     with:
       allow-snapshots: true


### PR DESCRIPTION
continue-on-error suppresses the job's failure status while keeping the existing compose-check-jobs gate logic (which already treats snapshot failure as tolerable) intact.