### PR TITLE
Bugfix/list ivarator union drops documents

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/ExceededOr.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/nodes/ExceededOr.java
@@ -20,6 +20,7 @@ import org.apache.log4j.Logger;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import datawave.core.common.logging.ThreadConfigurableLogger;
@@ -106,7 +107,7 @@ public class ExceededOr {
      *            the source node
      * @return The field associated with this ExceededOrThresholdMarker
      */
-    private String decodeField(JexlNode source) {
+    public static String decodeField(JexlNode source) {
         Map<String,Object> parameters = JexlASTHelper.getAssignments(source);
         Object paramsObj = parameters.get(EXCEEDED_OR_FIELD);
         if (paramsObj != null) {
@@ -130,6 +131,27 @@ public class ExceededOr {
         if (paramsObj != null) {
             try {
                 return objectMapper.readValue(String.valueOf(paramsObj), ExceededOrParams.class);
+            } catch (JsonProcessingException e) {
+                log.error("Unable to read exceeded or params from node", e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the parameters for this marker node as a list of strings
+     *
+     * @param source
+     *            the source
+     * @return The params as a list of strings
+     */
+    public static List<String> decodeParamsList(JexlNode source) {
+        Map<String,Object> parameters = JexlASTHelper.getAssignments(source);
+        Object paramsObj = parameters.get(EXCEEDED_OR_PARAMS);
+        if (paramsObj != null) {
+            try {
+                Map<String,List<String>> jsonMap = objectMapper.readValue(String.valueOf(paramsObj), new TypeReference<>() {});
+                return jsonMap.get("values");
             } catch (JsonProcessingException e) {
                 log.error("Unable to read exceeded or params from node", e);
             }

--- a/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EventDataQueryExpressionVisitor.java
+++ b/warehouse/query-core/src/main/java/datawave/query/jexl/visitors/EventDataQueryExpressionVisitor.java
@@ -41,6 +41,8 @@ import datawave.query.jexl.JexlASTHelper;
 import datawave.query.jexl.LiteralRange;
 import datawave.query.jexl.functions.JexlFunctionArgumentDescriptorFactory;
 import datawave.query.jexl.functions.arguments.JexlArgumentDescriptor;
+import datawave.query.jexl.nodes.ExceededOr;
+import datawave.query.jexl.nodes.QueryPropertyMarker;
 import datawave.query.predicate.PeekingPredicate;
 
 /**
@@ -124,6 +126,10 @@ public class EventDataQueryExpressionVisitor extends BaseVisitor {
 
         public void addFieldValue(String value) {
             fieldValues.add(value);
+        }
+
+        public void addFieldValues(List<String> values) {
+            fieldValues.addAll(values);
         }
 
         public void setNullValueFlag() {
@@ -416,11 +422,30 @@ public class EventDataQueryExpressionVisitor extends BaseVisitor {
 
     @Override
     public Object visit(ASTAndNode node, Object data) {
-        LiteralRange range = JexlASTHelper.findRange().getRange(node);
-        if (range != null) {
-            simpleRangeFilter(range);
+        QueryPropertyMarker.Instance marker = QueryPropertyMarker.findInstance(node);
+
+        // List ivarator does not have field and params in the same node
+        if (marker.isType(QueryPropertyMarker.MarkerType.EXCEEDED_OR)) {
+            String fieldName = ExceededOr.decodeField(node);
+            List<String> params = ExceededOr.decodeParamsList(node);
+            ExpressionFilter f = filterMap.get(fieldName);
+
+            if (f == null) {
+                filterMap.put(fieldName, f = createExpressionFilter(fieldName));
+            }
+
+            if (params != null) {
+                f.addFieldValues(params);
+            }
+
+            return data;
         } else {
-            super.visit(node, data);
+            LiteralRange range = JexlASTHelper.findRange().getRange(node);
+            if (range != null) {
+                simpleRangeFilter(range);
+            } else {
+                super.visit(node, data);
+            }
         }
 
         return null;

--- a/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
+++ b/warehouse/query-core/src/main/java/datawave/query/predicate/TLDEventDataFilter.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 
 import datawave.query.Constants;
 import datawave.query.jexl.JexlASTHelper;
+import datawave.query.jexl.nodes.ExceededOr;
 import datawave.query.jexl.visitors.EventDataQueryExpressionVisitor.ExpressionFilter;
 import datawave.table.util.TLD;
 
@@ -551,6 +552,13 @@ public class TLDEventDataFilter extends EventDataQueryExpressionFilter {
         for (ASTIdentifier identifier : identifiers) {
             ids.add(JexlASTHelper.deconstructIdentifier(identifier));
         }
+
+        // List ivarator keeps field as ASTStringLiteral
+        String fieldName = ExceededOr.decodeField(script);
+        if (fieldName != null) {
+            ids.add(fieldName);
+        }
+
         return ids;
     }
 

--- a/warehouse/query-core/src/test/java/datawave/query/ListIvaratorUnionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ListIvaratorUnionQueryTest.java
@@ -237,8 +237,7 @@ public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
         givenQuery(query());
         // the pushdown happens in the visitor function, so the planned query is still the union
         expectPlan(plannedQuery());
-        // BUG: every document is dropped. this should be MATCHING, with the uuids and hit terms asserted above
-        expectResultCount(0);
+        expectResultCount(MATCHING);
 
         expectListIvarator = true;
         planAndExecuteQuery();

--- a/warehouse/query-core/src/test/java/datawave/query/ListIvaratorUnionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ListIvaratorUnionQueryTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
@@ -33,7 +31,9 @@ import com.google.common.base.Preconditions;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
-import datawave.data.type.LcNoDiacriticsType;
+import datawave.data.type.IpAddressType;
+import datawave.data.type.LcType;
+import datawave.query.index.day.IndexIngestUtil;
 import datawave.query.iterator.QueryIterator;
 import datawave.query.iterator.QueryOptions;
 import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
@@ -42,22 +42,26 @@ import datawave.query.tables.ShardQueryLogic;
 import datawave.query.tables.async.event.VisitorFunction;
 import datawave.query.util.AbstractIngest;
 import datawave.query.util.AbstractQueryTest;
-import datawave.table.constants.TableName;
+import datawave.query.util.TestIndexTableNames;
 
 /**
- * Asserts that a union of equality terms returns the same documents whether the union is executed as a union of field index iterators or is pushed down into a
- * list ivarator.
+ * Pins a defect in the large fielded list pushdown for top level document queries.
  * <p>
- * The pushdown is performed by the {@link VisitorFunction}, not by the {@link DefaultQueryPlanner}, so the plan asserted by {@link #expectPlan(String)} is the
- * union in both cases. The distinguishing assertion is made against the query that exits the visitor function -- see
- * {@link #assertPlanExitingVisitorFunction()}.
- * <p>
- * The two tests differ only in {@code maxOrExpansionThreshold}:
+ * The query is an anchor union intersected with a union of addresses, {@code (A || B) && (IP1 || IP2 || ...)}, run against a top level document logic where the
+ * addresses live on child documents. Both tests query identical data and differ only in {@code maxOrExpansionThreshold}:
  * <ul>
- * <li>{@link #testUnionIsNotPushedDownWhenThresholdIsHigh()} keeps the threshold above the number of terms in the union, so the union survives intact</li>
- * <li>{@link #testUnionIsPushedDownIntoListIvarator()} drops the threshold below the number of terms, so the union becomes a list ivarator</li>
+ * <li>{@link #testUnionIsNotPushedDownWhenThresholdIsHigh()} keeps the threshold above the size of the address union, so the union survives as a union of field
+ * index iterators and every matching document is returned</li>
+ * <li>{@link #testUnionIsPushedDownIntoListIvarator()} drops the threshold below the size of the address union, so the {@link VisitorFunction} replaces it with
+ * a list ivarator - and <b>no documents are returned at all</b></li>
  * </ul>
- * Both tests expect the same documents. A difference between them is a defect in the pushdown, not in the query.
+ * <b>The defect:</b> {@code TLDIndexBuildingVisitor} overrides {@code visit(ASTEQNode)} so that an equality term builds a {@code TLDIndexIteratorBuilder},
+ * which rolls a hit on a child document's field index entry up to its top level document uid. It does not override {@code ivarateList}, so the pushed down
+ * union builds a plain {@code IndexListIteratorBuilder} instead. That ivarator emits the child uid unchanged, which never intersects the top level uids
+ * produced by the anchor union, and the intersection empties out.
+ * <p>
+ * The expectations below record the <b>current, incorrect</b> behavior so that a fix is forced to update them. {@link #testUnionIsPushedDownIntoListIvarator()}
+ * should return the same documents as {@link #testUnionIsNotPushedDownWhenThresholdIsHigh()}.
  */
 @ExtendWith(SpringExtension.class)
 @ComponentScan(basePackages = "datawave.query")
@@ -71,9 +75,7 @@ import datawave.table.constants.TableName;
 // @formatter:on
 public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
 
-    private static final Logger log = LoggerFactory.getLogger(ListIvaratorUnionQueryTest.class);
-
-    /** The label of the query property marker that denotes a list ivarator */
+    /** the label of the query property marker that denotes a list ivarator */
     private static final String LIST_MARKER = "_List_";
 
     @TempDir
@@ -84,17 +86,23 @@ public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
     private static AccumuloClient client;
     private static AbstractIngest ingest;
 
-    /** The values written to FIELD_A, one per document */
-    private static final List<String> VALUES = List.of("alpha", "bravo", "charlie", "delta", "echo", "foxtrot");
+    /** number of top level documents written */
+    private static final int DOCS = 6;
+    /** number of child documents, each holding one address, written per top level document */
+    private static final int ADDRESSES_PER_DOC = 2;
+    /** documents 0..MATCHING-1 carry an anchor value, the rest are excluded by the anchor union */
+    private static final int MATCHING = 4;
 
-    /** The uuid of the document that holds the value at the same offset in {@link #VALUES} */
-    private static final List<String> UUIDS = List.of("uuid-1", "uuid-2", "uuid-3", "uuid-4", "uuid-5", "uuid-6");
+    /** every address written, and therefore every address queried */
+    private static final List<String> ADDRESSES = new ArrayList<>();
+    /** the uuid of each top level document, in write order */
+    private static final List<String> UUIDS = new ArrayList<>();
 
-    /** Set when a test expects the visitor function to push the union down into a list ivarator */
+    /** set when a test expects the visitor function to push the address union down into a list ivarator */
     private boolean expectListIvarator = false;
 
     @Autowired
-    @Qualifier("EventQuery")
+    @Qualifier("TLDEventQuery")
     protected ShardQueryLogic logic;
 
     @Override
@@ -118,13 +126,13 @@ public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
     }
 
     /**
-     * {@link AbstractIngest} only populates the standard shard index, so the alternate index tables are not exercised here.
+     * The addresses resolve to whole shards rather than to individual documents, so the 'no uid' index is the relevant index format here.
      *
-     * @return the shard index table name
+     * @return the 'no uid' index table name
      */
     @Override
     protected List<String> getIndexTableNames() {
-        return List.of(TableName.SHARD_INDEX);
+        return List.of(TestIndexTableNames.NO_UID_INDEX);
     }
 
     @BeforeAll
@@ -134,16 +142,35 @@ public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
 
         ingest = new AbstractIngest(client, auths);
 
-        ingest.registerField("UUID", new LcNoDiacriticsType());
+        ingest.registerField("UUID", new LcType());
         ingest.registerColumns("UUID", List.of("i", "e"));
 
-        ingest.registerField("FIELD_A", new LcNoDiacriticsType());
-        ingest.registerColumns("FIELD_A", List.of("i", "e"));
+        ingest.registerField("ANCHOR", new LcType());
+        ingest.registerColumns("ANCHOR", List.of("i", "e"));
 
-        for (int i = 0; i < VALUES.size(); i++) {
-            ingest.writeFV(i + 1, "UUID", UUIDS.get(i));
-            ingest.writeFV(i + 1, "FIELD_A", VALUES.get(i));
+        ingest.registerField("IP", new IpAddressType());
+        ingest.registerColumns("IP", List.of("i", "e"));
+
+        for (int i = 0; i < DOCS; i++) {
+            String uuid = String.format("uuid-%02d", i);
+            UUIDS.add(uuid);
+
+            // the top level document carries the uuid and the anchor
+            ingest.writeFV(i + 1, "UUID", uuid);
+            ingest.writeFV(i + 1, "ANCHOR", (i >= MATCHING) ? "other" : (i % 2 == 0 ? "left" : "right"));
+
+            // the addresses are repeated values, so they live on child documents whose uid is the top
+            // level uid suffixed with '.N'. their field index entries are written against that child uid.
+            String topLevelUid = ingest.uid(i + 1);
+            for (int j = 0; j < ADDRESSES_PER_DOC; j++) {
+                String address = "200." + i + ".0." + (j + 1);
+                ADDRESSES.add(address);
+                ingest.writeFVForUid(ingest.getRow(), ingest.getDatatype(), topLevelUid + "." + (j + 1), "IP", address);
+            }
         }
+
+        // derive the alternate index tables, including the 'no uid' index used by this test
+        new IndexIngestUtil().write(client, auths);
     }
 
     @BeforeEach
@@ -164,75 +191,96 @@ public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
         logic.setIndexedMaxTermThreshold(1_000);
         logic.setFinalMaxTermThreshold(1_000);
 
-        // keep the fst threshold out of the way so the pushdown always produces an inline list of values
+        // keep the fst threshold out of the way so a pushdown always produces an inline list of values
         logic.setMaxOrExpansionFstThreshold(1_000);
 
         expectListIvarator = false;
 
         givenDate(ingest.getDate());
+        // a top level document holds several addresses, so only one of them is returned
+        givenParameter(QueryParameters.LIMIT_FIELDS, "IP=1");
     }
 
     /**
-     * A pushdown threshold larger than the union prevents the union from being pushed down. The query executes as a union of field index iterators.
+     * A pushdown threshold larger than the address union prevents the union from being pushed down. Every matching top level document is returned.
      *
      * @throws Exception
      *             if something goes wrong
      */
     @Test
     public void testUnionIsNotPushedDownWhenThresholdIsHigh() throws Exception {
-        logic.setMaxOrExpansionThreshold(VALUES.size() + 1);
+        logic.setMaxOrExpansionThreshold(ADDRESSES.size() + 1);
 
-        givenQuery(union());
-        expectPlan(union());
-        expectResultCount(VALUES.size());
-        expectUUIDs(Set.copyOf(UUIDS));
+        givenQuery(query());
+        expectPlan(plannedQuery());
+        expectResultCount(MATCHING);
+        expectUUIDs(Set.copyOf(UUIDS.subList(0, MATCHING)));
 
         expectListIvarator = false;
         planAndExecuteQuery();
     }
 
     /**
-     * A pushdown threshold smaller than the union causes the visitor function to replace the union with a list ivarator. The same documents must be returned.
+     * A pushdown threshold smaller than the address union causes the visitor function to replace it with a list ivarator, and the query then returns nothing.
+     * <p>
+     * The correct expectations are the ones asserted by {@link #testUnionIsNotPushedDownWhenThresholdIsHigh()}: {@code MATCHING} documents carrying the same
+     * uuids and hit terms. See the class javadoc for the defect this pins.
      *
      * @throws Exception
      *             if something goes wrong
      */
     @Test
     public void testUnionIsPushedDownIntoListIvarator() throws Exception {
-        logic.setMaxOrExpansionThreshold(2);
+        // large enough to leave the two term anchor union alone, small enough to push the address union down
+        logic.setMaxOrExpansionThreshold(3);
 
-        givenQuery(union());
-        // the planner does not perform the pushdown, so the planned query is still the union
-        expectPlan(union());
-        expectResultCount(VALUES.size());
-        expectUUIDs(Set.copyOf(UUIDS));
+        givenQuery(query());
+        // the pushdown happens in the visitor function, so the planned query is still the union
+        expectPlan(plannedQuery());
+        // BUG: every document is dropped. this should be MATCHING, with the uuids and hit terms asserted above
+        expectResultCount(0);
 
         expectListIvarator = true;
         planAndExecuteQuery();
     }
 
     /**
-     * Build the union of equality terms, one term per value in {@link #VALUES}.
+     * Build the query, an anchor union intersected with a union of every address written.
      *
-     * @return the union
+     * @return the query
      */
-    private static String union() {
+    private static String query() {
         //  @formatter:off
-        return VALUES.stream()
-                        .map(value -> "FIELD_A == '" + value + "'")
+        String addressUnion = ADDRESSES.stream()
+                        .map(address -> "IP == '" + address + "'")
                         .collect(Collectors.joining(" || "));
         //  @formatter:on
+        return "(ANCHOR == 'left' || ANCHOR == 'right') && (" + addressUnion + ")";
+    }
+
+    /**
+     * Build the expected query plan. The planner normalizes each address to its zero padded form.
+     *
+     * @return the expected plan
+     */
+    private static String plannedQuery() {
+        IpAddressType type = new IpAddressType();
+        //  @formatter:off
+        String addressUnion = ADDRESSES.stream()
+                        .map(address -> "IP == '" + type.normalize(address) + "'")
+                        .collect(Collectors.joining(" || "));
+        //  @formatter:on
+        return "(ANCHOR == 'left' || ANCHOR == 'right') && (" + addressUnion + ")";
     }
 
     /**
      * Assert whether the query that exits the {@link VisitorFunction} contains a list ivarator.
      * <p>
-     * The large fielded list pushdown runs per-scan-range inside the visitor function rather than in the planner, so it is invisible to
-     * {@link #expectPlan(String)}. Running the visitor function over the planned query reproduces exactly the query that is shipped to the tablet server.
+     * The large fielded list pushdown runs per scan range inside the visitor function rather than in the planner, so it is invisible to
+     * {@link #expectPlan(String)}. Running the visitor function over the planned query reproduces the query that is shipped to the tablet server.
      */
     private void assertPlanExitingVisitorFunction() {
         String plan = planExitingVisitorFunction();
-        log.info("plan exiting the visitor function: {}", plan);
 
         if (expectListIvarator) {
             assertTrue(plan.contains(LIST_MARKER), "expected a list ivarator in the plan exiting the visitor function but got: " + plan);

--- a/warehouse/query-core/src/test/java/datawave/query/ListIvaratorUnionQueryTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/ListIvaratorUnionQueryTest.java
@@ -1,0 +1,266 @@
+package datawave.query;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.google.common.base.Preconditions;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.data.type.LcNoDiacriticsType;
+import datawave.query.iterator.QueryIterator;
+import datawave.query.iterator.QueryOptions;
+import datawave.query.iterator.ivarator.IvaratorCacheDirConfig;
+import datawave.query.planner.DefaultQueryPlanner;
+import datawave.query.tables.ShardQueryLogic;
+import datawave.query.tables.async.event.VisitorFunction;
+import datawave.query.util.AbstractIngest;
+import datawave.query.util.AbstractQueryTest;
+import datawave.table.constants.TableName;
+
+/**
+ * Asserts that a union of equality terms returns the same documents whether the union is executed as a union of field index iterators or is pushed down into a
+ * list ivarator.
+ * <p>
+ * The pushdown is performed by the {@link VisitorFunction}, not by the {@link DefaultQueryPlanner}, so the plan asserted by {@link #expectPlan(String)} is the
+ * union in both cases. The distinguishing assertion is made against the query that exits the visitor function -- see
+ * {@link #assertPlanExitingVisitorFunction()}.
+ * <p>
+ * The two tests differ only in {@code maxOrExpansionThreshold}:
+ * <ul>
+ * <li>{@link #testUnionIsNotPushedDownWhenThresholdIsHigh()} keeps the threshold above the number of terms in the union, so the union survives intact</li>
+ * <li>{@link #testUnionIsPushedDownIntoListIvarator()} drops the threshold below the number of terms, so the union becomes a list ivarator</li>
+ * </ul>
+ * Both tests expect the same documents. A difference between them is a defect in the pushdown, not in the query.
+ */
+@ExtendWith(SpringExtension.class)
+@ComponentScan(basePackages = "datawave.query")
+// @formatter:off
+@ContextConfiguration(locations = {
+        "classpath:datawave/query/QueryLogicFactory.xml",
+        "classpath:beanRefContext.xml",
+        "classpath:MarkingFunctionsContext.xml",
+        "classpath:MetadataHelperContext.xml",
+        "classpath:CacheContext.xml"})
+// @formatter:on
+public class ListIvaratorUnionQueryTest extends AbstractQueryTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ListIvaratorUnionQueryTest.class);
+
+    /** The label of the query property marker that denotes a list ivarator */
+    private static final String LIST_MARKER = "_List_";
+
+    @TempDir
+    public static Path folder;
+
+    private static final Authorizations auths = new Authorizations("ALL");
+
+    private static AccumuloClient client;
+    private static AbstractIngest ingest;
+
+    /** The values written to FIELD_A, one per document */
+    private static final List<String> VALUES = List.of("alpha", "bravo", "charlie", "delta", "echo", "foxtrot");
+
+    /** The uuid of the document that holds the value at the same offset in {@link #VALUES} */
+    private static final List<String> UUIDS = List.of("uuid-1", "uuid-2", "uuid-3", "uuid-4", "uuid-5", "uuid-6");
+
+    /** Set when a test expects the visitor function to push the union down into a list ivarator */
+    private boolean expectListIvarator = false;
+
+    @Autowired
+    @Qualifier("EventQuery")
+    protected ShardQueryLogic logic;
+
+    @Override
+    public ShardQueryLogic getLogic() {
+        return logic;
+    }
+
+    @Override
+    public Authorizations getAuths() {
+        return auths;
+    }
+
+    @Override
+    protected void extraConfigurations() {
+        // no-op
+    }
+
+    @Override
+    protected void extraAssertions() {
+        assertPlanExitingVisitorFunction();
+    }
+
+    /**
+     * {@link AbstractIngest} only populates the standard shard index, so the alternate index tables are not exercised here.
+     *
+     * @return the shard index table name
+     */
+    @Override
+    protected List<String> getIndexTableNames() {
+        return List.of(TableName.SHARD_INDEX);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        InMemoryInstance instance = new InMemoryInstance(ListIvaratorUnionQueryTest.class.getName());
+        client = new InMemoryAccumuloClient("", instance);
+
+        ingest = new AbstractIngest(client, auths);
+
+        ingest.registerField("UUID", new LcNoDiacriticsType());
+        ingest.registerColumns("UUID", List.of("i", "e"));
+
+        ingest.registerField("FIELD_A", new LcNoDiacriticsType());
+        ingest.registerColumns("FIELD_A", List.of("i", "e"));
+
+        for (int i = 0; i < VALUES.size(); i++) {
+            ingest.writeFV(i + 1, "UUID", UUIDS.get(i));
+            ingest.writeFV(i + 1, "FIELD_A", VALUES.get(i));
+        }
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        setClientForTest(client);
+
+        // an ivarator cannot be built without an hdfs configuration and a cache directory, and the visitor
+        // function will not attempt a pushdown unless both are present
+        URL hadoopConfig = this.getClass().getResource("/testhadoop.config");
+        Preconditions.checkNotNull(hadoopConfig);
+        logic.setHdfsSiteConfigURLs(hadoopConfig.toExternalForm());
+        logic.setIvaratorCacheDirConfigs(Collections.singletonList(new IvaratorCacheDirConfig(folder.toUri().toString())));
+
+        // raise the term thresholds out of the way so that the size of the union is governed only by
+        // the pushdown threshold under test
+        logic.setInitialMaxTermThreshold(1_000);
+        logic.setIntermediateMaxTermThreshold(1_000);
+        logic.setIndexedMaxTermThreshold(1_000);
+        logic.setFinalMaxTermThreshold(1_000);
+
+        // keep the fst threshold out of the way so the pushdown always produces an inline list of values
+        logic.setMaxOrExpansionFstThreshold(1_000);
+
+        expectListIvarator = false;
+
+        givenDate(ingest.getDate());
+    }
+
+    /**
+     * A pushdown threshold larger than the union prevents the union from being pushed down. The query executes as a union of field index iterators.
+     *
+     * @throws Exception
+     *             if something goes wrong
+     */
+    @Test
+    public void testUnionIsNotPushedDownWhenThresholdIsHigh() throws Exception {
+        logic.setMaxOrExpansionThreshold(VALUES.size() + 1);
+
+        givenQuery(union());
+        expectPlan(union());
+        expectResultCount(VALUES.size());
+        expectUUIDs(Set.copyOf(UUIDS));
+
+        expectListIvarator = false;
+        planAndExecuteQuery();
+    }
+
+    /**
+     * A pushdown threshold smaller than the union causes the visitor function to replace the union with a list ivarator. The same documents must be returned.
+     *
+     * @throws Exception
+     *             if something goes wrong
+     */
+    @Test
+    public void testUnionIsPushedDownIntoListIvarator() throws Exception {
+        logic.setMaxOrExpansionThreshold(2);
+
+        givenQuery(union());
+        // the planner does not perform the pushdown, so the planned query is still the union
+        expectPlan(union());
+        expectResultCount(VALUES.size());
+        expectUUIDs(Set.copyOf(UUIDS));
+
+        expectListIvarator = true;
+        planAndExecuteQuery();
+    }
+
+    /**
+     * Build the union of equality terms, one term per value in {@link #VALUES}.
+     *
+     * @return the union
+     */
+    private static String union() {
+        //  @formatter:off
+        return VALUES.stream()
+                        .map(value -> "FIELD_A == '" + value + "'")
+                        .collect(Collectors.joining(" || "));
+        //  @formatter:on
+    }
+
+    /**
+     * Assert whether the query that exits the {@link VisitorFunction} contains a list ivarator.
+     * <p>
+     * The large fielded list pushdown runs per-scan-range inside the visitor function rather than in the planner, so it is invisible to
+     * {@link #expectPlan(String)}. Running the visitor function over the planned query reproduces exactly the query that is shipped to the tablet server.
+     */
+    private void assertPlanExitingVisitorFunction() {
+        String plan = planExitingVisitorFunction();
+        log.info("plan exiting the visitor function: {}", plan);
+
+        if (expectListIvarator) {
+            assertTrue(plan.contains(LIST_MARKER), "expected a list ivarator in the plan exiting the visitor function but got: " + plan);
+        } else {
+            assertFalse(plan.contains(LIST_MARKER), "expected no list ivarator in the plan exiting the visitor function but got: " + plan);
+        }
+    }
+
+    /**
+     * Run the {@link VisitorFunction} over the planned query and return the rewritten query.
+     *
+     * @return the query that exits the visitor function
+     */
+    private String planExitingVisitorFunction() {
+        assertInstanceOf(DefaultQueryPlanner.class, logic.getQueryPlanner());
+        DefaultQueryPlanner planner = (DefaultQueryPlanner) logic.getQueryPlanner();
+
+        IteratorSetting setting = new IteratorSetting(50, "query", QueryIterator.class);
+        setting.addOption(QueryOptions.QUERY, logic.getConfig().getQueryString());
+
+        List<Range> ranges = new ArrayList<>();
+        ranges.add(new Range(ingest.getRow()));
+
+        try {
+            VisitorFunction function = new VisitorFunction(logic.getConfig(), planner.getMetadataHelper());
+            return function.apply(setting, ranges).getOptions().get(QueryOptions.QUERY);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to run the visitor function", e);
+        }
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/util/AbstractIngest.java
@@ -279,7 +279,28 @@ public class AbstractIngest {
      *            the field value
      */
     public void writeFV(String row, String datatype, int eventId, String field, String value) {
-        String uid = uid(eventId);
+        writeFVForUid(row, datatype, uid(eventId), field, value);
+    }
+
+    /**
+     * Write the provided row, datatype, uid, field and value.
+     * <p>
+     * Unlike {@link #writeFV(String, String, int, String, String)} the uid is supplied directly rather than derived from an event id. This is what allows a
+     * test to express a top level document structure, where a child's uid is its parent's uid suffixed with {@code .N}. Operators writing a child must track
+     * the parent's uid themselves, via {@link #uid(int)}.
+     *
+     * @param row
+     *            the row
+     * @param datatype
+     *            the datatype
+     * @param uid
+     *            the event uid
+     * @param field
+     *            the field name
+     * @param value
+     *            the field value
+     */
+    public void writeFVForUid(String row, String datatype, String uid, String field, String value) {
         String normalizedValue = getNormalizedValue(field, value);
 
         writeShardIndex(row, datatype, uid, field, List.of(normalizedValue));


### PR DESCRIPTION
Filters are not gathering values for a field, to keep, due to the list ivarator JEXL structure. Field and its values aren't on the same node. This causes documents to drop, missing results. The changes have logic to handle the ivarator differently, so filters can pick what values to keep for a field, avoiding miss results.