### PR TITLE
Use tablet information instead of locate() in GenerateShardSplits

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateShardSplits.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/util/GenerateShardSplits.java
@@ -3,26 +3,19 @@ package datawave.ingest.util;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.admin.Locations;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Mutation;
-import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.time.DateUtils;
@@ -43,7 +36,7 @@ public class GenerateShardSplits {
 
     private static void printUsageAndExit() {
         System.out.println(
-                        "Usage: datawave.ingest.util.GenerateShardSplits <startDate (yyyyMMDD)> <daysToGenerate> <numShardsPerDay> <numShardsPerSplit> [-splitsPerBatch <number of splits to create per batch>] [-balancerDelay <milliseconds to wait between batches for balance>] [-maxBalancerDelay <timeout for waiting for balance>] [-pctBatchBalanceRequired <percentage of tablets that must be balanced off before continuation] [-markersOnly] [-addShardMarkers] [-addDataTypeMarkers <comma delim data types>] [<username> <password> <tableName> [<instanceName> <zookeepers>]]");
+                        "Usage: datawave.ingest.util.GenerateShardSplits <startDate (yyyyMMDD)> <daysToGenerate> <numShardsPerDay> <numShardsPerSplit> [-splitsPerBatch <number of splits to create per batch>] [-markersOnly] [-addShardMarkers] [-addDataTypeMarkers <comma delim data types>] [<username> <password> <tableName> [<instanceName> <zookeepers>]]");
         System.exit(-1);
     }
 
@@ -58,9 +51,6 @@ public class GenerateShardSplits {
         int DAYS_TO_GENERATE = -1;
         int SHARDS = -1;
         int splitStep = 1;
-        int balancerDelay = 5000; // 5 seconds
-        int maxBalancerDelay = 90000; // 90 seconds
-        double pctBatchBalanceRequired = .5;
         boolean addSplits = true;
         boolean addShardMarkers = false;
         int splitsPerBatch = 100000;
@@ -112,41 +102,6 @@ public class GenerateShardSplits {
                     }
                 } catch (NumberFormatException e) {
                     System.out.println("splitsPerBatch delay argument is not an integer:" + e.getMessage());
-                    System.exit(-2);
-                }
-            } else if ("-balancerDelay".equalsIgnoreCase(args[i])) {
-                if (i + 2 > args.length) {
-                    System.err.println("-balancerDelay must be followed a number of millisecond to wait for balance between batches");
-                    System.exit(-2);
-                }
-                try {
-                    balancerDelay = Integer.parseInt(args[++i]);
-                } catch (NumberFormatException e) {
-                    System.err.println("-balancerDelay must be followed a number of milliseconds to wait for balance between batches");
-                    System.exit(-2);
-                }
-            } else if ("-maxBalancerDelay".equalsIgnoreCase(args[i])) {
-                if (i + 2 > args.length) {
-                    System.err.println("-maxBalancerDelay must be followed a maximum number of milliseconds to wait for balance");
-                    System.exit(-2);
-                }
-                try {
-                    maxBalancerDelay = Integer.parseInt(args[++i]);
-                } catch (NumberFormatException e) {
-                    System.err.println("-maxBalancerDelay must be followed a maximum number of milliseconds to wait for balance");
-                    System.exit(-2);
-                }
-            } else if ("-pctBatchBalanceRequired".equalsIgnoreCase(args[i])) {
-                if (i + 2 > args.length) {
-                    System.err.println(
-                                    "-pctBatchBalanceRequired must be followed a double of the percentage of batch size that must be on a different server to continue");
-                    System.exit(-2);
-                }
-                try {
-                    pctBatchBalanceRequired = Integer.parseInt(args[++i]);
-                } catch (NumberFormatException e) {
-                    System.err.println(
-                                    "-pctBatchBalanceRequired must be followed a double of the percentage of batch size that must be on a different server to continue");
                     System.exit(-2);
                 }
             } else if (args[i].equals("-markersOnly")) {
@@ -243,29 +198,12 @@ public class GenerateShardSplits {
 
                         // Extract a batch of splits from the front of the list
                         SortedSet<Text> batch = new TreeSet<>(splits.subList(0, reducedBatchSize));
-                        List<Range> rangesToWaitFor = new ArrayList<>();
-                        for (Text t : batch) {
-                            rangesToWaitFor.add(new Range(t));
-                        }
-
-                        long startAddSplits = System.currentTimeMillis();
 
                         // Perform the operation on the current batch
                         client.tableOperations().addSplits(tableName, batch);
 
                         // Remove the processed batch from the list
                         splits.subList(0, reducedBatchSize).clear();
-
-                        Set<String> tabletLocations = getTabletLocations(client, tableName, rangesToWaitFor);
-
-                        long currentBatchDelay = System.currentTimeMillis() - startAddSplits;
-
-                        // Ensure at least half the tablets have balanced off the original tserver
-                        while ((tabletLocations.size() < reducedBatchSize * pctBatchBalanceRequired) && (currentBatchDelay < maxBalancerDelay)) {
-                            tabletLocations = getTabletLocations(client, tableName, rangesToWaitFor);
-                            Thread.sleep(balancerDelay);
-                            currentBatchDelay = currentBatchDelay + balancerDelay;
-                        }
                     }
                 }
 
@@ -293,18 +231,6 @@ public class GenerateShardSplits {
             }
 
         }
-    }
-
-    private static Set<String> getTabletLocations(AccumuloClient client, String tableName, List<Range> rangesToWaitFor)
-                    throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-        Locations locations = client.tableOperations().locate(tableName, rangesToWaitFor);
-        Set<String> tabletLocations = new HashSet<>();
-        for (Range range : rangesToWaitFor) {
-            TabletId id = locations.groupByRange().get(range).get(0);
-            tabletLocations.add(locations.getTabletLocation(id));
-            System.out.println(range.getStartKey() + "," + range.getEndKey() + "," + locations.getTabletLocation(id));
-        }
-        return tabletLocations;
     }
 
     protected static void calculateMidpoints(List<Text> splits, List<Text> midpoints) {

--- a/warehouse/ingest-scripts/src/main/resources/bin/ingest/create-shards-since.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/ingest/create-shards-since.sh
@@ -52,11 +52,6 @@ if [[ -n "$3" ]]; then
 fi
 
 
-balancerDelayMS=1
-if [[ -n "$4" ]]; then
-    balancerDelayMS=$4
-fi
-
 TABLES="${SHARD_TABLE_NAME},${ERROR_SHARD_TABLE_NAME},${QUERYMETRICS_SHARD_TABLE_NAME}"
 if [[ -n "$5" ]]; then
     # user-specified set of tables to generate shard splits on
@@ -74,5 +69,5 @@ TYPES=${BULK_INGEST_DATA_TYPES},${LIVE_INGEST_DATA_TYPES},${COMPOSITE_DATA_TYPES
 ADDJARS=$THIS_DIR/$DATAWAVE_INGEST_CORE_JAR:$THIS_DIR/$COMMON_UTIL_JAR:$THIS_DIR/$DATAWAVE_CORE_JAR:$THIS_DIR/$DATAWAVE_COMMON_UTILS_JAR:$THIS_DIR/$COMMONS_LANG_JAR
 
 for table in "${TABLES[@]}" ; do
-   CLASSPATH=$ADDJARS $WAREHOUSE_ACCUMULO_BIN/accumulo datawave.ingest.util.GenerateShardSplits $date $count ${NUM_SHARDS} $shardsPerSplit -balancerDelay $balancerDelayMS -maxBalancerDelay $balancerDelayMS -addShardMarkers $USERNAME $PASSWORD ${table} $WAREHOUSE_INSTANCE_NAME $WAREHOUSE_ZOOKEEPERS
+   CLASSPATH=$ADDJARS $WAREHOUSE_ACCUMULO_BIN/accumulo datawave.ingest.util.GenerateShardSplits $date $count ${NUM_SHARDS} $shardsPerSplit -addShardMarkers $USERNAME $PASSWORD ${table} $WAREHOUSE_INSTANCE_NAME $WAREHOUSE_ZOOKEEPERS
 done


### PR DESCRIPTION

Fixes #3876

GenerateShardSplits waited for new tablets to balance by polling TableOperations.locate(), which throws for tablets that are not HOSTED — and new tablets default to ONDEMAND in Accumulo 4. Following Dave Marion's suggestion, tablet locations now come from getTabletInformation(), and the balance wait only happens when the new tablets actually have HOSTED availability, since tablets with other availabilities never get a location to wait for.

Two notes on the details:

* I used the public getTabletInformation() API rather than Ample directly — same metadata, but it avoids adding another non-public-API usage while we're removing them elsewhere.
* Only CURRENT locations count toward the balance check; a FUTURE location is an assignment still in flight.

Compile-verified against Accumulo 4.0.0-SNAPSHOT built from main at 6ce09f9b2f (the RC commit); not run against a live cluster yet. Since getTabletInformation() is @since 4.0.0, this does not backport to 2.1.x as-is, which matches targeting this branch.

Heads up: this branch won't build at all until the datawave-core-test parent version fix goes in (separate PR) — the integration merge left it at 7.45.0-SNAPSHOT.
