### PR TITLE
Move tf aggregrator right before versioning

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/table/config/AbstractTableConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/table/config/AbstractTableConfigHelper.java
@@ -28,6 +28,13 @@ public abstract class AbstractTableConfigHelper implements TableConfigHelper {
     public static final String DISABLE_VERSIONING_ITERATOR = ".disable.versioning.iterator";
     protected Configuration config;
 
+    private static final String VERS_ITER_NAME = "vers";
+    private static final int VERS_ITER_PRI = 20;
+
+    // Aggregate must go before versioning
+    private static final String AGG_ITER_NAME = "agg";
+    private static final int AGG_ITER_PRI = VERS_ITER_PRI - 1;
+
     protected AbstractTableConfigHelper() {}
 
     @Override
@@ -125,8 +132,8 @@ public abstract class AbstractTableConfigHelper implements TableConfigHelper {
         boolean disableVersioning = config != null && config.getBoolean(tableName + DISABLE_VERSIONING_ITERATOR, false);
         if (!disableVersioning) {
             for (IteratorScope iterScope : IteratorScope.values()) {
-                props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + ".vers", "20," + VersioningIterator.class.getName());
-                props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + ".vers.opt.maxVersions", "1");
+                props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + "." + VERS_ITER_NAME, VERS_ITER_PRI + "," + VersioningIterator.class.getName());
+                props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + "." + VERS_ITER_NAME + ".opt.maxVersions", "1");
             }
         }
 
@@ -264,15 +271,15 @@ public abstract class AbstractTableConfigHelper implements TableConfigHelper {
 
         for (IteratorScope iterScope : IteratorScope.values()) {
             if (!aggregators.isEmpty()) {
-                props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + ".agg", "10," + PropogatingIterator.class.getName());
+                props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + "." + AGG_ITER_NAME, AGG_ITER_PRI + "," + PropogatingIterator.class.getName());
             }
         }
 
         for (CombinerConfiguration ac : aggregators) {
             for (IteratorSetting.Column column : ac.getColumns()) {
                 for (IteratorScope iterScope : IteratorScope.values()) {
-
-                    props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + ".agg.opt." + column.getColumnFamily(), ac.getSettings().getIteratorClass());
+                    props.put(Property.TABLE_ITERATOR_PREFIX + iterScope.name() + "." + AGG_ITER_NAME + ".opt." + column.getColumnFamily(),
+                                    ac.getSettings().getIteratorClass());
                 }
             }
         }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/TableConfigHelperFactoryTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/TableConfigHelperFactoryTest.java
@@ -88,7 +88,7 @@ public class TableConfigHelperFactoryTest {
         helper.configure(tops);
 
         TablePropertiesMap testShardProperties = new TablePropertiesMap(tops, TEST_SHARD_TABLE_NAME);
-        assertEquals("10,datawave.iterators.PropogatingIterator", testShardProperties.get("table.iterator.majc.agg"));
+        assertEquals("19,datawave.iterators.PropogatingIterator", testShardProperties.get("table.iterator.majc.agg"));
 
         TablePropertiesMap shardProperties = new TablePropertiesMap(tops, TableName.SHARD);
         assertNull(shardProperties.get("table.iterator.majc.agg"));
@@ -103,6 +103,6 @@ public class TableConfigHelperFactoryTest {
         assertNull(testShardProperties.get("table.iterator.majc.agg"));
 
         TablePropertiesMap shardProperties = new TablePropertiesMap(tops, TableName.SHARD);
-        assertEquals("10,datawave.iterators.PropogatingIterator", shardProperties.get("table.iterator.majc.agg"));
+        assertEquals("19,datawave.iterators.PropogatingIterator", shardProperties.get("table.iterator.majc.agg"));
     }
 }

--- a/warehouse/ingest-csv/src/test/java/datawave/ingest/csv/TableConfigurationUtilTest.java
+++ b/warehouse/ingest-csv/src/test/java/datawave/ingest/csv/TableConfigurationUtilTest.java
@@ -277,7 +277,7 @@ public class TableConfigurationUtilTest {
 
         Map<Integer,Map<String,String>> shardAggs = tcu.getTableAggregators("datawave.shard");
         Assert.assertEquals(1, shardAggs.size());
-        Assert.assertEquals("datawave.ingest.table.aggregator.TextIndexAggregator", shardAggs.get(10).get("tf"));
+        Assert.assertEquals("datawave.ingest.table.aggregator.TextIndexAggregator", shardAggs.get(19).get("tf"));
 
         Map<Integer,Map<String,String>> shardIndexAggs = tcu.getTableAggregators("datawave.shardIndex");
         Assert.assertEquals(1, shardIndexAggs.size());


### PR DESCRIPTION
The tf aggregator is clobbering the visibilityFilter being added by ScannerHelper (and a few other spots). We want visibility filtering to occur first so I moved tf aggregation immediately before VersionIter.