### PR TITLE
Fix CSVHelper field disallowlist configuration

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CSVHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/CSVHelper.java
@@ -188,7 +188,7 @@ public class CSVHelper extends DataTypeHelperImpl {
         // Get the disallowlist of event fields to drop.
         Collection<String> cb = config.getStringCollection(this.getType().typeName() + FIELD_DISALLOWLIST);
         if (cb != null && !cb.isEmpty()) {
-            this.fieldDisallowlist = new HashSet<>(cw);
+            this.fieldDisallowlist = new HashSet<>(cb);
         }
 
         final Collection<String> reqFields = config.getStringCollection(getType().typeName() + REQUIRED_FIELDS);

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CSVHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/CSVHelperTest.java
@@ -1,0 +1,38 @@
+package datawave.ingest.data.config;
+
+import static java.util.Objects.requireNonNull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import datawave.ingest.data.TypeRegistry;
+import datawave.policy.IngestPolicyEnforcer;
+
+public class CSVHelperTest {
+    @Test
+    public void testLoadsFieldAllowlistAndDisallowlistIndependently() {
+        // Verify allowlist and disallowlist configuration populate separate CSVHelper fields.
+        Configuration conf = new Configuration();
+        conf.addResource(requireNonNull(getClass().getResourceAsStream("/fake-datatype-config.xml")));
+        conf.set("all" + DataTypeHelper.Properties.INGEST_POLICY_ENFORCER_CLASS, IngestPolicyEnforcer.NoOpIngestPolicyEnforcer.class.getName());
+        conf.setStrings("fake" + CSVHelper.DATA_HEADER, "FIELD");
+        conf.setStrings("fake" + CSVHelper.FIELD_ALLOWLIST, "KEEP");
+        conf.setStrings("fake" + CSVHelper.FIELD_DISALLOWLIST, "DROP");
+
+        try {
+            TypeRegistry.reset();
+            TypeRegistry.getInstance(conf);
+            CSVHelper helper = new CSVHelper();
+            helper.setup(conf);
+
+            assertEquals(Set.of("KEEP"), helper.getFieldAllowlist());
+            assertEquals(Set.of("DROP"), helper.getFieldDisallowlist());
+        } finally {
+            TypeRegistry.reset();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- populate `CSVHelper.fieldDisallowlist` from the configured disallowlist instead of the allowlist
- add focused `CSVHelper` regression coverage for independent allowlist and disallowlist configuration loading
- leave existing `CSVIngestHelperTest` behavior coverage unchanged

Fixes [Bug (CSVHelper) - populates field disallowlist from allowlist configuration #3717](https://github.com/NationalSecurityAgency/datawave/issues/3717).

## Commit

- [`9f03b63b6` - Fix CSV field disallowlist configuration](https://github.com/arthurianresolve/datawave/commit/9f03b63b6097772e0d8cf783281061cf781cf854)

## Root cause and impact

`CSVHelper.setup()` read the disallowlist into `cb` but copied `cw` into `fieldDisallowlist`. A disallowlist configured without an allowlist could therefore fail to remove matching fields. When both lists were set, allowlisted fields could be removed because disallowlist checks take priority.

The fix is intentionally limited to using `cb` for the disallowlist. Inherited helpers, including JSON and extended CSV helpers, receive the corrected configuration through `CSVHelper`.

## Verification

- `git diff --check` passes
- `CSVHelperTest`: 1 test run, 0 failures, 0 errors, 0 skipped
- command: `mvn --batch-mode --errors --no-transfer-progress -Dmaven.build.cache.enabled=false -pl warehouse/ingest-core -am -Dtest=CSVHelperTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test`
- the optional build cache was disabled only for the Windows verification run because its `**/*.log` exclusion is rejected as a Windows path; no build-cache configuration was changed