### PR TITLE
speed up query tests

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/ExcerptTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ExcerptTest.java
@@ -133,9 +133,8 @@ public class ExcerptTest extends AbstractQueryTest {
     @BeforeEach
     public void setupLogic() {
         setClientForTest(client);
-        logic.setFullTableScanEnabled(true);
 
-        givenDate("19000101", "20240101");
+        givenDate("20121231", "20130102");
 
         extraParameters.clear();
         extraParameters.put("include.grouping.context", "true");

--- a/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedCommonalityTokenTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/HitsAreAlwaysIncludedCommonalityTokenTest.java
@@ -160,7 +160,6 @@ public class HitsAreAlwaysIncludedCommonalityTokenTest extends AbstractQueryTest
     @BeforeEach
     public void setup() {
         setClientForTest(clientForTest);
-        logic.setFullTableScanEnabled(true);
         logic.setCollapseUids(false);
 
         givenDate("20091231", "20150101");

--- a/warehouse/query-core/src/test/java/datawave/query/IvaratorInterruptTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/IvaratorInterruptTest.java
@@ -127,7 +127,7 @@ public class IvaratorInterruptTest extends AbstractQueryTest {
 
     @Test
     public void testIvaratorInterruptedUnsorted() throws Exception {
-        givenDate("20091231", "20150101");
+        givenDate("20121231", "20130102");
         givenQuery("UUID =~ '^[CS].*'");
         expectUUIDs(Set.of("CORLEONE", "SOPRANO", "CAPONE"));
 
@@ -141,7 +141,7 @@ public class IvaratorInterruptTest extends AbstractQueryTest {
         params.put(QueryOptions.SORTED_UIDS, "true");
         logic.getConfig().setUnsortedUIDsEnabled(false);
 
-        givenDate("20091231", "20150101");
+        givenDate("20121231", "20130102");
         givenQuery("UUID =~ '^[CS].*'");
         givenParameters(params);
         expectUUIDs(Set.of("CORLEONE", "SOPRANO", "CAPONE"));

--- a/warehouse/query-core/src/test/java/datawave/query/planner/DatePartitionedQueryPlannerTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/DatePartitionedQueryPlannerTest.java
@@ -157,7 +157,6 @@ public class DatePartitionedQueryPlannerTest {
     public void setup() throws Exception {
         // change to debug to see planning
         Logger.getLogger(DefaultQueryPlanner.class).setLevel(Level.WARN);
-        this.logic.setFullTableScanEnabled(true);
         this.logic.setMaxEvaluationPipelines(1);
         this.logic.setMaxDepthThreshold(100);
         this.logic.setQueryExecutionForPageTimeout(300000000000000L);

--- a/warehouse/query-core/src/test/java/datawave/query/planner/rules/FieldRuleTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/planner/rules/FieldRuleTest.java
@@ -85,7 +85,6 @@ public class FieldRuleTest extends AbstractQueryTest {
 
     @BeforeEach
     public void setup() throws ParseException {
-        this.logic.setFullTableScanEnabled(true);
         this.logic.setMaxEvaluationPipelines(1);
         this.logic.setQueryExecutionForPageTimeout(300000000000000L);
         setClientForTest(clientForTest);

--- a/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/predicate/ValueToAttributesTest.java
@@ -129,7 +129,6 @@ public class ValueToAttributesTest extends AbstractQueryTest {
     @BeforeEach
     public void setup() {
         setClientForTest(clientForTest);
-        logic.setFullTableScanEnabled(true);
         logic.setCollapseUids(false);
 
         givenDate("20091231", "20150101");

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionTest.java
@@ -1,7 +1,5 @@
 package datawave.query.tables;
 
-import static java.lang.Thread.sleep;
-
 import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -75,25 +73,6 @@ public class ScannerSessionTest {
         instance.stop();
     }
 
-    /**
-     * Waits for the requested number of splits to become visible on the table.
-     *
-     * @param tableName
-     *            the table to poll
-     * @param expected
-     *            the number of splits to wait for
-     */
-    private static void awaitSplits(String tableName, int expected)
-                    throws TableNotFoundException, AccumuloSecurityException, AccumuloException, InterruptedException {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
-        while (client.tableOperations().listSplits(tableName).size() < expected) {
-            if (System.nanoTime() > deadline) {
-                throw new IllegalStateException("Table " + tableName + " did not reach " + expected + " splits");
-            }
-            sleep(50);
-        }
-    }
-
     private static void setupTable()
                     throws TableExistsException, AccumuloSecurityException, AccumuloException, TableNotFoundException, InterruptedException, IOException {
         client.tableOperations().create("testTable");
@@ -105,8 +84,9 @@ public class ScannerSessionTest {
         }
         client.tableOperations().addSplits("testTable", splits);
 
-        // give the table a chance to be split, returning as soon as the splits are visible rather than always paying the worst case
-        awaitSplits("testTable", splits.size());
+        // clear client cache so its aware the splits have been created
+        client.tableOperations().clearLocatorCache("testTable");
+        Assert.assertEquals(splits.size(), client.tableOperations().listSplits("testTable").size());
 
         // force writing all the data or fail
         try {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ScannerSessionTest.java
@@ -75,6 +75,25 @@ public class ScannerSessionTest {
         instance.stop();
     }
 
+    /**
+     * Waits for the requested number of splits to become visible on the table.
+     *
+     * @param tableName
+     *            the table to poll
+     * @param expected
+     *            the number of splits to wait for
+     */
+    private static void awaitSplits(String tableName, int expected)
+                    throws TableNotFoundException, AccumuloSecurityException, AccumuloException, InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        while (client.tableOperations().listSplits(tableName).size() < expected) {
+            if (System.nanoTime() > deadline) {
+                throw new IllegalStateException("Table " + tableName + " did not reach " + expected + " splits");
+            }
+            sleep(50);
+        }
+    }
+
     private static void setupTable()
                     throws TableExistsException, AccumuloSecurityException, AccumuloException, TableNotFoundException, InterruptedException, IOException {
         client.tableOperations().create("testTable");
@@ -86,8 +105,8 @@ public class ScannerSessionTest {
         }
         client.tableOperations().addSplits("testTable", splits);
 
-        // give the table a chance to be split
-        sleep(10000);
+        // give the table a chance to be split, returning as soon as the splits are visible rather than always paying the worst case
+        awaitSplits("testTable", splits.size());
 
         // force writing all the data or fail
         try {

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicQueryValidationTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicQueryValidationTest.java
@@ -109,7 +109,6 @@ public class ShardQueryLogicQueryValidationTest {
 
     @BeforeEach
     public void setup() throws ParseException {
-        this.logic.setFullTableScanEnabled(true);
         this.deserializer = new KryoDocumentDeserializer();
         this.startDate = dateFormat.parse("20091231");
         this.endDate = dateFormat.parse("20150101");

--- a/warehouse/query-core/src/test/java/datawave/query/util/SummaryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/SummaryTest.java
@@ -155,7 +155,7 @@ public class SummaryTest extends AbstractQueryTest {
         this.goodResults.addAll(expectedGoodResults);
         this.shouldReturnSomething = shouldReturnSomething;
 
-        givenDate("19000101", "20240101");
+        givenDate("20121231", "20130102");
         givenQuery(queryString);
 
         planAndExecuteQuery();


### PR DESCRIPTION
Three major changes
- narrow date ranges where appropriate
- disable full table scans where appropriate
- ScannerSessionTest clears table cache to force immediate reload