### PR TITLE
Bump actions/github-script and actions/cache to Node 24 runtimes

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -88,7 +88,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
           overwrite-settings: false
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         if: ${{ !inputs.allow-snapshots }}
         with:
           path: ~/.m2/repository

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check required labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const requiredLabels = ["Integration Tested", "no-downstream-effects", "cherry-pick"];


### PR DESCRIPTION
## Summary
- `actions/github-script@v7` and `actions/cache@v4` both still target the deprecated Node.js 20 runtime, which GitHub now force-runs on Node 24 and flags with a warning annotation on every workflow run (seen recently on PR #3683's checks).
- Bump both to their minimum Node 24-native releases: `actions/github-script@v8` and `actions/cache@v5`. Neither introduces breaking changes relevant to our usage (v8/v5 changelogs are Node runtime bumps only; v9 of github-script would add breaking API changes we don't need).

## Test plan
- [x] Confirm the `require-labels.yml` and `compose-tests.yml` workflows run green on this PR
- [x] Confirm the Node.js 20 deprecation warning annotation no longer appears on the check runs