### PR TITLE
Normalize each value once on the normalized-but-not-indexed branch

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -761,8 +761,7 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         try {
             String normalized = datawaveType.normalize(copy.getIndexedFieldValue());
             copy.setEventFieldValue(normalized);
-            // Separate instance so the two fields never alias.
-            copy.setIndexedFieldValue(new String(normalized));
+            copy.setIndexedFieldValue(normalized);
         } catch (Exception ex) {
             copy.setError(ex);
         }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -759,8 +759,10 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         // copy it
         NormalizedContentInterface copy = new NormalizedFieldAndValue(normalizedContent);
         try {
-            copy.setEventFieldValue(datawaveType.normalize(copy.getIndexedFieldValue()));
-            copy.setIndexedFieldValue(datawaveType.normalize(copy.getIndexedFieldValue()));
+            String normalized = datawaveType.normalize(copy.getIndexedFieldValue());
+            copy.setEventFieldValue(normalized);
+            // Separate instance so the two fields never alias.
+            copy.setIndexedFieldValue(new String(normalized));
         } catch (Exception ex) {
             copy.setError(ex);
         }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestHotPathBenchmark.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/benchmark/IngestHotPathBenchmark.java
@@ -117,8 +117,7 @@ public class IngestHotPathBenchmark {
     // ---------------------------------------------------------------- instrumentation
 
     /**
-     * A cheap Type that counts {@code normalize} invocations. Counting rather than timing is what makes the "each normalizer runs twice" claim falsifiable
-     * independent of machine speed.
+     * A cheap Type that counts {@code normalize} invocations, so the once-per-value check does not depend on machine speed.
      */
     public static class CountingType extends BaseType<String> {
         private static final long serialVersionUID = 1L;
@@ -135,8 +134,8 @@ public class IngestHotPathBenchmark {
     }
 
     /**
-     * The same counter over an expensive normalizer. {@code DateNormalizer} walks its format list until one parses, so this shows what a redundant second
-     * normalize actually costs rather than only that it happens.
+     * The same counter over an expensive normalizer. {@code DateNormalizer} walks its format list until one parses, so an extra invocation shows up in the
+     * timings, not only the counts.
      */
     public static class CountingDateType extends DateType {
         private static final long serialVersionUID = 1L;
@@ -573,9 +572,8 @@ public class IngestHotPathBenchmark {
     }
 
     /**
-     * The audit predicted BaseIngestHelper normalizes each value twice. That is branch dependent: {@code normalize(NormalizedContentInterface, Type)} on the
-     * indexed path normalizes once, while {@code normalizeFieldValue(NormalizedContentInterface, Type)} on the normalized-but-not-indexed path normalizes the
-     * same input twice. Counted over a whole pass so the ratio holds across event sizes.
+     * Both BaseIngestHelper branches normalize each value exactly once, the indexed path through {@code normalize} and the normalized-only path through
+     * {@code normalizeFieldValue}. Counted over a whole pass so the ratio holds across event sizes.
      */
     public void normalizerInvocationsPerField() throws Exception {
         String cheap = CountingType.class.getName();
@@ -596,9 +594,9 @@ public class IngestHotPathBenchmark {
         System.out.printf("  NORMALIZED-ONLY Date:   %d (%.2f per field)%n", onlyDate, onlyDate / (double) totalFields);
 
         checkEquals(totalFields, indexedCheap, "indexed path should normalize each value once");
-        checkEquals(2 * totalFields, onlyCheap, "normalized-but-not-indexed path should normalize each value twice");
+        checkEquals(totalFields, onlyCheap, "normalized-but-not-indexed path should normalize each value once");
         checkEquals(totalFields, indexedDate, "expensive type, indexed path");
-        checkEquals(2 * totalFields, onlyDate, "expensive type, normalized-only path");
+        checkEquals(totalFields, onlyDate, "expensive type, normalized-only path");
     }
 
     /** Normalizes every event in the pool once and returns the total normalizer invocations. */
@@ -621,8 +619,8 @@ public class IngestHotPathBenchmark {
 
     /**
      * Times the normalization half of the hot path, {@code getEventFields} into {@code BaseIngestHelper.normalizeMap}. The scaling sweep deliberately hoists
-     * this out of the measured loop so it times key generation alone, which means the redundant second normalize on the normalized-but-not-indexed branch is
-     * invisible there. This measures it directly, cheap type against expensive type, indexed branch against normalized-only branch.
+     * this out of the measured loop so it times key generation alone, which means normalization cost is invisible there. This measures it directly, cheap type
+     * against expensive type, indexed branch against normalized-only branch.
      */
     public void benchmarkNormalizationPhase() throws Exception {
         String cheap = CountingType.class.getName();

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/BaseIngestHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/BaseIngestHelperTest.java
@@ -2,7 +2,6 @@ package datawave.ingest.data.config.ingest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -225,30 +224,17 @@ class BaseIngestHelperTest {
         }
 
         /**
-         * Verify that a value is normalized exactly once.
+         * Verify that a value is normalized exactly once and both fields carry the result.
          */
         @Test
         void givenAValueThenNormalizesExactlyOnce() {
             AtomicInteger calls = new AtomicInteger();
             TestBaseIngestHelper helper = new TestBaseIngestHelper();
 
-            helper.normalizeFieldValue(new NormalizedFieldAndValue("FIELD", "MixedCase Value"), new CountingType(calls));
+            NormalizedContentInterface result = helper.normalizeFieldValue(new NormalizedFieldAndValue("FIELD", "MixedCase Value"), new CountingType(calls));
 
             assertEquals(1, calls.get(), "normalize should be invoked once per value");
-        }
-
-        /**
-         * Verify that the event and indexed values are equal but not the same instance.
-         */
-        @Test
-        void givenAValueThenEventAndIndexedValuesAreDistinctInstances() {
-            TestBaseIngestHelper helper = new TestBaseIngestHelper();
-
-            NormalizedContentInterface result = helper.normalizeFieldValue(new NormalizedFieldAndValue("FIELD", "MixedCase Value"),
-                            new CountingType(new AtomicInteger()));
-
             assertEquals(result.getEventFieldValue(), result.getIndexedFieldValue(), "both fields should carry the same normalized text");
-            assertNotSame(result.getEventFieldValue(), result.getIndexedFieldValue(), "event and indexed values should not be the same String instance");
         }
 
         /**

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/BaseIngestHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/BaseIngestHelperTest.java
@@ -1,8 +1,11 @@
 package datawave.ingest.data.config.ingest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import org.apache.hadoop.conf.Configuration;
@@ -11,8 +14,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import datawave.TestBaseIngestHelper;
+import datawave.data.normalizer.Normalizer;
+import datawave.data.type.BaseType;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.DataTypeHelper;
+import datawave.ingest.data.config.NormalizedContentInterface;
+import datawave.ingest.data.config.NormalizedFieldAndValue;
 import datawave.policy.IngestPolicyEnforcer;
 
 class BaseIngestHelperTest {
@@ -190,5 +197,82 @@ class BaseIngestHelperTest {
         abstract String getDisallowListProperty();
 
         abstract Function<String,Boolean> getFunctionUnderTest();
+    }
+
+    /**
+     * Executes tests for {@link BaseIngestHelper#normalizeFieldValue(NormalizedContentInterface, datawave.data.type.Type)}.
+     */
+    @Nested
+    class NormalizeFieldValueTests {
+
+        /** Counts normalize invocations. */
+        private class CountingType extends BaseType<String> {
+
+            private static final long serialVersionUID = 1L;
+
+            private final AtomicInteger calls;
+
+            CountingType(AtomicInteger calls) {
+                super(Normalizer.LC_NO_DIACRITICS_NORMALIZER);
+                this.calls = calls;
+            }
+
+            @Override
+            public String normalize(String in) {
+                calls.incrementAndGet();
+                return super.normalize(in);
+            }
+        }
+
+        /**
+         * Verify that a value is normalized exactly once.
+         */
+        @Test
+        void givenAValueThenNormalizesExactlyOnce() {
+            AtomicInteger calls = new AtomicInteger();
+            TestBaseIngestHelper helper = new TestBaseIngestHelper();
+
+            helper.normalizeFieldValue(new NormalizedFieldAndValue("FIELD", "MixedCase Value"), new CountingType(calls));
+
+            assertEquals(1, calls.get(), "normalize should be invoked once per value");
+        }
+
+        /**
+         * Verify that the event and indexed values are equal but not the same instance.
+         */
+        @Test
+        void givenAValueThenEventAndIndexedValuesAreDistinctInstances() {
+            TestBaseIngestHelper helper = new TestBaseIngestHelper();
+
+            NormalizedContentInterface result = helper.normalizeFieldValue(new NormalizedFieldAndValue("FIELD", "MixedCase Value"),
+                            new CountingType(new AtomicInteger()));
+
+            assertEquals(result.getEventFieldValue(), result.getIndexedFieldValue(), "both fields should carry the same normalized text");
+            assertNotSame(result.getEventFieldValue(), result.getIndexedFieldValue(), "event and indexed values should not be the same String instance");
+        }
+
+        /**
+         * Verify that an unparseable value records the error rather than propagating it.
+         */
+        @Test
+        void givenAnUnparseableValueThenRecordsTheError() {
+            AtomicInteger calls = new AtomicInteger();
+            TestBaseIngestHelper helper = new TestBaseIngestHelper();
+
+            NormalizedContentInterface result = helper.normalizeFieldValue(new NormalizedFieldAndValue("FIELD", "not a date"),
+                            new datawave.data.type.DateType() {
+
+                                private static final long serialVersionUID = 1L;
+
+                                @Override
+                                public String normalize(String in) {
+                                    calls.incrementAndGet();
+                                    return super.normalize(in);
+                                }
+                            });
+
+            assertEquals(1, calls.get(), "a failing normalize should not be retried");
+            assertTrue(result.getError() != null, "the failure should be recorded on the result");
+        }
     }
 }


### PR DESCRIPTION
normalizeFieldValue called normalize twice on the same input, and the normalizer is a pure function, so the second call only recomputed the first result. Local benchmark runs measured the normalization phase about 32% faster for a cheap type and 41% for DateType.