### PR TITLE
Update references to Hadoop com.sun.jersey dependencies

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -10,9 +10,9 @@
     <!-- Declare all datawave modules as dependencies in order to have the javadoc include all the datawave source. -->
     <dependencies>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>1.9</version>
+            <version>2.46</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/warehouse/ingest-csv/pom.xml
+++ b/warehouse/ingest-csv/pom.xml
@@ -52,7 +52,7 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.sun.jersey</groupId>
+                    <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
@@ -74,7 +74,7 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.sun.jersey</groupId>
+                    <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>

--- a/warehouse/pom.xml
+++ b/warehouse/pom.xml
@@ -288,7 +288,7 @@
                 <version>${version.hadoop}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>com.sun.jersey</groupId>
+                        <groupId>org.glassfish.jersey.core</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
                     <exclusion>


### PR DESCRIPTION
Hadoop 3.5.0 uses Jersey 2.x (org.glassfish.jersey) instead of the legacy Jersey 1.x (com.sun.jersey). Update references to it throughout relevant pom files.