### PR TITLE
Give the count query a non-zero default page wait time

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/CountingShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/CountingShardQueryLogic.java
@@ -32,8 +32,9 @@ import datawave.query.transformer.ShardQueryCountTableTransformer;
 public class CountingShardQueryLogic extends ShardQueryLogic {
     private static final Logger log = Logger.getLogger(CountingShardQueryLogic.class);
 
-    // the time to wait before returning an intermediate result
-    private long pageWaitTimeMillis = 0L;
+    // the time to wait before returning an intermediate result. Zero would return an intermediate result
+    // on every call to next(), before the aggregating thread has had any chance to produce the count.
+    private long pageWaitTimeMillis = CountAggregatingIterator.DEFAULT_PAGE_WAIT_TIME_MILLIS;
 
     public CountingShardQueryLogic() {
         super();

--- a/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountAggregatingIterator.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountAggregatingIterator.java
@@ -36,7 +36,7 @@ import datawave.webservice.query.result.event.DefaultEvent;
 public class CountAggregatingIterator extends TransformIterator {
     private static final Logger log = Logger.getLogger(CountAggregatingIterator.class);
 
-    private static final long DEFAULT_PAGE_WAIT_TIME_MILLIS = 3_600_000L;
+    public static final long DEFAULT_PAGE_WAIT_TIME_MILLIS = 3_600_000L;
 
     private boolean done = false;
     private final AtomicBoolean executing = new AtomicBoolean(true);

--- a/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountResultPostprocessor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/shard/CountResultPostprocessor.java
@@ -92,6 +92,10 @@ public class CountResultPostprocessor implements ResultPostprocessor {
 
     private FieldBase<?> getCountField(List<FieldBase<?>> fields) {
         FieldBase<?> countField = null;
+        if (fields == null) {
+            // an intermediate result carries no fields at all
+            return null;
+        }
         for (FieldBase<?> field : fields) {
             if (field.getName().equals(COUNT_CELL)) {
                 countField = field;

--- a/warehouse/query-core/src/test/java/datawave/query/tables/shard/CountResultPostprocessorTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/shard/CountResultPostprocessorTest.java
@@ -1,0 +1,80 @@
+package datawave.query.tables.shard;
+
+import static datawave.query.transformer.ShardQueryCountTableTransformer.COUNT_CELL;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.marking.MarkingFunctions;
+import datawave.query.tables.CountingShardQueryLogic;
+import datawave.webservice.query.result.event.DefaultEvent;
+import datawave.webservice.query.result.event.DefaultField;
+
+class CountResultPostprocessorTest {
+
+    private static final String VISIBILITY = "PUBLIC";
+
+    /**
+     * {@link CountAggregatingIterator} emits an event carrying no fields at all while the count is still being aggregated.
+     */
+    @Test
+    void testIntermediateResultIsToleratedDuringAggregation() {
+        List<Object> results = new ArrayList<>();
+        results.add(intermediateEvent());
+        results.add(countEvent(5L));
+
+        assertDoesNotThrow(() -> postprocessor().apply(results));
+    }
+
+    @Test
+    void testCountsAreAggregated() {
+        List<Object> results = new ArrayList<>();
+        results.add(countEvent(5L));
+        results.add(countEvent(7L));
+
+        postprocessor().apply(results);
+
+        assertEquals(1, results.size());
+        assertEquals(12L, countOf(results.get(0)));
+    }
+
+    /**
+     * A zero wait returns an intermediate result on every call to next(), before any count can be produced.
+     */
+    @Test
+    void testPageWaitTimeDefaultsToNonZero() {
+        assertNotEquals(0L, new CountingShardQueryLogic().getPageWaitTimeMillis());
+    }
+
+    private CountResultPostprocessor postprocessor() {
+        return new CountResultPostprocessor(new MarkingFunctions.Default());
+    }
+
+    private long countOf(Object result) {
+        return ((Number) ((DefaultEvent) result).getFields().get(0).getValueOfTypedValue()).longValue();
+    }
+
+    private DefaultEvent intermediateEvent() {
+        DefaultEvent event = new DefaultEvent();
+        event.setIntermediateResult(true);
+        return event;
+    }
+
+    private DefaultEvent countEvent(long count) {
+        DefaultField field = new DefaultField();
+        field.setName(COUNT_CELL);
+        field.setColumnVisibility(VISIBILITY);
+        field.setTimestamp(0L);
+        field.setValue(count);
+
+        DefaultEvent event = new DefaultEvent();
+        event.setFields(Collections.singletonList(field));
+        return event;
+    }
+}


### PR DESCRIPTION
A zero wait made CountAggregatingIterator return a fields-less intermediate event on every next() call, which CountResultPostprocessor then dereferenced, failing every multi-result count query with a 500. Only the test config set this property, so unit tests passed while deployments did not.