### PR TITLE
Evict metadata helper caches between query-core test classes

### DIFF
--- a/warehouse/query-core/src/test/java/datawave/query/util/MetadataHelperCacheEvictor.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/MetadataHelperCacheEvictor.java
@@ -1,0 +1,46 @@
+package datawave.query.util;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Empties the metadata helper caches before each test class.
+ * <p>
+ * The metadata lookups on {@link AllFieldMetadataHelper}, {@link TypeMetadataHelper} and {@link datawave.query.composite.CompositeMetadataHelper} are
+ * {@code @Cacheable} keyed by {auths, metadataTableName} - never by Accumulo instance. Spring hands every test class sharing a context configuration the same
+ * application context, and so the same cache manager, while each class ingests into an Accumulo instance of its own under the same table names and auths.
+ * Without this eviction a class that runs second in a JVM reads the first class's field metadata and rejects its own fields as non-existent.
+ * <p>
+ * Fork-per-class hid this because the cache died with the JVM. It matters as soon as {@code surefire.reuseForks} is on.
+ */
+public class MetadataHelperCacheEvictor implements BeforeAllCallback {
+
+    private static final String CACHE_MANAGER_BEAN = "metadataHelperCacheManager";
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        // this is registered for every test class in the module, most of which never stand up a spring context
+        if (!AnnotatedElementUtils.hasAnnotation(context.getRequiredTestClass(), ContextConfiguration.class)) {
+            return;
+        }
+
+        ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
+        if (!applicationContext.containsBean(CACHE_MANAGER_BEAN)) {
+            return;
+        }
+
+        CacheManager cacheManager = applicationContext.getBean(CACHE_MANAGER_BEAN, CacheManager.class);
+        for (String cacheName : cacheManager.getCacheNames()) {
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache != null) {
+                cache.clear();
+            }
+        }
+    }
+}

--- a/warehouse/query-core/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/warehouse/query-core/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+datawave.query.util.MetadataHelperCacheEvictor

--- a/warehouse/query-core/src/test/resources/junit-platform.properties
+++ b/warehouse/query-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# Registers MetadataHelperCacheEvictor for every test class in this module. See that class for why.
+junit.jupiter.extensions.autodetection.enabled=true


### PR DESCRIPTION
Groundwork for reusing surefire forks in this module, and inert until that is enabled. The @Cacheable metadata lookups are keyed by {auths, metadataTableName} rather than by Accumulo instance, so with forks reused a test class reads the previous class's field metadata and rejects its own fields as non-existent.