### PR TITLE
Wait for a listening tserver client port before starting the web tier

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
@@ -140,7 +140,9 @@ function datawaveWebIsDeployed() {
 }
 
 function datawaveWebReadyToStart() {
-    ss -ln | grep 8020 && ss -ln | grep 2181 && ss -ln | grep 9997 && return 0
+    # Accumulo 4 tservers no longer bind the fixed 9997 client port (the default
+    # is now the 9800-9899 range), so check for a live tserver process instead
+    ss -ln | grep 8020 && ss -ln | grep 2181 && pgrep -f 'o.start.Main proc tserver' > /dev/null && return 0
     return 1
 }
 

--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
@@ -139,14 +139,26 @@ function datawaveWebIsDeployed() {
    return 0
 }
 
+# Client ports the running tservers report holding, space separated, empty when
+# none are running. 'accumulo-service tserver list' prints only its header and
+# still exits 0 in that case, so the port lines are what we read, not the exit
+# status. The port field can name more than one port, comma separated.
+function tserverClientPorts() {
+    "${ACCUMULO_HOME}/bin/accumulo-service" tserver list 2>/dev/null | awk 'NR > 1 { print $NF }' | tr ',' ' '
+}
+
 # Accumulo 4 tservers no longer bind the fixed 9997 client port (tserver.port.client
 # now defaults to the 9800-9899 range). Ask accumulo-service which ports the running
-# tservers hold, and confirm one of them is actually being listened on. Note that
-# 'list' prints only its header and still exits 0 when nothing is running, so the
-# port lines are what we test, not the exit status.
+# tservers hold, and confirm one of them is actually being listened on.
+#
+# One listening tserver is deliberate. This gate only decides whether Accumulo can
+# serve the web tier, which the fixed 9997 check it replaces also answered with a
+# single port, and the quickstart runs one tserver. Requiring every tserver to be
+# listening would make startup stricter than it was before a4 and would stall on a
+# straggler for no benefit.
 function tserverIsListening() {
     local port
-    for port in $( "${ACCUMULO_HOME}/bin/accumulo-service" tserver list 2>/dev/null | awk 'NR > 1 { print $NF }' | tr ',' ' ' ) ; do
+    for port in $(tserverClientPorts) ; do
         ss -ln | grep -qE "[:.]${port}([[:space:]]|\$)" && return 0
     done
     return 1
@@ -184,7 +196,20 @@ function datawaveWebStart() {
 
        sleep $pollInterval
     done
-    datawaveWebReadyToStart || return 1
+    if ! datawaveWebReadyToStart ; then
+       # Say why once, rather than leaving the poll counter as the only clue.
+       if ! tserverIsListening ; then
+          # One row per tserver, so flatten the newlines for a readable message.
+          local tserverPorts="$(tserverClientPorts)"
+          tserverPorts="${tserverPorts//$'\n'/ }"
+          if [[ -n "${tserverPorts// /}" ]] ; then
+             error "No tserver is listening on any of its client ports: ${tserverPorts}"
+          else
+             error "No tserver processes are running"
+          fi
+       fi
+       return 1
+    fi
 
     if datawaveWebIsRunning ; then
        info "Wildfly is already running"

--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-web.sh
@@ -139,10 +139,21 @@ function datawaveWebIsDeployed() {
    return 0
 }
 
+# Accumulo 4 tservers no longer bind the fixed 9997 client port (tserver.port.client
+# now defaults to the 9800-9899 range). Ask accumulo-service which ports the running
+# tservers hold, and confirm one of them is actually being listened on. Note that
+# 'list' prints only its header and still exits 0 when nothing is running, so the
+# port lines are what we test, not the exit status.
+function tserverIsListening() {
+    local port
+    for port in $( "${ACCUMULO_HOME}/bin/accumulo-service" tserver list 2>/dev/null | awk 'NR > 1 { print $NF }' | tr ',' ' ' ) ; do
+        ss -ln | grep -qE "[:.]${port}([[:space:]]|\$)" && return 0
+    done
+    return 1
+}
+
 function datawaveWebReadyToStart() {
-    # Accumulo 4 tservers no longer bind the fixed 9997 client port (the default
-    # is now the 9800-9899 range), so check for a live tserver process instead
-    ss -ln | grep 8020 && ss -ln | grep 2181 && pgrep -f 'o.start.Main proc tserver' > /dev/null && return 0
+    ss -ln | grep 8020 && ss -ln | grep 2181 && tserverIsListening && return 0
     return 1
 }
 


### PR DESCRIPTION

datawaveWebReadyToStart polled for a listener on the fixed port 9997, but Accumulo 4 moved tserver.port.client to the 9800-9899 range, so the check never passed and Wildfly never started. Per review, the check now asks accumulo-service which ports the running tservers hold and confirms one of them is being listened on via ss.

Work for #3766