### PR TITLE
Create DataWave tables with HOSTED tablet availability

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap.sh
@@ -71,7 +71,9 @@ function createAccumuloShellInitScript() {
    DW_ACCUMULO_SHELL_INIT_SCRIPT="
    createnamespace datawave
    createtable datawave.queryMetrics_m
+   setavailability -t datawave.queryMetrics_m -a HOSTED
    createtable datawave.queryMetrics_s
+   setavailability -t datawave.queryMetrics_s -a HOSTED
    setauths -s ${DW_DATAWAVE_ACCUMULO_AUTHS}"
 
    if [ "${DW_ACCUMULO_VFS_DATAWAVE_ENABLED}" != false ] ; then

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/TableConfigurationUtil.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/TableConfigurationUtil.java
@@ -31,6 +31,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.NamespaceOperations;
 import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.admin.TabletAvailability;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.constraints.DefaultKeySizeConstraint;
 import org.apache.accumulo.core.iterators.Combiner;
@@ -270,12 +271,14 @@ public class TableConfigurationUtil {
             try {
                 if (!tops.exists(table)) {
                     boolean disableVersioning = conf != null && conf.getBoolean(table + DISABLE_VERSIONING_ITERATOR, false);
+                    // Accumulo 4 defaults new tablets to ONDEMAND, but TableOperations.locate() throws
+                    // for anything other than HOSTED, which GenerateShardSplits depends on.
                     if (disableVersioning) {
-                        tops.create(table, new NewTableConfiguration().withoutDefaults());
+                        tops.create(table, new NewTableConfiguration().withoutDefaults().withInitialTabletAvailability(TabletAvailability.HOSTED));
                         // withoutDefaults will also skip the default table constraint, so set that
                         tops.setProperty(table, Property.TABLE_CONSTRAINT_PREFIX + "1", DefaultKeySizeConstraint.class.getName());
                     } else {
-                        tops.create(table);
+                        tops.create(table, new NewTableConfiguration().withInitialTabletAvailability(TabletAvailability.HOSTED));
                     }
                 }
             } catch (TableExistsException te) {


### PR DESCRIPTION

Accumulo 4 defaults new tablets to ONDEMAND. TableOperations.locate() throws for anything that is not HOSTED, and GenerateShardSplits calls it, so ingest fails. This creates DataWave's tables HOSTED, both in TableConfigurationUtil and in the quickstart's shell init script.

This is the blunt version and I am not sure it is the one you want: forcing HOSTED opts DataWave out of Accumulo 4's elasticity model wholesale. The narrower question is whether GenerateShardSplits should be using locate() at all. I would rather have your call before this goes anywhere.
