### PR TITLE
Migrate EdgeQuery tests to JUnit5

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/edge/ExtendedEdgeQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/edge/ExtendedEdgeQueryLogicTest.java
@@ -1,5 +1,10 @@
 package datawave.query.edge;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -9,8 +14,7 @@ import java.util.Set;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import datawave.core.iterators.ColumnRangeIterator;
 import datawave.core.query.configuration.GenericQueryConfiguration;
@@ -85,16 +89,17 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
         compareResults(logic, factory, expected);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUnknownFunction() throws Exception {
+    @Test
+    public void testUnknownFunction() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            QueryImpl q = configQuery("SOURCE == 'SUN' && (filter:includeregex(SINK, 'earth|mars'))", auths);
 
-        QueryImpl q = configQuery("SOURCE == 'SUN' && (filter:includeregex(SINK, 'earth|mars'))", auths);
+            EdgeQueryLogic logic = runLogic(q, auths);
 
-        EdgeQueryLogic logic = runLogic(q, auths);
+            List<String> expected = new ArrayList<>();
 
-        List<String> expected = new ArrayList<>();
-
-        compareResults(logic, factory, expected);
+            compareResults(logic, factory, expected);
+        });
     }
 
     @Test
@@ -129,7 +134,7 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
             ita.next();
             counter++;
         }
-        Assert.assertTrue(counter > 0);
+        assertTrue(counter > 0);
     }
 
     @Test
@@ -145,7 +150,7 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
             ita.next();
             counter++;
         }
-        Assert.assertTrue(counter > 0);
+        assertTrue(counter > 0);
     }
 
     /**
@@ -167,7 +172,7 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
         logic.setupQuery(config);
         String actualQueryString = config.getQueryString();
 
-        Assert.assertEquals(expectedQueryString, actualQueryString);
+        assertEquals(expectedQueryString, actualQueryString);
     }
 
     @Test
@@ -183,14 +188,14 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
 
         List<String> sources = logic.getSelectors(q);
 
-        Assert.assertTrue(sources.containsAll(expected));
+        assertTrue(sources.containsAll(expected));
 
         q = configQuery("SOURCE == 'MARS' OR SOURCE == 'JUPITER' OR SOURCE == 'VENUS'", auths);
         q.addParameter("query.syntax", "JEXL");
 
         sources = logic.getSelectors(q);
 
-        Assert.assertTrue(sources.containsAll(expected));
+        assertTrue(sources.containsAll(expected));
     }
 
     @Test
@@ -210,7 +215,7 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
         try {
             logic = runLogic(q, auths, 1);
             compareResults(logic, factory, expected);
-            Assert.fail("Expected to fail because the scan limit was reached");
+            fail("Expected to fail because the scan limit was reached");
         } catch (ColumnRangeIterator.ScanLimitReached e) {
             // expected
         }

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
@@ -36,7 +36,6 @@ import datawave.query.attributes.PreNormalizedAttribute;
 import datawave.query.attributes.TypeAttribute;
 import datawave.query.composite.CompositeMetadata;
 import datawave.query.tables.ShardQueryLogic;
-import datawave.query.tables.edge.BaseEdgeQueryTest;
 import datawave.query.util.AbstractQueryTest;
 import datawave.query.util.CompositeTestingIngest;
 import datawave.query.util.TypeMetadata;
@@ -119,7 +118,7 @@ public class ValueToAttributesTest extends AbstractQueryTest {
         CompositeTestingIngest.writeItAll(clientForTest, CompositeTestingIngest.WhatKindaRange.DOCUMENT);
         PrintUtility.printTable(clientForTest, auths, TableName.SHARD);
         PrintUtility.printTable(clientForTest, auths, TableName.SHARD_INDEX);
-        PrintUtility.printTable(clientForTest, auths, BaseEdgeQueryTest.MODEL_TABLE_NAME);
+        PrintUtility.printTable(clientForTest, auths, TableName.METADATA);
     }
 
     @AfterAll

--- a/warehouse/query-core/src/test/java/datawave/query/tables/edge/BaseEdgeQueryTestJUnit5.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/edge/BaseEdgeQueryTestJUnit5.java
@@ -1,5 +1,9 @@
 package datawave.query.tables.edge;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -29,8 +33,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.log4j.Logger;
-import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
@@ -47,15 +50,17 @@ import datawave.webservice.query.exception.QueryException;
 
 /**
  * A base test class to encapsulate everything needed to run query tests against an edge query logic.
- *
- * @deprecated this fixture is bound to JUnit 4, and JUnit 5 does not honor the {@code @BeforeClass} setup it declares when that setup is inherited by a
- *             subclass. Extend {@link BaseEdgeQueryTestJUnit5} instead, which is an otherwise identical copy. This class remains only for subclasses that have
- *             not yet been migrated, and should be deleted once there are none.
+ * <p>
+ * This is the JUnit 5 form of the fixture. It is a copy of the deprecated JUnit 4 {@link BaseEdgeQueryTest} and differs only in the test framework it binds to:
+ * one-time fixture setup is a JUnit 5 {@code @BeforeAll} rather than a JUnit 4 {@code @BeforeClass}, and assertions come from
+ * {@code org.junit.jupiter.api.Assertions}. JUnit 5 does not honor JUnit 4 lifecycle annotations inherited from a superclass, so a test written against JUnit 5
+ * must extend this class rather than {@link BaseEdgeQueryTest}.
+ * <p>
+ * New edge query tests should extend this class. {@link BaseEdgeQueryTest} remains only for subclasses that have not yet been migrated.
  */
-@Deprecated
-public abstract class BaseEdgeQueryTest {
+public abstract class BaseEdgeQueryTestJUnit5 {
 
-    public static final Logger log = Logger.getLogger(BaseEdgeQueryTest.class);
+    public static final Logger log = Logger.getLogger(BaseEdgeQueryTestJUnit5.class);
 
     protected static final boolean protobufEdgeFormat = true;
 
@@ -73,7 +78,7 @@ public abstract class BaseEdgeQueryTest {
     protected static final String UNEXPECTED_RECORD = "Found an unexpected record.";
 
     private String serializeAuths(Set<Authorizations> sentAuths) {
-        Assert.assertEquals(1, sentAuths.size());
+        assertEquals(1, sentAuths.size());
         return sentAuths.iterator().next().serialize();
     }
 
@@ -168,21 +173,21 @@ public abstract class BaseEdgeQueryTest {
 
                     logic = (BaseQueryLogic<Map.Entry<Key,Value>>) factory.getQueryLogic(logic.getLogicName());
                 } catch (CloneNotSupportedException | QueryException e) {
-                    Assert.fail("Failed to recreate checkpointable query logic  for " + logic.getLogicName() + ": " + e.getMessage());
+                    fail("Failed to recreate checkpointable query logic  for " + logic.getLogicName() + ": " + e.getMessage());
                 }
                 // now reset the logic given the checkpoint
                 try {
                     ((CheckpointableQueryLogic) logic).setupQuery(client, config, cp);
                 } catch (Exception e) {
                     log.error("Failed to setup query given last checkpoint", e);
-                    Assert.fail("Failed to setup query given last checkpoint: " + e.getMessage());
+                    fail("Failed to setup query given last checkpoint: " + e.getMessage());
                 }
                 Iterator<Map.Entry<Key,Value>> iter = logic.iterator();
                 if (iter.hasNext()) {
                     Map.Entry<Key,Value> next = iter.next();
                     Key k = next.getKey();
                     System.out.println("key = " + k.toStringNoTime());
-                    Assert.assertTrue(UNEXPECTED_RECORD + " : " + k.toStringNoTime(), expected.contains(k.toStringNoTime()));
+                    assertTrue(expected.contains(k.toStringNoTime()), UNEXPECTED_RECORD + " : " + k.toStringNoTime());
                     recordsFound++;
                     cps.addAll(((CheckpointableQueryLogic) logic).checkpoint(queryKey));
                 }
@@ -192,12 +197,12 @@ public abstract class BaseEdgeQueryTest {
                 foundKeys.add(entry.getKey());
                 Key k = entry.getKey();
                 System.out.println("key = " + k.toStringNoTime());
-                Assert.assertTrue(UNEXPECTED_RECORD + " : " + k.toStringNoTime(), expected.contains(k.toStringNoTime()));
+                assertTrue(expected.contains(k.toStringNoTime()), UNEXPECTED_RECORD + " : " + k.toStringNoTime());
                 recordsFound++;
             }
         }
 
-        Assert.assertEquals(UNEXPECTED_NUM_RECORDS, expected.size(), recordsFound);
+        assertEquals(expected.size(), recordsFound, UNEXPECTED_NUM_RECORDS);
     }
 
     public static void addEdges() throws IOException, InterruptedException {
@@ -219,7 +224,7 @@ public abstract class BaseEdgeQueryTest {
         recordWriter.close(context);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
         System.setProperty("file.encoding", "UTF8");
@@ -227,7 +232,7 @@ public abstract class BaseEdgeQueryTest {
         // Need to set SDFs after setting the timezone to GMT, else dates will be EST and converted to GMT
         simpleFormat = new SimpleDateFormat("yyyyMMdd");
 
-        InMemoryInstance i = new InMemoryInstance(BaseEdgeQueryTest.class.toString());
+        InMemoryInstance i = new InMemoryInstance(BaseEdgeQueryTestJUnit5.class.toString());
         client = new InMemoryAccumuloClient("root", i);
 
         // Create the CB tables

--- a/warehouse/query-core/src/test/java/datawave/query/tables/edge/EdgeQueryFunctionalTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/edge/EdgeQueryFunctionalTest.java
@@ -1,5 +1,7 @@
 package datawave.query.tables.edge;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -7,40 +9,45 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.inject.Inject;
-
 import org.apache.accumulo.core.security.Authorizations;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import datawave.core.query.configuration.GenericQueryConfiguration;
 import datawave.core.query.logic.QueryLogic;
 import datawave.core.query.logic.QueryLogicFactory;
 import datawave.microservice.query.QueryImpl;
 import datawave.security.authorization.ProxiedUserDetails;
-import datawave.webservice.edgedictionary.RemoteEdgeDictionary;
 import datawave.webservice.query.exception.DatawaveErrorCode;
 import datawave.webservice.query.exception.QueryException;
 import datawave.webservice.query.exception.UnauthorizedQueryException;
 
-@RunWith(Arquillian.class)
-public class EdgeQueryFunctionalTest extends BaseEdgeQueryTest {
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class EdgeQueryFunctionalTest extends BaseEdgeQueryTestJUnit5 {
     protected EdgeQueryLogic logic;
 
-    @Inject
+    @Autowired
     protected ApplicationContext applicationContext;
 
     protected QueryLogicFactory factory = new TestQueryLogicFactory();
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         logic = (EdgeQueryLogic) createLogic();
     }
@@ -58,18 +65,6 @@ public class EdgeQueryFunctionalTest extends BaseEdgeQueryTest {
      * This will override EdgeModelAware's default context loading behavior, and avoid the pitfalls of failed classpath resolution and/or non-interpolated
      * resource files while debugging within Eclipse...all the stuff that works seamlessly when running Maven from the CL
      */
-
-    @Deployment
-    public static JavaArchive createDeployment() throws Exception {
-        return ShrinkWrap.create(JavaArchive.class)
-                        .addPackages(true, "org.apache.deltaspike", "io.astefanutti.metrics.cdi", "datawave.query", "datawave.webservice.query.result.event",
-                                        "datawave.core.query.result.event")
-                        .deleteClass(DefaultEdgeEventQueryLogic.class).deleteClass(RemoteEdgeDictionary.class)
-                        .deleteClass(datawave.query.metrics.QueryMetricQueryLogic.class)
-                        .addAsManifestResource(new StringAsset(
-                                        "<alternatives>" + "<stereotype>datawave.query.tables.edge.MockAlternative</stereotype>" + "</alternatives>"),
-                                        "beans.xml");
-    }
 
     public EdgeQueryLogic runLogic(QueryImpl q, Set<Authorizations> auths) throws Exception {
         GenericQueryConfiguration config = logic.initialize(client, q, auths);
@@ -452,16 +447,17 @@ public class EdgeQueryFunctionalTest extends BaseEdgeQueryTest {
         compareResults(logic, factory, expected);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUnknownFunction() throws Exception {
+    @Test
+    public void testUnknownFunction() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            QueryImpl q = configQuery("SOURCE == 'SUN' && (filter:includeregex(SINK, 'earth|mars'))", auths);
 
-        QueryImpl q = configQuery("SOURCE == 'SUN' && (filter:includeregex(SINK, 'earth|mars'))", auths);
+            EdgeQueryLogic logic = runLogic(q, auths);
 
-        EdgeQueryLogic logic = runLogic(q, auths);
+            List<String> expected = new ArrayList<>();
 
-        List<String> expected = new ArrayList<>();
-
-        compareResults(logic, factory, expected);
+            compareResults(logic, factory, expected);
+        });
     }
 
     @Test


### PR DESCRIPTION
Migrate EdgeQuery tests to JUnit5
- updated a copy of the base edge test class instead of update-in-place