### PR TITLE
Remove the authentication path bottleneck in the Elytron security caches

### DIFF
--- a/commons/security/src/main/java/datawave/security/authorization/DatawavePrincipal.java
+++ b/commons/security/src/main/java/datawave/security/authorization/DatawavePrincipal.java
@@ -35,6 +35,7 @@ public class DatawavePrincipal implements ProxiedUserDetails, Principal, Seriali
     private final List<DatawaveUser> proxiedUsers = new ArrayList<>();
     @XmlElement
     private final long creationTime;
+    private transient int hashCode;
 
     /**
      * This constructor should not be used. It is here to allow JAX-B mapping and CDI proxying of this class.
@@ -203,10 +204,17 @@ public class DatawavePrincipal implements ProxiedUserDetails, Principal, Seriali
         return proxiedUsers.equals(that.proxiedUsers);
     }
 
+    /**
+     * Memoized, since hashing walks the auth and role sets of every proxied user. Valid only while this class remains immutable.
+     */
     @Override
     public int hashCode() {
-        int result = username.hashCode();
-        result = 31 * result + proxiedUsers.hashCode();
+        int result = hashCode;
+        if (result == 0) {
+            result = username.hashCode();
+            result = 31 * result + proxiedUsers.hashCode();
+            hashCode = result;
+        }
         return result;
     }
 

--- a/commons/security/src/main/java/datawave/security/authorization/DatawaveUser.java
+++ b/commons/security/src/main/java/datawave/security/authorization/DatawaveUser.java
@@ -41,6 +41,7 @@ public class DatawaveUser implements Serializable {
     private final Multimap<String,String> roleToAuthMapping;
     private final long creationTime;
     private final long expirationTime;
+    private transient int hashCode;
 
     public DatawaveUser(SubjectIssuerDNPair dn, UserType userType, Collection<String> auths, Collection<String> roles,
                     Multimap<String,String> roleToAuthMapping, long creationTime) {
@@ -132,13 +133,20 @@ public class DatawaveUser implements Serializable {
         return creationTime == that.creationTime && dn.equals(that.dn) && userType == that.userType && auths.equals(that.auths) && roles.equals(that.roles);
     }
 
+    /**
+     * Memoized, since hashing walks the full auth and role sets. Valid only while this class remains immutable.
+     */
     @Override
     public int hashCode() {
-        int result = dn.hashCode();
-        result = 31 * result + userType.hashCode();
-        result = 31 * result + auths.hashCode();
-        result = 31 * result + roles.hashCode();
-        result = 31 * result + (int) (creationTime ^ (creationTime >>> 32));
+        int result = hashCode;
+        if (result == 0) {
+            result = dn.hashCode();
+            result = 31 * result + userType.hashCode();
+            result = 31 * result + auths.hashCode();
+            result = 31 * result + roles.hashCode();
+            result = 31 * result + (int) (creationTime ^ (creationTime >>> 32));
+            hashCode = result;
+        }
         return result;
     }
 

--- a/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
+++ b/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
@@ -202,8 +202,8 @@ module add --name=com.mysql.driver --dependencies=javax.api,javax.transaction.ap
     configuration={ \
         jwtEnabled="${dw.jwt.header.authentication:false}", \
         trustedHeadersEnabled="${dw.trusted.header.authentication:false}", \
-        maxCacheEntries="-1", \
-        maxCacheAge="30000" \
+        maxCacheEntries="${dw.security.cache.maxEntries:20000}", \
+        maxCacheAge="${dw.security.cache.maxAge:30000}" \
     })
 
 # Create a custom realm that handles preparing the DatawavePrincipal for authentication. The realm can be configured via
@@ -214,7 +214,9 @@ module add --name=com.mysql.driver --dependencies=javax.api,javax.transaction.ap
     module="datawave.webservice.datawave-security-elytron-module", \
     configuration={ \
         certVerifier="datawave.security.cert.DatawaveCertVerifier", \
-        oscpLevel="off" \
+        oscpLevel="off", \
+        maxCacheEntries="${dw.security.cache.maxEntries:20000}", \
+        maxCacheAge="${dw.security.cache.maxAge:30000}" \
     })
 
 # Create and configure the security domain 'datawaveElytron' that will handle the authentication and authorization.

--- a/web-services/security-parent/security-elytron-module/src/main/java/datawave/security/cache/DatawaveRealmIdentityCache.java
+++ b/web-services/security-parent/security-elytron-module/src/main/java/datawave/security/cache/DatawaveRealmIdentityCache.java
@@ -3,9 +3,10 @@ package datawave.security.cache;
 import java.security.Principal;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -19,8 +20,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 import datawave.security.authorization.DatawavePrincipal;
 import datawave.security.authorization.DatawaveUser;
@@ -30,13 +29,12 @@ import datawave.security.authorization.DatawaveUser;
  * associated with security realm and security domain principals, and is intended for use with a {@link org.wildfly.security.auth.server.SecurityRealm} to
  * support caching of identities without wrapping the realm in a caching realm. This cache requires the domain principals to be instances of
  * {@link DatawavePrincipal}.
+ * <p>
+ * This cache is lock free. {@link #get(Principal)} sits on the authentication path of every request, so reads must never block behind a write.
  */
 public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCache {
 
     private static final Logger log = LoggerFactory.getLogger(DatawaveRealmIdentityCache.class);
-
-    // Create the lock with fairness to ensure write operations do not get perpetually blocked by read operations.
-    private final ReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     /**
      * Holds mappings for domain principals to realm identities.
@@ -44,9 +42,9 @@ public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCa
     private final Cache<DatawavePrincipal,RealmIdentity> domainPrincipalsToRealmIdentities;
 
     /**
-     * Holds mappings of realm identity principals to domain principals.
+     * Holds mappings of realm identity principals to the domain principals that resolved to them.
      */
-    private final Multimap<Principal,Principal> realmPrincipalsToDomainPrincipals;
+    private final ConcurrentMap<Principal,Set<Principal>> realmPrincipalsToDomainPrincipals = new ConcurrentHashMap<>();
 
     /**
      * Return a new {@link DatawaveRealmIdentityCache}.
@@ -65,27 +63,18 @@ public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCa
             cacheBuilder.expireAfterWrite(Duration.ofMillis(ttl));
         }
 
-        // Add an eviction listener to the cache that will remove corresponding entries from the realm principal cache if an entry in the domain principal
-        // cache is removed due to expiration or size.
+        // Drop the reverse mapping for an entry the cache evicted on its own. Only the evicted domain principal is unmapped. Other domain principals that
+        // resolve to the same realm identity principal may still have live entries.
         cacheBuilder.evictionListener(new RemovalListener<Principal,RealmIdentity>() {
             @Override
             public void onRemoval(@Nullable Principal principal, @Nullable RealmIdentity realmIdentity, RemovalCause removalCause) {
                 if (removalCause == RemovalCause.EXPIRED || removalCause == RemovalCause.SIZE) {
-                    if (realmIdentity != null) {
-                        if (obtainedWriteLock()) {
-                            try {
-                                realmPrincipalsToDomainPrincipals.removeAll(realmIdentity.getRealmIdentityPrincipal());
-                            } finally {
-                                lock.writeLock().unlock();
-                            }
-                        }
-                    }
+                    unmapDomainPrincipal(principal, realmIdentity);
                 }
             }
         });
 
         domainPrincipalsToRealmIdentities = cacheBuilder.build();
-        realmPrincipalsToDomainPrincipals = HashMultimap.create();
     }
 
     /**
@@ -100,18 +89,15 @@ public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCa
     public void put(Principal principal, RealmIdentity realmIdentity) {
         Preconditions.checkArgument(principal instanceof DatawavePrincipal, "principal must be of type " + DatawavePrincipal.class.getName());
 
-        if (obtainedWriteLock()) {
-            try {
-                domainPrincipalsToRealmIdentities.put((DatawavePrincipal) principal, realmIdentity);
-                realmPrincipalsToDomainPrincipals.put(realmIdentity.getRealmIdentityPrincipal(), principal);
-            } finally {
-                lock.writeLock().unlock();
-            }
+        domainPrincipalsToRealmIdentities.put((DatawavePrincipal) principal, realmIdentity);
+        Principal realmPrincipal = realmIdentity.getRealmIdentityPrincipal();
+        if (realmPrincipal != null) {
+            realmPrincipalsToDomainPrincipals.computeIfAbsent(realmPrincipal, k -> ConcurrentHashMap.newKeySet()).add(principal);
         }
     }
 
     /**
-     * Return the realm identity for the given principal. The principal may a realm derived from a realm identity, or a security domain.
+     * Return the realm identity for the given principal. The principal may be a realm identity principal or a security domain principal.
      *
      * @param principal
      *            the {@link Principal} that references a previously cached realm identity
@@ -119,24 +105,21 @@ public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCa
      */
     @Override
     public RealmIdentity get(Principal principal) {
-        if (obtainedReadLock()) {
-            try {
-                // Attempt to fetch an identity directly from the realm identity cache. This will succeed if the principal is a domain principal.
-                RealmIdentity identity = domainPrincipalsToRealmIdentities.getIfPresent(principal);
+        // Attempt to fetch an identity directly from the realm identity cache. This will succeed if the principal is a domain principal.
+        RealmIdentity identity = domainPrincipalsToRealmIdentities.getIfPresent(principal);
+        if (identity != null) {
+            return identity;
+        }
+
+        // If no identity was found, the principal may be a realm identity principal. If any domain principals are stored for the realm identity principal,
+        // return the realm identity associated with the first one that still has a live entry.
+        Set<Principal> domainPrincipals = realmPrincipalsToDomainPrincipals.get(principal);
+        if (domainPrincipals != null) {
+            for (Principal domainPrincipal : domainPrincipals) {
+                identity = domainPrincipalsToRealmIdentities.getIfPresent(domainPrincipal);
                 if (identity != null) {
                     return identity;
                 }
-
-                // If no identity was found, the principal may be a realm identity principal. If any domain principals are stored for the realm identity
-                // principal, return the realm identity associated with the first available domain principal.
-                Collection<Principal> domainPrincipals = realmPrincipalsToDomainPrincipals.get(principal);
-                if (!domainPrincipals.isEmpty()) {
-                    return domainPrincipalsToRealmIdentities.getIfPresent(domainPrincipals.iterator().next());
-                } else {
-                    return null;
-                }
-            } finally {
-                lock.readLock().unlock();
             }
         }
         return null;
@@ -150,97 +133,96 @@ public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCa
      */
     @Override
     public void remove(Principal principal) {
-        if (obtainedWriteLock()) {
-            try {
-                RealmIdentity identity = domainPrincipalsToRealmIdentities.getIfPresent(principal);
-                // If the identity is not null, the principal is a domain principal. Remove it from the cache and remove any mappings for the associated realm
-                // identity principal.
-                if (identity != null) {
-                    domainPrincipalsToRealmIdentities.invalidate(principal);
-                    Principal realmIdentityPrincipal = identity.getRealmIdentityPrincipal();
-                    realmPrincipalsToDomainPrincipals.get(realmIdentityPrincipal).forEach(domainPrincipalsToRealmIdentities::invalidate);
-                    realmPrincipalsToDomainPrincipals.removeAll(realmIdentityPrincipal);
-                } else {
-                    // Otherwise, the principal may be a realm identity principal. Remove all domain principal mappings for it, and remove any mappings for
-                    // those domain principals from the cache.
-                    if (realmPrincipalsToDomainPrincipals.containsKey(principal)) {
-                        realmPrincipalsToDomainPrincipals.get(principal).forEach(domainPrincipalsToRealmIdentities::invalidate);
-                        realmPrincipalsToDomainPrincipals.removeAll(principal);
-                    }
-                }
-            } finally {
-                lock.writeLock().unlock();
-            }
+        RealmIdentity identity = domainPrincipalsToRealmIdentities.getIfPresent(principal);
+        // If the identity is not null, the principal is a domain principal. Remove it from the cache and remove any mappings for the associated realm identity
+        // principal.
+        if (identity != null) {
+            domainPrincipalsToRealmIdentities.invalidate(principal);
+            removeRealmPrincipal(identity.getRealmIdentityPrincipal());
+        } else {
+            // Otherwise, the principal may be a realm identity principal. Remove all domain principal mappings for it, and remove any mappings for those
+            // domain principals from the cache.
+            removeRealmPrincipal(principal);
         }
+    }
+
+    /**
+     * Invalidate every domain principal mapped to the given realm identity principal, and drop the reverse mapping.
+     *
+     * @param realmPrincipal
+     *            the realm identity principal, possibly null
+     */
+    private void removeRealmPrincipal(Principal realmPrincipal) {
+        if (realmPrincipal == null) {
+            return;
+        }
+        Set<Principal> domainPrincipals = realmPrincipalsToDomainPrincipals.remove(realmPrincipal);
+        if (domainPrincipals != null) {
+            domainPrincipals.forEach(domainPrincipalsToRealmIdentities::invalidate);
+        }
+    }
+
+    /**
+     * Drop the reverse mapping for a single domain principal that is no longer cached.
+     *
+     * @param principal
+     *            the domain principal that was evicted, possibly null
+     * @param realmIdentity
+     *            the realm identity it was mapped to, possibly null
+     */
+    private void unmapDomainPrincipal(Principal principal, RealmIdentity realmIdentity) {
+        if (principal == null || realmIdentity == null) {
+            return;
+        }
+        Principal realmPrincipal = realmIdentity.getRealmIdentityPrincipal();
+        if (realmPrincipal == null) {
+            return;
+        }
+        realmPrincipalsToDomainPrincipals.computeIfPresent(realmPrincipal, (key, domainPrincipals) -> {
+            domainPrincipals.remove(principal);
+            return domainPrincipals.isEmpty() ? null : domainPrincipals;
+        });
     }
 
     @Override
     public void clear() {
         log.trace("Clearing the cache");
-        if (obtainedWriteLock()) {
-            try {
-                // Clear the cache.
-                domainPrincipalsToRealmIdentities.invalidateAll();
-                domainPrincipalsToRealmIdentities.cleanUp();
-                // Clear the domain principals.
-                realmPrincipalsToDomainPrincipals.clear();
-            } finally {
-                lock.writeLock().unlock();
-            }
-        }
+        domainPrincipalsToRealmIdentities.invalidateAll();
+        domainPrincipalsToRealmIdentities.cleanUp();
+        realmPrincipalsToDomainPrincipals.clear();
     }
 
     @Override
     public Set<DatawaveUser> getUsers() {
-        if (obtainedReadLock()) {
-            try {
-                // @formatter:off
-                return domainPrincipalsToRealmIdentities.asMap().keySet().stream()
-                                .map(DatawavePrincipal::getProxiedUsers)
-                                .flatMap(Collection::stream).collect(Collectors.toSet());
-                // @formatter:on
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-        return Set.of();
+        // @formatter:off
+        return domainPrincipalsToRealmIdentities.asMap().keySet().stream()
+                        .map(DatawavePrincipal::getProxiedUsers)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toSet());
+        // @formatter:on
     }
 
     @Override
     public Set<DatawaveUser> getUsersWhereNameContains(String substring) {
-        if (obtainedReadLock()) {
-            try {
-                // @formatter:off
-                return domainPrincipalsToRealmIdentities.asMap().keySet().stream()
-                                .map(DatawavePrincipal::getProxiedUsers)
-                                .flatMap(Collection::stream)
-                                .filter(user -> user.getName().contains(substring))
-                                .collect(Collectors.toSet());
-                // @formatter:on
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-        return Set.of();
+        // @formatter:off
+        return domainPrincipalsToRealmIdentities.asMap().keySet().stream()
+                        .map(DatawavePrincipal::getProxiedUsers)
+                        .flatMap(Collection::stream)
+                        .filter(user -> user.getName().contains(substring))
+                        .collect(Collectors.toSet());
+        // @formatter:on
     }
 
     @Override
     public DatawaveUser getUserWithName(String name) {
-        if (obtainedReadLock()) {
-            try {
-                // @formatter:off
-                return domainPrincipalsToRealmIdentities.asMap().keySet().stream()
-                                .map(DatawavePrincipal::getProxiedUsers)
-                                .flatMap(Collection::stream)
-                                .filter(user -> user.getName().equals(name))
-                                .findFirst()
-                                .orElse(null);
-                // @formatter:on
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-        return null;
+        // @formatter:off
+        return domainPrincipalsToRealmIdentities.asMap().keySet().stream()
+                        .map(DatawavePrincipal::getProxiedUsers)
+                        .flatMap(Collection::stream)
+                        .filter(user -> user.getName().equals(name))
+                        .findFirst()
+                        .orElse(null);
+        // @formatter:on
     }
 
     @Override
@@ -249,49 +231,18 @@ public class DatawaveRealmIdentityCache implements RealmIdentityCache, ElytronCa
             log.trace("Evicting users with name {}", name);
         }
 
-        if (obtainedWriteLock()) {
-            try {
-                int totalEvictions = 0;
-                for (DatawavePrincipal principal : domainPrincipalsToRealmIdentities.asMap().keySet()) {
-                    if (principal.getProxiedUsers().stream().anyMatch(user -> name.equals(user.getName()))) {
-                        totalEvictions++;
-                        remove(principal);
-                    }
-                }
-                if (log.isTraceEnabled()) {
-                    log.trace("Removed {} entries with user {}", totalEvictions, name);
-                }
-            } finally {
-                lock.writeLock().unlock();
+        int totalEvictions = 0;
+        Iterator<DatawavePrincipal> principals = domainPrincipalsToRealmIdentities.asMap().keySet().iterator();
+        while (principals.hasNext()) {
+            DatawavePrincipal principal = principals.next();
+            if (principal.getProxiedUsers().stream().anyMatch(user -> name.equals(user.getName()))) {
+                totalEvictions++;
+                remove(principal);
             }
         }
-    }
 
-    /**
-     * Attempt to obtain a read lock.
-     *
-     * @return true if the lock was obtained or false otherwise
-     */
-    private boolean obtainedReadLock() {
-        try {
-            lock.readLock().lockInterruptibly();
-            return true;
-        } catch (InterruptedException e) {
-            return false;
-        }
-    }
-
-    /**
-     * Attempt to obtain a write lock.
-     *
-     * @return true if the lock was obtained or false otherwise
-     */
-    private boolean obtainedWriteLock() {
-        try {
-            lock.writeLock().lockInterruptibly();
-            return true;
-        } catch (InterruptedException e) {
-            return false;
+        if (log.isTraceEnabled()) {
+            log.trace("Removed {} entries with user {}", totalEvictions, name);
         }
     }
 }

--- a/web-services/security-parent/security-elytron-module/src/main/java/datawave/security/realm/DatawaveEvidenceDecoder.java
+++ b/web-services/security-parent/security-elytron-module/src/main/java/datawave/security/realm/DatawaveEvidenceDecoder.java
@@ -49,12 +49,12 @@ public class DatawaveEvidenceDecoder implements EvidenceDecoder {
     /**
      * A cache of {@link DatawaveUser}.
      */
-    private DatawaveUserCache cache;
+    private volatile DatawaveUserCache cache;
 
     /**
      * Whether initialization is complete.
      */
-    private boolean initializationComplete = false;
+    private volatile boolean initializationComplete = false;
 
     /**
      * Initializes this role decoder with the given configuration options. This method is invoked once by the Wildfly Elytron subsystem when the decoder is
@@ -74,6 +74,17 @@ public class DatawaveEvidenceDecoder implements EvidenceDecoder {
      * Perform any initialization that could not be completed until EJBs are available for use.
      */
     private void completeInitialization() {
+        // Checked without synchronizing so that the steady state stays lock free. Concurrent first requests fall through to the synchronized path, which
+        // rechecks, so exactly one user cache is built and registered with the cache manager.
+        if (!initializationComplete) {
+            initializeOnce();
+        }
+    }
+
+    /**
+     * Perform the one time initialization guarded by this decoder's monitor.
+     */
+    private synchronized void initializeOnce() {
         if (!initializationComplete) {
             // Log the configuration.
             if (log.isDebugEnabled()) {

--- a/web-services/security-parent/security-elytron-module/src/main/java/datawave/security/realm/DatawaveSecurityRealm.java
+++ b/web-services/security-parent/security-elytron-module/src/main/java/datawave/security/realm/DatawaveSecurityRealm.java
@@ -78,7 +78,7 @@ public class DatawaveSecurityRealm implements SecurityRealm {
     /**
      * Indicates whether {@link #completeInitialization()} was called.
      */
-    private boolean initializationComplete = false;
+    private volatile boolean initializationComplete = false;
 
     /**
      * The validator that, if configured, will validate the certificate of any {@link X509CertificateEvidence} instances passed to this realm for verification.
@@ -89,7 +89,7 @@ public class DatawaveSecurityRealm implements SecurityRealm {
      * The realm identity cache. This cache will hold mappings of principals to realm identities to improve performance, and removes the need to wrap this
      * security realm in a Wildfly caching realm.
      */
-    private DatawaveRealmIdentityCache realmIdentityCache;
+    private volatile DatawaveRealmIdentityCache realmIdentityCache;
 
     /**
      * A provider for EJBs not normally injectable within an Elytron context.
@@ -131,6 +131,20 @@ public class DatawaveSecurityRealm implements SecurityRealm {
      *             if an error occurs while completing initialization
      */
     private void completeInitialization() throws RealmUnavailableException {
+        // Checked without synchronizing so that the steady state stays lock free. Concurrent first requests fall through to the synchronized path, which
+        // rechecks, so the realm is initialized exactly once and never publishes a half built cache.
+        if (!initializationComplete) {
+            initializeOnce();
+        }
+    }
+
+    /**
+     * Perform the one time initialization guarded by this realm's monitor.
+     *
+     * @throws RealmUnavailableException
+     *             if an error occurs while completing initialization
+     */
+    private synchronized void initializeOnce() throws RealmUnavailableException {
         if (!initializationComplete) {
             try {
                 logConfig();
@@ -353,8 +367,10 @@ public class DatawaveSecurityRealm implements SecurityRealm {
     private static class CachedRealmIdentity implements RealmIdentity {
 
         private final RealmIdentity identity;
-        private AuthorizationIdentity authorizationIdentity;
-        private Attributes attributes;
+        // A cached identity is shared by every concurrent request that authenticates as the same principal, and verifyEvidence resets both fields. They are
+        // volatile so that a request never observes a partially published value from another request's verification.
+        private volatile AuthorizationIdentity authorizationIdentity;
+        private volatile Attributes attributes;
 
         public CachedRealmIdentity(RealmIdentity identity) {
             this.identity = identity;
@@ -438,11 +454,17 @@ public class DatawaveSecurityRealm implements SecurityRealm {
 
         private final String principalName;
 
-        private Attributes attributes;
+        // The attributes decoded from the principal alone. verifyEvidence derives from these rather than from the last verification's result, so that
+        // per-evidence roles are not re-added to a cached identity on every request.
+        private final Attributes baseAttributes;
+
+        // Mutated by verifyEvidence on an instance shared by every concurrent request for this principal.
+        private volatile Attributes attributes;
 
         public DatawaveRealmIdentity(DatawavePrincipal principal) {
             this.principalName = principal.getName();
-            this.attributes = loadAttributes(principal);
+            this.baseAttributes = loadAttributes(principal);
+            this.attributes = this.baseAttributes;
         }
 
         /**
@@ -566,13 +588,17 @@ public class DatawaveSecurityRealm implements SecurityRealm {
                 if (!datawaveEvidence.getUsername().equalsIgnoreCase(principalName)) {
                     Collection<String> localRoles = localUserRoles.get(datawaveEvidence.getUsername());
                     if (!localRoles.isEmpty()) {
-                        MapAttributes updatedAttributes = new MapAttributes(this.attributes);
+                        MapAttributes updatedAttributes = new MapAttributes(this.baseAttributes);
                         updatedAttributes.addAll(AttributeConstants.ATTRIBUTE_PRIMARY_USER_ROLES, localRoles);
                         this.attributes = updatedAttributes.asReadOnly();
                         if (log.isTraceEnabled()) {
                             log.trace("Added local roles {} associated with evidence username {}", localRoles, datawaveEvidence.getUsername());
                         }
+                    } else {
+                        this.attributes = this.baseAttributes;
                     }
+                } else {
+                    this.attributes = this.baseAttributes;
                 }
             } catch (Exception e) {
                 log.error("Failed to load local user roles for evidence username {}", datawaveEvidence.getUsername(), e);

--- a/web-services/security-parent/security-elytron-module/src/test/java/datawave/security/cache/DatawaveRealmIdentityCacheTest.java
+++ b/web-services/security-parent/security-elytron-module/src/test/java/datawave/security/cache/DatawaveRealmIdentityCacheTest.java
@@ -9,9 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.Principal;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.wildfly.security.auth.SupportLevel;
@@ -363,6 +368,133 @@ class DatawaveRealmIdentityCacheTest {
 
         assertNull(cache.get(principal2));
         assertNull(cache.get(principal4));
+    }
+
+    /**
+     * Verify that {@link DatawaveRealmIdentityCache#put(Principal, RealmIdentity)} stores the entry when the calling thread carries an interrupt. The cache
+     * sits on the authentication path, where request threads can be interrupted by a client disconnect or a timeout.
+     */
+    @Test
+    void testPutOnInterruptedThread() {
+        DatawaveRealmIdentityCache cache = new DatawaveRealmIdentityCache(-1, -1);
+        DatawavePrincipal principal = createPrincipal(createUser("cn=user1"));
+        RealmIdentity identity = new SimpleNameRealmIdentity("realmUser1");
+
+        Thread.currentThread().interrupt();
+        try {
+            cache.put(principal, identity);
+        } finally {
+            assertTrue(Thread.interrupted(), "the interrupt should not have been consumed");
+        }
+
+        assertEquals(identity, cache.get(principal));
+    }
+
+    /**
+     * Verify that {@link DatawaveRealmIdentityCache#get(Principal)} returns a cached entry when the calling thread carries an interrupt. Reporting a miss here
+     * silently forces a full re-authentication for that request.
+     */
+    @Test
+    void testGetOnInterruptedThread() {
+        DatawaveRealmIdentityCache cache = new DatawaveRealmIdentityCache(-1, -1);
+        DatawavePrincipal principal = createPrincipal(createUser("cn=user1"));
+        RealmIdentity identity = new SimpleNameRealmIdentity("realmUser1");
+        cache.put(principal, identity);
+
+        Thread.currentThread().interrupt();
+        try {
+            assertEquals(identity, cache.get(principal));
+            assertEquals(identity, cache.get(new NamePrincipal("realmUser1")));
+        } finally {
+            assertTrue(Thread.interrupted(), "the interrupt should not have been consumed");
+        }
+    }
+
+    /**
+     * Verify that concurrent readers, writers and removers leave the cache consistent and never fail. Reads must also not stall behind the writers.
+     */
+    @Test
+    void testConcurrentAccess() throws Exception {
+        DatawaveRealmIdentityCache cache = new DatawaveRealmIdentityCache(-1, -1);
+
+        int threadCount = 16;
+        int iterations = 2000;
+        List<DatawavePrincipal> principals = new ArrayList<>();
+        List<RealmIdentity> identities = new ArrayList<>();
+        for (int i = 0; i < 32; i++) {
+            principals.add(createPrincipal(createUser("cn=user" + i)));
+            identities.add(new SimpleNameRealmIdentity("realmUser" + i));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (int t = 0; t < threadCount; t++) {
+                final int offset = t;
+                futures.add(executor.submit(() -> {
+                    for (int i = 0; i < iterations; i++) {
+                        int index = (i + offset) % principals.size();
+                        DatawavePrincipal principal = principals.get(index);
+                        switch ((i + offset) % 4) {
+                            case 0:
+                                cache.put(principal, identities.get(index));
+                                break;
+                            case 1:
+                                cache.get(principal);
+                                break;
+                            case 2:
+                                cache.get(new NamePrincipal("realmUser" + index));
+                                break;
+                            default:
+                                cache.remove(principal);
+                                break;
+                        }
+                    }
+                }));
+            }
+            // Any data race in the cache surfaces here as an exception from the worker.
+            for (Future<?> future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        // The cache must still be usable and internally consistent once the storm subsides.
+        cache.clear();
+        DatawavePrincipal principal = createPrincipal(createUser("cn=after"));
+        RealmIdentity identity = new SimpleNameRealmIdentity("realmAfter");
+        cache.put(principal, identity);
+        assertEquals(identity, cache.get(principal));
+        assertEquals(identity, cache.get(new NamePrincipal("realmAfter")));
+    }
+
+    /**
+     * Verify that evicting one domain principal leaves the reverse mapping intact for a sibling domain principal that resolves to the same realm identity
+     * principal and still holds a live entry.
+     */
+    @Test
+    void testEvictionRetainsSiblingMappings() {
+        // A size of one guarantees the first entry is evicted once the second is written.
+        DatawaveRealmIdentityCache cache = new DatawaveRealmIdentityCache(1, -1);
+
+        DatawavePrincipal principal1 = createPrincipal(createUser("cn=user1"));
+        DatawavePrincipal principal2 = createPrincipal(createUser("cn=user2"));
+        // Both principals resolve to the same realm identity principal.
+        cache.put(principal1, new SimpleNameRealmIdentity("sharedRealmUser"));
+        RealmIdentity identity2 = new SimpleNameRealmIdentity("sharedRealmUser");
+        cache.put(principal2, identity2);
+
+        // Caffeine evicts on a maintenance pass, so poll until the first entry is gone.
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (cache.get(principal1) != null && System.currentTimeMillis() < deadline) {
+            Thread.onSpinWait();
+        }
+        assertNull(cache.get(principal1), "the first entry should have been evicted on size");
+
+        // The surviving entry must still be reachable by its realm identity principal.
+        assertEquals(identity2, cache.get(principal2));
+        assertEquals(identity2, cache.get(new NamePrincipal("sharedRealmUser")));
     }
 
     private DatawaveUser createUser(String subjectDn) {


### PR DESCRIPTION
Every request took a fair ReadWriteLock in DatawaveRealmIdentityCache, which starves readers whenever a write is in flight, and rehashed a DatawavePrincipal key over every proxied user's full auth set while holding it. The realm and evidence decoder caches also shipped unbounded and non-expiring.