### PR TITLE
Remove JVM-wide lock from DatawaveArithmetic.matchesFst

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveArithmetic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/DatawaveArithmetic.java
@@ -26,8 +26,6 @@ public abstract class DatawaveArithmetic extends JexlArithmetic {
 
     private static final Logger log = Logger.getLogger(DatawaveArithmetic.class);
 
-    private static final Object LOCK = new Object();
-
     /**
      * Default to being lenient so we don't have to add "null" for every field in the query that doesn't exist in the document
      */
@@ -315,13 +313,25 @@ public abstract class DatawaveArithmetic extends JexlArithmetic {
         return false;
     }
 
+    /**
+     * Tests whether the string form of the given object is accepted by the FST.
+     * <p>
+     * Deliberately unsynchronized. A fully built {@link FST} is immutable and {@link FST#getBytesReader()} allocates a fresh reader on every call, so
+     * concurrent lookups against a shared FST are safe. Guarding this with a shared monitor serializes every scan thread in the JVM.
+     *
+     * @param object
+     *            the value to look up
+     * @param fst
+     *            a fully built FST
+     * @return true if the value is accepted by the FST
+     * @throws IOException
+     *             if the FST cannot be read
+     */
     public static boolean matchesFst(Object object, FST fst) throws IOException {
         final IntsRefBuilder irBuilder = new IntsRefBuilder();
         Util.toUTF16(object.toString(), irBuilder);
         final IntsRef ints = irBuilder.get();
-        synchronized (LOCK) {
-            return Util.get(fst, ints) != null;
-        }
+        return Util.get(fst, ints) != null;
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/DatawaveArithmeticTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/DatawaveArithmeticTest.java
@@ -1,0 +1,88 @@
+package datawave.query.jexl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.util.fst.FST;
+import org.junit.jupiter.api.Test;
+
+import datawave.core.iterators.DatawaveFieldIndexListIteratorJexl;
+
+class DatawaveArithmeticTest {
+
+    private static final int THREADS = 8;
+    private static final int LOOKUPS_PER_THREAD = 2000;
+
+    private static final String[] PRESENT = {"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"};
+    private static final String[] ABSENT = {"alph", "alphaa", "bravo1", "india", "juliett", "", "zulu", "Charlie"};
+
+    @Test
+    void testMatchesFst() throws Exception {
+        FST<?> fst = buildFst();
+
+        for (String value : PRESENT) {
+            assertTrue(DatawaveArithmetic.matchesFst(value, fst), "expected a match for " + value);
+        }
+        for (String value : ABSENT) {
+            assertFalse(DatawaveArithmetic.matchesFst(value, fst), "expected no match for " + value);
+        }
+    }
+
+    /**
+     * Hammers a single shared FST from several threads at once. This would also pass while matchesFst held a lock -- its purpose is to guard the correctness of
+     * the unlocked lookup path, so that the JVM-wide monitor that used to serialize every scan thread is not reintroduced.
+     */
+    @Test
+    void testMatchesFstIsThreadSafe() throws Exception {
+        final FST<?> fst = buildFst();
+        final CountDownLatch startGate = new CountDownLatch(1);
+        final ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+
+        try {
+            List<Future<Integer>> futures = new ArrayList<>(THREADS);
+            for (int t = 0; t < THREADS; t++) {
+                futures.add(executor.submit(() -> {
+                    startGate.await();
+                    int lookups = 0;
+                    for (int i = 0; i < LOOKUPS_PER_THREAD; i++) {
+                        String present = PRESENT[i % PRESENT.length];
+                        String absent = ABSENT[i % ABSENT.length];
+                        assertTrue(DatawaveArithmetic.matchesFst(present, fst), "expected a match for " + present);
+                        assertFalse(DatawaveArithmetic.matchesFst(absent, fst), "expected no match for " + absent);
+                        lookups++;
+                    }
+                    return lookups;
+                }));
+            }
+
+            startGate.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(60, TimeUnit.SECONDS), "threads did not finish in time");
+
+            // get() rethrows anything that escaped a worker
+            for (Future<Integer> future : futures) {
+                assertEquals(LOOKUPS_PER_THREAD, future.get().intValue());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private FST<?> buildFst() throws Exception {
+        SortedSet<String> values = new TreeSet<>();
+        Collections.addAll(values, PRESENT);
+        return DatawaveFieldIndexListIteratorJexl.getFST(values);
+    }
+}


### PR DESCRIPTION
A fully built Lucene FST is immutable and getBytesReader() allocates a fresh reader per call, so the shared monitor added for SonarQube S2445 bought no safety while serializing every tserver scan thread on the FST list path.