### PR TITLE
Pass the quickstart shard tables in the argument slot that reads them

### DIFF
--- a/contrib/datawave-quickstart/bin/services/datawave/bootstrap-ingest.sh
+++ b/contrib/datawave-quickstart/bin/services/datawave/bootstrap-ingest.sh
@@ -354,7 +354,10 @@ function datawaveIngestCreateTableSplits() {
    info "Generating table splits in Accumulo"
 
    # Create the shard table splits
-   ${DW_DATAWAVE_INGEST_HOME}/bin/ingest/create-shards-since.sh ${shardDateYYYYMMDD} ${numDays} "${shardTables}"
+   # create-shards-since.sh takes the table list as its fifth argument; the third
+   # and fourth are shardsPerSplit and the balancer delay. Pass those empty so
+   # they keep the script's own defaults.
+   ${DW_DATAWAVE_INGEST_HOME}/bin/ingest/create-shards-since.sh ${shardDateYYYYMMDD} ${numDays} "" "" "${shardTables}"
 
    # Go ahead and pre-split the global index and reverse index tables
    ${DW_DATAWAVE_INGEST_HOME}/bin/ingest/seed-index-splits.sh > /dev/null 2>&1


### PR DESCRIPTION
Fixes #3897


`datawaveIngestCreateTableSplits()` in `bootstrap-ingest.sh` (line 341) passes its shard table list as the third argument to `create-shards-since.sh`, but the third argument there is `shardsPerSplit`. The table list is the fifth.

Two things go wrong in that function. The list never takes effect, so the split run always uses the script's default of `shard,errorShard,queryMetrics_s` rather than what the caller asked for. And `shardsPerSplit` becomes a table name, which reaches `GenerateShardSplits` as its `splitStep` positional, where `Integer.parseInt` throws and the tool exits -2.

**Scope:** this is the operator-invoked helper, not the automatic install. `datawaveIngestCreateTableSplits()` requires `YYYYMMDD` and `numDays` and errors out without them; the automatic path is `install-ingest.sh:171`, which calls `create-shards-since.sh ${_today}` with a single argument and so cannot hit the mismatch. Ordinary quickstart installs do create shard splits.

Passing the two intervening arguments empty leaves them at the script's own defaults:

| | shardsPerSplit | balancerDelayMS | TABLES |
|---|---|---|---|
| before | `shard` | 1 | `shard,errorShard,queryMetrics_s` |
| after | 1 | 1 | `shard` |

So the only behavior that changes is the table list being honored and the split run completing.

---

*Correction: an earlier revision of this description said this happens on every quickstart run and that no shard splits get created at all. The automatic path passes a single argument and is unaffected.*