### PR TITLE
Start Zookeeper from /opt/zookeeper/bin

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -118,10 +118,10 @@ services:
     profiles: [datawave-stack]
     image: *stack-image
     user: zookeeper
-    entrypoint: ["/usr/lib/zookeeper/bin/zkServer.sh"]
+    entrypoint: ["/opt/zookeeper/bin/zkServer.sh"]
     command: ["--config", "/etc/zookeeper/conf.dist", "start-foreground"]
     environment:
-      - ZOOBINDIR=/usr/lib/zookeeper/bin
+      - ZOOBINDIR=/opt/zookeeper/bin
       - ZOO_LOG_DIR=/var/log/zookeeper
     ports:
       - "2181:2181"


### PR DESCRIPTION
Start the Zookeeper service using the scripts within /opt/zookeeper/bin directory. This will ensure that we are launching the version of Zookeeper configured and installed to /opt/zookeeper in the datawave-stack-accumulo image.

Note: this PR depends on [datawave-stack-docker-images/pull/23](https://github.com/NationalSecurityAgency/datawave-stack-docker-images/pull/23), and should not be merged in until that PR has, and an updated version of the datawave-stack-accumulo image has been deployed.