### PR TITLE
Point accumulo-env at the quickstart's Hadoop and ZooKeeper installs

### DIFF
--- a/contrib/datawave-quickstart/bin/services/accumulo/install.sh
+++ b/contrib/datawave-quickstart/bin/services/accumulo/install.sh
@@ -93,10 +93,15 @@ fi
 
 assertCreateDir "${DW_ACCUMULO_JVM_HEAPDUMP_DIR}" || exit 1
 
-# Update tserver and other options in accumulo-env.sh
-sed -i'' -e "s~\(ACCUMULO_TSERVER_OPTS=\).*$~\1\"${DW_ACCUMULO_TSERVER_OPTS}\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
-sed -i'' -e "s~\(export JAVA_HOME=\).*$~\1\"${JAVA_HOME}\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
-sed -i'' -e "s~\(export ACCUMULO_MONITOR_OPTS=\).*$~\1\"\${POLICY} -Xmx2g -Xms512m\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+# The Accumulo 4 accumulo-env.sh template no longer has the ACCUMULO_*_OPTS and
+# JAVA_HOME lines the old seds edited, so those substitutions silently did nothing
+# and the servers came up on the template's placeholder paths. Point it at our
+# Hadoop and ZooKeeper installs, and append JAVA_HOME, since accumulo-cluster
+# starts the servers over ssh where exports from this shell do not reach them.
+sed -i'' -e "s~/path/to/hadoop~${HADOOP_HOME}~" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+sed -i'' -e "s~/path/to/zookeeper~${ZOOKEEPER_HOME}~" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+echo "export JAVA_HOME=\"${JAVA_HOME}\"" >> "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+echo "export PATH=\"\${JAVA_HOME}/bin:\${PATH}\"" >> "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 echo 'JAVA_OPTS=('-Dcom.google.protobuf.use_unsafe_pre22_gencode' "${JAVA_OPTS[@]}")' >> "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 cat "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 # Update Accumulo bind host if it's not set to localhost


### PR DESCRIPTION

Work for #3766

install.sh substitutes tserver options and JAVA_HOME into accumulo-env.sh, but the Accumulo 4 template no longer has the lines those seds matched, so they silently did nothing and the servers came up on the template's placeholder paths. I substituted the real Hadoop and ZooKeeper paths instead, and appended JAVA_HOME and PATH, since accumulo-cluster starts the servers over ssh where exports from the calling shell never reach them.

Split out per your review — the scan server cache sizing that used to be in here is #3877 now, so this one is just the path substitution and touches only install.sh.

The sed-against-a-vendor-template approach is the one the quickstart already used, but if Accumulo 4 has a supported config hook I would rather use that.