### PR TITLE
BaseIngestHelper: Normalize once

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -759,8 +759,9 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         // copy it
         NormalizedContentInterface copy = new NormalizedFieldAndValue(normalizedContent);
         try {
-            copy.setEventFieldValue(datawaveType.normalize(copy.getIndexedFieldValue()));
-            copy.setIndexedFieldValue(datawaveType.normalize(copy.getIndexedFieldValue()));
+            String indexedFieldValue = datawaveType.normalize(copy.getIndexedFieldValue());
+            copy.setEventFieldValue(indexedFieldValue);
+            copy.setIndexedFieldValue(indexedFieldValue);
         } catch (Exception ex) {
             copy.setError(ex);
         }


### PR DESCRIPTION
`BaseIngestHelper` double normalizes  
Default ingest path should not double normalize for the same value  
```
copy.setEventFieldValue(datawaveType.normalize(copy.getIndexedFieldValue))
copy.setIndexedFieldValue(datawaveType.normalize(copy.getIndexedFieldValue)
```
The normalized value should be created once, outside the setters.  
Since the value is a String immutability is inherently preserved.