### PR TITLE
Replaced deleted class in application-mrquery.yml

### DIFF
--- a/docker/config/application-mrquery.yml
+++ b/docker/config/application-mrquery.yml
@@ -10,7 +10,7 @@ datawave:
       mapReduceBaseDirectory: "/datawave/MapReduceService"
       restrictInputFormats: true
       validInputFormats:
-        - "org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat"
+        - "org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat"
         - "datawave.mr.bulk.BulkInputFormat"
       jobs:
         'BulkResultsJob':


### PR DESCRIPTION
The application-mrquery.yml references the class `org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat` which was deleted in Accumulo 4. Replace it with the newer `org.apache.accumulo.hadoop.mapreduce.AccumuloInputFormat` class.