### PR TITLE
Add class to handle index-only fields' null checks

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/NullFieldIndexAggregator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/NullFieldIndexAggregator.java
@@ -1,0 +1,67 @@
+package datawave.query.iterator.logic;
+
+import datawave.query.attributes.AttributeFactory;
+import datawave.query.attributes.Document;
+import datawave.query.data.parsers.FieldIndexKey;
+import datawave.query.jexl.functions.FieldIndexAggregator;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A specialized {@link FieldIndexAggregator} that handles null and not-null checks efficiently
+ * for non-event (index-only) fields.
+ * <p>
+ * Instead of scanning all indexed terms for a document, it returns a single key per document ID
+ * and immediately seeks past the remaining terms.
+ */
+public class NullFieldIndexAggregator implements FieldIndexAggregator {
+
+    @Override
+    public Key apply(SortedKeyValueIterator<Key, Value> itr) throws IOException{
+        return apply(itr,null, Collections.emptyList(),false);
+    }
+
+    @Override
+    public Key apply(SortedKeyValueIterator<Key, Value> itr, Range range, Collection<ByteSequence> columnFamilies, boolean includeColumnFamilies) throws IOException {
+        if (itr.hasTop()) {
+            Key topKey = itr.getTopKey();
+
+            // Get the current key's Column Qualifier
+            Text cq = new Text();
+            topKey.getColumnQualifier(cq);
+
+            // Append bytes to skip past this document entry
+            byte[] boundaryBytes = "\0\uFFFF".getBytes(StandardCharsets.UTF_8);
+            cq.append(boundaryBytes, 0, boundaryBytes.length);
+
+            // Build target key
+            Key jumpTargetKey = new Key(topKey.getRow(), topKey.getColumnFamily(), cq);
+
+            Key endKey = (range != null) ? range.getEndKey() : null;
+            boolean endKeyInclusive = (range != null) && range.isEndKeyInclusive();
+
+            // Create range to jump past jumpTargetKey
+            Range jumpRange = new Range(jumpTargetKey, false, endKey, endKeyInclusive);
+
+            itr.seek(jumpRange, columnFamilies, includeColumnFamilies);
+
+            return topKey;
+        }
+        return null;
+    }
+
+    @Override
+    public Key apply(SortedKeyValueIterator<Key, Value> itr, Document doc, AttributeFactory attrs) throws IOException {
+        return apply(itr,null, Collections.emptyList(),false);
+    }
+}
+

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/logic/NullFieldIndexAggregator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/logic/NullFieldIndexAggregator.java
@@ -1,9 +1,10 @@
 package datawave.query.iterator.logic;
 
-import datawave.query.attributes.AttributeFactory;
-import datawave.query.attributes.Document;
-import datawave.query.data.parsers.FieldIndexKey;
-import datawave.query.jexl.functions.FieldIndexAggregator;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
@@ -11,27 +12,25 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.hadoop.io.Text;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Collections;
+import datawave.query.attributes.AttributeFactory;
+import datawave.query.attributes.Document;
+import datawave.query.jexl.functions.FieldIndexAggregator;
 
 /**
- * A specialized {@link FieldIndexAggregator} that handles null and not-null checks efficiently
- * for non-event (index-only) fields.
+ * A specialized {@link FieldIndexAggregator} that handles null and not-null checks efficiently for non-event (index-only) fields.
  * <p>
- * Instead of scanning all indexed terms for a document, it returns a single key per document ID
- * and immediately seeks past the remaining terms.
+ * Instead of scanning all indexed terms for a document, it returns a single key per document ID and immediately seeks past the remaining terms.
  */
 public class NullFieldIndexAggregator implements FieldIndexAggregator {
 
     @Override
-    public Key apply(SortedKeyValueIterator<Key, Value> itr) throws IOException{
-        return apply(itr,null, Collections.emptyList(),false);
+    public Key apply(SortedKeyValueIterator<Key,Value> itr) throws IOException {
+        return apply(itr, null, Collections.emptyList(), false);
     }
 
     @Override
-    public Key apply(SortedKeyValueIterator<Key, Value> itr, Range range, Collection<ByteSequence> columnFamilies, boolean includeColumnFamilies) throws IOException {
+    public Key apply(SortedKeyValueIterator<Key,Value> itr, Range range, Collection<ByteSequence> columnFamilies, boolean includeColumnFamilies)
+                    throws IOException {
         if (itr.hasTop()) {
             Key topKey = itr.getTopKey();
 
@@ -60,8 +59,7 @@ public class NullFieldIndexAggregator implements FieldIndexAggregator {
     }
 
     @Override
-    public Key apply(SortedKeyValueIterator<Key, Value> itr, Document doc, AttributeFactory attrs) throws IOException {
-        return apply(itr,null, Collections.emptyList(),false);
+    public Key apply(SortedKeyValueIterator<Key,Value> itr, Document doc, AttributeFactory attrs) throws IOException {
+        return apply(itr, null, Collections.emptyList(), false);
     }
 }
-

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -26,7 +26,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import datawave.query.iterator.logic.NullFieldIndexAggregator;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
@@ -92,6 +91,7 @@ import datawave.query.iterator.builder.OrIteratorBuilder;
 import datawave.query.iterator.builder.TermFrequencyIndexBuilder;
 import datawave.query.iterator.ivarator.IvaratorCacheDir;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.iterator.logic.NullFieldIndexAggregator;
 import datawave.query.iterator.logic.OrIterator;
 import datawave.query.iterator.logic.RangeFilterIterator;
 import datawave.query.iterator.logic.RegexFilterIterator;
@@ -628,7 +628,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             if (this.indexOnlyFields.contains(builder.getField())) {
                 builder.setKeyTransform(new NullFieldIndexAggregator());
                 builder.setValue("");
-            }else{
+            } else {
                 checkForSatisfactionError();
                 return null;
             }
@@ -689,9 +689,9 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         // the evaluation can handle a term in the form 'FIELD == null', however no IndexIterator should be built
         if (builder.getValue() == null) {
             if (indexOnlyFields.contains(builder.getField())) {
-               builder.setKeyTransform(new NullFieldIndexAggregator());
-               builder.setValue("");
-            }else{
+                builder.setKeyTransform(new NullFieldIndexAggregator());
+                builder.setValue("");
+            } else {
                 return null;
             }
 

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/IteratorBuildingVisitor.java
@@ -26,6 +26,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import datawave.query.iterator.logic.NullFieldIndexAggregator;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
 import org.apache.accumulo.core.data.Range;
@@ -625,14 +626,12 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         // the evaluation can handle a term in the form 'FIELD == null', however no IndexIterator should be built
         if (builder.getValue() == null) {
             if (this.indexOnlyFields.contains(builder.getField())) {
-                QueryException qe = new QueryException(DatawaveErrorCode.INDEX_ONLY_FIELDS_RETRIEVAL_ERROR,
-                                MessageFormat.format("{0} {1} {2}", "Unable to compare index only field", builder.getField(), "against null"));
-                throw new DatawaveFatalQueryException(qe);
+                builder.setKeyTransform(new NullFieldIndexAggregator());
+                builder.setValue("");
+            }else{
+                checkForSatisfactionError();
+                return null;
             }
-
-            // FIELD != null should have set satisfied to false
-            checkForSatisfactionError();
-            return null;
         }
 
         AbstractIteratorBuilder iterators = (AbstractIteratorBuilder) data;
@@ -649,7 +648,13 @@ public class IteratorBuildingVisitor extends BaseVisitor {
             builder.setTypeMetadata(typeMetadata);
             builder.setTimeFilter(timeFilter);
             builder.setDatatypeFilter(getDatatypeFilter());
-            builder.setKeyTransform(getFiAggregator());
+
+            // ONLY set default aggregator if a custom aggregator wasn't set above!
+            if (builder.getValue() != null || !this.indexOnlyFields.contains(builder.getField())) {
+                builder.setKeyTransform(getFiAggregator());
+                builder.setValue("");
+            }
+
             builder.setEnv(env);
             builder.setNode(node);
 
@@ -671,6 +676,7 @@ public class IteratorBuildingVisitor extends BaseVisitor {
     @Override
     public Object visit(ASTEQNode node, Object data) {
         // visit children first to populate the field and value
+        SortedKeyValueIterator<Key,Value> kvIter = null;
         IndexIteratorBuilder builder = getIteratorBuilder();
         node.childrenAccept(this, builder);
 
@@ -683,11 +689,12 @@ public class IteratorBuildingVisitor extends BaseVisitor {
         // the evaluation can handle a term in the form 'FIELD == null', however no IndexIterator should be built
         if (builder.getValue() == null) {
             if (indexOnlyFields.contains(builder.getField())) {
-                QueryException qe = new QueryException(DatawaveErrorCode.INDEX_ONLY_FIELDS_RETRIEVAL_ERROR,
-                                MessageFormat.format("{0} {1} {2}", "Unable to compare index only field", builder.getField(), "against null"));
-                throw new DatawaveFatalQueryException(qe);
+               builder.setKeyTransform(new NullFieldIndexAggregator());
+               builder.setValue("");
+            }else{
+                return null;
             }
-            return null;
+
         }
 
         // check to see if there is a mismatch between included and exclude references.

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import datawave.query.iterator.logic.IndexIterator;
 import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.Key;
@@ -32,14 +31,12 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.jupiter.api.Nested;
 import org.junit.rules.TemporaryFolder;
 
 import datawave.core.iterators.filesystem.FileSystemCache;
 import datawave.query.Constants;
 import datawave.query.attributes.Attribute;
 import datawave.query.attributes.Document;
-import datawave.query.exceptions.DatawaveFatalQueryException;
 import datawave.query.iterator.NestedIterator;
 import datawave.query.iterator.SeekableNestedIterator;
 import datawave.query.iterator.SortedListKeyValueIterator;

--- a/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/jexl/visitors/IteratorBuildingVisitorTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import datawave.query.iterator.logic.IndexIterator;
 import org.apache.accumulo.core.client.PluginEnvironment;
 import org.apache.accumulo.core.client.sample.SamplerConfiguration;
 import org.apache.accumulo.core.data.Key;
@@ -31,6 +32,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.Nested;
 import org.junit.rules.TemporaryFolder;
 
 import datawave.core.iterators.filesystem.FileSystemCache;
@@ -131,10 +133,7 @@ public class IteratorBuildingVisitorTest {
         Assert.assertEquals(0, visitor.getDeepCopiesCalled());
     }
 
-    /**
-     * index only null value should result in an error
-     */
-    @Test(expected = DatawaveFatalQueryException.class)
+    @Test
     public void visitEqNode_nullValueIndexOnlyTest() {
         ASTEQNode node = (ASTEQNode) JexlNodeFactory.buildEQNode("FIELD", "blah");
         node.jjtAddChild(JexlNodes.makeStringLiteral(), 1);
@@ -144,8 +143,9 @@ public class IteratorBuildingVisitorTest {
 
         node.jjtAccept(visitor, null);
 
-        // this should never be reached
-        Assert.assertFalse(true);
+        NestedIterator<Key> root = visitor.root();
+
+        Assert.assertNotNull("Root iterator should not be null", root);
     }
 
     /**
@@ -167,10 +167,7 @@ public class IteratorBuildingVisitorTest {
         Assert.assertEquals(1, visitor.getDeepCopiesCalled());
     }
 
-    /**
-     * null value should result in an error. In this case a top level negation is not allowed, so pair it with an indexed lookup
-     */
-    @Test(expected = DatawaveFatalQueryException.class)
+    @Test
     public void visitNeNode_nullValueIndexOnlyTest() throws ParseException {
         ASTJexlScript query = JexlASTHelper.parseJexlQuery("FOO == 'bar' && FIELD != null");
 
@@ -179,8 +176,8 @@ public class IteratorBuildingVisitorTest {
 
         query.jjtAccept(visitor, null);
 
-        // this should never be reached
-        Assert.assertFalse(true);
+        NestedIterator<Key> root = visitor.root();
+        Assert.assertNotNull("Root iterator should not be null", root);
     }
 
     @Test


### PR DESCRIPTION
### Summary
`IteratorBuildingVisitor` currently throws a fatal query exception when encountering null/not-null checks on non-event (index-only) fields. This PR introduces a specialized aggregator to efficiently support presence and absence queries against non-event fields within the field index.

### Changes
- Add `NullFieldIndexAggregator` implementing `FieldIndexAggregator` to evaluate non-event field presence by returning at most one key per document and seeking past remaining terms.
- Update `IteratorBuildingVisitor` to configure `NullFieldIndexAggregator` for index-only field null/not-null checks instead of throwing a `DatawaveFatalQueryException`.
- Update `IteratorBuildingVisitorTest` to assert that valid iterators are constructed for non-event null checks rather than expecting a fatal error.

Closes issue #876 