### PR TITLE
Migrate remaining static imports of deprecated datawave.util.TableName

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamQueryTest.java
@@ -7,8 +7,8 @@ import static datawave.query.index.lookup.RangeStreamQueryTest.TERM_CONTEXT.DELA
 import static datawave.query.index.lookup.RangeStreamQueryTest.TERM_CONTEXT.DELAYED_INTERSECT;
 import static datawave.query.index.lookup.RangeStreamQueryTest.TERM_CONTEXT.DELAYED_UNION;
 import static datawave.query.jexl.visitors.JexlStringBuildingVisitor.buildQuery;
-import static datawave.util.TableName.METADATA;
-import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.METADATA;
+import static datawave.table.constants.TableName.SHARD_INDEX;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
+++ b/warehouse/query-core/src/test/java/datawave/query/index/lookup/RangeStreamTestX.java
@@ -2,7 +2,7 @@ package datawave.query.index.lookup;
 
 import static datawave.common.test.utils.query.RangeFactoryForTests.makeShardedRange;
 import static datawave.common.test.utils.query.RangeFactoryForTests.makeTestRange;
-import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/FieldIndexIntegrationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/FieldIndexIntegrationTest.java
@@ -1,6 +1,6 @@
 package datawave.query.iterator;
 
-import static datawave.util.TableName.SHARD;
+import static datawave.table.constants.TableName.SHARD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerTest.java
@@ -1,6 +1,6 @@
 package datawave.query.tables;
 
-import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_INDEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;

--- a/warehouse/query-core/src/test/java/datawave/query/util/IndexExpansionIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/IndexExpansionIngest.java
@@ -1,9 +1,9 @@
 package datawave.query.util;
 
-import static datawave.util.TableName.METADATA;
-import static datawave.util.TableName.SHARD;
-import static datawave.util.TableName.SHARD_INDEX;
-import static datawave.util.TableName.SHARD_RINDEX;
+import static datawave.table.constants.TableName.METADATA;
+import static datawave.table.constants.TableName.SHARD;
+import static datawave.table.constants.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_RINDEX;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/warehouse/query-core/src/test/java/datawave/query/util/ShapesIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/ShapesIngest.java
@@ -1,9 +1,9 @@
 package datawave.query.util;
 
-import static datawave.util.TableName.METADATA;
-import static datawave.util.TableName.SHARD;
-import static datawave.util.TableName.SHARD_INDEX;
-import static datawave.util.TableName.SHARD_RINDEX;
+import static datawave.table.constants.TableName.METADATA;
+import static datawave.table.constants.TableName.SHARD;
+import static datawave.table.constants.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_RINDEX;
 
 import java.util.Date;
 import java.util.HashMap;

--- a/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionUtils.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/IndexConversionUtils.java
@@ -1,6 +1,6 @@
 package datawave.test.index;
 
-import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_INDEX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/warehouse/query-core/src/test/java/datawave/test/index/NoUidIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/NoUidIndexTest.java
@@ -1,6 +1,6 @@
 package datawave.test.index;
 
-import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_INDEX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/warehouse/query-core/src/test/java/datawave/test/index/TruncatedIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/test/index/TruncatedIndexTest.java
@@ -1,6 +1,6 @@
 package datawave.test.index;
 
-import static datawave.util.TableName.SHARD_INDEX;
+import static datawave.table.constants.TableName.SHARD_INDEX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 


### PR DESCRIPTION
## Summary
- PR #3641 replaced qualified `datawave.util.TableName` usages with `datawave.table.constants.TableName`, but missed 9 test files in `warehouse/query-core` that used static imports (`import static datawave.util.TableName.X`).
- Updates those static imports to the non-deprecated `datawave.table.constants.TableName`.
- No remaining references to `datawave.util.TableName` exist anywhere in the codebase after this change.

## Test plan
- [x] `mvn -pl warehouse/query-core -am test-compile` passes