### PR TITLE
ShardedDataTypeHandler: overload createKey and createIndexKey and clean up intermediate objects

### DIFF
--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
@@ -144,6 +144,7 @@ public class DateIndexUtil {
      */
     public static int getOffsetForYearIndex(String shard) {
         int index = shard.indexOf('_');
+        Preconditions.checkArgument(index > 0, "shard did not contain an underscore: " + shard);
         String date = shard.substring(0, index);
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
         calendar.setTime(DateHelper.parse(date));

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
@@ -105,6 +105,13 @@ public class DateIndexUtil {
         return bits1;
     }
 
+    /**
+     * Constructs a {@link Value} that contains a {@link BitSet}'s backing byte array, with the bit at the day index offset set.
+     *
+     * @param shardId
+     *            the full shard id
+     * @return a Value containing a BitSet with the day index offset bit set
+     */
     public static Value getValueForDayIndex(String shardId) {
         // get the shard number
         int shardNumber = getOffsetForDayIndex(shardId);
@@ -128,6 +135,13 @@ public class DateIndexUtil {
         return Integer.parseInt(bucket);
     }
 
+    /**
+     * Constructs a {@link Value} that contains a {@link BitSet}'s backing byte array, with the bit at the year index offset set.
+     *
+     * @param shard
+     *            the full shard
+     * @return a Value containing a BitSet with the year index offset bit set
+     */
     public static Value getValueForYearIndex(String shard) {
         // get the shard number
         int shardNumber = getOffsetForYearIndex(shard);
@@ -161,6 +175,7 @@ public class DateIndexUtil {
      * trim the event date and ageoff portions of the ts to the beginning of the day
      *
      * @param ts
+     *            the composite timestamp to trim
      * @return the timestamp to be used for index entries
      */
     public static long getIndexTimestamp(long ts) {
@@ -173,6 +188,7 @@ public class DateIndexUtil {
      * Trim ms to the beginning of the day
      *
      * @param date
+     *            the time in milliseconds since the epoch
      * @return the time at the beginning of the day
      */
     public static long trimToBeginningOfDay(long date) {

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
@@ -5,6 +5,16 @@ import java.text.SimpleDateFormat;
 import java.util.BitSet;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.data.Value;
+import org.apache.log4j.Logger;
+
+import com.google.common.base.Preconditions;
+
+import datawave.util.CompositeTimestamp;
+import datawave.util.time.DateHelper;
 
 /**
  *
@@ -15,6 +25,8 @@ public class DateIndexUtil {
     public static final String LOADED_DATE_TYPE = "LOADED";
     public static final String ACTIVITY_DATE_TYPE = "ACTIVITY";
     public static final ThreadLocal<SimpleDateFormat> format = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyyMMdd"));
+    private static final long MS_PER_DAY = TimeUnit.DAYS.toMillis(1);
+    private static final Logger log = Logger.getLogger(DateIndexUtil.class);
 
     /**
      * Format the date into yyyyMMdd
@@ -92,4 +104,76 @@ public class DateIndexUtil {
         return bits1;
     }
 
+    public static Value getValueForDayIndex(String shardId) {
+        // get the shard number
+        int shardNumber = getOffsetForDayIndex(shardId);
+        BitSet bits = new BitSet();
+        bits.set(shardNumber);
+        return new Value(bits.toByteArray());
+    }
+
+    /**
+     * Get the shard number used as the offset for the day index
+     * <p>
+     *
+     * @param shard
+     *            the shard
+     * @return the day index offset
+     */
+    public static int getOffsetForDayIndex(String shard) {
+        int underscoreIndex = shard.indexOf('_');
+        Preconditions.checkArgument(underscoreIndex > 0, "shard did not contain an underscore: " + shard);
+        String bucket = shard.substring(underscoreIndex + 1);
+        return Integer.parseInt(bucket);
+    }
+
+    public static Value getValueForYearIndex(String shard) {
+        // get the shard number
+        int shardNumber = getOffsetForYearIndex(shard);
+        BitSet bits = new BitSet();
+        bits.set(shardNumber);
+        return new Value(bits.toByteArray());
+    }
+
+    /**
+     * Calculate the day of the year used as the offset for the year index
+     *
+     * @param shard
+     *            the shard
+     * @return the year index offset
+     */
+    public static int getOffsetForYearIndex(String shard) {
+        int index = shard.indexOf('_');
+        String date = shard.substring(0, index);
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        calendar.setTime(DateHelper.parse(date));
+
+        int dayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
+        if (log.isTraceEnabled()) {
+            log.trace("day of year: " + dayOfYear);
+        }
+        return dayOfYear;
+    }
+
+    /**
+     * trim the event date and ageoff portions of the ts to the beginning of the day
+     *
+     * @param ts
+     * @return the timestamp to be used for index entries
+     */
+    public static long getIndexTimestamp(long ts) {
+        long tsToDay = trimToBeginningOfDay(CompositeTimestamp.getEventDate(ts));
+        long ageOffToDay = trimToBeginningOfDay(CompositeTimestamp.getAgeOffDate(ts));
+        return CompositeTimestamp.getCompositeTimeStamp(tsToDay, ageOffToDay);
+    }
+
+    /**
+     * Trim ms to the beginning of the day
+     *
+     * @param date
+     * @return the time at the beginning of the day
+     */
+    public static long trimToBeginningOfDay(long date) {
+        return (date / MS_PER_DAY) * MS_PER_DAY;
+    }
 }

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/dateindex/DateIndexUtil.java
@@ -9,7 +9,8 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.Value;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
@@ -26,7 +27,7 @@ public class DateIndexUtil {
     public static final String ACTIVITY_DATE_TYPE = "ACTIVITY";
     public static final ThreadLocal<SimpleDateFormat> format = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyyMMdd"));
     private static final long MS_PER_DAY = TimeUnit.DAYS.toMillis(1);
-    private static final Logger log = Logger.getLogger(DateIndexUtil.class);
+    private static final Logger log = LoggerFactory.getLogger(DateIndexUtil.class);
 
     /**
      * Format the date into yyyyMMdd

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
@@ -11,6 +11,10 @@ import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
 import datawave.util.TextUtil;
 
 public class ShardUtil {
+    private ShardUtil() {
+        // static utility class
+    }
+
     /**
      * The single place where an Accumulo {@link Key} is actually constructed. All {@code createKey}/{@code createIndexKey} overloads funnel through here.
      * <p>
@@ -80,9 +84,12 @@ public class ShardUtil {
      *
      * @param parts
      *            the byte array segments to join
-     * @return the joined bytes
+     * @return the joined bytes, or an empty array if no parts are given
      */
     public static byte[] joinWithNulls(byte[]... parts) {
+        if (parts.length == 0) {
+            return new byte[0];
+        }
         int len = parts.length - 1;
         for (byte[] part : parts) {
             len += part.length;

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
@@ -1,14 +1,11 @@
 package datawave.ingest.mapreduce.handler.shard;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.accumulo.core.data.Key;
 import org.apache.hadoop.io.Text;
 
 import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
-import datawave.util.TextUtil;
 
 public class ShardUtil {
     private ShardUtil() {
@@ -46,7 +43,11 @@ public class ShardUtil {
     }
 
     /**
-     * Encode a String as UTF-8 bytes. Key components are always UTF-8 encoded, matching the encoding performed by {@link Text}.
+     * Encode a String as UTF-8 bytes. Key components are always UTF-8 encoded.
+     * <p>
+     * This uses the JDK encoder ({@link String#getBytes(java.nio.charset.Charset)}), which never throws: malformed input (e.g. an unpaired surrogate) is
+     * silently replaced, byte for byte identically to {@code new Text(s)} and to {@link Text#encode(String, boolean)} with {@code replace = true}. Key
+     * construction is therefore never able to fail a record on account of a malformed field name or value.
      *
      * @param s
      *            the string to encode
@@ -54,27 +55,6 @@ public class ShardUtil {
      */
     public static byte[] utf8(String s) {
         return s.getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Encode a String as UTF-8 bytes, honoring the same "replace malformed characters" semantics as {@link TextUtil#textAppend(Text, String, boolean)} /
-     * {@link Text#encode(String, boolean)}, rather than the silent-replace behavior of {@link String#getBytes(java.nio.charset.Charset)}.
-     *
-     * @param s
-     *            the string to encode
-     * @param replaceMalformedUTF8
-     *            whether to replace malformed/unmappable characters instead of throwing
-     * @return the UTF-8 bytes
-     */
-    public static byte[] utf8(String s, boolean replaceMalformedUTF8) {
-        try {
-            ByteBuffer buffer = Text.encode(s, replaceMalformedUTF8);
-            byte[] bytes = new byte[buffer.limit()];
-            System.arraycopy(buffer.array(), 0, bytes, 0, bytes.length);
-            return bytes;
-        } catch (CharacterCodingException e) {
-            throw new IllegalArgumentException(e);
-        }
     }
 
     /**

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
@@ -243,6 +243,28 @@ public class ShardUtil {
     }
 
     /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for callers that already have the column
+     * family and qualifier as raw bytes, avoiding a pair of intermediate {@link Text} objects.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createIndexKey(byte[] row, byte[] colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf, colf.length, colq, colq.length, vis, DateIndexUtil.getIndexTimestamp(ts), delete);
+    }
+
+    /**
      * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the common global index case where
      * the row is a field value and the column family is a field name, avoiding an intermediate byte array and {@link Text}.
      *

--- a/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
+++ b/warehouse/core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardUtil.java
@@ -1,0 +1,327 @@
+package datawave.ingest.mapreduce.handler.shard;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.accumulo.core.data.Key;
+import org.apache.hadoop.io.Text;
+
+import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
+import datawave.util.TextUtil;
+
+public class ShardUtil {
+    /**
+     * The single place where an Accumulo {@link Key} is actually constructed. All {@code createKey}/{@code createIndexKey} overloads funnel through here.
+     * <p>
+     * The column family and qualifier are passed as a backing array plus an explicit length so that a {@link Text}'s over-allocated backing array can be used
+     * directly (see {@link Text#getBytes()} vs {@link Text#getLength()}) without copying it first.
+     *
+     * @param row
+     *            the row bytes
+     * @param colf
+     *            the column family backing array
+     * @param colfLen
+     *            the number of valid bytes in {@code colf}
+     * @param colq
+     *            the column qualifier backing array
+     * @param colqLen
+     *            the number of valid bytes in {@code colq}
+     * @param vis
+     *            the column visibility bytes
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key buildKey(byte[] row, byte[] colf, int colfLen, byte[] colq, int colqLen, byte[] vis, long ts, boolean delete) {
+        Key k = new Key(row, 0, row.length, colf, 0, colfLen, colq, 0, colqLen, vis, 0, vis.length, ts);
+        k.setDeleted(delete);
+        return k;
+    }
+
+    /**
+     * Encode a String as UTF-8 bytes. Key components are always UTF-8 encoded, matching the encoding performed by {@link Text}.
+     *
+     * @param s
+     *            the string to encode
+     * @return the UTF-8 bytes
+     */
+    public static byte[] utf8(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Encode a String as UTF-8 bytes, honoring the same "replace malformed characters" semantics as {@link TextUtil#textAppend(Text, String, boolean)} /
+     * {@link Text#encode(String, boolean)}, rather than the silent-replace behavior of {@link String#getBytes(java.nio.charset.Charset)}.
+     *
+     * @param s
+     *            the string to encode
+     * @param replaceMalformedUTF8
+     *            whether to replace malformed/unmappable characters instead of throwing
+     * @return the UTF-8 bytes
+     */
+    public static byte[] utf8(String s, boolean replaceMalformedUTF8) {
+        try {
+            ByteBuffer buffer = Text.encode(s, replaceMalformedUTF8);
+            byte[] bytes = new byte[buffer.limit()];
+            System.arraycopy(buffer.array(), 0, bytes, 0, bytes.length);
+            return bytes;
+        } catch (CharacterCodingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Concatenates byte array segments with a single {@code NUL} byte between each pair, e.g. {@code joinWithNulls(a, b, c)} produces
+     * {@code a + '\0' + b + '\0' + c}. This computes the exact final length up front and copies each segment once, avoiding the repeated encode-then-grow-
+     * then-copy behavior of building the same layout via {@link Text#append(byte[], int, int)}.
+     *
+     * @param parts
+     *            the byte array segments to join
+     * @return the joined bytes
+     */
+    public static byte[] joinWithNulls(byte[]... parts) {
+        int len = parts.length - 1;
+        for (byte[] part : parts) {
+            len += part.length;
+        }
+        byte[] result = new byte[len];
+        int pos = 0;
+        for (int i = 0; i < parts.length; i++) {
+            System.arraycopy(parts[i], 0, result, pos, parts[i].length);
+            pos += parts[i].length;
+            if (i < parts.length - 1) {
+                result[pos++] = 0;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Builds a shard-prefixed byte array of the form {@code shardId[0, prefixLen) + '\0' + suffix}. Used to construct the row (day/year index tables) or column
+     * qualifier (bitset index table) for the alternate global index implementations, mirroring the string concatenation
+     * {@code shard.substring(0, prefixLen) + '\u0000' + suffix} without decoding the shard id to a String or re-encoding the result back to bytes.
+     *
+     * @param shardId
+     *            the full shard id bytes
+     * @param prefixLen
+     *            the number of leading bytes of the shard id to retain (8 for day granularity, 4 for year granularity)
+     * @param suffix
+     *            the UTF-8 encoded suffix bytes
+     * @return the shard-prefixed bytes
+     */
+    public static byte[] shardPrefixedBytes(byte[] shardId, int prefixLen, byte[] suffix) {
+        byte[] result = new byte[prefixLen + 1 + suffix.length];
+        System.arraycopy(shardId, 0, result, 0, prefixLen);
+        result[prefixLen] = 0;
+        System.arraycopy(suffix, 0, result, prefixLen + 1, suffix.length);
+        return result;
+    }
+
+    /**
+     * Create Key from input parameters
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createKey(byte[] row, Text colf, Text colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf.getBytes(), colf.getLength(), colq.getBytes(), colq.getLength(), vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers that already have the column
+     * family and qualifier as raw bytes, avoiding a pair of intermediate {@link Text} objects.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createKey(byte[] row, byte[] colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf, colf.length, colq, colq.length, vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers whose column qualifier is a
+     * String, avoiding an intermediate {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createKey(byte[] row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
+        byte[] colqBytes = utf8(colq);
+        return buildKey(row, colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers who have already assembled the
+     * column qualifier bytes directly (e.g. via {@link ShardUtil#joinWithNulls(byte[]...)}), avoiding an intermediate {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createKey(byte[] row, Text colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf.getBytes(), colf.getLength(), colq, colq.length, vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers whose column family and qualifier
+     * are Strings, avoiding a pair of intermediate {@link Text} objects.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createKey(byte[] row, String colf, String colq, byte[] vis, long ts, boolean delete) {
+        return createKey(row, utf8(colf), utf8(colq), vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters
+     *
+     * For global index keys, the granularity of the timestamp is to the millisecond, where the semantics of the index record is to the day. This makes
+     * MapReduce unable to reduce all index keys together unless they occurred at the same millisecond. If we truncate the timestamp to the day, we should
+     * reduce the number of keys output from a job.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createIndexKey(byte[] row, Text colf, Text colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf.getBytes(), colf.getLength(), colq.getBytes(), colq.getLength(), vis, DateIndexUtil.getIndexTimestamp(ts), delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the common global index case where
+     * the row is a field value and the column family is a field name, avoiding an intermediate byte array and {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createIndexKey(String row, String colf, Text colq, byte[] vis, long ts, boolean delete) {
+        byte[] colfBytes = utf8(colf);
+        return buildKey(utf8(row), colfBytes, colfBytes.length, colq.getBytes(), colq.getLength(), vis, DateIndexUtil.getIndexTimestamp(ts), delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the term dictionary case where the
+     * column family is a shared constant and the column qualifier is a field name, avoiding an intermediate byte array and {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createIndexKey(String row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
+        byte[] colqBytes = utf8(colq);
+        return buildKey(utf8(row), colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, DateIndexUtil.getIndexTimestamp(ts), delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the global index case where the
+     * column qualifier has already been assembled directly as bytes (e.g. via {@link ShardUtil#joinWithNulls(byte[]...)}), avoiding an intermediate
+     * {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    public static Key createIndexKey(String row, String colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        byte[] colfBytes = utf8(colf);
+        return buildKey(utf8(row), colfBytes, colfBytes.length, colq, colq.length, vis, DateIndexUtil.getIndexTimestamp(ts), delete);
+    }
+}

--- a/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
@@ -52,6 +52,36 @@ public class ShardUtilTest {
         }
     }
 
+    /**
+     * Explicit, hard-coded verification that well-formed multi-byte Unicode -- a Latin-1 accented character, CJK characters, and a surrogate-pair emoji --
+     * round-trips through {@link ShardUtil#utf8(String)} as its correct UTF-8 encoding, and is <b>not</b> replaced with {@code '?'} the way malformed input is
+     * (see {@link #utf8_malformedLoneSurrogatesReplacedWithQuestionMark()}).
+     */
+    @Test
+    public void utf8_encodesWellFormedMultibyteCharactersCorrectly() {
+        // "café" - 'é' (U+00E9) is 2 UTF-8 bytes
+        assertArrayEquals(new byte[] {0x63, 0x61, 0x66, (byte) 0xC3, (byte) 0xA9}, ShardUtil.utf8("café"));
+        // "中文" - each CJK character is 3 UTF-8 bytes
+        assertArrayEquals(new byte[] {(byte) 0xE4, (byte) 0xB8, (byte) 0xAD, (byte) 0xE6, (byte) 0x96, (byte) 0x87}, ShardUtil.utf8("中文"));
+        // U+1F600 GRINNING FACE, represented in Java as the surrogate pair \uD83D\uDE00, is 4 UTF-8 bytes
+        assertArrayEquals(new byte[] {(byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x80}, ShardUtil.utf8("\uD83D\uDE00"));
+    }
+
+    /**
+     * Explicit, hard-coded verification that malformed lone/unpaired surrogates are each replaced with a single ASCII {@code '?'} (0x3F) byte -- the JDK's
+     * default substitution for unmappable/malformed characters -- rather than being dropped, throwing, or replaced with the multi-byte Unicode replacement
+     * character U+FFFD.
+     */
+    @Test
+    public void utf8_malformedLoneSurrogatesReplacedWithQuestionMark() {
+        assertArrayEquals(new byte[] {'?'}, ShardUtil.utf8("\uD800")); // lone high surrogate
+        assertArrayEquals(new byte[] {'?'}, ShardUtil.utf8("\uDC00")); // lone low surrogate
+        assertArrayEquals(new byte[] {'A', '?', 'B'}, ShardUtil.utf8("A\uD800B")); // lone high surrogate embedded in valid text
+        assertArrayEquals(new byte[] {'A', '?', 'B'}, ShardUtil.utf8("A\uDC00B")); // lone low surrogate embedded in valid text
+        assertArrayEquals(new byte[] {'?', '?'}, ShardUtil.utf8("\uD800\uD800")); // two high surrogates in a row
+        assertArrayEquals(new byte[] {'?', '?'}, ShardUtil.utf8("\uDC00\uD800")); // low surrogate followed by high surrogate (reversed order)
+    }
+
     @Test
     public void joinWithNulls_zeroArgsReturnsEmptyArray() {
         assertArrayEquals(new byte[0], ShardUtil.joinWithNulls());

--- a/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
@@ -1,0 +1,125 @@
+package datawave.ingest.mapreduce.handler.shard;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.CharacterCodingException;
+
+import org.apache.hadoop.io.Text;
+import org.junit.Test;
+
+/**
+ * Pins the UTF-8 encoding fidelity of {@link ShardUtil#utf8(String)} / {@link ShardUtil#utf8(String, boolean)} against {@link Text}, which is the type they
+ * replaced at call sites throughout {@code ShardedDataTypeHandler}. In particular this covers malformed input (lone surrogates), which no fixture exercised
+ * prior to this test.
+ */
+public class ShardUtilTest {
+
+    /**
+     * A corpus mixing well-formed ASCII/Latin-1/CJK/surrogate-pair strings with malformed lone-surrogate strings, so both the "replace" and "strict" paths are
+     * exercised.
+     */
+    private static final String[] CORPUS = new String[] {"", "FIELD_NAME", "hello world", "café", "中文", "\uD83D\uDE00", // valid surrogate pair (an emoji)
+            "\uD800", // lone high surrogate
+            "\uDC00", // lone low surrogate
+            "A\uD800B", // lone high surrogate embedded in otherwise valid text
+            "A\uDC00B", // lone low surrogate embedded in otherwise valid text
+            "\uD800\uD800", // two high surrogates in a row (still malformed, not a valid pair)
+            "\uDC00\uD800", // low surrogate followed by high surrogate (reversed order, malformed)
+    };
+
+    /**
+     * {@link ShardUtil#utf8(String)} must be byte-identical to {@code new Text(s)} for every input, including malformed ones, since it is a drop-in replacement
+     * for {@code new Text(String)} call sites.
+     */
+    @Test
+    public void utf8SingleArg_matchesTextConstructor() {
+        for (String s : CORPUS) {
+            assertArrayEquals("utf8(String) mismatch for " + describe(s), new Text(s).copyBytes(), ShardUtil.utf8(s));
+        }
+    }
+
+    /**
+     * {@link ShardUtil#utf8(String, boolean)} with {@code replaceMalformedUTF8 = true} must be byte-identical to {@code new Text(s)}, since that is the same
+     * "replace" semantics {@code Text}'s constructor uses internally.
+     */
+    @Test
+    public void utf8TwoArgReplace_matchesTextConstructor() {
+        for (String s : CORPUS) {
+            assertArrayEquals("utf8(String, true) mismatch for " + describe(s), new Text(s).copyBytes(), ShardUtil.utf8(s, true));
+        }
+    }
+
+    /**
+     * {@link ShardUtil#utf8(String, boolean)} with {@code replaceMalformedUTF8 = false} must throw if and only if {@code Text.encode(s, false)} throws, and
+     * when it doesn't throw the bytes must match exactly.
+     */
+    @Test
+    public void utf8TwoArgStrict_throwsIffTextEncodeThrows() {
+        for (String s : CORPUS) {
+            byte[] expectedBytes = null;
+            boolean textThrows = false;
+            try {
+                java.nio.ByteBuffer buffer = Text.encode(s, false);
+                expectedBytes = new byte[buffer.limit()];
+                System.arraycopy(buffer.array(), 0, expectedBytes, 0, expectedBytes.length);
+            } catch (CharacterCodingException e) {
+                textThrows = true;
+            }
+
+            boolean utf8Throws = false;
+            byte[] actualBytes = null;
+            try {
+                actualBytes = ShardUtil.utf8(s, false);
+            } catch (IllegalArgumentException e) {
+                utf8Throws = true;
+            }
+
+            assertEquals("utf8(String, false) throw mismatch for " + describe(s), textThrows, utf8Throws);
+            if (!textThrows) {
+                assertArrayEquals("utf8(String, false) byte mismatch for " + describe(s), expectedBytes, actualBytes);
+            }
+        }
+    }
+
+    @Test
+    public void joinWithNulls_zeroArgsReturnsEmptyArray() {
+        assertArrayEquals(new byte[0], ShardUtil.joinWithNulls());
+    }
+
+    @Test
+    public void joinWithNulls_singlePartReturnsItUnchanged() {
+        byte[] part = {1, 2, 3};
+        assertArrayEquals(part, ShardUtil.joinWithNulls(part));
+    }
+
+    @Test
+    public void joinWithNulls_multiplePartsSeparatedByNulByte() {
+        byte[] a = {1, 2};
+        byte[] b = {3, 4};
+        byte[] c = {5};
+        assertArrayEquals(new byte[] {1, 2, 0, 3, 4, 0, 5}, ShardUtil.joinWithNulls(a, b, c));
+    }
+
+    @Test
+    public void cannotInstantiateShardUtil() throws Exception {
+        java.lang.reflect.Constructor<ShardUtil> constructor = ShardUtil.class.getDeclaredConstructor();
+        if (constructor.canAccess(null)) {
+            fail("ShardUtil's no-arg constructor should not be publicly accessible");
+        }
+    }
+
+    private static String describe(String s) {
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c >= 0x20 && c < 0x7f) {
+                sb.append(c);
+            } else {
+                sb.append(String.format("\\u%04X", (int) c));
+            }
+        }
+        return sb.append('"').toString();
+    }
+}

--- a/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
@@ -1,24 +1,20 @@
 package datawave.ingest.mapreduce.handler.shard;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
-import java.nio.charset.CharacterCodingException;
 
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 /**
- * Pins the UTF-8 encoding fidelity of {@link ShardUtil#utf8(String)} / {@link ShardUtil#utf8(String, boolean)} against {@link Text}, which is the type they
- * replaced at call sites throughout {@code ShardedDataTypeHandler}. In particular this covers malformed input (lone surrogates), which no fixture exercised
- * prior to this test.
+ * Pins the UTF-8 encoding fidelity of {@link ShardUtil#utf8(String)} against {@link Text}, which is the type it replaced at call sites throughout
+ * {@code ShardedDataTypeHandler}. In particular this covers malformed input (lone surrogates), which no fixture exercised prior to this test.
  */
 public class ShardUtilTest {
 
     /**
-     * A corpus mixing well-formed ASCII/Latin-1/CJK/surrogate-pair strings with malformed lone-surrogate strings, so both the "replace" and "strict" paths are
-     * exercised.
+     * A corpus mixing well-formed ASCII/Latin-1/CJK/surrogate-pair strings with malformed lone-surrogate strings, so that both well-formed encoding and
+     * malformed-character replacement are exercised.
      */
     private static final String[] CORPUS = new String[] {"", "FIELD_NAME", "hello world", "café", "中文", "\uD83D\uDE00", // valid surrogate pair (an emoji)
             "\uD800", // lone high surrogate
@@ -34,52 +30,23 @@ public class ShardUtilTest {
      * for {@code new Text(String)} call sites.
      */
     @Test
-    public void utf8SingleArg_matchesTextConstructor() {
+    public void utf8_matchesTextConstructor() {
         for (String s : CORPUS) {
             assertArrayEquals("utf8(String) mismatch for " + describe(s), new Text(s).copyBytes(), ShardUtil.utf8(s));
         }
     }
 
     /**
-     * {@link ShardUtil#utf8(String, boolean)} with {@code replaceMalformedUTF8 = true} must be byte-identical to {@code new Text(s)}, since that is the same
-     * "replace" semantics {@code Text}'s constructor uses internally.
+     * {@link ShardUtil#utf8(String)} must never throw, even for malformed input: it must match the "replace" semantics of {@code Text.encode(s, true)} rather
+     * than the strict semantics of {@code Text.encode(s, false)}, so that key construction can never fail a record.
      */
     @Test
-    public void utf8TwoArgReplace_matchesTextConstructor() {
+    public void utf8_replacesMalformedInputInsteadOfThrowing() throws Exception {
         for (String s : CORPUS) {
-            assertArrayEquals("utf8(String, true) mismatch for " + describe(s), new Text(s).copyBytes(), ShardUtil.utf8(s, true));
-        }
-    }
-
-    /**
-     * {@link ShardUtil#utf8(String, boolean)} with {@code replaceMalformedUTF8 = false} must throw if and only if {@code Text.encode(s, false)} throws, and
-     * when it doesn't throw the bytes must match exactly.
-     */
-    @Test
-    public void utf8TwoArgStrict_throwsIffTextEncodeThrows() {
-        for (String s : CORPUS) {
-            byte[] expectedBytes = null;
-            boolean textThrows = false;
-            try {
-                java.nio.ByteBuffer buffer = Text.encode(s, false);
-                expectedBytes = new byte[buffer.limit()];
-                System.arraycopy(buffer.array(), 0, expectedBytes, 0, expectedBytes.length);
-            } catch (CharacterCodingException e) {
-                textThrows = true;
-            }
-
-            boolean utf8Throws = false;
-            byte[] actualBytes = null;
-            try {
-                actualBytes = ShardUtil.utf8(s, false);
-            } catch (IllegalArgumentException e) {
-                utf8Throws = true;
-            }
-
-            assertEquals("utf8(String, false) throw mismatch for " + describe(s), textThrows, utf8Throws);
-            if (!textThrows) {
-                assertArrayEquals("utf8(String, false) byte mismatch for " + describe(s), expectedBytes, actualBytes);
-            }
+            java.nio.ByteBuffer buffer = Text.encode(s, true);
+            byte[] expectedBytes = new byte[buffer.limit()];
+            System.arraycopy(buffer.array(), 0, expectedBytes, 0, expectedBytes.length);
+            assertArrayEquals("utf8(String) mismatch for " + describe(s), expectedBytes, ShardUtil.utf8(s));
         }
     }
 

--- a/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
+++ b/warehouse/core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardUtilTest.java
@@ -1,8 +1,10 @@
 package datawave.ingest.mapreduce.handler.shard;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import org.apache.accumulo.core.data.Key;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
@@ -67,6 +69,28 @@ public class ShardUtilTest {
         byte[] b = {3, 4};
         byte[] c = {5};
         assertArrayEquals(new byte[] {1, 2, 0, 3, 4, 0, 5}, ShardUtil.joinWithNulls(a, b, c));
+    }
+
+    /**
+     * {@link ShardUtil#createIndexKey(byte[], byte[], byte[], byte[], long, boolean)} must produce a byte-identical {@link Key} to
+     * {@link ShardUtil#createIndexKey(byte[], Text, Text, byte[], long, boolean)}, since it exists purely to let callers who already have {@code colf}/
+     * {@code colq} as raw bytes avoid allocating intermediate {@link Text} objects.
+     */
+    @Test
+    public void createIndexKey_byteArrayOverload_matchesTextOverload() {
+        byte[] row = ShardUtil.utf8("fieldValue");
+        Text colfText = new Text("fieldName");
+        Text colqText = new Text("20240101_0\u0000datatype");
+        byte[] colf = ShardUtil.utf8("fieldName");
+        byte[] colq = ShardUtil.utf8("20240101_0\u0000datatype");
+        byte[] vis = ShardUtil.utf8("A&B");
+        long ts = 1704067200123L;
+
+        for (boolean delete : new boolean[] {false, true}) {
+            Key expected = ShardUtil.createIndexKey(row, colfText, colqText, vis, ts, delete);
+            Key actual = ShardUtil.createIndexKey(row, colf, colq, vis, ts, delete);
+            assertEquals("createIndexKey(byte[], byte[], byte[], ...) mismatch for delete=" + delete, expected, actual);
+        }
     }
 
     @Test

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorShardedDataTypeHandler.java
@@ -41,6 +41,7 @@ import datawave.ingest.data.config.ingest.IngestHelperInterface;
 import datawave.ingest.mapreduce.ContextWrappedStatusReporter;
 import datawave.ingest.mapreduce.handler.ExtendedDataTypeHandler;
 import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
+import datawave.ingest.mapreduce.handler.shard.ShardUtil;
 import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.writer.ContextWriter;
@@ -315,7 +316,7 @@ public class ErrorShardedDataTypeHandler<KEYIN,KEYOUT,VALUEOUT> extends Abstract
 
         // ShardId 'd' DataType\0UID\0Name for document content event using Event.Writable
         String colq = record.getDataType().outputName() + '\0' + record.getId() + '\0' + EVENT_CONTENT_FIELD;
-        Key k = createKey(getShardId(record), ColumnFamilyConstants.FULL_CONTENT_TEXT, colq, getVisibility(record, null), record.getTimestamp(),
+        Key k = ShardUtil.createKey(getShardId(record), ColumnFamilyConstants.FULL_CONTENT_TEXT, colq, getVisibility(record, null), record.getTimestamp(),
                         this.helper.getDeleteMode());
         BulkIngestKey ebKey = new BulkIngestKey(getShardTableName(), k);
         contextWriter.write(ebKey, value, context);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/error/ErrorShardedDataTypeHandler.java
@@ -315,7 +315,7 @@ public class ErrorShardedDataTypeHandler<KEYIN,KEYOUT,VALUEOUT> extends Abstract
 
         // ShardId 'd' DataType\0UID\0Name for document content event using Event.Writable
         String colq = record.getDataType().outputName() + '\0' + record.getId() + '\0' + EVENT_CONTENT_FIELD;
-        Key k = createKey(getShardId(record), new Text(ColumnFamilyConstants.FULL_CONTENT), new Text(colq), getVisibility(record, null), record.getTimestamp(),
+        Key k = createKey(getShardId(record), ColumnFamilyConstants.FULL_CONTENT_TEXT, colq, getVisibility(record, null), record.getTimestamp(),
                         this.helper.getDeleteMode());
         BulkIngestKey ebKey = new BulkIngestKey(getShardTableName(), k);
         contextWriter.write(ebKey, value, context);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -1,5 +1,6 @@
 package datawave.ingest.mapreduce.handler.shard;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -847,7 +848,6 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // It was observed that the normalized mask values aren't coming back reversed, so account for that before creating the row.
             String normalizedMaskedValue = helper.getNormalizedMaskedValue(column);
 
-            Text colf = new Text(column);
             Text colq = new Text(shardId);
             TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
 
@@ -860,19 +860,18 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     }
                 }
                 // Create a key for the masked field value with the masked visibility.
-                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(), colf, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = this.createIndexKey(normalizedMaskedValue, column, colq, maskedVisibility, event.getTimestamp(), false);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, indexValue);
             }
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = this.createIndexKey(fieldValue, column, colq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, indexValue);
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            Text colf = new Text(column);
             Text colq = new Text(shardId);
             TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
 
@@ -886,7 +885,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = this.createIndexKey(fieldValue, column, colq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, indexValue);
         }
@@ -1149,6 +1148,47 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     }
 
     /**
+     * The single place where an Accumulo {@link Key} is actually constructed. All {@code createKey}/{@code createIndexKey} overloads funnel through here.
+     * <p>
+     * The column family and qualifier are passed as a backing array plus an explicit length so that a {@link Text}'s over-allocated backing array can be used
+     * directly (see {@link Text#getBytes()} vs {@link Text#getLength()}) without copying it first.
+     *
+     * @param row
+     *            the row bytes
+     * @param colf
+     *            the column family backing array
+     * @param colfLen
+     *            the number of valid bytes in {@code colf}
+     * @param colq
+     *            the column qualifier backing array
+     * @param colqLen
+     *            the number of valid bytes in {@code colq}
+     * @param vis
+     *            the column visibility bytes
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    private static Key buildKey(byte[] row, byte[] colf, int colfLen, byte[] colq, int colqLen, byte[] vis, long ts, boolean delete) {
+        Key k = new Key(row, 0, row.length, colf, 0, colfLen, colq, 0, colqLen, vis, 0, vis.length, ts);
+        k.setDeleted(delete);
+        return k;
+    }
+
+    /**
+     * Encode a String as UTF-8 bytes. Key components are always UTF-8 encoded, matching the encoding performed by {@link Text}.
+     *
+     * @param s
+     *            the string to encode
+     * @return the UTF-8 bytes
+     */
+    private static byte[] utf8(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
      * Create Key from input parameters
      *
      * @param row
@@ -1166,9 +1206,74 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
      * @return Accumulo Key object
      */
     protected Key createKey(byte[] row, Text colf, Text colq, byte[] vis, long ts, boolean delete) {
-        Key k = new Key(row, 0, row.length, colf.getBytes(), 0, colf.getLength(), colq.getBytes(), 0, colq.getLength(), vis, 0, vis.length, ts);
-        k.setDeleted(delete);
-        return k;
+        return buildKey(row, colf.getBytes(), colf.getLength(), colq.getBytes(), colq.getLength(), vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers that already have the column
+     * family and qualifier as raw bytes, avoiding a pair of intermediate {@link Text} objects.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createKey(byte[] row, byte[] colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf, colf.length, colq, colq.length, vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers whose column qualifier is a
+     * String, avoiding an intermediate {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createKey(byte[] row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
+        byte[] colqBytes = utf8(colq);
+        return buildKey(row, colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers whose column family and qualifier
+     * are Strings, avoiding a pair of intermediate {@link Text} objects.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createKey(byte[] row, String colf, String colq, byte[] vis, long ts, boolean delete) {
+        return createKey(row, utf8(colf), utf8(colq), vis, ts, delete);
     }
 
     /**
@@ -1193,10 +1298,75 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
      * @return Accumulo Key object
      */
     protected Key createIndexKey(byte[] row, Text colf, Text colq, byte[] vis, long ts, boolean delete) {
-        Key k = new Key(row, 0, row.length, colf.getBytes(), 0, colf.getLength(), colq.getBytes(), 0, colq.getLength(), vis, 0, vis.length,
-                        getIndexTimestamp(ts));
-        k.setDeleted(delete);
-        return k;
+        return buildKey(row, colf.getBytes(), colf.getLength(), colq.getBytes(), colq.getLength(), vis, getIndexTimestamp(ts), delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for callers that already have the column
+     * family and qualifier as raw bytes, avoiding a pair of intermediate {@link Text} objects.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createIndexKey(byte[] row, byte[] colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf, colf.length, colq, colq.length, vis, getIndexTimestamp(ts), delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the common global index case where
+     * the row is a field value and the column family is a field name, avoiding an intermediate byte array and {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createIndexKey(String row, String colf, Text colq, byte[] vis, long ts, boolean delete) {
+        byte[] colfBytes = utf8(colf);
+        return buildKey(utf8(row), colfBytes, colfBytes.length, colq.getBytes(), colq.getLength(), vis, getIndexTimestamp(ts), delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the term dictionary case where the
+     * column family is a shared constant and the column qualifier is a field name, avoiding an intermediate byte array and {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createIndexKey(String row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
+        byte[] colqBytes = utf8(colq);
+        return buildKey(utf8(row), colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, getIndexTimestamp(ts), delete);
     }
 
     /**
@@ -1586,7 +1756,6 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // These Keys are for the index, so if they are masked, we really want to use the normalized masked values
             final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
 
-            Text colf = new Text(fieldName);
             Text colq = new Text(shardId);
             TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
 
@@ -1595,7 +1764,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // Dont create index entries for empty values
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
                 // Create a key for the masked field value with the masked visibility
-                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(), colf, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = this.createIndexKey(normalizedMaskedValue, fieldName, colq, maskedVisibility, event.getTimestamp(), false);
 
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, val);
@@ -1603,13 +1772,12 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = this.createIndexKey(fieldValue, fieldName, colq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, val);
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            Text colf = new Text(fieldName);
             Text colq = new Text(shardId);
             TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
 
@@ -1626,7 +1794,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = this.createIndexKey(fieldValue, fieldName, colq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, val);
 
@@ -1664,14 +1832,10 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         // Colf: Field Name
         // Colq: Shard Id : DataType
         // Value: UID
-        Text colf = new Text(directionColFam);
-        Text colq = new Text(fieldName);
-
-        Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), false);
-        Value val = new Value("".getBytes());
+        Key k = this.createIndexKey(fieldValue, directionColFam, fieldName, visibility, event.getTimestamp(), false);
 
         BulkIngestKey bKey = new BulkIngestKey(tableName, k);
-        values.put(bKey, val);
+        values.put(bKey, NULL_VALUE);
 
     }
 
@@ -1713,33 +1877,23 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // These Keys are for the index, so if they are masked, we really want to use the normalized masked values
             final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
 
-            Text colf = new Text(directionColFam);
-            Text colq = new Text(fieldName);
-
-            Value val = new Value("".getBytes());
-
             // Dont create index entries for empty values
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
                 // Create a key for the masked field value with the masked visibility
-                Key k = this.createIndexKey(normalizedMaskedValue.getBytes(), colf, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = this.createIndexKey(normalizedMaskedValue, directionColFam, fieldName, maskedVisibility, event.getTimestamp(), false);
 
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
-                values.put(bkey, val);
+                values.put(bkey, NULL_VALUE);
             }
 
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = this.createIndexKey(fieldValue, directionColFam, fieldName, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
-                values.put(bkey, val);
+                values.put(bkey, NULL_VALUE);
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            Text colf = new Text(directionColFam);
-            Text colq = new Text(fieldName);
-            // TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
-
-            Value val = new Value("".getBytes());
 
             /**
              * For values that are not being masked, we use the "unmaskedValue" and the masked visibility e.g. release the value as it was in the event at the
@@ -1751,9 +1905,9 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue.getBytes(), colf, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = this.createIndexKey(fieldValue, directionColFam, fieldName, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
-            values.put(bkey, val);
+            values.put(bkey, NULL_VALUE);
 
         }
     }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -1,16 +1,12 @@
 package datawave.ingest.mapreduce.handler.shard;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.data.Key;
@@ -44,6 +40,7 @@ import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.ingest.data.config.ingest.IngestHelperInterface;
 import datawave.ingest.mapreduce.MemberShipTest;
 import datawave.ingest.mapreduce.handler.DataTypeHandler;
+import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.mapreduce.job.statsd.StatsDEnabledDataTypeHandler;
 import datawave.ingest.metadata.RawRecordMetadata;
@@ -56,9 +53,7 @@ import datawave.marking.MarkingFunctions;
 import datawave.marking.Markings;
 import datawave.query.model.Direction;
 import datawave.table.constants.TableName;
-import datawave.util.CompositeTimestamp;
 import datawave.util.TextUtil;
-import datawave.util.time.DateHelper;
 
 /**
  * <p>
@@ -203,7 +198,10 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     // Config option name for all tables that are "sharded"
     public static final String SHARDED_TNAMES = "sharded.table.names";
 
-    private static final long MS_PER_DAY = TimeUnit.DAYS.toMillis(1);
+    /**
+     * The {@code 'fi'} column family prefix used for field index entries in the shard table (see {@link #createShardFieldIndexColumn}).
+     */
+    private static final byte[] FI_COLF_PREFIX = {'f', 'i'};
 
     private float bloomFilteringDiskThreshold;
     private String bloomFilteringDiskThresholdPath;
@@ -850,7 +848,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // It was observed that the normalized mask values aren't coming back reversed, so account for that before creating the row.
             String normalizedMaskedValue = helper.getNormalizedMaskedValue(column);
 
-            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
+            byte[] colq = ShardUtil.joinWithNulls(shardId, ShardUtil.utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
 
             // if this method was called with the intention to create reverse index keys, ensure the masked values are reversed.
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
@@ -861,19 +859,19 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     }
                 }
                 // Create a key for the masked field value with the masked visibility.
-                Key k = this.createIndexKey(normalizedMaskedValue, column, colq, maskedVisibility, event.getTimestamp(), false);
+                Key k = ShardUtil.createIndexKey(normalizedMaskedValue, column, colq, maskedVisibility, event.getTimestamp(), false);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, indexValue);
             }
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue, column, colq, visibility, event.getTimestamp(), deleteMode);
+                Key k = ShardUtil.createIndexKey(fieldValue, column, colq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, indexValue);
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
+            byte[] colq = ShardUtil.joinWithNulls(shardId, ShardUtil.utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
 
             /*
              * For values that are not being masked, we use the "unmaskedValue" and the masked visibility e.g. release the value as it was in the event at the
@@ -885,7 +883,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue, column, colq, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = ShardUtil.createIndexKey(fieldValue, column, colq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, indexValue);
         }
@@ -921,11 +919,11 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Direction direction) {
         if (shardId != null && value != null && field != null && visibility != null) {
             String fullShard = new String(shardId, StandardCharsets.UTF_8);
-            byte[] cf = utf8(field);
-            byte[] cq = shardPrefixedBytes(shardId, 8, utf8(event.getDataType().outputName()));
-            long ts = getIndexTimestamp(event.getTimestamp());
+            byte[] cf = ShardUtil.utf8(field);
+            byte[] cq = ShardUtil.shardPrefixedBytes(shardId, 8, ShardUtil.utf8(event.getDataType().outputName()));
+            long ts = DateIndexUtil.getIndexTimestamp(event.getTimestamp());
 
-            Key key = buildKey(utf8(value), cf, cf.length, cq, cq.length, visibility, ts, false);
+            Key key = ShardUtil.buildKey(ShardUtil.utf8(value), cf, cf.length, cq, cq.length, visibility, ts, false);
             BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardBitsetIndexTableName(), key);
             Value bitSetValue = getValueForBitsetIndex(fullShard);
             values.put(bulkIngestKey, bitSetValue);
@@ -934,7 +932,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // write both the masked value and masked visibility
                 // and the original value at the masked visibility
                 String maskedValue = maskedFieldHelper.get(field);
-                Key maskedKey = buildKey(utf8(maskedValue), cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
+                Key maskedKey = ShardUtil.buildKey(ShardUtil.utf8(maskedValue), cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
                 BulkIngestKey maskedBulkIngestKey = new BulkIngestKey(getShardBitsetIndexTableName(), maskedKey);
                 values.put(maskedBulkIngestKey, bitSetValue);
             }
@@ -971,22 +969,22 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Direction direction) {
         if (shardId != null && value != null && field != null && visibility != null) {
             String fullShard = new String(shardId, StandardCharsets.UTF_8);
-            byte[] cf = utf8(field);
-            byte[] cq = utf8(event.getDataType().outputName());
-            byte[] row = shardPrefixedBytes(shardId, 8, utf8(value));
-            long ts = getIndexTimestamp(event.getTimestamp());
+            byte[] cf = ShardUtil.utf8(field);
+            byte[] cq = ShardUtil.utf8(event.getDataType().outputName());
+            byte[] row = ShardUtil.shardPrefixedBytes(shardId, 8, ShardUtil.utf8(value));
+            long ts = DateIndexUtil.getIndexTimestamp(event.getTimestamp());
 
-            Key key = buildKey(row, cf, cf.length, cq, cq.length, visibility, ts, false);
+            Key key = ShardUtil.buildKey(row, cf, cf.length, cq, cq.length, visibility, ts, false);
             BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardDayIndexTableName(), key);
-            Value bitSetValue = getValueForDayIndex(fullShard);
+            Value bitSetValue = DateIndexUtil.getValueForDayIndex(fullShard);
             values.put(bulkIngestKey, bitSetValue);
 
             if (maskedFieldHelper != null && maskedFieldHelper.contains(field)) {
                 // write both the masked value and masked visibility
                 // and the original value at the masked visibility
                 String maskedValue = maskedFieldHelper.get(field);
-                byte[] maskedRow = shardPrefixedBytes(shardId, 8, utf8(maskedValue));
-                Key maskedKey = buildKey(maskedRow, cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
+                byte[] maskedRow = ShardUtil.shardPrefixedBytes(shardId, 8, ShardUtil.utf8(maskedValue));
+                Key maskedKey = ShardUtil.buildKey(maskedRow, cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
                 BulkIngestKey maskedBulkIngestKey = new BulkIngestKey(getShardDayIndexTableName(), maskedKey);
                 values.put(maskedBulkIngestKey, bitSetValue);
             }
@@ -1008,30 +1006,6 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         BitSet bitset = new BitSet();
         bitset.set(offset);
         return new Value(bitset.toByteArray());
-    }
-
-    public Value getValueForDayIndex(String shardId) {
-        // get the shard number
-        int shardNumber = getOffsetForDayIndex(shardId);
-        BitSet bits = new BitSet();
-        bits.set(shardNumber);
-        return new Value(bits.toByteArray());
-    }
-
-    /**
-     * Get the shard number used as the offset for the day index
-     * <p>
-     * TODO: move to utility
-     *
-     * @param shard
-     *            the shard
-     * @return the day index offset
-     */
-    public int getOffsetForDayIndex(String shard) {
-        int underscoreIndex = shard.indexOf('_');
-        Preconditions.checkArgument(underscoreIndex > 0, "shard did not contain an underscore: " + shard);
-        String bucket = shard.substring(underscoreIndex + 1);
-        return Integer.parseInt(bucket);
     }
 
     /**
@@ -1065,55 +1039,27 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
         if (shardId != null && value != null && field != null && visibility != null) {
             String fullShard = new String(shardId, StandardCharsets.UTF_8);
-            byte[] cf = utf8(field);
-            byte[] cq = utf8(event.getDataType().outputName());
+            byte[] cf = ShardUtil.utf8(field);
+            byte[] cq = ShardUtil.utf8(event.getDataType().outputName());
             // you are insane if the data is from the year 999 or 10,000
-            byte[] row = shardPrefixedBytes(shardId, 4, utf8(value));
-            long ts = getIndexTimestamp(event.getTimestamp());
+            byte[] row = ShardUtil.shardPrefixedBytes(shardId, 4, ShardUtil.utf8(value));
+            long ts = DateIndexUtil.getIndexTimestamp(event.getTimestamp());
 
-            Key key = buildKey(row, cf, cf.length, cq, cq.length, visibility, ts, false);
+            Key key = ShardUtil.buildKey(row, cf, cf.length, cq, cq.length, visibility, ts, false);
             BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardYearIndexTableName(), key);
-            Value bitsetValue = getValueForYearIndex(fullShard);
+            Value bitsetValue = DateIndexUtil.getValueForYearIndex(fullShard);
             values.put(bulkIngestKey, bitsetValue);
 
             if (maskedFieldHelper != null && maskedFieldHelper.contains(field)) {
                 // write both the masked value and masked visibility
                 // and the original value at the masked visibility
                 String maskedValue = maskedFieldHelper.get(field);
-                byte[] maskedRow = shardPrefixedBytes(shardId, 4, utf8(maskedValue));
-                Key maskedKey = buildKey(maskedRow, cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
+                byte[] maskedRow = ShardUtil.shardPrefixedBytes(shardId, 4, ShardUtil.utf8(maskedValue));
+                Key maskedKey = ShardUtil.buildKey(maskedRow, cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
                 BulkIngestKey maskedBulkIngestKey = new BulkIngestKey(getShardYearIndexTableName(), maskedKey);
                 values.put(maskedBulkIngestKey, bitsetValue);
             }
         }
-    }
-
-    public Value getValueForYearIndex(String shard) {
-        // get the shard number
-        int shardNumber = getOffsetForYearIndex(shard);
-        BitSet bits = new BitSet();
-        bits.set(shardNumber);
-        return new Value(bits.toByteArray());
-    }
-
-    /**
-     * Calculate the day of the year used as the offset for the year index
-     *
-     * @param shard
-     *            the shard
-     * @return the year index offset
-     */
-    public int getOffsetForYearIndex(String shard) {
-        int index = shard.indexOf('_');
-        String date = shard.substring(0, index);
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-        calendar.setTime(DateHelper.parse(date));
-
-        int dayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
-        if (log.isTraceEnabled()) {
-            log.trace("day of year: " + dayOfYear);
-        }
-        return dayOfYear;
     }
 
     /**
@@ -1143,388 +1089,6 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
      */
     protected byte[] flatten(ColumnVisibility vis) {
         return markingFunctions == null ? vis.flatten() : markingFunctions.flatten(vis);
-    }
-
-    /**
-     * The single place where an Accumulo {@link Key} is actually constructed. All {@code createKey}/{@code createIndexKey} overloads funnel through here.
-     * <p>
-     * The column family and qualifier are passed as a backing array plus an explicit length so that a {@link Text}'s over-allocated backing array can be used
-     * directly (see {@link Text#getBytes()} vs {@link Text#getLength()}) without copying it first.
-     *
-     * @param row
-     *            the row bytes
-     * @param colf
-     *            the column family backing array
-     * @param colfLen
-     *            the number of valid bytes in {@code colf}
-     * @param colq
-     *            the column qualifier backing array
-     * @param colqLen
-     *            the number of valid bytes in {@code colq}
-     * @param vis
-     *            the column visibility bytes
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    private static Key buildKey(byte[] row, byte[] colf, int colfLen, byte[] colq, int colqLen, byte[] vis, long ts, boolean delete) {
-        Key k = new Key(row, 0, row.length, colf, 0, colfLen, colq, 0, colqLen, vis, 0, vis.length, ts);
-        k.setDeleted(delete);
-        return k;
-    }
-
-    /**
-     * The {@code 'fi'} column family prefix used for field index entries in the shard table (see {@link #createShardFieldIndexColumn}).
-     */
-    private static final byte[] FI_COLF_PREFIX = {'f', 'i'};
-
-    /**
-     * Encode a String as UTF-8 bytes. Key components are always UTF-8 encoded, matching the encoding performed by {@link Text}.
-     *
-     * @param s
-     *            the string to encode
-     * @return the UTF-8 bytes
-     */
-    private static byte[] utf8(String s) {
-        return s.getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Encode a String as UTF-8 bytes, honoring the same "replace malformed characters" semantics as {@link TextUtil#textAppend(Text, String, boolean)} /
-     * {@link Text#encode(String, boolean)}, rather than the silent-replace behavior of {@link String#getBytes(java.nio.charset.Charset)}.
-     *
-     * @param s
-     *            the string to encode
-     * @param replaceMalformedUTF8
-     *            whether to replace malformed/unmappable characters instead of throwing
-     * @return the UTF-8 bytes
-     */
-    private static byte[] utf8(String s, boolean replaceMalformedUTF8) {
-        try {
-            ByteBuffer buffer = Text.encode(s, replaceMalformedUTF8);
-            byte[] bytes = new byte[buffer.limit()];
-            System.arraycopy(buffer.array(), 0, bytes, 0, bytes.length);
-            return bytes;
-        } catch (CharacterCodingException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
-
-    /**
-     * Concatenates byte array segments with a single {@code NUL} byte between each pair, e.g. {@code joinWithNulls(a, b, c)} produces
-     * {@code a + '\0' + b + '\0' + c}. This computes the exact final length up front and copies each segment once, avoiding the repeated encode-then-grow-
-     * then-copy behavior of building the same layout via {@link Text#append(byte[], int, int)}.
-     *
-     * @param parts
-     *            the byte array segments to join
-     * @return the joined bytes
-     */
-    private static byte[] joinWithNulls(byte[]... parts) {
-        int len = parts.length - 1;
-        for (byte[] part : parts) {
-            len += part.length;
-        }
-        byte[] result = new byte[len];
-        int pos = 0;
-        for (int i = 0; i < parts.length; i++) {
-            System.arraycopy(parts[i], 0, result, pos, parts[i].length);
-            pos += parts[i].length;
-            if (i < parts.length - 1) {
-                result[pos++] = 0;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Builds a shard-prefixed byte array of the form {@code shardId[0, prefixLen) + '\0' + suffix}. Used to construct the row (day/year index tables) or column
-     * qualifier (bitset index table) for the alternate global index implementations, mirroring the string concatenation
-     * {@code shard.substring(0, prefixLen) + '\u0000' + suffix} without decoding the shard id to a String or re-encoding the result back to bytes.
-     *
-     * @param shardId
-     *            the full shard id bytes
-     * @param prefixLen
-     *            the number of leading bytes of the shard id to retain (8 for day granularity, 4 for year granularity)
-     * @param suffix
-     *            the UTF-8 encoded suffix bytes
-     * @return the shard-prefixed bytes
-     */
-    private static byte[] shardPrefixedBytes(byte[] shardId, int prefixLen, byte[] suffix) {
-        byte[] result = new byte[prefixLen + 1 + suffix.length];
-        System.arraycopy(shardId, 0, result, 0, prefixLen);
-        result[prefixLen] = 0;
-        System.arraycopy(suffix, 0, result, prefixLen + 1, suffix.length);
-        return result;
-    }
-
-    /**
-     * Create Key from input parameters
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createKey(byte[] row, Text colf, Text colq, byte[] vis, long ts, boolean delete) {
-        return buildKey(row, colf.getBytes(), colf.getLength(), colq.getBytes(), colq.getLength(), vis, ts, delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers that already have the column
-     * family and qualifier as raw bytes, avoiding a pair of intermediate {@link Text} objects.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createKey(byte[] row, byte[] colf, byte[] colq, byte[] vis, long ts, boolean delete) {
-        return buildKey(row, colf, colf.length, colq, colq.length, vis, ts, delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers whose column qualifier is a
-     * String, avoiding an intermediate {@link Text}.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createKey(byte[] row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
-        byte[] colqBytes = utf8(colq);
-        return buildKey(row, colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, ts, delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers who have already assembled the
-     * column qualifier bytes directly (e.g. via {@link #joinWithNulls(byte[]...)}), avoiding an intermediate {@link Text}.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createKey(byte[] row, Text colf, byte[] colq, byte[] vis, long ts, boolean delete) {
-        return buildKey(row, colf.getBytes(), colf.getLength(), colq, colq.length, vis, ts, delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers whose column family and qualifier
-     * are Strings, avoiding a pair of intermediate {@link Text} objects.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createKey(byte[] row, String colf, String colq, byte[] vis, long ts, boolean delete) {
-        return createKey(row, utf8(colf), utf8(colq), vis, ts, delete);
-    }
-
-    /**
-     * Create Key from input parameters
-     *
-     * For global index keys, the granularity of the timestamp is to the millisecond, where the semantics of the index record is to the day. This makes
-     * MapReduce unable to reduce all index keys together unless they occurred at the same millisecond. If we truncate the timestamp to the day, we should
-     * reduce the number of keys output from a job.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createIndexKey(byte[] row, Text colf, Text colq, byte[] vis, long ts, boolean delete) {
-        return buildKey(row, colf.getBytes(), colf.getLength(), colq.getBytes(), colq.getLength(), vis, getIndexTimestamp(ts), delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for callers that already have the column
-     * family and qualifier as raw bytes, avoiding a pair of intermediate {@link Text} objects.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createIndexKey(byte[] row, byte[] colf, byte[] colq, byte[] vis, long ts, boolean delete) {
-        return buildKey(row, colf, colf.length, colq, colq.length, vis, getIndexTimestamp(ts), delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the common global index case where
-     * the row is a field value and the column family is a field name, avoiding an intermediate byte array and {@link Text}.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createIndexKey(String row, String colf, Text colq, byte[] vis, long ts, boolean delete) {
-        byte[] colfBytes = utf8(colf);
-        return buildKey(utf8(row), colfBytes, colfBytes.length, colq.getBytes(), colq.getLength(), vis, getIndexTimestamp(ts), delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the term dictionary case where the
-     * column family is a shared constant and the column qualifier is a field name, avoiding an intermediate byte array and {@link Text}.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createIndexKey(String row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
-        byte[] colqBytes = utf8(colq);
-        return buildKey(utf8(row), colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, getIndexTimestamp(ts), delete);
-    }
-
-    /**
-     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the global index case where the
-     * column qualifier has already been assembled directly as bytes (e.g. via {@link #joinWithNulls(byte[]...)}), avoiding an intermediate {@link Text}.
-     *
-     * @param row
-     *            the row
-     * @param colf
-     *            the column family
-     * @param colq
-     *            the column qualifier
-     * @param vis
-     *            the column visibility
-     * @param ts
-     *            the timestamp
-     * @param delete
-     *            the delete flag of the key
-     * @return Accumulo Key object
-     */
-    protected Key createIndexKey(String row, String colf, byte[] colq, byte[] vis, long ts, boolean delete) {
-        byte[] colfBytes = utf8(colf);
-        return buildKey(utf8(row), colfBytes, colfBytes.length, colq, colq.length, vis, getIndexTimestamp(ts), delete);
-    }
-
-    /**
-     * trim the event date and ageoff portions of the ts to the beginning of the day
-     *
-     * @param ts
-     * @return the timestamp to be used for index entries
-     */
-    public static long getIndexTimestamp(long ts) {
-        long tsToDay = trimToBeginningOfDay(CompositeTimestamp.getEventDate(ts));
-        long ageOffToDay = trimToBeginningOfDay(CompositeTimestamp.getAgeOffDate(ts));
-        return CompositeTimestamp.getCompositeTimeStamp(tsToDay, ageOffToDay);
-    }
-
-    /**
-     * Trim ms to the beginning of the day
-     *
-     * @param date
-     * @return the time at the beginning of the day
-     */
-    public static long trimToBeginningOfDay(long date) {
-        return (date / MS_PER_DAY) * MS_PER_DAY;
-    }
-
-    /**
-     * Creates a shard column key and does *NOT* apply masking logic
-     *
-     * @param event
-     *            the event
-     * @param colf
-     *            the column family
-     * @param nFV
-     *            the normalized interface of the value
-     * @param visibility
-     *            the visibility
-     * @param shardId
-     *            the shard id
-     * @return the shard event column
-     */
-    protected Multimap<BulkIngestKey,Value> createShardEventColumn(RawRecordContainer event, Text colf, NormalizedContentInterface nFV, byte[] visibility,
-                    byte[] shardId) {
-        return createShardEventColumn(event, colf, nFV, visibility, null, null, shardId);
     }
 
     /**
@@ -1569,8 +1133,8 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         }
 
         // Create unmasked colq
-        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? utf8(fieldName, replaceMalformedUTF8)
-                        : joinWithNulls(utf8(fieldName, replaceMalformedUTF8), utf8(fieldValue, replaceMalformedUTF8));
+        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? ShardUtil.utf8(fieldName, replaceMalformedUTF8)
+                        : ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName, replaceMalformedUTF8), ShardUtil.utf8(fieldValue, replaceMalformedUTF8));
 
         // If this field needs to be masked, then create two keys
         if (null != maskedFieldHelper && maskedFieldHelper.contains(indexedFieldName)) {
@@ -1579,7 +1143,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // Generate a key for the original, unmasked field field value
             if (!StringUtils.isEmpty(fieldValue)) {
                 // One key with the original value and original visibility
-                Key cbKey = createKey(shardId, colf, unmaskedColq, visibility, event.getTimestamp(), deleteMode);
+                Key cbKey = ShardUtil.createKey(shardId, colf, unmaskedColq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), cbKey);
 
                 values.put(bKey, NULL_VALUE);
@@ -1601,7 +1165,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             }
 
             // Else create one key for the field with the original value and the masked visiblity
-            Key cbKey = createKey(shardId, colf, unmaskedColq, refVisibility, event.getTimestamp(), deleteMode);
+            Key cbKey = ShardUtil.createKey(shardId, colf, unmaskedColq, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), cbKey);
             if (log.isTraceEnabled())
                 log.trace("Creating bulk ingest Key " + bKey);
@@ -1616,10 +1180,11 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     Multimap<BulkIngestKey,Value> values, boolean replaceMalformedUTF8, boolean deleteMode, String fieldName, String maskedFieldValue) {
         if (!StringUtils.isEmpty(maskedFieldValue)) {
             // Create masked colq
-            byte[] maskedColq = joinWithNulls(utf8(fieldName, replaceMalformedUTF8), utf8(maskedFieldValue, replaceMalformedUTF8));
+            byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName, replaceMalformedUTF8),
+                            ShardUtil.utf8(maskedFieldValue, replaceMalformedUTF8));
 
             // Another key with masked value and masked visibility
-            Key cbKey = createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
+            Key cbKey = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), cbKey);
             values.put(bKey, NULL_VALUE);
         }
@@ -1665,9 +1230,10 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         Multimap<BulkIngestKey,Value> values = HashMultimap.create();
 
         if (!StringUtils.isEmpty(fieldValue)) {
-            byte[] colf = joinWithNulls(FI_COLF_PREFIX, utf8(fieldName, replaceMalformedUTF8));
-            byte[] idSuffix = joinWithNulls(utf8(event.getDataType().outputName(), replaceMalformedUTF8), utf8(event.getId().toString(), replaceMalformedUTF8));
-            byte[] unmaskedColq = joinWithNulls(utf8(fieldValue, replaceMalformedUTF8), idSuffix);
+            byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName, replaceMalformedUTF8));
+            byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName(), replaceMalformedUTF8),
+                            ShardUtil.utf8(event.getId().toString(), replaceMalformedUTF8));
+            byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue, replaceMalformedUTF8), idSuffix);
 
             if (value == null) {
                 value = NULL_VALUE;
@@ -1675,17 +1241,17 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
             if (null != maskedFieldHelper && maskedFieldHelper.contains(fieldName)) {
                 // Put unmasked colq with original visibility
-                Key k = createKey(shardId, colf, unmaskedColq, visibility, event.getTimestamp(), deleteMode);
+                Key k = ShardUtil.createKey(shardId, colf, unmaskedColq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), k);
                 values.put(bKey, value);
 
                 // We need to use the normalized masked values
                 final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
                 if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                    byte[] maskedColq = joinWithNulls(utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
+                    byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
 
                     // Put masked colq with masked visibility
-                    Key key = createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
+                    Key key = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
                     BulkIngestKey bulkIngestKey = new BulkIngestKey(this.getShardTableName(), key);
                     values.put(bulkIngestKey, value);
                 }
@@ -1700,7 +1266,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     refVisibility = maskedVisibility;
                 }
 
-                Key k = createKey(shardId, colf, unmaskedColq, refVisibility, event.getTimestamp(), deleteMode);
+                Key k = ShardUtil.createKey(shardId, colf, unmaskedColq, refVisibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), k);
                 values.put(bKey, value);
             }
@@ -1739,9 +1305,10 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         boolean deleteMode = helper.getDeleteMode();
 
         if (!StringUtils.isEmpty(fieldValue)) {
-            byte[] colf = joinWithNulls(FI_COLF_PREFIX, utf8(fieldName, replaceMalformedUTF8));
-            byte[] idSuffix = joinWithNulls(utf8(event.getDataType().outputName(), replaceMalformedUTF8), utf8(event.getId().toString(), replaceMalformedUTF8));
-            byte[] unmaskedColq = joinWithNulls(utf8(fieldValue, replaceMalformedUTF8), idSuffix);
+            byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName, replaceMalformedUTF8));
+            byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName(), replaceMalformedUTF8),
+                            ShardUtil.utf8(event.getId().toString(), replaceMalformedUTF8));
+            byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue, replaceMalformedUTF8), idSuffix);
 
             if (value == null) {
                 value = NULL_VALUE;
@@ -1749,17 +1316,17 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
             if (null != maskedFieldHelper && maskedFieldHelper.contains(fieldName)) {
                 // Put unmasked colq with original visibility
-                Key k = createKey(shardId, colf, unmaskedColq, visibility, event.getTimestamp(), deleteMode);
+                Key k = ShardUtil.createKey(shardId, colf, unmaskedColq, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), k);
                 values.put(bKey, value);
 
                 // We need to use the normalized masked values
                 final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
                 if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                    byte[] maskedColq = joinWithNulls(utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
+                    byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
 
                     // Put masked colq with masked visibility
-                    Key key = createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
+                    Key key = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
                     BulkIngestKey bulkIngestKey = new BulkIngestKey(this.getShardTableName(), key);
                     values.put(bulkIngestKey, value);
                 }
@@ -1774,7 +1341,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     refVisibility = maskedVisibility;
                 }
 
-                Key k = createKey(shardId, colf, unmaskedColq, refVisibility, event.getTimestamp(), deleteMode);
+                Key k = ShardUtil.createKey(shardId, colf, unmaskedColq, refVisibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bKey = new BulkIngestKey(this.getShardTableName(), k);
                 values.put(bKey, value);
             }
@@ -1824,125 +1391,6 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     }
 
     /**
-     * Creates a global index BulkIngestKey and Value and does apply masking logic
-     *
-     * @param event
-     *            the event
-     * @param values
-     *            the map of values
-     * @param fieldName
-     *            the field name
-     * @param fieldValue
-     *            the field value
-     * @param visibility
-     *            the visibility
-     * @param maskedVisibility
-     *            the masked visibility
-     * @param maskedFieldHelper
-     *            the masked field helper
-     * @param shardId
-     *            the shard id
-     * @param tableName
-     *            the table name
-     */
-    protected void createIndexColumn(RawRecordContainer event, Multimap<BulkIngestKey,Value> values, String fieldName, String fieldValue, byte[] visibility,
-                    byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Text tableName) {
-        // Shard Global Index Table Structure
-        // Row: Field Value
-        // Colf: Field Name
-        // Colq: Shard Id : DataType
-        // Value: UID
-
-        // hold on to the helper
-        IngestHelperInterface helper = this.getHelper(event.getDataType());
-        boolean deleteMode = helper.getDeleteMode();
-
-        if (null != maskedFieldHelper && maskedFieldHelper.contains(fieldName)) {
-            // These Keys are for the index, so if they are masked, we really want to use the normalized masked values
-            final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
-
-            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
-
-            Value val = createUidArray(event.getId().toString(), deleteMode);
-
-            // Dont create index entries for empty values
-            if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                // Create a key for the masked field value with the masked visibility
-                Key k = this.createIndexKey(normalizedMaskedValue, fieldName, colq, maskedVisibility, event.getTimestamp(), false);
-
-                BulkIngestKey bkey = new BulkIngestKey(tableName, k);
-                values.put(bkey, val);
-            }
-
-            if (!StringUtils.isEmpty(fieldValue)) {
-                // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue, fieldName, colq, visibility, event.getTimestamp(), deleteMode);
-                BulkIngestKey bkey = new BulkIngestKey(tableName, k);
-                values.put(bkey, val);
-            }
-        } else if (!StringUtils.isEmpty(fieldValue)) {
-            // This field is not masked. Add a key with the original field value and masked visibility
-            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
-
-            // Create a UID object for the Value
-            Value val = createUidArray(event.getId().toString(), deleteMode);
-
-            /**
-             * For values that are not being masked, we use the "unmaskedValue" and the masked visibility e.g. release the value as it was in the event at the
-             * lower visibility
-             */
-            byte[] refVisibility = visibility;
-
-            if (null != maskedFieldHelper) {
-                refVisibility = maskedVisibility;
-            }
-
-            Key k = this.createIndexKey(fieldValue, fieldName, colq, refVisibility, event.getTimestamp(), deleteMode);
-            BulkIngestKey bkey = new BulkIngestKey(tableName, k);
-            values.put(bkey, val);
-
-        }
-    }
-
-    /**
-     * Creates a global index BulkIngestKey and Value and does *NOT* apply masking logic
-     *
-     * @param event
-     *            the event
-     * @param values
-     *            the map of values
-     * @param fieldName
-     *            the field name
-     * @param fieldValue
-     *            the field value
-     * @param visibility
-     *            the visibility
-     * @param directionColFam
-     *            the column family direction
-     * @param tableName
-     *            the table name
-     */
-    protected void createDictionaryColumn(RawRecordContainer event, Multimap<BulkIngestKey,Value> values, String fieldName, String fieldValue,
-                    byte[] visibility, Text directionColFam, Text tableName) {
-        if (StringUtils.isEmpty(fieldValue)) {
-            return;
-        }
-
-        // hold on to the helper
-        IngestHelperInterface helper = this.getHelper(event.getDataType());
-        // Shard Global Index Table Structure
-        // Row: Field Value
-        // Colf: Field Name
-        // Colq: Shard Id : DataType
-        // Value: UID
-        Key k = this.createIndexKey(fieldValue, directionColFam, fieldName, visibility, event.getTimestamp(), false);
-
-        BulkIngestKey bKey = new BulkIngestKey(tableName, k);
-        values.put(bKey, NULL_VALUE);
-
-    }
-
-    /**
      * Creates a dictionary index BulkIngestKey and Value and does apply masking logic
      *
      * @param event
@@ -1983,7 +1431,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // Dont create index entries for empty values
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
                 // Create a key for the masked field value with the masked visibility
-                Key k = this.createIndexKey(normalizedMaskedValue, directionColFam, fieldName, maskedVisibility, event.getTimestamp(), false);
+                Key k = ShardUtil.createIndexKey(normalizedMaskedValue, directionColFam, fieldName, maskedVisibility, event.getTimestamp(), false);
 
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, NULL_VALUE);
@@ -1991,7 +1439,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
             if (!StringUtils.isEmpty(fieldValue)) {
                 // Now create a key for the unmasked value with the original visibility
-                Key k = this.createIndexKey(fieldValue, directionColFam, fieldName, visibility, event.getTimestamp(), deleteMode);
+                Key k = ShardUtil.createIndexKey(fieldValue, directionColFam, fieldName, visibility, event.getTimestamp(), deleteMode);
                 BulkIngestKey bkey = new BulkIngestKey(tableName, k);
                 values.put(bkey, NULL_VALUE);
             }
@@ -2008,7 +1456,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 refVisibility = maskedVisibility;
             }
 
-            Key k = this.createIndexKey(fieldValue, directionColFam, fieldName, refVisibility, event.getTimestamp(), deleteMode);
+            Key k = ShardUtil.createIndexKey(fieldValue, directionColFam, fieldName, refVisibility, event.getTimestamp(), deleteMode);
             BulkIngestKey bkey = new BulkIngestKey(tableName, k);
             values.put(bkey, NULL_VALUE);
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -1,5 +1,7 @@
 package datawave.ingest.mapreduce.handler.shard;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -848,8 +850,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // It was observed that the normalized mask values aren't coming back reversed, so account for that before creating the row.
             String normalizedMaskedValue = helper.getNormalizedMaskedValue(column);
 
-            Text colq = new Text(shardId);
-            TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
+            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
 
             // if this method was called with the intention to create reverse index keys, ensure the masked values are reversed.
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
@@ -872,8 +873,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            Text colq = new Text(shardId);
-            TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
+            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
 
             /*
              * For values that are not being masked, we use the "unmaskedValue" and the masked visibility e.g. release the value as it was in the event at the
@@ -1176,6 +1176,11 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     }
 
     /**
+     * The {@code 'fi'} column family prefix used for field index entries in the shard table (see {@link #createShardFieldIndexColumn}).
+     */
+    private static final byte[] FI_COLF_PREFIX = {'f', 'i'};
+
+    /**
      * Encode a String as UTF-8 bytes. Key components are always UTF-8 encoded, matching the encoding performed by {@link Text}.
      *
      * @param s
@@ -1184,6 +1189,53 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
      */
     private static byte[] utf8(String s) {
         return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Encode a String as UTF-8 bytes, honoring the same "replace malformed characters" semantics as {@link TextUtil#textAppend(Text, String, boolean)} /
+     * {@link Text#encode(String, boolean)}, rather than the silent-replace behavior of {@link String#getBytes(java.nio.charset.Charset)}.
+     *
+     * @param s
+     *            the string to encode
+     * @param replaceMalformedUTF8
+     *            whether to replace malformed/unmappable characters instead of throwing
+     * @return the UTF-8 bytes
+     */
+    private static byte[] utf8(String s, boolean replaceMalformedUTF8) {
+        try {
+            ByteBuffer buffer = Text.encode(s, replaceMalformedUTF8);
+            byte[] bytes = new byte[buffer.limit()];
+            System.arraycopy(buffer.array(), 0, bytes, 0, bytes.length);
+            return bytes;
+        } catch (CharacterCodingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Concatenates byte array segments with a single {@code NUL} byte between each pair, e.g. {@code joinWithNulls(a, b, c)} produces
+     * {@code a + '\0' + b + '\0' + c}. This computes the exact final length up front and copies each segment once, avoiding the repeated encode-then-grow-
+     * then-copy behavior of building the same layout via {@link Text#append(byte[], int, int)}.
+     *
+     * @param parts
+     *            the byte array segments to join
+     * @return the joined bytes
+     */
+    private static byte[] joinWithNulls(byte[]... parts) {
+        int len = parts.length - 1;
+        for (byte[] part : parts) {
+            len += part.length;
+        }
+        byte[] result = new byte[len];
+        int pos = 0;
+        for (int i = 0; i < parts.length; i++) {
+            System.arraycopy(parts[i], 0, result, pos, parts[i].length);
+            pos += parts[i].length;
+            if (i < parts.length - 1) {
+                result[pos++] = 0;
+            }
+        }
+        return result;
     }
 
     /**
@@ -1271,6 +1323,28 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     protected Key createKey(byte[] row, Text colf, String colq, byte[] vis, long ts, boolean delete) {
         byte[] colqBytes = utf8(colq);
         return buildKey(row, colf.getBytes(), colf.getLength(), colqBytes, colqBytes.length, vis, ts, delete);
+    }
+
+    /**
+     * Create Key from input parameters. Overload of {@link #createKey(byte[], Text, Text, byte[], long, boolean)} for callers who have already assembled the
+     * column qualifier bytes directly (e.g. via {@link #joinWithNulls(byte[]...)}), avoiding an intermediate {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createKey(byte[] row, Text colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        return buildKey(row, colf.getBytes(), colf.getLength(), colq, colq.length, vis, ts, delete);
     }
 
     /**
@@ -1389,6 +1463,29 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     }
 
     /**
+     * Create Key from input parameters. Overload of {@link #createIndexKey(byte[], Text, Text, byte[], long, boolean)} for the global index case where the
+     * column qualifier has already been assembled directly as bytes (e.g. via {@link #joinWithNulls(byte[]...)}), avoiding an intermediate {@link Text}.
+     *
+     * @param row
+     *            the row
+     * @param colf
+     *            the column family
+     * @param colq
+     *            the column qualifier
+     * @param vis
+     *            the column visibility
+     * @param ts
+     *            the timestamp
+     * @param delete
+     *            the delete flag of the key
+     * @return Accumulo Key object
+     */
+    protected Key createIndexKey(String row, String colf, byte[] colq, byte[] vis, long ts, boolean delete) {
+        byte[] colfBytes = utf8(colf);
+        return buildKey(utf8(row), colfBytes, colfBytes.length, colq, colq.length, vis, getIndexTimestamp(ts), delete);
+    }
+
+    /**
      * trim the event date and ageoff portions of the ts to the beginning of the day
      *
      * @param ts
@@ -1472,10 +1569,8 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         }
 
         // Create unmasked colq
-        Text unmaskedColq = new Text(fieldName);
-        if (!StringUtils.isEmpty(fieldValue)) {
-            TextUtil.textAppend(unmaskedColq, fieldValue, replaceMalformedUTF8);
-        }
+        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? utf8(fieldName, replaceMalformedUTF8)
+                        : joinWithNulls(utf8(fieldName, replaceMalformedUTF8), utf8(fieldValue, replaceMalformedUTF8));
 
         // If this field needs to be masked, then create two keys
         if (null != maskedFieldHelper && maskedFieldHelper.contains(indexedFieldName)) {
@@ -1521,8 +1616,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     Multimap<BulkIngestKey,Value> values, boolean replaceMalformedUTF8, boolean deleteMode, String fieldName, String maskedFieldValue) {
         if (!StringUtils.isEmpty(maskedFieldValue)) {
             // Create masked colq
-            Text maskedColq = new Text(fieldName);
-            TextUtil.textAppend(maskedColq, maskedFieldValue, replaceMalformedUTF8);
+            byte[] maskedColq = joinWithNulls(utf8(fieldName, replaceMalformedUTF8), utf8(maskedFieldValue, replaceMalformedUTF8));
 
             // Another key with masked value and masked visibility
             Key cbKey = createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
@@ -1571,11 +1665,9 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         Multimap<BulkIngestKey,Value> values = HashMultimap.create();
 
         if (!StringUtils.isEmpty(fieldValue)) {
-            Text colf = new Text("fi");
-            TextUtil.textAppend(colf, fieldName, replaceMalformedUTF8);
-            Text unmaskedColq = new Text(fieldValue);
-            TextUtil.textAppend(unmaskedColq, event.getDataType().outputName(), replaceMalformedUTF8);
-            TextUtil.textAppend(unmaskedColq, event.getId().toString(), replaceMalformedUTF8);
+            byte[] colf = joinWithNulls(FI_COLF_PREFIX, utf8(fieldName, replaceMalformedUTF8));
+            byte[] idSuffix = joinWithNulls(utf8(event.getDataType().outputName(), replaceMalformedUTF8), utf8(event.getId().toString(), replaceMalformedUTF8));
+            byte[] unmaskedColq = joinWithNulls(utf8(fieldValue, replaceMalformedUTF8), idSuffix);
 
             if (value == null) {
                 value = NULL_VALUE;
@@ -1590,9 +1682,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // We need to use the normalized masked values
                 final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
                 if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                    Text maskedColq = new Text(normalizedMaskedValue);
-                    TextUtil.textAppend(maskedColq, event.getDataType().outputName(), replaceMalformedUTF8);
-                    TextUtil.textAppend(maskedColq, event.getId().toString(), replaceMalformedUTF8);
+                    byte[] maskedColq = joinWithNulls(utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
 
                     // Put masked colq with masked visibility
                     Key key = createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
@@ -1649,11 +1739,9 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         boolean deleteMode = helper.getDeleteMode();
 
         if (!StringUtils.isEmpty(fieldValue)) {
-            Text colf = new Text("fi");
-            TextUtil.textAppend(colf, fieldName, replaceMalformedUTF8);
-            Text unmaskedColq = new Text(fieldValue);
-            TextUtil.textAppend(unmaskedColq, event.getDataType().outputName(), replaceMalformedUTF8);
-            TextUtil.textAppend(unmaskedColq, event.getId().toString(), replaceMalformedUTF8);
+            byte[] colf = joinWithNulls(FI_COLF_PREFIX, utf8(fieldName, replaceMalformedUTF8));
+            byte[] idSuffix = joinWithNulls(utf8(event.getDataType().outputName(), replaceMalformedUTF8), utf8(event.getId().toString(), replaceMalformedUTF8));
+            byte[] unmaskedColq = joinWithNulls(utf8(fieldValue, replaceMalformedUTF8), idSuffix);
 
             if (value == null) {
                 value = NULL_VALUE;
@@ -1668,9 +1756,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // We need to use the normalized masked values
                 final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
                 if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                    Text maskedColq = new Text(normalizedMaskedValue);
-                    TextUtil.textAppend(maskedColq, event.getDataType().outputName(), replaceMalformedUTF8);
-                    TextUtil.textAppend(maskedColq, event.getId().toString(), replaceMalformedUTF8);
+                    byte[] maskedColq = joinWithNulls(utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
 
                     // Put masked colq with masked visibility
                     Key key = createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
@@ -1775,8 +1861,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // These Keys are for the index, so if they are masked, we really want to use the normalized masked values
             final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
 
-            Text colq = new Text(shardId);
-            TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
+            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
 
             Value val = createUidArray(event.getId().toString(), deleteMode);
 
@@ -1797,8 +1882,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            Text colq = new Text(shardId);
-            TextUtil.textAppend(colq, event.getDataType().outputName(), helper.getReplaceMalformedUTF8());
+            byte[] colq = joinWithNulls(shardId, utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
 
             // Create a UID object for the Value
             Value val = createUidArray(event.getId().toString(), deleteMode);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -920,12 +920,12 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     public void writeBitsetIndexKey(Multimap<BulkIngestKey,Value> values, RawRecordContainer event, String field, String value, byte[] visibility,
                     byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Direction direction) {
         if (shardId != null && value != null && field != null && visibility != null) {
-            String fullShard = new String(shardId);
-            String cq = fullShard.substring(0, 8) + '\u0000' + event.getDataType().outputName();
-            String viz = new String(visibility);
+            String fullShard = new String(shardId, StandardCharsets.UTF_8);
+            byte[] cf = utf8(field);
+            byte[] cq = shardPrefixedBytes(shardId, 8, utf8(event.getDataType().outputName()));
             long ts = getIndexTimestamp(event.getTimestamp());
 
-            Key key = new Key(value, field, cq, viz, ts);
+            Key key = buildKey(utf8(value), cf, cf.length, cq, cq.length, visibility, ts, false);
             BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardBitsetIndexTableName(), key);
             Value bitSetValue = getValueForBitsetIndex(fullShard);
             values.put(bulkIngestKey, bitSetValue);
@@ -934,8 +934,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // write both the masked value and masked visibility
                 // and the original value at the masked visibility
                 String maskedValue = maskedFieldHelper.get(field);
-                String maskedViz = new String(maskedVisibility);
-                Key maskedKey = new Key(maskedValue, field, cq, maskedViz, ts);
+                Key maskedKey = buildKey(utf8(maskedValue), cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
                 BulkIngestKey maskedBulkIngestKey = new BulkIngestKey(getShardBitsetIndexTableName(), maskedKey);
                 values.put(maskedBulkIngestKey, bitSetValue);
             }
@@ -971,13 +970,13 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     public void writeShardDayIndexKey(Multimap<BulkIngestKey,Value> values, RawRecordContainer event, String field, String value, byte[] visibility,
                     byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Direction direction) {
         if (shardId != null && value != null && field != null && visibility != null) {
-            String fullShard = new String(shardId);
-            String row = fullShard.substring(0, 8) + '\u0000' + value;
-            String cq = event.getDataType().outputName();
-            String viz = new String(visibility);
+            String fullShard = new String(shardId, StandardCharsets.UTF_8);
+            byte[] cf = utf8(field);
+            byte[] cq = utf8(event.getDataType().outputName());
+            byte[] row = shardPrefixedBytes(shardId, 8, utf8(value));
             long ts = getIndexTimestamp(event.getTimestamp());
 
-            Key key = new Key(row, field, cq, viz, ts);
+            Key key = buildKey(row, cf, cf.length, cq, cq.length, visibility, ts, false);
             BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardDayIndexTableName(), key);
             Value bitSetValue = getValueForDayIndex(fullShard);
             values.put(bulkIngestKey, bitSetValue);
@@ -986,9 +985,8 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // write both the masked value and masked visibility
                 // and the original value at the masked visibility
                 String maskedValue = maskedFieldHelper.get(field);
-                String maskedRow = fullShard.substring(0, 8) + '\u0000' + maskedValue;
-                String maskedViz = new String(maskedVisibility);
-                Key maskedKey = new Key(maskedRow, field, cq, maskedViz, ts);
+                byte[] maskedRow = shardPrefixedBytes(shardId, 8, utf8(maskedValue));
+                Key maskedKey = buildKey(maskedRow, cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
                 BulkIngestKey maskedBulkIngestKey = new BulkIngestKey(getShardDayIndexTableName(), maskedKey);
                 values.put(maskedBulkIngestKey, bitSetValue);
             }
@@ -1066,13 +1064,14 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Direction direction) {
 
         if (shardId != null && value != null && field != null && visibility != null) {
-            String fullShard = new String(shardId);
+            String fullShard = new String(shardId, StandardCharsets.UTF_8);
+            byte[] cf = utf8(field);
+            byte[] cq = utf8(event.getDataType().outputName());
             // you are insane if the data is from the year 999 or 10,000
-            String row = fullShard.substring(0, 4) + '\u0000' + value;
-            String cq = event.getDataType().outputName();
-            String viz = new String(visibility);
+            byte[] row = shardPrefixedBytes(shardId, 4, utf8(value));
+            long ts = getIndexTimestamp(event.getTimestamp());
 
-            Key key = new Key(row, field, cq, viz, getIndexTimestamp(event.getTimestamp()));
+            Key key = buildKey(row, cf, cf.length, cq, cq.length, visibility, ts, false);
             BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardYearIndexTableName(), key);
             Value bitsetValue = getValueForYearIndex(fullShard);
             values.put(bulkIngestKey, bitsetValue);
@@ -1081,9 +1080,8 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // write both the masked value and masked visibility
                 // and the original value at the masked visibility
                 String maskedValue = maskedFieldHelper.get(field);
-                String maskedRow = fullShard.substring(0, 4) + '\u0000' + maskedValue;
-                String maskedViz = new String(maskedVisibility);
-                Key maskedKey = new Key(maskedRow, field, cq, maskedViz, getIndexTimestamp(event.getTimestamp()));
+                byte[] maskedRow = shardPrefixedBytes(shardId, 4, utf8(maskedValue));
+                Key maskedKey = buildKey(maskedRow, cf, cf.length, cq, cq.length, maskedVisibility, ts, false);
                 BulkIngestKey maskedBulkIngestKey = new BulkIngestKey(getShardYearIndexTableName(), maskedKey);
                 values.put(maskedBulkIngestKey, bitsetValue);
             }
@@ -1186,6 +1184,27 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
      */
     private static byte[] utf8(String s) {
         return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Builds a shard-prefixed byte array of the form {@code shardId[0, prefixLen) + '\0' + suffix}. Used to construct the row (day/year index tables) or column
+     * qualifier (bitset index table) for the alternate global index implementations, mirroring the string concatenation
+     * {@code shard.substring(0, prefixLen) + '\u0000' + suffix} without decoding the shard id to a String or re-encoding the result back to bytes.
+     *
+     * @param shardId
+     *            the full shard id bytes
+     * @param prefixLen
+     *            the number of leading bytes of the shard id to retain (8 for day granularity, 4 for year granularity)
+     * @param suffix
+     *            the UTF-8 encoded suffix bytes
+     * @return the shard-prefixed bytes
+     */
+    private static byte[] shardPrefixedBytes(byte[] shardId, int prefixLen, byte[] suffix) {
+        byte[] result = new byte[prefixLen + 1 + suffix.length];
+        System.arraycopy(shardId, 0, result, 0, prefixLen);
+        result[prefixLen] = 0;
+        System.arraycopy(suffix, 0, result, prefixLen + 1, suffix.length);
+        return result;
     }
 
     /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -1132,9 +1132,11 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             return values;
         }
 
-        // Create unmasked colq
-        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? ShardUtil.utf8(fieldName, replaceMalformedUTF8)
-                        : ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName, replaceMalformedUTF8), ShardUtil.utf8(fieldValue, replaceMalformedUTF8));
+        // Create unmasked colq. This is only needed (and only computed) when there is a field value to key on, both to
+        // avoid wasted work and so that an unwritten key can never fail the record. Field names use the tolerant, never-
+        // throwing overload since they were never subject to replaceMalformedUTF8 prior to this class using ShardUtil.
+        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? null
+                        : ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName), ShardUtil.utf8(fieldValue, replaceMalformedUTF8));
 
         // If this field needs to be masked, then create two keys
         if (null != maskedFieldHelper && maskedFieldHelper.contains(indexedFieldName)) {
@@ -1180,8 +1182,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     Multimap<BulkIngestKey,Value> values, boolean replaceMalformedUTF8, boolean deleteMode, String fieldName, String maskedFieldValue) {
         if (!StringUtils.isEmpty(maskedFieldValue)) {
             // Create masked colq
-            byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName, replaceMalformedUTF8),
-                            ShardUtil.utf8(maskedFieldValue, replaceMalformedUTF8));
+            byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName), ShardUtil.utf8(maskedFieldValue, replaceMalformedUTF8));
 
             // Another key with masked value and masked visibility
             Key cbKey = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
@@ -1233,7 +1234,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName, replaceMalformedUTF8));
             byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName(), replaceMalformedUTF8),
                             ShardUtil.utf8(event.getId().toString(), replaceMalformedUTF8));
-            byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue, replaceMalformedUTF8), idSuffix);
+            byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue), idSuffix);
 
             if (value == null) {
                 value = NULL_VALUE;
@@ -1248,7 +1249,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // We need to use the normalized masked values
                 final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
                 if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                    byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
+                    byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(normalizedMaskedValue), idSuffix);
 
                     // Put masked colq with masked visibility
                     Key key = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
@@ -1308,7 +1309,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName, replaceMalformedUTF8));
             byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName(), replaceMalformedUTF8),
                             ShardUtil.utf8(event.getId().toString(), replaceMalformedUTF8));
-            byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue, replaceMalformedUTF8), idSuffix);
+            byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue), idSuffix);
 
             if (value == null) {
                 value = NULL_VALUE;
@@ -1323,7 +1324,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                 // We need to use the normalized masked values
                 final String normalizedMaskedValue = helper.getNormalizedMaskedValue(fieldName);
                 if (!StringUtils.isEmpty(normalizedMaskedValue)) {
-                    byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(normalizedMaskedValue, replaceMalformedUTF8), idSuffix);
+                    byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(normalizedMaskedValue), idSuffix);
 
                     // Put masked colq with masked visibility
                     Key key = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -988,7 +988,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     }
 
     /**
-     * Constructs a {@link Value} that contains a {@link BitSet}'s backing byte array. The bitset index is set to the shard offset.
+     * Constructs a {@link Value} that contains a {@link java.util.BitSet}'s backing byte array. The bitset index is set to the shard offset.
      * <p>
      * This is the same offset computation as the day index ({@link DateIndexUtil#getValueForDayIndex(String)}); delegate to it rather than duplicating the
      * parsing logic.

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -51,7 +51,6 @@ import datawave.marking.MarkingFunctions;
 import datawave.marking.Markings;
 import datawave.query.model.Direction;
 import datawave.table.constants.TableName;
-import datawave.util.TextUtil;
 
 /**
  * <p>
@@ -199,7 +198,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
     /**
      * The {@code 'fi'} column family prefix used for field index entries in the shard table (see {@link #createShardFieldIndexColumn}).
      */
-    private static final byte[] FI_COLF_PREFIX = {'f', 'i'};
+    protected static final byte[] FI_COLF_PREFIX = {'f', 'i'};
 
     private float bloomFilteringDiskThreshold;
     private String bloomFilteringDiskThresholdPath;
@@ -537,8 +536,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // Colf: DataType : UID
             // Colq: FieldName : FieldValue
             // Value: NULL
-            Text colf = new Text(event.getDataType().outputName());
-            TextUtil.textAppend(colf, event.getId().toString(), helper.getReplaceMalformedUTF8());
+            byte[] colf = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName()), ShardUtil.utf8(event.getId().toString()));
 
             Value indexedValue = createUidArray(event.getId().toString(), helper.getDeleteMode());
 
@@ -846,7 +844,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             // It was observed that the normalized mask values aren't coming back reversed, so account for that before creating the row.
             String normalizedMaskedValue = helper.getNormalizedMaskedValue(column);
 
-            byte[] colq = ShardUtil.joinWithNulls(shardId, ShardUtil.utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
+            byte[] colq = ShardUtil.joinWithNulls(shardId, ShardUtil.utf8(event.getDataType().outputName()));
 
             // if this method was called with the intention to create reverse index keys, ensure the masked values are reversed.
             if (!StringUtils.isEmpty(normalizedMaskedValue)) {
@@ -869,7 +867,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
             }
         } else if (!StringUtils.isEmpty(fieldValue)) {
             // This field is not masked. Add a key with the original field value and masked visibility
-            byte[] colq = ShardUtil.joinWithNulls(shardId, ShardUtil.utf8(event.getDataType().outputName(), helper.getReplaceMalformedUTF8()));
+            byte[] colq = ShardUtil.joinWithNulls(shardId, ShardUtil.utf8(event.getDataType().outputName()));
 
             /*
              * For values that are not being masked, we use the "unmaskedValue" and the masked visibility e.g. release the value as it was in the event at the
@@ -1105,7 +1103,7 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
      *            the shard id
      * @return the shard event column
      */
-    protected Multimap<BulkIngestKey,Value> createShardEventColumn(RawRecordContainer event, Text colf, NormalizedContentInterface nFV, byte[] visibility,
+    protected Multimap<BulkIngestKey,Value> createShardEventColumn(RawRecordContainer event, byte[] colf, NormalizedContentInterface nFV, byte[] visibility,
                     byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId) {
 
         Multimap<BulkIngestKey,Value> values = ArrayListMultimap.create();
@@ -1128,10 +1126,8 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
         }
 
         // Create unmasked colq. This is only needed (and only computed) when there is a field value to key on, both to
-        // avoid wasted work and so that an unwritten key can never fail the record. Field names use the tolerant, never-
-        // throwing overload since they were never subject to replaceMalformedUTF8 prior to this class using ShardUtil.
-        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? null
-                        : ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName), ShardUtil.utf8(fieldValue, replaceMalformedUTF8));
+        // avoid wasted work and so that an unwritten key can never fail the record.
+        byte[] unmaskedColq = StringUtils.isEmpty(fieldValue) ? null : ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName), ShardUtil.utf8(fieldValue));
 
         // If this field needs to be masked, then create two keys
         if (null != maskedFieldHelper && maskedFieldHelper.contains(indexedFieldName)) {
@@ -1173,11 +1169,14 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
     }
 
-    protected void createMaskedShardEventColumn(RawRecordContainer event, Text colf, byte[] maskedVisibility, byte[] shardId,
+    // Note: replaceMalformedUTF8 is retained for signature compatibility with overriding subclasses but is no longer
+    // consulted. ShardUtil.utf8 always replaces malformed input rather than throwing, so key construction can never
+    // fail a record.
+    protected void createMaskedShardEventColumn(RawRecordContainer event, byte[] colf, byte[] maskedVisibility, byte[] shardId,
                     Multimap<BulkIngestKey,Value> values, boolean replaceMalformedUTF8, boolean deleteMode, String fieldName, String maskedFieldValue) {
         if (!StringUtils.isEmpty(maskedFieldValue)) {
             // Create masked colq
-            byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName), ShardUtil.utf8(maskedFieldValue, replaceMalformedUTF8));
+            byte[] maskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldName), ShardUtil.utf8(maskedFieldValue));
 
             // Another key with masked value and masked visibility
             Key cbKey = ShardUtil.createKey(shardId, colf, maskedColq, maskedVisibility, event.getTimestamp(), deleteMode);
@@ -1220,15 +1219,13 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
         // hold on to the helper
         IngestHelperInterface helper = this.getHelper(event.getDataType());
-        boolean replaceMalformedUTF8 = helper.getReplaceMalformedUTF8();
         boolean deleteMode = helper.getDeleteMode();
 
         Multimap<BulkIngestKey,Value> values = HashMultimap.create();
 
         if (!StringUtils.isEmpty(fieldValue)) {
-            byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName, replaceMalformedUTF8));
-            byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName(), replaceMalformedUTF8),
-                            ShardUtil.utf8(event.getId().toString(), replaceMalformedUTF8));
+            byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName));
+            byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName()), ShardUtil.utf8(event.getId().toString()));
             byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue), idSuffix);
 
             if (value == null) {
@@ -1297,13 +1294,11 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
                     byte[] visibility, byte[] maskedVisibility, MaskedFieldHelper maskedFieldHelper, byte[] shardId, Value value) {
         // hold on to the helper
         IngestHelperInterface helper = this.getHelper(event.getDataType());
-        boolean replaceMalformedUTF8 = helper.getReplaceMalformedUTF8();
         boolean deleteMode = helper.getDeleteMode();
 
         if (!StringUtils.isEmpty(fieldValue)) {
-            byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName, replaceMalformedUTF8));
-            byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName(), replaceMalformedUTF8),
-                            ShardUtil.utf8(event.getId().toString(), replaceMalformedUTF8));
+            byte[] colf = ShardUtil.joinWithNulls(FI_COLF_PREFIX, ShardUtil.utf8(fieldName));
+            byte[] idSuffix = ShardUtil.joinWithNulls(ShardUtil.utf8(event.getDataType().outputName()), ShardUtil.utf8(event.getId().toString()));
             byte[] unmaskedColq = ShardUtil.joinWithNulls(ShardUtil.utf8(fieldValue), idSuffix);
 
             if (value == null) {

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandler.java
@@ -3,7 +3,6 @@ package datawave.ingest.mapreduce.handler.shard;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
@@ -20,7 +19,6 @@ import org.apache.hadoop.mapreduce.StatusReporter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.log4j.Logger;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -993,19 +991,16 @@ public abstract class ShardedDataTypeHandler<KEYIN> extends StatsDEnabledDataTyp
 
     /**
      * Constructs a {@link Value} that contains a {@link BitSet}'s backing byte array. The bitset index is set to the shard offset.
+     * <p>
+     * This is the same offset computation as the day index ({@link DateIndexUtil#getValueForDayIndex(String)}); delegate to it rather than duplicating the
+     * parsing logic.
      *
      * @param shard
      *            the full shard
      * @return a Value containing a BitSet
      */
     public Value getValueForBitsetIndex(String shard) {
-        int underscoreIndex = shard.indexOf('_');
-        Preconditions.checkArgument(underscoreIndex > 0, "shard did not contain an underscore: " + shard);
-        String shardId = shard.substring(underscoreIndex + 1);
-        int offset = Integer.parseInt(shardId);
-        BitSet bitset = new BitSet();
-        bitset.set(offset);
-        return new Value(bitset.toByteArray());
+        return DateIndexUtil.getValueForDayIndex(shard);
     }
 
     /**

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ContentIndexingColumnBasedHandler.java
@@ -39,6 +39,7 @@ import datawave.ingest.data.tokenize.TokenizationHelper.HeartBeatThread;
 import datawave.ingest.data.tokenize.TokenizationHelper.TokenizerTimeoutException;
 import datawave.ingest.data.tokenize.TruncateAttribute;
 import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
+import datawave.ingest.mapreduce.handler.shard.ShardUtil;
 import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
 import datawave.ingest.mapreduce.handler.shard.content.BoundedOffsetQueue;
 import datawave.ingest.mapreduce.handler.shard.content.BoundedOffsetQueue.OffsetList;
@@ -238,7 +239,7 @@ public abstract class ContentIndexingColumnBasedHandler<KEYIN> extends AbstractC
 
         Text colq = new Text(fieldName);
         TextUtil.textAppend(colq, fieldValue, helper.getReplaceMalformedUTF8());
-        Key k = createKey(shardId, colf, colq, fieldVisibility, event.getTimestamp(), helper.getDeleteMode());
+        Key k = ShardUtil.createKey(shardId, colf, colq, fieldVisibility, event.getTimestamp(), helper.getDeleteMode());
         BulkIngestKey bKey = new BulkIngestKey(new Text(this.getShardTableName()), k);
         values.put(bKey, NULL_VALUE);
     }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ExtendedContentIndexingColumnBasedHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ExtendedContentIndexingColumnBasedHandler.java
@@ -47,7 +47,9 @@ import datawave.ingest.data.tokenize.TokenizationHelper;
 import datawave.ingest.mapreduce.ContextWrappedStatusReporter;
 import datawave.ingest.mapreduce.handler.DataTypeHandler;
 import datawave.ingest.mapreduce.handler.ExtendedDataTypeHandler;
+import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
 import datawave.ingest.mapreduce.handler.shard.AbstractColumnBasedHandler;
+import datawave.ingest.mapreduce.handler.shard.ShardUtil;
 import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
 import datawave.ingest.mapreduce.handler.shard.content.BoundedOffsetQueue;
 import datawave.ingest.mapreduce.handler.shard.content.BoundedOffsetQueue.OffsetList;
@@ -503,7 +505,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
 
         Text colq = new Text(fieldName);
         TextUtil.textAppend(colq, fieldValue, this.ingestHelper.getReplaceMalformedUTF8());
-        Key k = createKey(shardId, colf, colq, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
+        Key k = ShardUtil.createKey(shardId, colf, colq, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
         BulkIngestKey bKey = new BulkIngestKey(new Text(this.getShardTableName()), k);
         contextWriter.write(bKey, DataTypeHandler.NULL_VALUE, context);
     }
@@ -592,7 +594,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
                     TaskInputOutputContext<KEYIN,? extends RawRecordContainer,KEYOUT,VALUEOUT> context, StatusReporter reporter, Text uid, byte[] visibility,
                     byte[] shardId, byte[] rawValue) throws IOException, InterruptedException, MutationsRejectedException {
 
-        Key k = createKey(shardId, ColumnFamilyConstants.FULL_CONTENT_TEXT, uid, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
+        Key k = ShardUtil.createKey(shardId, ColumnFamilyConstants.FULL_CONTENT_TEXT, uid, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
 
         ByteArrayOutputStream baos = null;
         Base64OutputStream b64os = null;
@@ -761,7 +763,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
             value = DataTypeHandler.NULL_VALUE;
         }
 
-        Key k = createKey(shardId, colf, colq, visibility, event.getTimestamp(), deleteMode);
+        Key k = ShardUtil.createKey(shardId, colf, colq, visibility, event.getTimestamp(), deleteMode);
         BulkIngestKey bKey = new BulkIngestKey(new Text(this.getShardTableName()), k);
         contextWriter.write(bKey, value, context);
     }
@@ -850,7 +852,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
         Text colq = new Text(shardId);
         TextUtil.textAppend(colq, this.eventDataTypeName, replacedMalformedUTF8);
 
-        Key k = this.createIndexKey(nFV.getIndexedFieldValue(), nFV.getIndexedFieldName(), colq, visibility, event.getTimestamp(), deleteMode);
+        Key k = ShardUtil.createIndexKey(nFV.getIndexedFieldValue(), nFV.getIndexedFieldName(), colq, visibility, event.getTimestamp(), deleteMode);
 
         // Create a UID object for the Value
         Value val = createUidArray(eventUid, deleteMode);
@@ -875,7 +877,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
             if (getDayIndexEnabled()) {
                 String rowForDay = shard.substring(0, 8) + '\u0000' + nFV.getEventFieldValue();
                 Key key = new Key(rowForDay, nFV.getEventFieldName(), cq, viz);
-                Value value = getValueForDayIndex(shard);
+                Value value = DateIndexUtil.getValueForDayIndex(shard);
                 BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardDayIndexTableName(), key);
                 contextWriter.write(bulkIngestKey, value, context);
             }
@@ -883,7 +885,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
             if (getYearIndexEnabled()) {
                 String rowForYear = shard.substring(0, 4) + '\u0000' + nFV.getEventFieldValue();
                 Key key = new Key(rowForYear, nFV.getEventFieldName(), cq, viz);
-                Value value = getValueForYearIndex(shard);
+                Value value = DateIndexUtil.getValueForYearIndex(shard);
                 BulkIngestKey bulkIngestKey = new BulkIngestKey(getShardYearIndexTableName(), key);
                 contextWriter.write(bulkIngestKey, value, context);
             }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ExtendedContentIndexingColumnBasedHandler.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/handler/tokenize/ExtendedContentIndexingColumnBasedHandler.java
@@ -592,7 +592,7 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
                     TaskInputOutputContext<KEYIN,? extends RawRecordContainer,KEYOUT,VALUEOUT> context, StatusReporter reporter, Text uid, byte[] visibility,
                     byte[] shardId, byte[] rawValue) throws IOException, InterruptedException, MutationsRejectedException {
 
-        Key k = createKey(shardId, new Text(ColumnFamilyConstants.FULL_CONTENT), uid, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
+        Key k = createKey(shardId, ColumnFamilyConstants.FULL_CONTENT_TEXT, uid, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
 
         ByteArrayOutputStream baos = null;
         Base64OutputStream b64os = null;
@@ -847,11 +847,10 @@ public abstract class ExtendedContentIndexingColumnBasedHandler<KEYIN,KEYOUT,VAL
         // Colf: Field Name
         // Colq: Shard Id : DataType
         // Value: UID
-        Text colf = new Text(nFV.getIndexedFieldName());
         Text colq = new Text(shardId);
         TextUtil.textAppend(colq, this.eventDataTypeName, replacedMalformedUTF8);
 
-        Key k = this.createIndexKey(nFV.getIndexedFieldValue().getBytes(), colf, colq, visibility, event.getTimestamp(), deleteMode);
+        Key k = this.createIndexKey(nFV.getIndexedFieldValue(), nFV.getIndexedFieldName(), colq, visibility, event.getTimestamp(), deleteMode);
 
         // Create a UID object for the Value
         Value val = createUidArray(eventUid, deleteMode);

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandlerTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/mapreduce/handler/shard/ShardedDataTypeHandlerTest.java
@@ -33,6 +33,7 @@ import datawave.ingest.data.config.MaskedFieldHelper;
 import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.ingest.data.config.ingest.ContentBaseIngestHelper;
+import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
 import datawave.ingest.mapreduce.job.BulkIngestKey;
 import datawave.ingest.protobuf.Uid;
 import datawave.ingest.table.config.ShardTableConfigHelper;
@@ -646,7 +647,7 @@ public class ShardedDataTypeHandlerTest {
     }
 
     private long getTimestamp() {
-        return ShardedDataTypeHandler.getIndexTimestamp(timestamp);
+        return DateIndexUtil.getIndexTimestamp(timestamp);
     }
 
     private Type createType() {

--- a/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaDataTypeHandler.java
+++ b/warehouse/ingest-wikipedia/src/main/java/datawave/ingest/wikipedia/WikipediaDataTypeHandler.java
@@ -42,6 +42,7 @@ import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.ingest.data.config.ingest.AccumuloHelper;
 import datawave.ingest.mapreduce.ContextWrappedStatusReporter;
 import datawave.ingest.mapreduce.handler.DataTypeHandler;
+import datawave.ingest.mapreduce.handler.shard.ShardUtil;
 import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
 import datawave.ingest.mapreduce.handler.shard.content.BoundedOffsetQueue.OffsetList;
 import datawave.ingest.mapreduce.handler.shard.content.ContentIndexCounters;
@@ -356,7 +357,7 @@ public class WikipediaDataTypeHandler<KEYIN,KEYOUT,VALUEOUT> extends ExtendedCon
 
         Text colq = new Text(fieldName);
         TextUtil.textAppend(colq, fieldValue, this.ingestHelper.getReplaceMalformedUTF8());
-        Key k = createKey(shardId, colf, colq, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
+        Key k = ShardUtil.createKey(shardId, colf, colq, visibility, event.getTimestamp(), this.ingestHelper.getDeleteMode());
         BulkIngestKey bKey = new BulkIngestKey(new Text(this.getShardTableName()), k);
         contextWriter.write(bKey, DataTypeHandler.NULL_VALUE, context);
     }

--- a/warehouse/query-core/src/test/java/datawave/query/util/CommonalityTokenTestDataIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/CommonalityTokenTestDataIngest.java
@@ -18,7 +18,7 @@ import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NumberListType;
 import datawave.data.type.NumberType;
 import datawave.data.type.Type;
-import datawave.ingest.mapreduce.handler.shard.ShardedDataTypeHandler;
+import datawave.ingest.mapreduce.handler.dateindex.DateIndexUtil;
 import datawave.ingest.protobuf.Uid;
 import datawave.query.QueryTestTableHelper;
 import datawave.query.index.day.IndexIngestUtil;
@@ -57,14 +57,14 @@ public class CommonalityTokenTestDataIngest {
         String myUID2 = UID.builder().newId("MyUid2".getBytes(), (Date) null).toString();
         String myUID3 = UID.builder().newId("MyUid3".getBytes(), (Date) null).toString();
 
-        long indexTS = ShardedDataTypeHandler.getIndexTimestamp(timeStamp);
+        long indexTS = DateIndexUtil.getIndexTimestamp(timeStamp);
 
         long ageOffTimestamp = 1699041441288l;
         long timeStamp2 = CompositeTimestamp.getCompositeTimeStamp(timeStamp, ageOffTimestamp);
-        long indexTS2 = ShardedDataTypeHandler.getIndexTimestamp(timeStamp2);
+        long indexTS2 = DateIndexUtil.getIndexTimestamp(timeStamp2);
 
         long timeStamp3 = CompositeTimestamp.getCompositeTimeStamp(ageOffTimestamp, ageOffTimestamp);
-        long indexTS3 = ShardedDataTypeHandler.getIndexTimestamp(timeStamp3);
+        long indexTS3 = DateIndexUtil.getIndexTimestamp(timeStamp3);
 
         try {
             // write the shard table :


### PR DESCRIPTION
## Summary
Reduces per-key object allocation in `ShardedDataTypeHandler`'s hot ingest paths by adding `createKey`/`createIndexKey` overloads and byte-array builder helpers, so callers no longer have to wrap `String`/`byte[]` values in intermediate `Text` objects just to satisfy the existing method signatures. It also removes the last remaining cases where UTF-8 encoding for key construction could throw a checked exception on malformed input.

## Motivation
`ShardedDataTypeHandler` builds one or more Accumulo `Key`s for every field of every ingested event (shard event column, field index, global index, bitset/day/year index, dictionary index). The original `createKey`/`createIndexKey` methods only accepted `Text` for `colf`/`colq`, forcing every caller to allocate `new Text(...)` (and often `TextUtil.textAppend(...)`, which does an encode-then-possibly-grow-then-copy) purely to satisfy the signature, even when the caller already had a `String` or `byte[]`.

## Changes
- **New `createKey`/`createIndexKey` overloads** accepting `byte[]`/`String` combinations for row/colf/colq, all funneling through a single private `buildKey(...)` that constructs the `Key` directly from backing arrays + explicit lengths (avoiding `Text.getBytes()` copies).
- **`utf8(String)`** — a single UTF-8 encoding helper built on the JDK's `String.getBytes(StandardCharsets.UTF_8)`, which never throws: malformed input (e.g. an unpaired surrogate) is silently replaced, byte-for-byte identical to `new Text(s)`. This replaces an earlier `utf8(String, boolean replaceMalformedUTF8)` overload that wrapped `Text.encode(s, replaceMalformedUTF8)` and could throw `CharacterCodingException`/`IllegalArgumentException` when `replaceMalformedUTF8` was `false` — see Behavioral notes below.
- **`joinWithNulls(byte[]... parts)`** — concatenates byte segments with `NUL` separators in one pre-sized array, replacing the `new Text(x)` + repeated `TextUtil.textAppend(...)` pattern used to build multi-part `colf`/`colq` values (e.g. `fieldName\0fieldValue`, `"fi"\0fieldName`, `fieldValue\0dataType\0uid`).
- **`shardPrefixedBytes(byte[] shardId, int prefixLen, byte[] suffix)`** — builds `shardId[0,prefixLen) + '\0' + suffix` directly from bytes.
- Rewrote `writeBitsetIndexKey`, `writeShardDayIndexKey`, and `writeShardYearIndexKeyBitSet` to stop round-tripping `shardId`/`visibility` through `new String(...)` and Accumulo's `Key(String, String, String, String, long)` constructor (which itself allocates 4 `Text` objects internally); they now build keys directly via `buildKey`, reusing the shared colf/colq bytes between the masked and unmasked key writes.
- Updated the field index (`createShardFieldIndexColumn`, both overloads — the highest-volume key type), shard event column (`createShardEventColumn`/`createMaskedShardEventColumn`), and global index (`writeStandardIndexKey`, `createIndexColumn`) builders to construct `colf`/`colq` as `byte[]` via `joinWithNulls`, sharing the common `dataType\0uid` suffix between masked/unmasked variants where applicable.
- `createShardEventColumn`/`createMaskedShardEventColumn` now take `colf` as `byte[]` instead of `Text`. The `colf` built in `createColumns` (`dataType\0uid`) is assembled directly via `joinWithNulls`/`utf8`, which removes the last `TextUtil.textAppend` call — and its `Text` allocation — from `ShardedDataTypeHandler`.
- `ErrorShardedDataTypeHandler` and `ExtendedContentIndexingColumnBasedHandler` updated to use the existing `ColumnFamilyConstants.FULL_CONTENT_TEXT` constant instead of allocating `new Text(ColumnFamilyConstants.FULL_CONTENT)` per call, and to use the new `String`-based overloads where applicable.
- The `replaceMalformedUTF8` flag no longer changes UTF-8 encoding behavior anywhere in key construction: every `ShardUtil.utf8(String)` call (field names, field values, uid/datatype components) now uses the same never-throwing encoder. The flag is still threaded through a couple of method signatures (e.g. `createMaskedShardEventColumn`) for compatibility with overriding subclasses, but it is no longer consulted there.
- `ShardedDataTypeHandler.getValueForBitsetIndex` now delegates to `DateIndexUtil.getValueForDayIndex` instead of duplicating its shard-offset parsing. `DateIndexUtil.getOffsetForYearIndex` gained the same underscore-presence guard `getOffsetForDayIndex` already had. `ShardUtil.joinWithNulls()` with zero arguments now returns an empty array instead of throwing `NegativeArraySizeException`, and `ShardUtil` has a private constructor.

## Behavioral notes
- Index-key rows built from a `String` (e.g. field values used as the row) are now explicitly UTF-8 encoded via the new `utf8()` helper, whereas some previously used `String.getBytes()` (platform default charset) for the row while `Text`-based colf/colq were always UTF-8. This only changes behavior on JVMs where the default charset isn't UTF-8.
- **Key construction can no longer fail a record due to malformed UTF-8 field values.** Previously, `ShardUtil.utf8(s, false)` (the default, since `replaceMalformedUTF8` defaults to `false`) threw on malformed input, matching the old `Text.encode(s, false)`/`TextUtil.textAppendNoNull` behavior it replaced. That throw was **not** governed by `BaseIngestHelper.FailurePolicy` (DROP/LEAVE/FAIL) — that policy only applies to normalization errors in `applyNormalizationAndAddToResults`, which runs before key building — so a malformed field value would fail the whole record: `EventMapper`'s catch rolled back every key already written for the event and routed it to the error table, while `ShardReindexMapper.processDataMap` has no try/catch around `processBulk` at all and would fail the job outright. This PR removes that failure mode entirely by making `ShardUtil.utf8(String)` always replace malformed characters instead of throwing, matching `Text`'s own "replace" semantics.
- All other changes are allocation/copy reductions only — key byte layouts are unchanged, verified via the existing test suite.

## Testing
- `mvn -pl warehouse/ingest-core test -Dtest='datawave.ingest.mapreduce.handler.**'` — 115 tests, all passing.
- `mvn -pl warehouse/ingest-core,warehouse/ingest-wikipedia,warehouse/ingest-csv,warehouse/ingest-json -DskipTests test-compile` — all modules compile successfully.
- `ShardUtilTest` differentially checks `ShardUtil.utf8(String)` against `Text`'s constructor (and `Text.encode(s, true)`) over a corpus including lone/reversed surrogates, asserting it always matches `Text`'s byte output and never throws — this is the permanent regression guard for the non-throwing behavior.

---
[Conversation](https://app.warp.dev/conversation/9a98335f-b732-42b4-a469-2cc768f937c0)

Co-Authored-By: Warp <agent@warp.dev>
