### PR TITLE
Fixes read/assert-properties mojo warn messages

### DIFF
--- a/contrib/datawave-utils/assert-properties/pom.xml
+++ b/contrib/datawave-utils/assert-properties/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.15.1</version>
+                <version>3.15.2</version>
                 <configuration>
                    <goalPrefix>datawave</goalPrefix>
                 </configuration>
@@ -110,9 +110,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>      
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.15.2</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/contrib/datawave-utils/assert-properties/pom.xml
+++ b/contrib/datawave-utils/assert-properties/pom.xml
@@ -28,8 +28,7 @@
         </repository>
     </distributionManagement>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
@@ -37,17 +36,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
+                <version>3.14.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <tagNameFormat>@{project.artifactId}_@{project.version}</tagNameFormat>
                     <releaseProfiles>dist</releaseProfiles>
@@ -57,7 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/contrib/datawave-utils/assert-properties/src/main/java/datawave/maven/AssertProperties.java
+++ b/contrib/datawave-utils/assert-properties/src/main/java/datawave/maven/AssertProperties.java
@@ -1,9 +1,11 @@
 package datawave.maven;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 import java.io.BufferedReader;
@@ -18,31 +20,18 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
-/**
- * @goal assert-properties
- * @phase validate
- * @threadSafe true
- */
+@Mojo(name = "assert-properties", defaultPhase = LifecyclePhase.VALIDATE, threadSafe=true)
 @SuppressWarnings("unused")
 public class AssertProperties extends AbstractMojo {
     private static final Character COMMENT = '#', COMMA = ',';
 
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+    @Parameter(defaultValue = "{project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * @parameter
-     * @required
-     */
+    @Parameter(required = true)
     private File expectedPropertyNames;
 
-    /**
-     * @parameter
-     */
+    @Parameter
     private File configuredPropertyNames;
 
     @Override
@@ -67,11 +56,12 @@ public class AssertProperties extends AbstractMojo {
         Set<String> expectedProperties = getExpectedPropertyMap.keySet();
         expectedProperties.removeAll(propertyNames);
 
-        if (expectedProperties.size() > 0) {
+        if (!expectedProperties.isEmpty()) {
             StringBuilder errorMessage = new StringBuilder();
-            errorMessage.append(expectedProperties.size() + " properties were not provided:\n");
+            errorMessage.append(expectedProperties.size()).append(" properties were not provided:\n");
             for (Entry<String,String> entry : getExpectedPropertyMap.entrySet()) {
-                errorMessage.append("Missing property: " + entry.getKey() + ", Description: " + entry.getValue()).append("\n");
+                errorMessage.append("Missing property: ").append(entry.getKey()).append(", Description: ")
+                        .append(entry.getValue()).append("\n");
             }
 
             throw new MojoFailureException(errorMessage.toString());
@@ -96,58 +86,32 @@ public class AssertProperties extends AbstractMojo {
         if (null == this.configuredPropertyNames) {
             envProps = buildProps;
         } else {
-            FileReader propReader = null;
             envProps = new Properties();
-            try {
-                propReader = new FileReader(configuredPropertyNames);
+            try (FileReader propReader = new FileReader(configuredPropertyNames)) {
                 envProps.load(propReader);
             } catch (IOException e) {
                 throw new MojoExecutionException("Could not load configuredPropertyNames", e);
-            } finally {
-                // Make sure we don't leave any open file handles laying around
-                if (null != propReader) {
-                    try {
-                        propReader.close();
-                    } catch (IOException e) {
-                        throw new MojoExecutionException("Could not load configuredPropertyNames", e);
-                    }
-                }
             }
         }
-
-        for (Entry<Object,Object> entry : buildProps.entrySet()) {
-            envProps.put(entry.getKey(), entry.getValue());
-        }
-
+        envProps.putAll(buildProps);
         return envProps;
     }
 
     /**
      * Fetch the set of strings from the configured filename
-     * @return
-     * @throws MojoExecutionException
-     * @throws IOException
+     * @return a Map of strings
+     * @throws MojoExecutionException if the file cannot be found or read
      */
     protected Map<String,String> getExpectedPropertyMap() throws MojoExecutionException {
-        BufferedReader reader ;
-        try {
-            reader = new BufferedReader(new FileReader(this.expectedPropertyNames));
-        } catch (FileNotFoundException e) {
-            getLog().warn("Could not read exepcted properties files");
-
-            throw new MojoExecutionException("Could not read expected properties file", e);
-        }
-
         HashMap<String, String> expectedProperties = new HashMap<>();
-
-        String line = null;
-        try {
+        String line;
+        try (BufferedReader reader = new BufferedReader(new FileReader(this.expectedPropertyNames))) {
             while ((line = reader.readLine()) != null) {
                 // Remove leading/trailing whitespace
                 line = line.trim();
 
                 // Ignore empty lines or those starting with a '#'
-                if (StringUtils.isBlank(line) || line.charAt(0) == COMMENT) {
+                if (line.isBlank() || line.charAt(0) == COMMENT) {
                     continue;
                 }
 
@@ -166,19 +130,15 @@ public class AssertProperties extends AbstractMojo {
                 }
 
                 // Add it to the expected set i the line still isn't blank
-                if (StringUtils.isNotBlank(candidateName)) {
+                if (candidateName.isBlank()) {
                     expectedProperties.put(candidateName, candidateDescription);
                 }
             }
+        } catch (FileNotFoundException e) {
+            getLog().warn("Could not read expected properties files");
+            throw new MojoExecutionException("Could not read expected properties file", e);
         } catch (IOException e) {
             throw new MojoExecutionException("Could not read expected properties file", e);
-        } finally {
-            // Make sure we don't leave any open file handles laying around
-            try {
-                reader.close();
-            } catch (IOException e) {
-                throw new MojoExecutionException("Could not close reader to expected properties", e);
-            }
         }
 
         if (expectedProperties.isEmpty()) {

--- a/contrib/datawave-utils/code-style/pom.xml
+++ b/contrib/datawave-utils/code-style/pom.xml
@@ -29,8 +29,7 @@
         </repository>
     </distributionManagement>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
@@ -38,7 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <tagNameFormat>@{project.artifactId}_@{project.version}</tagNameFormat>
                     <releaseProfiles>dist</releaseProfiles>
@@ -48,7 +47,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/contrib/datawave-utils/read-properties/pom.xml
+++ b/contrib/datawave-utils/read-properties/pom.xml
@@ -28,8 +28,7 @@
         </repository>
     </distributionManagement>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>
@@ -37,12 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
-                <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
+                <version>3.14.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -57,7 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/contrib/datawave-utils/read-properties/pom.xml
+++ b/contrib/datawave-utils/read-properties/pom.xml
@@ -36,12 +36,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1</version>
                 <configuration>
                     <tagNameFormat>@{project.artifactId}_@{project.version}</tagNameFormat>
                     <releaseProfiles>dist</releaseProfiles>
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.15.1</version>
+                <version>3.15.2</version>
                 <configuration>
                    <goalPrefix>datawave</goalPrefix>
                 </configuration>
@@ -118,6 +118,12 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.15.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/contrib/datawave-utils/read-properties/src/main/java/datawave/maven/ReadProperties.java
+++ b/contrib/datawave-utils/read-properties/src/main/java/datawave/maven/ReadProperties.java
@@ -2,6 +2,9 @@ package datawave.maven;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.springframework.util.PropertyPlaceholderHelper;
 
@@ -15,41 +18,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-/**
- * @goal read-properties
- * @phase validate
- * @threadSafe true
- */
+@Mojo(name = "read-properties", defaultPhase = LifecyclePhase.VALIDATE, threadSafe=true)
 @SuppressWarnings("unused")
 public class ReadProperties extends AbstractMojo {
-    /**
-     * @parameter default-value="${project}"
-     * @required
-     * @readonly
-     */
+
+    @Parameter(defaultValue = "{project}", required = true, readonly = true)
     private MavenProject project;
 
-    /**
-     * The properties files that will be used when reading properties.
-     *
-     * @parameter
-     * @required
-     */
+    @Parameter(required = true)
     private File[] directories;
 
-    /**
-     * The properties files that will be used when reading properties.
-     *
-     * @parameter
-     * @required
-     */
+    @Parameter(required = true)
     private File[] files;
 
     /**
-     * If the plugin should be quiet if any of the files was nor found
-     *
-     * @parameter default-value="false"
+     * If the plugin should be quiet if any of the files was not found
      */
+    @Parameter(defaultValue = "false")
     private boolean quiet;
 
     @Override
@@ -86,7 +71,7 @@ public class ReadProperties extends AbstractMojo {
                 String filename = d.getAbsolutePath() + File.separator + f.getName();
                 File file = new File(filename);
                 if (file.exists()) {
-                    maxFilenameLength = (filename.length() > maxFilenameLength) ? filename.length() : maxFilenameLength;
+                    maxFilenameLength = Math.max(filename.length(), maxFilenameLength);
                     try {
                         getLog().info("Loading property file: " + file.getAbsolutePath());
 
@@ -142,11 +127,11 @@ public class ReadProperties extends AbstractMojo {
         project.getProperties().putAll(mergedProperties);
     }
 
-    private class PlaceholderResolver implements PropertyPlaceholderHelper.PlaceholderResolver {
+    private static class PlaceholderResolver implements PropertyPlaceholderHelper.PlaceholderResolver {
 
-        private Properties properties;
-        private Properties systemProperties;
-        private Map<String, String> environment;
+        private final Properties properties;
+        private final Properties systemProperties;
+        private final Map<String, String> environment;
 
         private PlaceholderResolver(Properties properties) {
             this.properties = properties;


### PR DESCRIPTION
Updates the read-properties and assert-properties maven plugins to use Mojo assertions. 
This removes the Mojo warning messages seen when using the plugins. 

Updates the compiler options to use the release flag which enforces a tighter java 11 byte code enforcement than using the source and target flags. 
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html 

Performed minor code quality cleanup:
 * Used try-with-resources loops
 * Refactored mixed string concat and append usage to only .append methods with StringBuilder.
 * Marked final objects as final
 * Removed dep on StringUtils