### PR TITLE
Make test fork reuse and heap configurable per module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,13 +38,13 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>${surefire.reuseForks}</reuseForks>
                         <forkCount>${surefire.forkCount}</forkCount>
                         <threadCount>1</threadCount>
                         <threadCountClasses>1</threadCountClasses>
                         <threadCountMethods>0</threadCountMethods>
                         <threadCountSuites>0</threadCountSuites>
-                        <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx1024m -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
+                        <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${surefire.maxMemory} -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <runOrder>random</runOrder>
                     </configuration>

--- a/microservices/configcheck/pom.xml
+++ b/microservices/configcheck/pom.xml
@@ -23,6 +23,8 @@
         <skipUTs>${skipTests}</skipUTs>
         <spotbugs.excludes.file />
         <surefire.forkCount>1C</surefire.forkCount>
+        <surefire.maxMemory>1024m</surefire.maxMemory>
+        <surefire.reuseForks>false</surefire.reuseForks>
         <!-- 2.14.X is the maximum version of jackson without snakeyaml version 2 causing spring-boot 2.7.1 conflict -->
         <version.jackson>2.14.3</version.jackson>
         <version.junit5>5.12.0</version.junit5>
@@ -379,13 +381,13 @@
                 <version>3.5.2</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
-                    <reuseForks>false</reuseForks>
+                    <reuseForks>${surefire.reuseForks}</reuseForks>
                     <forkCount>${surefire.forkCount}</forkCount>
                     <threadCount>1</threadCount>
                     <threadCountClasses>1</threadCountClasses>
                     <threadCountMethods>0</threadCountMethods>
                     <threadCountSuites>0</threadCountSuites>
-                    <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx1024m -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
+                    <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${surefire.maxMemory} -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <runOrder>random</runOrder>
                 </configuration>

--- a/microservices/microservice-parent/pom.xml
+++ b/microservices/microservice-parent/pom.xml
@@ -53,6 +53,8 @@
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
         <spotbugs.excludes.file />
         <surefire.forkCount>1C</surefire.forkCount>
+        <surefire.maxMemory>1024m</surefire.maxMemory>
+        <surefire.reuseForks>false</surefire.reuseForks>
         <version.hadoop>3.3.4</version.hadoop>
         <!-- 2.14.X is the maximum version of jackson without snakeyaml version 2 causing spring-boot 2.7.1 conflict -->
         <version.jackson>2.14.3</version.jackson>
@@ -468,13 +470,13 @@
                     <version>3.5.2</version>
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>${surefire.reuseForks}</reuseForks>
                         <forkCount>${surefire.forkCount}</forkCount>
                         <threadCount>1</threadCount>
                         <threadCountClasses>1</threadCountClasses>
                         <threadCountMethods>0</threadCountMethods>
                         <threadCountSuites>0</threadCountSuites>
-                        <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx1024m -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc= -Dcom.google.protobuf.use_unsafe_pre22_gencode</argLine>
+                        <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${surefire.maxMemory} -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc= -Dcom.google.protobuf.use_unsafe_pre22_gencode</argLine>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <runOrder>random</runOrder>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
         <build.env>dev</build.env>
         <container.registry>ghcr.io</container.registry>
         <env>dev</env>
+        <!-- Integration-test fork settings. Default to the surefire values so a module only has to set
+             the surefire property to move both plugins; override these to split unit and integration tests. -->
+        <failsafe.maxMemory>${surefire.maxMemory}</failsafe.maxMemory>
+        <failsafe.reuseForks>${surefire.reuseForks}</failsafe.reuseForks>
         <image.prefix>datawave/</image.prefix>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -51,6 +55,12 @@
         <sonar.exclusions>**/StandardLexer.java,**/*.js,**/*.css,**/*.html</sonar.exclusions>
         <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
         <surefire.forkCount>1C</surefire.forkCount>
+        <!-- Test JVM heap. Override in a module that needs more or less than the inherited default. -->
+        <surefire.maxMemory>1024m</surefire.maxMemory>
+        <!-- Fork per test class. A module whose tests do not leak static state can set this to true in its
+             own properties to reuse forks and skip the per-class JVM startup. Verify the module's tests
+             still pass before enabling: shared static caches and registries are the usual blocker. -->
+        <surefire.reuseForks>false</surefire.reuseForks>
         <version.accumulo>2.1.5</version.accumulo>
         <version.arquillian>1.4.1.Final</version.arquillian>
         <version.arquillian-weld-ee-embedded>1.0.0.Final</version.arquillian-weld-ee-embedded>
@@ -1934,7 +1944,7 @@
                     <configuration>
                         <skipTests>${skipTests}</skipTests>
                         <skipITs>${skipITs}</skipITs>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>${failsafe.reuseForks}</reuseForks>
                         <forkCount>${surefire.forkCount}</forkCount>
                         <threadCount>1</threadCount>
                         <threadCountClasses>1</threadCountClasses>

--- a/warehouse/core/pom.xml
+++ b/warehouse/core/pom.xml
@@ -9,6 +9,13 @@
     <artifactId>datawave-core</artifactId>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
+    <properties>
+        <!-- Unit tests run at a smaller heap than the warehouse default; integration tests keep it. -->
+        <failsafe.maxMemory>2g</failsafe.maxMemory>
+        <surefire.maxMemory>1024m</surefire.maxMemory>
+        <!-- This module's tests do not leak static state between classes, so forks are reused. -->
+        <surefire.reuseForks>true</surefire.reuseForks>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.beust</groupId>
@@ -232,13 +239,13 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
-                    <reuseForks>false</reuseForks>
+                    <reuseForks>${surefire.reuseForks}</reuseForks>
                     <forkCount>${surefire.forkCount}</forkCount>
                     <threadCount>1</threadCount>
                     <threadCountClasses>0</threadCountClasses>
                     <threadCountMethods>1</threadCountMethods>
                     <threadCountSuites>0</threadCountSuites>
-                    <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx1024m -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
+                    <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${surefire.maxMemory} -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED</argLine>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <runOrder>random</runOrder>

--- a/warehouse/pom.xml
+++ b/warehouse/pom.xml
@@ -43,6 +43,7 @@
         <!-- Unless a version is duplicated multiple times, just place the version on the dependency in dependencyManagement. -->
         <!-- <runOrder>random</runOrder> -->
         <runOrder>filesystem</runOrder>
+        <surefire.maxMemory>2g</surefire.maxMemory>
         <!-- default value -->
         <tests.to.skip />
         <!-- default value - override on command-line to skip tests -->
@@ -523,14 +524,14 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>${surefire.reuseForks}</reuseForks>
                         <forkCount>${surefire.forkCount}</forkCount>
                         <threadCount>1</threadCount>
                         <threadCountClasses>1</threadCountClasses>
                         <threadCountMethods>0</threadCountMethods>
                         <threadCountSuites>0</threadCountSuites>
                         <!-- BT_ROOT is for the tests that use basis tokenization -->
-                        <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -DBT_ROOT=${env.BT_ROOT} -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx2g -Djava.library.path=${env.HADOOP_HOME}/lib/native -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
+                        <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -DBT_ROOT=${env.BT_ROOT} -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${surefire.maxMemory} -Djava.library.path=${env.HADOOP_HOME}/lib/native -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
                             --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED</argLine>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <runOrder>${runOrder}</runOrder>
@@ -595,8 +596,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration combine.children="append">
-                    <reuseForks>false</reuseForks>
-                    <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -DBT_ROOT=${env.BT_ROOT} -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx2g -Djava.library.path=${env.HADOOP_HOME}/lib/native -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
+                    <reuseForks>${failsafe.reuseForks}</reuseForks>
+                    <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -DBT_ROOT=${env.BT_ROOT} -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${failsafe.maxMemory} -Djava.library.path=${env.HADOOP_HOME}/lib/native -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED</argLine>
                     <groups>datawave.common.test.integration.IntegrationTest</groups>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/web-services/deploy/spring-framework-integration/pom.xml
+++ b/web-services/deploy/spring-framework-integration/pom.xml
@@ -216,7 +216,7 @@
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                     <argLine>@{argLine}</argLine>
-                    <reuseForks>false</reuseForks>
+                    <reuseForks>${surefire.reuseForks}</reuseForks>
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.build.directory}/conf</additionalClasspathElement>
                         <additionalClasspathElement>${project.parent.basedir}/web-service/properties</additionalClasspathElement>

--- a/web-services/pom.xml
+++ b/web-services/pom.xml
@@ -33,6 +33,7 @@
         <!-- Control the rpm release number, for a final release change the rpm.release.number from the timestamp property to the number 1 -->
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <rpm.release.number>${timestamp}</rpm.release.number>
+        <surefire.maxMemory>2g</surefire.maxMemory>
         <timestamp>${maven.build.timestamp}</timestamp>
         <version.abdera>1.1.3</version.abdera>
         <version.asm>4.0</version.asm>
@@ -537,13 +538,13 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
-                        <reuseForks>false</reuseForks>
+                        <reuseForks>${surefire.reuseForks}</reuseForks>
                         <forkCount>${surefire.forkCount}</forkCount>
                         <threadCount>1</threadCount>
                         <threadCountClasses>0</threadCountClasses>
                         <threadCountMethods>1</threadCountMethods>
                         <threadCountSuites>0</threadCountSuites>
-                        <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx2g -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
+                        <argLine>@{argLine} -XX:+TieredCompilation -XX:TieredStopAtLevel=1  -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${surefire.maxMemory} -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
                             --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</argLine>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <runOrder>random</runOrder>
@@ -610,8 +611,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration combine.children="append">
-                    <reuseForks>false</reuseForks>
-                    <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -DBT_ROOT=${env.BT_ROOT} -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx2g -Djava.library.path=${env.HADOOP_HOME}/lib/native -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
+                    <reuseForks>${failsafe.reuseForks}</reuseForks>
+                    <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1  -DBT_ROOT=${env.BT_ROOT} -Dfile.encoding=UTF8 -Duser.timezone=GMT -Xmx${failsafe.maxMemory} -Djava.library.path=${env.HADOOP_HOME}/lib/native -Dapple.awt.UIElement=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED</argLine>
                     <groups>datawave.common.test.integration.IntegrationTest</groups>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>


### PR DESCRIPTION
Replaces the reuseForks and -Xmx values hardcoded in each parent pom with surefire/failsafe properties so a module can opt in from its own properties. Defaults preserve the current settings everywhere except warehouse/core, whose 162 tests pass repeatedly with forks reused.