### PR TITLE
Add an ingest hot path benchmark as a command line utility

### DIFF
--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/BenchmarkEventGenerator.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/BenchmarkEventGenerator.java
@@ -17,9 +17,9 @@ import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.marking.AccessExpressionMarkings;
 
 /**
- * Test data for the ingest benchmarks.
+ * Generates the synthetic event pools the ingest benchmarks measure.
  * <p>
- * Three axes matter for the measurements this fixture feeds:
+ * Three axes matter for the measurements they feed:
  * <ul>
  * <li><b>Event size.</b> Events carry between {@link #MIN_FIELDS} and {@link #MAX_FIELDS} fields, drawn from a seeded generator so a run is reproducible. A
  * pool of at least {@link #DEFAULT_EVENT_COUNT} events means no single event shape dominates the measurement, and inline caches and branch predictors see the
@@ -27,15 +27,15 @@ import datawave.marking.AccessExpressionMarkings;
  * <li><b>Normalizer coverage.</b> {@link #TYPE_SAMPLES} pairs every concrete {@code datawave.data.type.Type} with a value it normalizes cleanly, verified
  * rather than assumed. Types are assigned to fields round robin by field index, so every event of at least {@link #TYPE_COUNT} fields covers each normalizer
  * and the pool covers all of them many times over. Normalizer cost varies by more than an order of magnitude across these — {@code DateType} walks a list of
- * {@code SimpleDateFormat} patterns, {@code NoOpType} returns its input — so a single-type fixture misrepresents where time goes.</li>
+ * {@code SimpleDateFormat} patterns, {@code NoOpType} returns its input — so generating a single type misrepresents where time goes.</li>
  * <li><b>Visibility diversity.</b> Events rotate through {@link #EVENT_VISIBILITIES} and, when a marked stride is requested, individual fields carry their own
  * {@link AccessExpressionMarkings} drawn from {@link #FIELD_VISIBILITIES}. This matters because {@code FlattenedVisibilityCache} is keyed on
- * {@code ColumnVisibility}: a fixture with one visibility hits that cache on every lookup after the first and makes the visibility path look free.</li>
+ * {@code ColumnVisibility}: a pool with one visibility hits that cache on every lookup after the first and makes the visibility path look free.</li>
  * </ul>
  */
-final class IngestFixture {
+final class BenchmarkEventGenerator {
 
-    private IngestFixture() {}
+    private BenchmarkEventGenerator() {}
 
     /** Smallest event, in fields. */
     static final int MIN_FIELDS = 15;

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/FieldCategory.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/FieldCategory.java
@@ -28,8 +28,8 @@ enum FieldCategory {
     TOKENIZED_INDEX_ONLY;
 
     /**
-     * Category for a field index under the repeating assignment used by the fixture. Fields cycle event-only, indexed, index-only, tokenized so every event
-     * carries all four.
+     * Category for a field index under the repeating assignment used by {@link BenchmarkEventGenerator}. Fields cycle event-only, indexed, index-only,
+     * tokenized so every event carries all four.
      *
      * @param fieldIndex
      *            zero based field index

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/FieldCategory.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/FieldCategory.java
@@ -1,0 +1,50 @@
+package datawave.ingest.benchmark;
+
+/**
+ * How a benchmark field is configured, which decides which key-generation paths it exercises.
+ */
+enum FieldCategory {
+    /**
+     * Stored in the shard event table only. Not indexed, so it produces one event key and nothing else.
+     */
+    EVENT_ONLY,
+
+    /**
+     * Forward indexed and stored. Produces an event key, a field index key and a global index key, and is the category that drives the per-term loops in
+     * {@code createColumns}.
+     */
+    INDEXED,
+
+    /**
+     * Forward indexed but not stored in the event. Exercises the early return in {@code createShardEventColumn}, so it produces field index and global index
+     * keys but no event key.
+     */
+    INDEX_ONLY,
+
+    /**
+     * Tokenized and index only. Runs the Lucene analyzer in {@code tokenizeField}, contributing one indexed term per distinct token plus a term-frequency key
+     * per token/zone pair from {@code flushTokenOffsetCache}. The heaviest category by a wide margin.
+     */
+    TOKENIZED_INDEX_ONLY;
+
+    /**
+     * Category for a field index under the repeating assignment used by the fixture. Fields cycle event-only, indexed, index-only, tokenized so every event
+     * carries all four.
+     *
+     * @param fieldIndex
+     *            zero based field index
+     * @return the category for that field
+     */
+    static FieldCategory forIndex(int fieldIndex) {
+        switch (fieldIndex % 4) {
+            case 0:
+                return EVENT_ONLY;
+            case 1:
+                return INDEXED;
+            case 2:
+                return INDEX_ONLY;
+            default:
+                return TOKENIZED_INDEX_ONLY;
+        }
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestFixture.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestFixture.java
@@ -1,0 +1,333 @@
+package datawave.ingest.benchmark;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.accumulo.core.security.ColumnVisibility;
+
+import com.google.common.collect.Multimap;
+
+import datawave.ingest.config.RawRecordContainerImpl;
+import datawave.ingest.data.RawRecordContainer;
+import datawave.ingest.data.Type;
+import datawave.ingest.data.config.NormalizedContentInterface;
+import datawave.marking.AccessExpressionMarkings;
+
+/**
+ * Test data for the ingest benchmarks.
+ * <p>
+ * Three axes matter for the measurements this fixture feeds:
+ * <ul>
+ * <li><b>Event size.</b> Events carry between {@link #MIN_FIELDS} and {@link #MAX_FIELDS} fields, drawn from a seeded generator so a run is reproducible. A
+ * pool of at least {@link #DEFAULT_EVENT_COUNT} events means no single event shape dominates the measurement, and inline caches and branch predictors see the
+ * variation a real mapper sees rather than one shape repeated.</li>
+ * <li><b>Normalizer coverage.</b> {@link #TYPE_SAMPLES} pairs every concrete {@code datawave.data.type.Type} with a value it normalizes cleanly, verified
+ * rather than assumed. Types are assigned to fields round robin by field index, so every event of at least {@link #TYPE_COUNT} fields covers each normalizer
+ * and the pool covers all of them many times over. Normalizer cost varies by more than an order of magnitude across these — {@code DateType} walks a list of
+ * {@code SimpleDateFormat} patterns, {@code NoOpType} returns its input — so a single-type fixture misrepresents where time goes.</li>
+ * <li><b>Visibility diversity.</b> Events rotate through {@link #EVENT_VISIBILITIES} and, when a marked stride is requested, individual fields carry their own
+ * {@link AccessExpressionMarkings} drawn from {@link #FIELD_VISIBILITIES}. This matters because {@code FlattenedVisibilityCache} is keyed on
+ * {@code ColumnVisibility}: a fixture with one visibility hits that cache on every lookup after the first and makes the visibility path look free.</li>
+ * </ul>
+ */
+final class IngestFixture {
+
+    private IngestFixture() {}
+
+    /** Smallest event, in fields. */
+    static final int MIN_FIELDS = 15;
+
+    /** Largest event, in fields. Configuration always declares this many field names. */
+    static final int MAX_FIELDS = 45;
+
+    /** Events per pool. Large enough that no single event shape dominates a measurement. */
+    static final int DEFAULT_EVENT_COUNT = 250;
+
+    /** Fixed seed so event sizes, and therefore the numbers, are reproducible run to run. */
+    static final long FIELD_COUNT_SEED = 20260807L;
+
+    /**
+     * Every concrete Type in {@code datawave.data.type} paired with a value it normalizes without error. Verified by round-tripping each pair through
+     * {@code Type.normalize} (and {@code normalizeToMany} for the one-to-many types) before being recorded here.
+     */
+    static final String[][] TYPE_SAMPLES = {
+            // {type class, sample value}
+            {"datawave.data.type.DateType", "2024-06-15T10:30:00.000Z"}, //
+            {"datawave.data.type.RawDateType", "2024-06-15T10:30:00.000Z"}, //
+            {"datawave.data.type.GeoLatType", "38.8977"}, //
+            {"datawave.data.type.GeoLonType", "-77.0365"}, //
+            {"datawave.data.type.GeoType", "38.8977|-77.0365"}, //
+            {"datawave.data.type.GeometryType", "POINT(-77.0365 38.8977)"}, // one-to-many
+            {"datawave.data.type.PointType", "POINT(-77.0365 38.8977)"}, //
+            {"datawave.data.type.HexStringType", "DEADBEEF"}, //
+            {"datawave.data.type.HitTermType", "FIELD:value"}, //
+            {"datawave.data.type.IpAddressType", "192.168.1.100"}, //
+            {"datawave.data.type.IpV4AddressType", "192.168.1.100"}, //
+            {"datawave.data.type.LcNoDiacriticsType", "Café Ünicode Text"}, //
+            {"datawave.data.type.LcNoDiacriticsListType", "Alpha,Béta,Gamma"}, // one-to-many, 3 elements
+            {"datawave.data.type.LcType", "MixedCaseValue"}, //
+            {"datawave.data.type.MacAddressType", "00:1A:2B:3C:4D:5E"}, //
+            {"datawave.data.type.NumberType", "42.5"}, //
+            {"datawave.data.type.NumberListType", "42"}, // one-to-many
+            {"datawave.data.type.NoOpType", "raw value"}, //
+            {"datawave.data.type.StringType", "plain string"}, //
+            {"datawave.data.type.TrimLeadingZerosType", "000123"},};
+
+    static final int TYPE_COUNT = TYPE_SAMPLES.length;
+
+    /**
+     * The field index carrying paragraph-length content. Always below {@link #MIN_FIELDS} so every event in the pool has it, and always a
+     * {@link FieldCategory#TOKENIZED_INDEX_ONLY} slot.
+     */
+    static final int LONG_CONTENT_FIELD_INDEX = 3;
+
+    /**
+     * Paragraph-scale text for the long tokenized field. Deliberately prose rather than repeated filler: the analyzer's term-length filters, type
+     * classification and synonym handling all behave differently on realistic word-length distributions, and a repeated token would collapse the offset cache
+     * into one entry and hide the per-token term-frequency work entirely. The subject matter is unrelated to this codebase on purpose, so that nothing here
+     * reads as documentation of the system under test.
+     */
+    static final String LONG_CONTENT = String.join(" ", "A prime number has no divisors beyond itself and one, and Euclid showed more than two thousand",
+                    "years ago that the supply of them never runs out. The sieve attributed to Eratosthenes finds them",
+                    "by striking out multiples in turn until only the primes remain. Their spacing grows slowly and",
+                    "irregularly, yet the average gap near a large number follows its logarithm with surprising fidelity.",
+                    "Geometry began as the measurement of land and grew into the study of shape, distance and symmetry.",
+                    "The angles of a triangle sum to a straight line on a flat surface, but not on a sphere, where the",
+                    "excess is proportional to the area enclosed, and that single observation opens the door to curvature.",
+                    "Only five convex solids can be assembled from identical regular faces meeting alike at every vertex:",
+                    "the tetrahedron, the cube, the octahedron, the dodecahedron and the icosahedron. In the plane only",
+                    "three regular polygons tile without leaving gaps, the triangle, the square and the hexagon, which is",
+                    "why honeycomb and paving so often repeat one of those three arrangements. Color admits a comparable",
+                    "structure. Light mixes additively, so red, green and blue together approach white, while pigments mix",
+                    "subtractively, absorbing wavelengths until what remains approaches black. Arranging hues around a",
+                    "circle places complementary pairs opposite one another, and painters use that opposition to make a",
+                    "small patch of one hue appear vivid against a wide field of its complement. Saturation describes how",
+                    "far a color sits from grey, and value describes how much light it returns to the eye. The golden",
+                    "ratio divides a line so that the whole stands to the larger part as the larger stands to the smaller,",
+                    "and the same proportion surfaces in the pentagon, in spiral growth, and in a famous integer sequence.");
+
+    /**
+     * Content of a requested token count, using distinct words so the analyzer produces that many distinct indexed terms rather than collapsing them in the
+     * offset cache.
+     *
+     * @param tokens
+     *            number of tokens to generate
+     * @return the generated content
+     */
+    static String contentWithTokens(int tokens) {
+        StringBuilder sb = new StringBuilder(tokens * 8);
+        for (int i = 0; i < tokens; i++) {
+            if (i > 0) {
+                sb.append(' ');
+            }
+            sb.append("term").append(i).append("word");
+        }
+        return sb.toString();
+    }
+
+    /** Short phrases for the remaining tokenized fields, cycled by field index. */
+    static final String[] SHORT_CONTENT = {"quick brown fox jumps over the lazy dog", "distributed systems require careful capacity planning",
+            "the analyzer splits values into a stream of tokens", "shard identifiers derive from the event date and a hash",
+            "normalized content fans out across several tables"};
+
+    /** Event level visibilities, rotated across the event pool. Mixed arity and nesting depth. */
+    static final String[] EVENT_VISIBILITIES = {"PUBLIC", "PUBLIC&A", "(PUBLIC|PRIVATE)&(A|B)", "(PUBLIC|PRIVATE)&(A|B)&(C|D)",
+            "((PUBLIC|PRIVATE)&(A|B))|((INTERNAL|RESTRICTED)&(C|D))", "PRIVATE&INTERNAL&(A|B|C)", "RESTRICTED", "(A|B)&(C|D)&(E|F)&(G|H)"};
+
+    /** Field level visibilities, applied to a strided subset of fields when requested. */
+    static final String[] FIELD_VISIBILITIES = {"PUBLIC&FIELDMARK1", "PRIVATE&FIELDMARK2", "(PUBLIC|PRIVATE)&FIELDMARK3", "INTERNAL&(FIELDMARK4|FIELDMARK5)",
+            "RESTRICTED&FIELDMARK6"};
+
+    /**
+     * Field names declared in the configuration. Always {@link #MAX_FIELDS} of them regardless of the sizes actually generated, so a short event's fields are
+     * still configured as indexed and typed.
+     *
+     * @return the configured field names
+     */
+    static List<String> configuredFieldNames() {
+        return fieldNames(MAX_FIELDS);
+    }
+
+    static List<String> fieldNames(int n) {
+        List<String> names = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            names.add("FIELD_" + i);
+        }
+        return names;
+    }
+
+    /** The Type class configured for a given field index under round robin assignment. */
+    static String typeClassFor(int fieldIndex) {
+        return TYPE_SAMPLES[fieldIndex % TYPE_COUNT][0];
+    }
+
+    /**
+     * The sample value for a given field index. Tokenized fields get prose, since a normalizer sample value such as an IP address or a WKT point would tokenize
+     * into a handful of meaningless terms and would not exercise the analyzer the way real content does. Everything else gets the value matching its configured
+     * Type.
+     *
+     * @param fieldIndex
+     *            zero based field index
+     * @return the value to place in the payload
+     */
+    static String sampleValueFor(int fieldIndex) {
+        if (FieldCategory.forIndex(fieldIndex) == FieldCategory.TOKENIZED_INDEX_ONLY) {
+            return fieldIndex == LONG_CONTENT_FIELD_INDEX ? LONG_CONTENT : SHORT_CONTENT[(fieldIndex / 4) % SHORT_CONTENT.length];
+        }
+        return TYPE_SAMPLES[fieldIndex % TYPE_COUNT][1];
+    }
+
+    /**
+     * The Type class for a field index. Tokenized fields must take a text-friendly normalizer; the round robin type assignment applies only to the other
+     * categories.
+     *
+     * @param fieldIndex
+     *            zero based field index
+     * @return the fully qualified Type class name
+     */
+    static String typeClassForCategory(int fieldIndex) {
+        if (FieldCategory.forIndex(fieldIndex) == FieldCategory.TOKENIZED_INDEX_ONLY) {
+            return "datawave.data.type.LcNoDiacriticsType";
+        }
+        return TYPE_SAMPLES[fieldIndex % TYPE_COUNT][0];
+    }
+
+    /**
+     * Field names belonging to a given category, across the whole configured field space.
+     *
+     * @param category
+     *            the category to collect
+     * @return the matching field names
+     */
+    static List<String> fieldNamesFor(FieldCategory category) {
+        List<String> names = new ArrayList<>();
+        for (int i = 0; i < MAX_FIELDS; i++) {
+            if (FieldCategory.forIndex(i) == category) {
+                names.add("FIELD_" + i);
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Field counts for a pool of varying event sizes, uniform over {@code [MIN_FIELDS, MAX_FIELDS]} and reproducible via {@link #FIELD_COUNT_SEED}.
+     *
+     * @param eventCount
+     *            number of events in the pool
+     * @return one field count per event
+     */
+    static int[] variableFieldCounts(int eventCount) {
+        Random random = new Random(FIELD_COUNT_SEED);
+        int[] counts = new int[eventCount];
+        for (int i = 0; i < eventCount; i++) {
+            counts[i] = MIN_FIELDS + random.nextInt(MAX_FIELDS - MIN_FIELDS + 1);
+        }
+        return counts;
+    }
+
+    /**
+     * Field counts for a pool where every event is the same size. Used by the scaling sweep, which needs one size at a time to tell linear growth from
+     * quadratic.
+     *
+     * @param eventCount
+     *            number of events in the pool
+     * @param fields
+     *            the fixed field count
+     * @return one field count per event, all equal
+     */
+    static int[] fixedFieldCounts(int eventCount, int fields) {
+        int[] counts = new int[eventCount];
+        Arrays.fill(counts, fields);
+        return counts;
+    }
+
+    /**
+     * Builds a pool of events. Sizes come from {@code fieldCounts}; visibilities rotate through {@link #EVENT_VISIBILITIES} so the flattened-visibility cache
+     * sees more than one key; dates advance by a day per event so shard ids differ.
+     *
+     * @param fieldCounts
+     *            field count per event, one entry per event to generate
+     * @param dataType
+     *            the registered ingest type
+     * @param diverseTypes
+     *            true to assign the sample value matching each field's configured Type, false to give every field {@code uniformValue}
+     * @param uniformValue
+     *            the value used for every field when {@code diverseTypes} is false; must be parseable by whatever Type the uniform arm configures, otherwise
+     *            normalization throws and the caller measures the error path instead of the one it intended
+     * @return the event pool
+     */
+    static List<RawRecordContainer> eventPool(int[] fieldCounts, Type dataType, boolean diverseTypes, String uniformValue) {
+        return eventPool(fieldCounts, dataType, diverseTypes, uniformValue, null);
+    }
+
+    /**
+     * As {@link #eventPool(int[], Type, boolean, String)}, but replaces the long content field's value.
+     *
+     * @param fieldCounts
+     *            field count per event
+     * @param dataType
+     *            the registered ingest type
+     * @param diverseTypes
+     *            true to use per-field sample values
+     * @param uniformValue
+     *            value for every field when {@code diverseTypes} is false
+     * @param contentOverride
+     *            replacement value for {@link #LONG_CONTENT_FIELD_INDEX}, or null to keep the default
+     * @return the event pool
+     */
+    static List<RawRecordContainer> eventPool(int[] fieldCounts, Type dataType, boolean diverseTypes, String uniformValue, String contentOverride) {
+        List<RawRecordContainer> pool = new ArrayList<>(fieldCounts.length);
+        for (int e = 0; e < fieldCounts.length; e++) {
+            StringBuilder raw = new StringBuilder();
+            for (int i = 0; i < fieldCounts[e]; i++) {
+                if (i > 0) {
+                    raw.append(';');
+                }
+                String value = diverseTypes ? sampleValueFor(i) : uniformValue;
+                if (contentOverride != null && i == LONG_CONTENT_FIELD_INDEX) {
+                    value = contentOverride;
+                }
+                raw.append("FIELD_").append(i).append('=').append(value);
+            }
+            RawRecordContainer record = new RawRecordContainerImpl();
+            record.setDataType(dataType);
+            record.setRawFileName("bench.dat");
+            record.setRawRecordNumber(e + 1L);
+            record.setRawData(raw.toString().getBytes(StandardCharsets.UTF_8));
+            long date = 1749254400000L + (e * 86400000L);
+            record.setDate(date);
+            record.setTimestamp(date);
+            record.setVisibility(new ColumnVisibility(EVENT_VISIBILITIES[e % EVENT_VISIBILITIES.length]));
+            record.generateId(null);
+            pool.add(record);
+        }
+        return pool;
+    }
+
+    /**
+     * Applies per-field markings to every {@code stride}-th field, cycling through {@link #FIELD_VISIBILITIES}. A stride of zero leaves the map untouched,
+     * which is the case where every field inherits the event visibility.
+     *
+     * @param fields
+     *            the normalized field map to annotate in place
+     * @param stride
+     *            mark every stride-th field; zero to mark none
+     */
+    static void applyFieldMarkings(Multimap<String,NormalizedContentInterface> fields, int stride) {
+        if (stride <= 0) {
+            return;
+        }
+        int i = 0;
+        int marked = 0;
+        for (NormalizedContentInterface nci : fields.values()) {
+            if (i % stride == 0) {
+                nci.setMarkings(AccessExpressionMarkings.create(FIELD_VISIBILITIES[marked % FIELD_VISIBILITIES.length]));
+                marked++;
+            }
+            i++;
+        }
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestHotPathBenchmark.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestHotPathBenchmark.java
@@ -42,7 +42,8 @@ import datawave.table.constants.TableName;
  * Benchmark and structural-instrumentation harness for the ingest hot path, {@link ShardedDataTypeHandler#processBulk}.
  * <p>
  * This is a command line utility, not a test. It carries no test annotations and declares no test methods, so no build or CI configuration has to know it
- * exists; it lives under the test sources only because it needs the test-scoped dependencies and {@link IngestFixture}. Run it with {@link #main(String[])}.
+ * exists; it lives under the test sources only because it needs the test-scoped dependencies and {@link BenchmarkEventGenerator}. Run it with
+ * {@link #main(String[])}.
  * <p>
  * Measurements come in two kinds:
  * <ul>
@@ -50,8 +51,9 @@ import datawave.table.constants.TableName;
  * pool. These are exact and independent of machine speed, so a violation throws.</li>
  * <li><b>Timing</b> — wall clock and per-thread allocation, printed as a table and never checked, since it depends on the machine.</li>
  * </ul>
- * Test data comes from {@link IngestFixture}: pools of at least {@link IngestFixture#DEFAULT_EVENT_COUNT} events sized between {@link IngestFixture#MIN_FIELDS}
- * and {@link IngestFixture#MAX_FIELDS} fields, covering every concrete normalizer type and rotating event and field visibilities.
+ * Test data comes from {@link BenchmarkEventGenerator}: pools of at least {@link BenchmarkEventGenerator#DEFAULT_EVENT_COUNT} events sized between
+ * {@link BenchmarkEventGenerator#MIN_FIELDS} and {@link BenchmarkEventGenerator#MAX_FIELDS} fields, covering every concrete normalizer type and rotating event
+ * and field visibilities.
  * <p>
  * Iteration counts are overridable with {@code -Ddatawave.benchmark.iterations=N} and {@code -Ddatawave.benchmark.warmup=N};
  * {@code -Ddatawave.benchmark.scenarios=off|on|both} selects the bloom-filter arm for a profiler run.
@@ -72,12 +74,12 @@ public class IngestHotPathBenchmark {
     private static final int BLOOM_WARMUP = Integer.getInteger("datawave.benchmark.bloom.warmup", 5);
     private static final int BLOOM_ITERATIONS = Integer.getInteger("datawave.benchmark.bloom.iterations", 25);
 
-    /** Events per pool. Never below the fixture's floor. */
-    private static final int EVENT_COUNT = Math.max(IngestFixture.DEFAULT_EVENT_COUNT, Integer.getInteger("datawave.benchmark.events", 250));
+    /** Events per pool. Never below the generator's floor. */
+    private static final int EVENT_COUNT = Math.max(BenchmarkEventGenerator.DEFAULT_EVENT_COUNT, Integer.getInteger("datawave.benchmark.events", 250));
 
     /**
-     * Fixed event sizes for the scaling sweep, spanning the fixture's size range. The sweep needs one size at a time to separate linear growth from a quadratic
-     * term; the mixed-size arm is measured separately by {@link #benchmarkVariableEventSizes()}.
+     * Fixed event sizes for the scaling sweep, spanning the generator's size range. The sweep needs one size at a time to separate linear growth from a
+     * quadratic term; the mixed-size arm is measured separately by {@link #benchmarkVariableEventSizes()}.
      */
     private static final int[] SWEEP_FIELD_COUNTS = {15, 25, 30, 35, 45};
 
@@ -105,14 +107,14 @@ public class IngestHotPathBenchmark {
     }
 
     /** How much variety the test data carries. */
-    enum Fixture {
+    enum DataVariety {
         /** One cheap type, one value, no field markings — the original shape. */
         UNIFORM,
         /** Every concrete normalizer, rotating event visibilities, strided field markings. */
         DIVERSE
     }
 
-    // ---------------------------------------------------------------- fixtures
+    // ---------------------------------------------------------------- instrumentation
 
     /**
      * A cheap Type that counts {@code normalize} invocations. Counting rather than timing is what makes the "each normalizer runs twice" claim falsifiable
@@ -248,7 +250,7 @@ public class IngestHotPathBenchmark {
 
     private final List<Result> results = new ArrayList<>();
 
-    private Configuration baseConfiguration(String dataTypeName, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType) {
+    private Configuration baseConfiguration(String dataTypeName, boolean bloomEnabled, FieldMode mode, DataVariety variety, String uniformType) {
         Configuration conf = new Configuration();
         conf.set(dataTypeName + DataTypeHelper.Properties.INGEST_POLICY_ENFORCER_CLASS, IngestPolicyEnforcer.NoOpIngestPolicyEnforcer.class.getName());
         conf.set(DataTypeHelper.Properties.DATA_NAME, dataTypeName);
@@ -268,19 +270,19 @@ public class IngestHotPathBenchmark {
         conf.set(ShardedDataTypeHandler.SHARD_GRIDX_LPRIORITY, "30");
 
         // declare the full field-name space, so a short event's fields are configured just like a long one's
-        String allFields = String.join(",", IngestFixture.configuredFieldNames());
+        String allFields = String.join(",", BenchmarkEventGenerator.configuredFieldNames());
         if (mode == FieldMode.NORMALIZED_ONLY) {
             // normalized but NOT indexed: this is the branch that reaches
             // BaseIngestHelper.normalizeFieldValue(NormalizedContentInterface, Type)
             conf.set(dataTypeName + ".data.category.normalized", allFields);
-        } else if (fixture == Fixture.UNIFORM) {
+        } else if (variety == DataVariety.UNIFORM) {
             // single category, used by the normalization comparisons
             conf.set(dataTypeName + ".data.category.index", allFields);
         } else {
             // four categories: event-only fields are simply absent from every index list
-            List<String> indexed = IngestFixture.fieldNamesFor(FieldCategory.INDEXED);
-            List<String> indexOnly = IngestFixture.fieldNamesFor(FieldCategory.INDEX_ONLY);
-            List<String> tokenized = IngestFixture.fieldNamesFor(FieldCategory.TOKENIZED_INDEX_ONLY);
+            List<String> indexed = BenchmarkEventGenerator.fieldNamesFor(FieldCategory.INDEXED);
+            List<String> indexOnly = BenchmarkEventGenerator.fieldNamesFor(FieldCategory.INDEX_ONLY);
+            List<String> tokenized = BenchmarkEventGenerator.fieldNamesFor(FieldCategory.TOKENIZED_INDEX_ONLY);
 
             List<String> allIndexed = new ArrayList<>(indexed);
             allIndexed.addAll(indexOnly);
@@ -296,10 +298,10 @@ public class IngestHotPathBenchmark {
             conf.setBoolean(dataTypeName + ".data.category.token.fieldname.designator.enabled", false);
         }
 
-        if (fixture == Fixture.DIVERSE) {
+        if (variety == DataVariety.DIVERSE) {
             // one Type per field, round robin over every concrete normalizer except on tokenized fields
-            for (int i = 0; i < IngestFixture.MAX_FIELDS; i++) {
-                conf.set(dataTypeName + ".FIELD_" + i + ".data.field.type.class", IngestFixture.typeClassForCategory(i));
+            for (int i = 0; i < BenchmarkEventGenerator.MAX_FIELDS; i++) {
+                conf.set(dataTypeName + ".FIELD_" + i + ".data.field.type.class", BenchmarkEventGenerator.typeClassForCategory(i));
             }
             conf.set(dataTypeName + ".data.default.type.class", "datawave.data.type.NoOpType");
         } else {
@@ -321,7 +323,7 @@ public class IngestHotPathBenchmark {
         TypeRegistry.reset();
         if (!jvmWarmed) {
             jvmWarmed = true;
-            measure("jvm-warmup", IngestFixture.fixedFieldCounts(20, 30), false, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(),
+            measure("jvm-warmup", BenchmarkEventGenerator.fixedFieldCounts(20, 30), false, FieldMode.INDEXED, DataVariety.DIVERSE, CountingType.class.getName(),
                             UNIFORM_VALUE, MARKED_FIELD_STRIDE, 3000, 3000);
             results.clear();
             TypeRegistry.reset();
@@ -329,25 +331,26 @@ public class IngestHotPathBenchmark {
     }
 
     private Result measure(String name, int[] fieldCounts, boolean bloomEnabled) throws Exception {
-        return measure(name, fieldCounts, bloomEnabled, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE);
+        return measure(name, fieldCounts, bloomEnabled, FieldMode.INDEXED, DataVariety.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE,
+                        MARKED_FIELD_STRIDE);
     }
 
-    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType, String uniformValue,
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, DataVariety variety, String uniformType, String uniformValue,
                     int markedStride) throws Exception {
         int warmup = bloomEnabled ? BLOOM_WARMUP : WARMUP_ITERATIONS;
         int iterations = bloomEnabled ? BLOOM_ITERATIONS : MEASURED_ITERATIONS;
-        return measure(name, fieldCounts, bloomEnabled, mode, fixture, uniformType, uniformValue, markedStride, warmup, iterations);
+        return measure(name, fieldCounts, bloomEnabled, mode, variety, uniformType, uniformValue, markedStride, warmup, iterations);
     }
 
-    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType, String uniformValue,
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, DataVariety variety, String uniformType, String uniformValue,
                     int markedStride, int warmupIterations, int measuredIterations) throws Exception {
-        return measure(name, fieldCounts, bloomEnabled, mode, fixture, uniformType, uniformValue, markedStride, warmupIterations, measuredIterations, null);
+        return measure(name, fieldCounts, bloomEnabled, mode, variety, uniformType, uniformValue, markedStride, warmupIterations, measuredIterations, null);
     }
 
-    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType, String uniformValue,
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, DataVariety variety, String uniformType, String uniformValue,
                     int markedStride, int warmupIterations, int measuredIterations, String contentOverride) throws Exception {
         String dataTypeName = "bench" + SCENARIO_SEQ.incrementAndGet();
-        Configuration conf = baseConfiguration(dataTypeName, bloomEnabled, mode, fixture, uniformType);
+        Configuration conf = baseConfiguration(dataTypeName, bloomEnabled, mode, variety, uniformType);
         TypeRegistry.reset();
         TypeRegistry.getInstance(conf);
 
@@ -358,13 +361,13 @@ public class IngestHotPathBenchmark {
         helper.setup(conf);
 
         Type dataType = TypeRegistry.getType(dataTypeName);
-        List<RawRecordContainer> pool = IngestFixture.eventPool(fieldCounts, dataType, fixture == Fixture.DIVERSE, uniformValue, contentOverride);
+        List<RawRecordContainer> pool = BenchmarkEventGenerator.eventPool(fieldCounts, dataType, variety == DataVariety.DIVERSE, uniformValue, contentOverride);
 
         // pre-normalize each event's fields once, then annotate with per-field markings
         List<Multimap<String,NormalizedContentInterface>> fieldSets = new ArrayList<>(pool.size());
         for (RawRecordContainer record : pool) {
             Multimap<String,NormalizedContentInterface> f = helper.getEventFields(record);
-            IngestFixture.applyFieldMarkings(f, fixture == Fixture.DIVERSE ? markedStride : 0);
+            BenchmarkEventGenerator.applyFieldMarkings(f, variety == DataVariety.DIVERSE ? markedStride : 0);
             fieldSets.add(f);
         }
 
@@ -462,20 +465,20 @@ public class IngestHotPathBenchmark {
     // ---------------------------------------------------------------- scenarios
 
     /**
-     * Sweeps a fixed event size across the fixture's range with bloom filtering off and on. Per-key cost that stays flat as event size grows indicates linear
+     * Sweeps a fixed event size across the generator's range with bloom filtering off and on. Per-key cost that stays flat as event size grows indicates linear
      * scaling; per-key cost that itself grows indicates a quadratic term.
      */
     public void benchmarkCreateColumnsScaling() throws Exception {
-        // bloom is opt-in here: see benchmarkBloomVersusTokenCount for why it cannot run over this fixture
+        // bloom is opt-in here: see benchmarkBloomVersusTokenCount for why it cannot run over this data
         String arms = System.getProperty("datawave.benchmark.scenarios", "off");
         if (!"on".equals(arms)) {
             for (int fields : SWEEP_FIELD_COUNTS) {
-                measure("bloom-off/" + fields, IngestFixture.fixedFieldCounts(EVENT_COUNT, fields), false);
+                measure("bloom-off/" + fields, BenchmarkEventGenerator.fixedFieldCounts(EVENT_COUNT, fields), false);
             }
         }
         if (!"off".equals(arms)) {
             for (int fields : SWEEP_FIELD_COUNTS) {
-                measure("bloom-on/" + fields, IngestFixture.fixedFieldCounts(EVENT_COUNT, fields), true);
+                measure("bloom-on/" + fields, BenchmarkEventGenerator.fixedFieldCounts(EVENT_COUNT, fields), true);
             }
         }
         printTable();
@@ -486,10 +489,10 @@ public class IngestHotPathBenchmark {
      * whether size variation itself costs anything.
      */
     public void benchmarkVariableEventSizes() throws Exception {
-        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        int[] variable = BenchmarkEventGenerator.variableFieldCounts(EVENT_COUNT);
         int mean = (int) Math.round(Arrays.stream(variable).average().orElse(30));
 
-        Result fixed = measure("fixed at mean", IngestFixture.fixedFieldCounts(EVENT_COUNT, mean), false);
+        Result fixed = measure("fixed at mean", BenchmarkEventGenerator.fixedFieldCounts(EVENT_COUNT, mean), false);
         Result mixed = measure("mixed 15-45", variable, false);
 
         printTable();
@@ -500,9 +503,9 @@ public class IngestHotPathBenchmark {
 
     /**
      * Quantifies how bloom filtering scales against the number of tokens in a single tokenized field. {@code createBloomFilter} runs once per indexed term and
-     * each build walks the whole field map, so on a tokenized field the quadratic term is driven by token count, not field count. The full fixture, whose long
-     * content field produces several hundred tokens, does not complete in usable time with bloom filtering on; this sweep bounds the problem by holding the
-     * token count small and reporting the growth so the full-size cost can be extrapolated rather than waited for.
+     * each build walks the whole field map, so on a tokenized field the quadratic term is driven by token count, not field count. The full event pool, whose
+     * long content field produces several hundred tokens, does not complete in usable time with bloom filtering on; this sweep bounds the problem by holding
+     * the token count small and reporting the growth so the full-size cost can be extrapolated rather than waited for.
      */
     public void benchmarkBloomVersusTokenCount() throws Exception {
         System.out.println();
@@ -521,11 +524,11 @@ public class IngestHotPathBenchmark {
 
     /** One point of the token sweep: a 4-event pool whose long content field carries {@code tokens} tokens. */
     private Result measureTokenSweep(int tokens, boolean bloomEnabled) throws Exception {
-        String content = IngestFixture.contentWithTokens(tokens);
+        String content = BenchmarkEventGenerator.contentWithTokens(tokens);
         int warmup = bloomEnabled ? 2 : 50;
         int iterations = bloomEnabled ? 8 : 200;
-        return measure("tok" + tokens, IngestFixture.fixedFieldCounts(4, IngestFixture.MIN_FIELDS), bloomEnabled, FieldMode.INDEXED, Fixture.DIVERSE,
-                        CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE, warmup, iterations, content);
+        return measure("tok" + tokens, BenchmarkEventGenerator.fixedFieldCounts(4, BenchmarkEventGenerator.MIN_FIELDS), bloomEnabled, FieldMode.INDEXED,
+                        DataVariety.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE, warmup, iterations, content);
     }
 
     /**
@@ -535,19 +538,19 @@ public class IngestHotPathBenchmark {
      */
     public void bloomFilterIsBuiltOncePerIndexedTerm() throws Exception {
         // a short content override keeps the bloom arm affordable; see benchmarkBloomVersusTokenCount
-        int[] variable = IngestFixture.fixedFieldCounts(4, IngestFixture.MIN_FIELDS);
-        String shortContent = IngestFixture.contentWithTokens(5);
-        Result off = measure("bloom-off", variable, false, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE,
-                        20, 50, shortContent);
-        Result on = measure("bloom-on", variable, true, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE, 2,
-                        6, shortContent);
+        int[] variable = BenchmarkEventGenerator.fixedFieldCounts(4, BenchmarkEventGenerator.MIN_FIELDS);
+        String shortContent = BenchmarkEventGenerator.contentWithTokens(5);
+        Result off = measure("bloom-off", variable, false, FieldMode.INDEXED, DataVariety.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE,
+                        MARKED_FIELD_STRIDE, 20, 50, shortContent);
+        Result on = measure("bloom-on", variable, true, FieldMode.INDEXED, DataVariety.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE,
+                        MARKED_FIELD_STRIDE, 2, 6, shortContent);
 
         checkEquals(0, off.bloomPerPass, "bloom filter should not be built when disabled");
         check(on.bloomPerPass > on.events, "expected more than one build per event, got " + on.bloomPerPass + " over " + on.events + " events");
         check(on.bloomPerPass >= on.totalFieldsPerPass,
                         "expected at least one build per field, got " + on.bloomPerPass + " for " + on.totalFieldsPerPass + " fields");
         // Two flattens per indexed term come from createColumns (the shard event loop plus the forward
-        // term loop). The tokenized fixture adds more: flushTokenOffsetCache calls getVisibility once per
+        // term loop). The tokenized data adds more: flushTokenOffsetCache calls getVisibility once per
         // term-frequency entry and once for TERM_COUNT, so flatten runs ahead of 2x builds rather than
         // equalling it.
         check(on.flattenPerPass >= 2 * on.bloomPerPass,
@@ -562,7 +565,7 @@ public class IngestHotPathBenchmark {
      * event.
      */
     public void visibilityIsFlattenedPerFieldNotPerEvent() throws Exception {
-        Result r = measure("flatten-probe", IngestFixture.variableFieldCounts(EVENT_COUNT), false);
+        Result r = measure("flatten-probe", BenchmarkEventGenerator.variableFieldCounts(EVENT_COUNT), false);
         check(r.flattenPerPass > r.events, "expected far more flatten calls than events, got " + r.flattenPerPass + " over " + r.events);
         check(r.flattenPerPass >= 2 * r.totalFieldsPerPass, "expected at least two flatten calls per field");
         System.out.printf("flatten calls over %d events (%d fields): %d (%.2f per field)%n", r.events, r.totalFieldsPerPass, r.flattenPerPass,
@@ -578,7 +581,7 @@ public class IngestHotPathBenchmark {
         String cheap = CountingType.class.getName();
         String pricey = CountingDateType.class.getName();
         String dateValue = "2024-06-15T10:30:00.000Z";
-        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        int[] variable = BenchmarkEventGenerator.variableFieldCounts(EVENT_COUNT);
         long totalFields = Arrays.stream(variable).sum();
 
         long indexedCheap = countNormalizations(variable, FieldMode.INDEXED, cheap, UNIFORM_VALUE);
@@ -601,13 +604,13 @@ public class IngestHotPathBenchmark {
     /** Normalizes every event in the pool once and returns the total normalizer invocations. */
     private long countNormalizations(int[] fieldCounts, FieldMode mode, String uniformType, String uniformValue) throws Exception {
         String dataTypeName = "norm" + SCENARIO_SEQ.incrementAndGet();
-        Configuration conf = baseConfiguration(dataTypeName, false, mode, Fixture.UNIFORM, uniformType);
+        Configuration conf = baseConfiguration(dataTypeName, false, mode, DataVariety.UNIFORM, uniformType);
         TypeRegistry.reset();
         TypeRegistry.getInstance(conf);
 
         BenchIngestHelper helper = new BenchIngestHelper();
         helper.setup(conf);
-        List<RawRecordContainer> pool = IngestFixture.eventPool(fieldCounts, TypeRegistry.getType(dataTypeName), false, uniformValue);
+        List<RawRecordContainer> pool = BenchmarkEventGenerator.eventPool(fieldCounts, TypeRegistry.getType(dataTypeName), false, uniformValue);
 
         NORMALIZE_CALLS.set(0);
         for (RawRecordContainer record : pool) {
@@ -625,11 +628,11 @@ public class IngestHotPathBenchmark {
         String cheap = CountingType.class.getName();
         String pricey = CountingDateType.class.getName();
         String dateValue = "2024-06-15T10:30:00.000Z";
-        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        int[] variable = BenchmarkEventGenerator.variableFieldCounts(EVENT_COUNT);
 
         System.out.println();
-        System.out.printf("=== normalization phase: getEventFields (%d events, %d..%d fields, %d iterations) ===%n", variable.length, IngestFixture.MIN_FIELDS,
-                        IngestFixture.MAX_FIELDS, MEASURED_ITERATIONS);
+        System.out.printf("=== normalization phase: getEventFields (%d events, %d..%d fields, %d iterations) ===%n", variable.length,
+                        BenchmarkEventGenerator.MIN_FIELDS, BenchmarkEventGenerator.MAX_FIELDS, MEASURED_ITERATIONS);
         System.out.printf("%-26s %12s %12s %10s %12s%n", "scenario", "median(ns)", "p90(ns)", "norm/field", "bytes/event");
 
         timeNormalization("indexed, cheap type", variable, FieldMode.INDEXED, cheap, UNIFORM_VALUE);
@@ -641,18 +644,18 @@ public class IngestHotPathBenchmark {
         System.out.println();
     }
 
-    /** A {@code uniformValue} of null selects the diverse all-types fixture. */
+    /** A {@code uniformValue} of null selects the diverse all-types pool. */
     private void timeNormalization(String label, int[] fieldCounts, FieldMode mode, String uniformType, String uniformValue) throws Exception {
-        Fixture fixture = uniformValue == null ? Fixture.DIVERSE : Fixture.UNIFORM;
+        DataVariety variety = uniformValue == null ? DataVariety.DIVERSE : DataVariety.UNIFORM;
         String dataTypeName = "normt" + SCENARIO_SEQ.incrementAndGet();
-        Configuration conf = baseConfiguration(dataTypeName, false, mode, fixture, uniformType);
+        Configuration conf = baseConfiguration(dataTypeName, false, mode, variety, uniformType);
         TypeRegistry.reset();
         TypeRegistry.getInstance(conf);
 
         BenchIngestHelper helper = new BenchIngestHelper();
         helper.setup(conf);
         Type dataType = TypeRegistry.getType(dataTypeName);
-        List<RawRecordContainer> pool = IngestFixture.eventPool(fieldCounts, dataType, fixture == Fixture.DIVERSE,
+        List<RawRecordContainer> pool = BenchmarkEventGenerator.eventPool(fieldCounts, dataType, variety == DataVariety.DIVERSE,
                         uniformValue == null ? UNIFORM_VALUE : uniformValue);
 
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
@@ -686,17 +689,18 @@ public class IngestHotPathBenchmark {
     }
 
     /** Every concrete normalizer type should be represented across the pool. */
-    public void fixtureCoversEveryNormalizerType() throws Exception {
-        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+    public void generatorCoversEveryNormalizerType() throws Exception {
+        int[] variable = BenchmarkEventGenerator.variableFieldCounts(EVENT_COUNT);
         int maxFields = Arrays.stream(variable).max().orElse(0);
-        check(maxFields >= IngestFixture.TYPE_COUNT, "largest event must cover every type, was " + maxFields + " fields");
-        check(variable.length >= IngestFixture.DEFAULT_EVENT_COUNT, "pool must hold at least " + IngestFixture.DEFAULT_EVENT_COUNT + " events");
-        checkEquals(IngestFixture.MIN_FIELDS, Arrays.stream(variable).min().orElse(0), "smallest event size");
-        checkEquals(IngestFixture.MAX_FIELDS, maxFields, "largest event size");
+        check(maxFields >= BenchmarkEventGenerator.TYPE_COUNT, "largest event must cover every type, was " + maxFields + " fields");
+        check(variable.length >= BenchmarkEventGenerator.DEFAULT_EVENT_COUNT,
+                        "pool must hold at least " + BenchmarkEventGenerator.DEFAULT_EVENT_COUNT + " events");
+        checkEquals(BenchmarkEventGenerator.MIN_FIELDS, Arrays.stream(variable).min().orElse(0), "smallest event size");
+        checkEquals(BenchmarkEventGenerator.MAX_FIELDS, maxFields, "largest event size");
 
         Result r = measure("type-coverage", variable, false);
         System.out.printf("pool: %d events, %d..%d fields (mean %.1f), %d types, %d keys/pass%n", r.events, r.minFields, r.maxFields, r.meanFields,
-                        IngestFixture.TYPE_COUNT, r.keysPerPass);
+                        BenchmarkEventGenerator.TYPE_COUNT, r.keysPerPass);
     }
 
     /** Scenarios run when no arguments are given. {@code profile} is deliberately excluded: it duplicates work the others already do. */
@@ -725,7 +729,7 @@ public class IngestHotPathBenchmark {
             run("bloom-builds");
             run("flatten");
             run("normalizer-calls");
-            run("fixture-coverage");
+            run("generator-coverage");
             return;
         }
 
@@ -748,8 +752,8 @@ public class IngestHotPathBenchmark {
             benchmark.visibilityIsFlattenedPerFieldNotPerEvent();
         } else if ("normalizer-calls".equals(scenario)) {
             benchmark.normalizerInvocationsPerField();
-        } else if ("fixture-coverage".equals(scenario)) {
-            benchmark.fixtureCoversEveryNormalizerType();
+        } else if ("generator-coverage".equals(scenario)) {
+            benchmark.generatorCoversEveryNormalizerType();
         } else if ("profile".equals(scenario)) {
             benchmark.profileMixedWorkload();
         } else {
@@ -761,7 +765,7 @@ public class IngestHotPathBenchmark {
     /** The mixed-size workload on its own, so a profiler recording covers only it. Select an arm with {@code -Ddatawave.benchmark.scenarios=off|on|both}. */
     private void profileMixedWorkload() throws Exception {
         String arms = System.getProperty("datawave.benchmark.scenarios", "both");
-        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        int[] variable = BenchmarkEventGenerator.variableFieldCounts(EVENT_COUNT);
         if (!"on".equals(arms)) {
             measure("mixed bloom-off", variable, false);
         }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestHotPathBenchmark.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestHotPathBenchmark.java
@@ -1,0 +1,806 @@
+package datawave.ingest.benchmark;
+
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import datawave.data.normalizer.Normalizer;
+import datawave.data.type.BaseType;
+import datawave.data.type.DateType;
+import datawave.ingest.data.RawRecordContainer;
+import datawave.ingest.data.Type;
+import datawave.ingest.data.TypeRegistry;
+import datawave.ingest.data.config.DataTypeHelper;
+import datawave.ingest.data.config.NormalizedContentInterface;
+import datawave.ingest.data.config.NormalizedFieldAndValue;
+import datawave.ingest.data.config.ingest.AbstractContentIngestHelper;
+import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
+import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
+import datawave.ingest.mapreduce.handler.tokenize.ContentIndexingColumnBasedHandler;
+import datawave.ingest.mapreduce.job.BulkIngestKey;
+import datawave.ingest.table.config.ShardTableConfigHelper;
+import datawave.ingest.table.config.TableConfigHelper;
+import datawave.ingest.util.BloomFilterWrapper;
+import datawave.policy.IngestPolicyEnforcer;
+import datawave.table.constants.TableName;
+
+/**
+ * Benchmark and structural-instrumentation harness for the ingest hot path, {@link ShardedDataTypeHandler#processBulk}.
+ * <p>
+ * This is a command line utility, not a test. It carries no test annotations and declares no test methods, so no build or CI configuration has to know it
+ * exists; it lives under the test sources only because it needs the test-scoped dependencies and {@link IngestFixture}. Run it with {@link #main(String[])}.
+ * <p>
+ * Measurements come in two kinds:
+ * <ul>
+ * <li><b>Structural</b> — deterministic call counts collected by {@link InstrumentedHandler} and the counting types, aggregated over a full pass of the event
+ * pool. These are exact and independent of machine speed, so a violation throws.</li>
+ * <li><b>Timing</b> — wall clock and per-thread allocation, printed as a table and never checked, since it depends on the machine.</li>
+ * </ul>
+ * Test data comes from {@link IngestFixture}: pools of at least {@link IngestFixture#DEFAULT_EVENT_COUNT} events sized between {@link IngestFixture#MIN_FIELDS}
+ * and {@link IngestFixture#MAX_FIELDS} fields, covering every concrete normalizer type and rotating event and field visibilities.
+ * <p>
+ * Iteration counts are overridable with {@code -Ddatawave.benchmark.iterations=N} and {@code -Ddatawave.benchmark.warmup=N};
+ * {@code -Ddatawave.benchmark.scenarios=off|on|both} selects the bloom-filter arm for a profiler run.
+ */
+public class IngestHotPathBenchmark {
+
+    private static final int NUM_SHARDS = 241;
+
+    private static final int WARMUP_ITERATIONS = Integer.getInteger("datawave.benchmark.warmup", 1500);
+    private static final int MEASURED_ITERATIONS = Integer.getInteger("datawave.benchmark.iterations", 5000);
+
+    /**
+     * Iteration budget for the bloom-filter arms. Tokenizing a paragraph turns one field into hundreds of indexed terms, and {@code createBloomFilter} runs
+     * once per term over the whole field map, so the quadratic term is driven by token count rather than field count and a single event costs orders of
+     * magnitude more than with bloom filtering off. These arms get their own much smaller budget so the suite terminates in reasonable time; the medians are
+     * still taken over whole events.
+     */
+    private static final int BLOOM_WARMUP = Integer.getInteger("datawave.benchmark.bloom.warmup", 5);
+    private static final int BLOOM_ITERATIONS = Integer.getInteger("datawave.benchmark.bloom.iterations", 25);
+
+    /** Events per pool. Never below the fixture's floor. */
+    private static final int EVENT_COUNT = Math.max(IngestFixture.DEFAULT_EVENT_COUNT, Integer.getInteger("datawave.benchmark.events", 250));
+
+    /**
+     * Fixed event sizes for the scaling sweep, spanning the fixture's size range. The sweep needs one size at a time to separate linear growth from a quadratic
+     * term; the mixed-size arm is measured separately by {@link #benchmarkVariableEventSizes()}.
+     */
+    private static final int[] SWEEP_FIELD_COUNTS = {15, 25, 30, 35, 45};
+
+    /** Mark every Nth field with its own visibility in the diverse arms. */
+    private static final int MARKED_FIELD_STRIDE = 4;
+
+    /** Value used by the uniform arm when no type-specific one is needed. */
+    private static final String UNIFORM_VALUE = "SomeMixedCase Value-payload";
+
+    private static final com.sun.management.ThreadMXBean THREAD_BEAN = (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    /**
+     * Each scenario gets its own datatype name. {@link Type#getIngestHelper} caches helpers in a static map keyed by {@link Type}, whose equality is based on
+     * the type name and helper class but not on the {@link Configuration}; {@code TypeRegistry.reset()} does not clear that map. Reusing one name across
+     * scenarios therefore silently hands back the first scenario's helper, with the first scenario's indexed-field set.
+     */
+    private static final AtomicInteger SCENARIO_SEQ = new AtomicInteger();
+
+    /** Counts datawave Type normalizer invocations. Reset per scenario. */
+    static final AtomicLong NORMALIZE_CALLS = new AtomicLong();
+
+    /** Whether the generated fields are configured as indexed or as normalized-but-not-indexed. */
+    enum FieldMode {
+        INDEXED, NORMALIZED_ONLY
+    }
+
+    /** How much variety the test data carries. */
+    enum Fixture {
+        /** One cheap type, one value, no field markings — the original shape. */
+        UNIFORM,
+        /** Every concrete normalizer, rotating event visibilities, strided field markings. */
+        DIVERSE
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    /**
+     * A cheap Type that counts {@code normalize} invocations. Counting rather than timing is what makes the "each normalizer runs twice" claim falsifiable
+     * independent of machine speed.
+     */
+    public static class CountingType extends BaseType<String> {
+        private static final long serialVersionUID = 1L;
+
+        public CountingType() {
+            super(Normalizer.LC_NO_DIACRITICS_NORMALIZER);
+        }
+
+        @Override
+        public String normalize(String in) {
+            NORMALIZE_CALLS.incrementAndGet();
+            return super.normalize(in);
+        }
+    }
+
+    /**
+     * The same counter over an expensive normalizer. {@code DateNormalizer} walks its format list until one parses, so this shows what a redundant second
+     * normalize actually costs rather than only that it happens.
+     */
+    public static class CountingDateType extends DateType {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String normalize(String in) {
+            NORMALIZE_CALLS.incrementAndGet();
+            return super.normalize(in);
+        }
+    }
+
+    /**
+     * Handler that counts the protected extension points named in the audit, so per-pass call counts can be compared directly against the predicted ones.
+     * Extends the content-indexing handler so tokenized fields run the Lucene analyzer and emit term frequency keys, both of which happen inside the measured
+     * {@code processBulk}.
+     */
+    public static class InstrumentedHandler extends ContentIndexingColumnBasedHandler<Text> {
+        final AtomicLong flattenCalls = new AtomicLong();
+        final AtomicLong bloomFilterBuilds = new AtomicLong();
+
+        void resetCounts() {
+            flattenCalls.set(0);
+            bloomFilterBuilds.set(0);
+        }
+
+        @Override
+        protected byte[] flatten(ColumnVisibility vis) {
+            flattenCalls.incrementAndGet();
+            return super.flatten(vis);
+        }
+
+        @Override
+        protected BloomFilterWrapper createBloomFilter(Multimap<String,NormalizedContentInterface> fields) {
+            bloomFilterBuilds.incrementAndGet();
+            return super.createBloomFilter(fields);
+        }
+
+        @Override
+        public AbstractContentIngestHelper getContentIndexingDataTypeHelper() {
+            return (BenchIngestHelper) helper;
+        }
+    }
+
+    /** Ingest helper that parses the synthetic {@code NAME=value;NAME=value} payload. */
+    public static class BenchIngestHelper extends ContentBaseIngestHelper {
+        @Override
+        public Multimap<String,NormalizedContentInterface> getEventFields(RawRecordContainer record) {
+            Multimap<String,NormalizedContentInterface> eventFields = HashMultimap.create();
+            String raw = new String(record.getRawData(), StandardCharsets.UTF_8);
+            for (String pair : raw.split(";")) {
+                int eq = pair.indexOf('=');
+                String name = pair.substring(0, eq);
+                eventFields.put(name, new NormalizedFieldAndValue(name, pair.substring(eq + 1)));
+            }
+            return normalizeMap(eventFields);
+        }
+
+        @Override
+        public String getNormalizedMaskedValue(final String key) {
+            return "MASKED_VALUE";
+        }
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    /** One measured scenario's results, aggregated over a full pass of the event pool. */
+    static final class Result {
+        final String name;
+        final int events;
+        final double meanFields;
+        final int minFields;
+        final int maxFields;
+        final long medianNanos;
+        final long meanNanos;
+        final long p90Nanos;
+        final long bytesPerEvent;
+        final long keysPerPass;
+        final long flattenPerPass;
+        final long bloomPerPass;
+        final long totalFieldsPerPass;
+        /** keys/pass split by kind: event, field index, global index, term frequency. */
+        final long[] keyKinds;
+
+        Result(String name, int events, double meanFields, int minFields, int maxFields, long medianNanos, long meanNanos, long p90Nanos, long bytesPerEvent,
+                        long keysPerPass, long flattenPerPass, long bloomPerPass, long totalFieldsPerPass, long[] keyKinds) {
+            this.name = name;
+            this.events = events;
+            this.meanFields = meanFields;
+            this.minFields = minFields;
+            this.maxFields = maxFields;
+            this.medianNanos = medianNanos;
+            this.meanNanos = meanNanos;
+            this.p90Nanos = p90Nanos;
+            this.bytesPerEvent = bytesPerEvent;
+            this.keysPerPass = keysPerPass;
+            this.flattenPerPass = flattenPerPass;
+            this.bloomPerPass = bloomPerPass;
+            this.totalFieldsPerPass = totalFieldsPerPass;
+            this.keyKinds = keyKinds;
+        }
+
+        /**
+         * Size-normalized cost, the figure to compare across scenarios of differing event size. Based on the mean rather than the median: in a pool of mixed
+         * event sizes the median sample is a median-sized event, not an average one, so a median-based rate understates a heterogeneous pool against a uniform
+         * one. For uniform pools the two agree.
+         */
+        double nanosPerKey() {
+            return (meanNanos * (double) events) / Math.max(1, keysPerPass);
+        }
+    }
+
+    private final List<Result> results = new ArrayList<>();
+
+    private Configuration baseConfiguration(String dataTypeName, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType) {
+        Configuration conf = new Configuration();
+        conf.set(dataTypeName + DataTypeHelper.Properties.INGEST_POLICY_ENFORCER_CLASS, IngestPolicyEnforcer.NoOpIngestPolicyEnforcer.class.getName());
+        conf.set(DataTypeHelper.Properties.DATA_NAME, dataTypeName);
+        conf.set(TypeRegistry.INGEST_DATA_TYPES, dataTypeName);
+        conf.set(dataTypeName + TypeRegistry.INGEST_HELPER, BenchIngestHelper.class.getName());
+
+        conf.set(ShardedDataTypeHandler.METADATA_TABLE_NAME, TableName.METADATA);
+        conf.set(ShardedDataTypeHandler.NUM_SHARDS, Integer.toString(NUM_SHARDS));
+        conf.set(ShardedDataTypeHandler.SHARDED_TNAMES, TableName.SHARD + "," + TableName.ERROR_SHARD);
+        conf.set(ShardedDataTypeHandler.SHARD_TNAME, TableName.SHARD);
+        conf.set(ShardedDataTypeHandler.SHARD_LPRIORITY, "30");
+        conf.set(TableName.SHARD + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
+        conf.set(ShardedDataTypeHandler.SHARD_GIDX_TNAME, TableName.SHARD_INDEX);
+        conf.set(ShardedDataTypeHandler.SHARD_GIDX_LPRIORITY, "30");
+        conf.set(TableName.SHARD_INDEX + TableConfigHelper.TABLE_CONFIG_CLASS_SUFFIX, ShardTableConfigHelper.class.getName());
+        conf.set(ShardedDataTypeHandler.SHARD_GRIDX_TNAME, TableName.SHARD_RINDEX);
+        conf.set(ShardedDataTypeHandler.SHARD_GRIDX_LPRIORITY, "30");
+
+        // declare the full field-name space, so a short event's fields are configured just like a long one's
+        String allFields = String.join(",", IngestFixture.configuredFieldNames());
+        if (mode == FieldMode.NORMALIZED_ONLY) {
+            // normalized but NOT indexed: this is the branch that reaches
+            // BaseIngestHelper.normalizeFieldValue(NormalizedContentInterface, Type)
+            conf.set(dataTypeName + ".data.category.normalized", allFields);
+        } else if (fixture == Fixture.UNIFORM) {
+            // single category, used by the normalization comparisons
+            conf.set(dataTypeName + ".data.category.index", allFields);
+        } else {
+            // four categories: event-only fields are simply absent from every index list
+            List<String> indexed = IngestFixture.fieldNamesFor(FieldCategory.INDEXED);
+            List<String> indexOnly = IngestFixture.fieldNamesFor(FieldCategory.INDEX_ONLY);
+            List<String> tokenized = IngestFixture.fieldNamesFor(FieldCategory.TOKENIZED_INDEX_ONLY);
+
+            List<String> allIndexed = new ArrayList<>(indexed);
+            allIndexed.addAll(indexOnly);
+            allIndexed.addAll(tokenized);
+            conf.set(dataTypeName + ".data.category.index", String.join(",", allIndexed));
+
+            List<String> notStored = new ArrayList<>(indexOnly);
+            notStored.addAll(tokenized);
+            conf.set(dataTypeName + ".data.category.index.only", String.join(",", notStored));
+
+            conf.set(dataTypeName + ".data.category.index.tokenize.allowlist", String.join(",", tokenized));
+            // keep the token field name equal to the base field name, matching the deployed no-designator mode
+            conf.setBoolean(dataTypeName + ".data.category.token.fieldname.designator.enabled", false);
+        }
+
+        if (fixture == Fixture.DIVERSE) {
+            // one Type per field, round robin over every concrete normalizer except on tokenized fields
+            for (int i = 0; i < IngestFixture.MAX_FIELDS; i++) {
+                conf.set(dataTypeName + ".FIELD_" + i + ".data.field.type.class", IngestFixture.typeClassForCategory(i));
+            }
+            conf.set(dataTypeName + ".data.default.type.class", "datawave.data.type.NoOpType");
+        } else {
+            conf.set(dataTypeName + ".data.default.type.class", uniformType);
+        }
+
+        conf.setBoolean(ShardedDataTypeHandler.SHARD_ININDEX_BLOOM, bloomEnabled);
+        return conf;
+    }
+
+    /**
+     * Set once the JVM has executed the tokenized key-generation path enough for C2 to compile it. Without this the first scenario measured in a JVM pays
+     * compilation and, more visibly, allocates around 30% more per event because escape analysis has not yet kicked in — which silently made whichever scenario
+     * ran first look slower than the identical workload measured later.
+     */
+    private static boolean jvmWarmed = false;
+
+    public void setUp() throws Exception {
+        TypeRegistry.reset();
+        if (!jvmWarmed) {
+            jvmWarmed = true;
+            measure("jvm-warmup", IngestFixture.fixedFieldCounts(20, 30), false, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(),
+                            UNIFORM_VALUE, MARKED_FIELD_STRIDE, 3000, 3000);
+            results.clear();
+            TypeRegistry.reset();
+        }
+    }
+
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled) throws Exception {
+        return measure(name, fieldCounts, bloomEnabled, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE);
+    }
+
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType, String uniformValue,
+                    int markedStride) throws Exception {
+        int warmup = bloomEnabled ? BLOOM_WARMUP : WARMUP_ITERATIONS;
+        int iterations = bloomEnabled ? BLOOM_ITERATIONS : MEASURED_ITERATIONS;
+        return measure(name, fieldCounts, bloomEnabled, mode, fixture, uniformType, uniformValue, markedStride, warmup, iterations);
+    }
+
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType, String uniformValue,
+                    int markedStride, int warmupIterations, int measuredIterations) throws Exception {
+        return measure(name, fieldCounts, bloomEnabled, mode, fixture, uniformType, uniformValue, markedStride, warmupIterations, measuredIterations, null);
+    }
+
+    private Result measure(String name, int[] fieldCounts, boolean bloomEnabled, FieldMode mode, Fixture fixture, String uniformType, String uniformValue,
+                    int markedStride, int warmupIterations, int measuredIterations, String contentOverride) throws Exception {
+        String dataTypeName = "bench" + SCENARIO_SEQ.incrementAndGet();
+        Configuration conf = baseConfiguration(dataTypeName, bloomEnabled, mode, fixture, uniformType);
+        TypeRegistry.reset();
+        TypeRegistry.getInstance(conf);
+
+        InstrumentedHandler handler = new InstrumentedHandler();
+        handler.setup(new TaskAttemptContextImpl(conf, new TaskAttemptID()));
+
+        BenchIngestHelper helper = new BenchIngestHelper();
+        helper.setup(conf);
+
+        Type dataType = TypeRegistry.getType(dataTypeName);
+        List<RawRecordContainer> pool = IngestFixture.eventPool(fieldCounts, dataType, fixture == Fixture.DIVERSE, uniformValue, contentOverride);
+
+        // pre-normalize each event's fields once, then annotate with per-field markings
+        List<Multimap<String,NormalizedContentInterface>> fieldSets = new ArrayList<>(pool.size());
+        for (RawRecordContainer record : pool) {
+            Multimap<String,NormalizedContentInterface> f = helper.getEventFields(record);
+            IngestFixture.applyFieldMarkings(f, fixture == Fixture.DIVERSE ? markedStride : 0);
+            fieldSets.add(f);
+        }
+
+        int poolSize = pool.size();
+        for (int i = 0; i < warmupIterations; i++) {
+            int p = i % poolSize;
+            handler.processBulk(null, pool.get(p), fieldSets.get(p), null);
+        }
+
+        // one clean instrumented pass over the whole pool for the structural counts
+        handler.resetCounts();
+        long keysPerPass = 0;
+        long[] keyKinds = new long[KEY_KIND_COUNT];
+        // a full structural pass is unaffordable with bloom filtering on, so sample the pool instead
+        int structuralEvents = bloomEnabled ? Math.min(poolSize, 4) : poolSize;
+        for (int p = 0; p < structuralEvents; p++) {
+            Multimap<BulkIngestKey,Value> out = handler.processBulk(null, pool.get(p), fieldSets.get(p), null);
+            keysPerPass += out.size();
+            for (BulkIngestKey bik : out.keySet()) {
+                keyKinds[classify(bik)] += out.get(bik).size();
+            }
+        }
+        long flattenPerPass = handler.flattenCalls.get();
+        long bloomPerPass = handler.bloomFilterBuilds.get();
+
+        long[] samples = new long[measuredIterations];
+        long allocStart = THREAD_BEAN.getCurrentThreadAllocatedBytes();
+        for (int i = 0; i < measuredIterations; i++) {
+            int p = i % poolSize;
+            long t0 = System.nanoTime();
+            handler.processBulk(null, pool.get(p), fieldSets.get(p), null);
+            samples[i] = System.nanoTime() - t0;
+        }
+        long allocEnd = THREAD_BEAN.getCurrentThreadAllocatedBytes();
+
+        long sum = 0;
+        for (long sample : samples) {
+            sum += sample;
+        }
+        long mean = sum / samples.length;
+        Arrays.sort(samples);
+        long median = samples[samples.length / 2];
+        long p90 = samples[(int) (samples.length * 0.9)];
+        long bytesPerEvent = (allocEnd - allocStart) / measuredIterations;
+
+        long totalFields = 0;
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (int c : fieldCounts) {
+            totalFields += c;
+            min = Math.min(min, c);
+            max = Math.max(max, c);
+        }
+        // structural counters cover structuralEvents, so scale the field total to match
+        long fieldsCounted = 0;
+        for (int p = 0; p < structuralEvents; p++) {
+            fieldsCounted += fieldCounts[p];
+        }
+
+        Result r = new Result(name, structuralEvents, totalFields / (double) poolSize, min, max, median, mean, p90, bytesPerEvent, keysPerPass, flattenPerPass,
+                        bloomPerPass, fieldsCounted, keyKinds);
+        results.add(r);
+        return r;
+    }
+
+    static final int KEY_EVENT = 0;
+    static final int KEY_FIELD_INDEX = 1;
+    static final int KEY_GLOBAL_INDEX = 2;
+    static final int KEY_TERM_FREQUENCY = 3;
+    static final int KEY_KIND_COUNT = 4;
+    private static final String[] KEY_KIND_NAMES = {"event", "fi", "index", "tf"};
+
+    /**
+     * Buckets a generated key by the structure it belongs to. Shard-table keys carry either the {@code tf} column family, an {@code fi\0FIELD} column family,
+     * or the datatype/uid column family of an event key; anything on another table is a global index key.
+     *
+     * @param bik
+     *            the generated key
+     * @return an index into the key-kind array
+     */
+    private static int classify(BulkIngestKey bik) {
+        if (!TableName.SHARD.equals(bik.getTableName().toString())) {
+            return KEY_GLOBAL_INDEX;
+        }
+        String colf = bik.getKey().getColumnFamily().toString();
+        if ("tf".equals(colf)) {
+            return KEY_TERM_FREQUENCY;
+        }
+        if (colf.startsWith("fi\u0000")) {
+            return KEY_FIELD_INDEX;
+        }
+        return KEY_EVENT;
+    }
+
+    // ---------------------------------------------------------------- scenarios
+
+    /**
+     * Sweeps a fixed event size across the fixture's range with bloom filtering off and on. Per-key cost that stays flat as event size grows indicates linear
+     * scaling; per-key cost that itself grows indicates a quadratic term.
+     */
+    public void benchmarkCreateColumnsScaling() throws Exception {
+        // bloom is opt-in here: see benchmarkBloomVersusTokenCount for why it cannot run over this fixture
+        String arms = System.getProperty("datawave.benchmark.scenarios", "off");
+        if (!"on".equals(arms)) {
+            for (int fields : SWEEP_FIELD_COUNTS) {
+                measure("bloom-off/" + fields, IngestFixture.fixedFieldCounts(EVENT_COUNT, fields), false);
+            }
+        }
+        if (!"off".equals(arms)) {
+            for (int fields : SWEEP_FIELD_COUNTS) {
+                measure("bloom-on/" + fields, IngestFixture.fixedFieldCounts(EVENT_COUNT, fields), true);
+            }
+        }
+        printTable();
+    }
+
+    /**
+     * The realistic workload: a pool of mixed-size events rather than one shape repeated. Compared against a fixed-size pool at the same mean, which isolates
+     * whether size variation itself costs anything.
+     */
+    public void benchmarkVariableEventSizes() throws Exception {
+        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        int mean = (int) Math.round(Arrays.stream(variable).average().orElse(30));
+
+        Result fixed = measure("fixed at mean", IngestFixture.fixedFieldCounts(EVENT_COUNT, mean), false);
+        Result mixed = measure("mixed 15-45", variable, false);
+
+        printTable();
+        System.out.printf("mixed-size pool: %d events, %d..%d fields, mean %.1f%n", mixed.events, mixed.minFields, mixed.maxFields, mixed.meanFields);
+        System.out.printf("ns/key mixed %.1f vs fixed-at-mean %.1f (%.1f%%)%n", mixed.nanosPerKey(), fixed.nanosPerKey(),
+                        100.0 * (mixed.nanosPerKey() - fixed.nanosPerKey()) / fixed.nanosPerKey());
+    }
+
+    /**
+     * Quantifies how bloom filtering scales against the number of tokens in a single tokenized field. {@code createBloomFilter} runs once per indexed term and
+     * each build walks the whole field map, so on a tokenized field the quadratic term is driven by token count, not field count. The full fixture, whose long
+     * content field produces several hundred tokens, does not complete in usable time with bloom filtering on; this sweep bounds the problem by holding the
+     * token count small and reporting the growth so the full-size cost can be extrapolated rather than waited for.
+     */
+    public void benchmarkBloomVersusTokenCount() throws Exception {
+        System.out.println();
+        System.out.println("=== bloom filtering versus tokens in one tokenized field (4 events) ===");
+        System.out.printf("%-8s %14s %14s %10s %10s%n", "tokens", "bloom off(ns)", "bloom on(ns)", "ratio", "builds");
+
+        for (int tokens : new int[] {5, 10, 20, 40}) {
+            Result off = measureTokenSweep(tokens, false);
+            Result on = measureTokenSweep(tokens, true);
+            System.out.printf("%-8d %14d %14d %9.1fx %10d%n", tokens, off.medianNanos, on.medianNanos, on.medianNanos / (double) off.medianNanos,
+                            on.bloomPerPass / on.events);
+        }
+        System.out.println();
+        results.clear();
+    }
+
+    /** One point of the token sweep: a 4-event pool whose long content field carries {@code tokens} tokens. */
+    private Result measureTokenSweep(int tokens, boolean bloomEnabled) throws Exception {
+        String content = IngestFixture.contentWithTokens(tokens);
+        int warmup = bloomEnabled ? 2 : 50;
+        int iterations = bloomEnabled ? 8 : 200;
+        return measure("tok" + tokens, IngestFixture.fixedFieldCounts(4, IngestFixture.MIN_FIELDS), bloomEnabled, FieldMode.INDEXED, Fixture.DIVERSE,
+                        CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE, warmup, iterations, content);
+    }
+
+    /**
+     * The audit predicted {@code createBloomFilter} runs once per forward-indexed term rather than once per event. Asserted over a full pass of the mixed-size
+     * pool: builds should exceed the event count, should be at least one per field, and {@code flatten} should track them two to one, which together pin both
+     * calls to the per-term loop rather than the per-event scope.
+     */
+    public void bloomFilterIsBuiltOncePerIndexedTerm() throws Exception {
+        // a short content override keeps the bloom arm affordable; see benchmarkBloomVersusTokenCount
+        int[] variable = IngestFixture.fixedFieldCounts(4, IngestFixture.MIN_FIELDS);
+        String shortContent = IngestFixture.contentWithTokens(5);
+        Result off = measure("bloom-off", variable, false, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE,
+                        20, 50, shortContent);
+        Result on = measure("bloom-on", variable, true, FieldMode.INDEXED, Fixture.DIVERSE, CountingType.class.getName(), UNIFORM_VALUE, MARKED_FIELD_STRIDE, 2,
+                        6, shortContent);
+
+        checkEquals(0, off.bloomPerPass, "bloom filter should not be built when disabled");
+        check(on.bloomPerPass > on.events, "expected more than one build per event, got " + on.bloomPerPass + " over " + on.events + " events");
+        check(on.bloomPerPass >= on.totalFieldsPerPass,
+                        "expected at least one build per field, got " + on.bloomPerPass + " for " + on.totalFieldsPerPass + " fields");
+        // Two flattens per indexed term come from createColumns (the shard event loop plus the forward
+        // term loop). The tokenized fixture adds more: flushTokenOffsetCache calls getVisibility once per
+        // term-frequency entry and once for TERM_COUNT, so flatten runs ahead of 2x builds rather than
+        // equalling it.
+        check(on.flattenPerPass >= 2 * on.bloomPerPass,
+                        "flatten should be at least twice the indexed term count, got " + on.flattenPerPass + " against " + on.bloomPerPass + " builds");
+
+        System.out.printf("over %d events (%d fields total): %d bloom builds, %d flatten calls%n", on.events, on.totalFieldsPerPass, on.bloomPerPass,
+                        on.flattenPerPass);
+    }
+
+    /**
+     * The audit predicted the event ColumnVisibility is re-flattened once per field, once per forward term and once per reverse term, rather than once per
+     * event.
+     */
+    public void visibilityIsFlattenedPerFieldNotPerEvent() throws Exception {
+        Result r = measure("flatten-probe", IngestFixture.variableFieldCounts(EVENT_COUNT), false);
+        check(r.flattenPerPass > r.events, "expected far more flatten calls than events, got " + r.flattenPerPass + " over " + r.events);
+        check(r.flattenPerPass >= 2 * r.totalFieldsPerPass, "expected at least two flatten calls per field");
+        System.out.printf("flatten calls over %d events (%d fields): %d (%.2f per field)%n", r.events, r.totalFieldsPerPass, r.flattenPerPass,
+                        r.flattenPerPass / (double) r.totalFieldsPerPass);
+    }
+
+    /**
+     * The audit predicted BaseIngestHelper normalizes each value twice. That is branch dependent: {@code normalize(NormalizedContentInterface, Type)} on the
+     * indexed path normalizes once, while {@code normalizeFieldValue(NormalizedContentInterface, Type)} on the normalized-but-not-indexed path normalizes the
+     * same input twice. Counted over a whole pass so the ratio holds across event sizes.
+     */
+    public void normalizerInvocationsPerField() throws Exception {
+        String cheap = CountingType.class.getName();
+        String pricey = CountingDateType.class.getName();
+        String dateValue = "2024-06-15T10:30:00.000Z";
+        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        long totalFields = Arrays.stream(variable).sum();
+
+        long indexedCheap = countNormalizations(variable, FieldMode.INDEXED, cheap, UNIFORM_VALUE);
+        long onlyCheap = countNormalizations(variable, FieldMode.NORMALIZED_ONLY, cheap, UNIFORM_VALUE);
+        long indexedDate = countNormalizations(variable, FieldMode.INDEXED, pricey, dateValue);
+        long onlyDate = countNormalizations(variable, FieldMode.NORMALIZED_ONLY, pricey, dateValue);
+
+        System.out.printf("over %d events (%d fields total)%n", variable.length, totalFields);
+        System.out.printf("  INDEXED cheap:          %d (%.2f per field)%n", indexedCheap, indexedCheap / (double) totalFields);
+        System.out.printf("  NORMALIZED-ONLY cheap:  %d (%.2f per field)%n", onlyCheap, onlyCheap / (double) totalFields);
+        System.out.printf("  INDEXED DateType:       %d (%.2f per field)%n", indexedDate, indexedDate / (double) totalFields);
+        System.out.printf("  NORMALIZED-ONLY Date:   %d (%.2f per field)%n", onlyDate, onlyDate / (double) totalFields);
+
+        checkEquals(totalFields, indexedCheap, "indexed path should normalize each value once");
+        checkEquals(2 * totalFields, onlyCheap, "normalized-but-not-indexed path should normalize each value twice");
+        checkEquals(totalFields, indexedDate, "expensive type, indexed path");
+        checkEquals(2 * totalFields, onlyDate, "expensive type, normalized-only path");
+    }
+
+    /** Normalizes every event in the pool once and returns the total normalizer invocations. */
+    private long countNormalizations(int[] fieldCounts, FieldMode mode, String uniformType, String uniformValue) throws Exception {
+        String dataTypeName = "norm" + SCENARIO_SEQ.incrementAndGet();
+        Configuration conf = baseConfiguration(dataTypeName, false, mode, Fixture.UNIFORM, uniformType);
+        TypeRegistry.reset();
+        TypeRegistry.getInstance(conf);
+
+        BenchIngestHelper helper = new BenchIngestHelper();
+        helper.setup(conf);
+        List<RawRecordContainer> pool = IngestFixture.eventPool(fieldCounts, TypeRegistry.getType(dataTypeName), false, uniformValue);
+
+        NORMALIZE_CALLS.set(0);
+        for (RawRecordContainer record : pool) {
+            helper.getEventFields(record);
+        }
+        return NORMALIZE_CALLS.get();
+    }
+
+    /**
+     * Times the normalization half of the hot path, {@code getEventFields} into {@code BaseIngestHelper.normalizeMap}. The scaling sweep deliberately hoists
+     * this out of the measured loop so it times key generation alone, which means the redundant second normalize on the normalized-but-not-indexed branch is
+     * invisible there. This measures it directly, cheap type against expensive type, indexed branch against normalized-only branch.
+     */
+    public void benchmarkNormalizationPhase() throws Exception {
+        String cheap = CountingType.class.getName();
+        String pricey = CountingDateType.class.getName();
+        String dateValue = "2024-06-15T10:30:00.000Z";
+        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+
+        System.out.println();
+        System.out.printf("=== normalization phase: getEventFields (%d events, %d..%d fields, %d iterations) ===%n", variable.length, IngestFixture.MIN_FIELDS,
+                        IngestFixture.MAX_FIELDS, MEASURED_ITERATIONS);
+        System.out.printf("%-26s %12s %12s %10s %12s%n", "scenario", "median(ns)", "p90(ns)", "norm/field", "bytes/event");
+
+        timeNormalization("indexed, cheap type", variable, FieldMode.INDEXED, cheap, UNIFORM_VALUE);
+        timeNormalization("normalized-only, cheap", variable, FieldMode.NORMALIZED_ONLY, cheap, UNIFORM_VALUE);
+        timeNormalization("indexed, DateType", variable, FieldMode.INDEXED, pricey, dateValue);
+        timeNormalization("normalized-only, DateType", variable, FieldMode.NORMALIZED_ONLY, pricey, dateValue);
+        timeNormalization("indexed, all 20 types", variable, FieldMode.INDEXED, cheap, null);
+        timeNormalization("normalized-only, 20 types", variable, FieldMode.NORMALIZED_ONLY, cheap, null);
+        System.out.println();
+    }
+
+    /** A {@code uniformValue} of null selects the diverse all-types fixture. */
+    private void timeNormalization(String label, int[] fieldCounts, FieldMode mode, String uniformType, String uniformValue) throws Exception {
+        Fixture fixture = uniformValue == null ? Fixture.DIVERSE : Fixture.UNIFORM;
+        String dataTypeName = "normt" + SCENARIO_SEQ.incrementAndGet();
+        Configuration conf = baseConfiguration(dataTypeName, false, mode, fixture, uniformType);
+        TypeRegistry.reset();
+        TypeRegistry.getInstance(conf);
+
+        BenchIngestHelper helper = new BenchIngestHelper();
+        helper.setup(conf);
+        Type dataType = TypeRegistry.getType(dataTypeName);
+        List<RawRecordContainer> pool = IngestFixture.eventPool(fieldCounts, dataType, fixture == Fixture.DIVERSE,
+                        uniformValue == null ? UNIFORM_VALUE : uniformValue);
+
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            helper.getEventFields(pool.get(i % pool.size()));
+        }
+
+        NORMALIZE_CALLS.set(0);
+        long fieldsInPass = 0;
+        for (RawRecordContainer record : pool) {
+            helper.getEventFields(record);
+        }
+        for (int c : fieldCounts) {
+            fieldsInPass += c;
+        }
+        long normalizes = NORMALIZE_CALLS.get();
+
+        long[] samples = new long[MEASURED_ITERATIONS];
+        long allocStart = THREAD_BEAN.getCurrentThreadAllocatedBytes();
+        for (int i = 0; i < MEASURED_ITERATIONS; i++) {
+            long t0 = System.nanoTime();
+            helper.getEventFields(pool.get(i % pool.size()));
+            samples[i] = System.nanoTime() - t0;
+        }
+        long allocEnd = THREAD_BEAN.getCurrentThreadAllocatedBytes();
+
+        Arrays.sort(samples);
+        // the counter only fires for the counting types; the all-types arm uses the real ones
+        String normPerField = normalizes == 0 ? "n/a" : String.format("%.2f", normalizes / (double) fieldsInPass);
+        System.out.printf("%-26s %12d %12d %10s %12d%n", label, samples[samples.length / 2], samples[(int) (samples.length * 0.9)], normPerField,
+                        (allocEnd - allocStart) / MEASURED_ITERATIONS);
+    }
+
+    /** Every concrete normalizer type should be represented across the pool. */
+    public void fixtureCoversEveryNormalizerType() throws Exception {
+        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        int maxFields = Arrays.stream(variable).max().orElse(0);
+        check(maxFields >= IngestFixture.TYPE_COUNT, "largest event must cover every type, was " + maxFields + " fields");
+        check(variable.length >= IngestFixture.DEFAULT_EVENT_COUNT, "pool must hold at least " + IngestFixture.DEFAULT_EVENT_COUNT + " events");
+        checkEquals(IngestFixture.MIN_FIELDS, Arrays.stream(variable).min().orElse(0), "smallest event size");
+        checkEquals(IngestFixture.MAX_FIELDS, maxFields, "largest event size");
+
+        Result r = measure("type-coverage", variable, false);
+        System.out.printf("pool: %d events, %d..%d fields (mean %.1f), %d types, %d keys/pass%n", r.events, r.minFields, r.maxFields, r.meanFields,
+                        IngestFixture.TYPE_COUNT, r.keysPerPass);
+    }
+
+    /** Scenarios run when no arguments are given. {@code profile} is deliberately excluded: it duplicates work the others already do. */
+    private static final String[] DEFAULT_SCENARIOS = {"scaling", "variable", "bloom", "normalization", "structural"};
+
+    /**
+     * Entry point. With no arguments every scenario in {@link #DEFAULT_SCENARIOS} runs in order; otherwise each argument names one:
+     * <ul>
+     * <li>{@code scaling} — key generation over a fixed-size field sweep</li>
+     * <li>{@code variable} — a variable-size pool against a fixed pool at the same mean</li>
+     * <li>{@code bloom} — bloom filtering against token count, on a bounded pool</li>
+     * <li>{@code normalization} — the {@code getEventFields} phase</li>
+     * <li>{@code structural} — the deterministic call counts; throws {@link IllegalStateException} if one does not hold</li>
+     * <li>{@code profile} — the mixed-size workload alone, so a JFR recording covers only that</li>
+     * </ul>
+     * Exits non-zero on an unknown scenario or a failed structural check.
+     */
+    public static void main(String[] args) throws Exception {
+        for (String scenario : (args.length > 0 ? args : DEFAULT_SCENARIOS)) {
+            run(scenario);
+        }
+    }
+
+    private static void run(String scenario) throws Exception {
+        if ("structural".equals(scenario)) {
+            run("bloom-builds");
+            run("flatten");
+            run("normalizer-calls");
+            run("fixture-coverage");
+            return;
+        }
+
+        // A fresh instance per scenario, matching what the harness relied on when these were test methods: a printed
+        // table then holds only its own rows, and every scenario starts from a reset TypeRegistry.
+        IngestHotPathBenchmark benchmark = new IngestHotPathBenchmark();
+        benchmark.setUp();
+
+        if ("scaling".equals(scenario)) {
+            benchmark.benchmarkCreateColumnsScaling();
+        } else if ("variable".equals(scenario)) {
+            benchmark.benchmarkVariableEventSizes();
+        } else if ("bloom".equals(scenario)) {
+            benchmark.benchmarkBloomVersusTokenCount();
+        } else if ("normalization".equals(scenario)) {
+            benchmark.benchmarkNormalizationPhase();
+        } else if ("bloom-builds".equals(scenario)) {
+            benchmark.bloomFilterIsBuiltOncePerIndexedTerm();
+        } else if ("flatten".equals(scenario)) {
+            benchmark.visibilityIsFlattenedPerFieldNotPerEvent();
+        } else if ("normalizer-calls".equals(scenario)) {
+            benchmark.normalizerInvocationsPerField();
+        } else if ("fixture-coverage".equals(scenario)) {
+            benchmark.fixtureCoversEveryNormalizerType();
+        } else if ("profile".equals(scenario)) {
+            benchmark.profileMixedWorkload();
+        } else {
+            System.err.println("unknown scenario '" + scenario + "'; expected one of scaling, variable, bloom, normalization, structural, profile");
+            System.exit(2);
+        }
+    }
+
+    /** The mixed-size workload on its own, so a profiler recording covers only it. Select an arm with {@code -Ddatawave.benchmark.scenarios=off|on|both}. */
+    private void profileMixedWorkload() throws Exception {
+        String arms = System.getProperty("datawave.benchmark.scenarios", "both");
+        int[] variable = IngestFixture.variableFieldCounts(EVENT_COUNT);
+        if (!"on".equals(arms)) {
+            measure("mixed bloom-off", variable, false);
+        }
+        if (!"off".equals(arms)) {
+            measure("mixed bloom-on", variable, true);
+        }
+        printTable();
+    }
+
+    /** Structural counts are exact, so a violation is a defect in the harness or in the code under it, not a slow machine. */
+    private static void check(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+
+    private static void checkEquals(long expected, long actual, String message) {
+        if (expected != actual) {
+            throw new IllegalStateException(message + ": expected " + expected + ", got " + actual);
+        }
+    }
+
+    private void printTable() {
+        System.out.println();
+        System.out.println("=== ingest hot path (" + EVENT_COUNT + " events; " + MEASURED_ITERATIONS + " iterations, " + BLOOM_ITERATIONS
+                        + " for bloom arms) ===");
+        System.out.printf("%-20s %7s %12s %12s %12s %12s %10s %10s %9s %8s %12s%n", "scenario", "events", "fields", "median(ns)", "mean(ns)", "p90(ns)",
+                        "ns/key", "keys/pass", "flatten", "bloom", "bytes/event");
+        for (Result r : results) {
+            String fieldDesc = r.minFields == r.maxFields ? Integer.toString(r.minFields)
+                            : String.format("%d-%d(%.1f)", r.minFields, r.maxFields, r.meanFields);
+            StringBuilder kinds = new StringBuilder();
+            for (int k = 0; k < KEY_KIND_COUNT; k++) {
+                kinds.append(k == 0 ? "" : "/").append(KEY_KIND_NAMES[k]).append(':').append(r.keyKinds[k]);
+            }
+            System.out.printf("%-20s %7d %12s %12d %12d %12d %10.1f %10d %9d %8d %12d  %s%n", r.name, r.events, fieldDesc, r.medianNanos, r.meanNanos,
+                            r.p90Nanos, r.nanosPerKey(), r.keysPerPass, r.flattenPerPass, r.bloomPerPass, r.bytesPerEvent, kinds);
+        }
+        System.out.println();
+        results.clear();
+    }
+}


### PR DESCRIPTION
Covers ShardedDataTypeHandler.processBulk and the getEventFields normalization phase, with a field-count sweep over a range of event sizes.

    mvn test-compile -pl warehouse/ingest-core
    mvn -q -pl warehouse/ingest-core dependency:build-classpath \
        -Dmdep.outputFile=/tmp/cp.txt -Dmdep.includeScope=test
    java -cp "warehouse/ingest-core/target/test-classes:\
warehouse/ingest-core/target/classes:$(cat /tmp/cp.txt)" \
        datawave.ingest.benchmark.IngestHotPathBenchmark [scenario...]

Scenarios are scaling, variable, bloom, normalization, structural and profile; every one but profile runs when none is named. Structural counts are deterministic, so a violation throws IllegalStateException and the process exits non-zero.