### PR TITLE
More efficient output committer in the expected case

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SafeFileOutputCommitter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SafeFileOutputCommitter.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileExistsException;
+import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -80,14 +81,27 @@ public class SafeFileOutputCommitter extends FileOutputCommitter {
         if (checkForEmptyDir && super.getOutputPath() != null) {
             Path pendingJobAttemptsPath = getPendingJobAttemptsPath();
             FileSystem fs = pendingJobAttemptsPath.getFileSystem(context.getConfiguration());
-            // now verify we do not have any files left in the temporary directory structure
-            List<Path> fileList = new ArrayList<>();
-            boolean containsPendingFiles = containsFiles(fs, pendingJobAttemptsPath, fileList, lenientMode);
+            boolean isTempDirEmpty = false;
 
-            if (containsPendingFiles && lenientMode) {
-                verifyRemainingTemporaryFilesByName(fs, fileList);
-            } else if (containsPendingFiles) {
-                throw new FileExistsException("Found files still left in the temporary job attempts path: " + fileList);
+            try {
+                ContentSummary summary = fs.getContentSummary(pendingJobAttemptsPath);
+                if (summary.getFileCount() == 0) {
+                    isTempDirEmpty = true;
+                }
+            } catch (FileNotFoundException e) {
+                isTempDirEmpty = true;
+            }
+
+            if (!isTempDirEmpty) {
+                // now verify we do not have any files left in the temporary directory structure
+                List<Path> fileList = new ArrayList<>();
+                boolean containsPendingFiles = containsFiles(fs, pendingJobAttemptsPath, fileList, lenientMode);
+
+                if (containsPendingFiles && lenientMode) {
+                    verifyRemainingTemporaryFilesByName(fs, fileList);
+                } else if (containsPendingFiles) {
+                    throw new FileExistsException("Found files still left in the temporary job attempts path: " + fileList);
+                }
             }
         }
         super.cleanupJob(context);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SafeFileOutputCommitter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SafeFileOutputCommitter.java
@@ -90,7 +90,7 @@ public class SafeFileOutputCommitter extends FileOutputCommitter {
                 }
             } catch (FileNotFoundException e) {
                 // Protect against a FNFE on any intermediate dirs
-                isTempDirEmpty = fs.exists(pendingJobAttemptsPath);
+                isTempDirEmpty = !fs.exists(pendingJobAttemptsPath);
             }
 
             if (!isTempDirEmpty) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SafeFileOutputCommitter.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/SafeFileOutputCommitter.java
@@ -89,7 +89,8 @@ public class SafeFileOutputCommitter extends FileOutputCommitter {
                     isTempDirEmpty = true;
                 }
             } catch (FileNotFoundException e) {
-                isTempDirEmpty = true;
+                // Protect against a FNFE on any intermediate dirs
+                isTempDirEmpty = fs.exists(pendingJobAttemptsPath);
             }
 
             if (!isTempDirEmpty) {


### PR DESCRIPTION
Our safe file output committer is doing a very inefficient file listing of the _temporary directories - basically one path at a time, then add the children, then list those, then add those children... etc. 

Note that `fs.listFiles(dir, recursive)` is actually the same operation - client side, one dir at a time walking. For a large cluster with many reducers and many tables, you can hit the namenode with many requests. 

This patch will do a server-side `getContentSummary` which is a single request. The expected case is 0 files and we can early terminate there. If there are files, THEN we spend the effort to the do drill down.