### PR TITLE
Ingest field helper lookup cache

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/XMLFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/XMLFieldConfigHelper.java
@@ -33,15 +33,23 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     /** be explicit and use Apache Xerces-J here instead of relying on java to plug in the proper parser */
     private static final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
 
-    private boolean noMatchStored = true;
-    private boolean noMatchIndexed = false;
-    private boolean noMatchReverseIndexed = false;
-    private boolean noMatchTokenized = false;
-    private boolean noMatchReverseTokenized = false;
+    private final FieldInfo noMatchFieldInfo = new FieldInfo(true, false, false, false, false);
     private String noMatchFieldType = null;
 
     private final String configSource;
     private final Map<String,FieldInfo> knownFields = new HashMap<>();
+    /**
+     * Memoizes the fully resolved FieldInfo per field name, including pattern matches and no-match results. Not thread-safe: instances are confined to a single
+     * thread.
+     */
+    private final Map<String,FieldInfo> resolvedFields = new HashMap<>();
+    /**
+     * Single-entry "last field looked up" cache in front of {@link #resolvedFields}. Ingest call sites query the same field name several times in a row (once
+     * per {@code is*Field} accessor), so checking these two fields first skips the hash probe on repeat lookups. Relies on the same thread confinement as
+     * {@link #resolvedFields}.
+     */
+    private String previousFieldName;
+    private FieldInfo previousFieldInfo;
     private TreeMap<Matcher,String> patterns = new TreeMap<>(new BaseIngestHelper.MatcherComparator());
 
     private static final String UNEXPECTED_ATTRIBUTE = "Unexpected attribute encountered in: ";
@@ -52,6 +60,16 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
         boolean reverseIndexed;
         boolean tokenized;
         boolean reverseTokenized;
+
+        FieldInfo() {}
+
+        FieldInfo(boolean stored, boolean indexed, boolean reverseIndexed, boolean tokenized, boolean reverseTokenized) {
+            this.stored = stored;
+            this.indexed = indexed;
+            this.reverseIndexed = reverseIndexed;
+            this.tokenized = tokenized;
+            this.reverseTokenized = reverseTokenized;
+        }
     }
 
     /**
@@ -103,8 +121,8 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
 
     public String toString() {
         return "[FieldConfigHelper: " + knownFields.size() + " known fields, " + patterns.size() + " of those are patterns, " + "nomatch, indexed:"
-                        + noMatchIndexed + " reverseIndexed:" + noMatchReverseIndexed + " tokenized:" + noMatchTokenized + " reverseTokenized:"
-                        + noMatchReverseTokenized + "]";
+                        + isNoMatchIndexed() + " reverseIndexed:" + isNoMatchReverseIndexed() + " tokenized:" + isNoMatchTokenized() + " reverseTokenized:"
+                        + isNoMatchReverseTokenized() + "]";
 
     }
 
@@ -143,117 +161,101 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
 
     @Override
     public boolean isStoredField(String fieldName) {
-        if (knownFields.containsKey(fieldName)) {
-            return this.knownFields.get(fieldName).stored;
-        }
-
-        String pattern = findMatchingPattern(fieldName);
-        if (pattern != null) {
-            return this.knownFields.get(pattern).stored;
-        }
-
-        return isNoMatchStored();
+        return getFieldInfo(fieldName).stored;
     }
 
     @Override
     public boolean isIndexedField(String fieldName) {
-        if (knownFields.containsKey(fieldName)) {
-            return this.knownFields.get(fieldName).indexed;
-        }
-
-        String pattern = findMatchingPattern(fieldName);
-        if (pattern != null) {
-            return this.knownFields.get(pattern).indexed;
-        }
-
-        return isNoMatchIndexed();
+        return getFieldInfo(fieldName).indexed;
     }
 
     @Override
     public boolean isIndexOnlyField(String fieldName) {
-        return isIndexedField(fieldName) && !isStoredField(fieldName);
+        FieldInfo info = getFieldInfo(fieldName);
+        return info.indexed && !info.stored;
     }
 
     @Override
     public boolean isReverseIndexedField(String fieldName) {
-        if (knownFields.containsKey(fieldName)) {
-            return this.knownFields.get(fieldName).reverseIndexed;
-        }
-
-        String pattern = findMatchingPattern(fieldName);
-        if (pattern != null) {
-            return this.knownFields.get(pattern).reverseIndexed;
-        }
-
-        return isNoMatchReverseIndexed();
+        return getFieldInfo(fieldName).reverseIndexed;
     }
 
     @Override
     public boolean isTokenizedField(String fieldName) {
-        if (knownFields.containsKey(fieldName)) {
-            return this.knownFields.get(fieldName).tokenized;
-        }
-
-        String pattern = findMatchingPattern(fieldName);
-        if (pattern != null) {
-            return this.knownFields.get(pattern).tokenized;
-        }
-
-        return isNoMatchTokenized();
+        return getFieldInfo(fieldName).tokenized;
     }
 
     @Override
     public boolean isReverseTokenizedField(String fieldName) {
-        if (knownFields.containsKey(fieldName)) {
-            return this.knownFields.get(fieldName).reverseTokenized;
-        }
+        return getFieldInfo(fieldName).reverseTokenized;
+    }
 
-        String pattern = findMatchingPattern(fieldName);
-        if (pattern != null) {
-            return this.knownFields.get(pattern).reverseTokenized;
+    private FieldInfo getFieldInfo(String fieldName) {
+        if (fieldName.equals(previousFieldName)) {
+            return previousFieldInfo;
         }
+        FieldInfo info = resolvedFields.computeIfAbsent(fieldName, this::resolveFieldInfo);
+        previousFieldName = fieldName;
+        previousFieldInfo = info;
+        return info;
+    }
 
-        return isNoMatchReverseTokenized();
+    private FieldInfo resolveFieldInfo(String fieldName) {
+        FieldInfo info = knownFields.get(fieldName);
+        if (info != null) {
+            return info;
+        }
+        if (!patterns.isEmpty()) {
+            String pattern = findMatchingPattern(fieldName);
+            if (pattern != null) {
+                return knownFields.get(pattern);
+            }
+        }
+        return noMatchFieldInfo;
     }
 
     public boolean isNoMatchStored() {
-        return noMatchStored;
+        return noMatchFieldInfo.stored;
     }
 
     public void setNoMatchStored(boolean noMatchStored) {
-        this.noMatchStored = noMatchStored;
+        this.noMatchFieldInfo.stored = noMatchStored;
     }
 
     public boolean isNoMatchIndexed() {
-        return noMatchIndexed;
+        return noMatchFieldInfo.indexed;
     }
 
     public void setNoMatchIndexed(boolean noMatchIndexed) {
-        this.noMatchIndexed = noMatchIndexed;
+        this.noMatchFieldInfo.indexed = noMatchIndexed;
     }
 
     public boolean isNoMatchReverseIndexed() {
-        return noMatchReverseIndexed;
+        return noMatchFieldInfo.reverseIndexed;
     }
 
     public void setNoMatchReverseIndexed(boolean noMatchReverseIndexed) {
-        this.noMatchReverseIndexed = noMatchReverseIndexed;
+        this.noMatchFieldInfo.reverseIndexed = noMatchReverseIndexed;
     }
 
     public boolean isNoMatchTokenized() {
-        return noMatchTokenized;
+        return noMatchFieldInfo.tokenized;
     }
 
     public void setNoMatchTokenized(boolean noMatchTokenized) {
-        this.noMatchTokenized = noMatchTokenized;
+        this.noMatchFieldInfo.tokenized = noMatchTokenized;
     }
 
     public boolean isNoMatchReverseTokenized() {
-        return noMatchReverseTokenized;
+        return noMatchFieldInfo.reverseTokenized;
     }
 
     public void setNoMatchReverseTokenized(boolean noMatchReverseTokenized) {
-        this.noMatchReverseTokenized = noMatchReverseTokenized;
+        this.noMatchFieldInfo.reverseTokenized = noMatchReverseTokenized;
+    }
+
+    Map<String,FieldInfo> getResolvedFields() {
+        return this.resolvedFields;
     }
 
     /**

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/XMLFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/XMLFieldConfigHelperTest.java
@@ -1,9 +1,12 @@
 package datawave.ingest.data.config;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,8 +15,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,8 +64,10 @@ public class XMLFieldConfigHelperTest {
 
         try {
             FieldConfigHelper helper = XMLFieldConfigHelper.load(requestUrl, ingestHelper);
+
             assertTrue(helper.isIndexedField("A"));
             assertFalse(helper.isIndexedField("B"));
+
         } finally {
             server.stop(0);
 
@@ -394,5 +401,71 @@ public class XMLFieldConfigHelperTest {
         assertType(LcNoDiacriticsType.class, ingestHelper.getDataTypes("F"));
         assertType(HexStringType.class, ingestHelper.getDataTypes("G"));
         assertType(DateType.class, ingestHelper.getDataTypes("H"));
+    }
+
+    @Test
+    void testCachingBehaviorWillCallBaseMethods() throws Exception {
+        // test intent is to verify each is*Field accessor dispatches to the matching FieldInfo attribute
+        // (i.e. no copy/paste error) and that a single lookup memoizes the fully-resolved FieldInfo
+
+        String input = "<?xml version=\"1.0\"?>\n" + "<fieldConfig>\n"
+                        + "    <default stored=\"true\" indexed=\"false\" reverseIndexed=\"false\" tokenized=\"false\" reverseTokenized=\"false\" indexType=\"datawave.data.type.LcNoDiacriticsType\"/>\n"
+                        + "    <nomatch stored=\"true\" indexed=\"true\" reverseIndexed=\"true\" tokenized=\"true\"  reverseTokenized=\"true\" indexType=\"datawave.data.type.HexStringType\"/>\n"
+                        + "    <field name=\"A\" stored=\"true\" indexed=\"true\" reverseIndexed=\"false\" tokenized=\"true\" reverseTokenized=\"false\"/>\n"
+                        + "    <field name=\"B\" stored=\"true\" indexed=\"false\" reverseIndexed=\"true\" tokenized=\"true\" reverseTokenized=\"false\"/>\n"
+                        + "    <field name=\"C\" stored=\"false\" indexed=\"true\" reverseIndexed=\"true\" tokenized=\"true\" reverseTokenized=\"false\"/>\n"
+                        + "</fieldConfig>";
+
+        String field = "A";
+        XMLFieldConfigHelper helper = new XMLFieldConfigHelper(IOUtils.toInputStream(input, UTF_8), ingestHelper);
+        Map<String,XMLFieldConfigHelper.FieldInfo> cache = helper.getResolvedFields();
+
+        // a single lookup resolves and memoizes the whole FieldInfo for the field
+        assertTrue(cache.isEmpty());
+        helper.isStoredField(field);
+        assertEquals(1, cache.size());
+
+        XMLFieldConfigHelper.FieldInfo info = cache.get(field);
+        assertNotNull(info);
+        assertTrue(info.stored);
+        assertTrue(info.indexed);
+        assertFalse(info.reverseIndexed);
+        assertTrue(info.tokenized);
+        assertFalse(info.reverseTokenized);
+
+        // each accessor returns the matching flag on the resolved FieldInfo
+        assertEquals(info.stored, helper.isStoredField(field));
+        assertEquals(info.indexed, helper.isIndexedField(field));
+        assertEquals(info.reverseIndexed, helper.isReverseIndexedField(field));
+        assertEquals(info.tokenized, helper.isTokenizedField(field));
+        assertEquals(info.reverseTokenized, helper.isReverseTokenizedField(field));
+        assertEquals(info.indexed && !info.stored, helper.isIndexOnlyField(field));
+
+        // flags across A/B/C give every attribute a distinct value signature, so an accessor
+        // dispatching to the wrong attribute fails on at least one of the three fields
+        assertTrue(helper.isStoredField("B"));
+        assertFalse(helper.isIndexedField("B"));
+        assertTrue(helper.isReverseIndexedField("B"));
+        assertTrue(helper.isTokenizedField("B"));
+        assertFalse(helper.isReverseTokenizedField("B"));
+        assertFalse(helper.isIndexOnlyField("B"));
+
+        assertFalse(helper.isStoredField("C"));
+        assertTrue(helper.isIndexedField("C"));
+        assertTrue(helper.isReverseIndexedField("C"));
+        assertTrue(helper.isTokenizedField("C"));
+        assertFalse(helper.isReverseTokenizedField("C"));
+        assertTrue(helper.isIndexOnlyField("C"));
+
+        // repeated lookups of a known field return the same cached FieldInfo instance
+        assertSame(info, cache.get(field));
+
+        // two different unknown fields resolve to the same shared no-match FieldInfo instance
+        helper.isStoredField("UNKNOWNONE");
+        helper.isStoredField("UNKNOWNTWO");
+        XMLFieldConfigHelper.FieldInfo noMatchOne = cache.get("UNKNOWNONE");
+        XMLFieldConfigHelper.FieldInfo noMatchTwo = cache.get("UNKNOWNTWO");
+        assertNotNull(noMatchOne);
+        assertSame(noMatchOne, noMatchTwo);
     }
 }


### PR DESCRIPTION
Implements a lookup cache on field lookup evaluations and refactors a few calling paths from BaseIngestHelper. The optimization will help with ingest performance speed in some cases.