### PR TITLE
Memoize resolved field types in BaseIngestHelper via FieldLookupCache

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/config/IngestConfiguration.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/config/IngestConfiguration.java
@@ -22,7 +22,7 @@ public interface IngestConfiguration {
         if (fieldConfigFile == null) {
             return null;
         }
-        return XMLFieldConfigHelper.load(fieldConfigFile, helper);
+        return XMLFieldConfigHelper.load(fieldConfigFile, helper, config);
     }
 
     MarkingsHelper getMarkingsHelper(Configuration config, Type dataType);

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldConfigHelperConstants.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldConfigHelperConstants.java
@@ -2,4 +2,18 @@ package datawave.ingest.data.config;
 
 public class FieldConfigHelperConstants {
     public static final String FIELD_CONFIG_FILE = ".data.category.field.config.file";
+
+    /**
+     * Prefix for the settings controlling the field lookup cache in {@link XMLFieldConfigHelper}. Both settings honor an {@code all} datatype fallback -- see
+     * {@link FieldLookupCache}.
+     */
+    public static final String FIELD_CONFIG_CACHE = ".data.category.field.config.cache";
+
+    /**
+     * The maximum number of fields the cache may hold. When unset, the cache is unbounded -- see {@link FieldLookupCache}.
+     */
+    public static final String FIELD_CONFIG_CACHE_MAX_SIZE = FIELD_CONFIG_CACHE + FieldLookupCache.MAX_SIZE_SUFFIX;
+
+    /** What a lookup does once the cache is full, one of {@link FieldLookupCache.OverflowPolicy}. */
+    public static final String FIELD_CONFIG_CACHE_OVERFLOW_POLICY = FIELD_CONFIG_CACHE + FieldLookupCache.OVERFLOW_POLICY_SUFFIX;
 }

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldLookupCache.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/FieldLookupCache.java
@@ -1,0 +1,225 @@
+package datawave.ingest.data.config;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.hadoop.conf.Configuration;
+
+import datawave.ingest.data.TypeRegistry;
+
+/**
+ * A per-key lookup cache backed by a plain {@link HashMap}, with an optional upper bound on the number of entries it may hold and a configurable policy for
+ * what a lookup does once that bound is reached.
+ * <p>
+ * Unbounded by default -- the historical behavior. The two call sites that use this class, {@code BaseIngestHelper}'s resolved field type cache and
+ * {@code XMLFieldConfigHelper}'s resolved field cache, already grew their backing map by one entry per distinct field name (including pattern matches) before
+ * this class existed; the entries are tiny, and the mapper JVMs that hold them are short-lived, so unbounded growth was never a practical problem. Configure a
+ * {@code max.size} only for a datatype with a genuinely unbounded field vocabulary, where capping memory matters more than the cost of the misses a bound
+ * introduces.
+ * <p>
+ * At the bound, {@link OverflowPolicy#BYPASS} resolves a miss without storing it, so the cache never grows past its bound and the set of cached keys is frozen
+ * at whichever ones were seen first; {@link OverflowPolicy#CLEAR} clears the whole cache and starts over, trading periodic cold restarts for keeping whichever
+ * keys are currently hot rather than a possibly stale first-seen set.
+ * <p>
+ * Not thread-safe, matching the {@link HashMap} it wraps: instances are confined to a single thread.
+ *
+ * @param <K>
+ *            the key type
+ * @param <V>
+ *            the value type
+ */
+public final class FieldLookupCache<K,V> {
+
+    /** No bound: the cache grows without limit. The default, and the historical behavior. */
+    public static final int UNBOUNDED = Integer.MAX_VALUE;
+
+    /** Suffix appended to a settings prefix to name the property that carries the maximum cache size. */
+    public static final String MAX_SIZE_SUFFIX = ".max.size";
+
+    /** Suffix appended to a settings prefix to name the property that carries the overflow policy. */
+    public static final String OVERFLOW_POLICY_SUFFIX = ".overflow.policy";
+
+    private static final OverflowPolicy DEFAULT_OVERFLOW_POLICY = OverflowPolicy.BYPASS;
+
+    /** What a lookup does once the cache already holds {@code maxSize} entries and the key it was given is not one of them. */
+    public enum OverflowPolicy {
+        /** Resolve the value but do not store it, so the cache never grows past its bound and its first-seen keys stay cached. */
+        BYPASS,
+        /** Clear the cache and store only the new entry, trading periodic full misses for keeping whichever keys are currently hot. */
+        CLEAR
+    }
+
+    private final HashMap<K,V> map = new HashMap<>();
+    private final int maxSize;
+    private final OverflowPolicy overflowPolicy;
+
+    /**
+     * Create an unbounded cache -- the historical behavior, and the default when nothing is configured.
+     */
+    public FieldLookupCache() {
+        this.maxSize = UNBOUNDED;
+        this.overflowPolicy = DEFAULT_OVERFLOW_POLICY;
+    }
+
+    /**
+     * Create a bounded cache.
+     *
+     * @param maxSize
+     *            the maximum number of entries the cache may hold; must be positive
+     * @param overflowPolicy
+     *            what a lookup does once the cache is full
+     * @throws IllegalArgumentException
+     *             if {@code maxSize} is not positive
+     */
+    public FieldLookupCache(int maxSize, OverflowPolicy overflowPolicy) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize must be greater than zero, but was: " + maxSize);
+        }
+        this.maxSize = maxSize;
+        this.overflowPolicy = overflowPolicy;
+    }
+
+    /**
+     * Return the memoized value for the key, computing and storing it first if this is the first time the key has been seen. A hit costs a single
+     * {@link HashMap#get}. A miss that would grow the cache past its bound is handled according to the configured {@link OverflowPolicy}.
+     *
+     * @param key
+     *            the key
+     * @param fn
+     *            the function used to compute a value when the key is not already cached; must never return {@code null}
+     * @return the cached or newly computed value
+     */
+    public V computeIfAbsent(K key, Function<? super K,? extends V> fn) {
+        V value = map.get(key);
+        if (value != null) {
+            return value;
+        }
+
+        value = fn.apply(key);
+
+        if (map.size() >= maxSize) {
+            if (overflowPolicy == OverflowPolicy.BYPASS) {
+                return value;
+            }
+            map.clear();
+        }
+
+        map.put(key, value);
+        return value;
+    }
+
+    /**
+     * Remove every cached entry.
+     */
+    public void clear() {
+        map.clear();
+    }
+
+    /**
+     * The number of entries currently cached.
+     *
+     * @return the current size
+     */
+    public int size() {
+        return map.size();
+    }
+
+    /**
+     * The configured maximum number of entries.
+     *
+     * @return the maximum size, or {@link #UNBOUNDED}
+     */
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    /**
+     * The configured overflow policy.
+     *
+     * @return the overflow policy
+     */
+    public OverflowPolicy getOverflowPolicy() {
+        return overflowPolicy;
+    }
+
+    /**
+     * An unmodifiable view of the cached entries, for tests to inspect.
+     *
+     * @return an unmodifiable view of the backing map
+     */
+    Map<K,V> asMap() {
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Return the property that supplies this setting: the datatype specific one when it is set, otherwise the {@code all} one.
+     *
+     * @param conf
+     *            the configuration
+     * @param typeName
+     *            the datatype name
+     * @param suffix
+     *            the property suffix, which includes its leading dot
+     * @return the property name
+     */
+    private static String propertyFor(Configuration conf, String typeName, String suffix) {
+        String typeProperty = typeName + suffix;
+        return conf.get(typeProperty) != null ? typeProperty : TypeRegistry.ALL_PREFIX + suffix;
+    }
+
+    /**
+     * Parse the cache described for a datatype: {@code <typeName><prefix>.max.size} and {@code <typeName><prefix>.overflow.policy}, each falling back to
+     * {@code all<prefix>...} when the datatype declares none of its own. When neither the datatype nor {@code all} sets a size, the returned cache is unbounded
+     * and the overflow policy is not read, since it has nothing to act on. When only a size is set, the overflow policy defaults to
+     * {@link OverflowPolicy#BYPASS}.
+     *
+     * @param conf
+     *            the configuration
+     * @param typeName
+     *            the datatype name
+     * @param prefix
+     *            the settings prefix, which includes its leading dot
+     * @param <K>
+     *            the key type
+     * @param <V>
+     *            the value type
+     * @return a new, empty cache built from the parsed settings
+     */
+    public static <K,V> FieldLookupCache<K,V> parse(Configuration conf, String typeName, String prefix) {
+        String maxSizeProperty = propertyFor(conf, typeName, prefix + MAX_SIZE_SUFFIX);
+        String maxSizeValue = conf.get(maxSizeProperty);
+
+        if (maxSizeValue == null) {
+            return new FieldLookupCache<>();
+        }
+
+        int maxSize;
+        try {
+            maxSize = Integer.parseInt(maxSizeValue.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(maxSizeProperty + " must be an integer, but was: " + maxSizeValue, e);
+        }
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException(maxSizeProperty + " must be greater than zero, but was: " + maxSizeValue);
+        }
+
+        String overflowPolicyProperty = propertyFor(conf, typeName, prefix + OVERFLOW_POLICY_SUFFIX);
+        String overflowPolicyValue = conf.get(overflowPolicyProperty);
+
+        OverflowPolicy overflowPolicy = DEFAULT_OVERFLOW_POLICY;
+        if (overflowPolicyValue != null) {
+            try {
+                overflowPolicy = OverflowPolicy.valueOf(overflowPolicyValue.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                                overflowPolicyProperty + " must be one of " + Arrays.toString(OverflowPolicy.values()) + ", but was: " + overflowPolicyValue,
+                                e);
+            }
+        }
+
+        return new FieldLookupCache<>(maxSize, overflowPolicy);
+    }
+}

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/XMLFieldConfigHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/XMLFieldConfigHelper.java
@@ -8,12 +8,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
@@ -39,10 +41,12 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     private final String configSource;
     private final Map<String,FieldInfo> knownFields = new HashMap<>();
     /**
-     * Memoizes the fully resolved FieldInfo per field name, including pattern matches and no-match results. Not thread-safe: instances are confined to a single
-     * thread.
+     * Memoizes the fully resolved FieldInfo per field name, including pattern matches and no-match results. The cache's bound and overflow policy are described
+     * by {@link FieldConfigHelperConstants#FIELD_CONFIG_CACHE}. Not thread-safe: instances are confined to a single thread.
      */
-    private final Map<String,FieldInfo> resolvedFields = new HashMap<>();
+    private final FieldLookupCache<String,FieldInfo> resolvedFields;
+    /** the mapping function passed to {@code computeIfAbsent} on every lookup, held so the capturing method reference is allocated once */
+    private final Function<String,FieldInfo> resolveFieldInfoFunction = this::resolveFieldInfo;
     /**
      * Single-entry "last field looked up" cache in front of {@link #resolvedFields}. Ingest call sites query the same field name several times in a row (once
      * per {@code is*Field} accessor), so checking these two fields first skips the hash probe on repeat lookups. Relies on the same thread confinement as
@@ -73,7 +77,27 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     }
 
     /**
-     * Attempt to load the field config fieldHelper from the specified file, which is expected to be found on the classpath.
+     * Attempt to load the field config fieldHelper from the specified file, which is expected to be found on the classpath, with the field lookup cache
+     * described for this datatype.
+     *
+     * @param fieldConfigFile
+     *            the field configuration file name
+     * @param baseIngestHelper
+     *            the ingest helper
+     * @param conf
+     *            the configuration to read the cache settings from
+     * @throws IllegalArgumentException
+     *             if the file can't be found or an exception occurs when reading the file.
+     * @return null if no a null value was specified for fieldConfigFile - or a populated FieldConfigHelper.
+     */
+    public static XMLFieldConfigHelper load(String fieldConfigFile, BaseIngestHelper baseIngestHelper, Configuration conf) {
+        String typeName = baseIngestHelper.getType().typeName();
+        return load(fieldConfigFile, baseIngestHelper, FieldLookupCache.parse(conf, typeName, FieldConfigHelperConstants.FIELD_CONFIG_CACHE));
+    }
+
+    /**
+     * Attempt to load the field config fieldHelper from the specified file, which is expected to be found on the classpath, with an unbounded field lookup
+     * cache.
      *
      * @param fieldConfigFile
      *            the field configuration file name
@@ -84,6 +108,23 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
      * @return null if no a null value was specified for fieldConfigFile - or a populated FieldConfigHelper.
      */
     public static XMLFieldConfigHelper load(String fieldConfigFile, BaseIngestHelper baseIngestHelper) {
+        return load(fieldConfigFile, baseIngestHelper, new FieldLookupCache<>());
+    }
+
+    /**
+     * Attempt to load the field config fieldHelper from the specified file, which is expected to be found on the classpath.
+     *
+     * @param fieldConfigFile
+     *            the field configuration file name
+     * @param baseIngestHelper
+     *            the ingest helper
+     * @param resolvedFieldCache
+     *            the field lookup cache backing the loaded helper
+     * @throws IllegalArgumentException
+     *             if the file can't be found or an exception occurs when reading the file.
+     * @return null if no a null value was specified for fieldConfigFile - or a populated FieldConfigHelper.
+     */
+    private static XMLFieldConfigHelper load(String fieldConfigFile, BaseIngestHelper baseIngestHelper, FieldLookupCache<String,FieldInfo> resolvedFieldCache) {
         if (fieldConfigFile == null) {
             return null;
         }
@@ -91,7 +132,7 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
         try (InputStream in = getAsStream(fieldConfigFile)) {
             if (in != null) {
                 log.info("Loading field configuration from configuration file: {}", fieldConfigFile);
-                return new XMLFieldConfigHelper(in, baseIngestHelper, fieldConfigFile);
+                return new XMLFieldConfigHelper(in, baseIngestHelper, fieldConfigFile, resolvedFieldCache);
             } else {
                 throw new IllegalArgumentException("Field config file '" + fieldConfigFile + "' not found!");
             }
@@ -131,7 +172,13 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
     }
 
     public XMLFieldConfigHelper(InputStream in, BaseIngestHelper helper, String source) throws ParserConfigurationException, SAXException, IOException {
+        this(in, helper, source, new FieldLookupCache<>());
+    }
+
+    XMLFieldConfigHelper(InputStream in, BaseIngestHelper helper, String source, FieldLookupCache<String,FieldInfo> resolvedFields)
+                    throws ParserConfigurationException, SAXException, IOException {
         this.configSource = source;
+        this.resolvedFields = resolvedFields;
 
         final FieldConfigHandler handler = new FieldConfigHandler(this, helper);
         SAXParser parser = parserFactory.newSAXParser();
@@ -194,7 +241,7 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
         if (fieldName.equals(previousFieldName)) {
             return previousFieldInfo;
         }
-        FieldInfo info = resolvedFields.computeIfAbsent(fieldName, this::resolveFieldInfo);
+        FieldInfo info = resolvedFields.computeIfAbsent(fieldName, resolveFieldInfoFunction);
         previousFieldName = fieldName;
         previousFieldInfo = info;
         return info;
@@ -254,7 +301,7 @@ public final class XMLFieldConfigHelper implements FieldConfigHelper {
         this.noMatchFieldInfo.reverseTokenized = noMatchReverseTokenized;
     }
 
-    Map<String,FieldInfo> getResolvedFields() {
+    FieldLookupCache<String,FieldInfo> getResolvedFields() {
         return this.resolvedFields;
     }
 

--- a/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/data/config/ingest/BaseIngestHelper.java
@@ -1,16 +1,17 @@
 package datawave.ingest.data.config.ingest;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,6 +37,7 @@ import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.DataTypeHelperImpl;
 import datawave.ingest.data.config.FieldConfigHelper;
 import datawave.ingest.data.config.FieldConfigHelperConstants;
+import datawave.ingest.data.config.FieldLookupCache;
 import datawave.ingest.data.config.MarkingsHelper;
 import datawave.ingest.data.config.MaskedFieldHelper;
 import datawave.ingest.data.config.NormalizedContentInterface;
@@ -89,6 +91,20 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
      * datatypes and fields, so a valid value would be something like {@code product.productid.data.field.type.class}
      */
     public static final String FIELD_TYPE = ".data.field.type.class";
+
+    /**
+     * Prefix for the settings controlling the cache of resolved field types. Both settings honor an {@code all} datatype fallback -- see
+     * {@link FieldLookupCache}.
+     */
+    public static final String FIELD_TYPE_CACHE = ".data.field.type.cache";
+
+    /**
+     * The maximum number of fields the resolved type cache may hold. When unset, the cache is unbounded -- see {@link FieldLookupCache}.
+     */
+    public static final String FIELD_TYPE_CACHE_MAX_SIZE = FIELD_TYPE_CACHE + FieldLookupCache.MAX_SIZE_SUFFIX;
+
+    /** What a lookup does once the resolved type cache is full, one of {@link FieldLookupCache.OverflowPolicy}. */
+    public static final String FIELD_TYPE_CACHE_OVERFLOW_POLICY = FIELD_TYPE_CACHE + FieldLookupCache.OVERFLOW_POLICY_SUFFIX;
 
     /**
      * Configuration parameter to specify whether to use type regex hierarchy. If true, this will use the datatype associated with the "most precise" regex. If
@@ -147,6 +163,22 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
     private Multimap<String,datawave.data.type.Type<?>> typeFieldMap = null;
     private Multimap<String,datawave.data.type.Type<?>> typePatternMap = null;
     private TreeMultimap<Matcher,datawave.data.type.Type<?>> typeCompiledPatternMap = null;
+    /**
+     * Memoizes the fully resolved types per field name, including pattern matches and the default-type fallback. Keyed by the field name exactly as supplied,
+     * so a hit costs one hash probe with no case fold and no pattern walk. The cache's bound and overflow policy are described by the {@link #FIELD_TYPE_CACHE}
+     * settings. Not thread-safe: instances are confined to a single thread, as with {@code XMLFieldConfigHelper#resolvedFields}.
+     */
+    private FieldLookupCache<String,ResolvedTypes> typeResolvedMap = new FieldLookupCache<>();
+
+    /** the mapping function passed to {@code computeIfAbsent} on every lookup, held so the capturing method reference is allocated once */
+    private final Function<String,ResolvedTypes> resolveDataTypesFunction = this::resolveDataTypes;
+
+    /**
+     * The resolution shared by every field that falls back to the default type. The default does not vary by field name, so one instance serves them all rather
+     * than a fresh copy per distinct unmatched name. Discarded alongside {@link #typeResolvedMap}, since {@code updateDatawaveTypes(null, ...)} changes it.
+     */
+    private ResolvedTypes defaultResolvedTypes = null;
+
     protected Set<String> indexOnlyFields = Sets.newHashSet();
 
     protected Set<String> indexedFields = Sets.newHashSet();
@@ -192,6 +224,21 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
     protected FieldConfigHelper fieldConfigHelper = null;
 
     /**
+     * The resolved types for a single field name, together with whether they came from a configured entry -- an exact field name or a matching field pattern --
+     * as opposed to the default type.
+     */
+    private static final class ResolvedTypes {
+
+        private final List<datawave.data.type.Type<?>> types;
+        private final boolean configured;
+
+        private ResolvedTypes(List<datawave.data.type.Type<?>> types, boolean configured) {
+            this.types = types;
+            this.configured = configured;
+        }
+    }
+
+    /**
      * This matcher is used to create a deterministic ordering of regular expressions
      */
     public static class MatcherComparator implements Comparator<Matcher> {
@@ -223,6 +270,10 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         this.typeFieldMap.put(null, new NoOpType());
         this.typePatternMap = HashMultimap.create();
         this.typeCompiledPatternMap = null;
+        // rebuilt rather than cleared, so a re-setup picks up a changed cache type or size. must happen before the field
+        // config helper is loaded below, since parsing it calls back into updateDatawaveTypes, which clears this map.
+        this.typeResolvedMap = buildTypeResolvedMap(config);
+        this.defaultResolvedTypes = null;
 
         this.useMostPreciseFieldTypeRegex = config.getBoolean(USE_MOST_PRECISE_FIELD_TYPE_REGEX, false);
 
@@ -256,7 +307,7 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         String configProperty = null;
 
         // Load the field helper, which takes precedence over the individual field configurations
-        this.fieldConfigHelper = ingestConfiguration.getFieldConfigHelper(config, getType(), this);
+        this.fieldConfigHelper = ingestConfiguration.getFieldConfigHelper(config, this.getType(), this);
         if (this.fieldConfigHelper != null && log.isDebugEnabled()) {
             log.debug("Field config specified: {}", this.fieldConfigHelper.describeSource());
         }
@@ -452,6 +503,26 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         }
     }
 
+    /**
+     * Create the cache of resolved field types described by the {@link #FIELD_TYPE_CACHE} settings for this datatype.
+     *
+     * @param config
+     *            the configuration
+     * @return a new, empty cache
+     */
+    private FieldLookupCache<String,ResolvedTypes> buildTypeResolvedMap(Configuration config) {
+        return FieldLookupCache.parse(config, this.getType().typeName(), FIELD_TYPE_CACHE);
+    }
+
+    /**
+     * Expose the resolved type cache for testing.
+     *
+     * @return the cache of resolved field types
+     */
+    FieldLookupCache<String,?> getTypeResolvedCache() {
+        return typeResolvedMap;
+    }
+
     private void moveToPatternMap(Set<String> in, Map<String,Pattern> out) {
         for (Iterator<String> itr = in.iterator(); itr.hasNext();) {
             String str = itr.next();
@@ -605,10 +676,17 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
         return this.compositeIngest.isCompositeField(fieldName);
     }
 
+    /**
+     * Returns whether this field has a type of its own -- configured by exact name or matched by a field pattern -- as opposed to falling back to the default
+     * type.
+     *
+     * @param fieldName
+     *            the field name
+     * @return true if a type is configured for this field
+     */
     @Override
     public boolean isDataTypeField(String fieldName) {
-        return this.typeFieldMap.containsKey(fieldName);
-
+        return resolve(fieldName).configured;
     }
 
     private void compilePatterns() {
@@ -616,52 +694,34 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
                         (o1, o2) -> o1.toString().compareTo(o2.toString()));
         if (typePatternMap != null) {
             for (String pattern : typePatternMap.keySet()) {
-                patterns.putAll(compileFieldNamePattern(pattern), typePatternMap.get(pattern));
+                // field names are upper cased before matching, so compile case insensitively to keep lower cased
+                // patterns from the configuration source reachable
+                patterns.putAll(compileFieldNamePattern(pattern, Pattern.CASE_INSENSITIVE), typePatternMap.get(pattern));
             }
         }
         typeCompiledPatternMap = patterns;
     }
 
     public static Matcher compileFieldNamePattern(String fieldNamePattern) {
-        return Pattern.compile(fieldNamePattern.replace("*", ".*")).matcher("");
+        return compileFieldNamePattern(fieldNamePattern, 0);
+    }
+
+    /**
+     * Compile a field name pattern, applying the supplied {@link Pattern} match flags.
+     *
+     * @param fieldNamePattern
+     *            the field name pattern
+     * @param flags
+     *            the {@link Pattern} match flags to compile with
+     * @return a reusable {@link Matcher} for the pattern
+     */
+    public static Matcher compileFieldNamePattern(String fieldNamePattern, int flags) {
+        return Pattern.compile(fieldNamePattern.replace("*", ".*"), flags).matcher("");
     }
 
     @Override
     public List<datawave.data.type.Type<?>> getDataTypes(String fieldName) {
-
-        final String typeFieldName = fieldName.toUpperCase();
-
-        LinkedList<datawave.data.type.Type<?>> types = new LinkedList<>(typeFieldMap.get(typeFieldName));
-
-        if (types.isEmpty()) {
-            if (typeCompiledPatternMap == null) {
-                compilePatterns();
-            }
-
-            if (useMostPreciseFieldTypeRegex) {
-                Matcher bestMatch = getBestMatch(typeCompiledPatternMap.keySet(), fieldName);
-                if (null != bestMatch) {
-                    Collection<datawave.data.type.Type<?>> bestMatchTypes = typeCompiledPatternMap.get(bestMatch);
-                    types.addAll(bestMatchTypes);
-                    typeFieldMap.putAll(fieldName, bestMatchTypes);
-                }
-            } else {
-                for (Matcher patternMatcher : typeCompiledPatternMap.keySet()) {
-                    if (patternMatcher.reset(fieldName).matches()) {
-                        Collection<datawave.data.type.Type<?>> matchTypes = typeCompiledPatternMap.get(patternMatcher);
-                        types.addAll(matchTypes);
-                        typeFieldMap.putAll(fieldName, matchTypes);
-                    }
-                }
-            }
-        }
-
-        // if no types were defined or matched via regex, use the default
-        if (types.isEmpty()) {
-            types.addAll(typeFieldMap.get(null));
-        }
-
-        return types;
+        return resolve(fieldName).types;
     }
 
     public static Matcher getBestMatch(Set<Matcher> patterns, String fieldName) {
@@ -1198,7 +1258,7 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
      * This method allows updating the typeFieldMap from a derived helper.
      *
      * @param fieldName
-     *            the field name
+     *            the field name, or null to set the default type
      * @param typeClasses
      *            a comma-delimited string of {@link Type} classes
      */
@@ -1216,13 +1276,87 @@ public abstract class BaseIngestHelper extends AbstractIngestHelper implements C
                 log.debug("Setting {} as default type.", datawaveType);
                 typeFieldMap.put(null, datawaveType);
             } else if (fieldName.indexOf('*') >= 0 || fieldName.indexOf('+') >= 0) { // We need a more conclusive test for regex
+                // store the pattern verbatim. upper casing it would corrupt the regex itself (e.g. \d becomes \D, and
+                // inline flags such as (?i) become invalid), so patterns are instead compiled case insensitively.
                 typePatternMap.put(fieldName, datawaveType);
             } else {
-                typeFieldMap.put(fieldName, datawaveType);
+                // types are looked up by upper cased field name, so store exact names that way regardless of the case
+                // supplied by the configuration source.
+                typeFieldMap.put(fieldName.toUpperCase(), datawaveType);
             }
             if (log.isDebugEnabled()) {
                 log.debug("Registered a {} for type[{}], field[{}]", typeClass, this.getType().typeName(), fieldName);
             }
         }
+
+        // registering a type invalidates anything derived from the previous registrations
+        this.typeCompiledPatternMap = null;
+        this.typeResolvedMap.clear();
+        this.defaultResolvedTypes = null;
+    }
+
+    /**
+     * Return the memoized resolution for this field name, resolving it first if it has not been seen yet.
+     *
+     * @param fieldName
+     *            the field name
+     * @return the resolved types for the field
+     */
+    private ResolvedTypes resolve(String fieldName) {
+        return typeResolvedMap.computeIfAbsent(fieldName, resolveDataTypesFunction);
+    }
+
+    /**
+     * Resolve the types for a field name: an exact match on the configured field types first, then the configured field type patterns, and finally the default
+     * type. The result is memoized by {@link #resolve(String)}, so this runs at most once per distinct field name.
+     *
+     * @param fieldName
+     *            the field name
+     * @return the resolved types for the field
+     */
+    private ResolvedTypes resolveDataTypes(String fieldName) {
+
+        // types are registered under upper cased field names and patterns, so fold before matching against either
+        final String typeFieldName = fieldName.toUpperCase();
+
+        List<datawave.data.type.Type<?>> types = new ArrayList<>(typeFieldMap.get(typeFieldName));
+
+        if (types.isEmpty()) {
+            if (typeCompiledPatternMap == null) {
+                compilePatterns();
+            }
+
+            if (useMostPreciseFieldTypeRegex) {
+                Matcher bestMatch = getBestMatch(typeCompiledPatternMap.keySet(), typeFieldName);
+                if (null != bestMatch) {
+                    types.addAll(typeCompiledPatternMap.get(bestMatch));
+                }
+            } else {
+                for (Matcher patternMatcher : typeCompiledPatternMap.keySet()) {
+                    if (patternMatcher.reset(typeFieldName).matches()) {
+                        types.addAll(typeCompiledPatternMap.get(patternMatcher));
+                    }
+                }
+            }
+        }
+
+        // if no types were defined or matched via regex, use the default
+        if (types.isEmpty()) {
+            return defaultResolvedTypes();
+        }
+
+        return new ResolvedTypes(List.copyOf(types), true);
+    }
+
+    /**
+     * Return the resolution shared by every field that falls back to the default type, building it on first use.
+     *
+     * @return the default resolution
+     */
+    private ResolvedTypes defaultResolvedTypes() {
+        if (defaultResolvedTypes == null) {
+            defaultResolvedTypes = new ResolvedTypes(List.copyOf(typeFieldMap.get(null)), false);
+        }
+        return defaultResolvedTypes;
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/FieldLookupCacheTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/FieldLookupCacheTest.java
@@ -1,0 +1,325 @@
+package datawave.ingest.data.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import datawave.ingest.data.config.FieldLookupCache.OverflowPolicy;
+
+class FieldLookupCacheTest {
+
+    private static final String DATA_TYPE_NAME = "test";
+    private static final String PREFIX = ".data.field.type.cache";
+    private static final String MAX_SIZE_PROPERTY = DATA_TYPE_NAME + PREFIX + FieldLookupCache.MAX_SIZE_SUFFIX;
+    private static final String OVERFLOW_POLICY_PROPERTY = DATA_TYPE_NAME + PREFIX + FieldLookupCache.OVERFLOW_POLICY_SUFFIX;
+    private static final String ALL_MAX_SIZE_PROPERTY = "all" + PREFIX + FieldLookupCache.MAX_SIZE_SUFFIX;
+    private static final String ALL_OVERFLOW_POLICY_PROPERTY = "all" + PREFIX + FieldLookupCache.OVERFLOW_POLICY_SUFFIX;
+
+    private Configuration config;
+
+    @BeforeEach
+    void setUp() {
+        config = new Configuration(false);
+    }
+
+    /**
+     * A mapping function that counts how many times it was invoked, so a test can assert a hit never calls it.
+     */
+    private static final class CountingFunction implements Function<String,String> {
+        int calls;
+
+        @Override
+        public String apply(String key) {
+            calls++;
+            return key + "-resolved";
+        }
+    }
+
+    @Nested
+    class UnboundedTests {
+
+        /**
+         * Verify that the default constructor never evicts, however many distinct keys are cached.
+         */
+        @Test
+        void neverEvicts() {
+            FieldLookupCache<String,String> cache = new FieldLookupCache<>();
+
+            for (int i = 0; i < 500; i++) {
+                cache.computeIfAbsent("KEY_" + i, k -> k + "-value");
+            }
+
+            assertEquals(500, cache.size());
+            assertEquals(FieldLookupCache.UNBOUNDED, cache.getMaxSize());
+        }
+
+        /**
+         * Verify that size grows by one per distinct key and is unaffected by repeat lookups of the same key.
+         */
+        @Test
+        void sizeGrowsWithDistinctKeys() {
+            FieldLookupCache<String,String> cache = new FieldLookupCache<>();
+
+            cache.computeIfAbsent("A", k -> "a");
+            cache.computeIfAbsent("A", k -> "a-again");
+            cache.computeIfAbsent("B", k -> "b");
+
+            assertEquals(2, cache.size());
+        }
+    }
+
+    /**
+     * Verify that a hit never invokes the mapping function, regardless of overflow policy.
+     */
+    @Test
+    void hitNeverCallsTheMappingFunction() {
+        FieldLookupCache<String,String> cache = new FieldLookupCache<>(2, OverflowPolicy.BYPASS);
+        CountingFunction fn = new CountingFunction();
+
+        cache.computeIfAbsent("A", fn);
+        cache.computeIfAbsent("A", fn);
+        cache.computeIfAbsent("A", fn);
+
+        assertEquals(1, fn.calls);
+    }
+
+    @Nested
+    class BypassTests {
+
+        /**
+         * Verify that once the cache is full, a miss resolves and returns the value without growing the cache, size stays at the bound, the originally cached
+         * keys remain, and the mapping function is invoked again the next time the bypassed key is looked up.
+         */
+        @Test
+        void bypassesWithoutGrowingPastBound() {
+            FieldLookupCache<String,String> cache = new FieldLookupCache<>(2, OverflowPolicy.BYPASS);
+            CountingFunction fn = new CountingFunction();
+
+            cache.computeIfAbsent("A", fn);
+            cache.computeIfAbsent("B", fn);
+            assertEquals(2, cache.size());
+
+            String value = cache.computeIfAbsent("C", fn);
+            assertEquals("C-resolved", value);
+            assertEquals(2, cache.size());
+            assertTrue(cache.asMap().containsKey("A"));
+            assertTrue(cache.asMap().containsKey("B"));
+            assertFalse(cache.asMap().containsKey("C"));
+
+            int callsBefore = fn.calls;
+            cache.computeIfAbsent("C", fn);
+            assertEquals(callsBefore + 1, fn.calls, "a bypassed key must be resolved again on its next lookup");
+        }
+    }
+
+    @Nested
+    class ClearTests {
+
+        /**
+         * Verify that once the cache is full, a miss clears it and stores only the new entry.
+         */
+        @Test
+        void clearsAndStoresTheNewEntry() {
+            FieldLookupCache<String,String> cache = new FieldLookupCache<>(2, OverflowPolicy.CLEAR);
+
+            cache.computeIfAbsent("A", k -> "a");
+            cache.computeIfAbsent("B", k -> "b");
+            assertEquals(2, cache.size());
+
+            cache.computeIfAbsent("C", k -> "c");
+
+            assertEquals(1, cache.size());
+            assertTrue(cache.asMap().containsKey("C"));
+            assertFalse(cache.asMap().containsKey("A"));
+            assertFalse(cache.asMap().containsKey("B"));
+        }
+    }
+
+    @Nested
+    class ConstructorTests {
+
+        /**
+         * Verify that a non-positive size is rejected by the two argument constructor.
+         */
+        @Test
+        void nonPositiveMaxSizeThrows() {
+            assertThrows(IllegalArgumentException.class, () -> new FieldLookupCache<String,String>(0, OverflowPolicy.BYPASS));
+            assertThrows(IllegalArgumentException.class, () -> new FieldLookupCache<String,String>(-1, OverflowPolicy.CLEAR));
+        }
+    }
+
+    @Nested
+    class ParseTests {
+
+        /**
+         * Verify that an unconfigured datatype gets the historical unbounded cache.
+         */
+        @Test
+        void givenNothingSetThenUnbounded() {
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(FieldLookupCache.UNBOUNDED, cache.getMaxSize());
+        }
+
+        /**
+         * Verify that setting only the size bounds the cache and defaults the overflow policy to BYPASS.
+         */
+        @Test
+        void givenOnlyMaxSizeThenPolicyDefaultsToBypass() {
+            config.set(MAX_SIZE_PROPERTY, "5");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(5, cache.getMaxSize());
+            assertEquals(OverflowPolicy.BYPASS, cache.getOverflowPolicy());
+        }
+
+        /**
+         * Verify that the datatype specific max size wins over the {@code all} one.
+         */
+        @Test
+        void givenDataTypeAndAllMaxSizeThenDataTypeWins() {
+            config.set(ALL_MAX_SIZE_PROPERTY, "10");
+            config.set(MAX_SIZE_PROPERTY, "20");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(20, cache.getMaxSize());
+        }
+
+        /**
+         * Verify that the {@code all} max size applies when the datatype declares none of its own.
+         */
+        @Test
+        void givenOnlyAllMaxSizeThenItApplies() {
+            config.set(ALL_MAX_SIZE_PROPERTY, "10");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(10, cache.getMaxSize());
+        }
+
+        /**
+         * Verify that the datatype specific overflow policy wins over the {@code all} one.
+         */
+        @Test
+        void givenDataTypeAndAllOverflowPolicyThenDataTypeWins() {
+            config.set(MAX_SIZE_PROPERTY, "5");
+            config.set(ALL_OVERFLOW_POLICY_PROPERTY, "BYPASS");
+            config.set(OVERFLOW_POLICY_PROPERTY, "CLEAR");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(OverflowPolicy.CLEAR, cache.getOverflowPolicy());
+        }
+
+        /**
+         * Verify that the {@code all} overflow policy applies when the datatype declares none of its own.
+         */
+        @Test
+        void givenOnlyAllOverflowPolicyThenItApplies() {
+            config.set(MAX_SIZE_PROPERTY, "5");
+            config.set(ALL_OVERFLOW_POLICY_PROPERTY, "CLEAR");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(OverflowPolicy.CLEAR, cache.getOverflowPolicy());
+        }
+
+        /**
+         * Verify that the max size and overflow policy resolve independently, so {@code all} can set one while the datatype sets the other.
+         */
+        @Test
+        void maxSizeAndOverflowPolicyResolveIndependently() {
+            config.set(ALL_MAX_SIZE_PROPERTY, "5");
+            config.set(OVERFLOW_POLICY_PROPERTY, "CLEAR");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(5, cache.getMaxSize());
+            assertEquals(OverflowPolicy.CLEAR, cache.getOverflowPolicy());
+        }
+
+        /**
+         * Verify that overflow policy parsing tolerates surrounding whitespace and any letter case.
+         */
+        @Test
+        void overflowPolicyParsingIsCaseAndWhitespaceInsensitive() {
+            config.set(MAX_SIZE_PROPERTY, "5");
+            config.set(OVERFLOW_POLICY_PROPERTY, " clear ");
+
+            FieldLookupCache<String,String> cache = FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX);
+
+            assertEquals(OverflowPolicy.CLEAR, cache.getOverflowPolicy());
+        }
+
+        /**
+         * Verify that a non-integer max size fails, naming the property that carried it.
+         */
+        @Test
+        void nonIntegerMaxSizeThrows() {
+            config.set(MAX_SIZE_PROPERTY, "many");
+
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX));
+            assertTrue(e.getMessage().contains(MAX_SIZE_PROPERTY), e.getMessage());
+        }
+
+        /**
+         * Verify that a non-positive max size fails, naming the property that carried it.
+         */
+        @Test
+        void nonPositiveMaxSizeThrows() {
+            config.set(MAX_SIZE_PROPERTY, "0");
+
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX));
+            assertTrue(e.getMessage().contains(MAX_SIZE_PROPERTY), e.getMessage());
+        }
+
+        /**
+         * Verify that an unrecognized overflow policy fails, naming the property that carried it.
+         */
+        @Test
+        void unknownOverflowPolicyThrows() {
+            config.set(MAX_SIZE_PROPERTY, "5");
+            config.set(OVERFLOW_POLICY_PROPERTY, "BOGUS");
+
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX));
+            assertTrue(e.getMessage().contains(OVERFLOW_POLICY_PROPERTY), e.getMessage());
+            assertTrue(e.getMessage().contains("BOGUS"), e.getMessage());
+        }
+
+        /**
+         * Verify that a bad max size under {@code all} is reported against the {@code all} property, not the datatype one.
+         */
+        @Test
+        void badAllMaxSizeReportsAllProperty() {
+            config.set(ALL_MAX_SIZE_PROPERTY, "many");
+
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> FieldLookupCache.parse(config, DATA_TYPE_NAME, PREFIX));
+            assertTrue(e.getMessage().contains(ALL_MAX_SIZE_PROPERTY), e.getMessage());
+        }
+    }
+
+    /**
+     * Verify that {@link FieldLookupCache#asMap()} reflects the cache contents but cannot be used to mutate it.
+     */
+    @Test
+    void asMapIsAnUnmodifiableView() {
+        FieldLookupCache<String,String> cache = new FieldLookupCache<>();
+        cache.computeIfAbsent("A", k -> "a");
+
+        Set<String> keys = new HashSet<>(cache.asMap().keySet());
+        assertEquals(Set.of("A"), keys);
+        assertThrows(UnsupportedOperationException.class, () -> cache.asMap().put("B", "b"));
+    }
+}

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/XMLFieldConfigHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/XMLFieldConfigHelperTest.java
@@ -15,13 +15,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.util.List;
-import java.util.Map;
 import java.util.Scanner;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import com.sun.net.httpserver.HttpServer;
 
@@ -31,6 +32,7 @@ import datawave.data.type.HexStringType;
 import datawave.data.type.LcNoDiacriticsType;
 import datawave.data.type.NoOpType;
 import datawave.data.type.Type;
+import datawave.ingest.config.IngestConfigurationFactory;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.ingest.BaseIngestHelper;
 import datawave.ingest.mapreduce.SimpleDataTypeHandler;
@@ -418,14 +420,14 @@ public class XMLFieldConfigHelperTest {
 
         String field = "A";
         XMLFieldConfigHelper helper = new XMLFieldConfigHelper(IOUtils.toInputStream(input, UTF_8), ingestHelper);
-        Map<String,XMLFieldConfigHelper.FieldInfo> cache = helper.getResolvedFields();
+        FieldLookupCache<String,XMLFieldConfigHelper.FieldInfo> cache = helper.getResolvedFields();
 
         // a single lookup resolves and memoizes the whole FieldInfo for the field
-        assertTrue(cache.isEmpty());
+        assertEquals(0, cache.size());
         helper.isStoredField(field);
         assertEquals(1, cache.size());
 
-        XMLFieldConfigHelper.FieldInfo info = cache.get(field);
+        XMLFieldConfigHelper.FieldInfo info = cache.asMap().get(field);
         assertNotNull(info);
         assertTrue(info.stored);
         assertTrue(info.indexed);
@@ -458,14 +460,93 @@ public class XMLFieldConfigHelperTest {
         assertTrue(helper.isIndexOnlyField("C"));
 
         // repeated lookups of a known field return the same cached FieldInfo instance
-        assertSame(info, cache.get(field));
+        assertSame(info, cache.asMap().get(field));
 
         // two different unknown fields resolve to the same shared no-match FieldInfo instance
         helper.isStoredField("UNKNOWNONE");
         helper.isStoredField("UNKNOWNTWO");
-        XMLFieldConfigHelper.FieldInfo noMatchOne = cache.get("UNKNOWNONE");
-        XMLFieldConfigHelper.FieldInfo noMatchTwo = cache.get("UNKNOWNTWO");
+        XMLFieldConfigHelper.FieldInfo noMatchOne = cache.asMap().get("UNKNOWNONE");
+        XMLFieldConfigHelper.FieldInfo noMatchTwo = cache.asMap().get("UNKNOWNTWO");
         assertNotNull(noMatchOne);
         assertSame(noMatchOne, noMatchTwo);
+    }
+
+    /**
+     * The field config XML used by the cache option tests. {@code A}, {@code B} and {@code C} differ from the nomatch defaults, so an evicted and re-resolved
+     * field is still distinguishable from a field the config says nothing about.
+     */
+    private static final String CACHE_TEST_CONFIG = "<?xml version=\"1.0\"?>\n" + "<fieldConfig>\n"
+                    + "    <default stored=\"true\" indexed=\"false\" reverseIndexed=\"false\" tokenized=\"false\" reverseTokenized=\"false\" indexType=\"datawave.data.type.LcNoDiacriticsType\"/>\n"
+                    + "    <nomatch stored=\"false\" indexed=\"false\" reverseIndexed=\"false\" tokenized=\"false\" reverseTokenized=\"false\" indexType=\"datawave.data.type.LcNoDiacriticsType\"/>\n"
+                    + "    <field name=\"A\" indexed=\"true\"/>\n" + "    <field name=\"B\" indexed=\"true\"/>\n" + "    <field name=\"C\" indexed=\"true\"/>\n"
+                    + "</fieldConfig>";
+
+    private XMLFieldConfigHelper cacheTestHelper(FieldLookupCache<String,XMLFieldConfigHelper.FieldInfo> cache) throws Exception {
+        return new XMLFieldConfigHelper(IOUtils.toInputStream(CACHE_TEST_CONFIG, UTF_8), ingestHelper, null, cache);
+    }
+
+    /**
+     * Verify that an unconfigured datatype keeps the historical unbounded cache, whether the helper is built through load or directly.
+     */
+    @Test
+    void shouldDefaultToAnUnboundedCache() throws Exception {
+        assertEquals(FieldLookupCache.UNBOUNDED, cacheTestHelper(new FieldLookupCache<>()).getResolvedFields().getMaxSize());
+
+        XMLFieldConfigHelper loaded = XMLFieldConfigHelper.load("config/sample-field-config.xml", ingestHelper, conf);
+        assertEquals(FieldLookupCache.UNBOUNDED, loaded.getResolvedFields().getMaxSize());
+    }
+
+    /**
+     * Verify that the cache settings declared for the datatype reach the helper loaded for it.
+     */
+    @Test
+    void shouldLoadCacheOptionsFromConfiguration() {
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_CACHE_MAX_SIZE, "2");
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_CACHE_OVERFLOW_POLICY, "CLEAR");
+
+        XMLFieldConfigHelper helper = XMLFieldConfigHelper.load("config/sample-field-config.xml", ingestHelper, conf);
+
+        assertEquals(2, helper.getResolvedFields().getMaxSize());
+        assertEquals(FieldLookupCache.OverflowPolicy.CLEAR, helper.getResolvedFields().getOverflowPolicy());
+    }
+
+    /**
+     * Verify that the cache settings reach the helper along the path production actually takes -- {@code BaseIngestHelper.setup} asks
+     * {@link datawave.ingest.config.IngestConfiguration} for the helper, rather than calling load itself.
+     */
+    @Test
+    void shouldLoadCacheOptionsThroughIngestConfiguration() {
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_FILE, "config/sample-field-config.xml");
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_CACHE_MAX_SIZE, "2");
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_CACHE_OVERFLOW_POLICY, "CLEAR");
+
+        FieldConfigHelper helper = IngestConfigurationFactory.getIngestConfiguration().getFieldConfigHelper(conf, ingestHelper.getType(), ingestHelper);
+
+        assertEquals(2, ((XMLFieldConfigHelper) helper).getResolvedFields().getMaxSize());
+        assertEquals(FieldLookupCache.OverflowPolicy.CLEAR, ((XMLFieldConfigHelper) helper).getResolvedFields().getOverflowPolicy());
+    }
+
+    /**
+     * Verify that a bounded cache stays within its bound under either overflow policy while still answering correctly for the fields it did not keep -- the
+     * ones a {@code BYPASS} cache never got to store, and the ones a {@code CLEAR} cache has since cleared away.
+     */
+    @ParameterizedTest
+    @EnumSource(FieldLookupCache.OverflowPolicy.class)
+    void shouldBoundTheCacheAndStillResolveFieldsItDidNotKeep(FieldLookupCache.OverflowPolicy policy) throws Exception {
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_CACHE_MAX_SIZE, "2");
+        conf.set("test" + FieldConfigHelperConstants.FIELD_CONFIG_CACHE_OVERFLOW_POLICY, policy.name());
+
+        XMLFieldConfigHelper helper = cacheTestHelper(FieldLookupCache.parse(conf, "test", FieldConfigHelperConstants.FIELD_CONFIG_CACHE));
+        FieldLookupCache<String,XMLFieldConfigHelper.FieldInfo> cache = helper.getResolvedFields();
+
+        for (String field : new String[] {"A", "B", "C", "UNKNOWN"}) {
+            helper.isIndexedField(field);
+            assertTrue(cache.size() <= 2, "cache grew past its bound");
+        }
+
+        assertTrue(helper.isIndexedField("A"));
+        assertTrue(helper.isIndexedField("B"));
+        assertTrue(helper.isIndexedField("C"));
+        assertFalse(helper.isIndexedField("UNKNOWN"));
     }
 }

--- a/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/BaseIngestHelperTest.java
+++ b/warehouse/ingest-core/src/test/java/datawave/ingest/data/config/ingest/BaseIngestHelperTest.java
@@ -2,8 +2,14 @@ package datawave.ingest.data.config.ingest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -11,19 +17,59 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.google.common.collect.Multimap;
 
 import datawave.TestBaseIngestHelper;
 import datawave.data.normalizer.Normalizer;
 import datawave.data.type.BaseType;
+import datawave.data.type.DateType;
+import datawave.data.type.HexStringType;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.NoOpType;
+import datawave.data.type.NumberType;
+import datawave.data.type.Type;
+import datawave.ingest.data.RawRecordContainer;
 import datawave.ingest.data.TypeRegistry;
 import datawave.ingest.data.config.DataTypeHelper;
+import datawave.ingest.data.config.FieldLookupCache;
 import datawave.ingest.data.config.NormalizedContentInterface;
 import datawave.ingest.data.config.NormalizedFieldAndValue;
+import datawave.ingest.data.config.XMLFieldConfigHelper;
 import datawave.policy.IngestPolicyEnforcer;
 
 class BaseIngestHelperTest {
 
     private static final String FIELD_CONFIG_FILE = "datawave/ingest/data/config/ingest/BaseIngestHelperTest_IsIndexedFieldTests_field-config.xml";
+
+    private static final String DATA_TYPE_NAME = "test";
+
+    /**
+     * Declares {@code FOO} with its own type, {@code BAR} with no type of its own, a {@code *_DATE} pattern, a {@code default} type applied to fields that
+     * declare no {@code indexType}, and a {@code nomatch} type used for fields the config says nothing about.
+     */
+    private static final String FIELD_TYPE_CONFIG_FILE = "datawave/ingest/data/config/ingest/BaseIngestHelperTest_FieldTypeTests_field-config.xml";
+
+    /**
+     * The configuration shared by the field type tests: the {@code test} datatype wired to {@link TypeTestIngestHelper}, with no field config file declared
+     * yet.
+     */
+    private static Configuration typeTestConfig() {
+        Configuration config = new Configuration();
+        config.set(DataTypeHelper.Properties.DATA_NAME, DATA_TYPE_NAME);
+        config.set(DATA_TYPE_NAME + DataTypeHelper.Properties.INGEST_POLICY_ENFORCER_CLASS, IngestPolicyEnforcer.NoOpIngestPolicyEnforcer.class.getName());
+        config.set(TypeRegistry.INGEST_DATA_TYPES, DATA_TYPE_NAME);
+        config.set(DATA_TYPE_NAME + TypeRegistry.INGEST_HELPER, TypeTestIngestHelper.class.getName());
+        TypeRegistry.reset();
+        return config;
+    }
+
+    private static void assertSoleType(Class<?> expected, List<Type<?>> types) {
+        assertEquals(1, types.size(), "Expected a single type, but was: " + types);
+        assertInstanceOf(expected, types.get(0));
+    }
 
     /**
      * Executes tests for {@link BaseIngestHelper#isIndexedField(String)}.
@@ -259,6 +305,311 @@ class BaseIngestHelperTest {
 
             assertEquals(1, calls.get(), "a failing normalize should not be retried");
             assertTrue(result.getError() != null, "the failure should be recorded on the result");
+        }
+    }
+
+    /**
+     * Executes tests for {@link BaseIngestHelper#getDataTypes(String)} and {@link BaseIngestHelper#isDataTypeField(String)}.
+     */
+    @Nested
+    class FieldTypeTests {
+
+        private Configuration config;
+        private TypeTestIngestHelper ingestHelper;
+
+        @BeforeEach
+        void setUp() {
+            config = typeTestConfig();
+            ingestHelper = new TypeTestIngestHelper();
+        }
+
+        /**
+         * Set up the helper against {@link #FIELD_TYPE_CONFIG_FILE}.
+         */
+        private TypeTestIngestHelper helperWithFieldConfig() {
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_CONFIG_FILE, FIELD_TYPE_CONFIG_FILE);
+            ingestHelper.setup(config);
+            return ingestHelper;
+        }
+
+        /**
+         * Set up the helper and then apply the given field config XML to it.
+         */
+        private TypeTestIngestHelper helperWithFieldConfig(String xml) throws Exception {
+            ingestHelper.setup(config);
+            // constructing the config helper is what registers the declared types with the ingest helper
+            new XMLFieldConfigHelper(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), ingestHelper);
+            return ingestHelper;
+        }
+
+        /**
+         * Verify that a field declaring its own type resolves to that type.
+         */
+        @Test
+        void givenFieldWithDeclaredTypeThenDeclaredTypeIsUsed() {
+            assertSoleType(HexStringType.class, helperWithFieldConfig().getDataTypes("FOO"));
+        }
+
+        /**
+         * Verify that a declared field with no type of its own resolves to the type from the {@code default} tag.
+         */
+        @Test
+        void givenFieldWithNoDeclaredTypeThenDefaultTagTypeIsUsed() {
+            assertSoleType(LcNoDiacriticsType.class, helperWithFieldConfig().getDataTypes("BAR"));
+        }
+
+        /**
+         * Verify that a field matching a declared pattern resolves to the pattern's type.
+         */
+        @Test
+        void givenFieldMatchingPatternThenPatternTypeIsUsed() {
+            assertSoleType(DateType.class, helperWithFieldConfig().getDataTypes("SOME_DATE"));
+        }
+
+        /**
+         * Verify that a field the config says nothing about resolves to the {@code nomatch} type, and keeps resolving to it on repeat calls. Prior to memoizing
+         * the default-type fallback, this path re-walked the pattern list on every call.
+         */
+        @Test
+        void givenUnknownFieldThenNoMatchTypeIsUsed() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            assertSoleType(NumberType.class, helper.getDataTypes("UNKNOWN"));
+            assertSoleType(NumberType.class, helper.getDataTypes("UNKNOWN"));
+        }
+
+        /**
+         * Verify that repeated lookups return the memoized result rather than resolving anew.
+         */
+        @Test
+        void givenRepeatedLookupsThenMemoizedResultIsReturned() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            assertSame(helper.getDataTypes("FOO"), helper.getDataTypes("FOO"));
+            assertSame(helper.getDataTypes("SOME_DATE"), helper.getDataTypes("SOME_DATE"));
+            assertSame(helper.getDataTypes("UNKNOWN"), helper.getDataTypes("UNKNOWN"));
+        }
+
+        /**
+         * Verify that a lower cased field name resolves to the same types as its upper cased form, for both an exact entry and a pattern match.
+         */
+        @Test
+        void givenLowerCaseFieldNameThenSameTypesResolve() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            assertSoleType(HexStringType.class, helper.getDataTypes("foo"));
+            assertSoleType(HexStringType.class, helper.getDataTypes("FOO"));
+            assertSoleType(DateType.class, helper.getDataTypes("some_date"));
+            assertSoleType(DateType.class, helper.getDataTypes("SOME_DATE"));
+        }
+
+        /**
+         * Verify that lower cased names and patterns in a field config are reachable, i.e. that the types they declare are not silently ignored.
+         */
+        @Test
+        void givenLowerCaseFieldConfigEntriesThenTypesResolve() throws Exception {
+            String xml = "<?xml version=\"1.0\"?>\n" + "<fieldConfig>\n"
+                            + "    <default stored=\"true\" indexed=\"true\" reverseIndexed=\"false\" tokenized=\"false\" reverseTokenized=\"false\" indexType=\"datawave.data.type.LcNoDiacriticsType\"/>\n"
+                            + "    <nomatch stored=\"true\" indexed=\"false\" reverseIndexed=\"false\" tokenized=\"false\" reverseTokenized=\"false\" indexType=\"datawave.data.type.NumberType\"/>\n"
+                            + "    <field name=\"lower\" indexType=\"datawave.data.type.HexStringType\"/>\n"
+                            + "    <fieldPattern pattern=\"*_lowerdate\" indexType=\"datawave.data.type.DateType\"/>\n" + "</fieldConfig>";
+
+            TypeTestIngestHelper helper = helperWithFieldConfig(xml);
+            assertSoleType(HexStringType.class, helper.getDataTypes("LOWER"));
+            assertSoleType(HexStringType.class, helper.getDataTypes("lower"));
+            assertSoleType(DateType.class, helper.getDataTypes("SOME_LOWERDATE"));
+            assertSoleType(DateType.class, helper.getDataTypes("some_lowerdate"));
+        }
+
+        /**
+         * Verify that regex metacharacters in a field pattern survive registration. Upper casing the pattern text would invert character classes, e.g.
+         * {@code \d} would become {@code \D}, and the pattern would match the wrong fields.
+         */
+        @Test
+        void givenPatternWithCharacterClassThenClassIsNotInverted() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            helper.updateDatawaveTypes("FOO_\\d+", HexStringType.class.getName());
+
+            assertSoleType(HexStringType.class, helper.getDataTypes("FOO_123"));
+            // a non-numeric suffix must fall through to the nomatch type, not match an inverted \D+
+            assertSoleType(NumberType.class, helper.getDataTypes("FOO_ABC"));
+        }
+
+        /**
+         * Verify that a pattern carrying an inline flag still compiles. Upper casing the pattern text would turn {@code (?i)} into {@code (?I)}, which throws a
+         * {@link java.util.regex.PatternSyntaxException} when the patterns are compiled.
+         */
+        @Test
+        void givenPatternWithInlineFlagThenPatternCompiles() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            helper.updateDatawaveTypes("(?i)baz.*", HexStringType.class.getName());
+
+            assertSoleType(HexStringType.class, helper.getDataTypes("BAZ_ONE"));
+        }
+
+        /**
+         * Verify that a field with a configured type is reported as a data type field, whether the type came from an exact entry or a pattern, and regardless
+         * of whether the types have already been resolved for that field.
+         */
+        @Test
+        void givenConfiguredFieldThenIsDataTypeField() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+
+            assertTrue(helper.isDataTypeField("FOO"));
+            assertTrue(helper.isDataTypeField("SOME_DATE"));
+            assertTrue(helper.isDataTypeField("some_date"));
+
+            helper.getDataTypes("FOO");
+            helper.getDataTypes("SOME_DATE");
+            helper.getDataTypes("some_date");
+
+            assertTrue(helper.isDataTypeField("FOO"));
+            assertTrue(helper.isDataTypeField("SOME_DATE"));
+            assertTrue(helper.isDataTypeField("some_date"));
+        }
+
+        /**
+         * Verify that a field falling back to the default type is not reported as a data type field, before or after its types are resolved.
+         */
+        @Test
+        void givenUnconfiguredFieldThenIsNotDataTypeField() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+
+            assertFalse(helper.isDataTypeField("UNKNOWN"));
+            helper.getDataTypes("UNKNOWN");
+            assertFalse(helper.isDataTypeField("UNKNOWN"));
+        }
+
+        /**
+         * Verify that types registered after a field has already been resolved take effect, rather than the stale resolution being served from the memo.
+         */
+        @Test
+        void givenTypesRegisteredAfterResolutionThenMemoIsInvalidated() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            assertSoleType(NumberType.class, helper.getDataTypes("LATE"));
+            assertFalse(helper.isDataTypeField("LATE"));
+
+            helper.updateDatawaveTypes("LATE", HexStringType.class.getName());
+
+            assertSoleType(HexStringType.class, helper.getDataTypes("LATE"));
+            assertTrue(helper.isDataTypeField("LATE"));
+        }
+
+        /**
+         * Verify that a second setup discards the types and resolutions from the first.
+         */
+        @Test
+        void givenSecondSetupThenPriorResolutionsAreDiscarded() {
+            TypeTestIngestHelper helper = helperWithFieldConfig();
+            assertSoleType(HexStringType.class, helper.getDataTypes("FOO"));
+
+            config.unset(DATA_TYPE_NAME + BaseIngestHelper.FIELD_CONFIG_FILE);
+            helper.setup(config);
+
+            // with the field config gone, FOO has no configured type and falls back to the NoOpType default
+            assertFalse(helper.isDataTypeField("FOO"));
+            assertSoleType(NoOpType.class, helper.getDataTypes("FOO"));
+        }
+    }
+
+    /**
+     * Covers the settings that choose the cache backing the resolved field types.
+     */
+    @Nested
+    class FieldTypeCacheTests {
+
+        private Configuration config;
+        private TypeTestIngestHelper ingestHelper;
+
+        @BeforeEach
+        void setUp() {
+            config = typeTestConfig();
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_CONFIG_FILE, FIELD_TYPE_CONFIG_FILE);
+            ingestHelper = new TypeTestIngestHelper();
+        }
+
+        /**
+         * Verify that an unconfigured datatype keeps the historical unbounded cache.
+         */
+        @Test
+        void givenNoSettingsThenCacheIsUnbounded() {
+            ingestHelper.setup(config);
+            assertEquals(FieldLookupCache.UNBOUNDED, ingestHelper.getTypeResolvedCache().getMaxSize());
+        }
+
+        /**
+         * Verify that a bounded cache stays within its bound under either overflow policy while still resolving types correctly for the fields it did not keep
+         * -- the ones a {@code BYPASS} cache never got to store, and the ones a {@code CLEAR} cache has since cleared away.
+         */
+        @ParameterizedTest
+        @EnumSource(FieldLookupCache.OverflowPolicy.class)
+        void givenBoundedSettingsThenCacheIsBounded(FieldLookupCache.OverflowPolicy policy) {
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_MAX_SIZE, "2");
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_OVERFLOW_POLICY, policy.name());
+            ingestHelper.setup(config);
+
+            assertEquals(2, ingestHelper.getTypeResolvedCache().getMaxSize());
+            assertEquals(policy, ingestHelper.getTypeResolvedCache().getOverflowPolicy());
+
+            for (String field : new String[] {"FOO", "BAR", "SOME_DATE", "UNKNOWN"}) {
+                ingestHelper.getDataTypes(field);
+                assertTrue(ingestHelper.getTypeResolvedCache().size() <= 2, "cache grew past its bound");
+            }
+
+            assertSoleType(HexStringType.class, ingestHelper.getDataTypes("FOO"));
+            assertSoleType(LcNoDiacriticsType.class, ingestHelper.getDataTypes("BAR"));
+            assertSoleType(DateType.class, ingestHelper.getDataTypes("SOME_DATE"));
+            assertSoleType(NumberType.class, ingestHelper.getDataTypes("UNKNOWN"));
+        }
+
+        /**
+         * Verify that the settings are read under the datatype this helper was set up for, so an {@code all} setting reaches it. The full precedence matrix
+         * belongs to {@code FieldLookupCacheTest}; this only checks the wiring.
+         */
+        @Test
+        void givenAllSettingThenItReachesTheCache() {
+            config.set(TypeRegistry.ALL_PREFIX + BaseIngestHelper.FIELD_TYPE_CACHE_MAX_SIZE, "2");
+            config.set(TypeRegistry.ALL_PREFIX + BaseIngestHelper.FIELD_TYPE_CACHE_OVERFLOW_POLICY, "CLEAR");
+            ingestHelper.setup(config);
+
+            assertEquals(2, ingestHelper.getTypeResolvedCache().getMaxSize());
+            assertEquals(FieldLookupCache.OverflowPolicy.CLEAR, ingestHelper.getTypeResolvedCache().getOverflowPolicy());
+        }
+
+        /**
+         * Verify that a second setup rebuilds the cache with the new bound rather than merely emptying the first one.
+         */
+        @Test
+        void givenSecondSetupThenCacheImplementationIsSwapped() {
+            ingestHelper.setup(config);
+            assertEquals(FieldLookupCache.UNBOUNDED, ingestHelper.getTypeResolvedCache().getMaxSize());
+
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_MAX_SIZE, "2");
+            ingestHelper.setup(config);
+
+            assertEquals(2, ingestHelper.getTypeResolvedCache().getMaxSize());
+        }
+
+        /**
+         * Verify that an unusable cache setting fails setup rather than being silently ignored.
+         */
+        @Test
+        void givenInvalidSettingsThenSetupThrows() {
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_MAX_SIZE, "2");
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_OVERFLOW_POLICY, "BOGUS");
+            assertThrows(IllegalArgumentException.class, () -> ingestHelper.setup(config));
+
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_OVERFLOW_POLICY, "BYPASS");
+            config.set(DATA_TYPE_NAME + BaseIngestHelper.FIELD_TYPE_CACHE_MAX_SIZE, "0");
+            assertThrows(IllegalArgumentException.class, () -> ingestHelper.setup(config));
+        }
+    }
+
+    /**
+     * A minimal concrete helper. Unlike {@link TestBaseIngestHelper}, it does not override {@link BaseIngestHelper#isDataTypeField(String)}.
+     */
+    public static class TypeTestIngestHelper extends BaseIngestHelper {
+
+        @Override
+        public Multimap<String,NormalizedContentInterface> getEventFields(RawRecordContainer event) {
+            return null;
         }
     }
 }

--- a/warehouse/ingest-core/src/test/resources/datawave/ingest/data/config/ingest/BaseIngestHelperTest_FieldTypeTests_field-config.xml
+++ b/warehouse/ingest-core/src/test/resources/datawave/ingest/data/config/ingest/BaseIngestHelperTest_FieldTypeTests_field-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<fieldConfig>
+    <default stored="true" indexed="true" reverseIndexed="false" tokenized="false" reverseTokenized="false" indexType="datawave.data.type.LcNoDiacriticsType"/>
+    <nomatch stored="true" indexed="false" reverseIndexed="false" tokenized="false" reverseTokenized="false" indexType="datawave.data.type.NumberType"/>
+    <fieldPattern pattern="*_DATE" indexType="datawave.data.type.DateType"/>
+    <field name="FOO" indexType="datawave.data.type.HexStringType"/>
+    <!-- no indexType, so the type declared by the default tag applies -->
+    <field name="BAR"/>
+</fieldConfig>


### PR DESCRIPTION
getDataTypes re-walked the compiled field type patterns on every call for any field that fell through to the default type, since that path never populated typeFieldMap. Resolve each distinct field name once into a memoized result holding the types and whether they came from a configured entry, and invalidate the memo on setup and on updateDatawaveTypes.

The memo is backed by a plain HashMap and unbounded by default, matching prior behavior; a datatype with a genuinely unbounded field vocabulary can cap it via <typeName>.<prefix>.max.size (data type cache and field cache each configured separately), with a configurable overflow policy once the map hits that threshold.

isDataTypeField now reports on the same resolution, so a field matched only by a pattern is recognized as a data type field. Pattern matching and updateDatawaveTypes both fold the field name to upper case, matching how types are keyed, so lower cased names and patterns in a field config are no longer silently unreachable.

AI was used to help create and validate the pull request.