### PR TITLE
Derive the security EJB JNDI name from build.env

### DIFF
--- a/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
+++ b/web-services/deploy/application/src/main/wildfly/add-datawave-configuration.cli
@@ -94,7 +94,7 @@ module add --name=com.mysql.driver --dependencies=javax.api,javax.transaction.ap
 /system-property=dw.ssl.context.info.trustStorePassword:add(value="${TRUSTSTORE_PASSWORD}")
 
 # Required to allow the elytron module to lookup a SecurityEJBProvider instance from JNDI.
-/system-property=dw.security.ejb.provider.jndi:add(value=java:global/datawave-ws-deploy-application-${project.version}-compose/gov.nsa.datawave.webservices-datawave-ws-security-${project.version}/SecurityEJBProviderImpl)
+/system-property=dw.security.ejb.provider.jndi:add(value=java:global/datawave-ws-deploy-application-${project.version}-${build.env}/gov.nsa.datawave.webservices-datawave-ws-security-${project.version}/SecurityEJBProviderImpl)
 
 # Proxied entities to be pruned from credentials.
 /system-property=dw.trusted.proxied.entities:add(value="${trusted.proxied.entities}")


### PR DESCRIPTION

The Wildfly CLI script hardcodes the "compose" application name in the security EJB's JNDI lookup, so a quickstart deployment fails with a NameNotFoundException naming the compose application. The surrounding pom already parameterises this with ${build.env}, so I used the same property here.
