### PR TITLE
Preserve all authorization sets in DocumentScheduler

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
@@ -43,7 +43,7 @@ public class DocumentRangeScan implements RunnableWithContext {
 
     private final KeyWithContext keyWithContext;
     private final DocumentScannerConfig config;
-    private final Authorizations auths;
+    private final Set<Authorizations> auths;
 
     private final long resultQueueOfferTimeMillis;
     private final BlockingQueue<Result> resultQueue;

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScannerConfig.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScannerConfig.java
@@ -1,6 +1,7 @@
 package datawave.next.scanner;
 
 import java.io.Serializable;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,7 +27,10 @@ public class DocumentScannerConfig implements Serializable {
     private static final long serialVersionUID = 404271911443485394L;
 
     private AccumuloClient client;
-    private Authorizations authorizations;
+
+    // the full set of authorizations for the calling entity chain. Every set must be applied, so this must not be
+    // collapsed to a single Authorizations -- see ScannerHelper#createScanner and AuthorizationsMinimizer#minimize
+    private Set<Authorizations> authorizations;
     private transient BlockingQueue<KeyWithContext> candidateQueue;
     private transient BlockingQueue<Result> results;
     private transient ContextThreadFactory searchThreadFactory;
@@ -100,11 +104,11 @@ public class DocumentScannerConfig implements Serializable {
         this.client = client;
     }
 
-    public Authorizations getAuthorizations() {
+    public Set<Authorizations> getAuthorizations() {
         return authorizations;
     }
 
-    public void setAuthorizations(Authorizations authorizations) {
+    public void setAuthorizations(Set<Authorizations> authorizations) {
         this.authorizations = authorizations;
     }
 

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScheduler.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScheduler.java
@@ -22,7 +22,6 @@ import datawave.query.scheduler.Scheduler;
 import datawave.query.tables.ScannerFactory;
 import datawave.query.tables.async.event.VisitorFunction;
 import datawave.query.tables.stats.ScanSessionStats;
-import datawave.security.util.AuthorizationsMinimizer;
 
 /**
  * An alternate to the {@link PushdownScheduler} that splits query execution into two stages, finding documents and aggregating documents.
@@ -42,7 +41,9 @@ public class DocumentScheduler extends Scheduler {
     public DocumentScheduler(ShardQueryConfiguration config) {
         this.config = config.getDocumentScannerConfig();
         this.config.setClient(config.getClient());
-        this.config.setAuthorizations(AuthorizationsMinimizer.minimize(config.getAuthorizations()).iterator().next());
+        // the full set is required. ScannerHelper applies the first set to the scanner and installs a visibility
+        // filter for each remaining set, which is how data is restricted to what the whole entity chain may see
+        this.config.setAuthorizations(config.getAuthorizations());
         this.config.setQueryId(config.getQuery().getId().toString());
 
         this.queryDataIterator = config.getQueriesIter();

--- a/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentSchedulerAuthorizationsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentSchedulerAuthorizationsTest.java
@@ -1,0 +1,67 @@
+package datawave.next.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.Test;
+
+import datawave.microservice.query.QueryImpl;
+import datawave.query.config.ShardQueryConfiguration;
+
+/**
+ * Verifies that the {@link DocumentScheduler} preserves the full set of authorizations for the calling entity chain.
+ * <p>
+ * Every set produced by {@link datawave.security.util.AuthorizationsMinimizer#minimize(java.util.Collection)} must reach the scanner. The first set is applied
+ * to the scanner itself and each remaining set becomes a visibility filter, which is what restricts results to data visible to every entity in the chain.
+ */
+public class DocumentSchedulerAuthorizationsTest {
+
+    /**
+     * Two authorization sets where neither is a subset of the other, so minimization cannot reduce them to one.
+     */
+    private static final Authorizations USER_AUTHS = new Authorizations("A", "B", "ORG1");
+    private static final Authorizations SERVER_AUTHS = new Authorizations("A", "C", "ORG2");
+
+    @Test
+    public void testMultipleAuthorizationSetsSurviveSchedulerConstruction() {
+        Set<Authorizations> auths = Set.of(USER_AUTHS, SERVER_AUTHS);
+        ShardQueryConfiguration config = createConfig(auths);
+
+        new DocumentScheduler(config);
+
+        Set<Authorizations> applied = config.getDocumentScannerConfig().getAuthorizations();
+        assertEquals(2, applied.size(), "both authorization sets must reach the scanner");
+        assertTrue(applied.contains(USER_AUTHS));
+        assertTrue(applied.contains(SERVER_AUTHS));
+    }
+
+    @Test
+    public void testSingleAuthorizationSetIsPreserved() {
+        Set<Authorizations> auths = Set.of(USER_AUTHS);
+        ShardQueryConfiguration config = createConfig(auths);
+
+        new DocumentScheduler(config);
+
+        Set<Authorizations> applied = config.getDocumentScannerConfig().getAuthorizations();
+        assertEquals(1, applied.size());
+        assertTrue(applied.contains(USER_AUTHS));
+    }
+
+    private ShardQueryConfiguration createConfig(Set<Authorizations> auths) {
+        ShardQueryConfiguration config = new ShardQueryConfiguration();
+        config.setDocumentScannerConfig(new DocumentScannerConfig());
+        config.setAuthorizations(auths);
+        config.setQueries(List.of());
+
+        QueryImpl query = new QueryImpl();
+        query.setId(UUID.randomUUID());
+        config.setQuery(query);
+
+        return config;
+    }
+}


### PR DESCRIPTION
The scheduler collapsed the minimized authorizations to a single set, so ScannerBuilder had nothing left to install as visibility filters and results were restricted to only one entity in the calling chain.