### PR TITLE
Ship the two jars the tserver needs to build ColumnVisibilitySecurityMarking

### DIFF
--- a/warehouse/assemble/datawave/src/main/assembly/dist.xml
+++ b/warehouse/assemble/datawave/src/main/assembly/dist.xml
@@ -95,6 +95,8 @@
                 <include>org.apache.commons:commons-collections4</include>
                 <include>org.apache.commons:commons-jexl3</include>
                 <include>org.apache.curator:curator-client</include>
+                <include>javax.xml.bind:jaxb-api</include>
+                <include>org.apache.accumulo:accumulo-access-core</include>
                 <include>${groupId}:datawave-accumulo-extensions</include>
                 <include>${groupId}:datawave-common</include>
                 <include>${groupId}:datawave-core</include>


### PR DESCRIPTION
Fixes #3920

Two `<include>` lines in the `accumulo-warehouse/lib/ext` dependencySet. `ColumnVisibilitySecurityMarking` was already being shipped there via `base-rest-responses`, but `javax.xml.bind:jaxb-api` and `org.apache.accumulo:accumulo-access-core` were not on the list, so the class arrived without the classes it imports and `MarkingFunctions$Factory` returned null for every query.

The compose stack already works around exactly this. `docker/docker-compose.yml`'s `datawave-extlib` init container copies all of `accumulo-warehouse/lib` and `lib/ext` into the tserver's `lib/ext`, and then copies two more jars by name — `accumulo-access-core-*.jar` and `jaxb-api-*.jar`. Those are the same two jars. This change puts them in the assembly instead, so every consumer gets them and that hand-copy becomes redundant.

I measured it on the bare-metal quickstart at 8.1.0-SNAPSHOT on JDK 11, by putting the two jars in `lib/ext` by hand and restarting Accumulo: web tests went 31/56 to 51/56 and `AttributeBag` NPEs in the tserver log went 984 to 0. Both jars are needed; with only `jaxb-api` the error is identical. Then I built the assembly to confirm the change actually delivers them: `accumulo-warehouse/lib/ext` goes from 58 to 60 jars and contains `jaxb-api-2.2.11.jar` and `accumulo-access-core-1.0.0-beta3.jar`. I have not re-run the web tests against that build — the 51/56 above was measured with the jars placed by hand.

Two caveats:

* The jar I tested with was `jaxb-api` 2.3.1; the assembly ships 2.2.11, because jaxb-api only arrives transitively through `hadoop-yarn-api`. Both carry the five `javax.xml.bind.annotation` classes `ColumnVisibilitySecurityMarking` imports, so I do not expect a difference, but I have not measured 2.2.11 end to end. Both artifacts already resolve in this module's graph, so `useStrictFiltering` is satisfied and no new dependency is introduced. If you'd rather have `jaxb-api` declared explicitly at 2.3.1 I'm happy to do that; it would also be stable against Hadoop upgrades.
* That transitive path is exactly what `accumulo4-2026-quickstart` loses. Hadoop 3.5.0 moved to Jersey 2 and no longer supplies `javax.xml.bind:jaxb-api` — that's the reason given in cf4085c201 for dropping the jaxb-api copy from that branch's compose file — while `ColumnVisibilitySecurityMarking` still imports it unchanged. So this change as written will probably not carry over to that branch, and the underlying gap there looks worse rather than better. I have not run it on a4 yet, so that is reasoning from the poms, not a measured result.

The 5 web-test failures that remain are all `KeywordExtraction/*` and look like a separate web-tier issue unrelated to this change.
