### PR TITLE
Add feature-flagged Kryo serialization for TypeMetadata

### DIFF
--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
@@ -310,6 +310,11 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         return typeMap;
     }
 
+    /**
+     * Renders this instance in the form described by {@link #fromString(String)}, populating the ingest type and normalizer type mini-maps as a side effect.
+     *
+     * @return a serialized TypeMetadata
+     */
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
@@ -374,17 +379,30 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         return sb.toString();
     }
 
+    /**
+     * Populates this instance from the semicolon delimited form produced by {@link #toString()}: a {@code dts} mini-map assigning an index to each ingest type,
+     * a {@code types} mini-map assigning an index to each normalizer type held against a field, then one entry per field name whose bracketed list holds
+     * {@code ingestTypeIndex:normalizerTypeIndex} pairs.
+     *
+     * <pre>
+     * dts:[0:ingestA,1:ingestB];types:[0:LcNoDiacriticsType,1:NumberType];FIELD1:[0:0,1:0];FIELD2:[0:0,0:1,1:1]
+     * </pre>
+     *
+     * The example above gives FIELD1 an LcNoDiacriticsType in both ingest types, and FIELD2 both types in ingestA and a NumberType in ingestB. Parsing is
+     * lenient: input with fewer than three entries is discarded, empty values are skipped (a field absent from a trailing ingest type emits a trailing comma),
+     * and an index with no mini-map entry yields an empty type name.
+     *
+     * @param data
+     *            a serialized TypeMetadata
+     */
     private void fromString(String data) {
         String[] entries = parse(data, ';');
 
         if (entries.length > 2) {
-            // invert each index -> name mini-map once, as its prefix entry is parsed, so every field/value
-            // entry below is an O(1) lookup instead of rebuilding and linearly scanning an ImmutableMap per
-            // value (see git history for the prior implementation, which dominated profiler traces on large
-            // TypeMetadata instances). These start empty rather than inverting the current mini-maps: those
-            // are unpopulated for a freshly parsed instance, and are still null when called from readObject,
-            // which does not run a constructor. A value entry preceding its prefix entry resolves to "" here
-            // just as it did before.
+            // invert each index -> name mini-map once, as its prefix entry is parsed, so that every field entry below
+            // is an O(1) lookup instead of a linear scan per value. These start empty rather than inverting the
+            // current mini-maps: those are unpopulated for a freshly parsed instance, and are still null when called
+            // from readObject, which does not run a constructor.
             Map<Integer,String> ingestTypesByIndex = Collections.emptyMap();
             Map<Integer,String> dataTypesByIndex = Collections.emptyMap();
 
@@ -396,6 +414,8 @@ public class TypeMetadata implements Serializable, KryoSerializable {
                     setDataTypesMiniMap(parseTypes(entry));
                     dataTypesByIndex = invert(getDataTypesMiniMap());
                 } else {
+                    // a field entry, FIELD_NAME:[ingestTypeIndex:normalizerTypeIndex,...], splitting into the field
+                    // name and the bracketed list of index pairs
                     String[] entrySplits = parse(entry, ':');
 
                     // get rid of the leading and trailing brackets:
@@ -404,6 +424,9 @@ public class TypeMetadata implements Serializable, KryoSerializable {
 
                     for (String aValue : values) {
                         if (!aValue.isEmpty()) { // ignore last entry for trailing comma
+                            // an index pair, vs[0] into the ingest type mini-map and vs[1] into the normalizer type
+                            // mini-map. An index the corresponding mini-map does not hold, including any index seen
+                            // before its mini-map entry was parsed, resolves to "".
                             String[] vs = Iterables.toArray(Splitter.on(':').omitEmptyStrings().trimResults().split(aValue), String.class);
 
                             String ingestType = ingestTypesByIndex.getOrDefault(Integer.valueOf(vs[0]), "");

--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
@@ -3,6 +3,7 @@ package datawave.query.util;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -487,8 +488,13 @@ public class TypeMetadata implements Serializable, KryoSerializable {
     }
 
     /**
-     * Writes this instance directly from its underlying {@code typeMetadata} map, avoiding the {@link #toString()} round trip (and its mini-map bookkeeping)
-     * that {@link #writeObject(ObjectOutputStream)} relies on.
+     * Writes this instance in the binary equivalent of the form described by {@link #fromString(String)}: an ingest type mini-map, a normalizer type mini-map,
+     * then one entry per field name holding its {@code ingestTypeIndex:normalizerTypeIndex} pairs as variable length ints. Each name is written exactly once,
+     * which matters because a normalizer type name is otherwise repeated for every field it is held against. The mini-maps are populated as a side effect, as
+     * they are by {@link #toString()}.
+     * <p>
+     * Unlike {@link #writeObject(ObjectOutputStream)} this bypasses {@link #toString()}, building the mini-maps against the underlying {@code typeMetadata} map
+     * rather than through a {@link StringBuilder}.
      *
      * @param kryo
      *            the kryo instance
@@ -497,21 +503,57 @@ public class TypeMetadata implements Serializable, KryoSerializable {
      */
     @Override
     public void write(Kryo kryo, Output output) {
-        output.writeInt(typeMetadata.size(), true);
+        // the ingest types actually referenced below, sorted so the assigned indices are stable across instances
+        Set<String> ingestTypes = new TreeSet<>(typeMetadata.keySet());
+        Map<String,Integer> ingestTypeIndices = new TreeMap<>();
+        output.writeInt(ingestTypes.size(), true);
+        for (String ingestType : ingestTypes) {
+            output.writeString(ingestType);
+            ingestTypeIndices.put(ingestType, ingestTypeIndices.size());
+        }
+        setIngestTypesMiniMap(ingestTypeIndices);
+
+        Set<String> dataTypes = new TreeSet<>();
+        for (Multimap<String,String> fieldMap : typeMetadata.values()) {
+            dataTypes.addAll(fieldMap.values());
+        }
+        Map<String,Integer> dataTypeIndices = new TreeMap<>();
+        output.writeInt(dataTypes.size(), true);
+        for (String dataType : dataTypes) {
+            output.writeString(dataType);
+            dataTypeIndices.put(dataType, dataTypeIndices.size());
+        }
+        setDataTypesMiniMap(dataTypeIndices);
+
+        // invert the ingest type major typeMetadata into the field major order written below, in a single pass over
+        // its entries rather than a lookup per field per ingest type. Field names come from typeMetadata rather than
+        // the fieldNames member because filter() populates the former without the latter.
+        Map<String,List<Integer>> pairsByField = new TreeMap<>();
         for (Entry<String,Multimap<String,String>> ingestEntry : typeMetadata.entrySet()) {
-            output.writeString(ingestEntry.getKey());
-            Collection<Entry<String,String>> entries = ingestEntry.getValue().entries();
-            output.writeInt(entries.size(), true);
-            for (Entry<String,String> fieldEntry : entries) {
-                output.writeString(fieldEntry.getKey());
-                output.writeString(fieldEntry.getValue());
+            Integer ingestTypeIndex = ingestTypeIndices.get(ingestEntry.getKey());
+            for (Entry<String,Collection<String>> fieldEntry : ingestEntry.getValue().asMap().entrySet()) {
+                List<Integer> pairs = pairsByField.computeIfAbsent(fieldEntry.getKey(), field -> new ArrayList<>());
+                for (String dataType : fieldEntry.getValue()) {
+                    pairs.add(ingestTypeIndex);
+                    pairs.add(dataTypeIndices.get(dataType));
+                }
+            }
+        }
+
+        output.writeInt(pairsByField.size(), true);
+        for (Entry<String,List<Integer>> fieldEntry : pairsByField.entrySet()) {
+            output.writeString(fieldEntry.getKey());
+            List<Integer> pairs = fieldEntry.getValue();
+            output.writeInt(pairs.size() / 2, true);
+            for (Integer index : pairs) {
+                output.writeInt(index, true);
             }
         }
     }
 
     /**
-     * Reads this instance directly into its underlying {@code typeMetadata} map, avoiding the {@link #fromString(String)} parse (and its repeated index-to-name
-     * map lookups) that {@link #readObject(ObjectInputStream)} relies on.
+     * Reads this instance from the form written by {@link #write(Kryo, Output)}, resolving each index pair against the two mini-maps held as arrays, so that
+     * every field entry is an O(1) lookup rather than the repeated map lookups {@link #fromString(String)} performs.
      *
      * @param kryo
      *            the kryo instance
@@ -526,19 +568,28 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         this.ingestTypesMiniMap = new TreeMap<>();
         this.dataTypesMiniMap = new TreeMap<>();
 
-        int numIngestTypes = input.readInt(true);
-        for (int i = 0; i < numIngestTypes; i++) {
-            String ingestType = input.readString();
-            int numEntries = input.readInt(true);
-            Multimap<String,String> fieldMap = HashMultimap.create();
-            for (int j = 0; j < numEntries; j++) {
-                String fieldName = input.readString();
-                String dataType = input.readString();
-                fieldMap.put(fieldName, dataType);
-                this.fieldNames.add(fieldName);
+        String[] ingestTypesByIndex = new String[input.readInt(true)];
+        for (int i = 0; i < ingestTypesByIndex.length; i++) {
+            ingestTypesByIndex[i] = input.readString();
+            this.ingestTypesMiniMap.put(ingestTypesByIndex[i], i);
+        }
+
+        String[] dataTypesByIndex = new String[input.readInt(true)];
+        for (int i = 0; i < dataTypesByIndex.length; i++) {
+            dataTypesByIndex[i] = input.readString();
+            this.dataTypesMiniMap.put(dataTypesByIndex[i], i);
+        }
+
+        int numFields = input.readInt(true);
+        for (int i = 0; i < numFields; i++) {
+            String fieldName = input.readString();
+            int pairs = input.readInt(true);
+            for (int j = 0; j < pairs; j++) {
+                String ingestType = ingestTypesByIndex[input.readInt(true)];
+                String dataType = dataTypesByIndex[input.readInt(true)];
+                this.addTypeMetadata(fieldName, ingestType, dataType);
             }
-            this.typeMetadata.put(ingestType, fieldMap);
-            this.ingestTypes.add(ingestType);
+            this.fieldNames.add(fieldName);
         }
     }
 

--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
@@ -16,9 +16,12 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -26,7 +29,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
-public class TypeMetadata implements Serializable {
+public class TypeMetadata implements Serializable, KryoSerializable {
 
     private Set<String> ingestTypes = new TreeSet<>();
 
@@ -375,11 +378,19 @@ public class TypeMetadata implements Serializable {
         String[] entries = parse(data, ';');
 
         if (entries.length > 2) {
+            // invert the index -> name mini-maps once so each field/value entry below is an O(1) lookup
+            // instead of rebuilding and linearly scanning an ImmutableMap per value (see git history for the
+            // prior implementation, which dominated profiler traces on large TypeMetadata instances)
+            Map<Integer,String> ingestTypesByIndex = invert(getIngestTypesMiniMap());
+            Map<Integer,String> dataTypesByIndex = invert(getDataTypesMiniMap());
+
             for (String entry : entries) {
                 if (entry.startsWith(INGESTTYPE_PREFIX)) {
                     setIngestTypesMiniMap(parseTypes(entry));
+                    ingestTypesByIndex = invert(getIngestTypesMiniMap());
                 } else if (entry.startsWith(DATATYPES_PREFIX)) {
                     setDataTypesMiniMap(parseTypes(entry));
+                    dataTypesByIndex = invert(getDataTypesMiniMap());
                 } else {
                     String[] entrySplits = parse(entry, ':');
 
@@ -389,27 +400,10 @@ public class TypeMetadata implements Serializable {
 
                     for (String aValue : values) {
                         if (!aValue.isEmpty()) { // ignore last entry for trailing comma
-                            // @formatter:off
-                        String[] vs = Iterables
-                                .toArray(Splitter.on(':')
-                                        .omitEmptyStrings()
-                                        .trimResults()
-                                        .split(aValue), String.class);
+                            String[] vs = Iterables.toArray(Splitter.on(':').omitEmptyStrings().trimResults().split(aValue), String.class);
 
-                        String ingestType = ImmutableMap.copyOf(getIngestTypesMiniMap())
-                                .entrySet()
-                                .stream()
-                                .filter(e -> e.getValue().equals(Integer.valueOf(vs[0])))
-                                .map(Entry::getKey)
-                                .findFirst().orElse("");
-
-                        String dataType = ImmutableMap.copyOf(getDataTypesMiniMap())
-                                .entrySet()
-                                .stream()
-                                .filter(e -> e.getValue().equals(Integer.valueOf(vs[1])))
-                                .map(Entry::getKey)
-                                .findFirst().orElse("");
-                        // @formatter:on
+                            String ingestType = ingestTypesByIndex.getOrDefault(Integer.valueOf(vs[0]), "");
+                            String dataType = dataTypesByIndex.getOrDefault(Integer.valueOf(vs[1]), "");
 
                             this.addTypeMetadata(entrySplits[0], ingestType, dataType);
                         }
@@ -418,6 +412,14 @@ public class TypeMetadata implements Serializable {
                 }
             }
         }
+    }
+
+    private static Map<Integer,String> invert(Map<String,Integer> nameToIndex) {
+        Map<Integer,String> byIndex = Maps.newHashMapWithExpectedSize(nameToIndex.size());
+        for (Entry<String,Integer> entry : nameToIndex.entrySet()) {
+            byIndex.put(entry.getValue(), entry.getKey());
+        }
+        return byIndex;
     }
 
     @Override
@@ -452,6 +454,62 @@ public class TypeMetadata implements Serializable {
         this.fieldNames = Sets.newTreeSet();
         this.typeMetadata = Maps.newHashMap();
         this.fromString((String) in.readObject());
+    }
+
+    /**
+     * Writes this instance directly from its underlying {@code typeMetadata} map, avoiding the {@link #toString()} round trip (and its mini-map bookkeeping)
+     * that {@link #writeObject(ObjectOutputStream)} relies on.
+     *
+     * @param kryo
+     *            the kryo instance
+     * @param output
+     *            the kryo output
+     */
+    @Override
+    public void write(Kryo kryo, Output output) {
+        output.writeInt(typeMetadata.size(), true);
+        for (Entry<String,Multimap<String,String>> ingestEntry : typeMetadata.entrySet()) {
+            output.writeString(ingestEntry.getKey());
+            Collection<Entry<String,String>> entries = ingestEntry.getValue().entries();
+            output.writeInt(entries.size(), true);
+            for (Entry<String,String> fieldEntry : entries) {
+                output.writeString(fieldEntry.getKey());
+                output.writeString(fieldEntry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Reads this instance directly into its underlying {@code typeMetadata} map, avoiding the {@link #fromString(String)} parse (and its repeated index-to-name
+     * map lookups) that {@link #readObject(ObjectInputStream)} relies on.
+     *
+     * @param kryo
+     *            the kryo instance
+     * @param input
+     *            the kryo input
+     */
+    @Override
+    public void read(Kryo kryo, Input input) {
+        this.ingestTypes = Sets.newTreeSet();
+        this.fieldNames = Sets.newTreeSet();
+        this.typeMetadata = Maps.newHashMap();
+        this.ingestTypesMiniMap = new TreeMap<>();
+        this.dataTypesMiniMap = new TreeMap<>();
+
+        int numIngestTypes = input.readInt(true);
+        for (int i = 0; i < numIngestTypes; i++) {
+            String ingestType = input.readString();
+            int numEntries = input.readInt(true);
+            Multimap<String,String> fieldMap = HashMultimap.create();
+            for (int j = 0; j < numEntries; j++) {
+                String fieldName = input.readString();
+                String dataType = input.readString();
+                fieldMap.put(fieldName, dataType);
+                this.fieldNames.add(fieldName);
+            }
+            this.typeMetadata.put(ingestType, fieldMap);
+            this.ingestTypes.add(ingestType);
+        }
     }
 
     public static final TypeMetadata EMPTY_TYPE_METADATA = new EmptyTypeMetadata();

--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
@@ -378,11 +378,15 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         String[] entries = parse(data, ';');
 
         if (entries.length > 2) {
-            // invert the index -> name mini-maps once so each field/value entry below is an O(1) lookup
-            // instead of rebuilding and linearly scanning an ImmutableMap per value (see git history for the
-            // prior implementation, which dominated profiler traces on large TypeMetadata instances)
-            Map<Integer,String> ingestTypesByIndex = invert(getIngestTypesMiniMap());
-            Map<Integer,String> dataTypesByIndex = invert(getDataTypesMiniMap());
+            // invert each index -> name mini-map once, as its prefix entry is parsed, so every field/value
+            // entry below is an O(1) lookup instead of rebuilding and linearly scanning an ImmutableMap per
+            // value (see git history for the prior implementation, which dominated profiler traces on large
+            // TypeMetadata instances). These start empty rather than inverting the current mini-maps: those
+            // are unpopulated for a freshly parsed instance, and are still null when called from readObject,
+            // which does not run a constructor. A value entry preceding its prefix entry resolves to "" here
+            // just as it did before.
+            Map<Integer,String> ingestTypesByIndex = Collections.emptyMap();
+            Map<Integer,String> dataTypesByIndex = Collections.emptyMap();
 
             for (String entry : entries) {
                 if (entry.startsWith(INGESTTYPE_PREFIX)) {
@@ -453,6 +457,9 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         this.ingestTypes = Sets.newTreeSet();
         this.fieldNames = Sets.newTreeSet();
         this.typeMetadata = Maps.newHashMap();
+        // deserialization does not run a constructor, so the mini-maps must be initialized here too
+        this.ingestTypesMiniMap = new TreeMap<>();
+        this.dataTypesMiniMap = new TreeMap<>();
         this.fromString((String) in.readObject());
     }
 

--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadataSerializer.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadataSerializer.java
@@ -1,0 +1,51 @@
+package datawave.query.util;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoSerializable;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Serializer for {@link TypeMetadata} that uses its native {@link KryoSerializable} methods, encoded to and from a Base64 string so the result can be carried
+ * anywhere a {@link String} is expected, such as an Accumulo {@code IteratorSetting} option value. Not thread-safe; each thread that serializes or deserializes
+ * {@link TypeMetadata} should hold its own instance.
+ */
+public class TypeMetadataSerializer {
+
+    private final Kryo kryo = new Kryo();
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    /**
+     * Serializes the given {@link TypeMetadata} to a Base64-encoded Kryo byte stream.
+     *
+     * @param typeMetadata
+     *            the instance to serialize
+     * @return a Base64-encoded string suitable for use as an iterator option value
+     */
+    public String serialize(TypeMetadata typeMetadata) {
+        baos.reset();
+        try (Output output = new Output(baos)) {
+            typeMetadata.write(kryo, output);
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    /**
+     * Deserializes a {@link TypeMetadata} previously written by {@link #serialize(TypeMetadata)}.
+     *
+     * @param serialized
+     *            a Base64-encoded Kryo byte stream produced by {@link #serialize(TypeMetadata)}
+     * @return the deserialized {@link TypeMetadata}
+     */
+    public TypeMetadata deserialize(String serialized) {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        byte[] bytes = Base64.getDecoder().decode(serialized);
+        try (Input input = new Input(bytes)) {
+            typeMetadata.read(kryo, input);
+        }
+        return typeMetadata;
+    }
+}

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationPerformanceTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationPerformanceTest.java
@@ -3,6 +3,7 @@ package datawave.query.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -23,7 +24,7 @@ import com.esotericsoftware.kryo.io.Output;
  * {@code new TypeMetadata(String)} text format, versus native Kryo serialization via {@link TypeMetadata#write(Kryo, Output)} /
  * {@link TypeMetadata#read(Kryo, Input)}. Runs across a matrix of small/medium/large datatype counts and field counts, since the two serialization approaches
  * scale differently with each dimension. This isn't a strict pass/fail gate on timing (wall-clock timing is noisy in CI); it verifies both round trips produce
- * an equivalent instance and prints the relative throughput of each combination.
+ * an equivalent instance, and prints the relative throughput and payload size of each combination.
  * <p>
  * The matrix combinations are shuffled before running so that no single ordering (e.g. always smallest-first) biases JIT warmup across combinations, but
  * results are collected and printed in sorted order afterward so the report is easy to read.
@@ -32,7 +33,10 @@ public class TypeMetadataSerializationPerformanceTest {
 
     private static final int[] DATATYPE_COUNTS = {1, 5, 20};
     private static final int[] FIELD_COUNTS = {25, 250, 2_500};
-    private static final String[] NORMALIZERS = {"LcNoDiacriticsType", "NumberType", "DateType", "GeometryType"};
+    // fully qualified, as they are in a TypeMetadata built from the metadata table, since their length is what the
+    // mini-map convention saves on and a short name would understate it
+    private static final String[] NORMALIZERS = {"datawave.data.type.LcNoDiacriticsType", "datawave.data.type.NumberType", "datawave.data.type.DateType",
+            "datawave.data.type.GeometryType"};
 
     // total field entries processed per timed round trip, held roughly constant across the matrix so the smallest
     // combination doesn't run for a trivial fraction of a millisecond and the largest doesn't dominate the build
@@ -49,17 +53,25 @@ public class TypeMetadataSerializationPerformanceTest {
         private final int iterations;
         private final double stringMsPerOp;
         private final double kryoMsPerOp;
+        private final int stringBytes;
+        private final int kryoBytes;
 
-        private Result(int datatypeCount, int fieldCount, int iterations, double stringMsPerOp, double kryoMsPerOp) {
+        private Result(int datatypeCount, int fieldCount, int iterations, double stringMsPerOp, double kryoMsPerOp, int stringBytes, int kryoBytes) {
             this.datatypeCount = datatypeCount;
             this.fieldCount = fieldCount;
             this.iterations = iterations;
             this.stringMsPerOp = stringMsPerOp;
             this.kryoMsPerOp = kryoMsPerOp;
+            this.stringBytes = stringBytes;
+            this.kryoBytes = kryoBytes;
         }
 
         private double speedup() {
             return stringMsPerOp / kryoMsPerOp;
+        }
+
+        private double relativeSize() {
+            return (double) kryoBytes / stringBytes;
         }
     }
 
@@ -83,8 +95,11 @@ public class TypeMetadataSerializationPerformanceTest {
 
         System.out.println("TypeMetadata serialization round-trip: toString()/fromString() vs Kryo");
         for (Result result : sorted) {
-            System.out.printf("%2d datatypes x %5d fields (%d iterations): toString/fromString=%.4f ms/op, Kryo=%.4f ms/op, speedup=%.2fx%n",
-                            result.datatypeCount, result.fieldCount, result.iterations, result.stringMsPerOp, result.kryoMsPerOp, result.speedup());
+            System.out.printf(
+                            "%2d datatypes x %5d fields (%d iterations): toString/fromString=%.4f ms/op, Kryo=%.4f ms/op, speedup=%.2fx, "
+                                            + "toString=%d bytes, Kryo=%d bytes, relative size=%.2fx%n",
+                            result.datatypeCount, result.fieldCount, result.iterations, result.stringMsPerOp, result.kryoMsPerOp, result.speedup(),
+                            result.stringBytes, result.kryoBytes, result.relativeSize());
         }
     }
 
@@ -161,6 +176,9 @@ public class TypeMetadataSerializationPerformanceTest {
         double stringMsPerOp = (stringElapsedNanos / 1_000_000.0) / iterations;
         double kryoMsPerOp = (kryoElapsedNanos / 1_000_000.0) / iterations;
 
-        RESULTS.add(new Result(datatypeCount, fieldCount, iterations, stringMsPerOp, kryoMsPerOp));
+        int stringBytes = original.toString().getBytes(StandardCharsets.UTF_8).length;
+        int kryoBytes = toKryoBytes(kryo, original).length;
+
+        RESULTS.add(new Result(datatypeCount, fieldCount, iterations, stringMsPerOp, kryoMsPerOp, stringBytes, kryoBytes));
     }
 }

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationPerformanceTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationPerformanceTest.java
@@ -1,0 +1,166 @@
+package datawave.query.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Demonstrates the relative cost of the two ways a {@link TypeMetadata} instance can be round-tripped: the native {@link TypeMetadata#toString()} /
+ * {@code new TypeMetadata(String)} text format, versus native Kryo serialization via {@link TypeMetadata#write(Kryo, Output)} /
+ * {@link TypeMetadata#read(Kryo, Input)}. Runs across a matrix of small/medium/large datatype counts and field counts, since the two serialization approaches
+ * scale differently with each dimension. This isn't a strict pass/fail gate on timing (wall-clock timing is noisy in CI); it verifies both round trips produce
+ * an equivalent instance and prints the relative throughput of each combination.
+ * <p>
+ * The matrix combinations are shuffled before running so that no single ordering (e.g. always smallest-first) biases JIT warmup across combinations, but
+ * results are collected and printed in sorted order afterward so the report is easy to read.
+ */
+public class TypeMetadataSerializationPerformanceTest {
+
+    private static final int[] DATATYPE_COUNTS = {1, 5, 20};
+    private static final int[] FIELD_COUNTS = {25, 250, 2_500};
+    private static final String[] NORMALIZERS = {"LcNoDiacriticsType", "NumberType", "DateType", "GeometryType"};
+
+    // total field entries processed per timed round trip, held roughly constant across the matrix so the smallest
+    // combination doesn't run for a trivial fraction of a millisecond and the largest doesn't dominate the build
+    private static final long TIMED_ENTRY_BUDGET = 500_000L;
+    private static final int MIN_TIMED_ITERATIONS = 3;
+    private static final int MAX_TIMED_ITERATIONS = 2_000;
+    private static final int WARMUP_ITERATIONS = 20;
+
+    private static final List<Result> RESULTS = Collections.synchronizedList(new ArrayList<>());
+
+    private static final class Result {
+        private final int datatypeCount;
+        private final int fieldCount;
+        private final int iterations;
+        private final double stringMsPerOp;
+        private final double kryoMsPerOp;
+
+        private Result(int datatypeCount, int fieldCount, int iterations, double stringMsPerOp, double kryoMsPerOp) {
+            this.datatypeCount = datatypeCount;
+            this.fieldCount = fieldCount;
+            this.iterations = iterations;
+            this.stringMsPerOp = stringMsPerOp;
+            this.kryoMsPerOp = kryoMsPerOp;
+        }
+
+        private double speedup() {
+            return stringMsPerOp / kryoMsPerOp;
+        }
+    }
+
+    private static Stream<Arguments> matrix() {
+        List<Arguments> combinations = new ArrayList<>();
+        for (int datatypeCount : DATATYPE_COUNTS) {
+            for (int fieldCount : FIELD_COUNTS) {
+                combinations.add(Arguments.of(datatypeCount, fieldCount));
+            }
+        }
+        // shuffle so the timing runs don't always execute smallest-to-largest, which would let later (larger)
+        // combinations benefit from JIT warmup accumulated by earlier (smaller) ones
+        Collections.shuffle(combinations);
+        return combinations.stream();
+    }
+
+    @AfterAll
+    public static void printResultsSortedByDatatypeThenFieldCount() {
+        List<Result> sorted = new ArrayList<>(RESULTS);
+        sorted.sort(Comparator.<Result> comparingInt(r -> r.datatypeCount).thenComparingInt(r -> r.fieldCount));
+
+        System.out.println("TypeMetadata serialization round-trip: toString()/fromString() vs Kryo");
+        for (Result result : sorted) {
+            System.out.printf("%2d datatypes x %5d fields (%d iterations): toString/fromString=%.4f ms/op, Kryo=%.4f ms/op, speedup=%.2fx%n",
+                            result.datatypeCount, result.fieldCount, result.iterations, result.stringMsPerOp, result.kryoMsPerOp, result.speedup());
+        }
+    }
+
+    private TypeMetadata buildTypeMetadata(int datatypeCount, int fieldCount) {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        for (int d = 0; d < datatypeCount; d++) {
+            String ingestType = "datatype" + d;
+            for (int f = 0; f < fieldCount; f++) {
+                String field = "FIELD_" + f;
+                String normalizer = NORMALIZERS[f % NORMALIZERS.length];
+                typeMetadata.put(field, ingestType, normalizer);
+            }
+        }
+        return typeMetadata;
+    }
+
+    private byte[] toKryoBytes(Kryo kryo, TypeMetadata typeMetadata) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (Output output = new Output(baos)) {
+            typeMetadata.write(kryo, output);
+        }
+        return baos.toByteArray();
+    }
+
+    private TypeMetadata fromKryoBytes(Kryo kryo, byte[] bytes) {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        try (Input input = new Input(bytes)) {
+            typeMetadata.read(kryo, input);
+        }
+        return typeMetadata;
+    }
+
+    @ParameterizedTest(name = "{0} datatypes x {1} fields")
+    @MethodSource("matrix")
+    public void kryoRoundTripIsEquivalentToStringRoundTrip(int datatypeCount, int fieldCount) {
+        TypeMetadata original = buildTypeMetadata(datatypeCount, fieldCount);
+        Kryo kryo = new Kryo();
+
+        TypeMetadata viaString = new TypeMetadata(original.toString());
+        TypeMetadata viaKryo = fromKryoBytes(kryo, toKryoBytes(kryo, original));
+
+        assertEquals(original, viaString);
+        assertEquals(original, viaKryo);
+        assertEquals(original.fold(), viaKryo.fold());
+    }
+
+    @ParameterizedTest(name = "{0} datatypes x {1} fields")
+    @MethodSource("matrix")
+    public void compareToStringVersusKryoRoundTripSpeed(int datatypeCount, int fieldCount) {
+        TypeMetadata original = buildTypeMetadata(datatypeCount, fieldCount);
+        Kryo kryo = new Kryo();
+
+        long totalEntries = (long) datatypeCount * fieldCount;
+        int iterations = (int) Math.max(MIN_TIMED_ITERATIONS, Math.min(MAX_TIMED_ITERATIONS, TIMED_ENTRY_BUDGET / totalEntries));
+
+        // warm up the JIT for both code paths before timing
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            new TypeMetadata(original.toString());
+            fromKryoBytes(kryo, toKryoBytes(kryo, original));
+        }
+
+        long stringStart = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            new TypeMetadata(original.toString());
+        }
+        long stringElapsedNanos = System.nanoTime() - stringStart;
+
+        long kryoStart = System.nanoTime();
+        for (int i = 0; i < iterations; i++) {
+            fromKryoBytes(kryo, toKryoBytes(kryo, original));
+        }
+        long kryoElapsedNanos = System.nanoTime() - kryoStart;
+
+        double stringMsPerOp = (stringElapsedNanos / 1_000_000.0) / iterations;
+        double kryoMsPerOp = (kryoElapsedNanos / 1_000_000.0) / iterations;
+
+        RESULTS.add(new Result(datatypeCount, fieldCount, iterations, stringMsPerOp, kryoMsPerOp));
+    }
+}

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializerTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializerTest.java
@@ -1,10 +1,19 @@
 package datawave.query.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+
 public class TypeMetadataSerializerTest {
+
+    private static final String[] NORMALIZERS = {"datawave.data.type.LcNoDiacriticsType", "datawave.data.type.NumberType", "datawave.data.type.DateType"};
 
     @Test
     public void testRoundTrip() {
@@ -57,5 +66,64 @@ public class TypeMetadataSerializerTest {
         // re-serializing the large instance again must still be unaffected by the intervening small call
         String serializedLargeAgain = serializer.serialize(large);
         assertEquals(large, serializer.deserialize(serializedLargeAgain));
+    }
+
+    private TypeMetadata buildTypeMetadata(int ingestTypeCount, int fieldCount) {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        for (int i = 0; i < ingestTypeCount; i++) {
+            for (int f = 0; f < fieldCount; f++) {
+                typeMetadata.put("FIELD_" + f, "ingest" + i, NORMALIZERS[f % NORMALIZERS.length]);
+            }
+        }
+        return typeMetadata;
+    }
+
+    private byte[] toKryoBytes(TypeMetadata typeMetadata) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (Output output = new Output(baos)) {
+            typeMetadata.write(new Kryo(), output);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * The Kryo form has to stay at least as compact as the {@link TypeMetadata#toString()} form it can replace, since both travel as an iterator option.
+     * Writing each ingest type and normalizer type name once and referring to it by index thereafter is what keeps it there: a normalizer type name is
+     * otherwise repeated for every field it is held against, so the payload grows with the product of the field and ingest type counts rather than their sum.
+     */
+    @Test
+    public void testKryoFormIsSmallerThanTheStringForm() {
+        for (int ingestTypeCount : new int[] {1, 2, 5, 20}) {
+            for (int fieldCount : new int[] {25, 250}) {
+                TypeMetadata typeMetadata = buildTypeMetadata(ingestTypeCount, fieldCount);
+
+                int stringLength = typeMetadata.toString().getBytes(StandardCharsets.UTF_8).length;
+                int kryoLength = toKryoBytes(typeMetadata).length;
+
+                String combination = ingestTypeCount + " ingest types x " + fieldCount + " fields";
+                assertTrue(kryoLength < stringLength, combination + ": Kryo length " + kryoLength + " should be under the string length " + stringLength);
+            }
+        }
+    }
+
+    /**
+     * Base64 encoding costs the Kryo form a third of its size on the way out, which leaves the transported string at rough parity with
+     * {@link TypeMetadata#toString()} for a single ingest type. Every additional ingest type adds a full set of index pairs to the string form but only re-uses
+     * the mini-map entries in the Kryo form, so from two ingest types on the encoded payload is the smaller of the two.
+     */
+    @Test
+    public void testSerializedFormIsSmallerThanTheStringFormForMultipleIngestTypes() {
+        for (int ingestTypeCount : new int[] {2, 5, 20}) {
+            for (int fieldCount : new int[] {25, 250}) {
+                TypeMetadata typeMetadata = buildTypeMetadata(ingestTypeCount, fieldCount);
+
+                int stringLength = typeMetadata.toString().getBytes(StandardCharsets.UTF_8).length;
+                int serializedLength = new TypeMetadataSerializer().serialize(typeMetadata).getBytes(StandardCharsets.UTF_8).length;
+
+                String combination = ingestTypeCount + " ingest types x " + fieldCount + " fields";
+                assertTrue(serializedLength < stringLength,
+                                combination + ": serialized length " + serializedLength + " should be under the string length " + stringLength);
+            }
+        }
     }
 }

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializerTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializerTest.java
@@ -1,0 +1,61 @@
+package datawave.query.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TypeMetadataSerializerTest {
+
+    @Test
+    public void testRoundTrip() {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        typeMetadata.put("FIELD1", "ingestA", "LcNoDiacriticsType");
+        typeMetadata.put("FIELD1", "ingestB", "NumberType");
+        typeMetadata.put("FIELD2", "ingestA", "DateType");
+
+        TypeMetadataSerializer serializer = new TypeMetadataSerializer();
+        String serialized = serializer.serialize(typeMetadata);
+        TypeMetadata deserialized = serializer.deserialize(serialized);
+
+        assertEquals(typeMetadata, deserialized);
+        assertEquals(typeMetadata.fold(), deserialized.fold());
+    }
+
+    @Test
+    public void testRoundTripOfEmptyTypeMetadata() {
+        TypeMetadata typeMetadata = new TypeMetadata();
+
+        TypeMetadataSerializer serializer = new TypeMetadataSerializer();
+        String serialized = serializer.serialize(typeMetadata);
+        TypeMetadata deserialized = serializer.deserialize(serialized);
+
+        assertEquals(typeMetadata, deserialized);
+        assertEquals(true, deserialized.isEmpty());
+    }
+
+    /**
+     * A single serializer instance is meant to be reused across many calls within the same thread, so serializing a smaller instance after a larger one must
+     * not leak leftover bytes from the previous call's internal buffer.
+     */
+    @Test
+    public void testInstanceReuseAcrossDifferentlySizedInstances() {
+        TypeMetadata large = new TypeMetadata();
+        for (int i = 0; i < 50; i++) {
+            large.put("FIELD_" + i, "ingestA", "LcNoDiacriticsType");
+        }
+        TypeMetadata small = new TypeMetadata();
+        small.put("FIELD1", "ingestA", "LcNoDiacriticsType");
+
+        TypeMetadataSerializer serializer = new TypeMetadataSerializer();
+
+        String serializedLarge = serializer.serialize(large);
+        assertEquals(large, serializer.deserialize(serializedLarge));
+
+        String serializedSmall = serializer.serialize(small);
+        assertEquals(small, serializer.deserialize(serializedSmall));
+
+        // re-serializing the large instance again must still be unaffected by the intervening small call
+        String serializedLargeAgain = serializer.serialize(large);
+        assertEquals(large, serializer.deserialize(serializedLargeAgain));
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIteratorOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIteratorOptions.java
@@ -78,7 +78,7 @@ public class DocumentIteratorOptions implements OptionDescriber {
     protected String query;
     protected boolean compressedOptions = false;
     // not thread-safe; consistent with the rest of this class's per-instance state
-    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
+    private final transient TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
     protected TypeMetadata typeMetadata;
     protected CompositeMetadata compositeMetadata;
     protected LongRange timeFilter;

--- a/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIteratorOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/next/retrieval/DocumentIteratorOptions.java
@@ -11,6 +11,7 @@ import static datawave.query.iterator.QueryOptions.QUERY_MAPPING_COMPRESS;
 import static datawave.query.iterator.QueryOptions.START_TIME;
 import static datawave.query.iterator.QueryOptions.TERM_FREQUENCY_FIELDS;
 import static datawave.query.iterator.QueryOptions.TYPE_METADATA;
+import static datawave.query.iterator.QueryOptions.TYPE_METADATA_KRYO;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -56,6 +57,7 @@ import datawave.query.jexl.HitListArithmetic;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.predicate.ValueToAttributes;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 
 /**
  * Similar to {@link QueryOptions}, a class that handles the busy work of parsing options to clean up the implementation of the {@link DocumentIterator}.
@@ -75,6 +77,8 @@ public class DocumentIteratorOptions implements OptionDescriber {
     // variables set from options
     protected String query;
     protected boolean compressedOptions = false;
+    // not thread-safe; consistent with the rest of this class's per-instance state
+    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
     protected TypeMetadata typeMetadata;
     protected CompositeMetadata compositeMetadata;
     protected LongRange timeFilter;
@@ -111,6 +115,7 @@ public class DocumentIteratorOptions implements OptionDescriber {
             START_TIME,
             END_TIME,
             TYPE_METADATA,
+            TYPE_METADATA_KRYO,
             COMPOSITE_METADATA,
             PROJECTION_FIELDS,
             DISALLOWLISTED_FIELDS,
@@ -150,6 +155,7 @@ public class DocumentIteratorOptions implements OptionDescriber {
         options.put(QUERY, "the query string");
         options.put(QUERY_MAPPING_COMPRESS, "true if the type metadata is base64 encoded");
         options.put(TYPE_METADATA, "TypeMetadata");
+        options.put(TYPE_METADATA_KRYO, "Boolean value to indicate TYPE_METADATA is a Base64-encoded Kryo stream rather than the native toString() format");
         options.put(COMPOSITE_METADATA, "CompositeMetadata");
         options.put(START_TIME, "the start time");
         options.put(END_TIME, "the end time");
@@ -187,11 +193,15 @@ public class DocumentIteratorOptions implements OptionDescriber {
         if (options.containsKey(TYPE_METADATA)) {
             String option = options.get(TYPE_METADATA);
             try {
-                if (compressedOptions) {
-                    option = decompressOption(option, QueryOptions.UTF8);
-                }
+                if (Boolean.parseBoolean(options.get(TYPE_METADATA_KRYO))) {
+                    this.typeMetadata = typeMetadataSerializer.deserialize(option);
+                } else {
+                    if (compressedOptions) {
+                        option = decompressOption(option, QueryOptions.UTF8);
+                    }
 
-                this.typeMetadata = new TypeMetadata(option);
+                    this.typeMetadata = new TypeMetadata(option);
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -3002,6 +3002,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 getReduceQueryFieldsPerShard() == that.getReduceQueryFieldsPerShard() &&
                 getReduceTypeMetadata() == that.getReduceTypeMetadata() &&
                 getReduceTypeMetadataPerShard() == that.getReduceTypeMetadataPerShard() &&
+                isKryoTypeMetadata() == that.isKryoTypeMetadata() &&
                 isRebuildDatatypeFilter() == that.isRebuildDatatypeFilter() &&
                 isRebuildDatatypeFilterPerShard() == that.isRebuildDatatypeFilterPerShard() &&
                 getCollectTimingDetails() == that.getCollectTimingDetails() &&
@@ -3240,6 +3241,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
                 getReduceQueryFieldsPerShard(),
                 getReduceTypeMetadata(),
                 getReduceTypeMetadataPerShard(),
+                isKryoTypeMetadata(),
                 isRebuildDatatypeFilter(),
                 isRebuildDatatypeFilterPerShard(),
                 getCollectTimingDetails(),

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -127,6 +127,8 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
     private boolean reduceQueryFieldsPerShard = false;
     private boolean reduceTypeMetadata = false;
     private boolean reduceTypeMetadataPerShard = false;
+    // should TypeMetadata be serialized to iterator options via Kryo instead of its native toString() format
+    private boolean kryoTypeMetadata = false;
     private boolean collectTimingDetails = false;
     private boolean logTimingDetails = false;
     private boolean sendTimingToStatsd = true;
@@ -635,6 +637,7 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
         this.setReduceQueryFieldsPerShard(other.getReduceQueryFieldsPerShard());
         this.setReduceTypeMetadata(other.getReduceTypeMetadata());
         this.setReduceTypeMetadataPerShard(other.getReduceTypeMetadataPerShard());
+        this.setKryoTypeMetadata(other.isKryoTypeMetadata());
         this.setRebuildDatatypeFilter(other.isRebuildDatatypeFilter());
         this.setRebuildDatatypeFilterPerShard(other.isRebuildDatatypeFilterPerShard());
         this.setParseTldUids(other.getParseTldUids());
@@ -2408,6 +2411,14 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     public void setReduceTypeMetadataPerShard(boolean reduceTypeMetadataPerShard) {
         this.reduceTypeMetadataPerShard = reduceTypeMetadataPerShard;
+    }
+
+    public boolean isKryoTypeMetadata() {
+        return kryoTypeMetadata;
+    }
+
+    public void setKryoTypeMetadata(boolean kryoTypeMetadata) {
+        this.kryoTypeMetadata = kryoTypeMetadata;
     }
 
     public boolean getLimitAnyFieldLookups() {

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -98,6 +98,7 @@ import datawave.query.statsd.QueryStatsDClient;
 import datawave.query.tables.async.Scan;
 import datawave.query.tracking.ActiveQueryLog;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 import datawave.query.util.count.CountMap;
 import datawave.query.util.count.CountMapSerDe;
 import datawave.query.util.sortedset.FileSortedSet;
@@ -124,6 +125,7 @@ public class QueryOptions implements OptionDescriber {
     public static final String QUERY_ID = "query.id";
     public static final String TYPE_METADATA = "type.metadata";
     public static final String TYPE_METADATA_AUTHS = "type.metadata.auths";
+    public static final String TYPE_METADATA_KRYO = "type.metadata.kryo";
     public static final String METADATA_TABLE_NAME = "model.table.name";
 
     public static final String REDUCED_RESPONSE = "reduced.response";
@@ -301,6 +303,9 @@ public class QueryOptions implements OptionDescriber {
     protected long sourceLimit = -1;
     protected boolean disableIndexOnlyDocuments = false;
     protected TypeMetadata typeMetadata = new TypeMetadata();
+    // reused across calls to validateTypeMetadata; not thread-safe, so deliberately not copied by deepCopy() -
+    // each QueryOptions (and each deep copy of it) gets its own instance via this field initializer
+    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
     protected Set<String> typeMetadataAuthsKey = Sets.newHashSet();
     protected CompositeMetadata compositeMetadata = null;
     protected int compositeSeekThreshold = 10;
@@ -1342,6 +1347,7 @@ public class QueryOptions implements OptionDescriber {
         options.put(QUERY, "The JEXL query to evaluate documents against");
         options.put(QUERY_ID, "The UUID of the query");
         options.put(TYPE_METADATA, "A mapping of field name to a set of DataType class names");
+        options.put(TYPE_METADATA_KRYO, "Boolean value to indicate TYPE_METADATA is a Base64-encoded Kryo stream rather than the native toString() format");
         options.put(QUERY_MAPPING_COMPRESS, "Boolean value to indicate Normalizer mapping is compressed");
         options.put(REDUCED_RESPONSE, "Whether or not to return visibility markings on each attribute. Default: " + reducedResponse);
         options.put(Constants.RETURN_TYPE, "The method to use to serialize data for return to the client");
@@ -1997,10 +2003,14 @@ public class QueryOptions implements OptionDescriber {
         if (options.containsKey(TYPE_METADATA)) {
             String typeMetadataString = options.get(TYPE_METADATA);
             try {
-                if (compressedMappings) {
-                    typeMetadataString = decompressOption(typeMetadataString, QueryOptions.UTF8);
+                if (Boolean.parseBoolean(options.get(TYPE_METADATA_KRYO))) {
+                    this.typeMetadata = typeMetadataSerializer.deserialize(typeMetadataString);
+                } else {
+                    if (compressedMappings) {
+                        typeMetadataString = decompressOption(typeMetadataString, QueryOptions.UTF8);
+                    }
+                    this.typeMetadata = buildTypeMetadata(typeMetadataString);
                 }
-                this.typeMetadata = buildTypeMetadata(typeMetadataString);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -305,7 +305,7 @@ public class QueryOptions implements OptionDescriber {
     protected TypeMetadata typeMetadata = new TypeMetadata();
     // reused across calls to validateTypeMetadata; not thread-safe, so deliberately not copied by deepCopy() -
     // each QueryOptions (and each deep copy of it) gets its own instance via this field initializer
-    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
+    private final transient TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
     protected Set<String> typeMetadataAuthsKey = Sets.newHashSet();
     protected CompositeMetadata compositeMetadata = null;
     protected int compositeSeekThreshold = 10;

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -318,7 +318,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     protected CompositeMetadata compositeMetadata;
     protected TypeMetadata typeMetadata;
     // reused across calls to configureTypeMappings; not thread-safe, so each DefaultQueryPlanner (and clone) gets its own instance
-    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
+    private final transient TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
     protected String contentExpansionFields;
     protected String serializedIvaratorDirs;
     protected Set<String> indexedFields;

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -196,6 +196,7 @@ import datawave.query.util.QueryStopwatch;
 import datawave.query.util.ShardQueryUtils;
 import datawave.query.util.Tuple2;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 import datawave.util.time.TraceStopwatch;
 import datawave.webservice.query.exception.BadRequestQueryException;
 import datawave.webservice.query.exception.DatawaveErrorCode;
@@ -316,6 +317,8 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
 
     protected CompositeMetadata compositeMetadata;
     protected TypeMetadata typeMetadata;
+    // reused across calls to configureTypeMappings; not thread-safe, so each DefaultQueryPlanner (and clone) gets its own instance
+    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
     protected String contentExpansionFields;
     protected String serializedIvaratorDirs;
     protected Set<String> indexedFields;
@@ -2675,12 +2678,19 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
                     typeMetadata = typeMetadata.reduce(fieldsToRetain);
                 }
 
-                // only compress if enabled AND not reducing per shard
-                // type metadata will be serialized in the VisitorFunction
-                String serializedTypeMetadata = typeMetadata.toString();
-                if (compressMappings && !config.getReduceTypeMetadataPerShard()) {
-                    serializedTypeMetadata = QueryOptions.compressOption(serializedTypeMetadata, QueryOptions.UTF8);
+                // only compress/Kryo-encode if enabled AND not reducing per shard, since in that case
+                // type metadata is re-serialized via toString() in the VisitorFunction instead
+                boolean kryoTypeMetadata = config.isKryoTypeMetadata() && !config.getReduceTypeMetadataPerShard();
+                String serializedTypeMetadata;
+                if (kryoTypeMetadata) {
+                    serializedTypeMetadata = typeMetadataSerializer.serialize(typeMetadata);
+                } else {
+                    serializedTypeMetadata = typeMetadata.toString();
+                    if (compressMappings && !config.getReduceTypeMetadataPerShard()) {
+                        serializedTypeMetadata = QueryOptions.compressOption(serializedTypeMetadata, QueryOptions.UTF8);
+                    }
                 }
+                addOption(cfg, QueryOptions.TYPE_METADATA_KRYO, Boolean.toString(kryoTypeMetadata), false);
 
                 addOption(cfg, QueryOptions.TYPE_METADATA, serializedTypeMetadata, false);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -2913,6 +2913,14 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
         getConfig().setReduceTypeMetadataPerShard(reduceTypeMetadataPerShard);
     }
 
+    public boolean isKryoTypeMetadata() {
+        return getConfig().isKryoTypeMetadata();
+    }
+
+    public void setKryoTypeMetadata(boolean kryoTypeMetadata) {
+        getConfig().setKryoTypeMetadata(kryoTypeMetadata);
+    }
+
     public long getMaxIndexScanTimeMillis() {
         return getConfig().getMaxIndexScanTimeMillis();
     }

--- a/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
@@ -65,6 +65,7 @@ import datawave.query.tables.async.ScannerChunk;
 import datawave.query.transformer.UniqueTransform;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 import datawave.util.time.DateHelper;
 import datawave.webservice.query.exception.BadRequestQueryException;
 import datawave.webservice.query.exception.DatawaveErrorCode;
@@ -91,6 +92,8 @@ public class VisitorFunction implements Function<ScannerChunk,ScannerChunk> {
     private Cache<String,String> queryCache;
 
     private TypeMetadata cachedTypeMetadata = null;
+    // not thread-safe; consistent with cachedTypeMetadata above, this assumes a VisitorFunction instance is confined to a single thread
+    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
 
     private static final Logger log = Logger.getLogger(VisitorFunction.class);
 
@@ -573,10 +576,14 @@ public class VisitorFunction implements Function<ScannerChunk,ScannerChunk> {
      * @param newIteratorSetting
      *            the iterator settings
      */
-    private void reduceIngestTypes(ASTJexlScript script, IteratorSetting newIteratorSetting) {
+    protected void reduceIngestTypes(ASTJexlScript script, IteratorSetting newIteratorSetting) {
         if (cachedTypeMetadata == null) {
             String serializedTypeMetadata = newIteratorSetting.getOptions().get(QueryOptions.TYPE_METADATA);
-            cachedTypeMetadata = new TypeMetadata(serializedTypeMetadata);
+            if (Boolean.parseBoolean(newIteratorSetting.getOptions().get(QueryOptions.TYPE_METADATA_KRYO))) {
+                cachedTypeMetadata = typeMetadataSerializer.deserialize(serializedTypeMetadata);
+            } else {
+                cachedTypeMetadata = new TypeMetadata(serializedTypeMetadata);
+            }
         }
 
         // get requested types

--- a/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/async/event/VisitorFunction.java
@@ -93,7 +93,7 @@ public class VisitorFunction implements Function<ScannerChunk,ScannerChunk> {
 
     private TypeMetadata cachedTypeMetadata = null;
     // not thread-safe; consistent with cachedTypeMetadata above, this assumes a VisitorFunction instance is confined to a single thread
-    private final TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
+    private final transient TypeMetadataSerializer typeMetadataSerializer = new TypeMetadataSerializer();
 
     private static final Logger log = Logger.getLogger(VisitorFunction.class);
 

--- a/warehouse/query-core/src/test/java/datawave/next/retrieval/DocumentIteratorOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/retrieval/DocumentIteratorOptionsTest.java
@@ -1,0 +1,54 @@
+package datawave.next.retrieval;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.query.iterator.QueryOptions;
+import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
+
+public class DocumentIteratorOptionsTest {
+
+    private Map<String,String> baseOptions() {
+        Map<String,String> options = new HashMap<>();
+        options.put(QueryOptions.QUERY, "FIELD_A == 'a'");
+        options.put(DocumentIteratorOptions.CANDIDATES, "dt\0uid-1");
+        options.put(QueryOptions.START_TIME, String.valueOf(0L));
+        options.put(QueryOptions.END_TIME, String.valueOf(Long.MAX_VALUE));
+        return options;
+    }
+
+    @Test
+    public void testTypeMetadataFromNativeStringFormat() {
+        TypeMetadata expected = new TypeMetadata();
+        expected.put("FIELD_A", "ingestA", LcNoDiacriticsType.class.getSimpleName());
+
+        Map<String,String> options = baseOptions();
+        options.put(QueryOptions.TYPE_METADATA, expected.toString());
+
+        DocumentIteratorOptions documentIteratorOptions = new DocumentIteratorOptions();
+        documentIteratorOptions.validateOptions(options);
+
+        assertEquals(expected, documentIteratorOptions.typeMetadata);
+    }
+
+    @Test
+    public void testTypeMetadataFromKryoFormat() {
+        TypeMetadata expected = new TypeMetadata();
+        expected.put("FIELD_A", "ingestA", LcNoDiacriticsType.class.getSimpleName());
+
+        Map<String,String> options = baseOptions();
+        options.put(QueryOptions.TYPE_METADATA, new TypeMetadataSerializer().serialize(expected));
+        options.put(QueryOptions.TYPE_METADATA_KRYO, "true");
+
+        DocumentIteratorOptions documentIteratorOptions = new DocumentIteratorOptions();
+        documentIteratorOptions.validateOptions(options);
+
+        assertEquals(expected, documentIteratorOptions.typeMetadata);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ColorsTest.java
@@ -130,6 +130,9 @@ public class ColorsTest extends AbstractQueryTest {
         givenParameter(QueryParameters.HIT_LIST, "true");
         logic.setHitList(true);
 
+        // every test also exercises the Kryo TypeMetadata serialization path
+        logic.setKryoTypeMetadata(true);
+
         // default to full date range
         givenDate(ColorsIngest.getStartDay(), ColorsIngest.getEndDay());
     }

--- a/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/config/ShardQueryConfigurationTest.java
@@ -186,6 +186,8 @@ public class ShardQueryConfigurationTest {
         updatedValues.put("reduceTypeMetadata", true);
         defaultValues.put("reduceTypeMetadataPerShard", false);
         updatedValues.put("reduceTypeMetadataPerShard", true);
+        defaultValues.put("kryoTypeMetadata", false);
+        updatedValues.put("kryoTypeMetadata", true);
         defaultValues.put("collectTimingDetails", false);
         updatedValues.put("collectTimingDetails", true);
         defaultValues.put("logTimingDetails", false);

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/QueryOptionsTest.java
@@ -37,6 +37,8 @@ import datawave.query.function.Equality;
 import datawave.query.function.PrefixEquality;
 import datawave.query.iterator.filter.EntryKeyIdentity;
 import datawave.query.iterator.filter.FieldIndexKeyDataTypeFilter;
+import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 
 public class QueryOptionsTest {
 
@@ -235,6 +237,39 @@ public class QueryOptionsTest {
         QueryOptions qopts = new QueryOptions();
         qopts.validateOptions(opts);
         Assert.assertTrue(qopts.getFieldIndexKeyDataTypeFilter() instanceof FieldIndexKeyDataTypeFilter);
+    }
+
+    @Test
+    public void testTypeMetadataFromNativeStringFormat() {
+        TypeMetadata expected = new TypeMetadata();
+        expected.put("FIELD1", "ingestA", "LcNoDiacriticsType");
+        expected.put("FIELD2", "ingestA", "NumberType");
+
+        Map<String,String> optionsMap = new HashMap<>();
+        optionsMap.put(QUERY, "set to avoid early return");
+        optionsMap.put(QueryOptions.TYPE_METADATA, expected.toString());
+
+        QueryOptions options = new QueryOptions();
+        options.validateOptions(optionsMap);
+
+        assertEquals(expected, options.getTypeMetadata());
+    }
+
+    @Test
+    public void testTypeMetadataFromKryoFormat() {
+        TypeMetadata expected = new TypeMetadata();
+        expected.put("FIELD1", "ingestA", "LcNoDiacriticsType");
+        expected.put("FIELD2", "ingestA", "NumberType");
+
+        Map<String,String> optionsMap = new HashMap<>();
+        optionsMap.put(QUERY, "set to avoid early return");
+        optionsMap.put(QueryOptions.TYPE_METADATA, new TypeMetadataSerializer().serialize(expected));
+        optionsMap.put(QueryOptions.TYPE_METADATA_KRYO, "true");
+
+        QueryOptions options = new QueryOptions();
+        options.validateOptions(optionsMap);
+
+        assertEquals(expected, options.getTypeMetadata());
     }
 
     @Test

--- a/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/DefaultQueryPlannerTest.java
@@ -1,18 +1,22 @@
 package datawave.query.planner;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.commons.jexl3.parser.ASTJexlScript;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import datawave.data.type.DateType;
 import datawave.data.type.LcNoDiacriticsListType;
@@ -27,12 +31,14 @@ import datawave.query.config.ShardQueryConfiguration;
 import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.exceptions.DatawaveQueryException;
 import datawave.query.exceptions.NoResultsException;
+import datawave.query.iterator.QueryOptions;
 import datawave.query.jexl.JexlASTHelper;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.util.DateIndexHelper;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.MockDateIndexHelper;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 import datawave.test.JexlNodeAssert;
 import datawave.util.time.DateHelper;
 
@@ -388,6 +394,85 @@ class DefaultQueryPlannerTest {
 
             assertEquals(beginDate, config.getBeginDate());
             assertEquals(endDate, config.getEndDate());
+        }
+    }
+
+    /**
+     * Contains tests for {@link DefaultQueryPlanner#configureTypeMappings(ShardQueryConfiguration, IteratorSetting, MetadataHelper, boolean, boolean)}
+     */
+    @Nested
+    class ConfigureTypeMappingsTests {
+
+        private DefaultQueryPlanner planner;
+        private ShardQueryConfiguration config;
+        private MetadataHelper metadataHelper;
+        private TypeMetadata typeMetadata;
+
+        @BeforeEach
+        void setUp() {
+            planner = new DefaultQueryPlanner();
+            config = new ShardQueryConfiguration();
+            metadataHelper = Mockito.mock(MetadataHelper.class);
+            Mockito.when(metadataHelper.getUsersMetadataAuthorizationSubset()).thenReturn("");
+
+            typeMetadata = new TypeMetadata();
+            typeMetadata.put("FIELD1", "ingestA", "LcNoDiacriticsType");
+            typeMetadata.put("FIELD2", "ingestA", "NumberType");
+            planner.setTypeMetadata(typeMetadata);
+        }
+
+        /**
+         * Verify that when {@code kryoTypeMetadata} is disabled (the default), TYPE_METADATA is serialized via {@link TypeMetadata#toString()} and the
+         * TYPE_METADATA_KRYO marker option is false.
+         */
+        @Test
+        void testKryoTypeMetadataDisabledUsesNativeStringFormat() throws Exception {
+            IteratorSetting cfg = new IteratorSetting(100, "test", "test");
+
+            planner.configureTypeMappings(config, cfg, metadataHelper, false);
+
+            Map<String,String> options = cfg.getOptions();
+            assertFalse(Boolean.parseBoolean(options.get(QueryOptions.TYPE_METADATA_KRYO)));
+            assertEquals(typeMetadata.toString(), options.get(QueryOptions.TYPE_METADATA));
+        }
+
+        /**
+         * Verify that when {@code kryoTypeMetadata} is enabled, TYPE_METADATA is serialized via {@link TypeMetadataSerializer} and the TYPE_METADATA_KRYO
+         * marker option is true, and that the result decodes back to the original TypeMetadata.
+         */
+        @Test
+        void testKryoTypeMetadataEnabledUsesKryoFormat() throws Exception {
+            config.setKryoTypeMetadata(true);
+            IteratorSetting cfg = new IteratorSetting(100, "test", "test");
+
+            planner.configureTypeMappings(config, cfg, metadataHelper, false);
+
+            Map<String,String> options = cfg.getOptions();
+            assertTrue(Boolean.parseBoolean(options.get(QueryOptions.TYPE_METADATA_KRYO)));
+            assertEquals(typeMetadata, new TypeMetadataSerializer().deserialize(options.get(QueryOptions.TYPE_METADATA)));
+        }
+
+        /**
+         * Verify that {@code kryoTypeMetadata} is ignored (falls back to the native string format) when per-shard type metadata reduction is enabled, since
+         * VisitorFunction re-serializes TypeMetadata via toString() after reducing it per shard and does not understand the Kryo format.
+         */
+        @Test
+        void testKryoTypeMetadataIgnoredWhenReducingPerShard() throws Exception {
+            config.setKryoTypeMetadata(true);
+            // canReduceTypeMetadata requires a non-empty project/disallowlist field set, otherwise configureTypeMappings
+            // forces reduceTypeMetadataPerShard back to false before it ever reaches the serialization branch below
+            config.setProjectFields(Set.of("FIELD1"));
+            config.setQueryTree(JexlASTHelper.parseJexlQuery("FIELD1 == 'bar'"));
+            config.setReduceTypeMetadataPerShard(true);
+            IteratorSetting cfg = new IteratorSetting(100, "test", "test");
+
+            planner.configureTypeMappings(config, cfg, metadataHelper, false);
+
+            // the planner still performs a first-pass reduction to FIELD1 regardless of the kryo flag; only the
+            // serialization format (native toString(), not Kryo) is under test here
+            Map<String,String> options = cfg.getOptions();
+            assertFalse(Boolean.parseBoolean(options.get(QueryOptions.TYPE_METADATA_KRYO)));
+            assertEquals(typeMetadata.reduce(Set.of("FIELD1")).toString(), options.get(QueryOptions.TYPE_METADATA));
         }
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/tables/async/event/VisitorFunctionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/async/event/VisitorFunctionTest.java
@@ -41,6 +41,7 @@ import datawave.query.tables.async.ScannerChunk;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.MockMetadataHelper;
 import datawave.query.util.TypeMetadata;
+import datawave.query.util.TypeMetadataSerializer;
 import datawave.table.constants.TableName;
 
 public class VisitorFunctionTest extends EasyMockSupport {
@@ -503,6 +504,30 @@ public class VisitorFunctionTest extends EasyMockSupport {
 
         TypeMetadata metadata = new TypeMetadata(option);
         Assert.assertEquals(Set.of("FIELD_A", "FIELD_C"), metadata.keySet());
+    }
+
+    /**
+     * Verify that {@link VisitorFunction#reduceIngestTypes(ASTJexlScript, IteratorSetting)} correctly decodes a Kryo-encoded TYPE_METADATA option (marked by
+     * TYPE_METADATA_KRYO) instead of assuming the native toString() format.
+     */
+    @Test
+    public void testReduceIngestTypesHonorsKryoTypeMetadata() throws Exception {
+        ShardQueryConfiguration config = new ShardQueryConfiguration();
+        config.setRebuildDatatypeFilterPerShard(true);
+        MockMetadataHelper helper = new MockMetadataHelper();
+        VisitorFunction function = new VisitorFunction(config, helper);
+
+        TypeMetadata typeMetadata = new TypeMetadata();
+        typeMetadata.put("FIELD_A", "type-a", LcNoDiacriticsType.class.getSimpleName());
+
+        ASTJexlScript script = JexlASTHelper.parseAndFlattenJexlQuery("FIELD_A == 'a'");
+        IteratorSetting settings = new IteratorSetting(10, "itr", QueryIterator.class);
+        settings.addOption(QueryOptions.TYPE_METADATA, new TypeMetadataSerializer().serialize(typeMetadata));
+        settings.addOption(QueryOptions.TYPE_METADATA_KRYO, "true");
+
+        function.reduceIngestTypes(script, settings);
+
+        Assert.assertEquals("type-a", settings.getOptions().get(QueryOptions.DATATYPE_FILTER));
     }
 
     private void loadSettings(IteratorSetting settings) {

--- a/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/EventQueryLogicFactory.xml
@@ -137,6 +137,8 @@
         <!--   reduce type metadata     -->
         <property name="reduceTypeMetadata" value="false" />
         <property name="reduceTypeMetadataPerShard" value="false" />
+        <!--   should TypeMetadata be serialized to iterator options via Kryo instead of its native toString() format    -->
+        <property name="kryoTypeMetadata" value="false" />
         <!--   query sorting options     -->
         <property name="sortQueryPreIndexWithImpliedCounts" value="true" />
         <property name="sortQueryPreIndexWithFieldCounts" value="true" />

--- a/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
+++ b/warehouse/query-core/src/test/resources/datawave/query/QueryLogicFactory.xml
@@ -397,6 +397,8 @@
         <property name="reduceQueryFieldsPerShard" value="false" />
         <property name="reduceTypeMetadata" value="false" />
         <property name="reduceTypeMetadataPerShard" value="false" />
+        <!--   should TypeMetadata be serialized to iterator options via Kryo instead of its native toString() format    -->
+        <property name="kryoTypeMetadata" value="false" />
         <!--    should the query prune fields by ingest type    -->
         <property name="pruneQueryByIngestTypes" value="false" />
         <!--   should the range stream also generate field and term counts    -->


### PR DESCRIPTION
## Summary
- `toString()`/`fromString()` dominated profiler traces (`HashMap.put`/`calculateHash`) from rebuilding index-to-name lookup maps per field/value pair; fixes that hot path.
- Adds native Kryo support: `TypeMetadata` implements `KryoSerializable`, and `TypeMetadataSerializer` wraps it into a Base64 string round trip, reusing its `Kryo`/buffer per instance (matching the `CandidateResultSerializer` convention) since it's called many times per thread.
- The Kryo form uses the same mini-map convention as `toString()`: an ingest type dictionary, a normalizer type dictionary, then one entry per field name holding its `ingestTypeIndex:normalizerTypeIndex` pairs as variable length ints. Each name is written exactly once, and `read` holds both dictionaries as arrays so resolving a pair is an array index rather than a map rebuild, keeping deserialization O(1) per entry.
- Wires it through a new `kryoTypeMetadata` flag on `ShardQueryConfiguration`: `DefaultQueryPlanner` serializes via Kryo when enabled, marking the iterator option so `QueryOptions` decodes it correctly. The flag is skipped during per-shard type metadata reduction, since `VisitorFunction` re-serializes via `toString()` afterward and doesn't understand the Kryo format.
- A parameterized performance test (1/5/20 datatypes x 25/250/2500 fields) shows the Kryo round trip is consistently 1.7-3.0x faster.

## Payload size

The mini-map convention is what keeps the payload smaller than the string form it replaces. An earlier revision of this branch wrote the full ingest type and normalizer class name for every field/normalizer pair, which made it **larger** than `toString()` — measured against the same fixture, with fully qualified normalizer names:

| datatypes x fields | `toString()` | Kryo, repeated names | Kryo, mini-map |
| --- | --- | --- | --- |
| 1 x 25 | 526 | 982 (1.87x) | 401 (0.76x) |
| 1 x 2500 | 41,551 | 101,402 (2.44x) | 31,527 (0.76x) |
| 5 x 250 | 8,099 | 49,526 (6.12x) | 5,063 (0.63x) |
| 5 x 2500 | 81,599 | 507,006 (6.21x) | 51,563 (0.63x) |
| 20 x 250 | 25,799 | 198,111 (7.68x) | 12,708 (0.49x) |
| 20 x 2500 | 256,799 | 2,028,031 (7.90x) | 126,708 (0.49x) |

The Kryo form is now 0.49-0.76x of the string form, i.e. 2.5-16x smaller than writing the names repeatedly.

Two caveats worth noting for review:

- Building the dictionaries and inverting to field-major order is write-side work the repeated-name layout skipped, so the round trip speedup drops from 3.1-5.5x to 1.7-3.0x. Both figures are measured on the same fixture, so this is a real trade: roughly half the speed advantage in exchange for a payload that is 4-16x smaller and no longer larger than what it replaces.
- `TypeMetadataSerializer` Base64-encodes on the way out, which adds a third back. The transported string is therefore at rough parity with `toString()` for a single ingest type (1.00x) and only pulls ahead from two ingest types on (0.66-0.94x). The raw Kryo form is smaller in every combination; Base64 is what consumes the margin at the low end. Both properties are asserted separately rather than averaged together.

## Test plan
- [x] `metadata-utils` module test suite (379 tests) passes, via `install` so the enforcer rules run
- [x] Targeted `query-core` suites (`QueryOptionsTest`, `DefaultQueryPlannerTest`, `DocumentIteratorOptionsTest`, `VisitorFunctionTest`, `TypeMetadataTest`) pass
- [x] `ColorsTest` exercises the Kryo path end to end through the planner and iterator
- [x] `TypeMetadataSerializerTest` covers round trip correctness, instance reuse across differently-sized inputs, and the two payload size properties above
- [x] `TypeMetadataSerializationPerformanceTest` reports throughput and payload size across the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
