### PR TITLE
Add ability to disable query limiter

### DIFF
--- a/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLimiterFactory.xml
+++ b/web-services/deploy/configuration/src/main/resources/datawave/query/QueryLimiterFactory.xml
@@ -94,6 +94,7 @@
 
     <!-- Sample configuration for the query limit configuration.
 
+        - enabled: Whether to enable the query limit feature. Defaults to false.
         - defaultSystemQueryLimit: The default number of active concurrent queries that may be running on a system. A
             value less than zero will indicate that by default, there is no max limit for queries on systems. When
             there is no limit for the system, the total queries for the system will not be aggregated when checking
@@ -108,6 +109,7 @@
     -->
     <!--
     <bean id="queryLimitConfiguration" class="datawave.webservice.query.limit.QueryLimitConfiguration">
+        <property name="enabled" value="true"/>
         <property name="defaultSystemQueryLimit" value="5000"/>
         <property name="defaultUserQueryLimit" value="100"/>
         <property name="internalCacheMaxSize" value="200"/>
@@ -132,6 +134,7 @@
 
     <!-- Configuration for the QueryLimitConfiguration. -->
     <bean id="queryLimitConfiguration" class="datawave.webservice.query.limit.QueryLimitConfiguration">
+        <property name="enabled" value="true"/>
         <property name="defaultSystemQueryLimit" value="5000"/>
         <property name="defaultUserQueryLimit" value="100"/>
     </bean>

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimitConfiguration.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimitConfiguration.java
@@ -10,6 +10,11 @@ import java.util.StringJoiner;
 public class QueryLimitConfiguration {
 
     /**
+     * Enable/disable checking query limits
+     */
+    private boolean enabled = false;
+
+    /**
      * The default maximum number of active concurrent queries a user may have across all systems.
      */
     private int defaultUserQueryLimit;
@@ -110,5 +115,13 @@ public class QueryLimitConfiguration {
                         .add("defaultSystemQueryLimit=" + defaultSystemQueryLimit).add("internalCacheMaxSize=" + internalCacheMaxSize)
                         .add("userConfigs=" + userConfigs).add("systemConfigs=" + systemConfigs).add("queryLogicGroupConfigs=" + queryLogicGroupConfigs)
                         .toString();
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
     }
 }

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimiter.java
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/QueryLimiter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.log4j.Logger;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
@@ -37,6 +38,8 @@ public class QueryLimiter {
 
     // The tracker responsible for interfacing with Zookeeper.
     private ActiveQueryTracker activeQueryTracker;
+
+    private final AtomicBoolean activated = new AtomicBoolean(false);
 
     public static final String EMPTY_SYSTEM_FROM = "EMPTY_SYSTEM_FROM";
 
@@ -83,6 +86,15 @@ public class QueryLimiter {
     }
 
     /**
+     * Return whether this {@link QueryLimiter} is currently enforcing limits.
+     *
+     * @return true if this {@link QueryLimiter} is enforcing limits, or false otherwise
+     */
+    public boolean isEnforcingLimits() {
+        return activated.get();
+    }
+
+    /**
      * Validate the configuration and extract the query limits to enforce. In practice this should be marked as the init method for the {@link QueryLimiter}
      * instance configured in bean XMLs. For testing purposes, this method should be called after setting the zookeeper config and query limit configs.
      */
@@ -91,7 +103,7 @@ public class QueryLimiter {
             log.debug("Initializing with zookeeperConfig: '" + zookeeperConfig + "' and query limit config: " + configuration);
         }
 
-        if (this.configuration != null) {
+        if (this.configuration != null && this.configuration.isEnabled()) {
             if (this.configuration.getDefaultUserQueryLimit() < 1) {
                 throw new IllegalArgumentException("Default user query limit must be greater than 0");
             }
@@ -106,6 +118,8 @@ public class QueryLimiter {
                             configuration.getUserConfigs(), queryLogicGroupLimitProvider);
             this.systemLimitProvider = new SystemLimitProvider(configuration.getDefaultSystemQueryLimit(), configuration.getInternalCacheMaxSize(),
                             configuration.getSystemConfigs(), queryLogicGroupLimitProvider);
+            this.activated.set(true);
+
         } else {
             this.queryLogicGroupLimitProvider = null;
             this.userLimitProvider = null;
@@ -147,26 +161,31 @@ public class QueryLimiter {
      *             if an exception occurs
      */
     public QueryLimiterResponse checkForLimits(String userDn, String system, String queryLogic) throws Exception {
-        // Cast the user DN to lowercase to ensure a consistent format.
-        userDn = userDn.trim().toLowerCase();
+        if (isEnforcingLimits()) {
+            // Cast the user DN to lowercase to ensure a consistent format.
+            userDn = userDn.trim().toLowerCase();
 
-        // Do not cast the system or query logic to lowercase, they will be getting matched against regex patterns.
-        queryLogic = queryLogic.trim();
+            // Do not cast the system or query logic to lowercase, they will be getting matched against regex patterns.
+            queryLogic = queryLogic.trim();
 
-        // Ensure the system is non-null if empty
-        if (system == null || system.isBlank()) {
-            system = EMPTY_SYSTEM_FROM;
-        }
+            // Ensure the system is non-null if empty
+            if (system == null || system.isBlank()) {
+                system = EMPTY_SYSTEM_FROM;
+            }
 
-        if (log.isDebugEnabled()) {
-            log.debug("Checking limits - userDn: " + userDn + ", system: " + system + ", queryLogic: " + queryLogic);
-        }
+            if (log.isDebugEnabled()) {
+                log.debug("Checking limits - userDn: " + userDn + ", system: " + system + ", queryLogic: " + queryLogic);
+            }
 
-        // Check if the snapshot reveals that any limits have been met.
-        LimitChecker checker = new LimitChecker(userDn, system, queryLogic);
-        checker.checkLimits();
-        if (checker.metLimit) {
-            return QueryLimiterResponse.metLimit(checker.message);
+            // Check if the snapshot reveals that any limits have been met.
+            LimitChecker checker = new LimitChecker(userDn, system, queryLogic);
+            checker.checkLimits();
+            if (checker.metLimit) {
+                return QueryLimiterResponse.metLimit(checker.message);
+            } else {
+                return QueryLimiterResponse.hasNotMetLimit();
+            }
+
         } else {
             return QueryLimiterResponse.hasNotMetLimit();
         }
@@ -187,21 +206,24 @@ public class QueryLimiter {
      *             if an error occurs
      */
     public void countQueryTowardsLimits(String queryId, String userDn, String system, String queryLogic) throws Exception {
-        if (log.isDebugEnabled()) {
-            log.debug("Start counting query " + queryId + " towards limits");
+        if (isEnforcingLimits()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Start counting query " + queryId + " towards limits");
+            }
+
+            userDn = userDn.trim().toLowerCase();
+            // Ensure the system is non-null if empty
+            if (system == null || system.isBlank()) {
+                system = EMPTY_SYSTEM_FROM;
+            }
+
+            boolean systemCountsTowardsUserLimits = systemLimitProvider.countsAgainstUserLimit(system);
+
+            QueryHeartbeat heartbeat = getActiveQueryTracker().trackQuery(queryId, userDn, system, queryLogic, systemCountsTowardsUserLimits);
+            // Store the heartbeat into the cache. This acts as a means to keep the connection to Zookeeper alive for the ephemeral nodes stored in the
+            // heartbeat.
+            heartbeatCache.put(heartbeat);
         }
-
-        userDn = userDn.trim().toLowerCase();
-        // Ensure the system is non-null if empty
-        if (system == null || system.isBlank()) {
-            system = EMPTY_SYSTEM_FROM;
-        }
-
-        boolean systemCountsTowardsUserLimits = systemLimitProvider.countsAgainstUserLimit(system);
-
-        QueryHeartbeat heartbeat = getActiveQueryTracker().trackQuery(queryId, userDn, system, queryLogic, systemCountsTowardsUserLimits);
-        // Store the heartbeat into the cache. This acts as a means to keep the connection to Zookeeper alive for the ephemeral nodes stored in the heartbeat.
-        heartbeatCache.put(heartbeat);
     }
 
     /**

--- a/web-services/query/src/main/java/datawave/webservice/query/limit/README.md
+++ b/web-services/query/src/main/java/datawave/webservice/query/limit/README.md
@@ -16,6 +16,8 @@ Information about active queries is tracked and managed in Zookeeper where the f
 - The system the query was submitted on.
 - The query logic the query originated from.
 
+**NOTE**: The query limiter feature is disabled by default unless the property `enabled` has a value of `true` in the configured QueryLimitConfiguration.
+
 ## Configuration
 
 The QueryLimiter bean is typically defined in the file [QueryLimiterFactory.xml](../../../../../../../../deploy/configuration/src/main/resources/datawave/query/QueryLimiterFactory.xml) within the datawave-ws-deploy-configuration module. At a minimum, the following beans must be configured:
@@ -25,7 +27,7 @@ The QueryLimiter bean is typically defined in the file [QueryLimiterFactory.xml]
 
 Limits may be defined and customized on a per-user and per-system basis. They also may be defined for groups of query logics. On a platform-wide basis, the following may be configured:
 - The default concurrent user query limit. This is the total concurrent queries a user may have running across all systems. May be overridden per user.
-- The default concurrent system query limit. Primarily to avoid a system getting overloaded. If the value is set to a negative limit, no limit will be enforced by default on systemsMay be overridden per system.
+- The default concurrent system query limit. Primarily to avoid a system getting overloaded. If the value is set to a negative limit, no limit will be enforced by default on systems. May be overridden per system.
 
 Custom limits for users, systems, and query logic groups are created by defining instances of the following classes and referencing them within the QueryLimitConfiguration bean:
 - [UserLimitConfiguration](UserLimitConfiguration.java) - supports specifying:

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterConcurrencyTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterConcurrencyTest.java
@@ -116,6 +116,7 @@ class QueryLimiterConcurrencyTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(20);
+        config.setEnabled(true);
         givenLimitConfig(config);
 
         // Create three separate tasks representing different servers. Each 'server' will receive 10 client requests. This means we will attempt to create a
@@ -144,6 +145,7 @@ class QueryLimiterConcurrencyTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(10);
         config.setDefaultUserQueryLimit(15);
+        config.setEnabled(true);
         givenLimitConfig(config);
 
         // Create three separate tasks targeting the same server. Each task will attempt to create 5 client requests for random users and query logics.
@@ -172,6 +174,7 @@ class QueryLimiterConcurrencyTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(15);
+        config.setEnabled(true);
 
         // Set a limit of 10 TLD queries per user across all systems.
         QueryLogicGroupLimitConfiguration groupLimitConfig = new QueryLogicGroupLimitConfiguration();
@@ -220,6 +223,7 @@ class QueryLimiterConcurrencyTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(20);
+        config.setEnabled(true);
 
         // Set a limit of 10 queries for the user testUserA.
         UserLimitConfiguration userLimitConfig = new UserLimitConfiguration();
@@ -289,6 +293,7 @@ class QueryLimiterConcurrencyTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(20);
+        config.setEnabled(true);
 
         SystemLimitConfiguration systemLimitConfig = new SystemLimitConfiguration();
         systemLimitConfig.setSystemPattern("server-01");

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterSpringTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterSpringTest.java
@@ -29,6 +29,8 @@ class QueryLimiterSpringTest {
 
         QueryLimitConfiguration config = limiter.getConfiguration();
         assertThat(config).isNotNull();
+        // verify that the default value of "enabled" is false
+        assertThat(config.isEnabled()).isFalse();
 
         assertThat(config.getDefaultUserQueryLimit()).isEqualTo(100);
         assertThat(config.getDefaultSystemQueryLimit()).isEqualTo(5000);

--- a/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterTest.java
+++ b/web-services/query/src/test/java/datawave/webservice/query/limit/QueryLimiterTest.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +52,124 @@ class QueryLimiterTest {
     }
 
     /**
+     * Verify {@link QueryLimiter#checkForLimits(String, String, String)} returns {@link QueryLimiterResponse#hasNotMetLimit()} when the configuration for the
+     * QueryLimiter is null.
+     */
+    @Test
+    void testCheckForLimitsGivenNullConfig() throws Exception {
+        QueryLimiter limiter = new QueryLimiter();
+        limiter.setZookeeperConfig(server.getConnectString());
+        limiter.setHeartbeatCache(new QueryHeartbeatCache());
+        limiter.setup();
+
+        QueryLimiterResponse response = limiter.checkForLimits(userA, system1, tldQueryLogic);
+        assertThat(response).isEqualTo(QueryLimiterResponse.hasNotMetLimit());
+    }
+
+    /**
+     * Verify {@link QueryLimiter#checkForLimits(String, String, String)} returns {@link QueryLimiterResponse#hasNotMetLimit()} when the configured
+     * QueryLimitConfiguration has a value of 'false' for 'enabled'.
+     */
+    @Test
+    void testCheckForLimitsWhenDisabled() throws Exception {
+        QueryLimitConfiguration config = new QueryLimitConfiguration();
+        config.setDefaultSystemQueryLimit(100);
+        config.setDefaultUserQueryLimit(2);
+
+        QueryLimiter limiter = new QueryLimiter();
+        limiter.setZookeeperConfig(server.getConnectString());
+        limiter.setHeartbeatCache(new QueryHeartbeatCache());
+        limiter.setConfiguration(config);
+        limiter.setup();
+
+        try (ActiveQueryTracker tracker = new ActiveQueryTracker(server.getConnectString())) {
+            tracker.trackQuery(UUID.randomUUID().toString(), userA, system1, tldQueryLogic, true);
+            tracker.trackQuery(UUID.randomUUID().toString(), userA, system1, tldQueryLogic, true);
+
+            QueryLimiterResponse response = limiter.checkForLimits(userA, system1, tldQueryLogic);
+            assertThat(response).isEqualTo(QueryLimiterResponse.hasNotMetLimit());
+        }
+    }
+
+    /**
+     * Verify that queries are not tracked when the configured QueryLimitConfiguration has a value of 'false' for 'enabled'.
+     */
+    @Test
+    void testCountQueryTowardsLimitsWhenDisabled() throws Exception {
+        QueryLimitConfiguration config = new QueryLimitConfiguration();
+        config.setDefaultSystemQueryLimit(100);
+        config.setDefaultUserQueryLimit(5);
+
+        QueryHeartbeatCache heartbeatCache = new QueryHeartbeatCache();
+
+        QueryLimiter limiter = new QueryLimiter();
+        limiter.setZookeeperConfig(server.getConnectString());
+
+        limiter.setConfiguration(config);
+        limiter.setHeartbeatCache(heartbeatCache);
+        limiter.setup();
+        String queryId = UUID.randomUUID().toString();
+
+        assertThat(limiter.isEnforcingLimits()).isFalse();
+
+        if (limiter.getConfiguration() != null && !limiter.isEnforcingLimits()) {
+            limiter.countQueryTowardsLimits(queryId, userA, system1, tldQueryLogic);
+
+            // Verify a heartbeat was not added to the heartbeat cache.
+            assertThat(heartbeatCache.get(queryId)).isNull();
+
+            // @formatter:off
+            try (CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString())
+                    .namespace("ActiveQueries")
+                    .sessionTimeoutMs(60000)
+                    .connectionTimeoutMs(60000)
+                    .retryPolicy(new RetryNTimes(10, 1000))
+                    .build()) {
+                client.start();
+                // Verify that the nodes for tracking the active queries were never created.
+                assertThat(client.checkExists().forPath("/users/" + userA.toLowerCase() + "/" + tldQueryLogic + "/" + queryId)).isNull();
+                assertThat(client.checkExists().forPath("/systems/" + system1 + "/" + tldQueryLogic + "/" + queryId)).isNull();
+            }
+            // @formatter:on
+        }
+    }
+
+    /**
+     * Verify that queries are not tracked when the configuration for the QueryLimiter is null.
+     */
+    @Test
+    void testCountQueryTowardsLimitsWhenConfigIsNull() throws Exception { // resolved
+        QueryHeartbeatCache heartbeatCache = new QueryHeartbeatCache();
+
+        QueryLimiter limiter = new QueryLimiter();
+        limiter.setZookeeperConfig(server.getConnectString());
+        limiter.setHeartbeatCache(heartbeatCache);
+        limiter.setup();
+        String queryId = UUID.randomUUID().toString();
+
+        if (limiter.getConfiguration() == null) {
+            limiter.countQueryTowardsLimits(queryId, userA, system1, tldQueryLogic);
+
+            // Verify a heartbeat was not added to the heartbeat cache.
+            assertThat(heartbeatCache.get(queryId)).isNull();
+
+            // @formatter:off
+            try (CuratorFramework client = CuratorFrameworkFactory.builder().connectString(server.getConnectString())
+                    .namespace("ActiveQueries")
+                    .sessionTimeoutMs(60000)
+                    .connectionTimeoutMs(60000)
+                    .retryPolicy(new RetryNTimes(10, 1000))
+                    .build()) {
+                client.start();
+                // Verify that the nodes for tracking the active queries were never created.
+                assertThat(client.checkExists().forPath("/users/" + userA.toLowerCase() + "/" + tldQueryLogic + "/" + queryId)).isNull();
+                assertThat(client.checkExists().forPath("/systems/" + system1 + "/" + tldQueryLogic + "/" + queryId)).isNull();
+            }
+            // @formatter:on
+        }
+    }
+
+    /**
      * Verify {@link QueryLimiter#setup()} throws an exception if given a default user query limit less than 1.
      */
     @Test
@@ -58,6 +179,7 @@ class QueryLimiterTest {
 
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultUserQueryLimit(0);
+        config.setEnabled(true);
         limiter.setConfiguration(config);
 
         assertThatThrownBy(limiter::setup).isInstanceOf(IllegalArgumentException.class).hasMessage("Default user query limit must be greater than 0");
@@ -75,6 +197,7 @@ class QueryLimiterTest {
         config.setDefaultUserQueryLimit(100);
         config.setDefaultSystemQueryLimit(5000);
         config.setInternalCacheMaxSize(0);
+        config.setEnabled(true);
         limiter.setConfiguration(config);
 
         assertThatThrownBy(limiter::setup).isInstanceOf(IllegalArgumentException.class).hasMessage("Internal cache max size must be greater than 0");
@@ -88,6 +211,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(5);
+        config.setEnabled(true);
         givenConfig(config);
 
         startQueries(1, userA, system1, tldQueryLogic);
@@ -112,6 +236,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(8);
         config.setDefaultUserQueryLimit(5);
+        config.setEnabled(true);
         givenConfig(config);
 
         startQueries(2, userA, system1, tldQueryLogic);
@@ -135,6 +260,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(10);
+        config.setEnabled(true);
 
         // Set a default limit of 3 TLDQueryLogic queries per user.
         QueryLogicGroupLimitConfiguration groupLimitConfig = new QueryLogicGroupLimitConfiguration();
@@ -167,6 +293,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(5);
+        config.setEnabled(true);
 
         // Set a custom limit of 8 queries for userA.
         UserLimitConfiguration userConfig = new UserLimitConfiguration();
@@ -200,6 +327,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(10);
+        config.setEnabled(true);
 
         // Set a default limit of 5 TLDQueryLogic queries per user.
         QueryLogicGroupLimitConfiguration groupLimitConfig = new QueryLogicGroupLimitConfiguration();
@@ -244,6 +372,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(25);
+        config.setEnabled(true);
 
         // Set a limit of 10 queries for system2.
         SystemLimitConfiguration systemConfig = new SystemLimitConfiguration();
@@ -276,6 +405,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(50);
+        config.setEnabled(true);
 
         // Set a default limit of 20 TLDQueryLogic queries per user.
         QueryLogicGroupLimitConfiguration groupLimitConfig = new QueryLogicGroupLimitConfiguration();
@@ -321,6 +451,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(25);
+        config.setEnabled(true);
 
         // Set a limit of 10 queries for system2.
         SystemLimitConfiguration systemConfig = new SystemLimitConfiguration();
@@ -355,6 +486,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(50);
+        config.setEnabled(true);
 
         // Set a default limit of 20 TLDQueryLogic queries per user.
         QueryLogicGroupLimitConfiguration groupLimitConfig = new QueryLogicGroupLimitConfiguration();
@@ -412,6 +544,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(20);
+        config.setEnabled(true);
 
         // Set a default limit of 20 TLDQueryLogic queries per user.
         QueryLogicGroupLimitConfiguration groupLimitConfig = new QueryLogicGroupLimitConfiguration();
@@ -447,6 +580,7 @@ class QueryLimiterTest {
         QueryLimitConfiguration config = new QueryLimitConfiguration();
         config.setDefaultSystemQueryLimit(100);
         config.setDefaultUserQueryLimit(10);
+        config.setEnabled(true);
         givenConfig(config);
 
         List<String> queryIds = startQueries(10, userA, system1, tldQueryLogic);


### PR DESCRIPTION
Currently the query limit feature does not provide a system-wide ability to disable query enforcement.

Add the property `QueryLimitConfiguration.enabled` that will default to a value of false. When the QueryLimiter is initially set up, query limits will only be enforced if the QueryLimitConfiguration set for the limiter is not null, and the value of `enabled` is true. Add the method QueryLimiter.isEnforcingLimits() that will return whether limits are being enforced.

Add tests to verify the expected behavior of QueryLimiter when it is disabled.

Update documentation to cover the new 'enabled' property.

Closes https://github.com/NationalSecurityAgency/datawave/issues/3691