### PR TITLE
Point validInputFormats at the Accumulo 4 AccumuloInputFormat

### DIFF
--- a/docker/config/application-mrquery.yml
+++ b/docker/config/application-mrquery.yml
@@ -10,7 +10,7 @@ datawave:
       mapReduceBaseDirectory: "/datawave/MapReduceService"
       restrictInputFormats: true
       validInputFormats:
-        - "org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat"
+        - "org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat"
         - "datawave.mr.bulk.BulkInputFormat"
       jobs:
         'BulkResultsJob':


### PR DESCRIPTION
The query service exits(1) at startup on Accumulo 4:

```
Failed to bind properties under 'datawave.query.mapreduce.valid-input-formats[0]'
  Value: org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat
  Origin: application-mrquery.yml
  caused by java.lang.ClassNotFoundException
```

Accumulo 4 removed the old `core` MapReduce API. Confirmed against the Accumulo
source at `0e7eaba32d`: there is no `core/client/mapreduce/AccumuloInputFormat.java`,
while `hadoop-mapreduce/.../hadoop/mapreduce/AccumuloInputFormat.java` is present.

Pointed `validInputFormats` at `org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat`.
No classpath change is needed - `accumulo-hadoop-mapreduce-4.0.0-SNAPSHOT.jar` is
already inside the query service's `app.jar` and carries the class.

Verified on a running a4 stack: query went from `Exited (1)` to healthy, and
`testAll.sh` got past "Query and/or Executor Services never became ready".

Work for #3766


Fixes #3933
