### PR TITLE
Use libthrift 0.23.0 to match Accumulo 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.spring>5.3.39</version.spring>
         <version.springframework>${version.spring}</version.springframework>
         <version.stream>2.9.6</version.stream>
-        <version.thrift>0.17.0</version.thrift>
+        <version.thrift>0.23.0</version.thrift>
         <version.weld>3.1.9.Final</version.weld>
         <version.weld-se>3.1.9.Final</version.weld-se>
         <!-- Different version of weld for tests since the Arquillian embedded EE container needs an older version. -->


### PR DESCRIPTION

DataWave pins libthrift 0.17.0 while Accumulo 4 builds against 0.23.0, so the older jar wins on the classpath. Bumped the pin to match.
