### PR TITLE
Fixes issues with annotaton validation context, error messages and leaked threads

### DIFF
--- a/core/annotation/src/main/java/datawave/annotation/data/v1/FederatedAnnotationReader.java
+++ b/core/annotation/src/main/java/datawave/annotation/data/v1/FederatedAnnotationReader.java
@@ -224,12 +224,17 @@ public class FederatedAnnotationReader implements AnnotationReader {
             log.warn("Interrupted while retrieving {}", formatOperationDescription(messageTemplate, templateArgs));
         }
 
-        // Anything still pending did not complete before the timeout elapsed.
+        // Anything still pending did not complete before the timeout elapsed (or we were interrupted while waiting). Cancel these
+        // rather than merely abandoning them: with the caller-provided executor typically being an unbounded cached thread pool,
+        // a DAO call that blocks indefinitely (e.g. a hung Accumulo scan) would otherwise permanently occupy a pooled thread that
+        // is never reclaimed, since it never returns to idle. Interrupting gives blocking DAO implementations a chance to unwind.
         if (!pendingDaos.isEmpty()) {
             long elapsed = System.currentTimeMillis() - (deadline - daoTimeoutMillis);
-            if (log.isDebugEnabled()) {
-                for (String daoName : pendingDaos.values()) {
-                    log.debug("Timeout retrieving {} from {} after {}ms", formatOperationDescription(messageTemplate, templateArgs), daoName, elapsed);
+            for (Map.Entry<Future<T>,String> pending : pendingDaos.entrySet()) {
+                pending.getKey().cancel(true);
+                if (log.isDebugEnabled()) {
+                    log.debug("Timeout retrieving {} from {} after {}ms", formatOperationDescription(messageTemplate, templateArgs), pending.getValue(),
+                                    elapsed);
                 }
             }
         }

--- a/core/annotation/src/main/java/datawave/annotation/util/Validator.java
+++ b/core/annotation/src/main/java/datawave/annotation/util/Validator.java
@@ -81,7 +81,7 @@ public class Validator<T> {
      *            the type of member object we'll be validating
      */
     public <U> Validator<T> addMemberValidator(Function<T,List<U>> memberSupplier, Validator<U> validator, String messageContext) {
-        return addMemberValidator(memberSupplier, u -> validator, "");
+        return addMemberValidator(memberSupplier, u -> validator, messageContext);
     }
 
     /**

--- a/core/annotation/src/main/java/datawave/annotation/util/v1/AnnotationValidators.java
+++ b/core/annotation/src/main/java/datawave/annotation/util/v1/AnnotationValidators.java
@@ -28,8 +28,8 @@ public class AnnotationValidators {
             .addCheck(b -> b.getPointsList().isEmpty(), "All boundary must not contain points");
 
     private static final Validator<SegmentBoundary> spanBoundaryValidator = Validator.<SegmentBoundary>create()
-            .addCheck(SegmentBoundary::hasEnd, "Span boundary must have a start value")
-            .addCheck(SegmentBoundary::hasStart, "Span boundary must have an end value")
+            .addCheck(SegmentBoundary::hasEnd, "Span boundary must have an end value")
+            .addCheck(SegmentBoundary::hasStart, "Span boundary must have a start value")
             .addCheck(b -> b.getPointsList().isEmpty(), "Span boundary must not contain points");
 
     private static final Validator<SegmentBoundary> pointsBoundaryValidator = Validator.<SegmentBoundary>create()

--- a/core/annotation/src/test/java/datawave/annotation/data/v1/FederatedAnnotationReaderTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/data/v1/FederatedAnnotationReaderTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -833,6 +834,57 @@ public class FederatedAnnotationReaderTest {
 
                 assertTrue(result.isPresent());
                 assertEquals(fastSource, result.get());
+            } finally {
+                executor.shutdownNow();
+                try {
+                    executor.awaitTermination(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        /**
+         * Regression test: previously, a DAO call that was still running when the per-call deadline elapsed was merely abandoned (logged as timed out) but
+         * never actually cancelled/interrupted. With the caller's real executor typically being an unbounded cached thread pool, a DAO implementation that
+         * blocks indefinitely (e.g. a hung backend call) would permanently occupy a pooled thread forever, since it never becomes idle and so is never
+         * reclaimed. Verifies that a blocked DAO call is actually interrupted shortly after the timeout elapses, rather than left to run indefinitely.
+         */
+        @Test
+        @DisplayName("Should interrupt a DAO call that is still blocked when the timeout elapses")
+        void testTimedOutDaoCallIsCancelled() throws InterruptedException {
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            CountDownLatch interrupted = new CountDownLatch(1);
+            try {
+                Map<String,AnnotationReader> localDaos = new HashMap<>();
+                AnnotationReader hungDao = mock(AnnotationReader.class);
+                AnnotationReader fastDao = mock(AnnotationReader.class);
+
+                String analyticHash = "hash-cancel";
+                AnnotationSource fastSource = createTestAnnotationSource("fast-engine", "fast-model");
+
+                when(hungDao.getAnnotationSource(analyticHash)).thenAnswer(invocation -> {
+                    try {
+                        // block far longer than the configured timeout; only an actual interrupt should end this early.
+                        Thread.sleep(10_000);
+                    } catch (InterruptedException e) {
+                        interrupted.countDown();
+                        Thread.currentThread().interrupt();
+                    }
+                    return Optional.empty();
+                });
+                when(fastDao.getAnnotationSource(analyticHash)).thenReturn(Optional.of(fastSource));
+
+                localDaos.put("hung", hungDao);
+                localDaos.put("fast", fastDao);
+
+                FederatedAnnotationReader timeoutReader = new FederatedAnnotationReader(localDaos, executor, 25);
+                Optional<AnnotationSource> result = timeoutReader.getAnnotationSource(analyticHash);
+
+                assertTrue(result.isPresent());
+                assertEquals(fastSource, result.get());
+                // the hung DAO's thread should be interrupted well before its own 10s sleep would otherwise complete
+                assertTrue(interrupted.await(2, TimeUnit.SECONDS), "expected the timed-out DAO call to be cancelled/interrupted");
             } finally {
                 executor.shutdownNow();
                 try {

--- a/core/annotation/src/test/java/datawave/annotation/util/ValidatorTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/util/ValidatorTest.java
@@ -127,4 +127,26 @@ public class ValidatorTest {
         assertTrue(error.contains("not be null"), error);
 
     }
+
+    /**
+     * Regression test: the fixed-validator overload of {@link Validator#addMemberValidator(java.util.function.Function, Validator, String)} previously
+     * discarded its {@code messageContext} argument and hardcoded {@code ""} when delegating to the dynamic-validator overload, so the descriptive context
+     * suffix (e.g. "in children validation") was silently dropped from every member-validation error produced through this overload.
+     */
+    @Test
+    public void testMemberValidatorAppendsMessageContextSuffix() {
+        // bob has no start/end dates, so the child validator's "must be null" checks (which alice satisfies but bob technically also
+        // satisfies here) won't trigger; instead make bob fail the "Name is required" check to produce a deterministic single error.
+        bob.name = "";
+
+        Validator<Person> childValidator = Validator.<Person> create().addCheck(o -> o.name != null && !o.name.isBlank(), "Name is required");
+
+        Validator<Container> validator = Validator.<Container> create().addMemberValidator(o -> o.children, childValidator, "in children validation");
+
+        Validator.ValidationState<Container> validationState = validator.check(container, false);
+        assertFalse(validationState.isValid());
+        List<String> errors = validationState.getErrors();
+        assertEquals(1, errors.size());
+        assertEquals("Name is required in children validation", errors.get(0));
+    }
 }

--- a/core/annotation/src/test/java/datawave/annotation/util/v1/AnnotationValidatorsTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/util/v1/AnnotationValidatorsTest.java
@@ -10,9 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import datawave.annotation.protobuf.v1.Annotation;
 import datawave.annotation.protobuf.v1.AnnotationSource;
-import datawave.annotation.protobuf.v1.BoundaryType;
 import datawave.annotation.protobuf.v1.Segment;
-import datawave.annotation.protobuf.v1.SegmentBoundary;
 import datawave.annotation.test.v1.AnnotationTestDataUtil;
 import datawave.annotation.util.Validator;
 
@@ -73,33 +71,6 @@ public class AnnotationValidatorsTest {
         Segment testIdentifiedSegment = AnnotationUtils.injectAllHashes(testSegment);
         assertValid(AnnotationValidators.checkSegment(testIdentifiedSegment));
         assertValid(AnnotationValidators.checkSegmentIds(testIdentifiedSegment));
-    }
-
-    /**
-     * Regression test: the span-boundary validator's error messages were previously swapped -- a missing {@code end} value was reported as "must have a start
-     * value" and a missing {@code start} value was reported as "must have an end value" -- making the 400 response actively misleading about which field is
-     * actually missing.
-     */
-    @Test
-    public void testSpanBoundaryMissingEndReportsEndSpecificMessage() {
-        SegmentBoundary missingEnd = SegmentBoundary.newBuilder().setBoundaryType(BoundaryType.TIME_MILLI).setStart(100).build();
-        Segment segment = AnnotationTestDataUtil.generateTestSegment().toBuilder().setBoundary(missingEnd).build();
-
-        Validator.ValidationState<Segment> validationState = AnnotationValidators.checkSegment(segment);
-        assertInvalid(validationState);
-        assertTrue(validationState.getErrors().stream().anyMatch(e -> e.contains("must have an end value")), getErrorMessage(validationState));
-        assertFalse(validationState.getErrors().stream().anyMatch(e -> e.contains("must have a start value")), getErrorMessage(validationState));
-    }
-
-    @Test
-    public void testSpanBoundaryMissingStartReportsStartSpecificMessage() {
-        SegmentBoundary missingStart = SegmentBoundary.newBuilder().setBoundaryType(BoundaryType.TIME_MILLI).setEnd(100).build();
-        Segment segment = AnnotationTestDataUtil.generateTestSegment().toBuilder().setBoundary(missingStart).build();
-
-        Validator.ValidationState<Segment> validationState = AnnotationValidators.checkSegment(segment);
-        assertInvalid(validationState);
-        assertTrue(validationState.getErrors().stream().anyMatch(e -> e.contains("must have a start value")), getErrorMessage(validationState));
-        assertFalse(validationState.getErrors().stream().anyMatch(e -> e.contains("must have an end value")), getErrorMessage(validationState));
     }
 
     public static void assertValid(Validator.ValidationState<?> validationState) {

--- a/core/annotation/src/test/java/datawave/annotation/util/v1/AnnotationValidatorsTest.java
+++ b/core/annotation/src/test/java/datawave/annotation/util/v1/AnnotationValidatorsTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test;
 
 import datawave.annotation.protobuf.v1.Annotation;
 import datawave.annotation.protobuf.v1.AnnotationSource;
+import datawave.annotation.protobuf.v1.BoundaryType;
 import datawave.annotation.protobuf.v1.Segment;
+import datawave.annotation.protobuf.v1.SegmentBoundary;
 import datawave.annotation.test.v1.AnnotationTestDataUtil;
 import datawave.annotation.util.Validator;
 
@@ -71,6 +73,33 @@ public class AnnotationValidatorsTest {
         Segment testIdentifiedSegment = AnnotationUtils.injectAllHashes(testSegment);
         assertValid(AnnotationValidators.checkSegment(testIdentifiedSegment));
         assertValid(AnnotationValidators.checkSegmentIds(testIdentifiedSegment));
+    }
+
+    /**
+     * Regression test: the span-boundary validator's error messages were previously swapped -- a missing {@code end} value was reported as "must have a start
+     * value" and a missing {@code start} value was reported as "must have an end value" -- making the 400 response actively misleading about which field is
+     * actually missing.
+     */
+    @Test
+    public void testSpanBoundaryMissingEndReportsEndSpecificMessage() {
+        SegmentBoundary missingEnd = SegmentBoundary.newBuilder().setBoundaryType(BoundaryType.TIME_MILLI).setStart(100).build();
+        Segment segment = AnnotationTestDataUtil.generateTestSegment().toBuilder().setBoundary(missingEnd).build();
+
+        Validator.ValidationState<Segment> validationState = AnnotationValidators.checkSegment(segment);
+        assertInvalid(validationState);
+        assertTrue(validationState.getErrors().stream().anyMatch(e -> e.contains("must have an end value")), getErrorMessage(validationState));
+        assertFalse(validationState.getErrors().stream().anyMatch(e -> e.contains("must have a start value")), getErrorMessage(validationState));
+    }
+
+    @Test
+    public void testSpanBoundaryMissingStartReportsStartSpecificMessage() {
+        SegmentBoundary missingStart = SegmentBoundary.newBuilder().setBoundaryType(BoundaryType.TIME_MILLI).setEnd(100).build();
+        Segment segment = AnnotationTestDataUtil.generateTestSegment().toBuilder().setBoundary(missingStart).build();
+
+        Validator.ValidationState<Segment> validationState = AnnotationValidators.checkSegment(segment);
+        assertInvalid(validationState);
+        assertTrue(validationState.getErrors().stream().anyMatch(e -> e.contains("must have a start value")), getErrorMessage(validationState));
+        assertFalse(validationState.getErrors().stream().anyMatch(e -> e.contains("must have an end value")), getErrorMessage(validationState));
     }
 
     public static void assertValid(Validator.ValidationState<?> validationState) {


### PR DESCRIPTION
- Addressed issue where `Validator.addMemberValidator` discarded its `messageContext` argument, hardcoding an empty string when delegating to the overloaded method. Every `AnnotationValidators` call site using this overloaded method (segment identity, base segment, annotation identity, annotation, annotation-update validation) silently lost its descriptive error-context suffix.
- Fixed incorrect span validation messages: `AnnotationValidators.spanBoundaryValidator` i paired its two checks with the wrong messages: a missing `end` value reported "must have a start value", and a missing `start` value reported "must have an end value". The validation logic was correct, but the 400 response text describing which field was actually missing was reversed. Swapped the two message strings to match the field being tested
- Fixed issue where DAO threads wouldn't be cleaned up on error: `FederatedAnnotationReader.callDaos` logged still-pending DAO `Future`s as timed out but never cancelled them. Since the caller-provided executor is typically an unbounded cached thread pool  a DAO call that blocks indefinitely would permanently occupy a pooled thread that is never reclaimed, since it never returns to idle. Now calls `future.cancel(true)` on each remaining pending DAO after the timeout elapses.
- Added tests for these fixes