### PR TITLE
Probe the Accumulo 4 tserver port range in the healthcheck

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -183,7 +183,11 @@ services:
       accumulo-manager:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/9997'"]
+      # Accumulo 4 changed tserver.port.client from 9997 to the range 9800-9899
+      # (core Property.java: TSERV_CLIENTPORT default "9800-9899"). Probing 9997
+      # fails forever against a perfectly healthy tserver, which then blocks
+      # ingest/query/webservice/metrics from ever starting.
+      test: ["CMD-SHELL", "for p in $$(seq 9800 9810); do bash -c \"</dev/tcp/localhost/$$p\" 2>/dev/null && exit 0; done; exit 1"]
       interval: 3s
       timeout: 3s
       retries: 30


### PR DESCRIPTION
The healthcheck probes 9997, the Accumulo 2 default. Accumulo 4 sets
tserver.port.client to the range 9800-9899 (core Property.java:686) and 9997
appears nowhere in that file, so a healthy tserver listening on 9800 is reported
unhealthy forever - which blocks ingest, query, webservice, metrics and
executor-pool1 from ever starting.

Probes the range rather than a single port, since the server takes the first
free one.

Work for #3766


Fixes #3926
