### PR TITLE
Copy the shard index aggregator iterators into core-tables

### DIFF
--- a/core/tables/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
+++ b/core/tables/src/main/java/datawave/ingest/table/aggregator/GlobalIndexUidAggregator.java
@@ -1,0 +1,350 @@
+package datawave.ingest.table.aggregator;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import datawave.ingest.protobuf.Uid;
+import datawave.ingest.protobuf.Uid.List.Builder;
+import datawave.iterators.ValueCombiner;
+
+/**
+ * Implementation of an Aggregator that aggregates objects of the type Uid.List. This is an optimization for the shardIndex and shardReverseIndex, where the
+ * list of UIDs for events will be maintained in the global index for low cardinality terms.
+ */
+public class GlobalIndexUidAggregator extends PropogatingCombiner {
+    private static final Logger log = LoggerFactory.getLogger(GlobalIndexUidAggregator.class);
+
+    /**
+     * Using a set instead of a list so that duplicate UIDs are filtered out of the list. This might happen in the case of rows with masked fields that share a
+     * UID.
+     */
+    private final HashSet<String> uids = new HashSet<>();
+
+    /**
+     * List of UIDs to remove.
+     */
+    private final HashSet<String> uidsToRemove = new HashSet<>();
+
+    /**
+     * flag for whether or not we have seen ignore
+     */
+    private boolean seenIgnore = false;
+
+    /**
+     * Maximum number of UIDs.
+     */
+    public static final int MAX = 20;
+
+    /**
+     * Maximum number of UIDs.
+     */
+    public int maxUids;
+
+    /**
+     * representative count.
+     */
+    private long count = 0;
+
+    public GlobalIndexUidAggregator(int max) {
+        this.maxUids = max;
+    }
+
+    public GlobalIndexUidAggregator() {
+        this.maxUids = MAX;
+    }
+
+    /**
+     * @return True if we saw a "count only" protobuf during the last reduce operation.
+     */
+    protected boolean isSeenIgnore() {
+        return seenIgnore;
+    }
+
+    /**
+     * Normally this class will return the most recent key associated with the combined values. We need this key to have a truncated timestamp.
+     *
+     * @return The top key with a truncated timestamp.
+     */
+    @Override
+    public Key getTopKey() {
+        return TruncatingTimestampIterator.getTruncatedTimestampKey(super.getTopKey());
+    }
+
+    /**
+     * We want timestamps in the global index to be combined separately. Normally all of the timestamps on the global index are truncated to the day at
+     * 00:00:00. However we could have a composite timestamp (@see CompositeTimestamp) in which case we want separate entries. A TruncatingTimestampIterator was
+     * added in-case entries are added that are not truncated to the beginning of the day.
+     *
+     * @param iterator
+     * @return an iterator of values
+     */
+    @Override
+    public Iterator<Value> getValues(SortedKeyValueIterator<Key,Value> iterator) {
+        return new ValueCombiner(new TruncatingTimestampIterator(iterator), PartialKey.ROW_COLFAM_COLQUAL_COLVIS_TIME);
+    }
+
+    @Override
+    public Value aggregate() {
+
+        Builder builder = Uid.List.newBuilder();
+        builder.setIGNORE(seenIgnore);
+        if (seenIgnore) {
+            // If we're over the max UID size, then the count is simply the sum of counts
+            // as reported by the protocol buffers. If UIDs were duplicated, then this
+            // count might include that info, but there's no way to know since we're not
+            // tracking individual UIDs.
+            builder.setCOUNT(count);
+        } else {
+            uids.removeAll(uidsToRemove);
+            builder.addAllUID(uids);
+            // If we're not over the max UID size, then the count is simply the number of
+            // UIDs we have in memory. This will take care of de-duping any UIDs that were
+            // added more than once. Note that we specifically do not account for any UIDs
+            // in uidsToRemove (other than those that were removed from uids above). If we
+            // saw removals for 10 UIDs, we'd have those 10 UIDs in the uidsToRemove list.
+            // Then if the next value contains adds for those 10 UIDs, we would not add
+            // them to the uids set since they're in uidsToRemove, but we would also NOT
+            // remove them from uidsToRemove since we don't know whether or not we'll see
+            // any of those UIDs again and don't want to discard the fact that they are
+            // removed. In that case, we'd have a count of -10 after aggregation if we
+            // subtracted uidsToRemove.size() even though the correct count would be 0.
+            builder.setCOUNT(uids.size());
+
+            // Only track REMOVEDUIDs if we're propagating, which means it's a minor or
+            // partial major compaction and therefore the result of aggregation might not
+            // include all possible values for a key. In that case, it's possible the adds
+            // to which these removes apply are in a different file that wasn't involved in
+            // this operation.
+            if (propogate) {
+                builder.addAllREMOVEDUID(uidsToRemove);
+            }
+        }
+
+        log.trace("Building aggregate. propogate={}, count={}, uids.size()={}, uidsToRemove.size()={}, builder UIDCount={} REMOVEDUIDCount={}", propogate,
+                        count, uids.size(), uidsToRemove.size(), builder.getUIDCount(), builder.getREMOVEDUIDCount());
+        return new Value(builder.build().toByteArray());
+    }
+
+    /**
+     * Combines UID lists. The {@link Uid.List} protocol buffer contains a count, ignore flag, and lists of UIDs and REMOVEDUIDs. The intent is that the list
+     * can store up to a certain number of UIDs and after that, the lists are no longer tracked (the ignore flag will be set) and only counts are tracked.
+     * REMOVEDUIDs are tracked to handle minor and partial major compactions where this reduce method won't necessarily see all possible values for a given key
+     * (e.g., the UIDs that are being removed might be in a different RFile that isn't involved in the current compaction).
+     *
+     * Aggregation operates in one of two modes depending on whether or not timestamps are ignored. By default, timestamps are ignored since DataWave uses date
+     * to the day as the timestamp in the global term index. When timestamps are ignored, we cannot infer anything about the order of values under aggregation.
+     * Therefore, a decision must be made about how to handle removed UIDs vs added UIDs. In that case, removed UIDs take priority. This means that adding a
+     * UID, then removing it, and adding it back again is not a supported operation. When timestamps are not ignored, then it is assumed that the timestamps are
+     * set properly and values will be processed in order from newest to oldest. In that case, it is possible to add a UID, then remove it, and add it back
+     * again.
+     *
+     * @param key
+     *            the current key
+     * @param iter
+     *            an {@link Iterator} providing the UID lists to be aggregated
+     * @return a new {@link Value} containing the aggregated result
+     */
+    @Override
+    public Value reduce(Key key, Iterator<Value> iter) {
+        log.trace("has next ? {}", iter.hasNext());
+        while (iter.hasNext()) {
+
+            Value value = iter.next();
+
+            // Collect the values, which are serialized Uid.List objects
+            try {
+                Uid.List v = Uid.List.parseFrom(value.get());
+
+                // For best performance, don't attempt to accumulate any individual UIDs (or removals)
+                // if this PB has its ignore flag set or we've seen any other PB with the ignored flag set.
+                if (seenIgnore) {
+                    log.debug("SeenIgnore is true. Skipping collections");
+                } else if (v.getIGNORE()) {
+                    // After a PB has its ignore flag set, from that point forward UIDs will increment
+                    // the count and removal UIDs will decrement it. Apply this logic on the existing
+                    // information available (the list of UIDs and removal UIDs) for consistency.
+                    seenIgnore = true;
+                    count = (long) this.uids.size() - this.uidsToRemove.size();
+                    log.debug("Switch to seenIgnore is true. Skipping collections");
+                } else {
+                    // Save a starting count in the event that we go over the max UID count while
+                    // aggregating the current protocol buffer, v.
+                    //
+                    // Once we cross the max UID threshold, then we'll switch to an estimation approach
+                    // for the count where UID additions increment the count and UID removals decrement
+                    // the count. In this scenario, the starting count will be needed to avoid double
+                    // counting items that were added prior to exceeding the max. Also, the starting count
+                    // should follow the same estimation approach because it's only used if the maximum
+                    // is exceeded.
+                    //
+                    // However, if the maximum is not exceeded, we want to track UIDs by name in the internal
+                    // set because that will take care of de-duping any duplicate UIDs.
+                    long prevCount = (long) uids.size() - uidsToRemove.size();
+
+                    boolean isUnderMaxThreshold = processRemovalUids(v) && processAddedUids(v);
+                    if (!isUnderMaxThreshold) {
+                        enterCountOnlyMode(prevCount);
+                    }
+                }
+
+                // If the ignore flag is set, the UIDs will not be tracked by name and an
+                // estimated count will be used instead.
+                if (seenIgnore) {
+                    if (v.getIGNORE()) {
+                        // If the incoming protocol buffer is marked with the ignore flag,
+                        // assume the count in the incoming protocol buffer is already an
+                        // estimated count and simply add it to the current count. It may
+                        // be a negative count if it represents a net removal.
+                        count += v.getCOUNT();
+                    } else {
+                        // If the incoming protocol buffer is not marked with the ignore flag,
+                        // use the sizes of its additions and removals to provide the best
+                        // possible estimate.
+                        count += v.getUIDCount();
+                        count -= v.getREMOVEDUIDCount();
+                    }
+                }
+
+            } catch (InvalidProtocolBufferException e) {
+                if (key.isDeleted()) {
+                    log.trace("Value passed to aggregator for a delete key was not of type Uid.List");
+                } else {
+                    log.error("Value passed to aggregator was not of type Uid.List", e);
+                }
+            }
+        }
+        // When the ignore flag is NOT set, the count is equal to the size of the uid list.
+        // When the ignore flag is set, the count could represent either:
+        // - a partial answer (propagate = true)
+        // - a final answer (propagate = false)
+        // As a final answer, a negative count is nonsensical because the count represents
+        // the number of records that are estimated to exist.
+        // A partial answer doesn't have all of the counts available, so to be as accurate
+        // as possible it's worth propagating negative counts.
+        if (seenIgnore && !propogate) {
+            count = Math.max(0, count);
+        }
+        return aggregate();
+    }
+
+    /**
+     * Remove any UIDs in the REMOVEDUID list.
+     *
+     * @param value
+     *            the protobuf object to process
+     * @return true if the removals were processed without exceeding the max limit, false otherwise.
+     */
+    private boolean processRemovalUids(Uid.List value) {
+        for (String uid : value.getREMOVEDUIDList()) {
+            // The order of incoming values for the same timestamp is non-deterministic. In that case
+            // we give precedence to a removal over an add and mark this UID as removed even
+            // if it was in the UID list.
+            uids.remove(uid);
+            // Even if propagate is false, the removal UID should persist until all PB lists
+            // in the current iteration have been seen, in case a subsequent PB has the UID
+            // marked for removal.
+            uidsToRemove.add(uid);
+            // Avoid exceeding maxUids in the uidToRemove list, even when propogating.
+            // Check for this condition after adding each of the remove UID entries to uidsToRemove,
+            // which also de-duplicates uids in that Set.
+            if (uidsToRemove.size() >= maxUids) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Add the UIDs in the UID list, ignoring those that have been marked for removal.
+     *
+     * @param value
+     *            the protobuf object to process
+     * @return true if the additions were processed without exceeding the max limit, false otherwise.
+     */
+    private boolean processAddedUids(Uid.List value) {
+        // Add UIDs from the UID list
+        for (String uid : value.getUIDList()) {
+            // Don't add a uid that's been removed. This is the same whether or
+            // not timestamps are ignored since if they are ignored, removals take
+            // priority and if they are not ignored, then this add is happening
+            // before a removal and therefore should not take place.
+            if (!uidsToRemove.contains(uid)) {
+                // Add the UID iff we are under our MAX. If we reach the max,
+                // then treat it as though we've seen an ignore--don't try to
+                // add any more UIDs to the list (or removals from the REMOVEDUIDs
+                // list) since they won't be included when we aggregate anyway.
+                if (uids.size() < maxUids) {
+                    uids.add(uid);
+                } else if (!uids.contains(uid)) {
+                    // This UID will not push the PB over the max UID limit if it is
+                    // already in the list of UIDs.
+                    // If aggregating this PB pushed us over the max UID limit,
+                    // then ignore any work we've done integrating this PB so far
+                    // and instead treat it as though its ignore flag had been set.
+                    // Set the count to the number of collected UIDs before we went
+                    // over the max, and then we'll add this PB's count below.
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void enterCountOnlyMode(long count) {
+        this.seenIgnore = true;
+        this.count = count;
+        this.uids.clear();
+        this.uidsToRemove.clear();
+    }
+
+    public void reset() {
+        log.debug("Resetting GlobalIndexUidAggregator");
+        count = 0;
+        seenIgnore = false;
+        uids.clear();
+        uidsToRemove.clear();
+    }
+
+    @Override
+    public boolean propogateKey() {
+
+        // This method is called after reduce and then aggregate, so all of the work to combine has been done.
+        // If the propogate flag is true, then this might have been a partial major compaction, scan, or minor
+        // compaction and we want to keep all keys no matter what. When propogate is false, that means it's a scan or
+        // full major compaction and therefore we can be certain that the aggregated result has combined all possible
+        // values for a given key. In that case, we only need to keep the resulting key/value pair if it has any UIDs
+        // (which means either UIDs in the uid list, or a positive uid count).
+        return propogate || !uids.isEmpty() || count > 0;
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        boolean valid = super.validateOptions(options);
+        return valid;
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+        GlobalIndexUidAggregator copy = (GlobalIndexUidAggregator) super.deepCopy(env);
+        copy.propogate = propogate;
+        // Not copying other fields that are all cleared in the reset() method.
+        return copy;
+    }
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        super.init(source, options, env);
+    }
+}

--- a/core/tables/src/main/java/datawave/ingest/table/aggregator/PropogatingCombiner.java
+++ b/core/tables/src/main/java/datawave/ingest/table/aggregator/PropogatingCombiner.java
@@ -1,0 +1,100 @@
+package datawave.ingest.table.aggregator;
+
+import java.util.Iterator;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.Combiner;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.log4j.Logger;
+
+import datawave.iterators.ValueCombiner;
+
+/**
+ *
+ * Aids in determining if a value and the corresponding keys should propogate
+ *
+ */
+public abstract class PropogatingCombiner extends Combiner {
+
+    private static final Value EMPTY_VALUE = new Value(new byte[0]);
+
+    private static final Logger log = Logger.getLogger(PropogatingCombiner.class);
+
+    /**
+     * Flag to determine if we propogate the removals
+     */
+    protected boolean propogate = true;
+
+    /**
+     * Get the iterator of values to be combined
+     *
+     * @param iterator
+     * @return a value iterator
+     */
+    public Iterator<Value> getValues(SortedKeyValueIterator<Key,Value> iterator) {
+        return new ValueCombiner(iterator);
+    }
+
+    /**
+     * Shpuld return a thread safe value.
+     *
+     * @return a value
+     */
+    public Value aggregate() {
+        return EMPTY_VALUE;
+    }
+
+    /**
+     * Collects a value into the current state;
+     *
+     * @param value
+     *            a value
+     */
+    public void collect(Value value) {
+
+    }
+
+    /**
+     * Sets the propogating factor in the aggregator.
+     *
+     * @param propogate
+     *            the boolean to set
+     */
+    public void setPropogate(boolean propogate) {
+        this.propogate = propogate;
+    }
+
+    /**
+     * Determines whether or not to propogate the key depending on the result of the value
+     *
+     * @return a boolean on whether to propogate
+     */
+    public boolean propogateKey() {
+        return this.propogate;
+    }
+
+    /**
+     * Method to reset the state within the propogating aggregator.
+     */
+    public void reset() {
+        // empty method
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.accumulo.core.iterators.Combiner#reduce(org.apache.accumulo.core.data.Key, java.util.Iterator)
+     */
+    @Override
+    public Value reduce(Key key, Iterator<Value> iter) {
+        if (log.isTraceEnabled()) {
+            log.trace("combining key " + key + ", iter.hasNext? " + iter.hasNext());
+        }
+        while (iter.hasNext()) {
+            collect(iter.next());
+        }
+        return aggregate();
+    }
+
+}

--- a/core/tables/src/main/java/datawave/ingest/table/aggregator/TruncatingTimestampIterator.java
+++ b/core/tables/src/main/java/datawave/ingest/table/aggregator/TruncatingTimestampIterator.java
@@ -1,0 +1,112 @@
+package datawave.ingest.table.aggregator;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+
+import datawave.util.CompositeTimestamp;
+
+public class TruncatingTimestampIterator implements SortedKeyValueIterator<Key,Value> {
+
+    private final SortedKeyValueIterator<Key,Value> delegate;
+
+    public TruncatingTimestampIterator(SortedKeyValueIterator<Key,Value> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        delegate.init(source, options, env);
+    }
+
+    @Override
+    public SortedKeyValueIterator<Key,Value> deepCopy(IteratorEnvironment env) {
+        return new TruncatingTimestampIterator(delegate.deepCopy(env));
+    }
+
+    @Override
+    public Key getTopKey() {
+        return getTruncatedTimestampKey(delegate.getTopKey());
+    }
+
+    @Override
+    public Value getTopValue() {
+        return delegate.getTopValue();
+    }
+
+    @Override
+    public boolean hasTop() {
+        return delegate.hasTop();
+    }
+
+    @Override
+    public void next() throws IOException {
+        delegate.next();
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        delegate.seek(range, columnFamilies, inclusive);
+    }
+
+    /**
+     * Return the key with a truncated timestamp
+     *
+     * @param key
+     *            The key
+     * @return The key with a truncated timestamp
+     */
+    public static Key getTruncatedTimestampKey(Key key) {
+        if (key == null) {
+            return key;
+        }
+
+        long timestamp = key.getTimestamp();
+        long newTimestamp = truncateTimestamp(timestamp);
+        if (timestamp == newTimestamp) {
+            return key;
+        }
+
+        return new Key(key.getRow().getBytes(), key.getColumnFamily().getBytes(), key.getColumnQualifier().getBytes(), key.getColumnVisibility().getBytes(),
+                        newTimestamp, key.isDeleted(), false);
+    }
+
+    /**
+     * truncate a timestamp (possibly composite timestamp) to the beginning of the day.
+     *
+     * @param timestamp
+     *            timestamp (possibly composite timestamp)
+     * @return timestamp with the event date truncated to the beginning of the day
+     */
+    public static long truncateTimestamp(long timestamp) {
+        if (CompositeTimestamp.isCompositeTimestamp(timestamp)) {
+            long eventDate = CompositeTimestamp.getEventDate(timestamp);
+            int ageOffDeltaDays = CompositeTimestamp.getAgeOffDeltaDays(timestamp);
+            return CompositeTimestamp.getCompositeDeltaTimeStamp(beginningOfDay(eventDate), ageOffDeltaDays);
+        } else {
+            return beginningOfDay(timestamp);
+        }
+    }
+
+    /**
+     * Return the beginning of the day for a timestamp
+     *
+     * @param timestamp
+     *            timestamp
+     * @return beginning of the day
+     */
+    public static long beginningOfDay(long timestamp) {
+        Instant truncated = Instant.ofEpochMilli(timestamp).truncatedTo(ChronoUnit.DAYS);
+        return truncated.toEpochMilli();
+    }
+
+}

--- a/core/tables/src/main/java/datawave/iterators/PropogatingIterator.java
+++ b/core/tables/src/main/java/datawave/iterators/PropogatingIterator.java
@@ -1,0 +1,355 @@
+package datawave.iterators;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.Combiner;
+import org.apache.accumulo.core.iterators.IteratorEnvironment;
+import org.apache.accumulo.core.iterators.IteratorUtil;
+import org.apache.accumulo.core.iterators.IteratorUtil.IteratorScope;
+import org.apache.accumulo.core.iterators.OptionDescriber;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.accumulo.core.iteratorsImpl.conf.ColumnToClassMapping;
+import org.apache.log4j.Logger;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+import datawave.ingest.table.aggregator.PropogatingCombiner;
+
+/**
+ * Purpose: Handle arbitrary propogating aggregations.
+ *
+ * Design: Though very similar to the DeletingIterator, due to private methods and members, we cannot directly extend the DeletingIterator. As a result, the
+ * class extends SKVI. This class {@code USES --> PropogatingAggregator}. Note that propAgg can be null
+ *
+ * Initially the TotalAggregatingIterator, this class was a direct copy. At some point it was identified that there was an artifact where deletes would not be
+ * propogated. As a result, this class becomes nearly identical to the DeletingIterator, whereby deletes are always propogated until a full major compaction.
+ */
+public class PropogatingIterator implements SortedKeyValueIterator<Key,Value>, OptionDescriber {
+
+    public static final String ATTRIBUTE_NAME = "agg";
+
+    public static final String ATTRIBUTE_DESCRIPTION = "Aggregators apply aggregating functions to values with identical keys. You can specify the column family. DEFAULT matches the default locality group";
+
+    public static final String UNNAMED_OPTION_DESCRIPTION = "<Column Family>  <Combiner>";
+
+    public static final String AGGREGATOR_DEFAULT = "DEFAULT";
+
+    public static final String AGGREGATOR_DEFAULT_OPT = "*";
+
+    public static final Map<String,String> defaultMapOptions;
+
+    static {
+        defaultMapOptions = Maps.newHashMap();
+        defaultMapOptions.put(AGGREGATOR_DEFAULT, "default aggregator class");
+    }
+
+    /**
+     * Underlying iterator.
+     */
+    protected SortedKeyValueIterator<Key,Value> iterator;
+
+    /**
+     * current working key
+     */
+    protected Key workKey = new Key();
+
+    /**
+     * Aggregated key and value.
+     */
+    protected Key aggrKey;
+    protected Value aggrValue;
+
+    /**
+     * Current iterator environment.
+     */
+    protected IteratorEnvironment env;
+
+    /**
+     * Propogating iterator
+     */
+    protected PropogatingCombiner defaultAgg = null;
+    protected Map<ByteSequence,PropogatingCombiner> aggMap;
+
+    /**
+     * variable to determine if we should propogate deletes
+     */
+    private boolean shouldPropogate;
+
+    /**
+     * Combiner options so that we can effectively deep copy
+     */
+    protected Map<String,String> options = Maps.newHashMap();
+
+    private static final Logger log = Logger.getLogger(PropogatingIterator.class);
+
+    /**
+     * Deep copy implementation
+     */
+    public PropogatingIterator deepCopy(IteratorEnvironment env) {
+        return new PropogatingIterator(this, env);
+    }
+
+    /**
+     * Private constructor.
+     *
+     * @param other
+     *            the other iterator
+     * @param env
+     *            an interator environment
+     */
+    private PropogatingIterator(PropogatingIterator other, IteratorEnvironment env) {
+        iterator = other.iterator.deepCopy(env);
+        this.env = env;
+        if (null != defaultAgg)
+            defaultAgg = (PropogatingCombiner) other.defaultAgg.deepCopy(env);
+        this.aggMap = Maps.newHashMap();
+        options.putAll(other.options);
+        // this will configure us and deep copy safely
+        validateOptions(options);
+    }
+
+    public PropogatingIterator() {
+        aggMap = Maps.newHashMap();
+    }
+
+    /**
+     * Aggregates the same partial key.
+     *
+     * @return a partial key
+     * @throws IOException
+     *             for issues with read/write
+     */
+    private boolean aggregateRowColumn() throws IOException {
+        // this function assumes that first value is not delete
+
+        workKey.set(iterator.getTopKey());
+
+        final Key keyToAggregate = workKey;
+
+        PropogatingCombiner aggr = getAggregator(workKey);
+
+        Value aggregatedValue;
+
+        if (aggr != null) {
+
+            if (log.isTraceEnabled()) {
+                log.trace("aggregator is not null");
+            }
+
+            // reset the state of the combiner.
+            aggr.reset();
+
+            aggregatedValue = aggr.reduce(keyToAggregate, aggr.getValues(iterator));
+
+            // always propagate deletes
+            if (aggr.propogateKey() || workKey.isDeleted()) {
+                if (log.isTraceEnabled())
+                    log.trace("propogating " + workKey);
+                aggrKey = workKey;
+            } else {
+                if (log.isTraceEnabled())
+                    log.trace("Not propogating " + workKey);
+                return false;
+            }
+        } else {
+            aggregatedValue = new Value(iterator.getTopValue());
+        }
+
+        aggrKey = new Key(workKey);
+
+        aggrValue = aggregatedValue;
+
+        return true;
+
+    }
+
+    private PropogatingCombiner getAggregator(Key key) {
+        PropogatingCombiner aggr = aggMap.get(key.getColumnFamilyData());
+
+        if (null == aggr) {
+            if (log.isTraceEnabled()) {
+                log.trace("using the default aggregator");
+            }
+            aggr = defaultAgg;
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("Key is " + key);
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace(key + "agg == " + (aggr == null) + " " + key.isDeleted());
+        }
+        return aggr;
+    }
+
+    /**
+     * Find Top method, will attempt to aggregate, iff an aggregator is specified
+     *
+     * @throws IOException
+     *             for issues with read/write
+     */
+    private void findTop() throws IOException {
+        // check if aggregation is needed
+        while (iterator.hasTop() && !aggregateRowColumn())
+            ;
+
+    }
+
+    /**
+     * SKVI Constructor
+     *
+     * @param iterator
+     *            an iterator
+     * @param Aggregators
+     *            mapping of aggregators
+     * @throws IOException
+     *             for issues with read/write
+     */
+    public PropogatingIterator(SortedKeyValueIterator<Key,Value> iterator, ColumnToClassMapping<Combiner> Aggregators) throws IOException {
+        this.iterator = iterator;
+        findTop();
+    }
+
+    @Override
+    public Key getTopKey() {
+        if (aggrKey != null) {
+            return aggrKey;
+        }
+        return iterator.getTopKey();
+    }
+
+    @Override
+    public Value getTopValue() {
+        if (aggrKey != null) {
+            return aggrValue;
+        }
+        return iterator.getTopValue();
+    }
+
+    @Override
+    public boolean hasTop() {
+        return aggrKey != null || iterator.hasTop();
+    }
+
+    @Override
+    public void next() throws IOException {
+        if (aggrKey != null) {
+            // if aggrKey isn't configured for aggregation, then we previously didn't call next and need to now
+            if (iterator.hasTop() && getAggregator(aggrKey) == null) {
+                iterator.next();
+            }
+            aggrKey = null;
+            aggrValue = null;
+        }
+        findTop();
+    }
+
+    @Override
+    public void seek(Range range, Collection<ByteSequence> columnFamilies, boolean inclusive) throws IOException {
+        if (aggrKey != null) {
+            aggrKey = null;
+            aggrValue = null;
+        }
+
+        Range seekRange = range;
+        // if there isn't an aggregator configured for the start key, timestamp modification isn't necessary
+        if (range.getStartKey() != null && getAggregator(range.getStartKey()) != null) {
+            // do not want to seek to the middle of a value that should be
+            // aggregated...
+            seekRange = IteratorUtil.maximizeStartKeyTimeStamp(range);
+        }
+
+        iterator.seek(seekRange, columnFamilies, inclusive);
+
+        findTop();
+
+        // (only if the range was modified) it's necessary to skip keys until the start key is found
+        if (seekRange != range) {
+            while (hasTop() && getTopKey().equals(range.getStartKey(), PartialKey.ROW_COLFAM_COLQUAL_COLVIS)
+                            && getTopKey().getTimestamp() > range.getStartKey().getTimestamp()) {
+                next();
+            }
+
+            while (hasTop() && range.beforeStartKey(getTopKey())) {
+
+                next();
+            }
+        }
+
+    }
+
+    @Override
+    public void init(SortedKeyValueIterator<Key,Value> source, Map<String,String> options, IteratorEnvironment env) throws IOException {
+        if (null != source)
+            this.iterator = source.deepCopy(env);
+        else
+            this.iterator = null;
+        this.env = env;
+        this.options.putAll(options);
+        validateOptions(options);
+
+    }
+
+    @Override
+    public IteratorOptions describeOptions() {
+
+        return new IteratorOptions(ATTRIBUTE_NAME, ATTRIBUTE_DESCRIPTION, defaultMapOptions, Collections.singletonList("<ColumnFamily> <Combiner>"));
+    }
+
+    @Override
+    public boolean validateOptions(Map<String,String> options) {
+        // fail if environment is null
+        Preconditions.checkNotNull(env);
+        Preconditions.checkNotNull(options);
+
+        // Don't propagate for either scan or full major compaction. In either case, the aggregated result has combined
+        // all existing values for a key so we don't need to propagate temporary state that is only used to combine
+        // partial results with new info.
+        shouldPropogate = !(env.getIteratorScope() == IteratorScope.majc && env.isFullMajorCompaction()) && !(env.getIteratorScope() == IteratorScope.scan);
+
+        PropogatingCombiner propAgg = null;
+
+        for (Entry<String,String> familyOption : options.entrySet()) {
+            Object agg = createAggregator(familyOption.getValue());
+            if (agg instanceof PropogatingCombiner) {
+                propAgg = PropogatingCombiner.class.cast(agg);
+                propAgg.setPropogate(shouldPropogate);
+                if (familyOption.getKey().equals(AGGREGATOR_DEFAULT) || familyOption.getKey().equals(AGGREGATOR_DEFAULT_OPT)) {
+                    if (log.isTraceEnabled())
+                        log.debug("Default aggregator is " + propAgg.getClass());
+                    defaultAgg = propAgg;
+                } else {
+                    aggMap.put(new ArrayByteSequence(familyOption.getKey().getBytes()), propAgg);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Create the aggregator using the provided options.
+     *
+     * @param className
+     *            name of the class
+     * @return an aggregator class
+     */
+    private Object createAggregator(String className) {
+        try {
+            return this.getClass().getClassLoader().loadClass(className).getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Exception while attempting to create : " + className, e);
+        }
+    }
+}

--- a/core/tables/src/main/java/datawave/iterators/TotalAggregatingIterator.java
+++ b/core/tables/src/main/java/datawave/iterators/TotalAggregatingIterator.java
@@ -1,0 +1,24 @@
+package datawave.iterators;
+
+import org.apache.accumulo.core.data.Key;
+
+import datawave.ingest.table.aggregator.TruncatingTimestampIterator;
+
+/**
+ *
+ * This is a propogating iterator that will truncate the key timestamps down to the begininning of the day. Currently this iterator is only used on index
+ * tables.
+ *
+ */
+
+public class TotalAggregatingIterator extends PropogatingIterator {
+    /**
+     * The only difference with this iterator is that the timestamps are truncated
+     */
+
+    @Override
+    public Key getTopKey() {
+        return TruncatingTimestampIterator.getTruncatedTimestampKey(super.getTopKey());
+    }
+
+}

--- a/core/tables/src/main/java/datawave/iterators/ValueCombiner.java
+++ b/core/tables/src/main/java/datawave/iterators/ValueCombiner.java
@@ -1,0 +1,90 @@
+package datawave.iterators;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.PartialKey;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.log4j.Logger;
+
+/**
+ *
+ * A Java Iterator that iterates over the Values for a given Key from a source SortedKeyValueIterator.
+ */
+public class ValueCombiner implements Iterator<Value> {
+    Key topKey;
+    SortedKeyValueIterator<Key,Value> source;
+    boolean hasNext;
+    PartialKey keysToCombine = PartialKey.ROW_COLFAM_COLQUAL_COLVIS;
+
+    private static final Logger log = Logger.getLogger(ValueCombiner.class);
+
+    /**
+     * Constructs an iterator over Values whose Keys are versions of the current topKey of the source SortedKeyValueIterator.
+     *
+     * @param source
+     *            The {@code SortedKeyValueIterator<Key,Value>} from which to read data.
+     */
+    public ValueCombiner(SortedKeyValueIterator<Key,Value> source) {
+        this(source, PartialKey.ROW_COLFAM_COLQUAL_COLVIS);
+    }
+
+    public ValueCombiner(SortedKeyValueIterator<Key,Value> source, PartialKey keysToCombine) {
+        this.source = source;
+        this.keysToCombine = keysToCombine;
+        topKey = new Key(source.getTopKey());
+        hasNext = _hasNext();
+    }
+
+    private boolean _hasNext() {
+        if (log.isTraceEnabled()) {
+            log.trace("source hastop ? " + source.hasTop() + " " + topKey);
+            if (source.hasTop())
+                log.trace(source.getTopKey());
+
+        }
+        return source.hasTop() && topKey.equals(source.getTopKey(), keysToCombine);
+    }
+
+    /**
+     * @return <code>true</code> if there is another Value
+     *
+     * @see java.util.Iterator#hasNext()
+     */
+    @Override
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    /**
+     * @return the next Value
+     *
+     * @see java.util.Iterator#next()
+     */
+    @Override
+    public Value next() {
+        if (!hasNext)
+            throw new NoSuchElementException();
+        Value topValue = new Value(source.getTopValue());
+        try {
+            source.next();
+            hasNext = _hasNext();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return topValue;
+    }
+
+    /**
+     * unsupported
+     *
+     * @see java.util.Iterator#remove()
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/tables/src/main/java/datawave/util/CompositeTimestamp.java
+++ b/core/tables/src/main/java/datawave/util/CompositeTimestamp.java
@@ -1,0 +1,212 @@
+package datawave.util;
+
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.TimeZone;
+
+/**
+ * The composite timestamp allows us to encode two values in the timestamp to be used in accumulo keys. The event date will take the first (right hand most) 46
+ * bits. The last 17 bits (except for the sign bit) will be used to encode how many days after the event date that we should base the ageoff on. If the
+ * timestamp is negative, then to calculate the values the complement is taken and then the two values are extracted. The ageoff is encoded as an age off delta
+ * which is the number of days after the event date.
+ */
+public class CompositeTimestamp {
+
+    // The number of bits for the event date
+    private static final int allocationForEventDate = 46;
+    // A mask for the event date
+    private static final long mask = -1L >>> (8 * 8 - allocationForEventDate);
+    // The max age off delta in days
+    private static final long maxDiff = (-1L << (allocationForEventDate + 1)) >>> (allocationForEventDate + 1);
+    // A useful constant
+    public static final long MILLIS_PER_DAY = 1000 * 60 * 60 * 24;
+
+    // A constant for an invalid timestamp
+    public static final long INVALID_TIMESTAMP = Long.MIN_VALUE;
+    // The minimum event date
+    public static final long MIN_EVENT_DATE = (0 - mask); // also equivalent to Long.MIN_VALUE + 1
+    // the maximum event date
+    public static final long MAX_EVENT_DATE = mask;
+
+    /**
+     * Determine if the timestamp is composite (i.e. non-zero age off delta)
+     *
+     * @param ts
+     * @return True if composite
+     */
+    public static boolean isCompositeTimestamp(long ts) {
+        validateTimestamp(ts);
+        return (Math.abs(ts) >>> allocationForEventDate > 0);
+    }
+
+    /**
+     * Get the event date portion of the timestamp
+     *
+     * @param ts
+     * @return the event date
+     */
+    public static long getEventDate(long ts) {
+        validateTimestamp(ts);
+        long eventTs = (Math.abs(ts) & mask);
+        if (ts < 0) {
+            eventTs = 0 - eventTs;
+        }
+        return eventTs;
+    }
+
+    /**
+     * Determine the age off date portion of the timestamp. This is the event date plus the ageoff delta converted to milliseconds.
+     *
+     * @param ts
+     * @return The age off date
+     */
+    public static long getAgeOffDate(long ts) {
+        validateTimestamp(ts);
+        long baseTs = Math.abs(ts);
+        long eventTs = (baseTs & mask);
+        long ageOffDiff = ((baseTs >>> allocationForEventDate) * MILLIS_PER_DAY);
+        if (ts < 0) {
+            eventTs = 0 - eventTs;
+        }
+        return eventTs + ageOffDiff;
+    }
+
+    /**
+     * Determine the age off delta porton of the timestamp. This is the number of days difference from the event date.
+     *
+     * @param ts
+     * @return the age off delta
+     */
+    public static int getAgeOffDeltaDays(long ts) {
+        validateTimestamp(ts);
+        long baseTs = Math.abs(ts);
+        long ageOffDiff = (baseTs >>> allocationForEventDate);
+        return (int) ageOffDiff;
+    }
+
+    /**
+     * Calculate an age off delta based on a timezone. This will calculate the begininning of the day in the given timezone for both the event date and the age
+     * off date, and then will return that difference in days.
+     *
+     * @param eventDate
+     * @param ageOffDate
+     * @param tz
+     * @return the age off delta
+     */
+    public static int computeAgeOffDeltaDays(long eventDate, long ageOffDate, TimeZone tz) {
+        validateEventDate(eventDate);
+        Calendar c = Calendar.getInstance(tz);
+        c.setTimeInMillis(eventDate);
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+        long eventDateStart = c.getTimeInMillis();
+
+        c.setTimeInMillis(ageOffDate);
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.set(Calendar.SECOND, 0);
+        c.set(Calendar.MILLISECOND, 0);
+        long ageOffDateStart = c.getTimeInMillis();
+
+        long delta = (ageOffDateStart - eventDateStart) / MILLIS_PER_DAY;
+        validateAgeOffDelta(delta);
+        return (int) delta;
+    }
+
+    /**
+     * Get the composite timestamp using the supplied event date and age off delta in days.
+     *
+     * @param eventDate
+     * @param ageOffDeltaDays
+     * @return The composite timestamp
+     */
+    public static long getCompositeDeltaTimeStamp(long eventDate, int ageOffDeltaDays) {
+        validateEventDate(eventDate);
+        validateAgeOffDelta(ageOffDeltaDays);
+        long eventBase = Math.abs(eventDate);
+        long compositeTS = ((long) ageOffDeltaDays << allocationForEventDate) | eventBase;
+        if (eventDate < 0) {
+            compositeTS = 0 - compositeTS;
+        }
+        return compositeTS;
+    }
+
+    /**
+     * Get the composite timestamp using the supplied eventDate and an age off delta in days based on the supplied age off date and time zone.
+     *
+     * @param eventDate
+     * @param ageOffDate
+     * @param tz
+     * @return The composite timestamp
+     */
+    public static long getCompositeTimeStamp(long eventDate, long ageOffDate, TimeZone tz) {
+        return getCompositeDeltaTimeStamp(eventDate, computeAgeOffDeltaDays(eventDate, ageOffDate, tz));
+    }
+
+    /**
+     * Get the composite timestamp using the supplied eventDate and an age off delta in days based on the supplied age off date using the GMT timezone
+     *
+     * @param eventDate
+     * @param ageOffDate
+     * @return The composite timestamp
+     */
+    public static long getCompositeTimeStamp(long eventDate, long ageOffDate) {
+        return getCompositeTimeStamp(eventDate, ageOffDate, TimeZone.getTimeZone("GMT"));
+    }
+
+    /**
+     * Return a comparator for composite timestamps. Orders firstly on the event date, and if equal then on the ageoff date. Note for values with the same event
+     * date, the timestamps will order naturally for positive event dates, but need to be reversed for negative event dates. This should only be an issue for
+     * the global index and hence this comparator can be used in that case.
+     *
+     * @return a comparison of the timestamps
+     */
+    public static Comparator<Long> comparator() {
+        return (o1, o2) -> {
+            long eventDate1 = CompositeTimestamp.getEventDate(o1);
+            long eventDate2 = CompositeTimestamp.getEventDate(o2);
+            if (eventDate1 < eventDate2) {
+                return -1;
+            } else if (eventDate1 == eventDate2) {
+                long ageOffDate1 = CompositeTimestamp.getAgeOffDate(o1);
+                long ageOffDate2 = CompositeTimestamp.getAgeOffDate(o2);
+                if (ageOffDate1 < ageOffDate2) {
+                    return -1;
+                } else if (ageOffDate1 == ageOffDate2) {
+                    return 0;
+                } else {
+                    return 1;
+                }
+            } else {
+                return 1;
+            }
+        };
+    }
+
+    private static void validateTimestamp(long ts) {
+        if (ts == INVALID_TIMESTAMP) {
+            throw new IllegalArgumentException("Invalid timestamp");
+        }
+    }
+
+    private static void validateEventDate(long eventDate) {
+        if (eventDate < MIN_EVENT_DATE) {
+            throw new IllegalArgumentException("Event date cannot be less than " + MIN_EVENT_DATE);
+        }
+        if (eventDate > MAX_EVENT_DATE) {
+            throw new IllegalArgumentException("Event Date cannot be greater than " + MAX_EVENT_DATE);
+        }
+    }
+
+    private static void validateAgeOffDelta(long ageOffDeltaDays) {
+        if (ageOffDeltaDays < 0) {
+            throw new IllegalArgumentException("Age off date must be greater to or equal to the event date");
+        }
+        if (ageOffDeltaDays > maxDiff) {
+            throw new IllegalArgumentException("Difference between event date and age off date cannot be more than " + maxDiff + " days");
+        }
+    }
+
+}


### PR DESCRIPTION
A core module that creates a shard index needs GlobalIndexUidAggregator and TotalAggregatingIterator to scan it: the aggregator is what merges the single-uid entries that collide within a shard, and a scan of a table configured with it fails to load the class otherwise. Both lived only in warehouse/ingest-core, which a core module cannot depend on.

The seven files are byte-identical to their originals in warehouse/ingest-core and warehouse/core, so a diff detects drift.