### PR TITLE
Start the Accumulo 4 servers through `accumulo proc`

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -138,7 +138,7 @@ services:
   accumulo-manager:
     profiles: [datawave-stack]
     image: *stack-image
-    command: [manager]
+    command: [proc, manager]   # Accumulo 4 moved server processes under `accumulo proc`
     environment:
       - ACCUMULO_INSTANCE_NAME=my-instance-01
       - ACCUMULO_ROOT_PASSWORD=secret
@@ -168,7 +168,7 @@ services:
   accumulo-tserver:
     profiles: [datawave-stack]
     image: *stack-image
-    command: [tserver]
+    command: [proc, tserver]   # Accumulo 4 moved server processes under `accumulo proc`
     environment:
       - HADOOP_CONF_DIR=/stack
       - ACCUMULO_LIB_EXT=/opt/accumulo/lib/ext
@@ -191,7 +191,7 @@ services:
   accumulo-gc:
     profiles: [datawave-stack]
     image: *stack-image
-    command: [gc]
+    command: [proc, gc]   # Accumulo 4 moved server processes under `accumulo proc`
     environment:
       - HADOOP_CONF_DIR=/stack
       - ACCUMULO_LIB_EXT=/opt/accumulo/lib/ext
@@ -209,7 +209,7 @@ services:
   accumulo-monitor:
     profiles: [datawave-stack]
     image: *stack-image
-    command: [monitor]
+    command: [proc, monitor]   # Accumulo 4 moved server processes under `accumulo proc`
     environment:
       - HADOOP_CONF_DIR=/stack
       - ACCUMULO_LIB_EXT=/opt/accumulo/lib/ext


### PR DESCRIPTION
Accumulo 4 regrouped the server processes under a proc subcommand, so
command: [manager] now fails with "Invalid argument: Java <main class> 'manager'
was not found". Same for tserver, gc and monitor.

Must land together with the datawave-stack-docker-images entrypoint change:
that script gates Accumulo initialization on the argument position, so changing
only this file skips init entirely and brings up a stack with no instance -
a worse failure than the one being fixed.

Work for #3766


Fixes #3924
