### PR TITLE
speed up sorted set tests

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedmap/SortedMapTempFileHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedmap/SortedMapTempFileHandler.java
@@ -15,6 +15,10 @@ import datawave.query.util.sortedset.FileSortedSet;
  * A sorted set file handler factory that uses temporary local based files.
  */
 public class SortedMapTempFileHandler implements FileSortedMap.SortedMapFileHandler {
+    // Configuration re-parses the Hadoop XML resources every time one is constructed, which is far too expensive to repeat for each
+    // persisted file. Nothing here mutates it, so a single shared instance serves every handler.
+    private static final Configuration CONF = new Configuration();
+
     private final FileSystem fs;
     private final File file;
     private final Path path;
@@ -23,8 +27,7 @@ public class SortedMapTempFileHandler implements FileSortedMap.SortedMapFileHand
         this.file = File.createTempFile("SortedSet", ".bin");
         this.file.deleteOnExit();
         this.path = new Path(file.toURI());
-        Configuration conf = new Configuration();
-        this.fs = path.getFileSystem(conf);
+        this.fs = path.getFileSystem(CONF);
     }
 
     public File getFile() {

--- a/warehouse/query-core/src/main/java/datawave/query/util/sortedset/SortedSetTempFileHandler.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/sortedset/SortedSetTempFileHandler.java
@@ -16,6 +16,10 @@ import org.apache.hadoop.fs.Path;
  *
  */
 public class SortedSetTempFileHandler implements FileSortedSet.SortedSetFileHandler {
+    // Configuration re-parses the Hadoop XML resources every time one is constructed, which is far too expensive to repeat for each
+    // persisted file. Nothing here mutates it, so a single shared instance serves every handler.
+    private static final Configuration CONF = new Configuration();
+
     private final FileSystem fs;
     private final File file;
     private final Path path;
@@ -24,8 +28,7 @@ public class SortedSetTempFileHandler implements FileSortedSet.SortedSetFileHand
         this.file = File.createTempFile("SortedSet", ".bin");
         this.file.deleteOnExit();
         this.path = new Path(file.toURI());
-        Configuration conf = new Configuration();
-        this.fs = path.getFileSystem(conf);
+        this.fs = path.getFileSystem(CONF);
     }
 
     public File getFile() {

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedRewritableSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedRewritableSortedMapTest.java
@@ -81,7 +81,7 @@ public abstract class BufferedFileBackedRewritableSortedMapTest<K,V> extends Buf
 
         // adding in the data set multiple times to create underlying files with duplicate values making the
         // MergeSortIterator's job a little tougher...
-        for (int d = 0; d < 11; d++) {
+        for (int d = 0; d < 4; d++) {
             addDataRandomly(map, data);
             addDataRandomly(map, data2);
         }

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedSortedMapTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedmap/BufferedFileBackedSortedMapTest.java
@@ -113,7 +113,7 @@ public abstract class BufferedFileBackedSortedMapTest<K,V> {
 
         // adding in the data map multiple times to create underlying files with duplicate values making the
         // MergeSortIterator's job a little tougher...
-        for (int d = 0; d < 11; d++) {
+        for (int d = 0; d < 4; d++) {
             addDataRandomly(map, data);
         }
         while (map.getMaps().size() <= 7) {

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedset/BufferedFileBackedKeySortedSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedset/BufferedFileBackedKeySortedSetTest.java
@@ -64,7 +64,7 @@ public class BufferedFileBackedKeySortedSetTest {
 
         // adding in the data set multiple times to create underlying files with duplicate values making the
         // MergeSortIterator's job a little tougher...
-        for (int d = 0; d < 11; d++) {
+        for (int d = 0; d < 4; d++) {
             Collections.addAll(set, data);
         }
     }
@@ -252,6 +252,12 @@ public class BufferedFileBackedKeySortedSetTest {
 
     @Test
     public void testCompaction() throws IOException {
+        // only this test needs enough underlying sets to reach the compaction threshold, so top up here rather than
+        // making every other test in the class pay for the extra rounds in setUp. The round cap keeps a change in
+        // persist/compact behavior from spinning here forever -- the assertion below reports it instead.
+        for (int d = 0; set.getSets().size() <= 7 && d < 20; d++) {
+            Collections.addAll(set, data);
+        }
         assertEquals(8, set.getSets().size());
         set.persist();
         assertEquals(3, set.getSets().size());

--- a/warehouse/query-core/src/test/java/datawave/query/util/sortedset/BufferedFileBackedSortedSetTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/sortedset/BufferedFileBackedSortedSetTest.java
@@ -65,7 +65,7 @@ public class BufferedFileBackedSortedSetTest {
 
         // adding in the data set multiple times to create underlying files with duplicate values making the
         // MergeSortIterator's job a little tougher...
-        for (int d = 0; d < 11; d++) {
+        for (int d = 0; d < 4; d++) {
             Collections.addAll(set, data);
         }
     }
@@ -377,6 +377,12 @@ public class BufferedFileBackedSortedSetTest {
 
     @Test
     public void testCompaction() throws IOException {
+        // only this test needs enough underlying sets to reach the compaction threshold, so top up here rather than
+        // making every other test in the class pay for the extra rounds in setUp. The round cap keeps a change in
+        // persist/compact behavior from spinning here forever -- the assertion below reports it instead.
+        for (int d = 0; set.getSets().size() <= 7 && d < 20; d++) {
+            Collections.addAll(set, data);
+        }
         assertEquals(8, set.getSets().size());
         set.persist();
         assertEquals(3, set.getSets().size());


### PR DESCRIPTION
Two changes
- reuse hadoop conf object
- reduce rounds in buffered file map tests