### PR TITLE
Fix IllegalMonitorStateException and stream leak in CardinalityRecord.writeToDisk

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/cardinality/CardinalityRecord.java
+++ b/warehouse/query-core/src/main/java/datawave/query/cardinality/CardinalityRecord.java
@@ -248,7 +248,6 @@ public class CardinalityRecord implements Serializable {
                         log.error(e.getMessage(), e);
                     } finally {
                         IOUtils.closeQuietly(oos);
-                        file.notifyAll();
                     }
                 }
             });

--- a/warehouse/query-core/src/main/java/datawave/query/cardinality/CardinalityRecord.java
+++ b/warehouse/query-core/src/main/java/datawave/query/cardinality/CardinalityRecord.java
@@ -16,7 +16,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -239,15 +238,10 @@ public class CardinalityRecord implements Serializable {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             executor.execute(() -> {
                 synchronized (LOCK) {
-                    ObjectOutputStream oos = null;
-                    try {
-                        FileOutputStream fos = new FileOutputStream(file);
-                        oos = new ObjectOutputStream(fos);
+                    try (FileOutputStream fos = new FileOutputStream(file); ObjectOutputStream oos = new ObjectOutputStream(fos)) {
                         oos.writeObject(cardinalityRecord);
                     } catch (Exception e) {
                         log.error(e.getMessage(), e);
-                    } finally {
-                        IOUtils.closeQuietly(oos);
                     }
                 }
             });

--- a/warehouse/query-core/src/test/java/datawave/query/cardinality/TestCardinalityRecord.java
+++ b/warehouse/query-core/src/test/java/datawave/query/cardinality/TestCardinalityRecord.java
@@ -1,11 +1,22 @@
 package datawave.query.cardinality;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import org.locationtech.jts.util.Assert;
@@ -108,5 +119,54 @@ public class TestCardinalityRecord {
 
         int expectedSize = list1.size() * list2.size() * list3.size() * list4.size() * list5.size();
         Assert.equals(expectedSize, results.size());
+    }
+
+    /**
+     * The asynchronous write used to call {@link Object#notifyAll()} on the target file while holding an unrelated monitor, which raised an
+     * {@link IllegalMonitorStateException} on the executor thread after every write.
+     */
+    @Test
+    public void testWriteToDiskDoesNotThrowOnTheExecutorThread() throws Exception {
+
+        Set<String> recordedFields = new HashSet<>();
+        recordedFields.add("FIELD1");
+        CardinalityRecord cr = new CardinalityRecord(recordedFields, CardinalityRecord.DateType.DOCUMENT);
+
+        Map<String,List<String>> valueMap = new HashMap<>();
+        valueMap.put("FIELD1", Collections.singletonList("L1V1"));
+        cr.addEntry(valueMap, "eventId", "datatype", "20260729");
+
+        Path directory = Files.createTempDirectory("cardinality-record-test");
+        File file = new File(directory.toFile(), "cardinality.obj");
+
+        AtomicReference<Throwable> uncaught = new AtomicReference<>();
+        CountDownLatch uncaughtLatch = new CountDownLatch(1);
+        Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            uncaught.set(throwable);
+            uncaughtLatch.countDown();
+        });
+
+        try {
+            CardinalityRecord.writeToDisk(cr, file);
+
+            // the write is asynchronous, so wait for the record to land before checking whether it also failed
+            Clock clock = Clock.systemUTC();
+            long deadline = clock.millis() + TimeUnit.SECONDS.toMillis(10);
+            CardinalityRecord written = null;
+            while (written == null && clock.millis() < deadline) {
+                Thread.sleep(50);
+                written = CardinalityRecord.readFromDisk(file);
+            }
+            assertNotNull("record was never written to disk", written);
+
+            // the monitor violation is raised immediately after the stream is closed, so give it a chance to surface
+            uncaughtLatch.await(500, TimeUnit.MILLISECONDS);
+            assertNull("writeToDisk failed on the executor thread", uncaught.get());
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previousHandler);
+            file.delete();
+            directory.toFile().delete();
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two defects in the asynchronous cardinality write, `CardinalityRecord.writeToDisk`.

**1. `IllegalMonitorStateException` on every write.** The task held the monitor of the static `LOCK` but called `notifyAll()` on the `File`:

```java
synchronized (LOCK) {
    ...
    } finally {
        IOUtils.closeQuietly(oos);
        file.notifyAll();   // monitor of `file` is not held -> IllegalMonitorStateException
    }
}
```

`Object.notifyAll()` requires ownership of that object's monitor, so this threw every time a non-empty record was written. Because the throw is in the `finally` block, the file itself was written correctly and the exception surfaced only as an uncaught exception on the pool thread — `execute()` is used rather than `submit()`, so there was no `Future` to carry it back to the caller.

No thread anywhere waits on that `File` (or on `LOCK`); both call sites in `DocumentTransformerSupport.writeResultCardinalities` are fire-and-forget. The `notifyAll()` had no waiter to wake, so it is removed rather than retargeted.

**2. Leaked `FileOutputStream`.** Only the `ObjectOutputStream` was closed in `finally`. If `new ObjectOutputStream(fos)` threw — it writes the stream header, so it can — `oos` was still `null` and the already-open descriptor leaked. Now uses try-with-resources, matching the existing shape of `readFromDisk`.

## Testing

`TestCardinalityRecord.testWriteToDiskDoesNotThrowOnTheExecutorThread` covers the first fix. Since the failure lands on the executor thread rather than the caller, it captures throwables through a temporarily-installed default uncaught-exception handler, waits for the record to deserialize back off disk, then asserts nothing threw. Verified to fail against the unfixed code with `IllegalMonitorStateException: current thread is not owner`, and to pass after.

The stream leak has no dedicated test — inducing a failure in the `ObjectOutputStream` constructor against a real file would require refactoring `writeToDisk` to accept an injected stream. The fix is structural.

`mvn -pl warehouse/query-core -DskipTests install` passes, and `TestCardinalityRecord` is 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)