### PR TITLE
Let ingest and verifySplits talk to Accumulo 4

### DIFF
--- a/docker/scripts/verifySplits.sh
+++ b/docker/scripts/verifySplits.sh
@@ -80,7 +80,7 @@ fi
 # reader to the init script when the stack is simply down or the table is missing.
 GETSPLITS_ERR=$(mktemp)
 GETSPLITS_OUT=$(compose exec -T "${ACCUMULO_SERVICE}" \
-    accumulo shell -u "${ACCUMULO_USER}" -p "${ACCUMULO_PASSWORD}" -e "getsplits -t ${SHARD_TABLE}" 2>"${GETSPLITS_ERR}")
+    accumulo shell -c /opt/accumulo/conf/accumulo-client.properties -e "getsplits -t ${SHARD_TABLE}" 2>"${GETSPLITS_ERR}")
 GETSPLITS_STATUS=$?
 
 if [ "${GETSPLITS_STATUS}" -ne 0 ] ; then

--- a/docker/stack/accumulo-client.properties
+++ b/docker/stack/accumulo-client.properties
@@ -11,7 +11,7 @@
 instance.name=my-instance-01
 
 ## Zookeeper connection information for Accumulo instance
-instance.zookeepers=localhost:2181
+instance.zookeepers=zookeeper:2181
 
 ## Zookeeper session timeout
 #instance.zookeepers.timeout=30s

--- a/docker/stack/initialize-datawave.sh
+++ b/docker/stack/initialize-datawave.sh
@@ -6,8 +6,9 @@ readonly HDFS_INGEST_DIR=/datawave/ingest
 readonly FIXTURES=/opt/datawave-test-data
 readonly SHARD_SPLITS=/stack/shard-splits.txt
 readonly NUM_SHARDS_FLOOR_DATE=19000101
+readonly ACCUMULO_CLIENT_PROPS=/opt/accumulo/conf/accumulo-client.properties
 
-until accumulo shell -u root -p secret -e info >/dev/null 2>&1; do
+until accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e info >/dev/null 2>&1; do
     echo "Waiting for Accumulo..."
     sleep 2
 done
@@ -17,22 +18,22 @@ done
 HADOOP_USER_NAME=hdfs hdfs dfs -mkdir -p \
     /accumulo /tmp/hadoop-yarn/staging/history "${HDFS_INGEST_DIR}"
 HADOOP_USER_NAME=hdfs hdfs dfs -chmod -R 777 /tmp /datawave
-accumulo shell -u root -p secret -e \
+accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e \
     "setauths -u root -s JBOSS_ADMIN,DW_ADMIN,AUTH_USER,BAR,FOO,PRIVATE,PUBLIC,PUB,PVT,DEF,A,B,C,D,E,F,G,H,I,DW_USER,DW_SERV"
-accumulo shell -u root -p secret -e "createnamespace datawave" 2>/dev/null || true
-accumulo shell -u root -p secret -e "createtable datawave.queryMetrics_m" 2>/dev/null || true
-accumulo shell -u root -p secret -e "createtable datawave.queryMetrics_s" 2>/dev/null || true
+accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e "createnamespace datawave" 2>/dev/null || true
+accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e "createtable datawave.queryMetrics_m" 2>/dev/null || true
+accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e "createtable datawave.queryMetrics_s" 2>/dev/null || true
 
 mkdir -p /srv/logs/ingest /srv/data/datawave/flags /var/run/datawave
 
 "${INGEST_HOME}/bin/ingest/create-all-tables.sh"
 
 # Otherwise the whole sharded schema lives in one tablet.
-accumulo shell -u root -p secret -e "addsplits -t datawave.shard -sf ${SHARD_SPLITS}"
+accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e "addsplits -t datawave.shard -sf ${SHARD_SPLITS}"
 
 # The query side expands a day into shards from this entry, not from num.shards.
 num_shards=$(cut -d_ -f2 "${SHARD_SPLITS}" | sort -u | wc -l)
-accumulo shell -u root -p secret -e "insert num_shards ns ${NUM_SHARDS_FLOOR_DATE}_${num_shards} '' -t datawave.metadata"
+accumulo shell -c "${ACCUMULO_CLIENT_PROPS}" -e "insert num_shards ns ${NUM_SHARDS_FLOOR_DATE}_${num_shards} '' -t datawave.metadata"
 
 "${INGEST_HOME}/bin/ingest/load-job-cache.sh"
 


### PR DESCRIPTION
`initialize-datawave.sh` hung on "Waiting for Accumulo" because its `accumulo
shell` calls could not connect.

**Accumulo 4 dropped the client `-p` option.** From the release notes: "The
Client options `-p` have been dropped. Use `accumulo-client.properties` for any
connection or token options. See `-c, --config-file` option." All seven shell
calls in `initialize-datawave.sh`, and the one in `scripts/verifySplits.sh`,
still passed `-u`/`-p`, so every one of them failed. They now pass
`-c /opt/accumulo/conf/accumulo-client.properties` - the file compose already
mounts into these containers.

That file needs `auth.type`, which Accumulo 4 validates. #3932 added it.

**One follow-on fix.** #3932 replaced `accumulo-client.properties` with the
stock Accumulo 4 template, which ships `instance.zookeepers=localhost:2181`.
Compose mounts this file into `accumulo-manager`, `accumulo-tserver`,
`accumulo-gc`, `accumulo-monitor` and `ingest`; ZooKeeper runs in its own
`zookeeper` service, so `localhost:2181` resolves to nothing in any of them.
Restored `instance.zookeepers=zookeeper:2181`, the value the file carried
before #3932. `accumulo.properties` still has
`instance.zookeeper.host=zookeeper:2181`, so the server processes were never
affected - only client calls.

Verified on a running a4 stack: the "Waiting for Accumulo" count went 38 to 0,
ingest reached `TableCreator` and completed, and `verifySplits.sh` reported
51/51 splits - the same number integration gives.

Work for #3766


Fixes #3928