### PR TITLE
Fix query span locking in LogTiming and QuerySpanCollector

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/function/LogTiming.java
+++ b/warehouse/query-core/src/main/java/datawave/query/function/LogTiming.java
@@ -21,17 +21,17 @@ public class LogTiming implements Function<Entry<Key,Document>,Entry<Key,Documen
 
     public static final String TIMING_METADATA = "TIMING_METADATA";
     protected QuerySpan spanRunner;
-    private static String host = null;
     private static Logger log = Logger.getLogger(QuerySpan.class);
-
-    private static final Object LOCK = new Object();
+    private static final String host;
 
     static {
+        String canonicalHostName = null;
         try {
-            host = InetAddress.getLocalHost().getCanonicalHostName();
+            canonicalHostName = InetAddress.getLocalHost().getCanonicalHostName();
         } catch (UnknownHostException e) {
             log.error(e.getMessage(), e);
         }
+        host = canonicalHostName;
     }
 
     public LogTiming(QuerySpan spanRunner) {
@@ -45,31 +45,39 @@ public class LogTiming implements Function<Entry<Key,Document>,Entry<Key,Documen
         return entry;
     }
 
+    /**
+     * Adds a {@link TimingMetadata} attribute to the document from the current values of the query span, then resets the span.
+     * <p>
+     * The query span must be confined to the calling thread; this method deliberately does not lock.
+     *
+     * @param document
+     *            the document to annotate, may be null
+     * @param querySpan
+     *            a thread-confined query span, may be null
+     */
     public static void addTimingMetadata(Document document, QuerySpan querySpan) {
 
         if (document != null && querySpan != null) {
             TimingMetadata timingMetadata = new TimingMetadata();
-            synchronized (LOCK) {
-                timingMetadata.setHost(host);
-                timingMetadata.setSourceCount(querySpan.getSourceCount());
-                timingMetadata.setSeekCount(querySpan.getSeekCount());
-                timingMetadata.setNextCount(querySpan.getNextCount());
-                if (querySpan.getYield()) {
-                    timingMetadata.setYieldCount(1L);
-                } else {
-                    timingMetadata.setYieldCount(0L);
-                }
-
-                long totalStageTimers = querySpan.getStageTimerTotal();
-                // do not report timers that are less than 5% of the total
-                double threshold = totalStageTimers * 0.05;
-                for (Entry<String,Long> e : querySpan.getStageTimers().entrySet()) {
-                    if (e.getValue().longValue() >= threshold) {
-                        timingMetadata.addStageTimer(e.getKey(), new Numeric(e.getValue(), document.getMetadata(), document.isToKeep()));
-                    }
-                }
-                querySpan.reset();
+            timingMetadata.setHost(host);
+            timingMetadata.setSourceCount(querySpan.getSourceCount());
+            timingMetadata.setSeekCount(querySpan.getSeekCount());
+            timingMetadata.setNextCount(querySpan.getNextCount());
+            if (querySpan.getYield()) {
+                timingMetadata.setYieldCount(1L);
+            } else {
+                timingMetadata.setYieldCount(0L);
             }
+
+            long totalStageTimers = querySpan.getStageTimerTotal();
+            // do not report timers that are less than 5% of the total
+            double threshold = totalStageTimers * 0.05;
+            for (Entry<String,Long> e : querySpan.getStageTimers().entrySet()) {
+                if (e.getValue().longValue() >= threshold) {
+                    timingMetadata.addStageTimer(e.getKey(), new Numeric(e.getValue(), document.getMetadata(), document.isToKeep()));
+                }
+            }
+            querySpan.reset();
             document.put(TIMING_METADATA, timingMetadata);
         }
     }

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/profile/QuerySpanCollector.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/profile/QuerySpanCollector.java
@@ -9,12 +9,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.log4j.Logger;
 
 public class QuerySpanCollector {
-    private AtomicLong seekCount = new AtomicLong();
-    private AtomicLong nextCount = new AtomicLong();
-    private AtomicBoolean yield = new AtomicBoolean();
-    private AtomicLong sourceCount = new AtomicLong();
-    private Map<String,Long> stageTimers = new LinkedHashMap<>();
-    private Logger log = Logger.getLogger(QuerySpan.class);
+    private final AtomicLong seekCount = new AtomicLong();
+    private final AtomicLong nextCount = new AtomicLong();
+    private final AtomicBoolean yield = new AtomicBoolean();
+    private final AtomicLong sourceCount = new AtomicLong();
+    private final Map<String,Long> stageTimers = new LinkedHashMap<>();
+    private final Logger log = Logger.getLogger(QuerySpan.class);
 
     public void addQuerySpan(QuerySpan querySpan) {
 
@@ -62,6 +62,7 @@ public class QuerySpanCollector {
                     combinedQuerySpan.setSeek(this.seekCount.getAndSet(0));
                     combinedQuerySpan.setYield(this.yield.getAndSet(false));
                     combinedQuerySpan.setSourceCount(this.sourceCount.getAndSet(0));
+                    // setStageTimers copies the entries into the QuerySpan's own map, so clearing ours afterwards is safe
                     combinedQuerySpan.setStageTimers(this.stageTimers);
                     this.stageTimers.clear();
                 } else {
@@ -76,7 +77,7 @@ public class QuerySpanCollector {
         return combinedQuerySpan;
     }
 
-    public boolean hasEntries() {
+    public synchronized boolean hasEntries() {
         if (this.seekCount.intValue() > 0 || this.nextCount.intValue() > 0 || this.yield.get() || this.sourceCount.intValue() > 0
                         || !this.stageTimers.isEmpty()) {
             return true;
@@ -136,8 +137,15 @@ public class QuerySpanCollector {
         return sourceCount.longValue();
     }
 
+    /**
+     * An unmodifiable snapshot of the accumulated stage timers, in insertion order.
+     *
+     * @return a copy of the stage timers, unaffected by subsequent mutation of this collector
+     */
     public Map<String,Long> getStageTimers() {
-        return Collections.unmodifiableMap(stageTimers);
+        synchronized (this) {
+            return Collections.unmodifiableMap(new LinkedHashMap<>(stageTimers));
+        }
     }
 
 }

--- a/warehouse/query-core/src/test/java/datawave/query/function/LogTimingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/function/LogTimingTest.java
@@ -1,0 +1,58 @@
+package datawave.query.function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.query.attributes.Document;
+import datawave.query.attributes.TimingMetadata;
+import datawave.query.iterator.profile.QuerySpan;
+
+class LogTimingTest {
+
+    @Test
+    void testAddTimingMetadataRecordsSpanAndResetsIt() {
+        Document document = new Document();
+        QuerySpan querySpan = new QuerySpan(null);
+        querySpan.seek();
+        querySpan.next();
+        querySpan.next();
+        querySpan.yield();
+        querySpan.addStageTimer(QuerySpan.Stage.Aggregation, 100L);
+        // below the five percent threshold, so it should not be reported
+        querySpan.addStageTimer(QuerySpan.Stage.DocumentEvaluation, 1L);
+
+        LogTiming.addTimingMetadata(document, querySpan);
+
+        TimingMetadata timingMetadata = assertInstanceOf(TimingMetadata.class, document.get(LogTiming.TIMING_METADATA));
+        assertEquals(1L, timingMetadata.getSeekCount());
+        assertEquals(2L, timingMetadata.getNextCount());
+        assertEquals(1L, timingMetadata.getSourceCount());
+        assertEquals(1L, timingMetadata.getYieldCount());
+
+        Map<String,Long> stageTimers = timingMetadata.getStageTimers();
+        assertEquals(1, stageTimers.size());
+        assertEquals(100L, stageTimers.get(QuerySpan.Stage.Aggregation.name()).longValue());
+
+        assertEquals(0L, querySpan.getSeekCount());
+        assertEquals(0L, querySpan.getNextCount());
+        assertEquals(0L, querySpan.getSourceCount());
+        assertFalse(querySpan.getYield());
+        assertTrue(querySpan.getStageTimers().isEmpty());
+    }
+
+    @Test
+    void testAddTimingMetadataIgnoresNullArguments() {
+        Document document = new Document();
+
+        LogTiming.addTimingMetadata(document, null);
+        LogTiming.addTimingMetadata(null, new QuerySpan(null));
+
+        assertFalse(document.getDictionary().containsKey(LogTiming.TIMING_METADATA));
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/iterator/profile/QuerySpanCollectorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/iterator/profile/QuerySpanCollectorTest.java
@@ -1,0 +1,90 @@
+package datawave.query.iterator.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class QuerySpanCollectorTest {
+
+    @Test
+    void testGetStageTimersReturnsSnapshot() {
+        QuerySpanCollector collector = new QuerySpanCollector();
+        collector.addQuerySpan(spanWith(QuerySpan.Stage.Aggregation, 100L));
+
+        Map<String,Long> snapshot = collector.getStageTimers();
+        assertEquals(1, snapshot.size());
+        assertEquals(100L, snapshot.get(QuerySpan.Stage.Aggregation.name()).longValue());
+
+        collector.addQuerySpan(spanWith(QuerySpan.Stage.DocumentEvaluation, 50L));
+
+        // the previously returned map is a copy and must not observe the new entry
+        assertEquals(1, snapshot.size());
+        assertEquals(100L, snapshot.get(QuerySpan.Stage.Aggregation.name()).longValue());
+
+        assertEquals(2, collector.getStageTimers().size());
+    }
+
+    @Test
+    void testGetStageTimersIsUnmodifiable() {
+        QuerySpanCollector collector = new QuerySpanCollector();
+        collector.addQuerySpan(spanWith(QuerySpan.Stage.Aggregation, 100L));
+
+        Map<String,Long> stageTimers = collector.getStageTimers();
+        assertThrows(UnsupportedOperationException.class, () -> stageTimers.put(QuerySpan.Stage.PostProcessing.name(), 1L));
+    }
+
+    @Test
+    void testGetStageTimersIsSafeToIterateWhileCollecting() throws Exception {
+        QuerySpanCollector collector = new QuerySpanCollector();
+        QuerySpan.Stage[] stages = QuerySpan.Stage.values();
+        int iterations = 5000;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(6);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (int writer = 0; writer < 4; writer++) {
+                futures.add(executorService.submit(() -> {
+                    for (int i = 0; i < iterations; i++) {
+                        collector.addQuerySpan(spanWith(stages[i % stages.length], 1L));
+                    }
+                }));
+            }
+            // repeatedly drain the collector so that the stage timer map is structurally modified while it is read
+            futures.add(executorService.submit(() -> {
+                for (int i = 0; i < iterations; i++) {
+                    collector.getCombinedQuerySpan(null, true);
+                }
+            }));
+            // any ConcurrentModificationException here surfaces via Future.get below
+            futures.add(executorService.submit(() -> {
+                for (int i = 0; i < iterations; i++) {
+                    for (Map.Entry<String,Long> entry : collector.getStageTimers().entrySet()) {
+                        assertTrue(entry.getValue() >= 0);
+                    }
+                }
+            }));
+
+            for (Future<?> future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private QuerySpan spanWith(QuerySpan.Stage stage, long elapsed) {
+        QuerySpan querySpan = new QuerySpan(null);
+        querySpan.addStageTimer(stage, elapsed);
+        return querySpan;
+    }
+}


### PR DESCRIPTION
Drop the JVM-wide mutex in LogTiming, whose callers all pass a thread-confined span, and return a defensive copy from QuerySpanCollector.getStageTimers so callers cannot observe the backing map being mutated or cleared.