### PR TITLE
Add the query test framework metadata core

### DIFF
--- a/core/datawave-core-test/src/main/java/datawave/test/framework/FieldMetadata.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/FieldMetadata.java
@@ -1,0 +1,334 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.T;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.data.type.Type;
+import datawave.test.framework.generators.id.EventIdGenerator;
+import datawave.test.framework.generators.value.ValueGenerator;
+import datawave.test.framework.util.MetadataColumn;
+
+/**
+ * Contains all information required to generate a field and its associated values
+ * <p>
+ * The {@link ValueGenerator} determines what kind of values are generated
+ * <p>
+ * The {@link EventIdGenerator} determines the distribution of values.
+ * <p>
+ * Note: if the value generator is a singleton the values will be repeated across events
+ * <p>
+ * If the event id count is greater than the number of values then repeats are possible.
+ */
+public class FieldMetadata {
+
+    private static final Logger log = LoggerFactory.getLogger(FieldMetadata.class);
+
+    private final String fieldName;
+    private List<MetadataColumn> metadataColumns;
+    private List<Type<?>> normalizers;
+    private List<String> datatypes;
+
+    private int offset;
+    private List<Integer> eventIds = null;
+    private Map<Integer,Integer> eventIdIndex = null;
+    private List<String> values = null;
+
+    // built on first use and discarded whenever the values or event ids change, so repeated query generation does not rescan the event ids per value
+    private Map<String,List<Integer>> eventIdsByValue = null;
+
+    private boolean isFieldNumeric = false;
+    private ValueGenerator<?> valueGenerator;
+    private EventIdGenerator eventIdGenerator;
+
+    public FieldMetadata(String fieldName) {
+        Preconditions.checkNotNull(fieldName, "FieldName cannot be null");
+        this.fieldName = fieldName;
+    }
+
+    /**
+     * Set the normalizers applied to this field's values.
+     * <p>
+     * A normalized field always carries a type ({@link MetadataColumn#T}) column, which is derived rather than set by the caller. This setter and
+     * {@link #setMetadataColumns(List)} may therefore be called in either order.
+     *
+     * @param normalizers
+     *            the normalizers
+     */
+    public void setNormalizers(List<Type<?>> normalizers) {
+        Preconditions.checkNotNull(normalizers, "normalizers cannot be null");
+        this.normalizers = normalizers;
+        addTypeColumnIfNormalized();
+    }
+
+    /**
+     * Set the metadata columns this field is written to. See {@link #setNormalizers(List)} for how the type column is derived.
+     *
+     * @param metadataColumns
+     *            the metadata columns
+     */
+    public void setMetadataColumns(List<MetadataColumn> metadataColumns) {
+        Preconditions.checkNotNull(metadataColumns, "metadataColumns cannot be null");
+        this.metadataColumns = new ArrayList<>(metadataColumns);
+        addTypeColumnIfNormalized();
+    }
+
+    /**
+     * Add the type column once both halves of the pair are known, so neither setter depends on being called first.
+     */
+    private void addTypeColumnIfNormalized() {
+        if (normalizers == null || normalizers.isEmpty() || metadataColumns == null) {
+            return;
+        }
+        if (!metadataColumns.contains(T)) {
+            metadataColumns.add(T);
+        }
+    }
+
+    public void setDatatypes(List<String> datatypes) {
+        Preconditions.checkNotNull(datatypes, "datatypes cannot be null");
+        this.datatypes = List.copyOf(datatypes);
+    }
+
+    public void setValues(List<String> values) {
+        Preconditions.checkNotNull(values, "values cannot be null");
+        // an empty list would make the value-to-event mapping divide by zero
+        Preconditions.checkArgument(!values.isEmpty(), "values cannot be empty");
+        this.values = values;
+        this.eventIdsByValue = null;
+    }
+
+    public void setValueGenerator(ValueGenerator<?> valueGenerator) {
+        this.valueGenerator = valueGenerator;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    /**
+     * JEXL prepends a dollar sign to field names that are numeric
+     *
+     * @return the normalized field name
+     */
+    public String getNormalizedFieldName() {
+        if (isFieldNumeric) {
+            return "$" + fieldName;
+        }
+        return fieldName;
+    }
+
+    public List<Type<?>> getNormalizers() {
+        return normalizers;
+    }
+
+    public List<MetadataColumn> getMetadataColumns() {
+        return metadataColumns;
+    }
+
+    public List<String> getDatatypes() {
+        return datatypes;
+    }
+
+    public List<String> getValues() {
+        Preconditions.checkNotNull(values, "FieldMetadata values were not created");
+        return values;
+    }
+
+    public ValueGenerator<?> getValueGenerator() {
+        return valueGenerator;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+
+    public boolean isFieldNumeric() {
+        return isFieldNumeric;
+    }
+
+    public void setFieldNumeric(boolean isFieldNumeric) {
+        this.isFieldNumeric = isFieldNumeric;
+    }
+
+    /**
+     * The presence of the {@link MetadataColumn#TF} column is itself the signal that content functions (e.g. {@code content:phrase}) apply to this field: its
+     * value is a tokenizable phrase rather than an atomic term.
+     *
+     * @return true if this field carries a term frequency column
+     */
+    public boolean isContentField() {
+        return metadataColumns.contains(MetadataColumn.TF);
+    }
+
+    public EventIdGenerator getEventIdGenerator() {
+        return eventIdGenerator;
+    }
+
+    /**
+     * Set the {@link EventIdGenerator} used by this instance of FieldMetadata.
+     *
+     * @param eventIdGenerator
+     *            the generator
+     */
+    public void setEventIdGenerator(EventIdGenerator eventIdGenerator) {
+        this.eventIdGenerator = eventIdGenerator;
+    }
+
+    /**
+     * Populate the values given the event id count and the values per field
+     *
+     * @param eventCount
+     *            the number of events
+     * @param valuesPerField
+     *            the number of values to generate
+     */
+    public void populateValues(int eventCount, int valuesPerField) {
+        Preconditions.checkNotNull(eventIdGenerator, "EventIdGenerator cannot be null");
+        Preconditions.checkNotNull(valueGenerator, "ValueGenerator cannot be null");
+        Preconditions.checkArgument(eventCount > 0, "eventCount must be greater than 0");
+        // a field with no values has no value-to-event mapping to divide by
+        Preconditions.checkArgument(valuesPerField > 0, "valuesPerField must be greater than 0");
+        eventIdGenerator.setOffset(offset);
+
+        setEventIds(eventIdGenerator.generateWithinBound(eventCount));
+
+        values = new ArrayList<>();
+        eventIdsByValue = null;
+        // valuesPerField is a fixed property of the field's configuration and must not vary with the event distribution, otherwise the number of queries
+        // generated from these values (one per distinct value) would change whenever the event count changes. A value with no backing events is a valid
+        // "matches nothing" test case; writers must skip persisting such a value rather than this method dropping it from the list.
+        for (int i = 0; i < valuesPerField; i++) {
+            values.add(String.valueOf(valueGenerator.next()));
+        }
+    }
+
+    public List<Integer> getEventIds() {
+        return eventIds;
+    }
+
+    public void setEventIds(List<Integer> eventIds) {
+        Preconditions.checkNotNull(eventIds, "eventIds cannot be null");
+        this.eventIds = eventIds;
+        this.eventIdIndex = new HashMap<>();
+        for (int i = 0; i < eventIds.size(); i++) {
+            eventIdIndex.put(eventIds.get(i), i);
+        }
+        this.eventIdsByValue = null;
+    }
+
+    /**
+     * Find the value at the provided event index and return it. If the field does not map to the index then a null value is returned.
+     *
+     * @param eventId
+     *            the event id
+     * @return the value at the event index, or null if the field does not appear in the event
+     */
+    public String getValueForEventId(int eventId) {
+        Preconditions.checkNotNull(eventIds, "EventIds cannot be null");
+        Preconditions.checkNotNull(values, "FieldMetadata values were not created");
+
+        Integer eventIndex = eventIdIndex.get(eventId);
+        if (eventIndex == null) {
+            return null;
+        }
+
+        int modifiedIndex = eventIndex % values.size();
+        String value = values.get(modifiedIndex);
+        log.trace("field {} index {} modified index {} value {}", fieldName, eventId, modifiedIndex, value);
+        return value;
+    }
+
+    /**
+     * Get all event ids for the given value, in ascending event id order.
+     * <p>
+     * Query generation calls this once per value per field, so the mapping is indexed on first use rather than rescanning every event id on each call. The
+     * returned list is immutable and shared between callers.
+     *
+     * @param value
+     *            the value
+     * @return the list of event ids where the value appears, empty if the value has no backing events
+     */
+    public List<Integer> getEventIdsForValue(String value) {
+        Preconditions.checkNotNull(value, "Cannot find event ids for a null value");
+        if (eventIdsByValue == null) {
+            eventIdsByValue = indexEventIdsByValue();
+        }
+        return eventIdsByValue.getOrDefault(value, List.of());
+    }
+
+    /**
+     * Build the value to event id mapping, walking the event ids once.
+     *
+     * @return an immutable map of value to the event ids carrying it
+     */
+    private Map<String,List<Integer>> indexEventIdsByValue() {
+        Preconditions.checkNotNull(eventIds, "EventIds cannot be null");
+        Preconditions.checkNotNull(values, "FieldMetadata values were not created");
+
+        Map<String,List<Integer>> byValue = new HashMap<>();
+        for (int i = 0; i < eventIds.size(); i++) {
+            String value = values.get(i % values.size());
+            byValue.computeIfAbsent(value, k -> new ArrayList<>()).add(eventIds.get(i));
+        }
+
+        Map<String,List<Integer>> immutable = new HashMap<>();
+        for (Map.Entry<String,List<Integer>> entry : byValue.entrySet()) {
+            immutable.put(entry.getKey(), List.copyOf(entry.getValue()));
+        }
+        return immutable;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        FieldMetadata metadata = (FieldMetadata) o;
+        //  @formatter:off
+        return new EqualsBuilder()
+                .append(offset, metadata.offset)
+                .append(fieldName, metadata.fieldName)
+                .append(isFieldNumeric, metadata.isFieldNumeric)
+                .append(metadataColumns, metadata.metadataColumns)
+                .append(normalizers, metadata.normalizers)
+                .append(datatypes, metadata.datatypes)
+                .append(eventIds, metadata.eventIds)
+                .append(values, metadata.values)
+                .isEquals();
+        //  @formatter:on
+    }
+
+    @Override
+    public int hashCode() {
+        //  @formatter:off
+        return new HashCodeBuilder(17, 37)
+                .append(fieldName)
+                .append(isFieldNumeric)
+                .append(metadataColumns)
+                .append(normalizers)
+                .append(datatypes)
+                .append(offset)
+                .append(eventIds)
+                .append(values)
+                .toHashCode();
+        //  @formatter:on
+    }
+}

--- a/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadata.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadata.java
@@ -1,0 +1,368 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.E;
+import static datawave.test.framework.util.MetadataColumn.I;
+import static datawave.test.framework.util.MetadataColumn.TF;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.NoOpType;
+import datawave.data.type.NumberType;
+import datawave.data.type.Type;
+import datawave.test.framework.generators.field.AlphabeticFieldNameGenerator;
+import datawave.test.framework.generators.field.FieldNameGenerator;
+import datawave.test.framework.generators.field.NumericFieldNameGenerator;
+import datawave.test.framework.generators.id.ModuloEventIdGenerator;
+import datawave.test.framework.generators.id.SequentialEventIdGenerator;
+import datawave.test.framework.generators.value.LinearNumberGenerator;
+import datawave.test.framework.generators.value.PhraseGenerator;
+import datawave.test.framework.generators.value.RandomAlphabeticGenerator;
+import datawave.test.framework.generators.value.RandomNumericGenerator;
+import datawave.test.framework.generators.value.ValueGenerator;
+import datawave.test.framework.util.Combination;
+import datawave.test.framework.util.InfiniteIterator;
+import datawave.test.framework.util.MetadataColumn;
+
+/**
+ * Deterministically generates a list of {@link FieldMetadata} used for test data and queries.
+ */
+public class IngestMetadata {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestMetadata.class);
+
+    private static final int DEFAULT_EVENT_COUNT = 25;
+    private static final int DEFAULT_VALUES_PER_FIELD = 2;
+    public static final int DEFAULT_NUM_SHARDS = 10;
+
+    /**
+     * Each eligible (metadata column combination, normalizer) pairing produces this many fields - one per event id offset - so that two fields sharing a shape
+     * can still land on overlapping-but-distinct event id sets.
+     */
+    private static final int FIELDS_PER_PAIRING = 2;
+
+    /**
+     * The field name of the synthetic, per-event unique identifier field. Callers that need to build queries against it should use
+     * {@code QueryGenerator.singleTermId} rather than looking it up by this name directly.
+     */
+    public static final String ID_FIELD_NAME = "ID";
+
+    private final boolean alphabeticFieldsEnabled;
+    private final boolean numericFieldsEnabled;
+    private final int numShards;
+    private final List<MetadataColumn> baseMetadataColumns;
+    private final List<String> baseDatatypes = List.of("datatype-a");
+    private final List<Type<?>> baseNormalizers;
+
+    private final long seed;
+    private final Random random;
+
+    private final List<FieldMetadata> fieldMetadata = new ArrayList<>();
+
+    private int eventCount = DEFAULT_EVENT_COUNT;
+
+    /**
+     * Default constructor for IngestMetadata
+     *
+     * @param baseMetadataColumns
+     *            the metadata columns used
+     * @param baseNormalizers
+     *            the normalizers used
+     * @param alphabeticFieldsEnabled
+     *            flag that enables alphabetic fields
+     * @param numericFieldsEnabled
+     *            flag that enables numeric fields
+     * @param numShards
+     *            the number of shards to distribute events across
+     * @param seed
+     *            the seed every generated value derives from, logged by {@link #createEvents(int, int)} so a failing run can be reproduced
+     */
+    public IngestMetadata(List<MetadataColumn> baseMetadataColumns, List<Type<?>> baseNormalizers, boolean alphabeticFieldsEnabled,
+                    boolean numericFieldsEnabled, int numShards, long seed) {
+        Preconditions.checkArgument(numShards > 0, "numShards must be greater than 0");
+        Preconditions.checkArgument(alphabeticFieldsEnabled || numericFieldsEnabled, "alphabetic or numeric fields must be enabled");
+        for (Type<?> normalizer : baseNormalizers) {
+            Preconditions.checkArgument(isSupportedNormalizer(normalizer), "normalizer not supported: %s", normalizer.getClass().getName());
+        }
+        this.baseMetadataColumns = baseMetadataColumns;
+        this.baseNormalizers = baseNormalizers;
+        this.alphabeticFieldsEnabled = alphabeticFieldsEnabled;
+        this.numericFieldsEnabled = numericFieldsEnabled;
+        this.numShards = numShards;
+        this.seed = seed;
+        this.random = new Random(seed);
+    }
+
+    /**
+     * The seed every generated value derives from. Passing it back through {@link IngestMetadataBuilder#setSeed(long)} reproduces this instance's data exactly.
+     *
+     * @return the seed
+     */
+    public long getSeed() {
+        return seed;
+    }
+
+    /**
+     * Plan the number of unique {@link FieldMetadata} entries given the input metadata columns, normalizers, and field types.
+     * <p>
+     * This is the exact size of {@link #getFieldMetadata()} after {@link #createEvents()}: every eligible (metadata column combination, normalizer) pairing
+     * yields {@link #FIELDS_PER_PAIRING} fields per enabled field name type, and the synthetic {@link #ID_FIELD_NAME} field is always added on top.
+     *
+     * @return the number of unique {@link FieldMetadata} entries
+     */
+    public int plan() {
+        // metadata * normalizers * field types, excluding TF combos paired with a non-text normalizer. Normalizers do not get combinatoric.
+        int generatedFields = countEligiblePairings(Combination.getAllCombinations(baseMetadataColumns)) * FIELDS_PER_PAIRING * enabledFieldTypes();
+        // the synthetic ID field is created unconditionally, outside the combinatoric field space
+        return generatedFields + 1;
+    }
+
+    /**
+     * The number of field name types in play, which multiplies the field space.
+     *
+     * @return 1 if only alphabetic or only numeric field names are enabled, 2 if both are
+     */
+    private int enabledFieldTypes() {
+        int enabledFieldTypes = 0;
+        if (numericFieldsEnabled) {
+            enabledFieldTypes++;
+        }
+        if (alphabeticFieldsEnabled) {
+            enabledFieldTypes++;
+        }
+        return enabledFieldTypes;
+    }
+
+    /**
+     * Count the (metadataColumn combo, normalizer) pairings eligible for field generation.
+     * <p>
+     * A combo containing {@link MetadataColumn#TF} requires a phrase value, so it is only eligible when paired with {@link LcNoDiacriticsType}; other
+     * normalizers are skipped for that combo since a phrase generator does not apply to them.
+     *
+     * @param metadataColumns
+     *            all combinations of the base metadata columns
+     * @return the number of eligible (combo, normalizer) pairings
+     */
+    private int countEligiblePairings(List<List<MetadataColumn>> metadataColumns) {
+        int eligiblePairings = 0;
+        for (List<MetadataColumn> combo : metadataColumns) {
+            for (Type<?> normalizer : baseNormalizers) {
+                if (combo.contains(TF) && !(normalizer instanceof LcNoDiacriticsType)) {
+                    continue;
+                }
+                eligiblePairings++;
+            }
+        }
+        return eligiblePairings;
+    }
+
+    /**
+     * Create the default number of events using a metadata-first approach
+     *
+     * <pre>
+     * Metadata-first approach:
+     * First generate all combinations of metadata columns {i, ri, e, tf}
+     * Then, generate all combinations of normalizers
+     * Then, for each metadata column roll through each normalizer.
+     * Then, for each field (alpha, numeric) apply appropriate data (fixed, random)
+     * </pre>
+     */
+    public void createEvents() {
+        createEvents(DEFAULT_EVENT_COUNT, DEFAULT_VALUES_PER_FIELD);
+    }
+
+    /**
+     * Create the provided number of events using a metadata-first approach
+     *
+     * <pre>
+     * Metadata-first approach:
+     * First generate all combinations of metadata columns {i, ri, e, tf}
+     * Then, generate all combinations of normalizers
+     * Then, for each metadata column roll through each normalizer.
+     * Then, for each field (alpha, numeric) apply appropriate data (fixed, random)
+     * </pre>
+     *
+     * @param eventCount
+     *            the number of events to generate
+     */
+    public void createEvents(int eventCount) {
+        createEvents(eventCount, DEFAULT_VALUES_PER_FIELD);
+    }
+
+    /**
+     * Creates the provided number of events using a metadata-first approach
+     *
+     * <pre>
+     * Metadata-first approach:
+     * First generate all combinations of metadata columns {i, ri, e, tf}
+     * Then, generate all combinations of normalizers
+     * Then, for each metadata column roll through each normalizer.
+     * Then, for each field (alpha, numeric) apply appropriate data (fixed, random)
+     * </pre>
+     *
+     * @param eventCount
+     *            the number of events to generate
+     * @param valuesPerField
+     *            the number of distinct values generated for each field
+     */
+    public void createEvents(int eventCount, int valuesPerField) {
+        Preconditions.checkArgument(eventCount > 0, "Event count must be positive");
+        Preconditions.checkArgument(valuesPerField > 0, "Values per field must be positive");
+        // generation appends to the field space, so a second call would duplicate every field name and leave plan() disagreeing with getFieldMetadata()
+        Preconditions.checkState(fieldMetadata.isEmpty(), "Events have already been created");
+        // logged so a failing run can be replayed via IngestMetadataBuilder.setSeed(long)
+        log.info("generating values with seed {}", seed);
+        List<List<MetadataColumn>> metadataColumns = Combination.getAllCombinations(baseMetadataColumns);
+        int enabledFieldTypes = enabledFieldTypes();
+        log.info("creating {} field metadata entries from {} metadata column combinations, {} normalizers and {} field name types", plan(),
+                        metadataColumns.size(), baseNormalizers.size(), enabledFieldTypes);
+
+        int eventsPerFieldSpace = eventCount / enabledFieldTypes;
+
+        if (alphabeticFieldsEnabled) {
+            FieldNameGenerator alphaNameGenerator = AlphabeticFieldNameGenerator.create(random);
+            fieldMetadata.addAll(
+                            createMetadataForFields(metadataColumns, baseNormalizers, alphaNameGenerator, eventCount, eventsPerFieldSpace, valuesPerField));
+        }
+
+        if (numericFieldsEnabled) {
+            FieldNameGenerator numericNameGenerator = NumericFieldNameGenerator.create(random);
+            fieldMetadata.addAll(
+                            createMetadataForFields(metadataColumns, baseNormalizers, numericNameGenerator, eventCount, eventsPerFieldSpace, valuesPerField));
+        }
+
+        // always add the ID field
+        fieldMetadata.add(createIDFieldMetadata(eventCount));
+
+        for (FieldMetadata metadata : fieldMetadata) {
+            int eventIdCount = metadata.getEventIds().size();
+            log.info("{} count: {}", metadata.getFieldName(), eventIdCount);
+        }
+
+        this.eventCount = eventCount;
+    }
+
+    private List<FieldMetadata> createMetadataForFields(List<List<MetadataColumn>> metadataColumns, List<Type<?>> baseNormalizers,
+                    FieldNameGenerator fieldNameGenerator, int eventCount, int eventsPerFieldSpace, int valuesPerField) {
+        // 2x for offsets to ensure full coverage
+        fieldNameGenerator.generate(metadataColumns.size() * baseNormalizers.size() * 2);
+        Iterator<String> fieldNameIterator = new InfiniteIterator<>(fieldNameGenerator.getFieldNames());
+
+        int maxMods = Math.max(fieldNameGenerator.getFieldNames().size(), eventsPerFieldSpace) / 2;
+        // we are going to strip off the leading 1, so generate one more
+        List<Integer> modCounts = SequentialEventIdGenerator.create().generateCount(maxMods + 1);
+        // start with value 2
+        modCounts = modCounts.subList(1, modCounts.size());
+        Iterator<Integer> modCountIterator = new InfiniteIterator<>(modCounts);
+
+        List<FieldMetadata> metadata = new ArrayList<>();
+        for (List<MetadataColumn> metadataColumn : metadataColumns) {
+            for (Type<?> normalizer : baseNormalizers) {
+                boolean isContentCombo = metadataColumn.contains(TF);
+                if (isContentCombo && !(normalizer instanceof LcNoDiacriticsType)) {
+                    // phrases are text-only; skip pairings a phrase generator cannot service
+                    continue;
+                }
+
+                int modCount = modCountIterator.next();
+                for (int offset = 0; offset < FIELDS_PER_PAIRING; offset++) {
+                    FieldMetadata field = new FieldMetadata(fieldNameIterator.next());
+                    field.setFieldNumeric(fieldNameGenerator.isNumeric());
+                    field.setMetadataColumns(metadataColumn);
+                    field.setDatatypes(baseDatatypes);
+                    field.setNormalizers(List.of(normalizer));
+
+                    ValueGenerator<?> valueGenerator = isContentCombo ? PhraseGenerator.create(random) : getValueGeneratorForType(normalizer);
+                    field.setValueGenerator(valueGenerator);
+                    field.setEventIdGenerator(ModuloEventIdGenerator.create(modCount));
+
+                    field.setOffset(offset);
+                    field.populateValues(eventCount, valuesPerField);
+                    metadata.add(field);
+                }
+            }
+        }
+        return metadata;
+    }
+
+    /**
+     * The ID field should be present on every event
+     *
+     * @param eventCount
+     *            the number of events requested
+     * @return the FieldMetadata for the ID field
+     */
+    private FieldMetadata createIDFieldMetadata(int eventCount) {
+        FieldMetadata metadata = new FieldMetadata(ID_FIELD_NAME);
+        metadata.setDatatypes(baseDatatypes);
+        metadata.setMetadataColumns(List.of(I, E));
+        metadata.setNormalizers(List.of(new LcNoDiacriticsType()));
+        metadata.setEventIdGenerator(SequentialEventIdGenerator.create());
+        metadata.setValueGenerator(LinearNumberGenerator.create());
+        metadata.setOffset(0);
+        // the ID field needs exactly one distinct value per event, so request eventCount values directly rather than relying on populateValues to
+        // implicitly cap an "unlimited" request by the event count
+        metadata.populateValues(eventCount, eventCount);
+        return metadata;
+    }
+
+    /**
+     * Whether a value generator exists for the normalizer.
+     * <p>
+     * Checked by {@link IngestMetadataBuilder} when the normalizer is supplied, so an unsupported type is rejected at the call that introduced it rather than
+     * partway through {@link #createEvents(int, int)}.
+     *
+     * @param type
+     *            the normalizer
+     * @return true if values can be generated for the normalizer
+     */
+    public static boolean isSupportedNormalizer(Type<?> type) {
+        return type instanceof LcNoDiacriticsType || type instanceof NumberType || type instanceof NoOpType;
+    }
+
+    private ValueGenerator<?> getValueGeneratorForType(Type<?> type) {
+        if (type instanceof LcNoDiacriticsType || type instanceof NoOpType) {
+            return RandomAlphabeticGenerator.create(2, random);
+        } else if (type instanceof NumberType) {
+            return RandomNumericGenerator.create(random);
+        } else {
+            throw new IllegalStateException("Type not supported: " + type.getClass().getName());
+        }
+    }
+
+    public List<MetadataColumn> getBaseMetadataColumns() {
+        return baseMetadataColumns;
+    }
+
+    public List<Type<?>> getBaseNormalizers() {
+        return baseNormalizers;
+    }
+
+    public boolean isAlphabeticFieldsEnabled() {
+        return alphabeticFieldsEnabled;
+    }
+
+    public boolean isNumericFieldsEnabled() {
+        return numericFieldsEnabled;
+    }
+
+    public List<FieldMetadata> getFieldMetadata() {
+        return fieldMetadata;
+    }
+
+    public int getEventCount() {
+        return eventCount;
+    }
+
+    public int getNumShards() {
+        return numShards;
+    }
+}

--- a/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadata.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadata.java
@@ -5,6 +5,7 @@ import static datawave.test.framework.util.MetadataColumn.I;
 import static datawave.test.framework.util.MetadataColumn.TF;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
@@ -73,9 +74,9 @@ public class IngestMetadata {
      * Default constructor for IngestMetadata
      *
      * @param baseMetadataColumns
-     *            the metadata columns used
+     *            the metadata columns used, copied so later changes to the list cannot alter this instance
      * @param baseNormalizers
-     *            the normalizers used
+     *            the normalizers used, copied so later changes to the list cannot alter this instance
      * @param alphabeticFieldsEnabled
      *            flag that enables alphabetic fields
      * @param numericFieldsEnabled
@@ -92,8 +93,8 @@ public class IngestMetadata {
         for (Type<?> normalizer : baseNormalizers) {
             Preconditions.checkArgument(isSupportedNormalizer(normalizer), "normalizer not supported: %s", normalizer.getClass().getName());
         }
-        this.baseMetadataColumns = baseMetadataColumns;
-        this.baseNormalizers = baseNormalizers;
+        this.baseMetadataColumns = List.copyOf(baseMetadataColumns);
+        this.baseNormalizers = List.copyOf(baseNormalizers);
         this.alphabeticFieldsEnabled = alphabeticFieldsEnabled;
         this.numericFieldsEnabled = numericFieldsEnabled;
         this.numShards = numShards;
@@ -354,8 +355,14 @@ public class IngestMetadata {
         return numericFieldsEnabled;
     }
 
+    /**
+     * The generated field space, empty until {@link #createEvents(int, int)} runs. Returned as a read-only view, since adding to it would leave {@link #plan()}
+     * disagreeing with the fields a query is built against.
+     *
+     * @return the field metadata
+     */
     public List<FieldMetadata> getFieldMetadata() {
-        return fieldMetadata;
+        return Collections.unmodifiableList(fieldMetadata);
     }
 
     public int getEventCount() {

--- a/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadataBuilder.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadataBuilder.java
@@ -14,6 +14,9 @@ import datawave.test.framework.util.MetadataColumn;
  */
 public class IngestMetadataBuilder {
 
+    // safe to share, as SecureRandom is thread-safe, and cheaper than a per-builder instance re-seeding from the entropy source on every build
+    private static final SecureRandom SEED_GENERATOR = new SecureRandom();
+
     private boolean alphabeticFieldsEnabled = false;
     private boolean numericFieldsEnabled = false;
     private int numShards = IngestMetadata.DEFAULT_NUM_SHARDS;
@@ -21,7 +24,7 @@ public class IngestMetadataBuilder {
     private final List<Type<?>> normalizers = new ArrayList<>();
 
     // a fresh seed per build keeps the suite exploring new data; IngestMetadata logs it so any run can be replayed via setSeed
-    private long seed = new SecureRandom().nextLong();
+    private long seed = SEED_GENERATOR.nextLong();
 
     private boolean built = false;
 

--- a/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadataBuilder.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadataBuilder.java
@@ -1,0 +1,119 @@
+package datawave.test.framework;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+import datawave.data.type.Type;
+import datawave.test.framework.util.MetadataColumn;
+
+/**
+ * A builder for {@link IngestMetadata}
+ */
+public class IngestMetadataBuilder {
+
+    private boolean alphabeticFieldsEnabled = false;
+    private boolean numericFieldsEnabled = false;
+    private int numShards = IngestMetadata.DEFAULT_NUM_SHARDS;
+    private final List<MetadataColumn> metadataColumns = new ArrayList<>();
+    private final List<Type<?>> normalizers = new ArrayList<>();
+
+    // a fresh seed per build keeps the suite exploring new data; IngestMetadata logs it so any run can be replayed via setSeed
+    private long seed = new SecureRandom().nextLong();
+
+    private IngestMetadataBuilder() {
+        // enforce static access
+    }
+
+    public static IngestMetadataBuilder builder() {
+        return new IngestMetadataBuilder();
+    }
+
+    /**
+     * Set the metadata columns, replacing any set previously.
+     *
+     * @param metadataColumns
+     *            the metadata columns
+     * @return this builder
+     */
+    public IngestMetadataBuilder setMetadataColumns(List<MetadataColumn> metadataColumns) {
+        Preconditions.checkNotNull(metadataColumns, "metadataColumns cannot be null");
+        Preconditions.checkArgument(!metadataColumns.isEmpty(), "metadataColumns cannot be empty");
+        this.metadataColumns.clear();
+        this.metadataColumns.addAll(metadataColumns);
+        return this;
+    }
+
+    /**
+     * Add a normalizer to those already configured.
+     *
+     * @param normalizer
+     *            the normalizer
+     * @return this builder
+     */
+    public IngestMetadataBuilder addNormalizer(Type<?> normalizer) {
+        Preconditions.checkNotNull(normalizer, "normalizer cannot be null");
+        Preconditions.checkArgument(IngestMetadata.isSupportedNormalizer(normalizer), "normalizer not supported: %s", normalizer.getClass().getName());
+        this.normalizers.add(normalizer);
+        return this;
+    }
+
+    /**
+     * Add normalizers to those already configured.
+     *
+     * @param normalizers
+     *            the normalizers
+     * @return this builder
+     */
+    public IngestMetadataBuilder addNormalizers(List<Type<?>> normalizers) {
+        Preconditions.checkNotNull(normalizers, "normalizers cannot be null");
+        Preconditions.checkArgument(!normalizers.isEmpty(), "normalizers cannot be empty");
+        normalizers.forEach(this::addNormalizer);
+        return this;
+    }
+
+    public IngestMetadataBuilder enableAlphabeticFields() {
+        this.alphabeticFieldsEnabled = true;
+        return this;
+    }
+
+    public IngestMetadataBuilder enableNumericFields() {
+        this.numericFieldsEnabled = true;
+        return this;
+    }
+
+    public IngestMetadataBuilder setNumShards(int numShards) {
+        Preconditions.checkArgument(numShards > 0, "numShards must be greater than 0");
+        this.numShards = numShards;
+        return this;
+    }
+
+    /**
+     * Pin the seed every generated value derives from.
+     * <p>
+     * Left unset, each build picks a fresh seed so the suite keeps exploring new data. {@link IngestMetadata#createEvents(int, int)} logs whichever seed is in
+     * effect, so a failing run can be replayed exactly by passing that value here.
+     *
+     * @param seed
+     *            the seed
+     * @return this builder
+     */
+    public IngestMetadataBuilder setSeed(long seed) {
+        this.seed = seed;
+        return this;
+    }
+
+    /**
+     * Build the ingest metadata, rejecting a configuration that would generate no fields
+     *
+     * @return the configured ingest metadata
+     */
+    public IngestMetadata build() {
+        Preconditions.checkState(!metadataColumns.isEmpty(), "metadataColumns must be set");
+        Preconditions.checkState(!normalizers.isEmpty(), "normalizers must be set");
+        Preconditions.checkState(alphabeticFieldsEnabled || numericFieldsEnabled, "alphabetic or numeric fields must be enabled");
+        return new IngestMetadata(metadataColumns, normalizers, alphabeticFieldsEnabled, numericFieldsEnabled, numShards, seed);
+    }
+}

--- a/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadataBuilder.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/IngestMetadataBuilder.java
@@ -10,7 +10,7 @@ import datawave.data.type.Type;
 import datawave.test.framework.util.MetadataColumn;
 
 /**
- * A builder for {@link IngestMetadata}
+ * A builder for {@link IngestMetadata}. Single-use: {@link #build()} may be called once.
  */
 public class IngestMetadataBuilder {
 
@@ -22,6 +22,8 @@ public class IngestMetadataBuilder {
 
     // a fresh seed per build keeps the suite exploring new data; IngestMetadata logs it so any run can be replayed via setSeed
     private long seed = new SecureRandom().nextLong();
+
+    private boolean built = false;
 
     private IngestMetadataBuilder() {
         // enforce static access
@@ -106,14 +108,20 @@ public class IngestMetadataBuilder {
     }
 
     /**
-     * Build the ingest metadata, rejecting a configuration that would generate no fields
+     * Build the ingest metadata, rejecting a configuration that would generate no fields.
+     * <p>
+     * Reuse is rejected rather than supported: the seed is drawn once per builder, so a second build would quietly repeat the first instance's data unless
+     * {@link #setSeed(long)} intervened.
      *
      * @return the configured ingest metadata
      */
     public IngestMetadata build() {
+        Preconditions.checkState(!built, "build() has already been called on this builder");
         Preconditions.checkState(!metadataColumns.isEmpty(), "metadataColumns must be set");
         Preconditions.checkState(!normalizers.isEmpty(), "normalizers must be set");
         Preconditions.checkState(alphabeticFieldsEnabled || numericFieldsEnabled, "alphabetic or numeric fields must be enabled");
-        return new IngestMetadata(metadataColumns, normalizers, alphabeticFieldsEnabled, numericFieldsEnabled, numShards, seed);
+        IngestMetadata metadata = new IngestMetadata(metadataColumns, normalizers, alphabeticFieldsEnabled, numericFieldsEnabled, numShards, seed);
+        built = true;
+        return metadata;
     }
 }

--- a/core/datawave-core-test/src/main/java/datawave/test/framework/QueryFieldMetadata.java
+++ b/core/datawave-core-test/src/main/java/datawave/test/framework/QueryFieldMetadata.java
@@ -1,0 +1,163 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.E;
+import static datawave.test.framework.util.MetadataColumn.I;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+
+import datawave.test.framework.util.MetadataColumn;
+
+/**
+ * A wrapper around a list of {@link FieldMetadata} that allows the test framework to generate queries and calculate the expected event ids.
+ * <p>
+ * Supports access to logical groups of {@link FieldMetadata} such as "index-only fields" or "event-only" fields.
+ */
+public class QueryFieldMetadata {
+
+    private final List<FieldMetadata> fields;
+
+    /**
+     * Wrap a snapshot of the fields. The list is copied, so a view stays fixed even if the source list is added to afterwards.
+     *
+     * @param fields
+     *            the fields to expose
+     * @return the query view over the fields
+     */
+    public static QueryFieldMetadata of(List<FieldMetadata> fields) {
+        return new QueryFieldMetadata(List.copyOf(fields));
+    }
+
+    private QueryFieldMetadata(List<FieldMetadata> fields) {
+        this.fields = fields;
+    }
+
+    /**
+     * Get any {@link FieldMetadata} that has a {@link MetadataColumn#I} entry.
+     * <p>
+     * Excludes the synthetic ID field (see {@link #getId()}): it is indexed like a content field, but its value count is defined to always equal the event
+     * count, so mixing it into this group would make query counts derived from it vary with the event count.
+     *
+     * @return all indexed field metadata
+     */
+    public List<FieldMetadata> getIndexed() {
+        return selectNonIdFields(field -> has(field, I));
+    }
+
+    /**
+     * Get any {@link FieldMetadata} that has a {@link MetadataColumn#I} entry without a {@link MetadataColumn#E} entry.
+     *
+     * @return all index only field metadata
+     */
+    public List<FieldMetadata> getIndexOnly() {
+        return selectNonIdFields(field -> has(field, I) && !has(field, E));
+    }
+
+    /**
+     * Get any {@link FieldMetadata} that has a {@link MetadataColumn#E} entry without a {@link MetadataColumn#I} entry.
+     *
+     * @return all event only field metadata
+     */
+    public List<FieldMetadata> getEventOnly() {
+        return selectNonIdFields(field -> has(field, E) && !has(field, I));
+    }
+
+    /**
+     * Get any {@link FieldMetadata} that is a content field (see {@link FieldMetadata#isContentField()}) with a {@link MetadataColumn#I} entry, without a
+     * {@link MetadataColumn#E} entry.
+     * <p>
+     * These fields can self-anchor a {@code content:phrase(...)} query via the function's own index-expansion into {@code FIELD == 'word'} nodes, the same way
+     * {@link #getIndexOnly()} fields self-anchor an equality query.
+     *
+     * @return all tokenized, index-only field metadata
+     */
+    public List<FieldMetadata> getTokenizedIndexOnly() {
+        return selectNonIdFields(field -> field.isContentField() && has(field, I) && !has(field, E));
+    }
+
+    /**
+     * Get any {@link FieldMetadata} that is a content field (see {@link FieldMetadata#isContentField()}) with a {@link MetadataColumn#E} entry, without a
+     * {@link MetadataColumn#I} entry.
+     * <p>
+     * These fields have no index anchor of their own, so a {@code content:phrase(...)} query against them must be paired with an external indexed anchor term
+     * elsewhere in the query, the same way {@link #getEventOnly()} fields must be paired with filter functions.
+     *
+     * @return all tokenized, event-only field metadata
+     */
+    public List<FieldMetadata> getTokenizedEventOnly() {
+        return selectNonIdFields(field -> field.isContentField() && has(field, E) && !has(field, I));
+    }
+
+    /**
+     * Get the synthetic, per-event unique identifier field (see {@link IngestMetadata#ID_FIELD_NAME}), if present.
+     *
+     * @return the ID field metadata, or an empty list if it is not present in this instance's fields
+     */
+    public List<FieldMetadata> getId() {
+        return select(this::isIdField);
+    }
+
+    /**
+     * Select the fields matching the predicate, excluding the synthetic ID field.
+     * <p>
+     * Every group except {@link #getId()} excludes it, so the exclusion lives here rather than being restated in each accessor where it could be forgotten.
+     *
+     * @param predicate
+     *            the predicate a field must satisfy
+     * @return the matching field metadata
+     */
+    private List<FieldMetadata> selectNonIdFields(Predicate<FieldMetadata> predicate) {
+        return select(field -> !isIdField(field) && predicate.test(field));
+    }
+
+    /**
+     * Select the fields matching the predicate.
+     *
+     * @param predicate
+     *            the predicate a field must satisfy
+     * @return the matching field metadata
+     */
+    private List<FieldMetadata> select(Predicate<FieldMetadata> predicate) {
+        List<FieldMetadata> results = new ArrayList<>();
+        for (FieldMetadata field : fields) {
+            if (predicate.test(field)) {
+                results.add(field);
+            }
+        }
+        return results;
+    }
+
+    private boolean has(FieldMetadata field, MetadataColumn column) {
+        return field.getMetadataColumns().contains(column);
+    }
+
+    private boolean isIdField(FieldMetadata field) {
+        return field.getFieldName().equals(IngestMetadata.ID_FIELD_NAME);
+    }
+
+    /**
+     * Count how many of a field's generated values equal the given value.
+     * <p>
+     * This is a count of values, not of events. For the number of events carrying a value use {@link FieldMetadata#getEventIdsForValue(String)}.
+     *
+     * @param fieldValue
+     *            the field value pair
+     * @return the number of the field's values equal to the given value
+     */
+    public int getValueCountForEntry(Entry<String,String> fieldValue) {
+        int count = 0;
+        for (FieldMetadata field : fields) {
+            if (field.getFieldName().equals(fieldValue.getKey())) {
+                List<String> values = field.getValues();
+                for (String value : values) {
+                    if (value.equals(fieldValue.getValue())) {
+                        count++;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/FieldMetadataTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/FieldMetadataTest.java
@@ -1,0 +1,135 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.E;
+import static datawave.test.framework.util.MetadataColumn.I;
+import static datawave.test.framework.util.MetadataColumn.T;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.test.framework.generators.id.ModuloEventIdGenerator;
+import datawave.test.framework.generators.value.PresetGenerator;
+
+public class FieldMetadataTest {
+
+    @Test
+    public void testNullFieldName() {
+        Exception e = assertThrows(NullPointerException.class, () -> new FieldMetadata(null));
+        assertEquals("FieldName cannot be null", e.getMessage());
+    }
+
+    @Test
+    public void testPopulateModuloValues() {
+
+        FieldMetadata metadata = new FieldMetadata("A");
+        metadata.setValueGenerator(PresetGenerator.of(List.of("a", "b")));
+        metadata.setEventIdGenerator(ModuloEventIdGenerator.create(2));
+
+        // should generate {a, b, a, b, a}
+        metadata.populateValues(9, 2);
+
+        // verify frequencies
+        List<Integer> frequencies = metadata.getEventIds();
+        List<Integer> expectedFrequencies = List.of(2, 4, 6, 8);
+        assertEquals(expectedFrequencies, frequencies);
+
+        // verify values
+        List<String> values = metadata.getValues();
+        List<String> expectedValues = List.of("a", "b");
+        assertEquals(expectedValues, values);
+
+        // verify value via index
+        for (int i = 0; i < frequencies.size(); i++) {
+            int frequency = frequencies.get(i);
+            String value = metadata.getValueForEventId(frequency);
+            String expected = i % 2 == 0 ? "a" : "b";
+            assertEquals(expected, value, "frequency " + frequency + " returned wrong value");
+        }
+
+        // verify frequencies per value
+        List<Integer> frequenciesA = metadata.getEventIdsForValue("a");
+        assertEquals(List.of(2, 6), frequenciesA);
+
+        List<Integer> frequenciesB = metadata.getEventIdsForValue("b");
+        assertEquals(List.of(4, 8), frequenciesB);
+    }
+
+    /**
+     * valuesPerField is a fixed property of the field's configuration. Query generators count {@code values.size()} to determine how many queries to emit per
+     * field, so that count must never shrink just because a small event count backs fewer of the field's values with an actual event.
+     */
+    @Test
+    public void testValuesPerFieldIsConstantRegardlessOfEventCount() {
+        FieldMetadata metadata = new FieldMetadata("A");
+        metadata.setValueGenerator(PresetGenerator.of(List.of("a", "b")));
+        metadata.setEventIdGenerator(ModuloEventIdGenerator.create(1));
+
+        // only 1 event exists, so only one of the two values can ever map to an actual event; the value count must still be 2
+        metadata.populateValues(1, 2);
+
+        assertEquals(List.of("a", "b"), metadata.getValues());
+    }
+
+    /**
+     * The type column is implied by the presence of normalizers, so neither setter may depend on being called first.
+     */
+    @Test
+    public void testTypeColumnAddedRegardlessOfSetterOrder() {
+        FieldMetadata columnsFirst = new FieldMetadata("A");
+        columnsFirst.setMetadataColumns(List.of(I, E));
+        columnsFirst.setNormalizers(List.of(new LcNoDiacriticsType()));
+        assertTrue(columnsFirst.getMetadataColumns().contains(T), "type column missing when columns were set first");
+
+        FieldMetadata normalizersFirst = new FieldMetadata("B");
+        normalizersFirst.setNormalizers(List.of(new LcNoDiacriticsType()));
+        normalizersFirst.setMetadataColumns(List.of(I, E));
+        assertTrue(normalizersFirst.getMetadataColumns().contains(T), "type column missing when normalizers were set first");
+
+        assertEquals(columnsFirst.getMetadataColumns(), normalizersFirst.getMetadataColumns());
+    }
+
+    /**
+     * An empty value list would make the value-to-event mapping divide by zero, so it is rejected where it enters.
+     */
+    @Test
+    public void testEmptyValuesRejected() {
+        FieldMetadata metadata = new FieldMetadata("A");
+
+        Exception e1 = assertThrows(IllegalArgumentException.class, () -> metadata.setValues(Collections.emptyList()));
+        assertEquals("values cannot be empty", e1.getMessage());
+
+        metadata.setValueGenerator(PresetGenerator.of(List.of("a")));
+        metadata.setEventIdGenerator(ModuloEventIdGenerator.create(1));
+        Exception e2 = assertThrows(IllegalArgumentException.class, () -> metadata.populateValues(5, 0));
+        assertEquals("valuesPerField must be greater than 0", e2.getMessage());
+    }
+
+    /**
+     * The value to event id mapping is indexed on first use, so it has to be discarded when either side of the mapping is replaced.
+     */
+    @Test
+    public void testEventIdsForValueReflectsLaterChanges() {
+        FieldMetadata metadata = new FieldMetadata("A");
+        metadata.setValues(List.of("a", "b"));
+        metadata.setEventIds(List.of(1, 2, 3, 4));
+
+        assertEquals(List.of(1, 3), metadata.getEventIdsForValue("a"));
+
+        // replacing the values must not serve the previously indexed mapping
+        metadata.setValues(List.of("a"));
+        assertEquals(List.of(1, 2, 3, 4), metadata.getEventIdsForValue("a"));
+
+        // and neither must replacing the event ids
+        metadata.setEventIds(List.of(7, 8));
+        assertEquals(List.of(7, 8), metadata.getEventIdsForValue("a"));
+
+        // a value with no backing events resolves to empty rather than failing
+        assertEquals(List.of(), metadata.getEventIdsForValue("absent"));
+    }
+}

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataBuilderTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataBuilderTest.java
@@ -1,0 +1,145 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.E;
+import static datawave.test.framework.util.MetadataColumn.I;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.Type;
+import datawave.test.framework.util.MetadataColumn;
+
+public class IngestMetadataBuilderTest {
+
+    @Test
+    public void testInvalidMetadataColumns() {
+        Exception e1 = assertThrows(IllegalStateException.class, () -> IngestMetadataBuilder.builder().build());
+        assertEquals("metadataColumns must be set", e1.getMessage());
+
+        Exception e2 = assertThrows(NullPointerException.class, () -> IngestMetadataBuilder.builder().setMetadataColumns(null).build());
+        assertEquals("metadataColumns cannot be null", e2.getMessage());
+
+        // rejecting the argument itself, rather than the builder's state, so this is an IllegalArgumentException
+        Exception e3 = assertThrows(IllegalArgumentException.class, () -> IngestMetadataBuilder.builder().setMetadataColumns(Collections.emptyList()).build());
+        assertEquals("metadataColumns cannot be empty", e3.getMessage());
+    }
+
+    @Test
+    public void testInvalidNormalizer() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+
+        Exception e1 = assertThrows(IllegalStateException.class, () -> IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns).build());
+        assertEquals("normalizers must be set", e1.getMessage());
+
+        Exception e2 = assertThrows(NullPointerException.class,
+                        () -> IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns).addNormalizer(null).build());
+        assertEquals("normalizer cannot be null", e2.getMessage());
+    }
+
+    @Test
+    public void testInvalidNormalizers() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+
+        Exception e1 = assertThrows(NullPointerException.class,
+                        () -> IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns).addNormalizers(null).build());
+        assertEquals("normalizers cannot be null", e1.getMessage());
+
+        // rejecting the argument itself, rather than the builder's state, so this is an IllegalArgumentException
+        Exception e2 = assertThrows(IllegalArgumentException.class,
+                        () -> IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns).addNormalizers(Collections.emptyList()).build());
+        assertEquals("normalizers cannot be empty", e2.getMessage());
+    }
+
+    @Test
+    public void testInvalidFieldState() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        //  @formatter:off
+        Exception e = assertThrows(IllegalStateException.class, () -> IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .build());
+        //  @formatter:on
+        assertEquals("alphabetic or numeric fields must be enabled", e.getMessage());
+    }
+
+    @Test
+    public void testInvalidNumShards() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        Exception e1 = assertThrows(IllegalArgumentException.class, () -> IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns)
+                        .addNormalizers(normalizers).enableAlphabeticFields().setNumShards(0).build());
+        assertEquals("numShards must be greater than 0", e1.getMessage());
+
+        Exception e2 = assertThrows(IllegalArgumentException.class, () -> IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns)
+                        .addNormalizers(normalizers).enableAlphabeticFields().setNumShards(-1).build());
+        assertEquals("numShards must be greater than 0", e2.getMessage());
+    }
+
+    @Test
+    public void testCustomNumShards() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableAlphabeticFields()
+                .setNumShards(5)
+                .build();
+        //  @formatter:on
+
+        assertEquals(5, metadata.getNumShards());
+    }
+
+    @Test
+    public void testValidBuild() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        //  @formatter:off
+        //  only alphabetic fields enabled
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableAlphabeticFields()
+                .build();
+        //  @formatter:on
+
+        assertEquals(metadataColumns, metadata.getBaseMetadataColumns());
+        assertEquals(normalizers, metadata.getBaseNormalizers());
+
+        //  @formatter:off
+        //  only numeric fields enabled
+        metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableNumericFields()
+                .build();
+        //  @formatter:on
+
+        assertEquals(metadataColumns, metadata.getBaseMetadataColumns());
+        assertEquals(normalizers, metadata.getBaseNormalizers());
+
+        //  @formatter:off
+        //  both alphabetic and numeric fields enabled
+        metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableAlphabeticFields()
+                .enableNumericFields()
+                .build();
+        //  @formatter:on
+
+        assertEquals(metadataColumns, metadata.getBaseMetadataColumns());
+        assertEquals(normalizers, metadata.getBaseNormalizers());
+    }
+}

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataBuilderTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataBuilderTest.java
@@ -142,4 +142,36 @@ public class IngestMetadataBuilderTest {
         assertEquals(metadataColumns, metadata.getBaseMetadataColumns());
         assertEquals(normalizers, metadata.getBaseNormalizers());
     }
+
+    /**
+     * A builder yields one instance. Were reuse allowed, the seed drawn at builder construction would carry over and the second build would generate data
+     * identical to the first.
+     */
+    @Test
+    public void testBuilderIsSingleUse() {
+        //  @formatter:off
+        IngestMetadataBuilder builder = IngestMetadataBuilder.builder()
+                .setMetadataColumns(List.of(I, E))
+                .addNormalizer(new LcNoDiacriticsType())
+                .enableAlphabeticFields();
+        //  @formatter:on
+
+        builder.build();
+
+        Exception e = assertThrows(IllegalStateException.class, builder::build);
+        assertEquals("build() has already been called on this builder", e.getMessage());
+    }
+
+    /**
+     * A failed build leaves the builder usable, so a caller can correct the configuration and try again.
+     */
+    @Test
+    public void testFailedBuildDoesNotConsumeTheBuilder() {
+        IngestMetadataBuilder builder = IngestMetadataBuilder.builder().setMetadataColumns(List.of(I, E)).addNormalizer(new LcNoDiacriticsType());
+
+        assertThrows(IllegalStateException.class, builder::build);
+
+        // 3 metadata column combinations x 1 normalizer x 2 offsets x 1 field name type, plus the synthetic ID field
+        assertEquals(7, builder.enableAlphabeticFields().build().plan());
+    }
 }

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataBuilderTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataBuilderTest.java
@@ -3,6 +3,7 @@ package datawave.test.framework;
 import static datawave.test.framework.util.MetadataColumn.E;
 import static datawave.test.framework.util.MetadataColumn.I;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
@@ -173,5 +174,18 @@ public class IngestMetadataBuilderTest {
 
         // 3 metadata column combinations x 1 normalizer x 2 offsets x 1 field name type, plus the synthetic ID field
         assertEquals(7, builder.enableAlphabeticFields().build().plan());
+    }
+
+    /**
+     * Each builder draws its own seed. The generator behind them is shared, and were the seed shared along with it, every instance would generate identical
+     * data.
+     */
+    @Test
+    public void testEachBuilderDrawsItsOwnSeed() {
+        assertNotEquals(unseededBuilder().build().getSeed(), unseededBuilder().build().getSeed());
+    }
+
+    private IngestMetadataBuilder unseededBuilder() {
+        return IngestMetadataBuilder.builder().setMetadataColumns(List.of(I, E)).addNormalizer(new LcNoDiacriticsType()).enableAlphabeticFields();
     }
 }

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataTest.java
@@ -1,0 +1,186 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.E;
+import static datawave.test.framework.util.MetadataColumn.I;
+import static datawave.test.framework.util.MetadataColumn.RI;
+import static datawave.test.framework.util.MetadataColumn.TF;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.data.type.DateType;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.NoOpType;
+import datawave.data.type.NumberType;
+import datawave.data.type.Type;
+import datawave.test.framework.util.MetadataColumn;
+
+public class IngestMetadataTest {
+
+    @Test
+    public void testSimplePlan() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableAlphabeticFields()
+                .build();
+        //  @formatter:on
+
+        // 3 metadata column combinations x 1 normalizer x 2 offsets x 1 field name type, plus the synthetic ID field
+        int numUniqueFieldMetadata = metadata.plan();
+        assertEquals(7, numUniqueFieldMetadata);
+    }
+
+    @Test
+    public void testComplexPlan() {
+        List<MetadataColumn> metadataColumns = List.of(I, RI, E, TF);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType(), new NumberType(), new NoOpType());
+
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableAlphabeticFields()
+                .enableNumericFields()
+                .build();
+        //  @formatter:on
+
+        int numUniqueFieldMetadata = metadata.plan();
+        // TF combos paired with a non-text normalizer (NumberType, NoOpType) are skipped: a phrase generator doesn't apply to them.
+        // 29 eligible pairings x 2 offsets x 2 field name types, plus the synthetic ID field
+        assertEquals(117, numUniqueFieldMetadata);
+    }
+
+    /**
+     * {@link IngestMetadata#plan()} exists so a configuration can be sized before it is generated, which is only useful if it agrees with what generation
+     * actually produces. It previously counted neither the per-offset fields nor the synthetic ID field, under-reporting by more than half.
+     */
+    @Test
+    public void testPlanMatchesGeneratedFieldCount() {
+        //  @formatter:off
+        List<List<MetadataColumn>> columnConfigurations = List.of(
+                List.of(I, E),
+                List.of(I, RI, E, TF),
+                List.of(I, E, TF));
+        //  @formatter:on
+
+        for (List<MetadataColumn> columns : columnConfigurations) {
+            //  @formatter:off
+            IngestMetadata metadata = IngestMetadataBuilder.builder()
+                    .setMetadataColumns(columns)
+                    .addNormalizers(List.of(new LcNoDiacriticsType(), new NumberType()))
+                    .enableAlphabeticFields()
+                    .enableNumericFields()
+                    .build();
+            //  @formatter:on
+
+            int planned = metadata.plan();
+            metadata.createEvents(25);
+            assertEquals(planned, metadata.getFieldMetadata().size(), "plan() disagrees with generated field count for columns " + columns);
+        }
+    }
+
+    @Test
+    public void testDefaultNumShards() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        IngestMetadata metadata = IngestMetadataBuilder.builder().setMetadataColumns(metadataColumns).addNormalizers(normalizers).enableAlphabeticFields()
+                        .build();
+
+        assertEquals(IngestMetadata.DEFAULT_NUM_SHARDS, metadata.getNumShards());
+    }
+
+    @Test
+    public void testSimpleCreate() {
+        List<MetadataColumn> metadataColumns = List.of(I, E);
+        List<Type<?>> normalizers = List.of(new LcNoDiacriticsType());
+
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(metadataColumns)
+                .addNormalizers(normalizers)
+                .enableAlphabeticFields()
+                .build();
+        //  @formatter:on
+        metadata.createEvents();
+    }
+
+    /**
+     * A failing statistical run is only actionable if it can be replayed, so the seed logged by {@link IngestMetadata#createEvents(int, int)} must fully
+     * determine the generated values.
+     */
+    @Test
+    public void testSameSeedProducesSameValues() {
+        assertEquals(valuesForSeed(20260202L), valuesForSeed(20260202L));
+    }
+
+    /**
+     * The companion to {@link #testSameSeedProducesSameValues()}: distinct seeds must actually explore distinct data, otherwise seeding would be reproducible
+     * but useless.
+     */
+    @Test
+    public void testDifferentSeedsProduceDifferentValues() {
+        assertNotEquals(valuesForSeed(20260202L), valuesForSeed(20260203L));
+    }
+
+    /**
+     * Generation appends to the field space, so a second call would duplicate every field name and leave {@link IngestMetadata#plan()} reporting half of what
+     * {@link IngestMetadata#getFieldMetadata()} holds. A duplicated field surfaces far from its cause, as a statistical mismatch in an unrelated query.
+     */
+    @Test
+    public void testCreateEventsRejectsASecondCall() {
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(List.of(I, E))
+                .addNormalizers(List.of(new LcNoDiacriticsType()))
+                .enableAlphabeticFields()
+                .build();
+        //  @formatter:on
+        metadata.createEvents();
+        int fieldCount = metadata.getFieldMetadata().size();
+
+        Exception e = assertThrows(IllegalStateException.class, metadata::createEvents);
+        assertEquals("Events have already been created", e.getMessage());
+        assertEquals(fieldCount, metadata.getFieldMetadata().size());
+    }
+
+    /**
+     * A normalizer with no value generator behind it used to fail partway through generation, after some field metadata had already been built. Rejecting it
+     * where it is supplied puts the error at the call the caller can act on.
+     */
+    @Test
+    public void testUnsupportedNormalizerIsRejectedWhenSupplied() {
+        IngestMetadataBuilder builder = IngestMetadataBuilder.builder();
+        Exception e = assertThrows(IllegalArgumentException.class, () -> builder.addNormalizer(new DateType()));
+        assertEquals("normalizer not supported: datawave.data.type.DateType", e.getMessage());
+    }
+
+    private List<String> valuesForSeed(long seed) {
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(List.of(I, E, TF))
+                .addNormalizers(List.of(new LcNoDiacriticsType(), new NumberType()))
+                .enableAlphabeticFields()
+                .enableNumericFields()
+                .setSeed(seed)
+                .build();
+        //  @formatter:on
+        metadata.createEvents(25);
+
+        List<String> values = new ArrayList<>();
+        for (FieldMetadata field : metadata.getFieldMetadata()) {
+            values.addAll(field.getValues());
+        }
+        return values;
+    }
+}

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/IngestMetadataTest.java
@@ -183,4 +183,48 @@ public class IngestMetadataTest {
         }
         return values;
     }
+
+    /**
+     * {@link IngestMetadata} is reachable without the builder, so it must copy what it is handed. A retained list that shifted afterwards would silently change
+     * the field space a query was built against.
+     */
+    @Test
+    public void testConstructorCopiesItsLists() {
+        List<MetadataColumn> metadataColumns = new ArrayList<>(List.of(I, E));
+        List<Type<?>> normalizers = new ArrayList<>(List.of(new LcNoDiacriticsType()));
+
+        IngestMetadata metadata = new IngestMetadata(metadataColumns, normalizers, true, false, 10, 0L);
+        int planned = metadata.plan();
+
+        metadataColumns.add(TF);
+        normalizers.add(new NumberType());
+
+        assertEquals(planned, metadata.plan(), "plan() changed after the source lists were mutated");
+        assertEquals(List.of(I, E), metadata.getBaseMetadataColumns());
+        assertEquals(1, metadata.getBaseNormalizers().size());
+    }
+
+    /**
+     * The copies are handed back as-is, so a caller cannot reach in and alter the plan through an accessor either.
+     */
+    @Test
+    public void testAccessorsAreImmutable() {
+        //  @formatter:off
+        IngestMetadata metadata = IngestMetadataBuilder.builder()
+                .setMetadataColumns(List.of(I, E))
+                .addNormalizer(new LcNoDiacriticsType())
+                .enableAlphabeticFields()
+                .build();
+        //  @formatter:on
+
+        assertThrows(UnsupportedOperationException.class, () -> metadata.getBaseMetadataColumns().add(TF));
+        assertThrows(UnsupportedOperationException.class, () -> metadata.getBaseNormalizers().add(new NumberType()));
+        assertThrows(UnsupportedOperationException.class, () -> metadata.getFieldMetadata().add(new FieldMetadata("FIELD")));
+
+        metadata.createEvents();
+
+        // the accessor is a view, so it reflects generation, and stays read-only afterwards
+        assertEquals(metadata.plan(), metadata.getFieldMetadata().size());
+        assertThrows(UnsupportedOperationException.class, () -> metadata.getFieldMetadata().add(new FieldMetadata("FIELD")));
+    }
 }

--- a/core/datawave-core-test/src/test/java/datawave/test/framework/QueryFieldMetadataTest.java
+++ b/core/datawave-core-test/src/test/java/datawave/test/framework/QueryFieldMetadataTest.java
@@ -1,0 +1,129 @@
+package datawave.test.framework;
+
+import static datawave.test.framework.util.MetadataColumn.E;
+import static datawave.test.framework.util.MetadataColumn.I;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import datawave.test.framework.generators.id.SequentialEventIdGenerator;
+import datawave.test.framework.generators.value.PresetGenerator;
+
+class QueryFieldMetadataTest {
+
+    private QueryFieldMetadata queryFieldMetadata;
+
+    @BeforeEach
+    public void beforeEach() {
+        FieldMetadata indexed = createIndexed();
+        FieldMetadata indexOnly = createIndexOnly();
+        FieldMetadata eventOnly = createEventOnly();
+        FieldMetadata id = createId();
+
+        List<FieldMetadata> fieldMetadata = List.of(indexed, indexOnly, eventOnly, id);
+        queryFieldMetadata = QueryFieldMetadata.of(fieldMetadata);
+    }
+
+    @Test
+    void testGetIndexed() {
+        List<FieldMetadata> results = queryFieldMetadata.getIndexed();
+
+        FieldMetadata indexed = createIndexed();
+        FieldMetadata indexOnly = createIndexOnly();
+        List<FieldMetadata> expected = List.of(indexed, indexOnly);
+        assertEquals(expected, results);
+    }
+
+    /**
+     * The ID field is indexed like a regular content field, but it is a synthetic per-event unique identifier, not a content field under test. It must be
+     * excluded from the generic classification groups so its always-scales-with-event-count value count doesn't leak into the query counts computed from these
+     * groups.
+     */
+    @Test
+    void testGetIndexedExcludesIdField() {
+        List<FieldMetadata> results = queryFieldMetadata.getIndexed();
+        assertEquals(List.of(), results.stream().filter(f -> f.getFieldName().equals(IngestMetadata.ID_FIELD_NAME)).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testGetId() {
+        List<FieldMetadata> results = queryFieldMetadata.getId();
+        assertEquals(List.of(createId()), results);
+    }
+
+    @Test
+    void getIndexOnly() {
+        List<FieldMetadata> results = queryFieldMetadata.getIndexOnly();
+        List<FieldMetadata> expected = List.of(createIndexOnly());
+        assertEquals(expected, results);
+    }
+
+    @Test
+    void testGetEventOnly() {
+        List<FieldMetadata> results = queryFieldMetadata.getEventOnly();
+        List<FieldMetadata> expected = List.of(createEventOnly());
+        assertEquals(expected, results);
+    }
+
+    @Test
+    void getValueCountForEntry() {
+        int count = queryFieldMetadata.getValueCountForEntry(Map.entry("EVENT_ONLY", "e"));
+        assertEquals(2, count);
+    }
+
+    private FieldMetadata createIndexed() {
+        FieldMetadata indexed = new FieldMetadata("INDEXED");
+        indexed.setMetadataColumns(List.of(I, E));
+        indexed.setValueGenerator(PresetGenerator.of(List.of("a", "b")));
+        indexed.setEventIdGenerator(SequentialEventIdGenerator.create());
+        indexed.populateValues(2, 2);
+        return indexed;
+    }
+
+    /**
+     * The obvious usage passes {@code IngestMetadata#getFieldMetadata()} straight in, which hands over the live list. A view that shifted afterwards would
+     * silently change the expected results a query was built against.
+     */
+    @Test
+    void testOfCopiesTheSourceList() {
+        List<FieldMetadata> source = new ArrayList<>(List.of(createIndexed()));
+        QueryFieldMetadata view = QueryFieldMetadata.of(source);
+
+        source.add(createEventOnly());
+
+        assertEquals(List.of(createIndexed()), view.getIndexed());
+    }
+
+    private FieldMetadata createIndexOnly() {
+        FieldMetadata indexOnly = new FieldMetadata("INDEX_ONLY");
+        indexOnly.setMetadataColumns(List.of(I));
+        indexOnly.setValueGenerator(PresetGenerator.of(List.of("c", "d")));
+        indexOnly.setEventIdGenerator(SequentialEventIdGenerator.create());
+        indexOnly.populateValues(2, 2);
+        return indexOnly;
+    }
+
+    private FieldMetadata createEventOnly() {
+        FieldMetadata eventOnly = new FieldMetadata("EVENT_ONLY");
+        eventOnly.setMetadataColumns(List.of(E));
+        eventOnly.setValueGenerator(PresetGenerator.of(List.of("e")));
+        eventOnly.setEventIdGenerator(SequentialEventIdGenerator.create());
+        eventOnly.populateValues(2, 2);
+        return eventOnly;
+    }
+
+    private FieldMetadata createId() {
+        FieldMetadata id = new FieldMetadata(IngestMetadata.ID_FIELD_NAME);
+        id.setMetadataColumns(List.of(I, E));
+        id.setValueGenerator(PresetGenerator.of(List.of("1", "2")));
+        id.setEventIdGenerator(SequentialEventIdGenerator.create());
+        id.populateValues(2, 2);
+        return id;
+    }
+}


### PR DESCRIPTION
Describes the fields an ingest will generate before any data is written, so both the writers and the query generator can work from one plan.