### PR TITLE
Run the compose ZooKeeper service from the 3.9.5 distribution

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -118,10 +118,14 @@ services:
     profiles: [datawave-stack]
     image: *stack-image
     user: zookeeper
-    entrypoint: ["/usr/lib/zookeeper/bin/zkServer.sh"]
-    command: ["--config", "/etc/zookeeper/conf.dist", "start-foreground"]
+    # Accumulo 4 needs a ZooKeeper server that understands addWatch (opcode 106,
+    # ZooKeeper 3.6+). /usr/lib/zookeeper is bigtop's 3.5.9, which answers ruok
+    # but rejects addWatch, so Accumulo's Initialize loops on ConnectionLoss.
+    # /opt/zookeeper is the 3.9.5 distribution the stack image downloads.
+    entrypoint: ["/opt/zookeeper/bin/zkServer.sh"]
+    command: ["--config", "/opt/zookeeper/conf", "start-foreground"]
     environment:
-      - ZOOBINDIR=/usr/lib/zookeeper/bin
+      - ZOOBINDIR=/opt/zookeeper/bin
       - ZOO_LOG_DIR=/var/log/zookeeper
     ports:
       - "2181:2181"


### PR DESCRIPTION
Accumulo 4 sets persistent recursive watchers during init (ZooKeeper addWatch,
opcode 106, added in 3.6). The service ran bigtop's 3.5.9 from /usr/lib/zookeeper,
which answers ruok but logs 'Received packet at server of unknown type 106' and
drops the connection, so Initialize loops on ConnectionLoss for /namespaces and
no tablet server ever starts. Verified with echo srvr: 3.5.9 before, 3.9.5 after,
and 'unknown type 106' goes from present to zero.

Needs the matching datawave-stack-docker-images change that actually puts a
3.9.5 server at /opt/zookeeper - today the image extracts only its jars.

Work for #3766


Fixes #3922
