### PR TITLE
Size the scan server caches and heap for the quickstart

### DIFF
--- a/contrib/datawave-quickstart/bin/services/accumulo/bootstrap.sh
+++ b/contrib/datawave-quickstart/bin/services/accumulo/bootstrap.sh
@@ -79,7 +79,13 @@ instance.secret=${DW_ACCUMULO_PASSWORD}
 tserver.memory.maps.native.enabled=false
 tserver.memory.maps.max=385M
 tserver.cache.data.size=64M
-tserver.cache.index.size=64M"
+tserver.cache.index.size=64M
+
+## Scan servers size their caches as a percentage of the heap by default, which
+## is more than the quickstart's small JVMs have. Pin them like the tserver caches.
+sserver.cache.data.size=64M
+sserver.cache.index.size=64M
+sserver.cache.summary.size=32M"
 
 if [ "${DW_ACCUMULO_VFS_DATAWAVE_ENABLED}" != false ] ; then
   DW_ACCUMULO_PROPERTIES="${DW_ACCUMULO_PROPERTIES}

--- a/contrib/datawave-quickstart/bin/services/accumulo/install.sh
+++ b/contrib/datawave-quickstart/bin/services/accumulo/install.sh
@@ -97,6 +97,9 @@ assertCreateDir "${DW_ACCUMULO_JVM_HEAPDUMP_DIR}" || exit 1
 sed -i'' -e "s~\(ACCUMULO_TSERVER_OPTS=\).*$~\1\"${DW_ACCUMULO_TSERVER_OPTS}\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 sed -i'' -e "s~\(export JAVA_HOME=\).*$~\1\"${JAVA_HOME}\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 sed -i'' -e "s~\(export ACCUMULO_MONITOR_OPTS=\).*$~\1\"\${POLICY} -Xmx2g -Xms512m\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+# The scan server validates the configured cache sizes against its heap, and the
+# template's 512m is too small for them, so give it the same heap as the tserver
+sed -i'' -e "s~sserver) JAVA_OPTS=('-Xmx512m' '-Xms512m'~sserver) JAVA_OPTS=('-Xmx768m' '-Xms768m'~" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 echo 'JAVA_OPTS=('-Dcom.google.protobuf.use_unsafe_pre22_gencode' "${JAVA_OPTS[@]}")' >> "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 cat "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 # Update Accumulo bind host if it's not set to localhost


### PR DESCRIPTION

Work for #3766

sserver.cache.{data,index,summary}.size default to a percentage of heap in Accumulo 4, and the scan server validates them against its heap at startup, which is more than the quickstart's small JVMs have — so the sserver exits immediately. I pinned the cache sizes like the tserver caches and raised the sserver heap from the template's 512m to match the tserver's.

Split out from the accumulo-env PR per review.
