### PR TITLE
Fix TypeMetadata serialization race and failure handling

### DIFF
--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
@@ -228,6 +228,8 @@ public class TypeMetadata implements Serializable, KryoSerializable {
      *
      * @param ingestTypeFilter
      * @return
+     * @throws IllegalStateException
+     *             if an ingest type is absent, rather than fold it away and normalize its values wrong
      */
     public Multimap<String,String> fold(Set<String> ingestTypeFilter) {
         if (ingestTypeFilter == null || ingestTypeFilter.isEmpty()) {
@@ -236,8 +238,13 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         Multimap<String,String> map = HashMultimap.create();
 
         for (String type : ingestTypeFilter) {
+            Multimap<String,String> types = this.typeMetadata.get(type);
+            if (types == null) {
+                throw new IllegalStateException("No TypeMetadata for ingest type '" + type + "'. Known ingest types: " + this.typeMetadata.keySet()
+                                + ". The metadata table cache is likely incomplete; proceeding would normalize values against the wrong types and silently drop valid results.");
+            }
             // defensive copy
-            map.putAll(HashMultimap.create(this.typeMetadata.get(type)));
+            map.putAll(HashMultimap.create(types));
         }
         return map;
     }
@@ -293,18 +300,39 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         return Iterables.toArray(list, String.class);
     }
 
+    /**
+     * Parses one of the index to name mini-maps.
+     *
+     * @param typeEntry
+     *            a {@code dts:[...]} or {@code types:[...]} entry
+     * @return the mini-map, empty only when the entry holds no types
+     * @throws IllegalStateException
+     *             if the entry is malformed, rather than return a mini-map that would resolve field entries to the wrong types
+     */
     private static Map<String,Integer> parseTypes(String typeEntry) {
         // dts:[0:ingest1,1:ingest2]
         // types:[0:DateType,1:IntegerType,2:LcType]
 
         // remove type designation and leading/trailing brackets
-        String types = typeEntry.split(":\\[")[1];
+        String[] split = typeEntry.split(":\\[");
+        if (split.length < 2) {
+            throw new IllegalStateException("Malformed TypeMetadata mini-map, expected a bracketed list: '" + typeEntry + "'");
+        }
+
+        String types = split[1];
         String typeEntries = types.substring(0, types.length() - 1);
 
         Map<String,Integer> typeMap = new TreeMap<>();
+        if (typeEntries.isEmpty()) {
+            // a legitimately empty list, not a malformed one
+            return typeMap;
+        }
 
         for (String entry : typeEntries.split(",")) {
             String[] entryParts = entry.split(":");
+            if (entryParts.length < 2) {
+                throw new IllegalStateException("Malformed TypeMetadata mini-map entry, expected 'index:name': '" + entry + "' in '" + typeEntry + "'");
+            }
             typeMap.put(entryParts[1], Integer.valueOf(entryParts[0]));
         }
 
@@ -312,12 +340,15 @@ public class TypeMetadata implements Serializable, KryoSerializable {
     }
 
     /**
-     * Renders this instance in the form described by {@link #fromString(String)}, populating the ingest type and normalizer type mini-maps as a side effect.
+     * Renders this instance in the form described by {@link #fromString(String)}. The ingest type and normalizer type mini-maps are built locally and published
+     * at the end, because a cached instance is serialized concurrently by every query sharing its auths and datatype filter.
      *
      * @return a serialized TypeMetadata
      */
     public String toString() {
         StringBuilder sb = new StringBuilder();
+        Map<String,Integer> ingestTypesMini = new TreeMap<>();
+        Map<String,Integer> dataTypesMini = new TreeMap<>();
 
         // create and append ingestTypes mini-map
         sb.append("dts:[");
@@ -326,9 +357,14 @@ public class TypeMetadata implements Serializable, KryoSerializable {
             String ingestType = ingestIter.next();
             sb.append(i).append(":");
             sb.append(ingestType);
-            sb.append(ingestIter.hasNext() ? "," : "];");
-            getIngestTypesMiniMap().put(ingestType, i);
+            sb.append(ingestIter.hasNext() ? "," : "]");
+            ingestTypesMini.put(ingestType, i);
         }
+        // an empty TypeMetadata still has to close the bracket, or the result cannot be parsed back
+        if (ingestTypes.isEmpty()) {
+            sb.append("]");
+        }
+        sb.append(";");
 
         // create and append dataTypes mini-map
         sb.append("types:[");
@@ -343,8 +379,11 @@ public class TypeMetadata implements Serializable, KryoSerializable {
             String dataType = dataIter.next();
             sb.append(i).append(":");
             sb.append(dataType);
-            sb.append(dataIter.hasNext() ? "," : "];");
-            getDataTypesMiniMap().put(dataType, i);
+            sb.append(dataIter.hasNext() ? "," : "]");
+            dataTypesMini.put(dataType, i);
+        }
+        if (dataTypes.isEmpty()) {
+            sb.append("]");
         }
 
         // append fieldNames and their associated ingestTypes and Normalizers
@@ -356,6 +395,9 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         }
 
         Iterator<String> fieldIter = fieldNames.iterator();
+        if (fieldIter.hasNext()) {
+            sb.append(";");
+        }
         while (fieldIter.hasNext()) {
             String fieldName = fieldIter.next();
             sb.append(fieldName).append(":[");
@@ -368,14 +410,18 @@ public class TypeMetadata implements Serializable, KryoSerializable {
                 Iterator<String> dataTypeIter = typeMetadata.get(ingestType).get(fieldName).iterator();
                 while (dataTypeIter.hasNext()) {
                     String dataType = dataTypeIter.next();
-                    sb.append(getIngestTypesMiniMap().get(ingestType)).append(':');
-                    sb.append(getDataTypesMiniMap().get(dataType));
+                    sb.append(ingestTypesMini.get(ingestType)).append(':');
+                    sb.append(dataTypesMini.get(dataType));
                     sb.append(dataTypeIter.hasNext() ? "," : "");
                 }
                 sb.append(iIter.hasNext() ? "," : "");
             }
             sb.append(fieldIter.hasNext() ? "];" : "]");
         }
+
+        // publish the completed maps as a single reference store, so a concurrent reader never observes a half-built map
+        setIngestTypesMiniMap(ingestTypesMini);
+        setDataTypesMiniMap(dataTypesMini);
 
         return sb.toString();
     }

--- a/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/core/utils/metadata-utils/src/main/java/datawave/query/util/TypeMetadata.java
@@ -320,6 +320,10 @@ public class TypeMetadata implements Serializable, KryoSerializable {
         }
 
         String types = split[1];
+        if (!types.endsWith("]")) {
+            throw new IllegalStateException("Malformed TypeMetadata mini-map, expected a closing bracket: '" + typeEntry + "'");
+        }
+
         String typeEntries = types.substring(0, types.length() - 1);
 
         Map<String,Integer> typeMap = new TreeMap<>();
@@ -436,11 +440,14 @@ public class TypeMetadata implements Serializable, KryoSerializable {
      * </pre>
      *
      * The example above gives FIELD1 an LcNoDiacriticsType in both ingest types, and FIELD2 both types in ingestA and a NumberType in ingestB. Parsing is
-     * lenient: input with fewer than three entries is discarded, empty values are skipped (a field absent from a trailing ingest type emits a trailing comma),
-     * and an index with no mini-map entry yields an empty type name.
+     * lenient about what {@link #toString()} emits: input with fewer than three entries is discarded, empty entries and values are skipped (a field absent from
+     * a trailing ingest type emits a trailing comma), and an index with no mini-map entry yields an empty type name. A malformed entry throws instead of
+     * resolving field entries to the wrong types.
      *
      * @param data
      *            a serialized TypeMetadata
+     * @throws IllegalStateException
+     *             if a mini-map or field entry is malformed
      */
     private void fromString(String data) {
         String[] entries = parse(data, ';');
@@ -460,13 +467,21 @@ public class TypeMetadata implements Serializable, KryoSerializable {
                 } else if (entry.startsWith(DATATYPES_PREFIX)) {
                     setDataTypesMiniMap(parseTypes(entry));
                     dataTypesByIndex = invert(getDataTypesMiniMap());
-                } else {
+                } else if (!entry.isEmpty()) {
                     // a field entry, FIELD_NAME:[ingestTypeIndex:normalizerTypeIndex,...], splitting into the field
-                    // name and the bracketed list of index pairs
+                    // name and the bracketed list of index pairs. An empty entry is a trailing delimiter, not a field.
                     String[] entrySplits = parse(entry, ':');
+                    if (entrySplits.length < 2) {
+                        throw new IllegalStateException("Malformed TypeMetadata field entry, expected 'FIELD:[...]': '" + entry + "'");
+                    }
 
                     // get rid of the leading and trailing brackets:
-                    entrySplits[1] = entrySplits[1].substring(1, entrySplits[1].length() - 1);
+                    String indexPairs = entrySplits[1];
+                    if (!indexPairs.startsWith("[") || !indexPairs.endsWith("]")) {
+                        throw new IllegalStateException("Malformed TypeMetadata field entry, expected a bracketed list: '" + entry + "'");
+                    }
+
+                    entrySplits[1] = indexPairs.substring(1, indexPairs.length() - 1);
                     String[] values = parse(entrySplits[1], ',');
 
                     for (String aValue : values) {
@@ -475,6 +490,10 @@ public class TypeMetadata implements Serializable, KryoSerializable {
                             // mini-map. An index the corresponding mini-map does not hold, including any index seen
                             // before its mini-map entry was parsed, resolves to "".
                             String[] vs = Iterables.toArray(Splitter.on(':').omitEmptyStrings().trimResults().split(aValue), String.class);
+                            if (vs.length < 2) {
+                                throw new IllegalStateException("Malformed TypeMetadata index pair, expected 'ingestTypeIndex:normalizerTypeIndex': '" + aValue
+                                                + "' in '" + entry + "'");
+                            }
 
                             String ingestType = ingestTypesByIndex.getOrDefault(Integer.valueOf(vs[0]), "");
                             String dataType = dataTypesByIndex.getOrDefault(Integer.valueOf(vs[1]), "");

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationRaceTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationRaceTest.java
@@ -118,4 +118,62 @@ public class TypeMetadataSerializationRaceTest {
     public void testMalformedMiniMapThrows() {
         assertThrows(IllegalStateException.class, () -> new TypeMetadata("dts:[0:ingestA];types:[bogus];FIELD:[0:0]"));
     }
+
+    /**
+     * An unclosed mini-map bracket hides the delimiters that follow it, so the ingest type entry swallows the normalizer entry. Parsed leniently it yields an
+     * ingest type named "ingestB;types" and no normalizer mini-map at all, leaving every field to resolve its normalizer to "".
+     */
+    @Test
+    public void testUnterminatedIngestTypeMiniMapThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                        () -> new TypeMetadata("dts:[0:ingestA,1:ingestB;types:[0:LcNoDiacriticsType];FIELD1:[0:0];FIELD2:[0:0]"));
+        assertTrue(e.getMessage(), e.getMessage().contains("closing bracket"));
+    }
+
+    /**
+     * The same truncation in the normalizer mini-map, which leniently names index 0 "LcNoDiacriticsType;FIELD1" and so resolves every field holding it to a
+     * normalizer that does not exist.
+     */
+    @Test
+    public void testUnterminatedNormalizerMiniMapThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                        () -> new TypeMetadata("dts:[0:ingestA];types:[0:LcNoDiacriticsType;FIELD1:[0:0];FIELD2:[0:0]"));
+        assertTrue(e.getMessage(), e.getMessage().contains("closing bracket"));
+    }
+
+    /**
+     * A field entry with no bracketed list at all, which used to fail on an array index rather than say what was wrong.
+     */
+    @Test
+    public void testFieldEntryWithoutListThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> new TypeMetadata("dts:[0:ingestA];types:[0:LcNoDiacriticsType];FIELD"));
+        assertTrue(e.getMessage(), e.getMessage().contains("FIELD"));
+    }
+
+    /**
+     * A field entry whose list is never closed, which used to drop the last index pair and then fail on an array index.
+     */
+    @Test
+    public void testUnterminatedFieldEntryThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> new TypeMetadata("dts:[0:ingestA];types:[0:LcNoDiacriticsType];FIELD:[0:0"));
+        assertTrue(e.getMessage(), e.getMessage().contains("bracketed list"));
+    }
+
+    /**
+     * A field entry holding an index with no normalizer index paired to it.
+     */
+    @Test
+    public void testMalformedIndexPairThrows() {
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> new TypeMetadata("dts:[0:ingestA];types:[0:LcNoDiacriticsType];FIELD:[0]"));
+        assertTrue(e.getMessage(), e.getMessage().contains("index pair"));
+    }
+
+    /**
+     * The guards above must not reject a trailing delimiter, which is an empty entry rather than a malformed field.
+     */
+    @Test
+    public void testTrailingDelimiterStillParses() {
+        TypeMetadata typeMetadata = new TypeMetadata("dts:[0:ingestA];types:[0:LcNoDiacriticsType];FIELD:[0:0];");
+        assertEquals(Collections.singleton("LcNoDiacriticsType"), typeMetadata.getNormalizerNamesForField("FIELD"));
+    }
 }

--- a/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationRaceTest.java
+++ b/core/utils/metadata-utils/src/test/java/datawave/query/util/TypeMetadataSerializationRaceTest.java
@@ -1,0 +1,121 @@
+package datawave.query.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+/**
+ * Demonstrates that {@link TypeMetadata#toString()} mutates instance state, which is unsafe because a {@link TypeMetadata} is shared between concurrent queries
+ * via the metadata helper cache.
+ */
+public class TypeMetadataSerializationRaceTest {
+
+    private static final int THREADS = 8;
+    private static final int ROUNDS = 500;
+
+    private static TypeMetadata newTypeMetadata() {
+        TypeMetadata typeMetadata = new TypeMetadata();
+        for (int i = 0; i < 40; i++) {
+            typeMetadata.put("FIELD_" + i, "ingest_" + (i % 7), "datawave.data.type.LcNoDiacriticsType");
+            typeMetadata.put("FIELD_" + i, "ingest_" + (i % 5), "datawave.data.type.NumberType");
+            typeMetadata.put("FIELD_" + i, "ingest_" + (i % 3), "datawave.data.type.DateType");
+        }
+        return typeMetadata;
+    }
+
+    /**
+     * Serialization must not write to the instance. A cached {@link TypeMetadata} is handed to every query that shares the same auths and datatype filter, so a
+     * write here is a write to state other threads are reading.
+     */
+    @Test
+    public void testToStringDoesNotMutateTheInstance() {
+        TypeMetadata typeMetadata = newTypeMetadata();
+
+        typeMetadata.setIngestTypesMiniMap(Collections.unmodifiableMap(new TreeMap<>()));
+        typeMetadata.setDataTypesMiniMap(Collections.unmodifiableMap(new TreeMap<>()));
+
+        try {
+            typeMetadata.toString();
+        } catch (UnsupportedOperationException e) {
+            fail("TypeMetadata.toString() wrote to the instance's mini-maps");
+        }
+    }
+
+    /**
+     * Serializing the same instance from several threads must produce the same string every time. The mini-maps are built on the first serialization, so the
+     * structural writes only race the first time an instance is serialized, which is why this only bites shortly after a metadata cache refresh.
+     */
+    @Test(timeout = 20_000)
+    public void testConcurrentSerializationIsConsistent() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+        try {
+            for (int round = 0; round < ROUNDS; round++) {
+                TypeMetadata shared = newTypeMetadata();
+                String expected = newTypeMetadata().toString();
+
+                CyclicBarrier barrier = new CyclicBarrier(THREADS);
+                // @formatter:off
+                List<Callable<String>> tasks = IntStream.range(0, THREADS)
+                                .mapToObj(i -> (Callable<String>) () -> {
+                                    barrier.await(30, TimeUnit.SECONDS);
+                                    return shared.toString();
+                                })
+                                .collect(Collectors.toList());
+                // @formatter:on
+
+                for (Future<String> future : executor.invokeAll(tasks)) {
+                    assertEquals("round " + round + " serialized a shared TypeMetadata inconsistently", expected, future.get());
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * A cache miss against the metadata table yields an empty {@link TypeMetadata}. Serializing it must produce something the tablet servers can parse back.
+     */
+    @Test
+    public void testEmptyTypeMetadataRoundTrips() {
+        String serialized = new TypeMetadata().toString();
+        assertTrue("empty TypeMetadata serialized to an unterminated string: " + serialized, serialized.endsWith("]") || serialized.endsWith("];"));
+        assertTrue(new TypeMetadata(serialized).isEmpty());
+    }
+
+    /**
+     * A datatype filter naming an ingest type the metadata table has no entry for must fail loudly. Folding it away would normalize that datatype's values
+     * against the wrong types and silently drop valid results.
+     */
+    @Test
+    public void testFoldWithUnknownIngestTypeThrows() {
+        TypeMetadata typeMetadata = newTypeMetadata();
+        Set<String> filter = Collections.singleton("ingest_not_in_the_metadata_table");
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> typeMetadata.fold(filter));
+        assertTrue(e.getMessage(), e.getMessage().contains("ingest_not_in_the_metadata_table"));
+    }
+
+    /**
+     * A malformed mini-map must fail loudly rather than resolve field entries to the wrong types.
+     */
+    @Test
+    public void testMalformedMiniMapThrows() {
+        assertThrows(IllegalStateException.class, () -> new TypeMetadata("dts:[0:ingestA];types:[bogus];FIELD:[0:0]"));
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -592,10 +592,11 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Construct IteratorSettings");
 
         if (!config.isGeneratePlanOnly()) {
-            cfg = getQueryIterator(metadataHelper, config, "", false, false);
             while (null == cfg) {
-                awaitSettingFuture();
                 cfg = getQueryIterator(metadataHelper, config, "", false, false);
+                if (null == cfg) {
+                    awaitSettingFuture();
+                }
             }
             configureIterator(config, cfg, newQueryString, isFullTable);
         }

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -592,7 +592,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - Construct IteratorSettings");
 
         if (!config.isGeneratePlanOnly()) {
+            cfg = getQueryIterator(metadataHelper, config, "", false, false);
             while (null == cfg) {
+                awaitSettingFuture();
                 cfg = getQueryIterator(metadataHelper, config, "", false, false);
             }
             configureIterator(config, cfg, newQueryString, isFullTable);
@@ -2394,6 +2396,24 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         // no-op
     }
 
+    /**
+     * Blocks until the iterator setting future completes, so that polling {@link #getQueryIterator} is not a hot spin. A failed future is left for the next
+     * getQueryIterator call to surface.
+     */
+    private void awaitSettingFuture() {
+        if (null == settingFuture) {
+            return;
+        }
+        try {
+            settingFuture.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DatawaveAsyncOperationException("Interrupted while building the query iterator", e);
+        } catch (ExecutionException e) {
+            // getQueryIterator will rethrow the cause
+        }
+    }
+
     protected Future<IteratorSetting> loadQueryIterator(final MetadataHelper metadataHelper, final ShardQueryConfiguration config, final Boolean isFullTable,
                     boolean isPreload) {
 
@@ -3510,8 +3530,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (compositeMetadata == null && compositeMetadataCallable != null) {
             TraceStopwatch stopwatch = stageStopWatch.newStartedStopwatch(compositeMetadataCallable.stageName());
             try {
-                while (compositeMetadata == null) {
-                    compositeMetadata = compositeMetadataFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                compositeMetadata = compositeMetadataFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                if (compositeMetadata == null) {
+                    throw new ExecutionException(new IllegalStateException("CompositeMetadata was null"));
                 }
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 log.error("Failed to fetch CompositeMetadata", e);
@@ -3531,8 +3552,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (typeMetadata == null && typeMetadataCallable != null) {
             TraceStopwatch stopwatch = stageStopWatch.newStartedStopwatch(typeMetadataCallable.stageName());
             try {
-                while (typeMetadata == null) {
-                    typeMetadata = typeMetadataFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                typeMetadata = typeMetadataFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                if (typeMetadata == null) {
+                    throw new ExecutionException(new IllegalStateException("TypeMetadata was null"));
                 }
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 log.error("Failed to fetch TypeMetadata", e);
@@ -3548,8 +3570,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (contentExpansionFields == null && contentExpansionFieldsCallable != null) {
             TraceStopwatch stopwatch = stageStopWatch.newStartedStopwatch(contentExpansionFieldsCallable.stageName());
             try {
-                while (contentExpansionFields == null) {
-                    contentExpansionFields = contentExpansionFieldsFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                contentExpansionFields = contentExpansionFieldsFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                if (contentExpansionFields == null) {
+                    throw new ExecutionException(new IllegalStateException("Content expansion fields were null"));
                 }
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 log.error("Failed to fetch Content Expansion fields", e);
@@ -3565,8 +3588,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         if (serializedIvaratorDirs == null && ivaratorCacheDirCallable != null) {
             TraceStopwatch stopwatch = stageStopWatch.newStartedStopwatch(ivaratorCacheDirCallable.stageName());
             try {
-                while (serializedIvaratorDirs == null) {
-                    serializedIvaratorDirs = ivaratorCacheDirFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                serializedIvaratorDirs = ivaratorCacheDirFuture.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+                if (serializedIvaratorDirs == null) {
+                    throw new ExecutionException(new IllegalStateException("Serialized ivarator cache dirs were null"));
                 }
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 log.error("Failed to serialize ivarator cache dirs", e);
@@ -3622,9 +3646,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     protected Set<String> getFieldSet(String stageName, Future<Set<String>> future) {
         TraceStopwatch stopwatch = stageStopWatch.newStartedStopwatch(stageName);
         try {
-            Set<String> fields = null;
-            while (fields == null) {
-                fields = future.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+            Set<String> fields = future.get(concurrentTimeoutMillis, TimeUnit.MILLISECONDS);
+            if (fields == null) {
+                throw new ExecutionException(new IllegalStateException("Stage[" + stageName + "] returned a null field set"));
             }
             return fields;
         } catch (ExecutionException | InterruptedException | TimeoutException e) {


### PR DESCRIPTION
toString() built its mini-maps into instance fields, but the metadata helper cache hands the same TypeMetadata to every concurrent query with matching auths, so the first serializations after a cache refresh raced on unsynchronized TreeMaps. They are now built locally and published once.

Where type metadata is missing or malformed, fail instead of degrading: folding away an absent ingest type, or parsing a corrupt mini-map, would normalize values against the wrong types and silently drop valid results. An empty instance also serialized to an unterminated string the tablet servers could not parse.

Planning waits could only iterate on a null result and then spun on a completed future forever, so they now fail fast, and the iterator setting poll blocks on its future rather than busy-waiting on isDone().