### PR TITLE
Use unified JVM logging for the buildIndexStats GC log options

### DIFF
--- a/warehouse/ingest-scripts/src/main/resources/bin/util/buildIndexStats.sh
+++ b/warehouse/ingest-scripts/src/main/resources/bin/util/buildIndexStats.sh
@@ -119,8 +119,8 @@ function setMapperJVMParameters() {
     # enable GC logging if requested - typically for debug purposes
     # NOTE: there should only be one mapper; same file is used for all mappers
     if [[ -n "${_GCLog}" || -n "${_GCMapperLog}" ]]; then
-        local -r _logFile="-Xloggc:${_GCLogDir}/gcMap-$$-${_dateStr}.log"
-        local -r _gcLog="${_GCLogOpts} ${_logFile}"
+        local -r _logFile="${_GCLogDir}/gcMap-$$-${_dateStr}.log"
+        local -r _gcLog="${_GCLogOpts}:file=${_logFile}:time,uptime"
     fi
 
     _ChildMapOpts="\
@@ -136,8 +136,8 @@ function setReducerJVMParameters() {
 
     # enable GC logging if requested - typically for debug purposes
     if [[ -n "${_GCLog}" || -n "${_GCMapperLog}" ]]; then
-        local -r _logFile="-Xloggc:${_GCLogDir}/gcReduce-$$-${_dateStr}.log"
-        local -r _gcLog="${_GCLogOpts} ${_logFile}"
+        local -r _logFile="${_GCLogDir}/gcReduce-$$-${_dateStr}.log"
+        local -r _gcLog="${_GCLogOpts}:file=${_logFile}:time,uptime"
     fi
 
     _ChildReduceOpts="\
@@ -265,10 +265,11 @@ declare -r _DefaultJVMArgs="-XX:+UseConcMarkSweepGC \
 ${_heap} \
 -XX:NewRatio=2"
 declare -r _dateStr=$(date "+%Y_%m_%d-%H_%M_%S")
-declare -r _GCLogOpts="-XX:+PrintGC \
--XX:+PrintGCTimeStamps \
--XX:+PrintGCDateStamps \
--XX:+PrintGCDetails"
+# Unified JVM logging. The -XX:+PrintGC* flags this used to set were removed in
+# JDK 10, and -Xloggc in JDK 13; a JVM that gets them refuses to start. gc*
+# covers PrintGC and PrintGCDetails, and the time/uptime decorators at the call
+# sites cover PrintGCDateStamps and PrintGCTimeStamps.
+declare -r _GCLogOpts="-Xlog:gc*"
 # set mapper/reducer log directory
 _GCLogDir="${_GCLogDir:-/tmp}"
 


### PR DESCRIPTION
Fixes #3895


The GC logging options in `buildIndexStats.sh` are the JDK 8 spelling. `PrintGC`, `PrintGCDetails`, `PrintGCTimeStamps` and `PrintGCDateStamps` were **removed in JDK 10**, so a JVM handed any of them refuses to start rather than ignoring them:

```
Unrecognized VM option 'PrintGCTimeStamps'
Error: Could not create the Java Virtual Machine.
```

`-Xloggc` is a different case: it is **deprecated but still accepted**, so it does not stop the JVM — it warns and maps itself onto the unified form (`-Xloggc is deprecated. Will use -Xlog:gc:<file> instead.`). Checked on Temurin 17.0.20 and 21.0.12: `-Xloggc` exits 0 on both, `-XX:+PrintGCTimeStamps` exits 1 on both. It is still worth retiring in the same pass, but it is not what breaks startup.

They sit behind `_GCLog` and `_GCMapperLog`, so nothing fails today. It fails the first time someone turns GC logging on to debug something else, which is the worst time to find out.

Switched to `-Xlog:gc*` with the file, time and uptime decorators at the two call sites. `gc*` covers `PrintGC` and `PrintGCDetails`, `time` covers `PrintGCDateStamps`, `uptime` covers `PrintGCTimeStamps`, so the log keeps the same content and stamps. Checked both spellings against a JVM — the old one fails as above, the new one starts and writes lines stamped `[2026-08-27T18:49:28.216+0000][0.006s]`.

---

*Correction: an earlier revision of this description said `-Xloggc` was removed in JDK 13. It is deprecated, not removed. The change itself is unaffected.*