### PR TITLE
Add tests pinning scanner session threading defects

### DIFF
--- a/core/utils/type-utils/src/test/java/datawave/webservice/query/util/QueryUncaughtExceptionHandlerTest.java
+++ b/core/utils/type-utils/src/test/java/datawave/webservice/query/util/QueryUncaughtExceptionHandlerTest.java
@@ -1,0 +1,125 @@
+package datawave.webservice.query.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the current, thread-unsafe behavior of {@link QueryUncaughtExceptionHandler}.
+ * <p>
+ * The handler guards its write with <code>if (this.throwable == null)</code> evaluated <em>outside</em> the <code>synchronized</code> block, and exposes
+ * <code>throwable</code> and <code>thread</code> through unsynchronized reads of non-volatile fields. That is a broken double-checked lock with two
+ * consequences: the documented "keep only the first one" invariant is not enforced, and a reader thread has no happens-before edge guaranteeing it ever
+ * observes a recorded failure.
+ * <p>
+ * The second consequence matters most in practice. {@link datawave.query.tables.ScannerSession} records scan failures here on its worker thread and checks them
+ * on the consumer thread; a missed write turns a failed scan into a silently empty result set.
+ * <p>
+ * These tests assert the broken behavior on purpose so that a fix is forced to update them. When the handler is made safe, every assertion here should be
+ * inverted rather than deleted.
+ */
+public class QueryUncaughtExceptionHandlerTest {
+
+    private static final long TIMEOUT_MILLIS = 10_000L;
+
+    /**
+     * A writer that reads the null guard before any throwable is recorded goes on to overwrite whatever was recorded in the meantime, so the first throwable is
+     * lost.
+     * <p>
+     * The race is made deterministic by holding the handler's own monitor: the writer thread clears the unsynchronized guard, then parks on the monitor this
+     * thread already owns, which lets this thread record the first throwable before the writer is released.
+     */
+    @Test
+    public void testFirstThrowableIsClobberedByAWriterThatAlreadyClearedTheGuard() throws Exception {
+        QueryUncaughtExceptionHandler handler = new QueryUncaughtExceptionHandler();
+
+        Throwable first = new RuntimeException("first failure");
+        Throwable second = new RuntimeException("second failure");
+
+        Thread writer = new Thread(() -> handler.uncaughtException(Thread.currentThread(), second), "clobbering-writer");
+
+        synchronized (handler) {
+            writer.start();
+
+            // the writer has read a null throwable and is now parked on the monitor held here
+            awaitBlocked(writer);
+
+            // reentrant on the monitor, so this write completes while the writer is still parked
+            handler.uncaughtException(Thread.currentThread(), first);
+            assertSame(first, handler.getThrowable());
+        }
+
+        writer.join(TIMEOUT_MILLIS);
+        assertFalse(writer.isAlive(), "writer thread did not finish");
+
+        // the guard was cleared before the lock was taken, so the first throwable is overwritten
+        assertSame(second, handler.getThrowable());
+        assertSame(writer, handler.getThread());
+    }
+
+    /**
+     * The failure state is written under a lock but read without one, from fields that are not volatile. Nothing establishes a happens-before edge between the
+     * thread that records a failure and the thread that polls for it.
+     */
+    @Test
+    public void testFailureStateIsPublishedWithoutVisibilityGuarantees() throws Exception {
+        Field throwable = QueryUncaughtExceptionHandler.class.getDeclaredField("throwable");
+        Field thread = QueryUncaughtExceptionHandler.class.getDeclaredField("thread");
+
+        assertFalse(Modifier.isVolatile(throwable.getModifiers()), "throwable is volatile, the visibility hole is closed");
+        assertFalse(Modifier.isVolatile(thread.getModifiers()), "thread is volatile, the visibility hole is closed");
+
+        Method getThrowable = QueryUncaughtExceptionHandler.class.getDeclaredMethod("getThrowable");
+        Method getThread = QueryUncaughtExceptionHandler.class.getDeclaredMethod("getThread");
+
+        assertFalse(Modifier.isSynchronized(getThrowable.getModifiers()), "getThrowable is synchronized, the visibility hole is closed");
+        assertFalse(Modifier.isSynchronized(getThread.getModifiers()), "getThread is synchronized, the visibility hole is closed");
+    }
+
+    /**
+     * The recorded thread and throwable are read through two separate unsynchronized accessors, so a reader can observe one without the other rather than a
+     * single consistent pair.
+     */
+    @Test
+    public void testThreadAndThrowableAreNotReadAsAPair() throws Exception {
+        for (Method method : QueryUncaughtExceptionHandler.class.getDeclaredMethods()) {
+            if (method.getReturnType().equals(Throwable.class) && method.getParameterCount() == 0) {
+                assertFalse(Modifier.isSynchronized(method.getModifiers()), method.getName() + " is synchronized");
+            }
+        }
+
+        QueryUncaughtExceptionHandler handler = new QueryUncaughtExceptionHandler();
+        Throwable failure = new RuntimeException("failure");
+        Thread recorded = new Thread(() -> handler.uncaughtException(Thread.currentThread(), failure), "recording-thread");
+        recorded.start();
+        recorded.join(TIMEOUT_MILLIS);
+
+        // no accessor returns both halves together, they can only be read one at a time
+        assertSame(failure, handler.getThrowable());
+        assertSame(recorded, handler.getThread());
+    }
+
+    /**
+     * Wait for a thread to park on a monitor.
+     *
+     * @param thread
+     *            the thread to wait on
+     * @throws InterruptedException
+     *             if this thread is interrupted while waiting
+     */
+    private void awaitBlocked(Thread thread) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TIMEOUT_MILLIS;
+        while (thread.getState() != Thread.State.BLOCKED) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("timed out waiting for " + thread.getName() + " to block, state was " + thread.getState());
+            }
+            Thread.sleep(1);
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/BatchScannerSessionThreadingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/BatchScannerSessionThreadingTest.java
@@ -1,0 +1,155 @@
+package datawave.query.tables;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.iterators.user.VersioningIterator;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.query.configuration.QueryData;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.tables.async.ScannerChunk;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
+/**
+ * Pins thread-safety defects in {@link BatchScannerSession}'s bookkeeping and executor management.
+ * <p>
+ * {@link BatchScannerSession#canRun(ScannerChunk)} dereferences a {@code serverMap} entry without a null check, and
+ * {@link BatchScannerSession#updateThreadService(ExecutorService)} null-checks its parameter while shutting down the field, so a null argument silently leaks
+ * the running executor.
+ * <p>
+ * These tests assert the broken behavior on purpose so that a fix is forced to update them.
+ */
+public class BatchScannerSessionThreadingTest {
+
+    private static final InMemoryInstance instance = new InMemoryInstance(BatchScannerSessionThreadingTest.class.getName());
+
+    private static final String tableName = "shard";
+
+    private static AccumuloClient client;
+
+    private final Set<Authorizations> authorizations = Set.of(new Authorizations("VIZ-A", "VIZ-B", "VIZ-C"));
+    private final Query query = new QueryImpl();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        client = new InMemoryAccumuloClient("user", instance);
+
+        TableOperations tops = client.tableOperations();
+
+        // create or recreate the table
+        if (tops.exists(tableName)) {
+            tops.delete(tableName);
+        }
+        tops.create(tableName);
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        this.query.setUncaughtExceptionHandler(new QueryUncaughtExceptionHandler());
+    }
+
+    /**
+     * With no work left to hand out, the backoff check reads a server that was never registered in {@code serverMap} and dereferences the resulting null.
+     */
+    @Test
+    public void testCanRunThrowsForAnUnregisteredLocation() {
+        BatchScannerSession session = create().build();
+
+        assertThrows(NullPointerException.class, () -> session.canRun(chunk()));
+
+        session.close();
+    }
+
+    /**
+     * Passing a null executor null-checks the argument rather than the field, so the running executor is neither shut down nor replaced with anything usable,
+     * and the session is left in a state where it cannot be closed.
+     */
+    @Test
+    public void testUpdateThreadServiceWithNullLeaksTheRunningExecutor() {
+        BatchScannerSession session = create().build();
+
+        ExecutorService existing = session.service;
+        assertFalse(existing.isShutdown());
+
+        session.updateThreadService(null);
+
+        // the executor is left running with no reference held by the session
+        assertFalse(existing.isShutdown(), "the previous executor was shut down");
+        assertNull(session.service, "the session still holds an executor");
+
+        // and the session can no longer be closed, because its close path dereferences the executor it just dropped
+        assertThrows(NullPointerException.class, session::close);
+
+        existing.shutdownNow();
+    }
+
+    /**
+     * Control for {@link #testUpdateThreadServiceWithNullLeaksTheRunningExecutor()}: a non-null executor does replace and shut down the previous one.
+     */
+    @Test
+    public void testUpdateThreadServiceWithAnExecutorShutsDownThePreviousOne() {
+        BatchScannerSession session = create().build();
+
+        ExecutorService existing = session.service;
+        ExecutorService replacement = Executors.newSingleThreadExecutor();
+
+        session.updateThreadService(replacement);
+
+        assertTrue(existing.isShutdown());
+        assertSame(replacement, session.service);
+
+        session.close();
+    }
+
+    /**
+     * Create a builder with the minimum required options.
+     *
+     * @return the builder
+     */
+    private BatchScannerSessionBuilder create() {
+        //  @formatter:off
+        return BatchScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+    }
+
+    /**
+     * Create a scanner chunk whose location was never registered with the session.
+     *
+     * @return the chunk
+     */
+    private ScannerChunk chunk() {
+        Key start = new Key("row");
+        Key stop = start.followingKey(PartialKey.ROW);
+        Range range = new Range(start, true, stop, false);
+
+        IteratorSetting settings = new IteratorSetting(1, "VersioningIterator", VersioningIterator.class);
+        QueryData queryData = new QueryData(tableName, "FOO == 'bar'", List.of(range), Collections.emptySet(), List.of(settings));
+
+        return new ScannerChunk(new SessionOptions(), List.of(range), queryData);
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionUncaughtExceptionHandlerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionUncaughtExceptionHandlerTest.java
@@ -1,0 +1,224 @@
+package datawave.query.tables;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.util.concurrent.Service.State;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.microservice.query.Query;
+import datawave.microservice.query.QueryImpl;
+import datawave.webservice.query.util.QueryUncaughtExceptionHandler;
+
+/**
+ * Pins how {@link ScannerSession} propagates failures through the {@link QueryUncaughtExceptionHandler} it takes from the {@link Query}.
+ * <p>
+ * Two defects are covered. First, the handler is owned by the {@link Query}, so every session built for one query shares a single write-once object that is
+ * never cleared: one session's failure permanently poisons its siblings. Second, a failing session records its failure in two independent places, the handler
+ * and the Guava {@link com.google.common.util.concurrent.Service} failure state, and {@link ScannerSession#hasNext()} can surface either one depending on which
+ * the consumer thread observes first. That is why {@code ScannerSessionBuilderTest#testTableNotFound}, which asserts an exact exception message, is sensitive
+ * to Guava's internal state-transition timing.
+ * <p>
+ * These tests assert the broken behavior on purpose so that a fix is forced to update them.
+ */
+public class ScannerSessionUncaughtExceptionHandlerTest {
+
+    private static final InMemoryInstance instance = new InMemoryInstance(ScannerSessionUncaughtExceptionHandlerTest.class.getName());
+
+    private static final String tableName = "shard";
+    private static final Long ts = System.currentTimeMillis();
+    private static final Key key = new Key("row", "cf", "cq", "VIZ-A", ts);
+    private static final Value EMPTY_VALUE = new Value();
+    private static final long TIMEOUT_MILLIS = 30_000L;
+
+    private static AccumuloClient client;
+    private static Range range;
+
+    private final Set<Authorizations> authorizations = Set.of(new Authorizations("VIZ-A", "VIZ-B", "VIZ-C"));
+    private final Query query = new QueryImpl();
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        client = new InMemoryAccumuloClient("user", instance);
+
+        TableOperations tops = client.tableOperations();
+
+        // create or recreate the table
+        if (tops.exists(tableName)) {
+            tops.delete(tableName);
+        }
+        tops.create(tableName);
+
+        try (BatchWriter bw = client.createBatchWriter(tableName)) {
+            Mutation m = new Mutation(key.getRow());
+            m.put(key.getColumnFamily(), key.getColumnQualifier(), key.getColumnVisibilityParsed(), key.getTimestamp(), EMPTY_VALUE);
+            bw.addMutation(m);
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        this.query.setUncaughtExceptionHandler(new QueryUncaughtExceptionHandler());
+
+        Key start = new Key(key.getRow());
+        Key stop = start.followingKey(PartialKey.ROW);
+        range = new Range(start, true, stop, false);
+    }
+
+    /**
+     * Every session built from the same {@link Query} shares that query's handler instance rather than owning one.
+     */
+    @Test
+    public void testSessionsBuiltFromTheSameQueryShareOneHandler() {
+        ScannerSession first = create().build();
+        ScannerSession second = create().build();
+
+        assertSame(query.getUncaughtExceptionHandler(), first.uncaughtExceptionHandler);
+        assertSame(first.uncaughtExceptionHandler, second.uncaughtExceptionHandler);
+
+        first.close();
+        second.close();
+    }
+
+    /**
+     * Control for {@link #testUnrelatedFailurePoisonsAHealthySession()}: with a clean handler the session reads its data without incident.
+     */
+    @Test
+    public void testHealthySessionReturnsResults() {
+        ScannerSession session = create().build();
+        session.setRanges(List.of(range));
+
+        assertTrue(session.hasNext());
+        assertNotNull(session.next());
+
+        session.close();
+    }
+
+    /**
+     * A failure recorded by any other holder of the query's handler is rethrown by a session that never failed, because {@link ScannerSession#hasNext()} checks
+     * the shared handler unconditionally and the handler is never cleared.
+     */
+    @Test
+    public void testUnrelatedFailurePoisonsAHealthySession() {
+        ScannerSession session = create().build();
+        session.setRanges(List.of(range));
+
+        // stands in for a sibling session, or any other component, failing against the same Query
+        RuntimeException unrelated = new RuntimeException("failure from an unrelated scanner session");
+        query.getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), unrelated);
+
+        RuntimeException e = assertThrows(RuntimeException.class, session::hasNext);
+        assertSame(unrelated, e.getCause());
+
+        session.close();
+    }
+
+    /**
+     * {@link AnyFieldScanner} opts out of the shared handler, which is the counter-example the shared-handler design forces on any session whose failures
+     * should not fail the whole query. This test documents the intended behavior and should keep passing after a fix.
+     */
+    @Test
+    public void testAnyFieldScannerDoesNotShareTheQueryHandler() {
+        ScannerSession session = create().build();
+        AnyFieldScanner anyField = new AnyFieldScanner(session);
+
+        assertNotSame(query.getUncaughtExceptionHandler(), anyField.uncaughtExceptionHandler);
+
+        session.close();
+        anyField.close();
+    }
+
+    /**
+     * A single failure is recorded in two independent channels: the shared handler and the Guava service's own failure state. Whichever the consumer thread
+     * observes first decides the type and message of the exception {@link ScannerSession#hasNext()} throws, which is what makes an exact-message assertion on
+     * this path dependent on Guava's timing.
+     */
+    @Test
+    public void testFailureIsRecordedInTwoCompetingChannels() {
+        //  @formatter:off
+        ScannerSession session = ScannerSessionBuilder.create(client)
+                .setTableName("NotFound")
+                .setAuthorizations(authorizations)
+                .setQuery(query)
+                .build();
+        //  @formatter:on
+        session.setRanges(List.of(range));
+
+        // both surfacing paths throw a RuntimeException, so this assertion is stable regardless of which one wins
+        assertThrows(RuntimeException.class, session::hasNext);
+
+        awaitFailed(session);
+
+        Throwable handlerFailure = query.getUncaughtExceptionHandler().getThrowable();
+        Throwable serviceFailure = session.failureCause();
+
+        assertNotNull(handlerFailure, "the handler channel did not record the failure");
+        assertNotNull(serviceFailure, "the service channel did not record the failure");
+
+        // the message asserted by ScannerSessionBuilderTest#testTableNotFound is produced only by the handler channel
+        String expected = "org.apache.accumulo.core.client.TableNotFoundException: Table NotFound (Id=NotFound) does not exist (no such table)";
+        assertEquals(expected, new RuntimeException(handlerFailure).getMessage());
+
+        // the service channel would surface the same failure as an IllegalStateException with an entirely different message
+        assertNotSame(handlerFailure, serviceFailure);
+
+        session.close();
+    }
+
+    /**
+     * Create a builder with the minimum required options.
+     *
+     * @return the builder
+     */
+    private ScannerSessionBuilder create() {
+        //  @formatter:off
+        return ScannerSessionBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query);
+        //  @formatter:on
+    }
+
+    /**
+     * Wait for a session's service to reach the failed state.
+     *
+     * @param session
+     *            the session to wait on
+     */
+    private void awaitFailed(ScannerSession session) {
+        long deadline = System.currentTimeMillis() + TIMEOUT_MILLIS;
+        while (session.state() != State.FAILED) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("timed out waiting for the session to fail, state was " + session.state());
+            }
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("interrupted while waiting for the session to fail");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Covers the unsynchronized read and broken double-checked lock in QueryUncaughtExceptionHandler, the handler that ScannerSession shares across every session built from one Query, and the null-executor handling in BatchScannerSession. The assertions capture current behavior so the fix has to update them.