### PR TITLE
Open HDFS file with FileStatus when readily available

### DIFF
--- a/microservices/services/query/service/src/main/java/datawave/microservice/query/mapreduce/MapReduceQueryManagementService.java
+++ b/microservices/services/query/service/src/main/java/datawave/microservice/query/mapreduce/MapReduceQueryManagementService.java
@@ -66,6 +66,7 @@ import datawave.microservice.query.mapreduce.status.MapReduceQueryCache;
 import datawave.microservice.query.mapreduce.status.MapReduceQueryStatus;
 import datawave.microservice.query.storage.QueryStatus;
 import datawave.security.util.ProxiedEntityUtils;
+import datawave.util.hdfs.HdfsFileUtils;
 import datawave.webservice.common.audit.AuditParameters;
 import datawave.webservice.query.exception.BadRequestQueryException;
 import datawave.webservice.query.exception.DatawaveErrorCode;
@@ -610,7 +611,7 @@ public class MapReduceQueryManagementService implements MapReduceQueryRequestHan
             // update the file status to reflect a relative file path
             fileStatus.setPath(getRelativeFilePath(filesystem.getFileStatus(resultsPath), fileStatus));
 
-            return new AbstractMap.SimpleEntry<>(fileStatus, getFileInputStream(resultFile));
+            return new AbstractMap.SimpleEntry<>(fileStatus, getFileInputStream(filesystem, resultFile, fileStatus));
         } catch (QueryException e) {
             throw e;
         } catch (Exception e) {
@@ -619,16 +620,12 @@ public class MapReduceQueryManagementService implements MapReduceQueryRequestHan
         }
     }
 
-    private FSDataInputStream getFileInputStream(FileSystem filesystem, Path filePath) throws QueryException {
+    private FSDataInputStream getFileInputStream(FileSystem filesystem, Path filePath, FileStatus status) throws QueryException {
         try {
-            return filesystem.open(filePath);
+            return HdfsFileUtils.openFile(filesystem, filePath, status);
         } catch (IOException e) {
             throw new NotFoundQueryException("Unable to open result file", e, HttpStatus.SC_INTERNAL_SERVER_ERROR + "-1");
         }
-    }
-
-    private FSDataInputStream getFileInputStream(Path filePath) throws QueryException, IOException {
-        return getFileInputStream(FileSystem.get(configuration), filePath);
     }
 
     public Map<FileStatus,FSDataInputStream> getAllFiles(String id, DatawaveUserDetails currentUser) throws QueryException {
@@ -646,7 +643,7 @@ public class MapReduceQueryManagementService implements MapReduceQueryRequestHan
             if (mapReduceQueryStatus.getResultsDirectory() != null && !mapReduceQueryStatus.getResultsDirectory().isEmpty()) {
                 for (LocatedFileStatus fileStatus : listFiles(mapReduceQueryStatus.getResultsDirectory())) {
                     if (fileStatus.isFile()) {
-                        FSDataInputStream inputStream = getFileInputStream(fs, fileStatus.getPath());
+                        FSDataInputStream inputStream = getFileInputStream(fs, fileStatus.getPath(), fileStatus);
 
                         // update the file status to reflect a relative file path
                         fileStatus.setPath(getRelativeFilePath(basePathStatus, fileStatus));

--- a/microservices/services/query/service/src/main/java/datawave/microservice/query/mapreduce/MapReduceQueryManagementService.java
+++ b/microservices/services/query/service/src/main/java/datawave/microservice/query/mapreduce/MapReduceQueryManagementService.java
@@ -608,10 +608,12 @@ public class MapReduceQueryManagementService implements MapReduceQueryRequestHan
                 throw new BadRequestQueryException("Requested path is not a file: " + fileName, HttpStatus.SC_BAD_REQUEST + "-1");
             }
 
+            FSDataInputStream is = getFileInputStream(filesystem, resultFile, fileStatus);
+
             // update the file status to reflect a relative file path
             fileStatus.setPath(getRelativeFilePath(filesystem.getFileStatus(resultsPath), fileStatus));
 
-            return new AbstractMap.SimpleEntry<>(fileStatus, getFileInputStream(filesystem, resultFile, fileStatus));
+            return new AbstractMap.SimpleEntry<>(fileStatus, is);
         } catch (QueryException e) {
             throw e;
         } catch (Exception e) {

--- a/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileSystemWatcher.java
+++ b/warehouse/core/src/main/java/datawave/ingest/util/cache/watch/FileSystemWatcher.java
@@ -6,10 +6,13 @@ import java.security.NoSuchAlgorithmException;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import datawave.util.hdfs.HdfsFileUtils;
 
 /**
  * File System Watch
@@ -104,10 +107,11 @@ public abstract class FileSystemWatcher<V> extends Reloadable<V> {
 
         try {
 
-            lastChange = fs.getFileStatus(filePath).getModificationTime();
+            FileStatus status = fs.getFileStatus(filePath);
+            lastChange = status.getModificationTime();
             log.debug("Reload called {}", lastChange);
 
-            FSDataInputStream in = fs.open(filePath);
+            FSDataInputStream in = HdfsFileUtils.openFile(fs, filePath, status);
             V result = loadContents(in);
             in.close();
             return result;

--- a/warehouse/core/src/main/java/datawave/util/accumulo/RFileUtil.java
+++ b/warehouse/core/src/main/java/datawave/util/accumulo/RFileUtil.java
@@ -24,8 +24,11 @@ import org.apache.accumulo.core.iteratorsImpl.system.MultiIterator;
 import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import datawave.util.hdfs.HdfsFileUtils;
 
 /**
  * Collection of utilities to locate, read, and split rfiles
@@ -71,7 +74,8 @@ public class RFileUtil {
                 if (!fs.exists(p)) {
                     throw new IOException("file not found " + p);
                 }
-                sources[i] = new RFileSource(fs.open(p), fs.getFileStatus(p).getLen());
+                FileStatus status = fs.getFileStatus(p);
+                sources[i] = new RFileSource(HdfsFileUtils.openFile(fs, p, status), status.getLen());
             }
         } catch (IOException e) {
             throw new RuntimeException("could not open source rfiles: " + paths, e);

--- a/warehouse/core/src/main/java/datawave/util/hdfs/HdfsFileUtils.java
+++ b/warehouse/core/src/main/java/datawave/util/hdfs/HdfsFileUtils.java
@@ -37,14 +37,6 @@ public class HdfsFileUtils {
     Objects.requireNonNull(status);
     
     final CompletableFuture<FSDataInputStream> future = fs.openFile(path).withFileStatus(status).build();
-    while (!future.isDone()) {
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new IOException("Interrupted while opening file: " + path, e);
-      }
-    }
     try {
       return future.get();
     } catch (InterruptedException e) {

--- a/warehouse/core/src/main/java/datawave/util/hdfs/HdfsFileUtils.java
+++ b/warehouse/core/src/main/java/datawave/util/hdfs/HdfsFileUtils.java
@@ -1,0 +1,63 @@
+package datawave.util.hdfs;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+public class HdfsFileUtils {
+  
+  /**
+   * Utility for opening a HDFS file when the
+   * FileStatus object for the associated file
+   * has already been retrieved from the NameNode.
+   * 
+   * HDFS-17593 added an optimization to FileSystem.openFile
+   * that will use the block locations in the FileStatus
+   * object in the client to reduce RPC calls to the
+   * NameNode.
+   * 
+   * @param fs Hadoop FileSystem object
+   * @param path Path to file
+   * @param status FileStatus object for the file
+   * @return stream for reading file
+   * @throws IOException
+   */
+  public static FSDataInputStream openFile(FileSystem fs, Path path, FileStatus status)
+      throws IOException {
+
+    Objects.requireNonNull(fs);
+    Objects.requireNonNull(path);
+    Objects.requireNonNull(status);
+    
+    final CompletableFuture<FSDataInputStream> future = fs.openFile(path).withFileStatus(status).build();
+    while (!future.isDone()) {
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while opening file: " + path, e);
+      }
+    }
+    try {
+      return future.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while opening file: " + path, e);
+    } catch (CancellationException e) {
+      throw new IOException("Cancelled while opening file: " + path, e);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      }
+      throw new IOException("Error trying to open file: " + path, e);
+    }
+  }
+
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/NumShards.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/NumShards.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import datawave.ingest.data.config.ConfigurationHelper;
 import datawave.ingest.data.config.ingest.AccumuloHelper;
+import datawave.util.hdfs.HdfsFileUtils;
 import datawave.util.time.DateHelper;
 
 public class NumShards {
@@ -168,29 +169,28 @@ public class NumShards {
      * @return a formatted string of the date based shards
      */
     public String readMultipleNumShardsConfig() {
-        if (isCacheValid()) {
+        try {
+          FileSystem fs = this.numShardsCachePath.getFileSystem(this.conf);
+          FileStatus fileStatus = fs.getFileStatus(this.numShardsCachePath);
+          if (isCacheValid(fileStatus)) {
             if (log.isInfoEnabled()) {
-                log.info("Loading the numshards cache (@ {})...", this.numShardsCachePath.toUri().toString());
+              log.info("Loading the numshards cache (@ {})...", this.numShardsCachePath.toUri().toString());
             }
             try (BufferedReader in = new BufferedReader(
-                            new InputStreamReader(this.numShardsCachePath.getFileSystem(this.conf).open(this.numShardsCachePath)))) {
-                return in.lines().collect(Collectors.joining(","));
+                new InputStreamReader(HdfsFileUtils.openFile(fs, this.numShardsCachePath, fileStatus)))) {
+              return in.lines().collect(Collectors.joining(","));
             } catch (IOException ioe) {
-                throw new RuntimeException("Could not read numshards cache file. See documentation for using generateMultipleNumShardsCache.sh");
+              throw new RuntimeException("Could not read numshards cache file. See documentation for using generateMultipleNumShardsCache.sh");
             }
-        } else {
+          } else {
             throw new RuntimeException("Multiple Numshards cache is invalid. See documentation for using generateMultipleNumShardsCache.sh");
+          }
+        } catch (IOException ioe) {
+          throw new RuntimeException("Could not get the FileStatus of the multiple numShards file");
         }
     }
 
-    public boolean isCacheValid() {
-        FileStatus fileStatus = null;
-        try {
-            fileStatus = this.numShardsCachePath.getFileSystem(this.conf).getFileStatus(this.numShardsCachePath);
-        } catch (IOException ioe) {
-            log.warn("Could not get the FileStatus of the multiple numShards file");
-        }
-
+    public boolean isCacheValid(FileStatus fileStatus) {
         return null != fileStatus && fileStatus.getModificationTime() >= System.currentTimeMillis()
                         - (conf.getLong(MULTIPLE_NUMSHARDS_CACHE_TIMEOUT, DEFAULT_CACHE_TIMEOUT));
     }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/NumShards.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/NumShards.java
@@ -2,6 +2,7 @@ package datawave.ingest.mapreduce.handler.shard;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
@@ -171,7 +172,12 @@ public class NumShards {
     public String readMultipleNumShardsConfig() {
         try {
           FileSystem fs = this.numShardsCachePath.getFileSystem(this.conf);
-          FileStatus fileStatus = fs.getFileStatus(this.numShardsCachePath);
+          FileStatus fileStatus = null;
+          try {
+            fileStatus = fs.getFileStatus(this.numShardsCachePath);
+          } catch (FileNotFoundException fnfe) {
+            throw new RuntimeException("Multiple Numshards cache is invalid. See documentation for using generateMultipleNumShardsCache.sh", fnfe);
+          }          
           if (isCacheValid(fileStatus)) {
             if (log.isInfoEnabled()) {
               log.info("Loading the numshards cache (@ {})...", this.numShardsCachePath.toUri().toString());

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/MultiRFileOutputFormatter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/MultiRFileOutputFormatter.java
@@ -696,9 +696,9 @@ public class MultiRFileOutputFormatter extends FileOutputFormat<BulkIngestKey,Va
                     try {
                         CryptoService cs = CryptoFactoryLoader.getServiceForClient(CryptoEnvironment.Scope.TABLE,
                                         context.getConfiguration().getPropsWithPrefix(TABLE_CRYPTO_PREFIX.name()));
-                        FileSKVIterator openReader = fops.newReaderBuilder().forFile(path.toString(), fs, conf, cs)
-                                        .withTableConfiguration(tableConfigs.get(table)).build();
                         FileStatus fileStatus = fs.getFileStatus(path);
+                        FileSKVIterator openReader = fops.newReaderBuilder().forFile(path.toString(), fs, conf, cs, fileStatus)
+                                        .withTableConfiguration(tableConfigs.get(table)).build();
                         long fileSize = fileStatus.getLen();
                         openReader.close();
                         log.info("Successfully wrote " + path + ". Total size: " + fileSize + " B. Total time: " + (System.currentTimeMillis() - startWriteTime)

--- a/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagEntryMover.java
+++ b/warehouse/ingest-core/src/main/java/datawave/util/flag/FlagEntryMover.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
@@ -13,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.cache.Cache;
 
 import datawave.util.flag.InputFile.TrackedDir;
+import datawave.util.hdfs.HdfsFileUtils;
 
 /**
  * Handles stage 1 of the job creation flow. Checks for destination directories, creates as needed, and returns information on whether it was successful.
@@ -67,11 +69,13 @@ public class FlagEntryMover extends SimpleMover {
     private boolean resolveConflict(final Path src, final Path dest) throws IOException {
         // check to see if checksum matches
         boolean resolved = false;
-        long srcLen = this.fs.getFileStatus(src).getLen();
-        long destLen = this.fs.getFileStatus(dest).getLen();
+        FileStatus srcStatus = this.fs.getFileStatus(src);
+        FileStatus dstStatus = this.fs.getFileStatus(dest);
+        long srcLen = srcStatus.getLen();
+        long destLen = dstStatus.getLen();
         if (srcLen == destLen) {
-            String sumSrc = calculateChecksum(src);
-            String sumDest = calculateChecksum(dest);
+            String sumSrc = calculateChecksum(src, srcStatus);
+            String sumDest = calculateChecksum(dest, dstStatus);
             if (!sumSrc.equals(sumDest)) {
                 resolved = true;
             }
@@ -106,8 +110,8 @@ public class FlagEntryMover extends SimpleMover {
      * @throws IOException
      *             for issues with read/write
      */
-    private String calculateChecksum(final Path file) throws IOException {
-        try (final InputStream is = this.fs.open(file)) {
+    private String calculateChecksum(final Path file, final FileStatus status) throws IOException {
+        try (final InputStream is = HdfsFileUtils.openFile(fs, file, status)) {
             byte[] buf = new byte[8096];
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             int len = 0;

--- a/warehouse/query-core/src/main/java/datawave/mr/bulk/RecordIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/mr/bulk/RecordIterator.java
@@ -520,14 +520,11 @@ public class RecordIterator extends RangeSplit implements SortedKeyValueIterator
 
                 // Path path = new Path(file);
 
-                closeable.setInputStream(fs.open(path));
-
                 FileStatus status = fs.getFileStatus(path);
                 long length = status.getLen();
 
                 //@formatter:off
                 CachableBlockFile.CachableBuilder builder = new CachableBlockFile.CachableBuilder()
-                        .input(closeable.getInputStream(), CachableBlockFile.pathToCacheId(path))
                         .cryptoService(CRYPTO_SERVICE)
                         .fsPath(fs, path, status)
                         .length(length)

--- a/warehouse/query-core/src/main/java/datawave/mr/bulk/RecordIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/mr/bulk/RecordIterator.java
@@ -56,6 +56,7 @@ import org.apache.accumulo.core.spi.crypto.CryptoEnvironment;
 import org.apache.accumulo.core.spi.crypto.CryptoService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -521,13 +522,14 @@ public class RecordIterator extends RangeSplit implements SortedKeyValueIterator
 
                 closeable.setInputStream(fs.open(path));
 
-                long length = fs.getFileStatus(path).getLen();
+                FileStatus status = fs.getFileStatus(path);
+                long length = status.getLen();
 
                 //@formatter:off
                 CachableBlockFile.CachableBuilder builder = new CachableBlockFile.CachableBuilder()
                         .input(closeable.getInputStream(), CachableBlockFile.pathToCacheId(path))
                         .cryptoService(CRYPTO_SERVICE)
-                        .fsPath(fs, path)
+                        .fsPath(fs, path, status)
                         .length(length)
                         .conf(conf);
                 //@formatter:on


### PR DESCRIPTION
This commit takes advantage of the changes in HDFS-17593 and Accumulo PR #6460 to reduce calls to the NameNode when opening a file if the FileStatus is already available.

These changes won't compile until Accumulo 2.1.7 is released and this project is updated to use it. Likewise, to realize the performance optimization in Hadoop, a version of Hadoop that includes HDFS-17593 will need to be used (at least 3.5.1).