### PR TITLE
Fix the datawave-core-test parent version after the integration merge

### DIFF
--- a/core/datawave-core-test/pom.xml
+++ b/core/datawave-core-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.core</groupId>
         <artifactId>datawave-core-parent</artifactId>
-        <version>7.45.0-SNAPSHOT</version>
+        <version>8.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>datawave-core-test</artifactId>


### PR DESCRIPTION

Work for #3766

The integration merge brought over the new core/datawave-core-test module still pointing at the 7.45.0-SNAPSHOT core parent, while the branch's core parent is at 8.0.0-SNAPSHOT. Maven fails while reading the reactor, so every build on the branch dies before it starts. Bumped the parent reference to match the branch.

There's one more 7.45.0-SNAPSHOT reference on the branch, in contrib/datawave-utils/check-tablet-extents/pom.xml — it's outside the default reactor so it doesn't break builds, mentioning it in case you want it synced in the same pass.
