### PR TITLE
Finish the microservice starter bump from 4.0.12 to 4.0.13

### DIFF
--- a/microservices/services/accumulo/service/pom.xml
+++ b/microservices/services/accumulo/service/pom.xml
@@ -28,7 +28,7 @@
         <version.datawave.accumulo-api>4.0.6</version.datawave.accumulo-api>
         <version.datawave.audit-api>4.0.5</version.datawave.audit-api>
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-audit>4.0.10</version.datawave.starter-audit>
         <version.guava>31.1-jre</version.guava>
         <version.hadoop>3.3.4</version.hadoop>

--- a/microservices/services/audit/service/pom.xml
+++ b/microservices/services/audit/service/pom.xml
@@ -26,7 +26,7 @@
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
         <version.datawave.hazelcast-client>4.0.7</version.datawave.hazelcast-client>
         <version.datawave.hazelcast-common>4.0.7</version.datawave.hazelcast-common>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.googlecode-findbugs>2.0.3</version.googlecode-findbugs>
         <version.guava>31.1-jre</version.guava>
         <version.hadoop>3.3.4</version.hadoop>

--- a/microservices/services/config/pom.xml
+++ b/microservices/services/config/pom.xml
@@ -25,7 +25,7 @@
     </scm>
     <properties>
         <start-class>datawave.microservice.config.server.ConfigServerApplication</start-class>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.jgit>5.13.5.202508271544-r</version.jgit>
         <version.jsch>0.2.26</version.jsch>
         <!-- dependency declared in datawave-microservice-parent, but the version can be overridden here -->

--- a/microservices/services/dictionary/service/pom.xml
+++ b/microservices/services/dictionary/service/pom.xml
@@ -31,7 +31,7 @@
         <version.datawave>8.0.0</version.datawave>
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
         <version.datawave.dictionary-api>4.0.11</version.datawave.dictionary-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-metadata>3.0.7</version.datawave.starter-metadata>
         <version.guava>31.1-jre</version.guava>
         <version.hadoop>3.3.4</version.hadoop>

--- a/microservices/services/file-provider/service/pom.xml
+++ b/microservices/services/file-provider/service/pom.xml
@@ -19,7 +19,7 @@
     </scm>
     <properties>
         <start-class>datawave.microservice.fileProvider.FileProviderService</start-class>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <!-- dependency declared in datawave-microservice-parent, but the version can be overridden here -->
         <version.log4j>2.26.1</version.log4j>
         <!-- dependency declared in datawave-microservice-parent, but the version can be overridden here -->

--- a/microservices/services/hazelcast/common/pom.xml
+++ b/microservices/services/hazelcast/common/pom.xml
@@ -17,7 +17,7 @@
         <url>https://github.com/NationalSecurityAgency/datawave</url>
     </scm>
     <properties>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-cache>4.0.5</version.datawave.starter-cache>
         <!-- dependency declared in datawave-microservice-parent, but the version can be overridden here -->
         <version.log4j>2.26.1</version.log4j>

--- a/microservices/services/mapreduce-query/service/pom.xml
+++ b/microservices/services/mapreduce-query/service/pom.xml
@@ -25,7 +25,7 @@
         <version.datawave>8.0.0</version.datawave>
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
         <version.datawave.mapreduce-query-core-job>1.0.7</version.datawave.mapreduce-query-core-job>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-query>1.0.14</version.datawave.starter-query>
         <version.hadoop>3.3.4</version.hadoop>
         <!-- dependency declared in datawave-microservice-parent, but the version can be overridden here -->

--- a/microservices/services/modification/service/pom.xml
+++ b/microservices/services/modification/service/pom.xml
@@ -23,7 +23,7 @@
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
         <version.datawave.modification-api>1.0.4</version.datawave.modification-api>
         <version.datawave.query-api>1.0.4</version.datawave.query-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-metadata>3.0.7</version.datawave.starter-metadata>
         <version.in-memory-accumulo>4.0.6</version.in-memory-accumulo>
         <!-- dependency declared in datawave-microservice-parent, but the version can be overridden here -->

--- a/microservices/services/query-executor/service/pom.xml
+++ b/microservices/services/query-executor/service/pom.xml
@@ -28,7 +28,7 @@
         <version.datawave.query-api>1.0.4</version.datawave.query-api>
         <version.datawave.query-executor-api>1.0.12</version.datawave.query-executor-api>
         <version.datawave.query-metric-api>4.1.8</version.datawave.query-metric-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-query>1.0.14</version.datawave.starter-query>
         <version.datawave.starter-query-metric>3.0.8</version.datawave.starter-query-metric>
         <version.guava>31.1-jre</version.guava>

--- a/microservices/services/query/service/pom.xml
+++ b/microservices/services/query/service/pom.xml
@@ -30,7 +30,7 @@
         <version.datawave.hazelcast-common>4.0.7</version.datawave.hazelcast-common>
         <version.datawave.query-api>1.0.4</version.datawave.query-api>
         <version.datawave.query-metric-api>4.1.8</version.datawave.query-metric-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-audit>4.0.10</version.datawave.starter-audit>
         <version.datawave.starter-cached-results>1.0.15</version.datawave.starter-cached-results>
         <version.datawave.starter-query>1.0.14</version.datawave.starter-query>

--- a/microservices/starters/audit/pom.xml
+++ b/microservices/starters/audit/pom.xml
@@ -28,7 +28,7 @@
         <version.datawave>8.0.0</version.datawave>
         <version.datawave.audit-api>4.0.5</version.datawave.audit-api>
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.guava>31.1-jre</version.guava>
         <version.hamcrest>2.2</version.hamcrest>
     </properties>

--- a/microservices/starters/cached-results/pom.xml
+++ b/microservices/starters/cached-results/pom.xml
@@ -31,7 +31,7 @@
         <version.datawave.hazelcast-client>4.0.7</version.datawave.hazelcast-client>
         <version.datawave.hazelcast-common>4.0.7</version.datawave.hazelcast-common>
         <version.datawave.query-api>1.0.4</version.datawave.query-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-audit>4.0.10</version.datawave.starter-audit>
         <version.datawave.starter-query>1.0.14</version.datawave.starter-query>
         <version.mysql-connector>9.3.0</version.mysql-connector>

--- a/microservices/starters/metadata/pom.xml
+++ b/microservices/starters/metadata/pom.xml
@@ -25,7 +25,7 @@
     <properties>
         <version.accumulo>2.1.5</version.accumulo>
         <version.datawave>8.0.0</version.datawave>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-cache>4.0.5</version.datawave.starter-cache>
         <version.swagger>2.2.42</version.swagger>
     </properties>

--- a/microservices/starters/query-metric/pom.xml
+++ b/microservices/starters/query-metric/pom.xml
@@ -27,7 +27,7 @@
         <version.datawave>8.0.0</version.datawave>
         <version.datawave.authorization-api>4.0.5</version.datawave.authorization-api>
         <version.datawave.query-metric-api>4.1.8</version.datawave.query-metric-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.guava>31.1-jre</version.guava>
         <!-- version set in datawave-microservice-parent, but can be overridden here -->
         <!-- 2.14.X is the maximum version of jackson without snakeyaml version 2 causing spring-boot 2.7.1 conflict -->

--- a/microservices/starters/query/pom.xml
+++ b/microservices/starters/query/pom.xml
@@ -35,7 +35,7 @@
         <version.datawave.mapreduce-query-api>1.0.4</version.datawave.mapreduce-query-api>
         <version.datawave.query-api>1.0.4</version.datawave.query-api>
         <version.datawave.query-metric-api>4.1.8</version.datawave.query-metric-api>
-        <version.datawave.starter>4.0.12</version.datawave.starter>
+        <version.datawave.starter>4.0.13</version.datawave.starter>
         <version.datawave.starter-metadata>3.0.7</version.datawave.starter-metadata>
         <version.datawave.starter-query-metric>3.0.8</version.datawave.starter-query-metric>
         <version.guava>31.1-jre</version.guava>


### PR DESCRIPTION
Fixes #3918

4.0.12 references `datawave.microservice.security.util.DnUtils`, which 8.0 moved to `datawave.security.util`, so `query` and `query-executor` crash-loop on `NoClassDefFoundError` and `testAll.sh` can't run. I bumped the remaining fifteen poms; nothing else changed. 4.0.13 is already released and already in use by `authorization/service` and `query-metric/service` in this repo, so no new version is introduced — this just finishes the bump.

After the bump both services came up healthy, and the documented path then ran end to end from a genuine cold start — repo, `~/.m2` and every image destroyed first. `docker compose up -d --wait` brought up 21 services (counted from `docker compose ps`, not from the exit code — `up --wait` returns 0 even with containers OOM-killed) with `datawave-extlib` at `Exited (0)` as expected, `verifySplits.sh` reported 51/51, and `testAll.sh` passed 13/13 with no assertion failures. The build was `docker/README.md`'s TLDR command plus two wagon retry flags (`-Dmaven.wagon.http.retryHandler.count=5`, `-Dmaven.wagon.httpconnectionManager.ttlSeconds=120`) — one TCP reset had killed an earlier cold build.
