### PR TITLE
Update Zookeeper config option

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     image: *stack-image
     user: zookeeper
     entrypoint: ["/opt/zookeeper/bin/zkServer.sh"]
-    command: ["--config", "/etc/zookeeper/conf.dist", "start-foreground"]
+    command: ["--config", "/opt/zookeeper/conf", "start-foreground"]
     environment:
       - ZOOBINDIR=/opt/zookeeper/bin
       - ZOO_LOG_DIR=/var/log/zookeeper


### PR DESCRIPTION
Make the zookeeper service start using the configurations located in /opt/zookeeper/conf.

Depends on https://github.com/NationalSecurityAgency/datawave-stack-docker-images/pull/26.