### PR TITLE
Fix the quickstart's accumulo-env.sh substitutions so allInstall stops hanging on integration

### DIFF
--- a/contrib/datawave-quickstart/bin/services/accumulo/install.sh
+++ b/contrib/datawave-quickstart/bin/services/accumulo/install.sh
@@ -94,9 +94,8 @@ fi
 assertCreateDir "${DW_ACCUMULO_JVM_HEAPDUMP_DIR}" || exit 1
 
 # Update tserver and other options in accumulo-env.sh
-sed -i'' -e "s~\(ACCUMULO_TSERVER_OPTS=\).*$~\1\"${DW_ACCUMULO_TSERVER_OPTS}\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
-sed -i'' -e "s~\(export JAVA_HOME=\).*$~\1\"${JAVA_HOME}\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
-sed -i'' -e "s~\(export ACCUMULO_MONITOR_OPTS=\).*$~\1\"\${POLICY} -Xmx2g -Xms512m\"~g" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+sed -i'' -e "s~/path/to/hadoop~${HADOOP_HOME}~" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
+sed -i'' -e "s~/path/to/zookeeper~${ZOOKEEPER_HOME}~" "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 echo 'JAVA_OPTS=('-Dcom.google.protobuf.use_unsafe_pre22_gencode' "${JAVA_OPTS[@]}")' >> "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 cat "${DW_ACCUMULO_CONF_DIR}/accumulo-env.sh"
 # Update Accumulo bind host if it's not set to localhost


### PR DESCRIPTION
Fixes #3916

The three seds in `install.sh` match strings that do not exist in the `accumulo-env.sh` shipped by the Accumulo tarball the quickstart downloads, so they do nothing and the file keeps `/path/to/hadoop` and `/path/to/zookeeper` — and the servers, started over ssh where the installing shell's exports do not reach them, use those placeholders. No tablet server comes up, and `install-ingest.sh`'s `accumulo shell -f` then blocks forever instead of failing.

I replaced the three dead seds with the two that match the template. `DW_ACCUMULO_TSERVER_OPTS` and `ACCUMULO_MONITOR_OPTS` are not referenced anywhere else in the repo — the removed seds were substituting an undefined variable into a line that does not exist — so nothing is lost by dropping them, and the per-process heaps come from the template's own `JAVA_OPTS` block.

Verified with a cold install on `integration` at 8.1.0-SNAPSHOT, checking state rather than the exit code: `/path/to/` occurrences in `accumulo-env.sh` went 2 to 0, the tablet server came up where before none did at all, and `install-ingest.sh` and `install-web.sh` both completed where before the first one hung and the second was never reached. A full uninstall is needed before retesting, or `accumuloIsInstalled` reports the hung run as a finished one.

One thing I deliberately left out. #3863 makes the same two substitutions, but its base branch is `accumulo4-2026-quickstart`, so merging it does not repair `integration`; it also appends `export JAVA_HOME` and `export PATH` to `accumulo-env.sh`. My install succeeded without those, but only because `java` happens to be on the ssh login PATH on my host and is the same JDK 11 the build used. On a host where those differ the exports look like the more robust fix. I kept this PR to the minimum that repairs `integration`; happy to add them if you'd rather have the two branches carry the same change.
