### PR TITLE
Size the RangeStreamScanner result queue from the query config

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
+++ b/warehouse/query-core/src/main/java/datawave/query/index/lookup/RangeStream.java
@@ -617,6 +617,7 @@ public class RangeStream extends BaseVisitor implements QueryPlanStream {
                         .setAuthorizations(config.getAuthorizations())
                         .setQuery(config.getQuery())
                         .setConfig(config)
+                        .setResultQueueSize(config.getMaxIndexBatchSize())
                         .build();
                 sessionManager.addScanner(scannerSession);
                  // @formatter:on
@@ -635,6 +636,7 @@ public class RangeStream extends BaseVisitor implements QueryPlanStream {
                         .setAuthorizations(config.getAuthorizations())
                         .setQuery(config.getQuery())
                         .setConfig(config)
+                        .setResultQueueSize(config.getMaxIndexBatchSize())
                         .build();
                 sessionManager.addScanner(scannerSession);
                 // @formatter:on

--- a/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerBuilderTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/RangeStreamScannerBuilderTest.java
@@ -121,6 +121,21 @@ public class RangeStreamScannerBuilderTest implements BaseScannerSessionTest<Ran
     }
 
     @Test
+    public void testResultQueueSizeSizesTheResultQueue() {
+        //  @formatter:off
+        RangeStreamScanner scanner = RangeStreamScannerBuilder.create(client)
+                .setTableName(tableName)
+                .setAuthorizations(authorizations)
+                .setQuery(query)
+                .setResultQueueSize(37)
+                .setConfig(getConfig())
+                .build();
+        //  @formatter:on
+
+        assertEquals(37, scanner.resultQueue.remainingCapacity());
+    }
+
+    @Test
     @Override
     public void testQueryNotSet() {
         //  @formatter:off


### PR DESCRIPTION
RangeStream stopped passing a size when it moved off the ScannerFactory, so the result queue silently fell back to the builder default and maxIndexBatchSize no longer reached the scanner.