### PR TITLE
Govern both document scheduler scan paths with their execution hints

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
@@ -96,7 +96,17 @@ public class DocumentIdProducer implements RunnableWithContext {
         }
     }
 
-    private Scanner createScanner() throws TableNotFoundException {
+    /**
+     * Create a scanner for the field index and configure it with an execution hint and consistency level.
+     * <p>
+     * This is a search scan, so it is governed by the search hint rather than the retrieval hint. Both are required, because the document scheduler relies on
+     * its scans being routed to a dedicated executor pool.
+     *
+     * @return a configured scanner
+     * @throws TableNotFoundException
+     *             if the table does not exist
+     */
+    protected Scanner createScanner() throws TableNotFoundException {
         // this check exists because datawave can produce day ranges for certain unit tests. The document scheduler is optimized for shard-specific plans and
         // thus is not compatible with day ranges.
         Range scanRange = Range.exact(range.getStartKey().getRow());
@@ -106,11 +116,17 @@ public class DocumentIdProducer implements RunnableWithContext {
             throw new RuntimeException("Scan range differed from input range");
         }
 
-        Preconditions.checkArgument(context.getTableName().equals(config.getRetrievalScanHintTable()), "Table name did not match execution hint");
+        String tableName = context.getTableName();
+
+        Preconditions.checkNotNull(tableName);
+        Preconditions.checkNotNull(config.getSearchScanHintTable(), "SearchScanHintTable cannot be null");
+        Preconditions.checkNotNull(config.getSearchExecutorPool(), "SearchExecutorPool cannot be null");
+        Preconditions.checkArgument(tableName.equals(config.getSearchScanHintTable()), "Table name did not match execution hint");
+        Preconditions.checkNotNull(config.getSearchConsistencyLevel(), "SearchConsistencyLevel cannot be null");
 
         //  @formatter:off
         ScannerBuilder builder = ScannerBuilder.create(config.getClient())
-                .setTableName(context.getTableName())
+                .setTableName(tableName)
                 .setAuthorizations(config.getAuthorizations())
                 .setConsistencyLevel(config.getSearchConsistencyLevel())
                 .setScanType(config.getSearchScanHintPool())

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
@@ -145,11 +145,14 @@ public class DocumentRangeScan implements RunnableWithContext {
     }
 
     /**
-     * Create a scanner and configure it with an execution hint and consistency level
+     * Create a scanner and configure it with an execution hint and consistency level.
+     * <p>
+     * An execution hint and a consistency level are required. The document scheduler relies on its scans being routed to a dedicated executor pool, so a scan
+     * that is missing either is a configuration error rather than something to fall back from.
      *
      * @return a configured scanner
      */
-    private Scanner createScanner() {
+    protected Scanner createScanner() {
         String tableName = keyWithContext.getContext().getTableName();
 
         Preconditions.checkNotNull(tableName);
@@ -192,8 +195,8 @@ public class DocumentRangeScan implements RunnableWithContext {
             setting.addOption(QueryOptions.QUERY, queryData.getQuery());
         }
 
-        try (Scanner scanner = ScannerBuilder.create(config.getClient()).setTableName(keyWithContext.getContext().getTableName()).setAuthorizations(auths)
-                        .build()) {
+        // this is the default retrieval path, so it must honour the configured execution hint and consistency level
+        try (Scanner scanner = createScanner()) {
             scanner.addScanIterator(setting);
 
             Key start = new Key(keyWithContext.getKey().getRow());

--- a/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentIdProducerHintTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentIdProducerHintTest.java
@@ -1,0 +1,135 @@
+package datawave.next.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.query.configuration.QueryData;
+import datawave.query.iterator.QueryOptions;
+
+/**
+ * Verifies that a field index scan is governed by the search execution hint.
+ * <p>
+ * The producer validated the table it was about to scan against the retrieval hint while applying the search pool, so the search hint's table was never checked
+ * against anything. The shipped configuration gives both hints the same value, which hid the mismatch.
+ */
+public class DocumentIdProducerHintTest {
+
+    private static final String SHARD = "shard";
+    private static final String SEARCH_POOL = "searchPool";
+
+    @Test
+    public void testFullyConfiguredProducerBuildsAScanner() throws Exception {
+        DocumentIdProducer producer = producerFor(createConfig());
+
+        assertNotNull(producer.createScanner(), "a fully configured search scan must build a scanner");
+    }
+
+    /**
+     * The search scan must be validated against the search hint. When the two hints name different tables, validating against the retrieval hint rejects a
+     * correctly configured scan.
+     */
+    @Test
+    public void testSearchHintIsUsedRatherThanTheRetrievalHint() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setSearchScanHintTable(SHARD);
+        config.setRetrievalScanHintTable("a-different-table");
+
+        DocumentIdProducer producer = producerFor(config);
+
+        assertDoesNotThrow(producer::createScanner, "the search scan must be governed by the search hint");
+    }
+
+    /**
+     * A retrieval hint that happens to match must not stand in for a missing search hint.
+     */
+    @Test
+    public void testMissingSearchHintTableIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setSearchScanHintTable(null);
+        config.setRetrievalScanHintTable(SHARD);
+
+        DocumentIdProducer producer = producerFor(config);
+
+        assertThrows(NullPointerException.class, producer::createScanner);
+    }
+
+    @Test
+    public void testMissingSearchConsistencyLevelIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setSearchConsistencyLevel(null);
+
+        DocumentIdProducer producer = producerFor(config);
+
+        assertThrows(NullPointerException.class, producer::createScanner);
+    }
+
+    @Test
+    public void testMissingSearchExecutorPoolIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setSearchExecutorPool(null);
+
+        DocumentIdProducer producer = producerFor(config);
+
+        assertThrows(NullPointerException.class, producer::createScanner);
+    }
+
+    /**
+     * The search hint is configured for one table, so scanning another would route the scan to the wrong pool.
+     */
+    @Test
+    public void testSearchHintForADifferentTableIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setSearchScanHintTable("a-different-table");
+
+        DocumentIdProducer producer = producerFor(config);
+
+        assertThrows(IllegalArgumentException.class, producer::createScanner);
+    }
+
+    private DocumentIdProducer producerFor(DocumentScannerConfig config) {
+        return new DocumentIdProducer(config, queryData(), Range.exact("20240101_0"));
+    }
+
+    private QueryData queryData() {
+        IteratorSetting setting = new IteratorSetting(100, "query", "datawave.query.iterator.QueryIterator");
+        setting.addOption(QueryOptions.START_TIME, "0");
+        setting.addOption(QueryOptions.END_TIME, String.valueOf(Long.MAX_VALUE));
+        setting.addOption(QueryOptions.INDEXED_FIELDS, "FIELD_A");
+
+        QueryData queryData = new QueryData();
+        queryData.setTableName(SHARD);
+        queryData.setQuery("FIELD_A == 'value'");
+        queryData.setSettings(List.of(setting));
+        return queryData;
+    }
+
+    private DocumentScannerConfig createConfig() throws Exception {
+        AccumuloClient client = new InMemoryAccumuloClient("root", new InMemoryInstance());
+        client.tableOperations().create(SHARD);
+
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setClient(client);
+        config.setAuthorizations(Set.of(new Authorizations("A", "B")));
+        config.setCandidateQueue(new LinkedBlockingQueue<>());
+        config.setResults(new LinkedBlockingQueue<>());
+        config.setSearchExecutorPool(Executors.newFixedThreadPool(1));
+        config.setSearchScanHintTable(SHARD);
+        config.setSearchScanHintPool(SEARCH_POOL);
+        config.setSearchConsistencyLevel("IMMEDIATE");
+        return config;
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentRangeScanHintTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentRangeScanHintTest.java
@@ -1,0 +1,156 @@
+package datawave.next.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.Scanner;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.Test;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.core.query.configuration.QueryData;
+
+/**
+ * Verifies that a retrieval scan is built through {@link DocumentRangeScan#createScanner()}, which requires an execution hint and a consistency level.
+ * <p>
+ * The document scheduler depends on its scans being routed to a dedicated tablet server executor pool, so the hint is a hard requirement and a missing one is a
+ * configuration error. The document scan path built its scanner inline and so skipped both the requirement and the routing.
+ */
+public class DocumentRangeScanHintTest {
+
+    private static final String TABLE = "shard";
+    private static final String POOL = "shardTablePool";
+
+    /**
+     * The default retrieval path must build its scanner through {@code createScanner}, which is where the hint and consistency level are applied. Building one
+     * inline instead silently drops both.
+     */
+    @Test
+    public void testDocumentScanPathBuildsItsScannerThroughCreateScanner() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setUseQueryIterator(false);
+
+        AtomicBoolean createScannerCalled = new AtomicBoolean(false);
+
+        DocumentRangeScan scan = new DocumentRangeScan(keyWithContext(), config) {
+            @Override
+            protected Scanner createScanner() {
+                createScannerCalled.set(true);
+                throw new ScannerBuiltSignal();
+            }
+        };
+        scan.setContext("hint-test");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, scan::run);
+        assertTrue(createScannerCalled.get(), "the document scan path must build its scanner through createScanner");
+        assertTrue(hasCause(thrown, ScannerBuiltSignal.class), "expected the scan to fail via the stubbed scanner");
+    }
+
+    @Test
+    public void testFullyConfiguredScanBuildsAScanner() throws Exception {
+        DocumentRangeScan scan = new DocumentRangeScan(keyWithContext(), createConfig());
+
+        assertNotNull(scan.createScanner(), "a fully configured scan must build a scanner");
+    }
+
+    /**
+     * The hint is a hard requirement, so a scan that cannot be routed must fail rather than run unrouted.
+     */
+    @Test
+    public void testMissingScanHintTableIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setRetrievalScanHintTable(null);
+
+        DocumentRangeScan scan = new DocumentRangeScan(keyWithContext(), config);
+        assertThrows(NullPointerException.class, scan::createScanner);
+    }
+
+    @Test
+    public void testMissingConsistencyLevelIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setRetrievalConsistencyLevel(null);
+
+        DocumentRangeScan scan = new DocumentRangeScan(keyWithContext(), config);
+        assertThrows(NullPointerException.class, scan::createScanner);
+    }
+
+    @Test
+    public void testMissingRetrievalExecutorPoolIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setRetrievalExecutorPool(null);
+
+        DocumentRangeScan scan = new DocumentRangeScan(keyWithContext(), config);
+        assertThrows(NullPointerException.class, scan::createScanner);
+    }
+
+    /**
+     * The hint is configured for one table, so applying it to another would route the scan to the wrong pool.
+     */
+    @Test
+    public void testHintForADifferentTableIsRejected() throws Exception {
+        DocumentScannerConfig config = createConfig();
+        config.setRetrievalScanHintTable("a-different-table");
+
+        DocumentRangeScan scan = new DocumentRangeScan(keyWithContext(), config);
+        assertThrows(IllegalArgumentException.class, scan::createScanner);
+    }
+
+    private KeyWithContext keyWithContext() {
+        QueryData queryData = new QueryData();
+        queryData.setTableName(TABLE);
+        queryData.setSettings(List.of(new IteratorSetting(100, "query", "datawave.query.iterator.QueryIterator")));
+
+        return new KeyWithContext(new Key("row", "datatype\0uid"), queryData, false);
+    }
+
+    private DocumentScannerConfig createConfig() throws Exception {
+        AccumuloClient client = new InMemoryAccumuloClient("root", new InMemoryInstance());
+        client.tableOperations().create(TABLE);
+
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setClient(client);
+        config.setAuthorizations(Set.of(new Authorizations("A", "B")));
+        config.setResults(new LinkedBlockingQueue<>());
+        config.setRetrievalExecutorPool(Executors.newFixedThreadPool(1));
+        config.setRetrievalScanHintTable(TABLE);
+        config.setRetrievalScanHintPool(POOL);
+        config.setRetrievalConsistencyLevel("IMMEDIATE");
+        return config;
+    }
+
+    /**
+     * Marker used to abort the scan as soon as the scanner would have been built.
+     */
+    private static class ScannerBuiltSignal extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+
+    /**
+     * The scan wraps failures more than once on the way out, so the chain has to be walked.
+     *
+     * @param throwable
+     *            the thrown exception
+     * @param type
+     *            the cause being looked for
+     * @return true if the cause appears anywhere in the chain
+     */
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> type) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Both paths now build their scanner through createScanner and validate their own hint. The retrieval path previously bypassed it entirely, and the search path validated its table against the retrieval hint, so the search hint was never checked against anything.