### PR TITLE
Update DateIndexUtil to use DateTimeFormatter

### DIFF
--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
@@ -1,7 +1,5 @@
 package datawave.ingest.mapreduce.handler.dateindex;
 
-import com.google.common.base.Preconditions;
-
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -10,14 +8,14 @@ import java.time.temporal.TemporalAccessor;
 import java.util.BitSet;
 import java.util.Date;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Utility class for handling date operations and shard tracking during MapReduce ingest.
  * <p>
- * This class provides thread-safe static methods to format and parse dates to and from
- * the {@code yyyyMMdd} string format, including resolving dates to the beginning or
- * end of a day. It also includes helper methods for generating and merging
- * {@link BitSet} objects, which are typically used to represent and track individual
- * shards for date-indexed records.
+ * This class provides thread-safe static methods to format and parse dates to and from the {@code yyyyMMdd} string format, including resolving dates to the
+ * beginning or end of a day. It also includes helper methods for generating and merging {@link BitSet} objects, which are typically used to represent and track
+ * individual shards for date-indexed records.
  * <p>
  * Defines standard constants for common date index types (EVENT, LOADED, ACTIVITY).
  */
@@ -51,7 +49,7 @@ public class DateIndexUtil {
      *             if there is a problem parsing the date
      */
     public static Date getBeginDate(String dateStr) throws ParseException {
-        Preconditions.checkArgument(dateStr != null && !dateStr.isBlank() , "date string cannot be null or blank");
+        Preconditions.checkArgument(dateStr != null && !dateStr.isBlank(), "date string cannot be null or blank");
         TemporalAccessor temp = formatter.get().parse(dateStr);
         LocalDate local = LocalDate.from(temp);
         return Date.from(local.atStartOfDay(ZoneId.systemDefault()).toInstant());
@@ -70,7 +68,7 @@ public class DateIndexUtil {
         Preconditions.checkArgument(dateStr != null && !dateStr.isBlank(), "date string cannot be null or blank");
         TemporalAccessor temp = formatter.get().parse(dateStr);
         LocalDate local = LocalDate.from(temp);
-        return Date.from(local.atTime(23, 59, 59,MAX_MILLIS).atZone(ZoneId.systemDefault()).toInstant());
+        return Date.from(local.atTime(23, 59, 59, MAX_MILLIS).atZone(ZoneId.systemDefault()).toInstant());
     }
 
     /**

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
@@ -1,34 +1,48 @@
 package datawave.ingest.mapreduce.handler.dateindex;
 
+import com.google.common.base.Preconditions;
+
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.BitSet;
-import java.util.Calendar;
 import java.util.Date;
 
 /**
- *
+ * Utility class for handling date operations and shard tracking during MapReduce ingest.
+ * <p>
+ * This class provides thread-safe static methods to format and parse dates to and from
+ * the {@code yyyyMMdd} string format, including resolving dates to the beginning or
+ * end of a day. It also includes helper methods for generating and merging
+ * {@link BitSet} objects, which are typically used to represent and track individual
+ * shards for date-indexed records.
+ * <p>
+ * Defines standard constants for common date index types (EVENT, LOADED, ACTIVITY).
  */
 public class DateIndexUtil {
-
     public static final String EVENT_DATE_TYPE = "EVENT";
     public static final String LOADED_DATE_TYPE = "LOADED";
     public static final String ACTIVITY_DATE_TYPE = "ACTIVITY";
-    public static final ThreadLocal<SimpleDateFormat> format = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyyMMdd"));
+    public static final ThreadLocal<DateTimeFormatter> formatter = ThreadLocal.withInitial(() -> DateTimeFormatter.BASIC_ISO_DATE);
+    private static final int MAX_MILLIS = 999_000_000;
 
     /**
-     * Format the date into yyyyMMdd
+     * Format the date into yyyyMMdd with time zone set to the system default.
      *
      * @param date
      *            then date to be formatted
      * @return the string representation in yyyyMMdd format
      */
     public static String format(Date date) {
-        return format.get().format(date);
+        Preconditions.checkNotNull(date, "date cannot be null");
+        LocalDate local = date.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate();
+        return local.format(formatter.get());
     }
 
     /**
-     * Get the date with time set to 00:00:00
+     * Get the date with time set to 00:00:00.000 and time zone set to the system default.
      *
      * @param dateStr
      *            string representation of the date
@@ -37,11 +51,14 @@ public class DateIndexUtil {
      *             if there is a problem parsing the date
      */
     public static Date getBeginDate(String dateStr) throws ParseException {
-        return format.get().parse(dateStr);
+        Preconditions.checkArgument(dateStr != null && !dateStr.isBlank() , "date string cannot be null or blank");
+        TemporalAccessor temp = formatter.get().parse(dateStr);
+        LocalDate local = LocalDate.from(temp);
+        return Date.from(local.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 
     /**
-     * Get the date with time set to 23:59:59
+     * Get the date with time set to 23:59:59.999 and time zone set to the system default.
      *
      * @param dateStr
      *            string representation of the date
@@ -50,13 +67,10 @@ public class DateIndexUtil {
      *             if there is a problem parsing the date
      */
     public static Date getEndDate(String dateStr) throws ParseException {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(format.get().parse(dateStr));
-        cal.set(Calendar.HOUR_OF_DAY, 23);
-        cal.set(Calendar.MINUTE, 59);
-        cal.set(Calendar.SECOND, 59);
-        cal.set(Calendar.MILLISECOND, 999);
-        return cal.getTime();
+        Preconditions.checkArgument(dateStr != null && !dateStr.isBlank(), "date string cannot be null or blank");
+        TemporalAccessor temp = formatter.get().parse(dateStr);
+        LocalDate local = LocalDate.from(temp);
+        return Date.from(local.atTime(23, 59, 59,MAX_MILLIS).atZone(ZoneId.systemDefault()).toInstant());
     }
 
     /**
@@ -73,7 +87,7 @@ public class DateIndexUtil {
     }
 
     /**
-     * Merge to bit sets into one. This will actually modify bits1 or bits2, depending which one is larger.
+     * Merge to bit sets into one. This will actually modify bits1 or bits2, depending on which one is larger.
      *
      * @param bits1
      *            the first bit set

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtilTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtilTest.java
@@ -1,29 +1,40 @@
 package datawave.ingest.mapreduce.handler.dateindex;
 
+import java.text.ParseException;
+import java.time.format.DateTimeParseException;
 import java.util.BitSet;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
- *
+ * Tests for DateIndexUtil.
  */
 public class DateIndexUtilTest {
 
+    /**
+     * Verify that {@link DateIndexUtil#getBits} returns a BitSet with only the specified index set to true.
+     */
     @Test
     public void testGetBits() {
         BitSet bits = DateIndexUtil.getBits(20);
         for (int i = 0; i < 20; i++) {
-            Assert.assertFalse(bits.get(i));
+            Assertions.assertFalse(bits.get(i));
         }
-        Assert.assertTrue(bits.get(20));
+        Assertions.assertTrue(bits.get(20));
         for (int i = 21; i < bits.size(); i++) {
-            Assert.assertFalse(bits.get(i));
+            Assertions.assertFalse(bits.get(i));
         }
     }
 
+    /**
+     * Verify that {@link DateIndexUtil#merge} correctly combines the true bits of two given BitSets into a single BitSet.
+     */
     @Test
     public void testMerge() {
 
@@ -48,11 +59,159 @@ public class DateIndexUtilTest {
 
         for (int i = 0; i < 40 * 4; i++) {
             if (bits.contains(i)) {
-                Assert.assertTrue(bitSet.get(i));
+                Assertions.assertTrue(bitSet.get(i));
             } else {
-                Assert.assertFalse(bitSet.get(i));
+                Assertions.assertFalse(bitSet.get(i));
             }
         }
+    }
+
+    private Date create(int year, int month, int day, int hour, int minute, int second, int millis) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(TimeZone.getDefault());
+        calendar.set(year, month, day, hour, minute, second);
+        calendar.set(Calendar.MILLISECOND, millis);
+        return calendar.getTime();
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#format} formats a valid Date object into a yyyyMMdd string representation.
+     */
+    @Test
+    public void testFormat() {
+        Date date = create(2026,Calendar.AUGUST,13,7,7,7,0);
+        String dateStr = "20260813";
+        Assertions.assertEquals(dateStr, DateIndexUtil.format(date));
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#format} throws a NullPointerException when attempting to format a null Date.
+     */
+    @Test
+    public void testFormatNullDate(){
+        Date date = null;
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            DateIndexUtil.format(date);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getBeginDate} properly parses a yyyyMMdd string into a Date representing the very beginning of that day.
+     */
+    @Test
+    public void testGetBeginDate() throws ParseException {
+        String dateStr = "20260813";
+        Date date = create(2026,Calendar.AUGUST,13,0,0,0,0);
+        Assertions.assertEquals(date, DateIndexUtil.getBeginDate(dateStr));
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getBeginDate} throws a DateTimeParseException when the date string is too short.
+     */
+    @Test
+    public void testGetBeginDateStringTooShort(){
+        String dateStr = "202608";
+        Assertions.assertThrows(DateTimeParseException.class, () -> {
+            DateIndexUtil.getBeginDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getBeginDate} throws a DateTimeParseException when the date string contains invalid non-numeric characters.
+     */
+    @Test
+    public void testGetBeginDateInvalidCharacter(){
+        String dateStr = "2026!081";
+        Assertions.assertThrows(DateTimeParseException.class, () -> {
+            DateIndexUtil.getBeginDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getBeginDate} throws an IllegalArgumentException when the input date string is null.
+     */
+    @Test
+    public void testGetBeginDateNullString(){
+        String dateStr = null;
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            DateIndexUtil.getBeginDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getBeginDate} throws an IllegalArgumentException when the input date string is empty.
+     */
+    @Test
+    public void testGetBeginDateEmptyString(){
+        String dateStr = "";
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            DateIndexUtil.getBeginDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getEndDate} properly parses a yyyyMMdd string into a Date representing the very end of that day (23:59:59.999).
+     */
+    @Test
+    public void testGetEndDate() throws ParseException {
+        String dateStr = "20260813";
+        Date date = create(2026,Calendar.AUGUST,13,23,59,59,999);
+        Assertions.assertEquals(date, DateIndexUtil.getEndDate(dateStr));
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getEndDate} throws a DateTimeParseException when the date string is too short.
+     */
+    @Test
+    public void testGetEndDateStringTooShort(){
+        String dateStr = "202608";
+        Assertions.assertThrows(DateTimeParseException.class, () -> {
+            DateIndexUtil.getEndDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getEndDate} throws a DateTimeParseException when the date string contains invalid non-numeric characters.
+     */
+    @Test
+    public void testGetEndDateInvalidCharacter(){
+        String dateStr = "2026!081";
+        Assertions.assertThrows(DateTimeParseException.class, () -> {
+            DateIndexUtil.getEndDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getEndDate} throws an IllegalArgumentException when the input date string is null.
+     */
+    @Test
+    public void testGetEndDateNullString(){
+        String dateStr = null;
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            DateIndexUtil.getEndDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getEndDate} throws an IllegalArgumentException when the input date string is empty.
+     */
+    @Test
+    public void testGetEndDateHasEmptyString(){
+        String dateStr = "";
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            DateIndexUtil.getEndDate(dateStr);
+        });
+    }
+
+    /**
+     * Verify that {@link DateIndexUtil#getEndDate} throws a DateTimeParseException when the input date string does not have the expected length.
+     */
+    @Test
+    public void testGetEndDateInvalidStringLength(){
+        String dateStr = "202608";
+        Assertions.assertThrows(DateTimeParseException.class, () -> {
+            DateIndexUtil.getEndDate(dateStr);
+        });
     }
 
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtilTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtilTest.java
@@ -9,8 +9,12 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for DateIndexUtil.
@@ -24,11 +28,11 @@ public class DateIndexUtilTest {
     public void testGetBits() {
         BitSet bits = DateIndexUtil.getBits(20);
         for (int i = 0; i < 20; i++) {
-            Assertions.assertFalse(bits.get(i));
+            assertFalse(bits.get(i));
         }
-        Assertions.assertTrue(bits.get(20));
+        assertTrue(bits.get(20));
         for (int i = 21; i < bits.size(); i++) {
-            Assertions.assertFalse(bits.get(i));
+            assertFalse(bits.get(i));
         }
     }
 
@@ -59,9 +63,9 @@ public class DateIndexUtilTest {
 
         for (int i = 0; i < 40 * 4; i++) {
             if (bits.contains(i)) {
-                Assertions.assertTrue(bitSet.get(i));
+                assertTrue(bitSet.get(i));
             } else {
-                Assertions.assertFalse(bitSet.get(i));
+                assertFalse(bitSet.get(i));
             }
         }
     }
@@ -81,7 +85,7 @@ public class DateIndexUtilTest {
     public void testFormat() {
         Date date = create(2026,Calendar.AUGUST,13,7,7,7,0);
         String dateStr = "20260813";
-        Assertions.assertEquals(dateStr, DateIndexUtil.format(date));
+        assertEquals(dateStr, DateIndexUtil.format(date));
     }
 
     /**
@@ -90,7 +94,7 @@ public class DateIndexUtilTest {
     @Test
     public void testFormatNullDate(){
         Date date = null;
-        Assertions.assertThrows(NullPointerException.class, () -> {
+        assertThrows(NullPointerException.class, () -> {
             DateIndexUtil.format(date);
         });
     }
@@ -102,7 +106,7 @@ public class DateIndexUtilTest {
     public void testGetBeginDate() throws ParseException {
         String dateStr = "20260813";
         Date date = create(2026,Calendar.AUGUST,13,0,0,0,0);
-        Assertions.assertEquals(date, DateIndexUtil.getBeginDate(dateStr));
+        assertEquals(date, DateIndexUtil.getBeginDate(dateStr));
     }
 
     /**
@@ -111,7 +115,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetBeginDateStringTooShort(){
         String dateStr = "202608";
-        Assertions.assertThrows(DateTimeParseException.class, () -> {
+        assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
         });
     }
@@ -122,7 +126,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetBeginDateInvalidCharacter(){
         String dateStr = "2026!081";
-        Assertions.assertThrows(DateTimeParseException.class, () -> {
+        assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
         });
     }
@@ -133,7 +137,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetBeginDateNullString(){
         String dateStr = null;
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
         });
     }
@@ -144,7 +148,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetBeginDateEmptyString(){
         String dateStr = "";
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
         });
     }
@@ -156,7 +160,7 @@ public class DateIndexUtilTest {
     public void testGetEndDate() throws ParseException {
         String dateStr = "20260813";
         Date date = create(2026,Calendar.AUGUST,13,23,59,59,999);
-        Assertions.assertEquals(date, DateIndexUtil.getEndDate(dateStr));
+        assertEquals(date, DateIndexUtil.getEndDate(dateStr));
     }
 
     /**
@@ -165,7 +169,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetEndDateStringTooShort(){
         String dateStr = "202608";
-        Assertions.assertThrows(DateTimeParseException.class, () -> {
+        assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
         });
     }
@@ -176,7 +180,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetEndDateInvalidCharacter(){
         String dateStr = "2026!081";
-        Assertions.assertThrows(DateTimeParseException.class, () -> {
+        assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
         });
     }
@@ -187,7 +191,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetEndDateNullString(){
         String dateStr = null;
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
         });
     }
@@ -198,7 +202,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetEndDateHasEmptyString(){
         String dateStr = "";
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
         });
     }
@@ -209,7 +213,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetEndDateInvalidStringLength(){
         String dateStr = "202608";
-        Assertions.assertThrows(DateTimeParseException.class, () -> {
+        assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
         });
     }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtilTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtilTest.java
@@ -1,5 +1,10 @@
 package datawave.ingest.mapreduce.handler.dateindex;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.text.ParseException;
 import java.time.format.DateTimeParseException;
 import java.util.BitSet;
@@ -10,11 +15,6 @@ import java.util.Set;
 import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for DateIndexUtil.
@@ -83,7 +83,7 @@ public class DateIndexUtilTest {
      */
     @Test
     public void testFormat() {
-        Date date = create(2026,Calendar.AUGUST,13,7,7,7,0);
+        Date date = create(2026, Calendar.AUGUST, 13, 7, 7, 7, 0);
         String dateStr = "20260813";
         assertEquals(dateStr, DateIndexUtil.format(date));
     }
@@ -92,7 +92,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#format} throws a NullPointerException when attempting to format a null Date.
      */
     @Test
-    public void testFormatNullDate(){
+    public void testFormatNullDate() {
         Date date = null;
         assertThrows(NullPointerException.class, () -> {
             DateIndexUtil.format(date);
@@ -105,7 +105,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetBeginDate() throws ParseException {
         String dateStr = "20260813";
-        Date date = create(2026,Calendar.AUGUST,13,0,0,0,0);
+        Date date = create(2026, Calendar.AUGUST, 13, 0, 0, 0, 0);
         assertEquals(date, DateIndexUtil.getBeginDate(dateStr));
     }
 
@@ -113,7 +113,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getBeginDate} throws a DateTimeParseException when the date string is too short.
      */
     @Test
-    public void testGetBeginDateStringTooShort(){
+    public void testGetBeginDateStringTooShort() {
         String dateStr = "202608";
         assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
@@ -124,7 +124,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getBeginDate} throws a DateTimeParseException when the date string contains invalid non-numeric characters.
      */
     @Test
-    public void testGetBeginDateInvalidCharacter(){
+    public void testGetBeginDateInvalidCharacter() {
         String dateStr = "2026!081";
         assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
@@ -135,7 +135,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getBeginDate} throws an IllegalArgumentException when the input date string is null.
      */
     @Test
-    public void testGetBeginDateNullString(){
+    public void testGetBeginDateNullString() {
         String dateStr = null;
         assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
@@ -146,7 +146,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getBeginDate} throws an IllegalArgumentException when the input date string is empty.
      */
     @Test
-    public void testGetBeginDateEmptyString(){
+    public void testGetBeginDateEmptyString() {
         String dateStr = "";
         assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getBeginDate(dateStr);
@@ -159,7 +159,7 @@ public class DateIndexUtilTest {
     @Test
     public void testGetEndDate() throws ParseException {
         String dateStr = "20260813";
-        Date date = create(2026,Calendar.AUGUST,13,23,59,59,999);
+        Date date = create(2026, Calendar.AUGUST, 13, 23, 59, 59, 999);
         assertEquals(date, DateIndexUtil.getEndDate(dateStr));
     }
 
@@ -167,7 +167,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getEndDate} throws a DateTimeParseException when the date string is too short.
      */
     @Test
-    public void testGetEndDateStringTooShort(){
+    public void testGetEndDateStringTooShort() {
         String dateStr = "202608";
         assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
@@ -178,7 +178,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getEndDate} throws a DateTimeParseException when the date string contains invalid non-numeric characters.
      */
     @Test
-    public void testGetEndDateInvalidCharacter(){
+    public void testGetEndDateInvalidCharacter() {
         String dateStr = "2026!081";
         assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
@@ -189,7 +189,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getEndDate} throws an IllegalArgumentException when the input date string is null.
      */
     @Test
-    public void testGetEndDateNullString(){
+    public void testGetEndDateNullString() {
         String dateStr = null;
         assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
@@ -200,7 +200,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getEndDate} throws an IllegalArgumentException when the input date string is empty.
      */
     @Test
-    public void testGetEndDateHasEmptyString(){
+    public void testGetEndDateHasEmptyString() {
         String dateStr = "";
         assertThrows(IllegalArgumentException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);
@@ -211,7 +211,7 @@ public class DateIndexUtilTest {
      * Verify that {@link DateIndexUtil#getEndDate} throws a DateTimeParseException when the input date string does not have the expected length.
      */
     @Test
-    public void testGetEndDateInvalidStringLength(){
+    public void testGetEndDateInvalidStringLength() {
         String dateStr = "202608";
         assertThrows(DateTimeParseException.class, () -> {
             DateIndexUtil.getEndDate(dateStr);


### PR DESCRIPTION
The class `datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil` uses legacy `SimpleDateFormat` and `Calendar` instances to parse and format dates.

Refactor the methods `format()`, `getBeginDate()`, and `getEndDate()` to use `DateTimeFormatter` wrapped in a `ThreadLocal` along with these related classes:
- `java.time.temporal.TemporalAccessor`
- `java.time.ZoneId`
- `java.time.LocalDate`

Add tests to verify the expected behavior of `DateIndexUtil`.

Closes #3825 