### PR TITLE
Match MemKey's equality contract in InMemoryMemKey

### DIFF
--- a/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryTable.java
+++ b/core/in-memory-accumulo/src/main/java/datawave/accumulo/inmemory/InMemoryTable.java
@@ -50,15 +50,10 @@ public class InMemoryTable {
             this.count = count;
         }
 
-        @Override
-        public int hashCode() {
-            return super.hashCode() + count;
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            return (other instanceof InMemoryMemKey) && super.equals(other) && count == ((InMemoryMemKey) other).count;
-        }
+        // equals and hashCode are deliberately not overridden, matching the tablet server's MemKey, which overrides only compareTo. Folding the mutation
+        // count into equality broke the symmetry Key.equals promises: memKey.equals(plainKey) was false while plainKey.equals(memKey) was true, and a
+        // MemKey never matched an equal plain Key in a HashSet or HashMap. User iterators see these keys directly, so they saw the asymmetry too. The
+        // count still participates in compareTo below, which is what orders newest-first for the versioning iterator.
 
         @Override
         public String toString() {


### PR DESCRIPTION
The tablet server's MemKey overrides only compareTo; it inherits equals and hashCode from Key, which compare the key fields and ignore the mutation count. InMemoryMemKey additionally overrode both, folding the count into equality and requiring the argument to be an InMemoryMemKey.

That broke the symmetry Key.equals promises. memKey.equals(plainKey) was false while plainKey.equals(memKey) was true, and a MemKey never matched an otherwise equal plain Key in a HashSet or HashMap. Real Accumulo hands MemKeys to user iterators too, so exposure was never the divergence - the semantics were. Any iterator deduplicating or map-keying on keys behaved differently here than in production.

compareTo is left alone: the count still sorts newest-first, which is what the versioning iterator relies on, and the table is a ConcurrentSkipListMap, so ordering rather than equality governs storage.