### PR TITLE
Add annotation microservice API module

### DIFF
--- a/microservices/services/annotation/README.md
+++ b/microservices/services/annotation/README.md
@@ -1,0 +1,6 @@
+## Annotation Service
+
+The annotation service modules provide a microservice boundary for DATAWAVE annotation capabilities.
+
+The `annotation-api` module currently exposes the released `datawave-core-annotation` artifact to
+microservice consumers. Service implementation and deployment support are added separately.

--- a/microservices/services/annotation/api/pom.xml
+++ b/microservices/services/annotation/api/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>gov.nsa.datawave.microservice</groupId>
+        <artifactId>datawave-microservice-parent</artifactId>
+        <version>4.0.14</version>
+        <relativePath>../../../microservice-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>annotation-api</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <properties>
+        <version.datawave>8.0.0</version.datawave>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>gov.nsa.datawave.core</groupId>
+            <artifactId>datawave-core-annotation</artifactId>
+            <version>${version.datawave}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microservices/services/annotation/pom.xml
+++ b/microservices/services/annotation/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>gov.nsa.datawave.microservice</groupId>
+        <artifactId>datawave-microservice-parent</artifactId>
+        <version>4.0.14</version>
+        <relativePath>../../microservice-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>annotation-service-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <url>https://code.nsa.gov/datawave-annotation-service</url>
+    <modules>
+        <module>api</module>
+    </modules>
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/NationalSecurityAgency/datawave</url>
+    </scm>
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>github-datawave</id>
+            <url>https://maven.pkg.github.com/NationalSecurityAgency/datawave</url>
+        </repository>
+    </repositories>
+</project>

--- a/microservices/services/pom.xml
+++ b/microservices/services/pom.xml
@@ -23,6 +23,17 @@
             </modules>
         </profile>
         <profile>
+            <id>service-annotation</id>
+            <activation>
+                <property>
+                    <name>service-annotation</name>
+                </property>
+            </activation>
+            <modules>
+                <module>annotation</module>
+            </modules>
+        </profile>
+        <profile>
             <id>service-audit</id>
             <activation>
                 <property>
@@ -152,6 +163,7 @@
             </activation>
             <modules>
                 <module>accumulo</module>
+                <module>annotation</module>
                 <module>audit</module>
                 <module>authorization</module>
                 <module>config</module>


### PR DESCRIPTION
## Summary

Adds the annotation parent and API modules and registers them with the services reactor.

See the [Datawave Annotation Microservice Review Guide](https://gist.github.com/drewfarris/26e97e780c96e4d9c367a656d68f3d97) for more details.

This is the first PR in a four-PR replacement for #3909.

## Scope

- Add the annotation service parent module.
- Add the dependency-only `annotation-api` module.
- Register annotation in the services aggregator.
- Use released `datawave-microservice-parent:4.0.14`.
- Use released `datawave-core-annotation:8.0.0`.

## Excluded

- Executable service implementation
- REST endpoints
- Persistence and messaging
- Deployment configuration
- Production enablement

## Validation

Focused build:

```text
mvn -f microservices/services/annotation/pom.xml test -DskipITs
```

Full 126-module build:

```text
mvn -Ddocker-release -Dmicroservice-docker -Ddist -Dutils -Dservices -Dstarters clean install -T 1C
```

Both builds passed.

## Production impact

None. This PR adds module and artifact structure only; it does not add an executable service.
