### PR TITLE
Adds the ability to mask metadata fields from annotation source in context of annotation request

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/annotation/AnnotationConfig.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/annotation/AnnotationConfig.java
@@ -1,6 +1,7 @@
 package datawave.query.config.annotation;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 import datawave.annotation.data.transform.TimestampTransformer;
@@ -13,6 +14,7 @@ public class AnnotationConfig implements Serializable {
     private String truthmarkSourceTableName = "truthmarkSource";
     private VisibilityTransformer visibilityTransformer;
     private TimestampTransformer timestampTransformer;
+    private List<String> maskSourceMetadata = List.of("visibility");
 
     public AnnotationConfig() {
 
@@ -25,6 +27,7 @@ public class AnnotationConfig implements Serializable {
         setTruthmarkSourceTableName(other.getTruthmarkSourceTableName());
         setVisibilityTransformer(other.getVisibilityTransformer());
         setTimestampTransformer(other.getTimestampTransformer());
+        setMaskSourceMetadata(other.getMaskSourceMetadata());
     }
 
     @Override
@@ -39,7 +42,8 @@ public class AnnotationConfig implements Serializable {
                 Objects.equals(getTruthmarkTableName(), ((AnnotationConfig) other).getTruthmarkTableName()) &&
                 Objects.equals(getTruthmarkSourceTableName(), ((AnnotationConfig) other).getTruthmarkSourceTableName()) &&
                 Objects.equals(getVisibilityTransformer(), ((AnnotationConfig) other).getVisibilityTransformer()) &&
-                Objects.equals(getTimestampTransformer(), ((AnnotationConfig) other).getTimestampTransformer());
+                Objects.equals(getTimestampTransformer(), ((AnnotationConfig) other).getTimestampTransformer()) &&
+                Objects.equals(getMaskSourceMetadata(), ((AnnotationConfig) other).getMaskSourceMetadata());
         // @formatter:on
     }
 
@@ -47,7 +51,7 @@ public class AnnotationConfig implements Serializable {
     public int hashCode() {
         // formatter:off
         return Objects.hash(getAnnotationTableName(), getAnnotationSourceTableName(), getTruthmarkTableName(), getTruthmarkSourceTableName(),
-                        getVisibilityTransformer(), getTimestampTransformer());
+                        getVisibilityTransformer(), getTimestampTransformer(), getMaskSourceMetadata());
         // formatter:on
     }
 
@@ -97,5 +101,13 @@ public class AnnotationConfig implements Serializable {
 
     public void setTimestampTransformer(TimestampTransformer timestampTransformer) {
         this.timestampTransformer = timestampTransformer;
+    }
+
+    public List<String> getMaskSourceMetadata() {
+        return maskSourceMetadata;
+    }
+
+    public void setMaskSourceMetadata(List<String> maskSourceMetadata) {
+        this.maskSourceMetadata = maskSourceMetadata;
     }
 }

--- a/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
+++ b/web-services/annotations/src/main/java/datawave/webservice/annotation/AnnotationManagerBean.java
@@ -371,12 +371,42 @@ public class AnnotationManagerBean implements AnnotationManager {
         final String analyticHash = a.getAnalyticSourceHash();
         final Optional<AnnotationSource> result = context.getAnnotationSource(analyticHash);
         if (result.isPresent()) {
-            return injectAnnotationSource(a, result.get());
+            // when returning the source in the context of an annotation, mask/remove the source's visibility
+            // (which currently is the union of visibility for all things annotated with that source)
+            return injectAnnotationSource(a, maskSourceMetadata(result.get()));
         } else {
             log.debug("No analytic source found for annotation {}/{}/{} {}, using analyticHash {}", a.getShard(), a.getDataType(), a.getUid(),
                             a.getAnnotationId(), a.getAnalyticSourceHash());
             return a;
         }
+    }
+
+    /**
+     * When returning the source in the context of an annotation mask/remove certain metadata from the source (e.g., visibility) because the metadata on the
+     * annotation itself takes precedence.
+     *
+     * @param annotationSource
+     *            the annotation source with metadata fields to mask
+     * @return a new source with masked fields removed, if no fields were found to remove, the original source.
+     */
+    protected final AnnotationSource maskSourceMetadata(AnnotationSource annotationSource) {
+        final List<String> fieldsToMask = config.getAnnotationConfig().getMaskSourceMetadata();
+        if (fieldsToMask == null || fieldsToMask.isEmpty()) {
+            // no fields to mask, make no changes.
+            return annotationSource;
+        }
+
+        AnnotationSource.Builder builder = null;
+        for (String key : fieldsToMask) {
+            if (annotationSource.containsMetadata(key)) {
+                if (builder == null) {
+                    builder = annotationSource.toBuilder();
+                }
+                builder.removeMetadata(key);
+            }
+        }
+
+        return (builder == null) ? annotationSource : builder.build();
     }
 
     /**

--- a/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanTest.java
+++ b/web-services/annotations/src/test/java/datawave/webservice/annotation/AnnotationManagerBeanTest.java
@@ -1,0 +1,111 @@
+package datawave.webservice.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.annotation.protobuf.v1.AnnotationSource;
+import datawave.query.config.annotation.AnnotationConfig;
+
+public class AnnotationManagerBeanTest {
+
+    @Test
+    public void maskSourceMetadataReturnsOriginalWhenMaskListIsNull() throws Exception {
+        AnnotationManagerBean bean = buildBeanWithMaskList(null);
+        AnnotationSource source = sourceWithMetadata("visibility", "A&B", "source", "demo");
+
+        AnnotationSource masked = bean.maskSourceMetadata(source);
+
+        assertSame(source, masked);
+    }
+
+    @Test
+    public void maskSourceMetadataReturnsOriginalWhenMaskListIsEmpty() throws Exception {
+        AnnotationManagerBean bean = buildBeanWithMaskList(Collections.emptyList());
+        AnnotationSource source = sourceWithMetadata("visibility", "A&B", "source", "demo");
+
+        AnnotationSource masked = bean.maskSourceMetadata(source);
+
+        assertSame(source, masked);
+    }
+
+    @Test
+    public void maskSourceMetadataReturnsOriginalWhenNoMetadataMatches() throws Exception {
+        AnnotationManagerBean bean = buildBeanWithMaskList(List.of("visibility"));
+        AnnotationSource source = sourceWithMetadata("source", "demo");
+
+        AnnotationSource masked = bean.maskSourceMetadata(source);
+
+        assertSame(source, masked);
+    }
+
+    @Test
+    public void maskSourceMetadataRemovesConfiguredKeyAndKeepsOtherMetadata() throws Exception {
+        AnnotationManagerBean bean = buildBeanWithMaskList(List.of("visibility"));
+        AnnotationSource source = sourceWithMetadata("visibility", "A&B", "source", "demo");
+
+        AnnotationSource masked = bean.maskSourceMetadata(source);
+
+        assertFalse(masked.containsMetadata("visibility"));
+        assertTrue(masked.containsMetadata("source"));
+        assertEquals("demo", masked.getMetadataMap().get("source"));
+    }
+
+    @Test
+    public void maskSourceMetadataRemovesAllConfiguredKeys() throws Exception {
+        AnnotationManagerBean bean = buildBeanWithMaskList(List.of("visibility", "securityMarking"));
+        AnnotationSource source = sourceWithMetadata("visibility", "A&B", "securityMarking", "HIGH", "source", "demo");
+
+        AnnotationSource masked = bean.maskSourceMetadata(source);
+
+        assertFalse(masked.containsMetadata("visibility"));
+        assertFalse(masked.containsMetadata("securityMarking"));
+        assertEquals(1, masked.getMetadataCount());
+        assertEquals("demo", masked.getMetadataMap().get("source"));
+    }
+
+    private static AnnotationManagerBean buildBeanWithMaskList(List<String> maskList) throws Exception {
+        AnnotationConfig annotationConfig = new AnnotationConfig();
+        annotationConfig.setMaskSourceMetadata(maskList);
+
+        AnnotationManagerConfig config = new AnnotationManagerConfig();
+        config.setAnnotationConfig(annotationConfig);
+
+        AnnotationManagerBean bean = new AnnotationManagerBean();
+        setField(bean, "config", config);
+        return bean;
+    }
+
+    private static AnnotationSource sourceWithMetadata(String... keyValuePairs) {
+        AnnotationSource.Builder builder = AnnotationSource.newBuilder();
+        for (int i = 0; i < keyValuePairs.length; i += 2) {
+            builder.putMetadata(keyValuePairs[i], keyValuePairs[i + 1]);
+        }
+        return builder.build();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = findField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        Class<?> current = clazz;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+}


### PR DESCRIPTION
* There's no need to return metadata fields like visibility for the source in the case where we're returning in the context of an annotation. This will extend to other security markings elsewhere.