### PR TITLE
Update microservice pom parent version to fix log4j inconsistency

### DIFF
--- a/microservices/services/accumulo/pom.xml
+++ b/microservices/services/accumulo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>accumulo-service-parent</artifactId>

--- a/microservices/services/audit/pom.xml
+++ b/microservices/services/audit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>audit-service-parent</artifactId>

--- a/microservices/services/authorization/pom.xml
+++ b/microservices/services/authorization/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>authorization-service-parent</artifactId>

--- a/microservices/services/dictionary/pom.xml
+++ b/microservices/services/dictionary/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dictionary-service-parent</artifactId>

--- a/microservices/services/file-provider/pom.xml
+++ b/microservices/services/file-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>file-provider-service-parent</artifactId>

--- a/microservices/services/hazelcast/pom.xml
+++ b/microservices/services/hazelcast/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>hazelcast-service-parent</artifactId>

--- a/microservices/services/mapreduce-query/pom.xml
+++ b/microservices/services/mapreduce-query/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>mapreduce-query-service-parent</artifactId>

--- a/microservices/services/modification/pom.xml
+++ b/microservices/services/modification/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>modification-service-parent</artifactId>

--- a/microservices/services/query-executor/pom.xml
+++ b/microservices/services/query-executor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-executor-service-parent</artifactId>

--- a/microservices/services/query-metric/pom.xml
+++ b/microservices/services/query-metric/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-metric-parent</artifactId>

--- a/microservices/services/query/pom.xml
+++ b/microservices/services/query/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>gov.nsa.datawave.microservice</groupId>
         <artifactId>datawave-microservice-parent</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
         <relativePath>../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>query-service-parent</artifactId>


### PR DESCRIPTION
Several service modules (accumulo, audit, authorization, dictionary, file-provider, hazelcast, mapreduce-query, modification, query-executor, query-metric, query) referenced the released datawave-microservice-parent version 4.0.12, which predates the log4j upgrade to 2.26.1 (#3660, released as microservice-parent 4.0.13). As a result, these modules resolved log4j-core/log4j-api/log4j-slf4j2-impl at 2.25.3 instead of the 2.26.1 line used elsewhere in the project.

Bump each affected module's parent reference to
datawave-microservice-parent:4.0.13 so all microservices consistently depend on log4j 2.26.1 via the log4j-bom managed in the parent POM.

Verified with `mvn dependency:tree` in each affected module that log4j-api, log4j-core, and log4j-slf4j2-impl now resolve to 2.26.1.