### PR TITLE
Narrow date ranges in the composite index tests

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/CompositeIndexTest.java
@@ -108,11 +108,13 @@ public class CompositeIndexTest extends AbstractQueryTest {
     private static final String formatPattern = "yyyyMMdd HHmmss.SSS";
     private static final SimpleDateFormat formatter = new SimpleDateFormat(formatPattern);
 
-    private static final String LEGACY_BEGIN_DATE = "20000101 000000.000";
+    // the legacy data sits on the three days immediately before the composite transition date, and the composite data on the three days from it, so that a
+    // query spanning the transition covers only six shard days rather than two years' worth
+    private static final String LEGACY_BEGIN_DATE = "20001229 000000.000";
     private static final String COMPOSITE_BEGIN_DATE = "20010101 000000.000";
 
-    private static final String BEGIN_DATE = "20000101 000000.000";
-    private static final String END_DATE = "20020101 000000.000";
+    private static final String BEGIN_DATE = "20001229 000000.000";
+    private static final String END_DATE = "20010103 235959.999";
 
     private static final Configuration conf = new Configuration();
 
@@ -134,8 +136,8 @@ public class CompositeIndexTest extends AbstractQueryTest {
 
     private static final long[] legacyDates = {
             0,
-            TimeUnit.DAYS.toMillis(90),
-            TimeUnit.DAYS.toMillis(180),
+            TimeUnit.DAYS.toMillis(1),
+            TimeUnit.DAYS.toMillis(2),
             0};
 
     private static final String[] wktCompositeData = {
@@ -166,16 +168,16 @@ public class CompositeIndexTest extends AbstractQueryTest {
 
     private static final long[] compositeDates = {
             0,
-            TimeUnit.DAYS.toMillis(90),
+            TimeUnit.DAYS.toMillis(1),
 
-            TimeUnit.DAYS.toMillis(180),
+            TimeUnit.DAYS.toMillis(2),
             0,
 
-            TimeUnit.DAYS.toMillis(90),
-            TimeUnit.DAYS.toMillis(180),
+            TimeUnit.DAYS.toMillis(1),
+            TimeUnit.DAYS.toMillis(2),
 
             0,
-            TimeUnit.DAYS.toMillis(90)};
+            TimeUnit.DAYS.toMillis(1)};
     // @formatter:on
 
     @Autowired
@@ -476,8 +478,9 @@ public class CompositeIndexTest extends AbstractQueryTest {
 
         ShardQueryLogic rangeLogic = getShardQueryLogic(true);
         if (!rangeLogic.isUseDocumentScheduler()) {
+            // the ivarator forces a full scan of the query's date range: six shard days at NUM_SHARDS shards apiece
             List<QueryData> queries = getQueryRanges(rangeLogic, query);
-            assertEquals(2196, queries.size());
+            assertEquals(6 * NUM_SHARDS, queries.size());
         }
 
         runGeoQuery(rangeLogic, query, 9);

--- a/warehouse/query-core/src/test/java/datawave/query/planner/MultiValueCompositeIndexTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/MultiValueCompositeIndexTest.java
@@ -105,8 +105,9 @@ public class MultiValueCompositeIndexTest extends AbstractQueryTest {
 
     private static final String COMPOSITE_BEGIN_DATE = "20010101 000000.000";
 
-    private static final String BEGIN_DATE = "20000101 000000.000";
-    private static final String END_DATE = "20020101 000000.000";
+    // every event is ingested at COMPOSITE_BEGIN_DATE, so the query only needs to cover that single shard day
+    private static final String BEGIN_DATE = "20010101 000000.000";
+    private static final String END_DATE = "20010101 235959.999";
 
     private static final Configuration conf = new Configuration();
 
@@ -417,7 +418,8 @@ public class MultiValueCompositeIndexTest extends AbstractQueryTest {
             if (logic.isUseShardedIndex()) {
                 assertEquals(2, queries.size());
             } else {
-                assertEquals(2196, queries.size());
+                // the ivarator forces a full scan of the query's date range: one shard day at NUM_SHARDS shards
+                assertEquals(NUM_SHARDS, queries.size());
             }
         }
 


### PR DESCRIPTION
Both tests queried a two-year span, so the ivarator cases expanded to 2196 shard ranges to cover data occupying only a handful of days. Packing the events onto adjacent days around the composite transition date cuts the combined runtime from 448s to 29s.