### PR TITLE
Update accumulo configuration with Accumulo 4 documentation

### DIFF
--- a/docker/stack/accumulo-client.properties
+++ b/docker/stack/accumulo-client.properties
@@ -1,4 +1,102 @@
+################################
+## Accumulo client configuration
+################################
+
+## NOTE - All properties that have a default are set with it. Properties that
+## are uncommented must be set by the user.
+
+## Instance properties
+## --------------
+## Name of Accumulo instance to connect to
 instance.name=my-instance-01
-instance.zookeepers=zookeeper:2181
+
+## Zookeeper connection information for Accumulo instance
+instance.zookeepers=localhost:2181
+
+## Zookeeper session timeout
+#instance.zookeepers.timeout=30s
+
+
+## Authentication properties
+## --------------
+## Authentication method (i.e password, kerberos, PasswordToken, KerberosToken, etc)
+auth.type=password
+
+## Accumulo principal/username for chosen authentication method
 auth.principal=root
+
+## Authentication token (ex. mypassword, /path/to/keytab)
 auth.token=secret
+
+
+## Batch Writer properties
+## --------------
+## The durability of writes to tables includes ensuring that mutations written by clients are persisted in the write-ahead log and that files written during a compaction are persisted to disk successfully. This property only configures the durability used to write to the write-ahead log. Legal values are: none, which skips the write-ahead log; log, which sends the data to the write-ahead log, but does nothing to make it durable; flush, which pushes data out of the JVM (likely to page cache); and sync, which ensures that each mutation is written to the physical disk. To configure the durability of files written during minor and major compactions, set the Hadoop property "dfs.datanode.synconclose" to "true". This will ensure that the blocks of the files in HDFS are written to the physical disk as the compaction output files are written (Note that this may only apply to replicated files in HDFS).  Setting this property will change the durability for the BatchWriter session. A value of "default" will use the table's durability setting.
+#batch.writer.durability=default
+
+## Max amount of time (in seconds) to hold data in memory before flushing it
+#batch.writer.latency.max=120s
+
+## Max memory (in bytes) to batch before writing
+#batch.writer.memory.max=50M
+
+## Maximum number of threads to use for writing data to tablet servers.
+#batch.writer.threads.max=3
+
+## Max amount of time (in seconds) an unresponsive server will be re-tried. An exception is thrown when this timeout is exceeded. Set to zero for no timeout.
+#batch.writer.timeout.max=0
+
+
+## Batch Scanner properties
+## --------------
+## Number of concurrent query threads to spawn for querying
+#batch.scanner.num.query.threads=3
+
+
+## Scanner properties
+## --------------
+## Number of key/value pairs that will be fetched at time from tablet server
+#scanner.batch.size=1000
+
+
+## SSL properties
+## --------------
+## Enable SSL for client RPC
+#ssl.enabled=false
+
+## Password used to encrypt keystore
+#ssl.keystore.password=
+
+## Path to SSL keystore file
+#ssl.keystore.path=
+
+## Type of SSL keystore
+#ssl.keystore.type=jks
+
+## Password used to encrypt truststore
+#ssl.truststore.password=
+
+## Path to SSL truststore file
+#ssl.truststore.path=
+
+## Type of SSL truststore
+#ssl.truststore.type=jks
+
+## Use JSSE system properties to configure SSL
+#ssl.use.jsse=false
+
+
+## SASL properties
+## --------------
+## Enable SASL for client RPC
+#sasl.enabled=false
+
+## Kerberos principal/primary that Accumulo servers use to login
+#sasl.kerberos.server.primary=accumulo
+
+## SASL quality of protection. Valid values are 'auth', 'auth-int', and 'auth-conf'
+#sasl.qop=auth
+
+
+## Tracing properties
+## --------------

--- a/docker/stack/accumulo-env.sh
+++ b/docker/stack/accumulo-env.sh
@@ -1,49 +1,133 @@
-#!/usr/bin/env bash
+#! /usr/bin/env bash
 
+## Before accumulo-env.sh is loaded, these environment variables are set and can be used in this file:
+
+# cmd - Command that is being called such as tserver, manager, etc.
+# basedir - Root of Accumulo installation
+# bin - Directory containing Accumulo scripts
+# conf - Directory containing Accumulo configuration
+# lib - Directory containing Accumulo libraries
+
+############################
+# Variables that must be set
+############################
+
+## Accumulo logs directory. Referenced by logger config.
 ACCUMULO_LOG_DIR="${ACCUMULO_LOG_DIR:-${basedir}/logs}"
+## Hadoop installation
 HADOOP_HOME="${HADOOP_HOME:-/usr/local/hadoop}"
+## Hadoop configuration
 HADOOP_CONF_DIR="${HADOOP_CONF_DIR:-/stack}"
+## Zookeeper installation
 ZOOKEEPER_HOME="${ZOOKEEPER_HOME:-/opt/zookeeper}"
 
-ZK_JARS=$(find "${ZOOKEEPER_HOME}/lib" -maxdepth 1 -name '*.jar' \
-    -not -name '*slf4j*' -not -name '*log4j*' | paste -sd:)
-# Put Accumulo's own libraries before an application-supplied classpath. The
-# DataWave ingest distribution intentionally exports its full job classpath;
-# prepending it would downgrade libraries required by the Accumulo launcher.
+##########################
+# Build CLASSPATH variable
+##########################
+
+## Verify that Hadoop & Zookeeper installation directories exist
+if [[ ! -d $ZOOKEEPER_HOME ]]; then
+  echo "ZOOKEEPER_HOME=$ZOOKEEPER_HOME is not set to a valid directory in accumulo-env.sh"
+  exit 1
+fi
+if [[ ! -d $HADOOP_HOME ]]; then
+  echo "HADOOP_HOME=$HADOOP_HOME is not set to a valid directory in accumulo-env.sh"
+  exit 1
+fi
+
+ZK_JARS=$(find "$ZOOKEEPER_HOME/lib/" -maxdepth 1 -name '*.jar' -not -name '*slf4j*' -not -name '*log4j*' | paste -sd: -)
+# 1. Ensure Accumulo's own libraries are put before an application-supplied classpath. The DataWave ingest distribution
+# intentionally exports its full job classpath; prepending it would downgrade libraries required by the Accumulo launcher.
+# 2. datawave-stack-hadoop installs Hadoop from RPMs. Those jars live in $HADOOP_HOME/client rather than the tarball-style
+# $HADOOP_HOME/share/hadoop/client location in the image's default configuration.
+# 3. conf and lib is set by calling script that sources this env file
+#shellcheck disable=SC2154
 CLASSPATH="${conf}:${lib}/*:${HADOOP_CONF_DIR}:${ZOOKEEPER_HOME}/*:${ZK_JARS}:/usr/lib/hadoop/client/*${CLASSPATH:+:${CLASSPATH}}"
 export CLASSPATH
 
+##################################################################
+# Build JAVA_OPTS variable. Defaults below work but can be edited.
+##################################################################
+
+## JVM options set for all processes. Extra options can be passed in by setting ACCUMULO_JAVA_OPTS to an array of options.
 read -r -a accumulo_initial_opts < <(echo "${ACCUMULO_JAVA_OPTS:-}")
 JAVA_OPTS=(
-    '-XX:OnOutOfMemoryError=kill -9 %p'
-    '-XX:-OmitStackTraceInFastThrow'
-    '-Djava.net.preferIPv4Stack=true'
-    '-Dcom.google.protobuf.use_unsafe_pre22_gencode'
-    "-Daccumulo.native.lib.path=${lib}/native"
-    "${accumulo_initial_opts[@]}"
+  '-XX:OnOutOfMemoryError=kill -9 %p'
+  '-XX:-OmitStackTraceInFastThrow'
+  '-Djava.net.preferIPv4Stack=true'
+  '-Dcom.google.protobuf.use_unsafe_pre22_gencode'
+  "-Daccumulo.native.lib.path=${lib}/native"
+  "${accumulo_initial_opts[@]}"
 )
 
-case "${cmd}" in
-    manager | sserver) JAVA_OPTS=('-Xmx512m' '-Xms512m' "${JAVA_OPTS[@]}") ;;
-    monitor) JAVA_OPTS=('-Xmx1g' '-Xms1g' "${JAVA_OPTS[@]}") ;;
-    gc) JAVA_OPTS=('-Xmx256m' '-Xms256m' "${JAVA_OPTS[@]}") ;;
-    tserver) JAVA_OPTS=('-Xmx1536m' '-Xms1536m' "${JAVA_OPTS[@]}") ;;
-    *) JAVA_OPTS=('-Xmx256m' '-Xms64m' "${JAVA_OPTS[@]}") ;;
+## JVM options set for individual applications
+# cmd is set by calling script that sources this env file
+#shellcheck disable=SC2154
+case "${ACCUMULO_RESOURCE_GROUP:-default}" in
+  default)
+    # shellcheck disable=SC2154
+    # $cmd is exported in the accumulo script, but not the accumulo-service script
+    case "$cmd" in
+      manager) JAVA_OPTS=('-Xmx512m' '-Xms512m' "${JAVA_OPTS[@]}") ;;
+      monitor) JAVA_OPTS=('-Xmx1g' '-Xms1g' "${JAVA_OPTS[@]}") ;;
+      gc) JAVA_OPTS=('-Xmx256m' '-Xms256m' "${JAVA_OPTS[@]}") ;;
+      tserver) JAVA_OPTS=('-Xmx1356m' '-Xms1356m' "${JAVA_OPTS[@]}") ;;
+      compactor) JAVA_OPTS=('-Xmx256m' '-Xms256m' "${JAVA_OPTS[@]}") ;;
+      sserver) JAVA_OPTS=('-Xmx512m' '-Xms512m' "${JAVA_OPTS[@]}") ;;
+      *) JAVA_OPTS=('-Xmx256m' '-Xms64m' "${JAVA_OPTS[@]}") ;;
+    esac
+    ;;
+  *)
+    echo "ACCUMULO_RESOURCE_GROUP named $ACCUMULO_RESOURCE_GROUP is not configured in accumulo-env.sh"
+    exit 1
+    ;;
 esac
 
-JAVA_OPTS=(
-    "-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
-    "-Daccumulo.application=${cmd}${ACCUMULO_SERVICE_INSTANCE:-}_$(hostname)"
-    "-Daccumulo.metrics.service.instance=${ACCUMULO_SERVICE_INSTANCE:-}"
-    '-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector'
-    "${JAVA_OPTS[@]}"
+## JVM options set for logging. Review log4j2.properties file to see how they are used.
+JAVA_OPTS=("-Daccumulo.log.dir=${ACCUMULO_LOG_DIR}"
+  "-Daccumulo.application=${cmd}${ACCUMULO_SERVICE_INSTANCE:-}_$(hostname)"
+  "-Daccumulo.metrics.service.instance=${ACCUMULO_SERVICE_INSTANCE:-}"
+  "-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
+  "${JAVA_OPTS[@]}"
 )
 
+## Optionally setup OpenTelemetry SDK AutoConfigure
+## See https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure
+#JAVA_OPTS=('-Dotel.traces.exporter=jaeger' '-Dotel.metrics.exporter=none' '-Dotel.logs.exporter=none' "${JAVA_OPTS[@]}")
+
+## Optionally setup OpenTelemetry Java Agent
+## See https://github.com/open-telemetry/opentelemetry-java-instrumentation for more options
+#JAVA_OPTS=('-javaagent:path/to/opentelemetry-javaagent-all.jar' "${JAVA_OPTS[@]}")
+
 case "${cmd}" in
-    monitor | gc | manager | tserver | compactor | sserver)
-        JAVA_OPTS=('-Dlog4j.configurationFile=log4j2-service.properties' "${JAVA_OPTS[@]}")
-        ;;
+  monitor | gc | manager | tserver | compactor | sserver)
+    JAVA_OPTS=('-Dlog4j.configurationFile=log4j2-service.properties' "${JAVA_OPTS[@]}")
+    ;;
+  *)
+    # let log4j use its default behavior (log4j2.properties, etc.)
+    true
+    ;;
 esac
+
+############################
+# Variables set to a default
+############################
 
 export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-1}"
-export LD_LIBRARY_PATH="${HADOOP_HOME}/lib/native:${LD_LIBRARY_PATH:-}"
+## Add Hadoop native libraries to shared library paths given operating system
+case "$(uname)" in
+  Darwin) export DYLD_LIBRARY_PATH="${HADOOP_HOME}/lib/native:${DYLD_LIBRARY_PATH}" ;;
+  *) export LD_LIBRARY_PATH="${HADOOP_HOME}/lib/native:${LD_LIBRARY_PATH:-}" ;;
+esac
+
+###############################################
+# Variables that are optional. Uncomment to set
+###############################################
+
+## ACCUMULO_JAVA_PREFIX can be used to specify commands to prepend to the "java"
+## command when it is executed. This can be declared as either a scalar or an
+## array variable. The following use of declare to check if it's already set is
+## not strictly necessary, but ensures that if you set it in the calling
+## environment, that will override what is set here, rather than some mangled
+## merged result. You can set the variable any way you like.
+#declare -p 'ACCUMULO_JAVA_PREFIX' &>/dev/null || ACCUMULO_JAVA_PREFIX=''

--- a/docker/stack/accumulo.properties
+++ b/docker/stack/accumulo.properties
@@ -1,7 +1,16 @@
+# This is the main configuration file for Apache Accumulo. Available configuration properties can be
+# found at https://accumulo.apache.org/docs/2.x/configuration/server-properties
+
+## Sets location in HDFS where Accumulo will store data
 instance.volumes=hdfs://hdfs-nn:9000/accumulo
+
+## Sets location of Zookeepers
 instance.zookeeper.host=zookeeper:2181
+
+## Change secret before initialization. All Accumulo servers must have same secret
 instance.secret=DEFAULT
 
+## Set to false if 'accumulo-util build-native' fails
 tserver.memory.maps.native.enabled=true
 tserver.memory.maps.max=384M
 tserver.cache.data.size=64M
@@ -10,7 +19,7 @@ tserver.total.mutation.queue.max=128M
 tserver.sort.buffer.size=128M
 tserver.walog.max.size=256M
 
-# datawave-stack-accumulo 4.0.0-SNAPSHOT installs Hadoop from RPMs. Those jars live in
-# /usr/lib/hadoop/client rather than the tarball-style $HADOOP_HOME/share path
-# in the image's default configuration.
-general.classpaths=$ACCUMULO_HOME/lib/accumulo-server.jar,$ACCUMULO_HOME/lib/accumulo-core.jar,$ACCUMULO_HOME/lib/accumulo-start.jar,$ACCUMULO_HOME/lib/accumulo-fate.jar,$ACCUMULO_HOME/lib/accumulo-proxy.jar,$ACCUMULO_HOME/lib/[^.].*.jar,$ACCUMULO_HOME/lib/ext/[^.].*.jar,$ZOOKEEPER_HOME/lib/zookeeper[^.].*.jar,$HADOOP_CONF_DIR,/usr/lib/hadoop/client/(?!slf4j)[^.].*.jar
+## (optional) include additional property files for a resource group
+## based on the ACCUMULO_RESOURCE_GROUP env var set in accumulo-service
+#include=group-${env:ACCUMULO_RESOURCE_GROUP}.properties
+#includeOptional=group-${env:ACCUMULO_RESOURCE_GROUP}.properties


### PR DESCRIPTION
Update the accumulo config files to contain the documentation included in the Accumulo 4 defaults, while respecting customizations.

Remove the deprecated general.classpaths property.