### PR TITLE
Add annotation microservice HTTP API

### DIFF
--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/health/rabbit/RabbitHealthChecker.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/health/rabbit/RabbitHealthChecker.java
@@ -32,6 +32,7 @@ import datawave.microservice.annotation.health.rabbit.config.RabbitHealthPropert
 import datawave.microservice.annotation.health.rabbit.config.RabbitHealthProperties.ExchangeProperties;
 import datawave.microservice.annotation.health.rabbit.config.RabbitHealthProperties.ManagementProperties;
 import datawave.microservice.annotation.health.rabbit.config.RabbitHealthProperties.QueueProperties;
+import datawave.microservice.annotation.service.AnnotationControllerV1;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -43,15 +44,15 @@ import lombok.extern.slf4j.Slf4j;
  * The poll rate used by the health checker differs depending on whether RabbitMQ is healthy or not. While this is configurable, the default behavior is to use
  * a slow poll rate when healthy, and a faster poll rate when unhealthy.
  * <p>
- * Once a problem is detected, the isHealthy method will return false, allowing request handling to reject annotation requests and causing the health endpoint
- * to report the annotation service as RABBITMQ_UNHEALTHY.
+ * Once a problem is detected, the isHealthy method will return false, which in turn will cause the {@link AnnotationControllerV1} to reject annotation
+ * requests, and cause the health endpoint to report the annotation service as RABBITMQ_UNHEALTHY.
  * <p>
  * If properly configured, the RabbitHealthChecker can attempt to repair the RabbitMQ configuration if a problem is detected. Any exchanges, queues, or bindings
  * which are missing will be created, and any exchanges, or bindings which have an invalid configuration will be deleted, and recreated. Queues with invalid
  * configurations will only be deleted, and recreated if they are empty.
  * <p>
- * Regardless, health checks will continue to be performed. Once we determine that RabbitMQ is healthy, request handling can resume processing messages, and the
- * health endpoint will report the annotation service as UP.
+ * Regardless, health checks will continue to be performed. Once we determine that RabbitMQ is healthy, the {@link AnnotationControllerV1} rest endpoint will
+ * resume processing messages, and the health endpoint will report the annotation service as UP.
  *
  */
 @Slf4j
@@ -223,7 +224,7 @@ public class RabbitHealthChecker implements HealthChecker, HealthIndicator {
      * Performs a health check of RabbitMQ.
      * <p>
      * This method is synchronized with the isHealthy method to ensure that the health check is given time to complete before deciding whether to accept an
-     * annotation request
+     * annotation request via the {@link AnnotationControllerV1}
      * <p>
      * RabbitMQ is considered to be healthy if the cluster, exchanges, queues, and bindings are configured as specified in the {@link RabbitHealthProperties}.
      * If we are not able to determine the health of the cluster, exchanges, queues, and bindings (perhaps due to the management API being unavailable, or the
@@ -567,7 +568,7 @@ public class RabbitHealthChecker implements HealthChecker, HealthIndicator {
      * Used to determine whether RabbitMQ is healthy.
      * <p>
      * This method is synchronized with the runHealthCheck method to ensure that the health check is given time to complete before deciding whether to accept an
-     * annotation request
+     * annotation request via the {@link AnnotationControllerV1}
      *
      * @return true if RabbitMQ is healthy, false if RabbitMQ is unhealthy
      */

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/AnnotationAckTracker.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/AnnotationAckTracker.java
@@ -1,0 +1,85 @@
+package datawave.microservice.annotation.service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Tracks in-flight annotation write operations by correlation ID so that async ack/timeout callbacks can resolve the original request.
+ */
+@Component
+public class AnnotationAckTracker {
+
+    private final Map<String,CountDownLatch> correlationLatchMap = new ConcurrentHashMap<>();
+
+    /**
+     * Register a new latch for the given correlation ID. If a latch already exists for this ID, the existing latch is returned instead.
+     *
+     * @param correlationId
+     *            the correlation ID to register
+     * @param latch
+     *            the latch to register
+     * @return the previously-registered latch for this ID, or {@code null} if none existed
+     */
+    public CountDownLatch putIfAbsent(String correlationId, CountDownLatch latch) {
+        return correlationLatchMap.putIfAbsent(correlationId, latch);
+    }
+
+    /**
+     * Remove and return the latch for the given correlation ID.
+     *
+     * @param correlationId
+     *            the correlation ID whose latch should be removed
+     * @param latch
+     *            the expected latch instance
+     * @return {@code true} if the latch was removed, {@code false} otherwise
+     */
+    public boolean remove(String correlationId, CountDownLatch latch) {
+        return correlationLatchMap.remove(correlationId, latch);
+    }
+
+    /**
+     * Count down the latch associated with the given correlation ID, if one exists. Uses {@link ConcurrentHashMap#computeIfPresent} to atomically fetch and
+     * count down the latch, eliminating the {@code containsKey()} → {@code get()} race that could occur if another thread removes the latch between the check
+     * and the count-down.
+     *
+     * @param correlationId
+     *            the correlation ID whose latch should be counted down
+     * @return {@code true} if a latch was found and counted down, {@code false} otherwise
+     */
+    public boolean countdown(String correlationId) {
+        return correlationLatchMap.computeIfPresent(correlationId, (key, latch) -> {
+            latch.countDown();
+            return latch;
+        }) != null;
+    }
+
+    /**
+     * Check whether a latch exists for the given correlation ID.
+     *
+     * @param correlationId
+     *            the correlation ID to check
+     * @return {@code true} if a latch exists, {@code false} otherwise
+     */
+    public boolean contains(String correlationId) {
+        return correlationLatchMap.containsKey(correlationId);
+    }
+
+    /**
+     * Check whether there are no tracked latches.
+     *
+     * @return {@code true} if no latches are currently tracked
+     */
+    public boolean isEmpty() {
+        return correlationLatchMap.isEmpty();
+    }
+
+    /**
+     * Clear all tracked latches. Used between tests to prevent leakage.
+     */
+    public void clear() {
+        correlationLatchMap.clear();
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
@@ -1,0 +1,1112 @@
+package datawave.microservice.annotation.service;
+
+import static datawave.annotation.util.v1.AnnotationUtils.injectAnnotationSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import datawave.annotation.data.transform.TimestampTransformer;
+import datawave.annotation.data.transform.VisibilityTransformer;
+import datawave.annotation.data.v1.AccumuloAnnotationSerializer;
+import datawave.annotation.data.v1.AccumuloAnnotationSourceSerializer;
+import datawave.annotation.data.v1.AnnotationDataAccess;
+import datawave.annotation.data.v1.AnnotationReader;
+import datawave.annotation.data.v1.FederatedAnnotationReader;
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.AnnotationMessage;
+import datawave.annotation.protobuf.v1.AnnotationSource;
+import datawave.annotation.protobuf.v1.Segment;
+import datawave.annotation.util.Validator;
+import datawave.annotation.util.v1.AnnotationJsonUtils;
+import datawave.annotation.util.v1.AnnotationUtils;
+import datawave.annotation.util.v1.AnnotationValidators;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.core.query.runner.AccumuloConnectionRequestMap;
+import datawave.microservice.annotation.common.AnnotationSupplier;
+import datawave.microservice.annotation.health.HealthChecker;
+import datawave.microservice.annotation.service.config.AnnotationProperties;
+import datawave.microservice.annotation.util.Metadata;
+import datawave.microservice.annotation.util.lookup.service.LookupService;
+import datawave.microservice.annotation.writers.AnnotationWriter;
+import datawave.microservice.authorization.user.DatawaveUserDetails;
+import datawave.microservice.authorization.util.AuthorizationsUtil;
+import datawave.webservice.query.exception.QueryException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+/** Provides REST endpoints for reading and writing annotations to Datawave */
+@Tag(name = "Annotation Controller /v1", description = "Operations related to annotations")
+@Slf4j
+@RestController
+@Secured({"AuthorizedUser", "AuthorizedQueryServer", "InternalUser", "Administrator"})
+@RequestMapping(path = "/v1", produces = {MediaType.APPLICATION_JSON_VALUE})
+public class AnnotationControllerV1 {
+    // Note: This must match 'annotationAckChannel' in the service configuration. Default set in bootstrap.yml.
+    public static final String ANNOTATION_ACK_CHANNEL = "annotationAckChannel";
+
+    public static final String ANNOTATION_SERVICE_SYSTEM_FROM = "annotation";
+
+    /** used to serialize error response bodies (see {@link #jsonError(String)}/{@link #jsonNotFound(String)}) */
+    private static final ObjectMapper JSON_ERROR_MAPPER = new ObjectMapper();
+
+    private final AnnotationProperties annotationProperties;
+
+    /** used for reading from accumulo */
+    private final AccumuloConnectionFactory connectionFactory;
+
+    /** tracks accumulo connections */
+    private final AccumuloConnectionRequestMap accumuloConnectionRequestMap = new AccumuloConnectionRequestMap();
+
+    /** used to transform external identifiers into internal identifiers */
+    private final LookupService lookupService;
+
+    /** executor service for federated annotation reads (fan-out across annotation + truthmark tables) */
+    private final ExecutorService federatedReadExecutorService;
+
+    // Configuration for the data access object
+    private final TimestampTransformer timestampTransformer;
+    private final VisibilityTransformer visibilityTransformer;
+
+    private final AnnotationAckTracker annotationAckTracker;
+
+    /** used as a 'sink' for annotation writes */
+    private final AnnotationSupplier annotationSource;
+
+    /** used as a backup writer for annotations */
+    @Autowired(required = false)
+    @Qualifier("fileAnnotationWriter")
+    private AnnotationWriter fileAnnotationWriter;
+
+    /** gates message publishing on messaging-infrastructure health, when the rabbit health checker is enabled */
+    @Autowired(required = false)
+    private HealthChecker healthChecker;
+
+    @Autowired
+    public AnnotationControllerV1(AccumuloConnectionFactory factory, LookupService lookupService, AnnotationProperties annotationProperties,
+                    TimestampTransformer timestampTransformer, VisibilityTransformer visibilityTransformer, AnnotationSupplier annotationSource,
+                    ExecutorService federatedReadExecutorService, AnnotationAckTracker annotationAckTracker) {
+        this.connectionFactory = factory;
+        this.lookupService = lookupService;
+        this.annotationProperties = annotationProperties;
+        this.timestampTransformer = timestampTransformer;
+        this.visibilityTransformer = visibilityTransformer;
+        this.annotationSource = annotationSource;
+        this.federatedReadExecutorService = federatedReadExecutorService;
+        this.annotationAckTracker = annotationAckTracker;
+    }
+
+    @GetMapping("/source/{analyticHash}")
+    public ResponseEntity<?> getAnnotationSource(@PathVariable String analyticHash, @RequestParam MultiValueMap<String,String> queryParameters,
+                    @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        try {
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+            Optional<AnnotationSource> results = annotationDataAccess.getAnnotationSource(analyticHash);
+            if (results.isEmpty()) {
+                return jsonNotFound("No annotation source found for analyticHash: " + analyticHash);
+            }
+            return jsonOk(results.get());
+        } catch (Exception e) {
+            final String message = String.format("Internal error fetching annotation source: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+
+    }
+
+    @GetMapping("/{idType}/{id}/types")
+    public ResponseEntity<?> getAnnotationTypes(@Parameter(description = "The type of identifier to use for lookup") @PathVariable String idType,
+                    @Parameter(description = "The identifier to use for lookup") @PathVariable String id,
+                    @RequestParam MultiValueMap<String,String> queryParameters, @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        // TODO sanitize input to make sure it contains nothing weird like nulls.
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        try {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadata.isEmpty()) {
+                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
+            }
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+            final Map<Metadata,Collection<String>> results = new HashMap<>();
+            for (Metadata md : metadata) {
+                final Collection<String> types = annotationDataAccess.getAnnotationTypes(md.getRow(), md.getDataType(), md.getInternalId());
+                if (!types.isEmpty()) {
+                    results.put(md, types);
+                }
+            }
+            if (results.isEmpty()) {
+                return jsonNotFound("annotation types", idType, id, metadata.toString(), null, null, null);
+            }
+            return jsonOk(results);
+        } catch (Exception e) {
+            final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    @GetMapping("/{idType}/{id}")
+    public ResponseEntity<?> getAnnotationsFor(@PathVariable String idType, @PathVariable String id, @RequestParam MultiValueMap<String,String> queryParameters,
+                    @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        // TODO sanitize input to make sure it contains nothing weird like nulls.
+        try {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadata.isEmpty()) {
+                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
+            }
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+
+            final List<Annotation> results = new ArrayList<>();
+            for (Metadata md : metadata) {
+                final Collection<Annotation> annotations = annotationDataAccess.getAnnotations(md.getRow(), md.getDataType(), md.getInternalId());
+                if (!annotations.isEmpty()) {
+                    List<Annotation> annotationsWithSources = lookupAndInjectAnnotationSources(context, annotations);
+                    results.addAll(annotationsWithSources);
+                }
+            }
+            if (results.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, null, null);
+            }
+            return jsonOk(results);
+        } catch (Exception e) {
+            final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    @GetMapping("/{idType}/{id}/type/{annotationType}")
+    public ResponseEntity<?> getAnnotationsByType(@PathVariable String idType, @PathVariable String id, @PathVariable String annotationType,
+                    @RequestParam MultiValueMap<String,String> queryParameters, @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        // TODO sanitize input to make sure it contains nothing weird like nulls.
+        try {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadata.isEmpty()) {
+                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
+            }
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+
+            final List<Annotation> results = new ArrayList<>();
+            for (Metadata md : metadata) {
+                final Collection<Annotation> annotations = annotationDataAccess.getAnnotationsForType(md.getRow(), md.getDataType(), md.getInternalId(),
+                                annotationType);
+                if (!annotations.isEmpty()) {
+                    List<Annotation> annotationsWithSources = lookupAndInjectAnnotationSources(context, annotations);
+                    results.addAll(annotationsWithSources);
+                }
+            }
+            if (results.isEmpty()) {
+                return jsonNotFound("annotations of type", idType, id, metadata.toString(), annotationType, null, null);
+            }
+            return jsonOk(results);
+        } catch (Exception e) {
+            final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    @GetMapping("/{idType}/{id}/annotation/{annotationId}")
+    public ResponseEntity<?> getAnnotation(@PathVariable String idType, @PathVariable String id, @PathVariable String annotationId,
+                    @RequestParam MultiValueMap<String,String> queryParameters, @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        try {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadata.isEmpty()) {
+                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
+            }
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+
+            final List<Annotation> results = new ArrayList<>();
+            for (Metadata md : metadata) {
+                final Optional<Annotation> annotations = annotationDataAccess.getAnnotation(md.getRow(), md.getDataType(), md.getInternalId(), annotationId);
+                if (annotations.isPresent()) {
+                    Annotation annotationWithSource = lookupAndInjectAnnotationSource(context, annotations.get());
+                    results.add(annotationWithSource);
+                }
+            }
+            if (results.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, annotationId, null);
+            }
+            return jsonOk(results);
+        } catch (Exception e) {
+            final String message = String.format("Internal error fetching annotation: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    /**
+     * Adds an annotation for the document identified by {@code idType}/{@code id}.
+     * <p>
+     * <b>HTTP response contract:</b> a {@code 200} response means the annotation write was durably accepted, either because the message broker
+     * producer-confirmed receipt of the annotation message, or because the configured file-fallback writer successfully persisted it after the broker was
+     * unavailable/unresponsive. A {@code 200} response does <i>not</i> mean the annotation has been committed to Accumulo; downstream consumer persistence (and
+     * its own retry/DLQ handling) happens independently and asynchronously after this call returns. This mirrors the audit microservice's established
+     * acknowledgement contract: producer-confirmed ingress or successful fallback, not end-to-end persistence.
+     */
+    // @formatter:off
+    @Operation(
+            summary = "Adds an annotation for the identified document.",
+            description = "A 200 response means the write was durably accepted (message broker producer confirmation, or successful file-fallback write), "
+                            + "not that the annotation has been committed to Accumulo; Accumulo persistence happens independently, asynchronously.")
+    @ApiResponse(
+            description = "the annotation that was accepted for durable write (ingress-accepted, not yet necessarily persisted to Accumulo)",
+            responseCode = "200")
+    // @formatter:on
+    @PostMapping(path = "/{idType}/{id}/annotation", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Secured("AnnotationWriter")
+    public ResponseEntity<?> addAnnotation(@PathVariable String idType, @PathVariable String id, @RequestBody String body,
+                    @RequestParam MultiValueMap<String,String> queryParameters, @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        try {
+            final Annotation rawAnnotation = AnnotationJsonUtils.annotationFromJson(body);
+            final Validator.ValidationState<Annotation> validationState = AnnotationValidators.checkAnnotation(rawAnnotation);
+            if (!validationState.isValid()) {
+                final String message = String.format("Invalid annotation json: %s", validationState.getErrors());
+                log.error(message);
+                return jsonError(message);
+            }
+
+            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadataList.isEmpty()) {
+                final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
+                log.info(message);
+                return jsonNotFound(message);
+            } else if (metadataList.size() > 1) {
+                final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
+                                id, metadataList);
+                log.error(message);
+                return jsonError(message);
+            }
+
+            final Metadata metadata = metadataList.get(0);
+
+            //@formatter:off
+            final Annotation localizedAnnotation = rawAnnotation.toBuilder()
+                    .setShard(metadata.getRow())
+                    .setDataType(metadata.getDataType())
+                    .setUid(metadata.getInternalId())
+                    .build();
+            //@formatter:on
+
+            Optional<Annotation> addResult = writeAnnotation(localizedAnnotation);
+            if (addResult.isPresent()) {
+                log.debug("Successfully added annotation: {}", addResult.get());
+                return jsonOk(addResult.get());
+            }
+
+            // if we make it here, there was a problem
+            String message = String.format(
+                            "Internal error: Optional return from dao addAnnotation was empty, id: %s, idType %s, internal id %s, localized annotation: %s",
+                            idType, id, metadata, localizedAnnotation);
+            log.error(message);
+            return jsonError(message);
+        } catch (InvalidProtocolBufferException e) {
+            final String message = String.format("Invalid annotation json: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } catch (QueryException e) {
+            final String message = String.format("Internal error adding annotation: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    /**
+     * Updates an existing annotation for the document identified by {@code idType}/{@code id}.
+     * <p>
+     * <b>HTTP response contract:</b> a {@code 200} response means the annotation write was durably accepted, either because the message broker
+     * producer-confirmed receipt of the annotation message, or because the configured file-fallback writer successfully persisted it after the broker was
+     * unavailable/unresponsive. A {@code 200} response does <i>not</i> mean the annotation has been committed to Accumulo; downstream consumer persistence (and
+     * its own retry/DLQ handling) happens independently and asynchronously after this call returns. This mirrors the audit microservice's established
+     * acknowledgement contract: producer-confirmed ingress or successful fallback, not end-to-end persistence.
+     */
+    // @formatter:off
+    @Operation(
+            summary = "Updates an existing annotation for the identified document.",
+            description = "A 200 response means the write was durably accepted (message broker producer confirmation, or successful file-fallback write), "
+                            + "not that the annotation has been committed to Accumulo; Accumulo persistence happens independently, asynchronously.")
+    @ApiResponse(
+            description = "the annotation that was accepted for durable write (ingress-accepted, not yet necessarily persisted to Accumulo)",
+            responseCode = "200")
+    // @formatter:on
+    @PutMapping(path = "/{idType}/{id}/annotation/{annotationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Secured("AnnotationWriter")
+    public ResponseEntity<?> updateAnnotation(@PathVariable String idType, @PathVariable String id, @PathVariable String annotationId, @RequestBody String body,
+                    @RequestParam MultiValueMap<String,String> queryParameters, @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        try {
+            final Annotation rawAnnotation = AnnotationJsonUtils.annotationFromJson(body);
+            final Validator.ValidationState<Annotation> validationState = AnnotationValidators.checkAnnotationUpdate(rawAnnotation);
+            if (!validationState.isValid()) {
+                final String message = String.format("Invalid annotation json: %s", validationState.getErrors());
+                log.error(message);
+                return jsonError(message);
+            }
+
+            final List<Metadata> metadataList = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadataList.isEmpty()) {
+                final String message = String.format("No internal identifier found for '%s:%s'", idType, id);
+                log.info(message);
+                return jsonNotFound(message);
+            } else if (metadataList.size() > 1) {
+                final String message = String.format("Multiple internal identifiers found for '%s:%s' must choose an id with a single internal id: %s", idType,
+                                id, metadataList);
+                log.error(message);
+                return jsonError(message);
+            }
+
+            final Metadata metadata = metadataList.get(0);
+
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+            final Optional<Annotation> targetAnnotation = annotationDataAccess.getAnnotation(metadata.getRow(), metadata.getDataType(),
+                            metadata.getInternalId(), annotationId);
+            if (targetAnnotation.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, annotationId, null);
+            }
+
+            //@formatter:off
+            final Annotation localizedAnnotation = rawAnnotation.toBuilder()
+                    .setShard(metadata.getRow())
+                    .setDataType(metadata.getDataType())
+                    .setUid(metadata.getInternalId())
+                    .build();
+            //@formatter:on
+
+            // link the replacement annotation back to the annotation it is updating so the two remain associated in the store.
+            final Annotation referencedAnnotation = AnnotationUtils.injectUpdateReference(localizedAnnotation, annotationId);
+
+            Optional<Annotation> addResult = writeAnnotation(referencedAnnotation);
+            if (addResult.isPresent()) {
+                log.debug("Successfully updated annotation: {}", addResult.get());
+                return jsonOk(addResult.get());
+            }
+            // if we make it here, there was a problem
+            String message = String.format(
+                            "Internal error: Optional return from dao updateAnnotation was empty, id: %s, idType %s, internal id %s, localized annotation: %s",
+                            idType, id, metadata, referencedAnnotation);
+            log.error(message);
+            return jsonError(message);
+        } catch (InvalidProtocolBufferException e) {
+            final String message = String.format("Invalid annotation json: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } catch (QueryException e) {
+            final String message = String.format("Internal error updating annotation: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    @GetMapping("/{idType}/{id}/annotation/{annotationId}/segment/{segmentHash}")
+    public ResponseEntity<?> getAnnotationSegment(@PathVariable String idType, @PathVariable String id, @PathVariable String annotationId,
+                    @PathVariable String segmentHash, @RequestParam MultiValueMap<String,String> queryParameters,
+                    @AuthenticationPrincipal DatawaveUserDetails currentUser) {
+        final RequestContext context = new RequestContext(queryParameters, currentUser, annotationProperties, connectionFactory, accumuloConnectionRequestMap,
+                        visibilityTransformer, timestampTransformer, federatedReadExecutorService);
+
+        try {
+            final List<Metadata> metadata = lookupDocumentIdentifier(idType, id, queryParameters, currentUser);
+            if (metadata.isEmpty()) {
+                return jsonNotFound(String.format("No internal identifier found for '%s:%s'", idType, id));
+            }
+            final AnnotationReader annotationDataAccess = context.initializeAnnotationService();
+
+            final Map<Metadata,Annotation> annotationResults = new HashMap<>();
+            for (Metadata md : metadata) {
+                final Optional<Annotation> annotation = annotationDataAccess.getAnnotation(md.getRow(), md.getDataType(), md.getInternalId(), annotationId);
+                annotation.ifPresent(value -> annotationResults.put(md, value));
+            }
+
+            if (annotationResults.isEmpty()) {
+                return jsonNotFound("annotations", idType, id, metadata.toString(), null, annotationId, segmentHash);
+            }
+
+            final Map<Metadata,Collection<Segment>> results = new HashMap<>();
+            for (Map.Entry<Metadata,Annotation> entry : annotationResults.entrySet()) {
+                // now select only the segments that were requested.
+                List<Segment> matchingSegments = new ArrayList<>();
+                for (Segment s : entry.getValue().getSegmentsList()) {
+                    if (s.getSegmentHash().equals(segmentHash)) {
+                        matchingSegments.add(s);
+                    }
+                }
+                if (!matchingSegments.isEmpty()) {
+                    results.put(entry.getKey(), matchingSegments);
+                }
+            }
+
+            if (results.isEmpty()) {
+                return jsonNotFound("segments", idType, id, metadata.toString(), null, annotationId, segmentHash);
+            }
+            return jsonOk(results);
+        } catch (QueryException e) {
+            final String message = String.format("Internal error fetching segment: %s", e.getMessage());
+            log.error(message, e);
+            return jsonError(message);
+        } finally {
+            context.returnAccumuloClient();
+        }
+    }
+
+    /* package-private for unit testing */
+    Optional<Annotation> writeAnnotation(Annotation annotation) {
+        Annotation identifiedAnnotation = AnnotationUtils.injectAllHashes(annotation);
+        Optional<Annotation> result;
+
+        final long writeStartTime = System.currentTimeMillis();
+        long currentTime = writeStartTime;
+        int attempts = 0;
+
+        AnnotationProperties.Retry retry = annotationProperties.getRetry();
+
+        do {
+            if (attempts++ > 0) {
+                try {
+                    // noinspection BusyWait
+                    Thread.sleep(retry.getBackoffIntervalMillis());
+                } catch (InterruptedException e) {
+                    // Restore the interrupt status so callers/executors (e.g. a pool shutting down) can observe that this
+                    // thread was asked to stop, then abandon retrying rather than continuing to loop on an interrupted thread.
+                    // The file-writer fallback below is still attempted, matching how any other retry exhaustion is handled.
+                    Thread.currentThread().interrupt();
+                    result = Optional.empty();
+                    break;
+                }
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Annotation write attempt {} of {}", identifiedAnnotation.getAnnotationId(), attempts, retry.getMaxAttempts());
+            }
+
+            result = sendAnnotation(identifiedAnnotation);
+            currentTime = System.currentTimeMillis();
+        } while (result.isEmpty() && retry.noTimeout(writeStartTime, currentTime) && retry.hasAttemptsRemaining(attempts));
+
+        if (result.isEmpty() && fileAnnotationWriter != null) {
+            result = Optional.of(identifiedAnnotation);
+            try {
+                log.debug("[{}] Attempting to write annotation to the filesystem", identifiedAnnotation.getAnnotationId());
+                fileAnnotationWriter.write(identifiedAnnotation);
+            } catch (Exception e) {
+                log.error("[{}] Unable to save annotation to the filesystem", identifiedAnnotation.getAnnotationId(), e);
+                result = Optional.empty();
+            }
+        }
+
+        if (result.isEmpty()) {
+            log.warn("[{}] Annotation write failed. {attempts = {}, elapsedMillis = {}{}}", identifiedAnnotation.getAnnotationId(), attempts,
+                            (currentTime - writeStartTime),
+                            ((fileAnnotationWriter != null) ? ", hdfsElapsedMillis = " + (System.currentTimeMillis() - currentTime) : ""));
+        } else {
+            log.info("[{}] Annotation write successful. {attempts = {}, elapsedMillis = {}{}}", identifiedAnnotation.getAnnotationId(), attempts,
+                            (currentTime - writeStartTime),
+                            ((fileAnnotationWriter != null) ? ", hdfsElapsedMillis = " + (System.currentTimeMillis() - currentTime) : ""));
+        }
+
+        return result;
+    }
+
+    /**
+     * Adapter between writeAnnotation(Annotation) and sendAnnotationMessage that manages the fact that messages sent and received by this controller only send
+     * a single Annotation at a time
+     *
+     * @param annotation
+     *            the annotation to send
+     * @return an Optional containing the annotation that was sent, possibly empty
+     */
+    /* package-private for unit testing */
+    Optional<Annotation> sendAnnotation(Annotation annotation) {
+        //@formatter:off
+        AnnotationMessage annotationMessage = AnnotationMessage.newBuilder()
+                .addAnnotations(annotation)
+                .setSource(annotationProperties.getSystemFrom())
+                .build();
+        //@formatter:on
+
+        Optional<AnnotationMessage> result = sendAnnotationMessage(annotationMessage);
+
+        if (result.isEmpty()) {
+            return Optional.empty();
+        }
+
+        AnnotationMessage resultMessage = result.get();
+        List<Annotation> annotationList = resultMessage.getAnnotationsList();
+        if (annotationList.isEmpty()) {
+            return Optional.empty();
+        } else if (annotationList.size() > 1) {
+            log.warn("Unexpected annotation list size in AnnotationMessage id {}: {}", resultMessage.getAnnotationMessageId(), annotationList.size());
+        }
+        return Optional.of(annotationList.get(0));
+    }
+
+    /* package-private for unit testing */
+    Optional<AnnotationMessage> sendAnnotationMessage(AnnotationMessage annotationMessage) {
+        // If a rabbit health checker is configured and reports the messaging infrastructure as unhealthy, skip attempting to send
+        // entirely -- the caller's retry/backoff loop in writeAnnotation will keep re-checking on subsequent attempts, and will
+        // eventually fall back to the file writer once its retry budget is exhausted.
+        if (healthChecker != null && !healthChecker.isHealthy()) {
+            return Optional.empty();
+        }
+
+        AnnotationMessage identifiedMessage = annotationMessage.getAnnotationMessageId().isBlank()
+                        ? AnnotationUtils.injectAnnotationMessageHash(annotationMessage)
+                        : annotationMessage;
+        String annotationMessageId = identifiedMessage.getAnnotationMessageId();
+
+        boolean success;
+        if (annotationProperties.isAnnotationAckEnabled()) {
+            final CountDownLatch newLatch = new CountDownLatch(1);
+            // if a send for this exact annotationMessageId is already in flight, reuse its latch instead of overwriting it -- overwriting
+            // would orphan the earlier caller's latch so that it never gets counted down and always times out.
+            final CountDownLatch existingLatch = annotationAckTracker.putIfAbsent(annotationMessageId, newLatch);
+            final boolean isOriginalSender = existingLatch == null;
+            final CountDownLatch latch = isOriginalSender ? newLatch : existingLatch;
+
+            success = !isOriginalSender || annotationSource.send(MessageBuilder.withPayload(identifiedMessage).setCorrelationId(annotationMessageId).build());
+
+            try {
+                success = success && latch.await(annotationProperties.getAnnotationAckTimeoutMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                // Restore the interrupt status so callers/executors can observe that this thread was asked to stop.
+                Thread.currentThread().interrupt();
+                success = false;
+            } finally {
+                // only the original sender owns this latch entry and should remove it; a duplicate caller must leave it alone
+                // so the original sender's await(...) above can still be satisfied by the eventual ack.
+                if (isOriginalSender) {
+                    annotationAckTracker.remove(annotationMessageId, latch);
+                }
+            }
+        } else {
+            success = annotationSource.send(MessageBuilder.withPayload(identifiedMessage).setCorrelationId(annotationMessageId).build());
+        }
+
+        return success ? Optional.of(identifiedMessage) : Optional.empty();
+    }
+
+    /**
+     * Receives producer confirm acknowledgements, and disengages the latch associated with the given correlation ID.
+     *
+     * @param message
+     *            the confirmation acknowledgements message
+     */
+    @ConditionalOnProperty(value = "annotation.annotationAckEnabled", havingValue = "true", matchIfMissing = true)
+    @ServiceActivator(inputChannel = ANNOTATION_ACK_CHANNEL)
+    public void processConfirmAck(Message<?> message) {
+        Object headerObj = message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+
+        if (headerObj != null) {
+            String correlationId = headerObj.toString();
+            if (annotationAckTracker.countdown(correlationId)) {} else {
+                log.warn("Unable to decrement latch for audit ID [{}]", correlationId);
+            }
+        } else {
+            log.warn("No correlation ID found in confirm ack message");
+        }
+    }
+
+    /**
+     * Look up the internal id for the annotation and return a 3 part tuple of shard, datatype uid
+     *
+     * @param idType
+     *            the type of id provided
+     * @param id
+     *            the id itself.
+     * @param queryParameters
+     *            the request query parameters used to prepare any remote lookup request
+     * @param currentUser
+     *            the current user whose authorizations should be applied to the lookup
+     * @return a list of zero to many Metadata objects with the internal shard, datatype, uid and table name of the identifier(s) provided. The list will be
+     *         empty if no identifier could be found using the authorizations and query logic employed by this class.
+     * @throws QueryException
+     *             if the id is malformed.
+     */
+    private List<Metadata> lookupDocumentIdentifier(String idType, String id, MultiValueMap<String,String> queryParameters, DatawaveUserDetails currentUser)
+                    throws QueryException {
+        // If the idType is RECORD_ID or DOCUMENT, treat the id provided as an internal id and perform a direct lookup
+        // against the annotations table, if that's enabled.
+        if (idType.equals("DOCUMENT") || idType.equals("RECORD_ID")) {
+            if (!annotationProperties.isEnableInternalIdLookup()) {
+                final String message = String.format("Internal identifier lookup is disabled for '%s:%s' please use a valid document id type.", idType, id);
+                throw new QueryException(message);
+            }
+
+            return parseDocumentIdentifier(id);
+        }
+
+        return lookupService.executeLookupUUIDQuery(idType, id, prepareLookupParameters(queryParameters, currentUser), annotationProperties.getSystemFrom(),
+                        currentUser);
+    }
+
+    /**
+     * Build the "legacy params" wrapper (semicolon-separated {@code name:value} pairs, e.g. {@code "auths:A,B,C"}) sent as the single {@code params} query
+     * parameter on the remote lookup request, per the Q07 (Option B) decision.
+     * <p>
+     * Only an explicit allowlist of caller-supplied query parameters is ever forwarded to the remote lookup service; every other caller-supplied parameter is
+     * discarded, since blindly forwarding arbitrary parameters could change the downstream lookup query's behavior or introduce an injection surface. Currently
+     * the allowlist contains exactly one entry: {@code auths}. If a caller did not supply {@code auths}, nothing is forwarded and the downstream lookup
+     * defaults to the caller's full authorization set - exactly mirroring the no-override branch of {@link RequestContext#initializeAuthorizations()} used for
+     * local reads. If a caller did supply {@code auths}, it is downgraded against that same caller's own authorizations using the identical
+     * {@link AuthorizationsUtil#downgradeUserAuths(String, ProxiedUserDetails, ProxiedUserDetails)} call used by {@code RequestContext}, so that a remote
+     * lookup and a local read triggered by the same request are guaranteed to operate under the same authorization scope.
+     *
+     * @param queryParameters
+     *            the incoming request's query parameters
+     * @param currentUser
+     *            the caller whose authorizations bound any requested downgrade
+     * @return the encoded legacy params string, or an empty string if no allowlisted parameter was supplied
+     * @throws QueryException
+     *             if the requested auths could not be downgraded against the caller's own authorizations
+     */
+    private String prepareLookupParameters(MultiValueMap<String,String> queryParameters, DatawaveUserDetails currentUser) throws QueryException {
+        String queryAuthorizations = queryParameters.getFirst(RequestContext.QUERY_AUTHORIZATIONS);
+        if (queryAuthorizations == null || queryAuthorizations.isBlank()) {
+            return "";
+        }
+
+        try {
+            final String downgradedAuths = AuthorizationsUtil.downgradeUserAuths(queryAuthorizations, currentUser, currentUser);
+            return RequestContext.QUERY_AUTHORIZATIONS + ":" + downgradedAuths;
+        } catch (Exception e) {
+            throw new QueryException("Failed to downgrade user query authorizations for remote lookup", e);
+        }
+    }
+
+    /**
+     * Given a list of annotations, retrieve the annotation source information that is referenced by their analyticHash. If an analyticHash is not found, we
+     * simply return the annotation without the source data injected. Currently, no errors are logged.
+     *
+     * @param context
+     *            the request-scoped context that provides cached annotation source lookups
+     * @param annotations
+     *            the annotations to inject sources into
+     * @return return annotations with sources injected where possible.
+     */
+    /**
+     * When returning the source in the context of an annotation, mask/remove certain metadata from the source (e.g., visibility) because the metadata on the
+     * annotation itself takes precedence. Mirrors the legacy {@code AnnotationManagerBean.maskSourceMetadata(AnnotationSource)} behavior.
+     *
+     * @param annotationSource
+     *            the annotation source with metadata fields to mask
+     * @return a new source with masked fields removed, or the original source if nothing was masked
+     */
+    private AnnotationSource maskSourceMetadata(AnnotationSource annotationSource) {
+        final List<String> fieldsToMask = annotationProperties.getMaskSourceMetadata();
+        if (fieldsToMask == null || fieldsToMask.isEmpty()) {
+            // no fields to mask, make no changes.
+            return annotationSource;
+        }
+
+        AnnotationSource.Builder builder = null;
+        for (String key : fieldsToMask) {
+            if (annotationSource.containsMetadata(key)) {
+                if (builder == null) {
+                    builder = annotationSource.toBuilder();
+                }
+                builder.removeMetadata(key);
+            }
+        }
+
+        return (builder == null) ? annotationSource : builder.build();
+    }
+
+    private List<Annotation> lookupAndInjectAnnotationSources(RequestContext context, Collection<Annotation> annotations) {
+        final List<Annotation> results = new ArrayList<>();
+        for (Annotation a : annotations) {
+            results.add(lookupAndInjectAnnotationSource(context, a));
+        }
+        return results;
+    }
+
+    /**
+     * Given an annotation, retrieve the annotation source information that is referenced by their analyticHash. Employs a per-request hash so we don't look up
+     * a single source multiple times.
+     *
+     * @param context
+     *            the request-scoped context that provides cached annotation source lookups
+     * @param a
+     *            the annotation whose source should be looked up and injected when available
+     * @return the original annotation, or the same annotation with its source injected when a matching source is found
+     */
+    private Annotation lookupAndInjectAnnotationSource(RequestContext context, Annotation a) {
+        // no need to inject a source if we already have one.
+        if (a.hasSource()) {
+            log.warn("Strange, this annotation already has a source. Annotation {}/{}/{} {}, using analyticHash {}", a.getShard(), a.getDataType(), a.getUid(),
+                            a.getAnnotationId(), a.getAnalyticSourceHash());
+            return a;
+        }
+
+        if (StringUtils.isBlank(a.getAnalyticSourceHash())) {
+            log.warn("Strange, this annotation does not have an analytic hash. Annotation {}/{}/{} {}", a.getShard(), a.getDataType(), a.getUid(),
+                            a.getAnnotationId());
+            return a;
+        }
+
+        // do the deed and cache the results.
+        final String analyticHash = a.getAnalyticSourceHash();
+        final Optional<AnnotationSource> result = context.getAnnotationSource(analyticHash);
+        if (result.isPresent()) {
+            return injectAnnotationSource(a, maskSourceMetadata(result.get()));
+        } else {
+            log.debug("No analytic source found for annotation {}/{}/{} {}, using analyticHash {}", a.getShard(), a.getDataType(), a.getUid(),
+                            a.getAnnotationId(), a.getAnalyticSourceHash());
+            return a;
+        }
+    }
+
+    /**
+     * Parse an identifier that is expected to be in the shardId/datatype/eventUID format into a Metadata object
+     *
+     * @param identifier
+     *            the identifier to parse
+     * @return a singleton list the corresponding Metadata object
+     * @throws IllegalArgumentException
+     *             if the identifier is not in the expected shardId/datatype/eventUID format.
+     */
+    private List<Metadata> parseDocumentIdentifier(String identifier) {
+        final String[] parts = identifier.split("[/:]");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException(
+                            "Identifier does not specify all needed 3 parts. Identifier must be in the form 'shardId/datatype/eventUID' or 'shardId:datatype:eventUID'.");
+        }
+
+        final Metadata md = new Metadata(annotationProperties.getShardTableName(), parts[0], parts[1], parts[2]);
+        return Collections.singletonList(md);
+    }
+
+    private static ResponseEntity<?> jsonNotFound(String objectType, String idType, String id, String internalId, String annotationType, String annotationId,
+                    String segmentHash) {
+        String message = id.contains(internalId) ? String.format("No %s found for identifier: '%s:%s'", objectType, idType, id)
+                        : String.format("No %s found for identifier '%s:%s', internalId: '%s'", objectType, idType, id, internalId);
+
+        if (!StringUtils.isEmpty(annotationType)) {
+            message += String.format(", annotationType '%s'", annotationType);
+        }
+        if (!StringUtils.isEmpty(annotationId)) {
+            message += String.format(", annotationId '%s'", annotationId);
+        }
+        if (!StringUtils.isEmpty(segmentHash)) {
+            message += String.format(", segmentHash '%s'", segmentHash);
+        }
+
+        return jsonNotFound(message);
+    }
+
+    @VisibleForTesting
+    static ResponseEntity<String> jsonNotFound(String message) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON).body(toJsonMessage(message));
+    }
+
+    @VisibleForTesting
+    static ResponseEntity<String> jsonError(String message) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(MediaType.APPLICATION_JSON).body(toJsonMessage(message));
+    }
+
+    /**
+     * Serializes a simple {@code {"message": "..."}} error body via Jackson, rather than hand-building the JSON via string concatenation, which would produce
+     * malformed or injectable output whenever {@code message} itself contains a quote, backslash, or control character (e.g. from an exception message or
+     * user-supplied identifier).
+     */
+    @VisibleForTesting
+    static String toJsonMessage(String message) {
+        try {
+            return JSON_ERROR_MAPPER.writeValueAsString(Collections.singletonMap("message", message));
+        } catch (JsonProcessingException e) {
+            // extremely unlikely for a single string value, but fall back to a safely-escaped literal rather than propagating
+            log.error("Unable to serialize error message to JSON", e);
+            return "{\"message\":\"Internal error\"}";
+        }
+    }
+
+    private static <T> ResponseEntity<T> jsonOk(T body) {
+        return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(body);
+    }
+
+    /** Per-request initialization code and related state */
+    protected static final class RequestContext {
+
+        public static final String QUERY_AUTHORIZATIONS = "auths";
+
+        private final AnnotationProperties config;
+
+        private final AccumuloConnectionFactory connectionFactory;
+
+        private final AccumuloConnectionRequestMap accumuloConnectionRequestBean;
+
+        /** the current user running the query. */
+        private final DatawaveUserDetails currentUser;
+
+        /** the dn of the user performing this request */
+        private final String userDn;
+
+        /** proxy servers involved in this request */
+        private final Collection<String> proxyServers;
+
+        private final String queryAuthorizations;
+
+        private final VisibilityTransformer visibilityTransformer;
+        private final TimestampTransformer timestampTransformer;
+        private final ExecutorService federatedReadExecutorService;
+
+        /** the final set of merged query and user authorizations. */
+        Set<Authorizations> authorizations;
+
+        /** the accumulo client to use for this request - obtained from the connection pool and must be returned. */
+        AccumuloClient client;
+
+        /** used to _read_ annotations directly from accumulo, scoped to the caller's authorizations */
+        AnnotationReader annotationDataAccess;
+
+        /** Cache lookups for unique analytic source hashes so we don't perform lookups more than once. TODO: make this a proper cross-request cache? */
+        private final Map<String,Optional<AnnotationSource>> retrievedSourcesCache = new HashMap<>();
+
+        /**
+         * Initialize the request context with the objects needed to perform various request state initialization. Validation of the objects provided is
+         * performed in the various initialize methods exposed by this class. Each of the objects provided as parameters are expected to be shared across many
+         * requests.
+         *
+         * @param queryParameters
+         *            the incoming request query parameters, including any requested authorization overrides
+         * @param currentUser
+         *            the current user whose identity and authorizations are used for the request
+         * @param config
+         *            the annotation manager configuration
+         * @param connectionFactory
+         *            the accumulo connection factory - used for getting accumulo clients
+         * @param accumuloConnectionRequestBean
+         *            the accumulo connection request bean - used for tracking accumulo clients requests
+         * @param visibilityTransformer
+         *            visibility transformer implementation
+         * @param timestampTransformer
+         *            timestamp transformer implementation
+         */
+        protected RequestContext(MultiValueMap<String,String> queryParameters, DatawaveUserDetails currentUser, AnnotationProperties config,
+                        AccumuloConnectionFactory connectionFactory, AccumuloConnectionRequestMap accumuloConnectionRequestBean,
+                        VisibilityTransformer visibilityTransformer, TimestampTransformer timestampTransformer, ExecutorService federatedReadExecutorService) {
+
+            this.currentUser = currentUser;
+
+            this.config = config;
+            this.connectionFactory = connectionFactory;
+            this.accumuloConnectionRequestBean = accumuloConnectionRequestBean;
+            this.visibilityTransformer = visibilityTransformer;
+            this.timestampTransformer = timestampTransformer;
+            this.federatedReadExecutorService = federatedReadExecutorService;
+
+            this.userDn = currentUser.getName();
+            this.proxyServers = currentUser.getProxyServers();
+
+            // TODO: allow downgrading by reading query auths from query parameters.
+            this.queryAuthorizations = queryParameters.getFirst(QUERY_AUTHORIZATIONS);
+        }
+
+        /**
+         * Calculate the authorizations for this request based on the principal and the queryAuths if any.
+         *
+         * @return a valid set of query auths, will throw an exception if this isn't possible.
+         * @throws QueryException
+         *             and exception if there was a problem calculating the auths
+         */
+        private Set<Authorizations> initializeAuthorizations() throws QueryException {
+            if (authorizations == null) {
+                log.trace("Initializing authorizations: userDn: {}, query: {}", userDn, queryAuthorizations);
+                if (currentUser == null) {
+                    throw new QueryException("Failed to get user principal from request, unable to proceed");
+                }
+
+                try {
+                    if (queryAuthorizations == null) {
+                        authorizations = AuthorizationsUtil.buildAuthorizations(currentUser.getAuthorizations());
+                    } else {
+                        final String downgradedAuths = AuthorizationsUtil.downgradeUserAuths(queryAuthorizations, currentUser, currentUser);
+                        authorizations = AuthorizationsUtil.buildAuthorizations(Collections.singleton(AuthorizationsUtil.splitAuths(downgradedAuths)));
+                    }
+
+                } catch (Exception e) {
+                    throw new QueryException("Failed to get user query authorizations", e);
+                }
+
+                log.debug("Authorizations initialized: userDn: {}, query: {}, final auths: {}", userDn, queryAuthorizations, authorizations);
+            }
+            return authorizations;
+        }
+
+        /**
+         * Initialize the accumulo client
+         *
+         * @return a valid client, will throw an exception if this isn't possibly
+         * @throws QueryException
+         *             if the client can't be initialized.
+         */
+        protected AccumuloClient initializeAccumuloClient() throws QueryException {
+            if (client == null) {
+                log.trace("Initializing accumulo client");
+                UUID transactionUUID = java.util.UUID.randomUUID();
+
+                if (connectionFactory == null) {
+                    throw new QueryException("The accumulo connection factory isn't present, unable to proceed");
+                }
+
+                Map<String,String> trackingMap = connectionFactory.getTrackingMap(Thread.currentThread().getStackTrace());
+                if (trackingMap != null) {
+                    trackingMap.put("query.user", userDn);
+                    trackingMap.put("query.id", transactionUUID.toString());
+                    trackingMap.put("query.query", "annotation manager");
+                } else {
+                    log.info("Accumulo connection tracking map was null, this isn't fatal, but odd.");
+                }
+
+                if (accumuloConnectionRequestBean == null) {
+                    throw new QueryException("The accumulo connection request manager isn't present, unable to proceed");
+                }
+
+                accumuloConnectionRequestBean.requestBegin(transactionUUID.toString(), userDn, trackingMap);
+                try {
+                    client = connectionFactory.getClient(userDn, proxyServers, config.getConnPoolName(), config.getPriority(), trackingMap);
+                } catch (Exception e) {
+                    throw new QueryException("Unable to get Accumulo client, exception encountered: ", e);
+                } finally {
+                    accumuloConnectionRequestBean.requestEnd(transactionUUID.toString());
+                }
+                log.debug("Accumulo client initialized successfully");
+
+            }
+            return client;
+        }
+
+        /**
+         * Initialize the annotation service, specifically the data access layer.
+         *
+         * @return a valid annotation data access object, throws an exception if this isn't possible.
+         * @throws QueryException
+         *             if the annotation data access object can't be initialized.
+         */
+        protected AnnotationReader initializeAnnotationService() throws QueryException {
+            if (annotationDataAccess == null) {
+                log.trace("Initializing annotation data access layer");
+                final Set<Authorizations> authorizations = initializeAuthorizations();
+                final AccumuloClient client = initializeAccumuloClient();
+                final AccumuloAnnotationSerializer annotationSerializer = new AccumuloAnnotationSerializer(visibilityTransformer, timestampTransformer);
+                final AccumuloAnnotationSourceSerializer annotationSourceSerializer = new AccumuloAnnotationSourceSerializer(visibilityTransformer,
+                                timestampTransformer);
+
+                // Construct DAOs for both the annotation table pair and the truthmark table pair
+                final AnnotationDataAccess annotationDao = new AnnotationDataAccess(client, authorizations, config.getAnnotationTableName(),
+                                config.getAnnotationSourceTableName(), annotationSerializer, annotationSourceSerializer);
+                final AnnotationDataAccess truthmarkDao = new AnnotationDataAccess(client, authorizations, config.getTruthmarkTableName(),
+                                config.getTruthmarkSourceTableName(), annotationSerializer, annotationSourceSerializer);
+
+                // Fan out reads across both table pairs (matching the legacy FederatedAnnotationReader behavior)
+                final Map<String,AnnotationReader> readers = new HashMap<>();
+                readers.put("annotation", annotationDao);
+                readers.put("truthmark", truthmarkDao);
+
+                annotationDataAccess = new FederatedAnnotationReader(readers, federatedReadExecutorService);
+                log.debug("Annotation data access layer initialized successfully with federated reads (annotation + truthmark)");
+            }
+            return annotationDataAccess;
+        }
+
+        /**
+         * Return the accumulo client currently held by this class. If there's a problem returning the client, logs a warning. Sets the internal client state to
+         * null.
+         */
+        protected void returnAccumuloClient() {
+            try {
+                log.trace("Returning accumulo client");
+                connectionFactory.returnClient(client);
+                log.debug("Accumulo client returned");
+            } catch (Exception e) {
+                log.warn("Error when returning client", e);
+            } finally {
+                client = null;
+            }
+        }
+
+        /**
+         * Lookup an annotation source or retrieve it from the cache.
+         *
+         * @param analyticHash
+         *            the analytic source hash to resolve
+         * @return the cached or retrieved annotation source for the supplied hash, if one exists
+         */
+        public Optional<AnnotationSource> getAnnotationSource(String analyticHash) {
+            return retrievedSourcesCache.computeIfAbsent(analyticHash, key -> annotationDataAccess.getAnnotationSource(analyticHash));
+        }
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/config/AnnotationProperties.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/config/AnnotationProperties.java
@@ -1,0 +1,80 @@
+package datawave.microservice.annotation.service.config;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.Valid;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "annotation")
+@Component
+public class AnnotationProperties {
+    private int maxConnections;
+
+    private String annotationTableName = "annotation";
+
+    private String annotationSourceTableName = "annotationSource";
+
+    private String truthmarkTableName = "truthmark";
+
+    private String truthmarkSourceTableName = "truthmarkSource";
+
+    private String connPoolName;
+
+    private boolean enableInternalIdLookup;
+
+    /**
+     * Metadata keys to mask (remove) from annotation sources when injecting them into annotations. Mirrors the legacy
+     * {@code AnnotationConfig.getMaskSourceMetadata()} default of {@code ["visibility"]}.
+     */
+    private List<String> maskSourceMetadata = List.of("visibility");
+
+    /**
+     * The name of the shard table used for internal document identifier lookups.
+     */
+    private String shardTableName = "shard";
+
+    private AccumuloConnectionFactory.Priority priority;
+
+    private boolean annotationAckEnabled = true;
+    private long annotationAckTimeoutMillis = 500L;
+
+    private List<String> fsConfigResources;
+
+    private String systemFrom = "datawave-annotation-service";
+
+    @Valid
+    private Retry retry = new Retry();
+
+    @Validated
+    @Getter
+    @Setter
+    public static class Retry {
+        @PositiveOrZero
+        private int maxAttempts = 10;
+
+        @PositiveOrZero
+        private long failTimeoutMillis = TimeUnit.MINUTES.toMillis(5);
+
+        @PositiveOrZero
+        private long backoffIntervalMillis = TimeUnit.SECONDS.toMillis(5);
+
+        public boolean noTimeout(long startTime, long currentTime) {
+            return (currentTime - startTime) < failTimeoutMillis;
+        }
+
+        public boolean hasAttemptsRemaining(int attempts) {
+            return attempts < maxAttempts;
+        }
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/config/AnnotationServiceConfig.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/service/config/AnnotationServiceConfig.java
@@ -1,0 +1,60 @@
+package datawave.microservice.annotation.service.config;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.Segment;
+import datawave.annotation.util.v1.JacksonAnnotationDeserializer;
+import datawave.annotation.util.v1.JacksonAnnotationSerializer;
+import datawave.annotation.util.v1.JacksonSegmentDeserializer;
+import datawave.annotation.util.v1.JacksonSegmentSerializer;
+import datawave.microservice.annotation.common.AnnotationSupplier;
+
+@Configuration
+@EnableConfigurationProperties(AnnotationProperties.class)
+public class AnnotationServiceConfig {
+    @Bean
+    public AnnotationSupplier annotationSource() {
+        return new AnnotationSupplier();
+    }
+
+    @Bean
+    public StrictHttpFirewall httpFirewall() {
+        // override the default strict http firewall to allow forward slashes. These are used in internal identifiers
+        // as separators for shard/datatype/uid structures. We also allow shard:datatype:uid, but in some cases we
+        // want to accept the slash variant which is returned by other services.
+        StrictHttpFirewall firewall = new StrictHttpFirewall();
+        firewall.setAllowUrlEncodedSlash(true);
+        // this is due to strangeness in the StrictHttpFirewall, you must also allow encoded percents to allow encoded
+        // slashes, arrived here via testing.
+        firewall.setAllowUrlEncodedPercent(true);
+        return firewall;
+    }
+
+    @Bean
+    public Module jacksonAnnotationModule() {
+        final SimpleModule simpleModule = new SimpleModule();
+
+        // Added for Annotation and Segment serialization and deserialization.
+        simpleModule.addDeserializer(Annotation.class, new JacksonAnnotationDeserializer());
+        simpleModule.addSerializer(Annotation.class, new JacksonAnnotationSerializer());
+        simpleModule.addDeserializer(Segment.class, new JacksonSegmentDeserializer());
+        simpleModule.addSerializer(Segment.class, new JacksonSegmentSerializer());
+
+        return simpleModule;
+    }
+
+    @Bean
+    public ExecutorService federatedReadExecutorService() {
+        return Executors.newCachedThreadPool();
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/AuthUtils.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/AuthUtils.java
@@ -1,0 +1,53 @@
+package datawave.microservice.annotation.util;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.HttpHeaders;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import datawave.microservice.annotation.util.exceptions.AuthenticationException;
+import datawave.microservice.authorization.user.DatawaveUserDetails;
+import datawave.security.authorization.DatawaveUser;
+import datawave.security.authorization.SubjectIssuerDNPair;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AuthUtils {
+    private static final String PROXIED_ENTITIES_HEADER = "X-ProxiedEntitiesChain";
+    private static final String PROXIED_ISSUERS_HEADER = "X-ProxiedIssuersChain";
+
+    public static PreAuthenticatedAuthenticationToken getAuthToken(Principal currentUser) {
+        if (currentUser instanceof PreAuthenticatedAuthenticationToken) {
+            return (PreAuthenticatedAuthenticationToken) currentUser;
+        }
+        throw new AuthenticationException("Cannot handle a " + currentUser.getClass() + ". Only PreAuthenticatedAuthenticationToken is accepted");
+    }
+
+    public static Map<String,String> buildOutgoingHeaders(DatawaveUserDetails proxiedUserDetails, String userAgent) {
+        HashMap<String,String> headers = new HashMap<>();
+
+        // Pass original user agent
+        if (userAgent != null) {
+            headers.put(HttpHeaders.USER_AGENT, userAgent);
+        }
+
+        // Build proxied entities headers
+        if (proxiedUserDetails == null) {
+            return headers;
+        }
+        StringBuilder userDnChain = new StringBuilder();
+        StringBuilder issuerDnChain = new StringBuilder();
+        for (DatawaveUser user : proxiedUserDetails.getProxiedUsers()) {
+            SubjectIssuerDNPair dnPair = user.getDn();
+            userDnChain.append('<').append(dnPair.subjectDN()).append('>');
+            issuerDnChain.append('<').append(dnPair.issuerDN()).append('>');
+        }
+
+        headers.put(PROXIED_ENTITIES_HEADER, userDnChain.toString());
+        headers.put(PROXIED_ISSUERS_HEADER, issuerDnChain.toString());
+        log.debug("Setting proxied entity headers: {}", headers);
+        return headers;
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/Metadata.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/Metadata.java
@@ -1,0 +1,74 @@
+package datawave.microservice.annotation.util;
+
+import java.util.Objects;
+
+import lombok.Getter;
+
+/**
+ * An immutable object that captures the internal Metadata associated with a record. It also provides a {@code equals} and {@code hashCode} implementation so
+ * that it can be used as a {@code Map} key. Similar to the {@link datawave.webservice.query.result.event.Metadata} class, but adds features specific to working
+ * with {@link datawave.annotation.protobuf.v1.Annotation} and {@link datawave.annotation.protobuf.v1.Segment}.
+ */
+@Getter
+public class Metadata {
+    /** the table where the record is stored */
+    private final String table;
+    /** the accumulo row / shard associated with a record */
+    private final String row;
+    /** the datatype of a record */
+    private final String dataType;
+    /** the internal identifier for a record */
+    private final String internalId;
+
+    /**
+     * Create a Metadata object using the field values from a {@link datawave.webservice.query.result.event.Metadata} object.
+     *
+     * @param eventMetadata
+     *            the object whose fields to copy.
+     */
+    public Metadata(datawave.webservice.query.result.event.Metadata eventMetadata) {
+        this(eventMetadata.getTable(), eventMetadata.getRow(), eventMetadata.getDataType(), eventMetadata.getInternalId());
+    }
+
+    /**
+     * Create a Metatata object based on the specified field values
+     *
+     * @param table
+     *            the table where the record is stored
+     * @param row
+     *            accumulo row / shard associated with a record
+     * @param dataType
+     *            the datatype of a record
+     * @param internalId
+     *            the internal identifier for a record
+     */
+    public Metadata(String table, String row, String dataType, String internalId) {
+        if (table == null || row == null || dataType == null || internalId == null) {
+            final String message = String.format("Null value provided when creating metadata: %s/%s/%s [%s]", row, dataType, internalId, table);
+            throw new NullPointerException(message);
+        }
+
+        this.row = row;
+        this.dataType = dataType;
+        this.internalId = internalId;
+        this.table = table;
+    }
+
+    public String toString() {
+        return String.format("%s/%s/%s [%s]", row, dataType, internalId, table);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Metadata metadata = (Metadata) o;
+        return Objects.equals(row, metadata.row) && Objects.equals(dataType, metadata.dataType) && Objects.equals(internalId, metadata.internalId)
+                        && Objects.equals(table, metadata.table);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(row, dataType, internalId, table);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/AuthenticationException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/AuthenticationException.java
@@ -1,0 +1,55 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown when a user cannot be authenticated or some other authentication error exists. This would correspond to an HTTP 401.
+ */
+public class AuthenticationException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public AuthenticationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public AuthenticationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public AuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public AuthenticationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/AuthorizationException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/AuthorizationException.java
@@ -1,0 +1,56 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown when a user cannot be authorized or some other authorization error exists. In other words, we know who the user is but they do
+ * not have sufficient permissions to access the resource or service. This would correspond to an HTTP 403.
+ */
+public class AuthorizationException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public AuthorizationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public AuthorizationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public AuthorizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public AuthorizationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/BadRequestException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/BadRequestException.java
@@ -1,0 +1,55 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * Exception thrown by the controller layer to indicate a bad request. Intended to be thrown by REST APIs to indicate that a HTTP 400 status should be returned.
+ */
+public class BadRequestException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public BadRequestException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
+     */
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public BadRequestException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ConflictException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ConflictException.java
@@ -1,0 +1,56 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown by controllers when a request cannot be completed due to a conflict with the current state of the resource. This corresponds to
+ * an HTTP 409.
+ */
+public class ConflictException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public ConflictException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ConflictException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ControllerException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ControllerException.java
@@ -1,0 +1,57 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * <code>ControllerException</code> is the superclass of exceptions that can be thrown by controllers.
+ *
+ * @see RuntimeException
+ */
+public class ControllerException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public ControllerException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public ControllerException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ControllerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ControllerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/InternalServerException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/InternalServerException.java
@@ -1,0 +1,56 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * Exception thrown by the controller layer to indicate an error during request processing. Intended to be thrown by REST APIs to indicate that a HTTP 500
+ * status should be returned.
+ */
+public class InternalServerException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public InternalServerException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
+     */
+    public InternalServerException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public InternalServerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public InternalServerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/MethodNotAllowedException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/MethodNotAllowedException.java
@@ -1,0 +1,55 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown by controllers when a requested resource is not found. This corresponds to an HTTP 405.
+ */
+public class MethodNotAllowedException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public MethodNotAllowedException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public MethodNotAllowedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public MethodNotAllowedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public MethodNotAllowedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/PayloadTooLargeException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/PayloadTooLargeException.java
@@ -1,0 +1,53 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown by controllers when a resource is too large. This corresponds to an HTTP 413.
+ */
+public class PayloadTooLargeException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception without a detail message or cause.
+     */
+    public PayloadTooLargeException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public PayloadTooLargeException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+
+    public PayloadTooLargeException(final Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public PayloadTooLargeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/PreconditionFailedException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/PreconditionFailedException.java
@@ -1,0 +1,55 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown when a system-imposed restriction put on a request fails.
+ */
+public class PreconditionFailedException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public PreconditionFailedException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public PreconditionFailedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public PreconditionFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public PreconditionFailedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/RangeNotSatisfiableException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/RangeNotSatisfiableException.java
@@ -1,0 +1,55 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown by controllers when a provided range request is not operable based on constraints. This corresponds to an HTTP 416.
+ */
+public class RangeNotSatisfiableException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public RangeNotSatisfiableException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public RangeNotSatisfiableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public RangeNotSatisfiableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public RangeNotSatisfiableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ResourceNotFoundException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,55 @@
+package datawave.microservice.annotation.util.exceptions;
+
+/**
+ * This exception may be thrown by controllers when a requested resource is not found. This corresponds to an HTTP 404.
+ */
+public class ResourceNotFoundException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public ResourceNotFoundException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ResourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ServiceUnavailableException.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/exceptions/ServiceUnavailableException.java
@@ -1,0 +1,52 @@
+package datawave.microservice.annotation.util.exceptions;
+
+public class ServiceUnavailableException extends ControllerException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with <code>null</code> as its detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     */
+    public ServiceUnavailableException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     */
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with <code>cause</code> is <i>not</i> automatically incorporated in this runtime exception's detail message.
+     *
+     * @param message
+     *            the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ? null : cause.toString())} (which typically contains the
+     * class and detail message of {@code cause}). This constructor is useful for runtime exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            the cause (which is saved for later retrieval by the {@link #getCause()} method). (A {@code null} value is permitted, and indicates that the
+     *            cause is nonexistent or unknown.)
+     */
+    public ServiceUnavailableException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/common/Lookup.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/common/Lookup.java
@@ -1,0 +1,5 @@
+package datawave.microservice.annotation.util.lookup.common;
+
+public enum Lookup {
+    CONTENT, METADATA, MARKINGS
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/common/LookupRequest.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/common/LookupRequest.java
@@ -1,0 +1,226 @@
+package datawave.microservice.annotation.util.lookup.common;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.AnnotationList;
+import datawave.annotation.util.v1.AnnotationJsonUtils;
+import datawave.microservice.annotation.util.exceptions.AuthenticationException;
+import datawave.microservice.annotation.util.exceptions.AuthorizationException;
+import datawave.microservice.annotation.util.exceptions.BadRequestException;
+import datawave.microservice.annotation.util.exceptions.ConflictException;
+import datawave.microservice.annotation.util.exceptions.InternalServerException;
+import datawave.microservice.annotation.util.exceptions.MethodNotAllowedException;
+import datawave.microservice.annotation.util.exceptions.PayloadTooLargeException;
+import datawave.microservice.annotation.util.exceptions.PreconditionFailedException;
+import datawave.microservice.annotation.util.exceptions.RangeNotSatisfiableException;
+import datawave.microservice.annotation.util.exceptions.ResourceNotFoundException;
+import datawave.microservice.annotation.util.exceptions.ServiceUnavailableException;
+import datawave.microservice.annotation.util.lookup.config.LookupProperties;
+import datawave.webservice.result.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Encapsulates Datawave lookup query requests
+ */
+@Slf4j
+@Component
+public class LookupRequest {
+    private final CloseableHttpClient httpClient;
+    private final LookupProperties lookupProperties;
+    private static final String PROTOCOL = "https";
+    private static final String PARAM_KEY = "params";
+    private static final String METADATA_URI = "DataWave/Query/lookupUUID/";
+    private static final String CONTENT_URI = "DataWave/Query/lookupContentUUID/";
+    private static final String MARKINGS_URI = "DataWave/Annotations/v1/";
+
+    @Autowired
+    public LookupRequest(CloseableHttpClient httpClient, LookupProperties lookupProperties) {
+        this.httpClient = httpClient;
+        this.lookupProperties = lookupProperties;
+    }
+
+    public ParsedResponse lookupId(Lookup lookup, String lookupPath, Map<String,String> headers, String queryParams, String systemFrom) {
+        // Set request parameters
+        HttpGet lookupQuery = buildLookupQueryRequest(lookup, lookupPath, headers, queryParams, systemFrom);
+        HttpContext context = getHttpContext();
+
+        try (CloseableHttpResponse response = httpClient.execute(lookupQuery, context)) {
+            int responseCode = response.getStatusLine().getStatusCode();
+
+            ParsedResponse parsedResponse = new ParsedResponse();
+            parsedResponse.setResponse(processResponse(response));
+            parsedResponse.setCode(responseCode);
+            return parsedResponse;
+        } catch (IOException e) {
+            log.error("Failed to execute datawave query: {}", lookupQuery, e);
+            throw new InternalServerException(e);
+        } finally {
+            lookupQuery.reset();
+        }
+    }
+
+    private String processResponse(CloseableHttpResponse response) throws IOException {
+        String rawResponse = null;
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            rawResponse = EntityUtils.toString(entity, StandardCharsets.UTF_8);
+        }
+        validateResponse(response.getStatusLine().getStatusCode(), rawResponse);
+        return rawResponse;
+    }
+
+    private void validateResponse(int responseCode, String rawResponse) {
+        if (responseCode < 200 || responseCode >= 300) {
+            switch (responseCode) {
+                case 400:
+                    throw new BadRequestException(rawResponse);
+                case 401:
+                    throw new AuthenticationException(rawResponse);
+                case 403:
+                    throw new AuthorizationException(rawResponse);
+                case 404:
+                    throw new ResourceNotFoundException(rawResponse);
+                case 405:
+                    throw new MethodNotAllowedException(rawResponse);
+                case 409:
+                    throw new ConflictException(rawResponse);
+                case 412:
+                    throw new PreconditionFailedException(rawResponse);
+                case 413:
+                    throw new PayloadTooLargeException(rawResponse);
+                case 416:
+                    throw new RangeNotSatisfiableException(rawResponse);
+                case 503:
+                    throw new ServiceUnavailableException(rawResponse);
+                default:
+                    // Catch 500 as well as any other codes not explicitly listed
+                    throw new InternalServerException(rawResponse);
+            }
+        } else if (rawResponse == null || rawResponse.isBlank()) {
+            throw new ResourceNotFoundException("No Content");
+        }
+    }
+
+    private HttpContext getHttpContext() {
+        HttpContext context = new BasicHttpContext();
+        // A fresh, request-scoped cookie store is used for every lookup so that a cookie set by one caller's
+        // response (e.g. a session cookie from the downstream DataWave query service) is never retained and
+        // resent on a different caller's subsequent lookup. LookupRequest is a shared singleton bean, so a
+        // field-level cookie store here would leak session state across principals/requests.
+        context.setAttribute(HttpClientContext.COOKIE_STORE, new BasicCookieStore());
+        context.setAttribute("X-Start-Time", String.valueOf(System.currentTimeMillis()));
+        return context;
+    }
+
+    /**
+     * Create lookup query URL from config properties, ID, and queryParams
+     *
+     * @param lookup
+     *            - the string to determine the DataWave endpoint being invoked
+     * @param lookupPath
+     *            - the lookupPath, either type + id, id, or uuid pairs (depending on endpoint invoked)
+     * @param headers
+     *            - headers for the lookup query
+     * @param queryParams
+     *            - parameters to be passed to the lookup query
+     * @param systemFrom
+     *            - the system making the request
+     * @return - an HttpGet object
+     */
+    protected HttpGet buildLookupQueryRequest(Lookup lookup, String lookupPath, Map<String,String> headers, String queryParams, String systemFrom) {
+        String uri;
+        try {
+            switch (lookup) {
+                case CONTENT:
+                    uri = CONTENT_URI;
+                    break;
+                case MARKINGS:
+                    uri = MARKINGS_URI;
+                    break;
+                case METADATA:
+                    uri = METADATA_URI;
+                    break;
+                default:
+                    uri = null;
+                    break;
+            }
+            // @formatter:off
+            URIBuilder builder = new URIBuilder()
+                    .setScheme(PROTOCOL)
+                    .setHost(lookupProperties.getDatawaveQueryHost())
+                    .setPath(uri + lookupPath)
+                    .setParameter(PARAM_KEY, queryParams);
+            // @formatter:on
+            URI lookupRequest = new URI(builder.build().toString() + "&systemFrom=" + systemFrom);
+            HttpGet get = new HttpGet(lookupRequest);
+            for (Map.Entry<String,String> header : headers.entrySet()) {
+                get.setHeader(header.getKey(), header.getValue());
+            }
+            return get;
+        } catch (URISyntaxException e) {
+            throw new InternalServerException("Failed to parse query from request.", e);
+        }
+    }
+
+    public BaseResponse parseQueryResponse(String rawResponse) {
+        try {
+            JAXBContext jc = JAXBContext.newInstance(lookupProperties.getDatawaveResponseClasses(), null);
+            Unmarshaller unmarshaller = jc.createUnmarshaller();
+            return (BaseResponse) unmarshaller.unmarshal(new StringReader(rawResponse));
+        } catch (JAXBException e) {
+            throw new InternalServerException("Failed to parse DataWave Query response.", e);
+        }
+    }
+
+    public List<Annotation> parseAnnotationResponse(String rawResponse) {
+        if (rawResponse == null || rawResponse.isBlank()) {
+            throw new ResourceNotFoundException("Datawave Annotation response was Blank");
+        }
+        if (rawResponse.startsWith("[") && rawResponse.endsWith("]")) {
+            rawResponse = "{\n  \"annotations\": " + rawResponse + "\n}";
+        }
+
+        JsonFormat.Parser parser = AnnotationJsonUtils.getParser();
+        AnnotationList.Builder builder = AnnotationList.newBuilder();
+
+        try {
+            if (lookupProperties.isAnnotationUnknownFieldsIgnored()) {
+                parser.ignoringUnknownFields().merge(rawResponse, builder);
+            } else {
+                parser.merge(rawResponse, builder);
+            }
+        } catch (InvalidProtocolBufferException e) {
+            throw new InternalServerException("Failed to parse DataWave Annotation response.", e);
+        }
+        AnnotationList aas = builder.build();
+        return new ArrayList<>(aas.getAnnotationsList());
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/common/ParsedResponse.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/common/ParsedResponse.java
@@ -1,0 +1,11 @@
+package datawave.microservice.annotation.util.lookup.common;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ParsedResponse {
+    String response;
+    int code;
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/config/HttpClientConfig.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/config/HttpClientConfig.java
@@ -1,0 +1,46 @@
+package datawave.microservice.annotation.util.lookup.config;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.ConnectionReuseStrategy;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Configuration for the HttpClient that will be used by the LookupService */
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public CloseableHttpClient httpClient(SSLContext sslContext) {
+        Registry r = RegistryBuilder.create()
+                        .register("https", new SSLConnectionSocketFactory(sslContext.getSocketFactory(), null, null, NoopHostnameVerifier.INSTANCE)).build();
+
+        PoolingHttpClientConnectionManager manager = new PoolingHttpClientConnectionManager(r);
+        // manager.setDefaultMaxPerRoute(httpClientProperties.getMaxConnections());
+        // manager.setMaxTotal(httpClientProperties.getMaxConnections());
+
+        // set timeouts
+        // @formatter:off
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(60 * 15 * 1000) // 15 minutes
+                .setConnectionRequestTimeout(60 * 1000) // 1 minute
+                .setSocketTimeout(78 * 60 * 1000)
+                .build();
+        // @formatter:on
+        // never re-use connections
+        ConnectionReuseStrategy connectionReuseStrategy = (httpResponse, httpContext) -> false;
+
+        // set retry strategy to max interval of five minutes
+        int maxInterval = 5 * 60 * 1000;
+        return HttpClientBuilder.create().setSSLContext(sslContext).setConnectionManager(manager).setDefaultRequestConfig(requestConfig)
+                        .setConnectionReuseStrategy(connectionReuseStrategy).build();
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/config/LookupConfig.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/config/LookupConfig.java
@@ -1,0 +1,16 @@
+package datawave.microservice.annotation.util.lookup.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LookupConfig {
+    @Bean
+    @ConditionalOnMissingBean(LookupProperties.class)
+    @ConfigurationProperties("annotation.lookup")
+    public LookupProperties lookupProperties() {
+        return new LookupProperties();
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/config/LookupProperties.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/config/LookupProperties.java
@@ -1,0 +1,29 @@
+package datawave.microservice.annotation.util.lookup.config;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LookupProperties {
+    private static final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+    private String datawaveQueryHost;
+    private Class<?>[] datawaveResponseClasses;
+    private boolean annotationUnknownFieldsIgnored;
+
+    Date beginDate;
+    Date endDate;
+
+    {
+        try {
+            beginDate = dateFormat.parse("19700101");
+            endDate = dateFormat.parse("30000101");
+        } catch (java.text.ParseException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/service/LookupService.java
+++ b/microservices/services/annotation/service/src/main/java/datawave/microservice/annotation/util/lookup/service/LookupService.java
@@ -1,0 +1,84 @@
+package datawave.microservice.annotation.util.lookup.service;
+
+import static datawave.microservice.annotation.util.AuthUtils.buildOutgoingHeaders;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import datawave.microservice.annotation.util.Metadata;
+import datawave.microservice.annotation.util.exceptions.ResourceNotFoundException;
+import datawave.microservice.annotation.util.lookup.common.Lookup;
+import datawave.microservice.annotation.util.lookup.common.LookupRequest;
+import datawave.microservice.annotation.util.lookup.common.ParsedResponse;
+import datawave.microservice.authorization.user.DatawaveUserDetails;
+import datawave.webservice.query.result.event.EventBase;
+import datawave.webservice.result.BaseResponse;
+import datawave.webservice.result.EventQueryResponseBase;
+import lombok.extern.slf4j.Slf4j;
+
+/** Used to perform lookupUUID request against a remote instance of Datawave */
+@Slf4j
+@Service
+public class LookupService {
+
+    private final LookupRequest request;
+
+    /**
+     *
+     * @param request
+     *            the configuration
+     */
+    @Autowired
+    public LookupService(LookupRequest request) {
+        this.request = request;
+    }
+
+    /**
+     * Executes a lookupUUID query for the specified idType and it and returns the item's internal identifiers (e.g., shard, datatype, uid) packaged in a
+     * Metadata object.
+     *
+     * @param idType
+     *            the type of id to query.
+     * @param id
+     *            the id value to query.
+     * @param queryParams
+     *            the encoded query parameters to send with the remote lookup request
+     * @param systemFrom
+     *            the systemFrom to indicate in the query params
+     * @param currentUser
+     *            the current user whose authorization headers should be forwarded to the remote lookup
+     * @return a list of zero to many Metadata objects with the internal shard, datatype, uid and table name of the identifier(s) provided. The list will be
+     *         empty if no identifier could be found using the authorizations and query logic employed by this class.
+     * @throws ResourceNotFoundException
+     *             if exceptions are encountered performing the lookup.
+     */
+    public List<Metadata> executeLookupUUIDQuery(String idType, String id, String queryParams, String systemFrom, DatawaveUserDetails currentUser) {
+        Map<String,String> headers = buildOutgoingHeaders(currentUser, null);
+        ParsedResponse parsedResponse = request.lookupId(Lookup.METADATA, idType + "/" + id, headers, queryParams, systemFrom);
+        BaseResponse response = request.parseQueryResponse(parsedResponse.getResponse());
+        if (!(EventQueryResponseBase.class.isAssignableFrom(response.getClass()))) {
+            throw new ResourceNotFoundException("Unexpected Response Class received from Datawave: " + response.getClass().getSimpleName());
+        }
+        EventQueryResponseBase eventQueryResponseBase = (EventQueryResponseBase) response;
+        @SuppressWarnings("rawtypes")
+        Iterator<EventBase> iter = eventQueryResponseBase.getEvents().iterator();
+        List<Metadata> metadataList = new ArrayList<>();
+        while (iter.hasNext()) {
+            EventBase<?,?> e = iter.next();
+            datawave.webservice.query.result.event.Metadata eventMetadata = e.getMetadata();
+            if (log.isDebugEnabled()) {
+
+                String metadataMessage = String.format("%s/%s/%s [%s]", eventMetadata.getRow(), eventMetadata.getDataType(), eventMetadata.getInternalId(),
+                                eventMetadata.getTable());
+                log.debug("Found metadata {} for idType {}, id {}", metadataMessage, idType, id);
+            }
+            metadataList.add(new Metadata(eventMetadata));
+        }
+        return metadataList;
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/client/AnnotationTestClient.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/client/AnnotationTestClient.java
@@ -1,0 +1,28 @@
+package datawave.microservice.annotation.client;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import datawave.webservice.result.VoidResponse;
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AnnotationTestClient {
+
+    public static final int DEFAULT_PORT = 9543;
+
+    protected String path = "/annotation/v1";
+    protected int port = DEFAULT_PORT;
+
+    @Autowired
+    private WebClient.Builder webClientBuilder;
+
+    public void testAnnotationServiceCall() {
+        WebClient webClient = webClientBuilder.baseUrl("https://localhost:" + port + path).build();
+        ResponseEntity<VoidResponse> responseEntity = webClient.get().uri("/testSingleQueryException").retrieve()
+                        .onStatus(HttpStatus::isError, response -> Mono.empty()).toEntity(VoidResponse.class).block();
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/AnnotationControllerV1SecurityTest.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/AnnotationControllerV1SecurityTest.java
@@ -1,0 +1,86 @@
+package datawave.microservice.annotation.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.core.GrantedAuthorityDefaults;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.LinkedMultiValueMap;
+
+import datawave.annotation.data.transform.DefaultTimestampTransformer;
+import datawave.annotation.data.transform.DefaultVisibilityTransformer;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.microservice.annotation.common.AnnotationSupplier;
+import datawave.microservice.annotation.service.config.AnnotationProperties;
+import datawave.microservice.annotation.util.lookup.service.LookupService;
+import datawave.microservice.authorization.user.DatawaveUserDetails;
+import datawave.security.authorization.DatawaveUser;
+import datawave.security.authorization.SubjectIssuerDNPair;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = AnnotationControllerV1SecurityTest.SecurityConfiguration.class)
+class AnnotationControllerV1SecurityTest {
+
+    @TestConfiguration
+    @EnableGlobalMethodSecurity(securedEnabled = true)
+    static class SecurityConfiguration {
+        @Bean
+        AnnotationControllerV1 annotationController() {
+            return new AnnotationControllerV1(mock(AccumuloConnectionFactory.class), mock(LookupService.class), new AnnotationProperties(),
+                            new DefaultTimestampTransformer(), new DefaultVisibilityTransformer(), new AnnotationSupplier(), mock(ExecutorService.class),
+                            new AnnotationAckTracker());
+        }
+
+        @Bean
+        GrantedAuthorityDefaults grantedAuthorityDefaults() {
+            return new GrantedAuthorityDefaults("");
+        }
+    }
+
+    @javax.annotation.Resource
+    private AnnotationControllerV1 annotationController;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void addAnnotationDeniesAuthenticatedNonWriter() {
+        DatawaveUserDetails currentUser = authenticate("AuthorizedUser");
+
+        assertThrows(AccessDeniedException.class,
+                        () -> annotationController.addAnnotation("DOCUMENT", "shard/datatype/uid", "{}", new LinkedMultiValueMap<>(), currentUser));
+    }
+
+    @Test
+    void addAnnotationPermitsAnnotationWriter() {
+        DatawaveUserDetails currentUser = authenticate("AuthorizedUser", "AnnotationWriter");
+
+        assertDoesNotThrow(() -> annotationController.addAnnotation("DOCUMENT", "shard/datatype/uid", "{}", new LinkedMultiValueMap<>(), currentUser));
+    }
+
+    private DatawaveUserDetails authenticate(String... roles) {
+        DatawaveUser user = new DatawaveUser(SubjectIssuerDNPair.of("test-user", "test-issuer"), DatawaveUser.UserType.USER, Collections.singleton("PUBLIC"),
+                        Arrays.asList(roles), null, System.currentTimeMillis());
+        DatawaveUserDetails currentUser = new DatawaveUserDetails(Collections.singleton(user), user.getCreationTime());
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(currentUser, "unused", currentUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return currentUser;
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/AnnotationServiceStartupTest.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/AnnotationServiceStartupTest.java
@@ -1,0 +1,167 @@
+package datawave.microservice.annotation.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.test.v1.AnnotationTestDataUtil;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.core.common.result.ConnectionPool;
+import datawave.microservice.annotation.common.AnnotationSupplier;
+import datawave.microservice.annotation.common.config.AnnotationSerializerConfiguration;
+import datawave.microservice.annotation.service.config.AnnotationServiceConfig;
+import datawave.microservice.annotation.util.lookup.service.LookupService;
+import datawave.microservice.annotation.writers.accumulo.config.AccumuloAnnotationWriterConfig;
+import datawave.microservice.annotation.writers.accumulo.config.AccumuloAnnotationWriterProperties;
+import datawave.microservice.annotation.writers.file.config.FileAnnotationWriterConfig;
+
+/**
+ * Boots the annotation service using the same writer topology shipped in {@code annotation.yml} for deployment (Accumulo and file writers enabled, log and dump
+ * writers disabled), with only external network dependencies (Accumulo, remote lookup) replaced by lightweight in-memory/mocked implementations. This proves
+ * that the production-shape configuration and writer topology assembled across T05-T09 actually resolves into a working Spring context - all expected
+ * writer/sink beans are present with no ambiguous or missing bindings - and that one authorized write reaches its defined acceptance boundary (Q01: Rabbit
+ * producer-confirmed ingress, not committed Accumulo persistence). The producer-confirm acknowledgement is simulated by subscribing directly to the real,
+ * fully-wired {@link AnnotationSupplier} bean's outbound {@code Flux} and immediately acking each message, exactly mirroring what the real Rabbit binder/broker
+ * does via the {@code annotationAckChannel} in production, without requiring a live broker in this test.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {AnnotationServiceConfig.class, AnnotationSerializerConfiguration.class, AccumuloAnnotationWriterConfig.class,
+        FileAnnotationWriterConfig.class, AnnotationAckTracker.class, AnnotationControllerV1.class,
+        AnnotationServiceStartupTest.AnnotationServiceStartupTestConfiguration.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles({"AnnotationServiceStartupTest", "accumulo-enabled", "file-enabled"})
+public class AnnotationServiceStartupTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Autowired
+    private AnnotationControllerV1 annotationController;
+
+    @Autowired
+    private AnnotationSupplier annotationSource;
+
+    @BeforeEach
+    void simulateHealthyBrokerProducerConfirms() {
+        // Every message the controller hands to the real annotationSource bean is immediately "confirmed", just as a
+        // healthy Rabbit broker would confirm receipt via the annotationAckChannel in production.
+        annotationSource.get().subscribe(sent -> {
+            Object correlationId = sent.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+            Message<String> ack = MessageBuilder.withPayload("ack").setCorrelationId(correlationId).build();
+            annotationController.processConfirmAck(ack);
+        });
+    }
+
+    @Test
+    void testProductionShapeWriterTopologyBootsCleanly() {
+        assertTrue(context.containsBean("accumuloAnnotationWriter"), "expected accumuloAnnotationWriter (enabled in shipped annotation.yml)");
+        assertTrue(context.containsBean("accumuloAnnotationSink"), "expected accumuloAnnotationSink (enabled in shipped annotation.yml)");
+        assertTrue(context.containsBean("fileAnnotationWriter"), "expected fileAnnotationWriter (enabled in shipped annotation.yml)");
+        assertTrue(context.containsBean("fileAnnotationWriterProperties"), "expected fileAnnotationWriterProperties (enabled in shipped annotation.yml)");
+        assertTrue(context.containsBean("annotationSource"), "expected the annotationSource message producer to be present");
+        assertTrue(context.containsBean("annotationControllerV1"), "expected the annotation write/read controller to be present");
+
+        // log and dump writers are disabled in the shipped annotation.yml topology; confirm they stay absent here too
+        assertFalse(context.containsBean("logAnnotationWriter"), "logAnnotationWriter is disabled in the shipped topology and should not be present");
+        assertFalse(context.containsBean("dumpAnnotationWriter"), "dumpAnnotationWriter is disabled in the shipped topology and should not be present");
+    }
+
+    @Test
+    void testAuthorizedWriteReachesProducerConfirmedAcceptanceBoundary() {
+        Annotation annotation = AnnotationTestDataUtil.generateTestAnnotation();
+
+        java.util.Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isPresent(), "an authorized write should succeed once producer-confirm ack is received, per the Q01 acceptance boundary");
+    }
+
+    @Configuration
+    public static class AnnotationServiceStartupTestConfiguration {
+        @Bean
+        public AccumuloConnectionFactory testAccumuloConnectionFactory(AccumuloAnnotationWriterProperties accumuloAnnotationWriterProperties) throws Exception {
+            AccumuloAnnotationWriterProperties.Accumulo accumulo = accumuloAnnotationWriterProperties.getAccumuloConfig();
+            return new MockInMemoryAccumuloConnectionFactory(accumulo.getUsername(), accumulo.getInstanceName());
+        }
+
+        @Bean
+        public LookupService lookupService() {
+            // the lookup subsystem (T11-T13) is exercised separately; this write acceptance test bypasses lookup entirely
+            // by calling writeAnnotation(Annotation) directly with a pre-localized annotation.
+            return Mockito.mock(LookupService.class);
+        }
+    }
+
+    private static class MockInMemoryAccumuloConnectionFactory implements AccumuloConnectionFactory {
+        private final org.apache.accumulo.core.client.AccumuloClient accumuloClient;
+
+        public MockInMemoryAccumuloConnectionFactory(String username, String instanceName) throws Exception {
+            InMemoryInstance inMemoryInstance = new InMemoryInstance(instanceName);
+            this.accumuloClient = new InMemoryAccumuloClient(username, inMemoryInstance);
+            accumuloClient.securityOperations().changeUserAuthorizations(username, new org.apache.accumulo.core.security.Authorizations("PUBLIC", "PRIVATE"));
+        }
+
+        @Override
+        public org.apache.accumulo.core.client.AccumuloClient getClient(String userDN, Collection<String> proxiedDNs, Priority priority,
+                        Map<String,String> trackingMap) throws Exception {
+            return accumuloClient;
+        }
+
+        @Override
+        public org.apache.accumulo.core.client.AccumuloClient getClient(String userDN, Collection<String> proxiedDNs, String poolName, Priority priority,
+                        Map<String,String> trackingMap) throws Exception {
+            return accumuloClient;
+        }
+
+        @Override
+        public void returnClient(org.apache.accumulo.core.client.AccumuloClient client) {
+
+        }
+
+        @Override
+        public String report() {
+            return null;
+        }
+
+        @Override
+        public List<ConnectionPool> getConnectionPools() {
+            return null;
+        }
+
+        @Override
+        public int getConnectionUsagePercent() {
+            return 0;
+        }
+
+        @Override
+        public Map<String,String> getTrackingMap(StackTraceElement[] stackTrace) {
+            return new java.util.HashMap<>();
+        }
+
+        @Override
+        public void close() throws Exception {
+
+        }
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/TestAnnotationControllerV1.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/TestAnnotationControllerV1.java
@@ -1,0 +1,794 @@
+package datawave.microservice.annotation.service;
+
+import static datawave.annotation.test.v1.AnnotationAssertions.assertAnnotationSourcesEqual;
+import static datawave.annotation.test.v1.AnnotationAssertions.assertAnnotationsEqual;
+import static datawave.annotation.test.v1.AnnotationAssertions.assertSegmentsEqual;
+import static datawave.annotation.test.v1.AnnotationTestDataUtil.generateMultiTestSegment;
+import static datawave.annotation.test.v1.AnnotationTestDataUtil.generateTestAnnotation;
+import static datawave.annotation.test.v1.AnnotationTestDataUtil.generateTestAnnotationSource;
+import static datawave.security.authorization.DatawaveUser.UserType.USER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+
+import datawave.annotation.data.transform.DefaultTimestampTransformer;
+import datawave.annotation.data.transform.DefaultVisibilityTransformer;
+import datawave.annotation.data.transform.TimestampTransformer;
+import datawave.annotation.data.transform.VisibilityTransformer;
+import datawave.annotation.data.v1.AccumuloAnnotationSerializer;
+import datawave.annotation.data.v1.AccumuloAnnotationSourceSerializer;
+import datawave.annotation.data.v1.AnnotationDataAccess;
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.AnnotationSource;
+import datawave.annotation.protobuf.v1.Segment;
+import datawave.annotation.util.v1.AnnotationJsonUtils;
+import datawave.annotation.util.v1.AnnotationUtils;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.helpers.PrintUtility;
+import datawave.microservice.annotation.common.AnnotationSupplier;
+import datawave.microservice.annotation.service.config.AnnotationProperties;
+import datawave.microservice.annotation.util.Metadata;
+import datawave.microservice.annotation.util.lookup.service.LookupService;
+import datawave.microservice.authorization.user.DatawaveUserDetails;
+import datawave.query.QueryTestTableHelper;
+import datawave.query.util.WiseGuysIngest;
+import datawave.security.authorization.DatawaveUser;
+import datawave.security.authorization.SubjectIssuerDNPair;
+import datawave.table.constants.TableName;
+import lombok.extern.slf4j.Slf4j;
+
+@SuppressWarnings({"unchecked", "SpellCheckingInspection"})
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class TestAnnotationControllerV1 {
+
+    private static final TimestampTransformer timestampTransformer = new DefaultTimestampTransformer();
+    private static final VisibilityTransformer visibilityTransformer = new DefaultVisibilityTransformer();
+    private static final AnnotationProperties annotationProperties = new AnnotationProperties();
+
+    private static final MultiValueMap<String,String> EMPTY_HTTP_HEADERS = new HttpHeaders();
+
+    private static AccumuloClient client;
+
+    @Mock
+    private AccumuloConnectionFactory connectionFactory;
+
+    @Mock
+    private LookupService lookupService;
+
+    private DatawaveUserDetails defaultUserDetails;
+
+    @Mock
+    private AnnotationSupplier annotationSink;
+
+    private AnnotationControllerV1 annotationController;
+
+    @BeforeAll
+    public static void setupAccumulo() throws Exception {
+        org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(TestAnnotationControllerV1.class);
+        QueryTestTableHelper queryTestTableHelper = new QueryTestTableHelper(TestAnnotationControllerV1.class.toString(), log);
+        client = queryTestTableHelper.client;
+
+        String annotationTableName = "annotation";
+        String annotationSourceTableName = "annotationSource";
+
+        TableOperations tops = client.tableOperations();
+        tops.create(annotationTableName);
+        tops.create(annotationSourceTableName);
+
+        AccumuloAnnotationSerializer annotationSerializer = new AccumuloAnnotationSerializer(visibilityTransformer, timestampTransformer);
+        AccumuloAnnotationSourceSerializer annotationSourceSerializer = new AccumuloAnnotationSourceSerializer(visibilityTransformer, timestampTransformer);
+
+        Authorizations auths = new Authorizations("ALL", "PUBLIC");
+        AnnotationDataAccess testDao = new AnnotationDataAccess(client, Set.of(auths), annotationTableName, annotationSourceTableName, annotationSerializer,
+                        annotationSourceSerializer);
+
+        Annotation testAnnotation = generateTestAnnotation();
+        testDao.addAnnotation(testAnnotation);
+
+        AnnotationSource testAnnotationSource = generateTestAnnotationSource();
+        testDao.addAnnotationSource(testAnnotationSource);
+
+        // Configurator.setLevel(PrintUtility.class, Level.DEBUG);
+
+        WiseGuysIngest.writeItAll(client, WiseGuysIngest.WhatKindaRange.DOCUMENT);
+
+        testDao.addAnnotation(generateCorleoneAnnotation());
+
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, TableName.SHARD);
+        PrintUtility.printTable(client, auths, TableName.SHARD_INDEX);
+        PrintUtility.printTable(client, auths, QueryTestTableHelper.MODEL_TABLE_NAME);
+        PrintUtility.printTable(client, auths, annotationTableName);
+        PrintUtility.printTable(client, auths, annotationSourceTableName);
+
+        String truthmarkTableName = "truthmark";
+        String truthmarkSourceTableName = "truthmarkSource";
+
+        tops.create(truthmarkTableName);
+        tops.create(truthmarkSourceTableName);
+
+        annotationProperties.setAnnotationTableName(annotationTableName);
+        annotationProperties.setAnnotationSourceTableName(annotationSourceTableName);
+        annotationProperties.setTruthmarkTableName(truthmarkTableName);
+        annotationProperties.setTruthmarkSourceTableName(truthmarkSourceTableName);
+        annotationProperties.setEnableInternalIdLookup(true);
+        annotationProperties.setSystemFrom("annotation");
+    }
+
+    @SuppressWarnings("SpellCheckingInspection")
+    public static Annotation generateCorleoneAnnotation() {
+        AnnotationSource baseAnnotationSource = generateTestAnnotationSource();
+        AnnotationSource annotationSource = AnnotationUtils.injectAnnotationSourceHashes(baseAnnotationSource);
+
+        Map<String,String> metadata = new HashMap<>();
+        metadata.put("UUID", "CORLEONE");
+        metadata.put("visibility", "ALL");
+        metadata.put("created_date", "2025-10-01T00:00:00.000Z");
+
+        //@formatter:off
+        return Annotation.newBuilder()
+                .setShard("20130101_0")
+                .setDataType("test")
+                .setUid("-d5uxna.msizfm.-oxy0iu")
+                .setAnnotationType("corleoneAnnotationType")
+                .setDocumentId("CORLEONE")
+                .setSource(annotationSource)
+                .addAllSegments(List.of(generateMultiTestSegment()))
+                .putAllMetadata(metadata)
+                .build();
+        //@formatter:on
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        SubjectIssuerDNPair DEFAULT_USER_DN = SubjectIssuerDNPair.of("userDn", "issuerDn");
+        Collection<String> DEFAULT_ROLES = Collections.singleton("Administrator");
+        Collection<String> DEFAULT_AUTHS = Arrays.asList("A", "B", "C", "D", "E", "F", "G", "H", "I", "ALL", "PUBLIC");
+        DatawaveUser dwUser = new DatawaveUser(DEFAULT_USER_DN, USER, DEFAULT_AUTHS, DEFAULT_ROLES, null, System.currentTimeMillis());
+        defaultUserDetails = new DatawaveUserDetails(Collections.singleton(dwUser), dwUser.getCreationTime());
+
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        annotationController = new AnnotationControllerV1(connectionFactory, lookupService, annotationProperties, timestampTransformer, visibilityTransformer,
+                        annotationSink, executorService, new AnnotationAckTracker());
+        lenient().when(connectionFactory.getClient(any(), any(), any(), any(), any())).thenReturn(client);
+    }
+
+    /**
+     * Simulates a message broker that immediately (synchronously) acknowledges every message sent through {@code annotationSink}, so that
+     * {@code writeAnnotation}/{@code updateAnnotation} calls that go through the durable-write acknowledgement protocol don't have to wait out a real ack
+     * timeout in these tests.
+     */
+    private void configureImmediateAck() {
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            org.springframework.messaging.Message<?> sent = invocation.getArgument(0);
+            Object correlationId = sent.getHeaders().get(org.springframework.integration.IntegrationMessageHeaderAccessor.CORRELATION_ID);
+            assertNotNull(correlationId);
+            org.springframework.messaging.Message<String> ack = org.springframework.integration.support.MessageBuilder.withPayload("ack")
+                            .setCorrelationId(correlationId).build();
+            annotationController.processConfirmAck(ack);
+            return true;
+        });
+    }
+
+    @Test
+    public void testGetAnnotationSource() {
+        AnnotationSource baseAnnotationSource = generateTestAnnotationSource();
+        AnnotationSource expectedAnnotationSource = AnnotationUtils.injectAnnotationSourceHashes(baseAnnotationSource);
+
+        ResponseEntity<?> response = annotationController.getAnnotationSource(expectedAnnotationSource.getAnalyticSourceHash(), EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(200, response);
+        AnnotationSource annotationSource = assertExpectedEntity(AnnotationSource.class, response);
+        assertNotNull(annotationSource);
+        assertAnnotationSourcesEqual(expectedAnnotationSource, annotationSource);
+    }
+
+    @Test
+    public void testGetMissingAnnotationSource() {
+        ResponseEntity<?> response = annotationController.getAnnotationSource("52EF0E07742AC65873C6DF80759AF193", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotation source found for analyticHash", errorResponse);
+        assertContains("52EF0E07742AC65873C6DF80759AF193", errorResponse);
+    }
+
+    @Test
+    public void testGetAnnotationTypesInternalId() {
+        Metadata expectedMetadata = new Metadata("shard", "20250704_249", "testDataType", "abcde.fghij.klmno");
+        ResponseEntity<?> response = annotationController.getAnnotationTypes("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(200, response);
+        Map<Metadata,Collection<String>> annotationTypeMap = assertExpectedEntity(HashMap.class, response);
+        assertEquals(1, annotationTypeMap.size());
+        Collection<String> annotationTypeList = annotationTypeMap.get(expectedMetadata);
+        assertNotNull(annotationTypeList);
+        assertEquals(1, annotationTypeList.size());
+        assertTrue(annotationTypeList.contains("testAnnotationType"));
+    }
+
+    @Test
+    public void testGetAnnotationTypesMissingInternalId() {
+        ResponseEntity<?> response = annotationController.getAnnotationTypes("DOCUMENT", "20250704_249/testDataType/12345.67890.12345", EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotation types found for identifier", errorResponse);
+        assertContains("20250704_249/testDataType/12345.67890.12345", errorResponse);
+    }
+
+    @Test
+    public void testGetAnnotationTypesExternalIdNoAnnotations() {
+        Metadata caponeMetadata = new Metadata("shard", "20130101_0", "test", "-cvy0gj.tlf59s.-duxzua");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CAPONE"), any(), any(), any())).thenReturn(List.of(caponeMetadata));
+
+        ResponseEntity<?> response = annotationController.getAnnotationTypes("UUID", "CAPONE", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotation types found for identifier", errorResponse);
+        assertContains("20130101_0/test/-cvy0gj.tlf59s.-duxzua", errorResponse);
+    }
+
+    @Test
+    public void testGetAnnotationTypesExternalIdWithAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-d5uxna.msizfm.-oxy0iu");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(List.of(expectedMetadata));
+        ResponseEntity<?> response = annotationController.getAnnotationTypes("UUID", "CORLEONE", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(200, response);
+        HashMap<Metadata,Collection<String>> annotationTypeMap = assertExpectedEntity(HashMap.class, response);
+        assertEquals(1, annotationTypeMap.size());
+        Collection<String> annotationTypeList = annotationTypeMap.get(expectedMetadata);
+        assertNotNull(annotationTypeList);
+        assertEquals(1, annotationTypeList.size());
+        assertTrue(annotationTypeList.contains("corleoneAnnotationType"));
+    }
+
+    @Test
+    public void testGetAnnotationsForInternalId() {
+        Annotation testAnnotation = generateTestAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        ResponseEntity<?> response = annotationController.getAnnotationsFor("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(200, response);
+        ArrayList<Annotation> annotationList = assertExpectedEntity(ArrayList.class, response);
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.get(0));
+    }
+
+    @Test
+    public void testGetAnnotationsForMissingInternalId() {
+        ResponseEntity<?> response = annotationController.getAnnotationsFor("DOCUMENT", "20250704_249/testDataType/12345.67890.12345", EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations found for identifier", errorResponse);
+        assertContains("20250704_249/testDataType/12345.67890.12345", errorResponse);
+    }
+
+    @Test
+    public void testGetAnnotationsForExternalIdNoAnnotations() {
+        Metadata caponeMetadata = new Metadata("shard", "20130101_0", "test", "-cvy0gj.tlf59s.-duxzua");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CAPONE"), any(), any(), any())).thenReturn(List.of(caponeMetadata));
+
+        ResponseEntity<?> response = annotationController.getAnnotationsFor("UUID", "CAPONE", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations found for identifier", errorResponse);
+        assertContains("20130101_0/test/-cvy0gj.tlf59s.-duxzua", errorResponse);
+    }
+
+    @Test
+    public void testAnnotationsForExternalIdWithAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-d5uxna.msizfm.-oxy0iu");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(List.of(expectedMetadata));
+
+        Annotation testAnnotation = generateCorleoneAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        ResponseEntity<?> response = annotationController.getAnnotationsFor("UUID", "CORLEONE", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(200, response);
+        ArrayList<Annotation> annotationList = assertExpectedEntity(ArrayList.class, response);
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.get(0));
+    }
+
+    /*
+     * T13 (Q07, Option B): only an explicit allowlist of caller-supplied query parameters (currently just 'auths') is ever forwarded to the remote lookup
+     * service. These tests exercise the real lookupDocumentIdentifier/prepareLookupParameters code path (invoked indirectly via getAnnotationsFor, which is an
+     * external, UUID-style lookup) and capture the exact "params" string that lookupService.executeLookupUUIDQuery is called with.
+     */
+
+    @Test
+    public void testLookupParametersOmitAuthsWhenNoneRequested() {
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(Collections.emptyList());
+
+        annotationController.getAnnotationsFor("UUID", "CORLEONE", EMPTY_HTTP_HEADERS, defaultUserDetails);
+
+        ArgumentCaptor<String> queryParamsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(lookupService).executeLookupUUIDQuery(eq("UUID"), eq("CORLEONE"), queryParamsCaptor.capture(), any(), eq(defaultUserDetails));
+        assertEquals("", queryParamsCaptor.getValue(),
+                        "no auths override was requested, so nothing should be forwarded -- the remote lookup then defaults to the caller's full "
+                                        + "authorization set, matching the no-override branch used for local reads");
+    }
+
+    @Test
+    public void testLookupParametersForwardOnlyAllowlistedAuths() throws Exception {
+        org.springframework.util.LinkedMultiValueMap<String,String> queryParameters = new org.springframework.util.LinkedMultiValueMap<>();
+        queryParameters.add(AnnotationControllerV1.RequestContext.QUERY_AUTHORIZATIONS, "B,A");
+        // 'foo' is not on the allowlist and must never reach the remote lookup, regardless of what it contains.
+        queryParameters.add("foo", "bar");
+
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(Collections.emptyList());
+
+        annotationController.getAnnotationsFor("UUID", "CORLEONE", queryParameters, defaultUserDetails);
+
+        ArgumentCaptor<String> queryParamsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(lookupService).executeLookupUUIDQuery(eq("UUID"), eq("CORLEONE"), queryParamsCaptor.capture(), any(), eq(defaultUserDetails));
+        String forwardedParams = queryParamsCaptor.getValue();
+
+        assertFalse(forwardedParams.contains("foo"), "non-allowlisted parameters must never be forwarded to the remote lookup");
+        assertFalse(forwardedParams.contains("bar"), "non-allowlisted parameter values must never be forwarded to the remote lookup");
+
+        String expectedDowngradedAuths = datawave.microservice.authorization.util.AuthorizationsUtil.downgradeUserAuths("B,A", defaultUserDetails,
+                        defaultUserDetails);
+        assertEquals(AnnotationControllerV1.RequestContext.QUERY_AUTHORIZATIONS + ":" + expectedDowngradedAuths, forwardedParams,
+                        "the only allowlisted parameter, 'auths', must be forwarded downgraded exactly as a local read would downgrade it");
+    }
+
+    @Test
+    public void testLookupParametersDowngradeToRequestedSubsetOfAuths() throws Exception {
+        // defaultUserDetails holds A,B,C,D,E,F,G,H,I,ALL,PUBLIC -- request a narrower subset than the caller's full grant.
+        org.springframework.util.LinkedMultiValueMap<String,String> queryParameters = new org.springframework.util.LinkedMultiValueMap<>();
+        queryParameters.add(AnnotationControllerV1.RequestContext.QUERY_AUTHORIZATIONS, "A");
+
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(Collections.emptyList());
+
+        annotationController.getAnnotationsFor("UUID", "CORLEONE", queryParameters, defaultUserDetails);
+
+        ArgumentCaptor<String> queryParamsCaptor = ArgumentCaptor.forClass(String.class);
+        verify(lookupService).executeLookupUUIDQuery(eq("UUID"), eq("CORLEONE"), queryParamsCaptor.capture(), any(), eq(defaultUserDetails));
+
+        assertEquals(AnnotationControllerV1.RequestContext.QUERY_AUTHORIZATIONS + ":A", queryParamsCaptor.getValue(),
+                        "a caller-requested narrower auths subset must be honored and forwarded downgraded, not silently widened back to the full grant");
+    }
+
+    @Test
+    public void testLookupParametersRejectAuthsNotHeldByCaller() {
+        org.springframework.util.LinkedMultiValueMap<String,String> queryParameters = new org.springframework.util.LinkedMultiValueMap<>();
+        // "NOPE" is not among defaultUserDetails' granted auths.
+        queryParameters.add(AnnotationControllerV1.RequestContext.QUERY_AUTHORIZATIONS, "A,NOPE");
+
+        ResponseEntity<?> response = annotationController.getAnnotationsFor("UUID", "CORLEONE", queryParameters, defaultUserDetails);
+
+        assertResponseStatus(500, response);
+        org.mockito.Mockito.verifyNoInteractions(lookupService);
+    }
+
+    @Test
+    public void testGetAllAnnotationsByTypeInternalId() {
+        Annotation testAnnotation = generateTestAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        // TODO: insert a second annotation for the same document with a different type?
+        //@formatter:off
+        ResponseEntity<?> response = annotationController.getAnnotationsByType(
+                "DOCUMENT",
+                "20250704_249/testDataType/abcde.fghij.klmno",
+                "testAnnotationType",EMPTY_HTTP_HEADERS, defaultUserDetails
+        );
+        //@formatter:on
+        assertResponseStatus(200, response);
+        ArrayList<Annotation> annotationList = assertExpectedEntity(ArrayList.class, response);
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.get(0));
+    }
+
+    @Test
+    public void testGetAllAnnotationByTypeInternalIdMissingType() {
+        // TODO: insert a second annotation for the same document with a different type?
+        //@formatter:off
+        ResponseEntity<?> response = annotationController.getAnnotationsByType(
+                "DOCUMENT",
+                "20250704_249/testDataType/abcde.fghij.klmno",
+                "missingType", EMPTY_HTTP_HEADERS, defaultUserDetails
+        );
+        //@formatter:on
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations of type found for identifier", errorResponse);
+        assertContains("20250704_249/testDataType/abcde.fghij.klmno", errorResponse);
+        assertContains("missingType", errorResponse);
+    }
+
+    @Test
+    public void testGetAllAnnotationByTypeExternalIdNoAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-cvy0gj.tlf59s.-duxzua");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CAPONE"), any(), any(), any())).thenReturn(List.of(expectedMetadata));
+
+        ResponseEntity<?> response = annotationController.getAnnotationsByType("UUID", "CAPONE", "testAnnotationType", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations of type found for identifier", errorResponse);
+        assertContains("20130101_0/test/-cvy0gj.tlf59s.-duxzua", errorResponse);
+        assertContains("UUID:CAPONE", errorResponse);
+        assertContains("testAnnotationType", errorResponse);
+
+    }
+
+    @Test
+    public void testGetAllAnnotationByTypeExternalIdWithAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-d5uxna.msizfm.-oxy0iu");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(List.of(expectedMetadata));
+
+        Annotation testAnnotation = generateCorleoneAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        ResponseEntity<?> response = annotationController.getAnnotationsByType("UUID", "CORLEONE", "corleoneAnnotationType", EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(200, response);
+        ArrayList<Annotation> annotationList = assertExpectedEntity(ArrayList.class, response);
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.get(0));
+    }
+
+    @Test
+    public void testGetAnnotationInternalId() {
+        Annotation testAnnotation = generateTestAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        ResponseEntity<?> response = annotationController.getAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", "23BD91EC",
+                        EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(200, response);
+        List<Annotation> annotationList = assertExpectedEntity(List.class, response);
+        assertFalse(annotationList.isEmpty());
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.iterator().next());
+    }
+
+    @Test
+    public void testGetAnnotationInternalIdDisabled() {
+        annotationProperties.setEnableInternalIdLookup(false);
+        try {
+            ResponseEntity<?> response = annotationController.getAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", "23BD91EC",
+                            EMPTY_HTTP_HEADERS, defaultUserDetails);
+            assertResponseStatus(500, response);
+            String errorResponse = assertExpectedEntity(String.class, response);
+            assertContains("Internal identifier lookup is disabled for", errorResponse);
+            assertContains("20250704_249/testDataType/abcde.fghij.klmno", errorResponse);
+        } finally {
+            // annotationProperties is shared across all tests in this class (initialized once in setupAccumulo), so restore
+            // it to avoid affecting other tests that rely on internal id lookup being enabled.
+            annotationProperties.setEnableInternalIdLookup(true);
+        }
+    }
+
+    @Test
+    public void testGetAnnotationMissingInternalId() {
+        ResponseEntity<?> response = annotationController.getAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", "aaaaaaaa",
+                        EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations found for identifier", errorResponse);
+        assertContains("20250704_249/testDataType/abcde.fghij.klmno", errorResponse);
+        assertContains("aaaaaaaa", errorResponse);
+    }
+
+    @Test
+    public void testGetAnnotationExternalIdNoAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-cvy0gj.tlf59s.-duxzua");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CAPONE"), any(), any(), any())).thenReturn(List.of(expectedMetadata));
+
+        ResponseEntity<?> response = annotationController.getAnnotation("UUID", "CAPONE", "e5feb4ba", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations found for identifier", errorResponse);
+        assertContains("20130101_0/test/-cvy0gj.tlf59s.-duxzua", errorResponse);
+        assertContains("e5feb4ba", errorResponse);
+        assertContains("UUID:CAPONE", errorResponse);
+
+    }
+
+    @Test
+    public void testGetAnnotationExternalIdWithAnnotations() {
+        Metadata expectedMetadata = new Metadata("shard", "20130101_0", "test", "-d5uxna.msizfm.-oxy0iu");
+        when(lookupService.executeLookupUUIDQuery(matches("UUID"), matches("CORLEONE"), any(), any(), any())).thenReturn(List.of(expectedMetadata));
+
+        Annotation testAnnotation = generateCorleoneAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+        ResponseEntity<?> response = annotationController.getAnnotation("UUID", "CORLEONE", expectedAnnotation.getAnnotationId(), EMPTY_HTTP_HEADERS,
+                        defaultUserDetails);
+        assertResponseStatus(200, response);
+        List<Annotation> annotationList = assertExpectedEntity(List.class, response);
+        assertFalse(annotationList.isEmpty());
+        assertEquals(1, annotationList.size());
+        assertAnnotationsEqual(expectedAnnotation, annotationList.iterator().next());
+    }
+
+    @Test
+    public void testUpdateAnnotationInternalId() throws Exception {
+        configureImmediateAck();
+
+        Annotation existingAnnotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+        // simulate an update that masks/deletes the existing segment by submitting one with an empty values list
+        Segment maskedSegment = existingAnnotation.getSegments(0).toBuilder().clearValues().build();
+        Annotation updatedAnnotation = existingAnnotation.toBuilder().clearSegments().addSegments(maskedSegment).build();
+        String body = AnnotationJsonUtils.annotationToJsonWithoutIds(updatedAnnotation);
+
+        ResponseEntity<?> response = annotationController.updateAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno",
+                        existingAnnotation.getAnnotationId(), body, EMPTY_HTTP_HEADERS, defaultUserDetails);
+
+        assertResponseStatus(200, response);
+        Annotation resultAnnotation = assertExpectedEntity(Annotation.class, response);
+        assertTrue(resultAnnotation.getSegments(0).getValuesList().isEmpty(), "expected the masked segment's empty values list to be preserved");
+        assertEquals(existingAnnotation.getAnnotationId(), resultAnnotation.getMetadataMap().get(AnnotationUtils.UPDATE_REFERENCE),
+                        "expected the updated annotation's metadata to reference the annotation it updates");
+        verify(annotationSink, times(1)).send(any());
+    }
+
+    @Test
+    public void testUpdateAnnotationInternalIdMissingId() {
+        ResponseEntity<?> response = annotationController.updateAnnotation("DOCUMENT", "20250704_249/testDataType/aaaaa.bbbbb.ccccc", "23BD91EC", "{}",
+                        EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(500, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("Invalid annotation json", errorResponse);
+    }
+
+    @Test
+    public void testUpdateAnnotationTargetNotFound() throws Exception {
+        Annotation existingAnnotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+        String body = AnnotationJsonUtils.annotationToJsonWithoutIds(existingAnnotation);
+
+        // "aaaaaaaa" is not a real annotation id for this document, so the update should be rejected before anything is sent.
+        ResponseEntity<?> response = annotationController.updateAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", "aaaaaaaa", body,
+                        EMPTY_HTTP_HEADERS, defaultUserDetails);
+
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations found for identifier", errorResponse);
+        assertContains("aaaaaaaa", errorResponse);
+        verify(annotationSink, times(0)).send(any());
+    }
+
+    @Test
+    public void testGetAnnotationSegmentInternalId() {
+        Metadata expectedMetadata = new Metadata("shard", "20250704_249", "testDataType", "abcde.fghij.klmno");
+        Annotation testAnnotation = generateTestAnnotation();
+        Annotation expectedAnnotation = AnnotationUtils.injectAllHashes(testAnnotation);
+
+        //@formatter:off
+        ResponseEntity<?> response = annotationController.getAnnotationSegment(
+                "DOCUMENT",
+                expectedAnnotation.getShard() + "/" + expectedAnnotation.getDataType() + "/" + expectedAnnotation.getUid(),
+                expectedAnnotation.getAnnotationId(),
+                expectedAnnotation.getSegments(0).getSegmentHash(), EMPTY_HTTP_HEADERS, defaultUserDetails
+        );
+        //@formatter:on
+
+        assertResponseStatus(200, response);
+        Map<Metadata,Collection<Segment>> result = assertExpectedEntity(Map.class, response);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+        Collection<Segment> segmentsList = result.get(expectedMetadata);
+        assertNotNull(segmentsList);
+        assertFalse(segmentsList.isEmpty());
+        assertEquals(1, segmentsList.size());
+        assertSegmentsEqual(expectedAnnotation.getSegmentsList(), segmentsList);
+    }
+
+    @Test
+    public void testGetAnnotationSegmentInternalIdMissingAnnotationId() {
+        //@formatter:off
+        ResponseEntity<?> response = annotationController.getAnnotationSegment(
+                "DOCUMENT",
+                "20250704_249/testDataType/abcde.fghij.klmno",
+                "aaaaaaaa",
+                "5a7bcdd9", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        //@formatter:on
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No annotations found for identifier", errorResponse);
+        assertContains("20250704_249/testDataType/abcde.fghij.klmno", errorResponse);
+        assertContains("aaaaaaaa", errorResponse);
+    }
+
+    @Test
+    public void testGetAnnotationSegmentInternalIdMissingSegmentHash() {
+        //@formatter:off
+        ResponseEntity<?> response = annotationController.getAnnotationSegment(
+                "DOCUMENT",
+                "20250704_249/testDataType/abcde.fghij.klmno",
+                "23BD91EC",
+                "bbbbbbbb", EMPTY_HTTP_HEADERS, defaultUserDetails);
+        //@formatter:on
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("No segments found for identifier", errorResponse);
+        assertContains("20250704_249/testDataType/abcde.fghij.klmno", errorResponse);
+        assertContains("bbbbbbbb", errorResponse);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // write target tests
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testUpdateAnnotationTargetNotFoundOnTruthmarkTable() throws Exception {
+        // Per Q4, updates target truthmark tables. The FederatedAnnotationReader (which reads both
+        // annotation + truthmark tables) will not find "UPDATE_TEST_ID" in any table pair, so the
+        // controller should return 404 before reaching the write path.
+        AnnotationSource testSource = AnnotationUtils.injectAnnotationSourceHashes(generateTestAnnotationSource());
+
+        Annotation updateAnnotation = generateTestAnnotation().toBuilder().setAnnotationId("UPDATE_TEST_ID").setSource(testSource)
+                        .setAnalyticSourceHash(testSource.getAnalyticSourceHash()).build();
+
+        ResponseEntity<?> response = annotationController.updateAnnotation("DOCUMENT", "20250704_249/testDataType/abcde.fghij.klmno", "UPDATE_TEST_ID",
+                        AnnotationJsonUtils.annotationToJsonWithoutIds(updateAnnotation), EMPTY_HTTP_HEADERS, defaultUserDetails);
+        assertResponseStatus(404, response);
+        String errorResponse = assertExpectedEntity(String.class, response);
+        assertContains("annotations", errorResponse);
+        assertContains("UPDATE_TEST_ID", errorResponse);
+        verify(annotationSink, times(0)).send(any());
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // maskSourceMetadata tests
+    // ----------------------------------------------------------------------------------------------------------------
+
+    private static AnnotationSource source(String... metadataPairs) {
+        AnnotationSource.Builder builder = generateTestAnnotationSource().toBuilder();
+        for (int i = 0; i < metadataPairs.length; i += 2) {
+            builder.putMetadata(metadataPairs[i], metadataPairs[i + 1]);
+        }
+        return builder.build();
+    }
+
+    @Test
+    public void testMaskSourceMetadata_RemovesVisibilityByDefault() throws Exception {
+        AnnotationSource source = source("visibility", "ALL", "engine", "foo");
+        AnnotationSource masked = invokeMaskSourceMetadata(source);
+        assertFalse(masked.containsMetadata("visibility"), "visibility metadata should be masked by default");
+        assertTrue(masked.containsMetadata("engine"), "other metadata should be preserved");
+        assertEquals("foo", masked.getMetadataOrDefault("engine", ""));
+    }
+
+    @Test
+    public void testMaskSourceMetadata_NoopWhenNoMatchingKeys() throws Exception {
+        // source with only non-masked metadata keys ("visibility" is the default mask target, so exclude it)
+        AnnotationSource.Builder builder = generateTestAnnotationSource().toBuilder();
+        builder.clearMetadata();
+        builder.putMetadata("engine", "foo");
+        builder.putMetadata("created_date", "2025-01-01");
+        AnnotationSource source = builder.build();
+        AnnotationSource masked = invokeMaskSourceMetadata(source);
+        assertSame(source, masked, "should return original when no fields are masked");
+    }
+
+    @Test
+    public void testMaskSourceMetadata_RespectsCustomMaskList() throws Exception {
+        AnnotationSource source = source("visibility", "ALL", "created_date", "2025-01-01");
+        annotationProperties.setMaskSourceMetadata(List.of("created_date"));
+        try {
+            AnnotationSource masked = invokeMaskSourceMetadata(source);
+            assertFalse(masked.containsMetadata("created_date"), "created_date should be masked when configured");
+            assertTrue(masked.containsMetadata("visibility"), "visibility should be preserved when not in mask list");
+        } finally {
+            annotationProperties.setMaskSourceMetadata(List.of("visibility"));
+        }
+    }
+
+    @Test
+    public void testMaskSourceMetadata_HandlesEmptyMaskList() throws Exception {
+        annotationProperties.setMaskSourceMetadata(List.of());
+        try {
+            AnnotationSource source = generateTestAnnotationSource();
+            AnnotationSource masked = invokeMaskSourceMetadata(source);
+            assertSame(source, masked, "should return original when mask list is empty");
+        } finally {
+            annotationProperties.setMaskSourceMetadata(List.of("visibility"));
+        }
+    }
+
+    @Test
+    public void testMaskSourceMetadata_HandlesNullMaskList() throws Exception {
+        annotationProperties.setMaskSourceMetadata(null);
+        try {
+            AnnotationSource source = generateTestAnnotationSource();
+            AnnotationSource masked = invokeMaskSourceMetadata(source);
+            assertSame(source, masked, "should return original when mask list is null");
+        } finally {
+            annotationProperties.setMaskSourceMetadata(List.of("visibility"));
+        }
+    }
+
+    /**
+     * Invoke the controller's maskSourceMetadata method via reflection (it is private).
+     */
+    private AnnotationSource invokeMaskSourceMetadata(AnnotationSource source) throws Exception {
+        java.lang.reflect.Method method = AnnotationControllerV1.class.getDeclaredMethod("maskSourceMetadata", AnnotationSource.class);
+        method.setAccessible(true);
+        return (AnnotationSource) method.invoke(annotationController, source);
+    }
+
+    /**
+     * Assert that the response has the expected http status code.
+     *
+     * @param expected
+     *            the expected http status code
+     * @param response
+     *            the response to check.
+     */
+    private static void assertResponseStatus(int expected, ResponseEntity<?> response) {
+        log.debug("Response entity in assertResponseStatus: {}", response);
+        assertEquals(expected, response.getStatusCode().value(),
+                        String.format("Unexpected response http status: '%d', expected '%d'", response.getStatusCode().value(), expected));
+    }
+
+    /**
+     * Assert that the response's entity has is a specific class, and return that entity cast to the specified class for convienience.
+     *
+     * @param clazz
+     *            the class to check for.
+     * @param response
+     *            the response whose entity we'll be checking
+     * @return the entity cast to the specified class.
+     * @param <T>
+     *            the type for the return, based on the specified class.
+     */
+    private static <T> T assertExpectedEntity(Class<T> clazz, ResponseEntity<?> response) {
+        final Object entity = response.getBody();
+        if (entity == null && clazz == null) {
+            fail("Unsupported null entity and expected class");
+        } else if (entity == null) {
+            fail(String.format("Unexpected null entity, expected '%s'", clazz));
+        } else if (clazz == null) {
+            fail(String.format("Unexpected entity class: '%s' expected null", entity.getClass()));
+        }
+
+        assertTrue(clazz.isAssignableFrom(entity.getClass()), String.format("Unexpected entity class: '%s', expected '%s'", entity.getClass(), clazz));
+        return clazz.cast(entity);
+    }
+
+    /**
+     * Assert that the provided message contains the expected string.
+     *
+     * @param expected
+     *            the expected substring
+     * @param message
+     *            the message to check.
+     */
+    private static void assertContains(String expected, String message) {
+        assertTrue(message.contains(expected), String.format("Unexpected response: '%s', did not contain the string '%s'", message, expected));
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/TestAnnotationControllerV1Delivery.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/TestAnnotationControllerV1Delivery.java
@@ -1,0 +1,694 @@
+package datawave.microservice.annotation.service;
+
+import static datawave.annotation.test.v1.AnnotationTestDataUtil.generateTestAnnotation;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+import datawave.annotation.data.transform.DefaultTimestampTransformer;
+import datawave.annotation.data.transform.DefaultVisibilityTransformer;
+import datawave.annotation.data.transform.TimestampTransformer;
+import datawave.annotation.data.transform.VisibilityTransformer;
+import datawave.annotation.protobuf.v1.Annotation;
+import datawave.annotation.protobuf.v1.AnnotationMessage;
+import datawave.annotation.util.v1.AnnotationUtils;
+import datawave.core.common.connection.AccumuloConnectionFactory;
+import datawave.microservice.annotation.common.AnnotationSupplier;
+import datawave.microservice.annotation.health.HealthChecker;
+import datawave.microservice.annotation.service.config.AnnotationProperties;
+import datawave.microservice.annotation.util.lookup.service.LookupService;
+import datawave.microservice.annotation.writers.AnnotationWriter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Focused unit tests for the message delivery path in {@link AnnotationControllerV1}: {@code writeAnnotation}, {@code sendAnnotation}, and
+ * {@code sendAnnotationMessage}. These methods are package-private (visible for testing), so they are called directly here. The durable-write acknowledgement
+ * protocol is simulated by invoking {@link AnnotationControllerV1#processConfirmAck(Message)} directly rather than standing up a real message broker.
+ */
+@SuppressWarnings("SpellCheckingInspection")
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class TestAnnotationControllerV1Delivery {
+
+    private static final TimestampTransformer timestampTransformer = new DefaultTimestampTransformer();
+    private static final VisibilityTransformer visibilityTransformer = new DefaultVisibilityTransformer();
+
+    @Mock
+    private AccumuloConnectionFactory connectionFactory;
+
+    @Mock
+    private LookupService lookupService;
+
+    @Mock
+    private AnnotationSupplier annotationSink;
+
+    private AnnotationProperties annotationProperties;
+
+    private AnnotationControllerV1 annotationController;
+
+    @BeforeEach
+    void setUp() {
+        annotationProperties = new AnnotationProperties();
+        annotationProperties.setSystemFrom("annotation");
+        annotationProperties.setAnnotationAckEnabled(true);
+        // keep timeouts/backoffs short so failure/retry paths run quickly in tests
+        annotationProperties.setAnnotationAckTimeoutMillis(150L);
+        annotationProperties.getRetry().setMaxAttempts(3);
+        annotationProperties.getRetry().setBackoffIntervalMillis(5L);
+        annotationProperties.getRetry().setFailTimeoutMillis(TimeUnit.SECONDS.toMillis(10));
+
+        annotationController = new AnnotationControllerV1(connectionFactory, lookupService, annotationProperties, timestampTransformer, visibilityTransformer,
+                        annotationSink, Executors.newCachedThreadPool(), new AnnotationAckTracker());
+
+        // ensure no latches leak between tests
+        getAnnotationAckTracker().clear();
+    }
+
+    /**
+     * Simulates a message broker that immediately (synchronously) acknowledges every message sent through {@code annotationSink}, mimicking a healthy
+     * downstream in the producer-confirms protocol. Only the successful-send case is simulated here; failed sends are covered directly by tests that stub
+     * {@code annotationSink.send(...)} to return {@code false} (see e.g. {@code testSendAnnotationMessage_SendFailureReturnsEmptyWithoutWaitingForAck}),
+     * since a failed send never waits on an acknowledgement.
+     */
+    private void configureImmediateAck() {
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            Message<AnnotationMessage> sent = invocation.getArgument(0);
+            Object correlationId = sent.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+            assertNotNull(correlationId);
+            Message<String> ack = MessageBuilder.withPayload("ack").setCorrelationId(correlationId).build();
+            annotationController.processConfirmAck(ack);
+            return true;
+        });
+    }
+
+    // Use reflection to access the AnnotationAckTracker and assert that no latches leak between test invocations.
+    private AnnotationAckTracker getAnnotationAckTracker() {
+        try {
+            Field field = AnnotationControllerV1.class.getDeclaredField("annotationAckTracker");
+            field.setAccessible(true);
+            return (AnnotationAckTracker) field.get(annotationController);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // fileAnnotationWriter is normally populated via @Autowired(required = false); inject a mock directly with reflection
+    private void setFileAnnotationWriter(AnnotationWriter writer) {
+        try {
+            Field field = AnnotationControllerV1.class.getDeclaredField("fileAnnotationWriter");
+            field.setAccessible(true);
+            field.set(annotationController, writer);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // healthChecker is normally populated via @Autowired(required = false); inject a mock directly with reflection
+    private void setHealthChecker(HealthChecker checker) {
+        try {
+            Field field = AnnotationControllerV1.class.getDeclaredField("healthChecker");
+            field.setAccessible(true);
+            field.set(annotationController, checker);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static AnnotationMessage buildMessage(Annotation annotation) {
+        //@formatter:off
+        return AnnotationMessage.newBuilder()
+                .addAnnotations(annotation)
+                .setSource("annotation")
+                .build();
+        //@formatter:on
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // sendAnnotationMessage(...) tests
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testSendAnnotationMessage_AssignsMessageIdWhenBlank() {
+        configureImmediateAck();
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+        AnnotationMessage annotationMessage = buildMessage(annotation);
+        assertTrue(annotationMessage.getAnnotationMessageId().isBlank(), "test precondition: message id should start blank");
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(annotationMessage);
+
+        assertTrue(result.isPresent());
+        assertFalse(result.get().getAnnotationMessageId().isBlank(), "annotationMessageId should have been assigned before sending");
+        assertEquals(AnnotationUtils.calculateAnnotationMessageHash(annotationMessage), result.get().getAnnotationMessageId());
+    }
+
+    @Test
+    public void testSendAnnotationMessage_PreservesExistingMessageId() {
+        configureImmediateAck();
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+        AnnotationMessage annotationMessage = buildMessage(annotation).toBuilder().setAnnotationMessageId("PRE-ASSIGNED-ID").build();
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(annotationMessage);
+
+        assertTrue(result.isPresent());
+        assertEquals("PRE-ASSIGNED-ID", result.get().getAnnotationMessageId());
+    }
+
+    @Test
+    public void testSendAnnotationMessage_UsesDistinctCorrelationIdsForDistinctMessages() {
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            Message<AnnotationMessage> sent = invocation.getArgument(0);
+            Object correlationId = sent.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+            assertNotNull(correlationId);
+            annotationController.processConfirmAck(MessageBuilder.withPayload("ack").setCorrelationId(correlationId).build());
+            return true;
+        });
+
+        Annotation annotationOne = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+        Annotation annotationTwo = AnnotationUtils.injectAllHashes(
+                        generateTestAnnotation().toBuilder().setAnnotationType("aCompletelyDifferentAnnotationType").build());
+
+        Optional<AnnotationMessage> resultOne = annotationController.sendAnnotationMessage(buildMessage(annotationOne));
+        Optional<AnnotationMessage> resultTwo = annotationController.sendAnnotationMessage(buildMessage(annotationTwo));
+
+        assertTrue(resultOne.isPresent());
+        assertTrue(resultTwo.isPresent());
+
+        // Validate that two distinct annotations produce two distinct, non-blank correlation ids.
+        String idOne = resultOne.get().getAnnotationMessageId();
+        String idTwo = resultTwo.get().getAnnotationMessageId();
+        assertFalse(idOne.isBlank());
+        assertFalse(idTwo.isBlank());
+        assertNotEquals(idOne, idTwo, "distinct annotation messages must not share a correlation id");
+
+        // and the map should be clean afterward -- no leaked latches
+        assertTrue(getAnnotationAckTracker().isEmpty());
+    }
+
+    @Test
+    public void testSendAnnotationMessage_DuplicateConcurrentSendsForSameMessageIdShareLatchAndBothSucceed() throws Exception {
+        // Two callers attempt to send the exact same (pre-assigned) annotationMessageId concurrently, simulating a
+        // client retry racing with the original in-flight send. Only one ack ever arrives for that correlation id.
+        // Both callers must be satisfied by that single ack -- the second call must not silently overwrite/orphan
+        // the first caller's latch, which would otherwise leave the first caller waiting out the full ack timeout
+        // and incorrectly reporting failure.
+        //
+        // This is made deterministic (rather than depending on thread-scheduling timing, which previously made this
+        // test intermittently flaky: if the original sender's entire send-ack-remove cycle completed before the
+        // "duplicate" caller's putIfAbsent even ran, the duplicate would legitimately see no in-flight latch and
+        // become a second original sender). A spy around AnnotationAckTracker signals exactly when the duplicate
+        // caller has observed the original sender's in-flight latch, and the mocked send(...) is held open until
+        // that has been confirmed before delivering the single ack.
+        AnnotationMessage annotationMessage = buildMessage(AnnotationUtils.injectAllHashes(generateTestAnnotation())).toBuilder()
+                        .setAnnotationMessageId("DUPLICATE-ID").build();
+
+        AnnotationAckTracker spyTracker = spy(new AnnotationAckTracker());
+        CountDownLatch duplicateObservedExistingLatch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            CountDownLatch existing = (CountDownLatch) invocation.callRealMethod();
+            if (existing != null) {
+                // this call found an already-registered latch, i.e. it is the "duplicate" caller
+                duplicateObservedExistingLatch.countDown();
+            }
+            return existing;
+        }).when(spyTracker).putIfAbsent(any(), any());
+
+        AnnotationControllerV1 controller = new AnnotationControllerV1(connectionFactory, lookupService, annotationProperties, timestampTransformer,
+                        visibilityTransformer, annotationSink, Executors.newCachedThreadPool(), spyTracker);
+
+        AtomicInteger sendCount = new AtomicInteger(0);
+        CountDownLatch originalSenderReachedSend = new CountDownLatch(1);
+        CountDownLatch releaseAck = new CountDownLatch(1);
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            // only the original sender should ever reach annotationSink.send(...); a duplicate should observe the
+            // existing latch and skip sending entirely.
+            sendCount.incrementAndGet();
+            Message<AnnotationMessage> sent = invocation.getArgument(0);
+            Object correlationId = sent.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+            assertNotNull(correlationId);
+
+            // Let the test know the original sender's latch is registered and it has reached send(...), then hold
+            // the ack back until the test confirms the duplicate caller has observed that latch -- this removes any
+            // dependency on thread-scheduling timing for reliably reproducing the race being tested.
+            originalSenderReachedSend.countDown();
+            assertTrue(releaseAck.await(10, TimeUnit.SECONDS), "test did not release the ack in time");
+
+            controller.processConfirmAck(MessageBuilder.withPayload("ack").setCorrelationId(correlationId).build());
+            return true;
+        });
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Optional<AnnotationMessage>> futureOne = executor.submit(() -> controller.sendAnnotationMessage(annotationMessage));
+
+            assertTrue(originalSenderReachedSend.await(10, TimeUnit.SECONDS), "original sender did not reach send(...) in time");
+
+            Future<Optional<AnnotationMessage>> futureTwo = executor.submit(() -> controller.sendAnnotationMessage(annotationMessage));
+
+            assertTrue(duplicateObservedExistingLatch.await(10, TimeUnit.SECONDS),
+                            "duplicate caller did not observe the original sender's in-flight latch in time");
+            releaseAck.countDown();
+
+            Optional<AnnotationMessage> resultOne = futureOne.get(10, TimeUnit.SECONDS);
+            Optional<AnnotationMessage> resultTwo = futureTwo.get(10, TimeUnit.SECONDS);
+
+            assertTrue(resultOne.isPresent(), "the original sender must be satisfied by the single ack");
+            assertTrue(resultTwo.isPresent(), "the duplicate sender must also be satisfied by the same ack rather than timing out");
+            assertEquals(1, sendCount.get(), "only the original sender should have actually sent a message; the duplicate should reuse its latch");
+            assertTrue(spyTracker.isEmpty(), "no latch should remain once both duplicate callers complete");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testSendAnnotationMessage_SendFailureReturnsEmptyWithoutWaitingForAck() {
+        when(annotationSink.send(any())).thenReturn(false);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        long start = System.currentTimeMillis();
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.isEmpty());
+        // failed sends should short-circuit rather than waiting out the ack timeout
+        assertTrue(elapsed < annotationProperties.getAnnotationAckTimeoutMillis(), "send failure should not wait for the ack timeout");
+        assertTrue(getAnnotationAckTracker().isEmpty(), "latch should be cleaned up even when send fails");
+    }
+
+    @Test
+    public void testSendAnnotationMessage_AckTimeoutReturnsEmptyAndCleansUpLatch() {
+        // send succeeds, but no acknowledgement ever arrives
+        when(annotationSink.send(any())).thenReturn(true);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        long start = System.currentTimeMillis();
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.isEmpty());
+        assertTrue(elapsed >= annotationProperties.getAnnotationAckTimeoutMillis(), "should have waited for the full ack timeout");
+        assertTrue(getAnnotationAckTracker().isEmpty(), "latch should be removed after timeout");
+    }
+
+    @Test
+    public void testSendAnnotationMessage_InterruptedWhileAwaitingAckReturnsEmptyRestoresInterruptStatusAndCleansUpLatch() throws Exception {
+        // send succeeds, but no ack ever arrives -- the calling thread is interrupted while awaiting the latch instead.
+        annotationProperties.setAnnotationAckTimeoutMillis(TimeUnit.SECONDS.toMillis(30));
+        when(annotationSink.send(any())).thenReturn(true);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            AtomicReference<Optional<AnnotationMessage>> resultRef = new AtomicReference<>();
+            AtomicBoolean interruptedStatusObservedAfterReturn = new AtomicBoolean(false);
+            CountDownLatch threadStarted = new CountDownLatch(1);
+
+            Future<?> future = executor.submit(() -> {
+                threadStarted.countDown();
+                resultRef.set(annotationController.sendAnnotationMessage(buildMessage(annotation)));
+                // the interrupt status must be restored by the time sendAnnotationMessage returns, so that the executing
+                // thread/pool can still observe that this task was asked to stop.
+                interruptedStatusObservedAfterReturn.set(Thread.currentThread().isInterrupted());
+            });
+
+            assertTrue(threadStarted.await(5, TimeUnit.SECONDS));
+            // give the worker thread a moment to actually enter latch.await(...) before interrupting it
+            Thread.sleep(50);
+            executor.shutdownNow();
+
+            future.get(5, TimeUnit.SECONDS);
+
+            assertNotNull(resultRef.get());
+            assertTrue(resultRef.get().isEmpty(), "an interrupted wait for the ack must be treated as a failed send");
+            assertTrue(interruptedStatusObservedAfterReturn.get(), "the thread's interrupt status must be restored, not swallowed, by sendAnnotationMessage");
+            assertTrue(getAnnotationAckTracker().isEmpty(), "latch should still be cleaned up when the wait is interrupted");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testSendAnnotationMessage_LateAckAfterTimeoutIsNoop() {
+        // send succeeds, no ack arrives for the duration of the timeout window,
+        // then a late ack arrives. The late ack must be safely ignored (no NPE,
+        // no exception) because the sender's finally block has already removed the latch.
+        when(annotationSink.send(any())).thenReturn(true);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        // Send the message — this will register a latch, wait for the ack timeout,
+        // receive no ack, and remove the latch in the finally block
+        long start = System.currentTimeMillis();
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result.isEmpty());
+        assertTrue(elapsed >= annotationProperties.getAnnotationAckTimeoutMillis(), "should have waited for the full ack timeout");
+
+        // Capture the correlation ID from what was sent
+        ArgumentCaptor<Message<AnnotationMessage>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(annotationSink, times(1)).send(captor.capture());
+        Object correlationId = captor.getValue().getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+        assertNotNull(correlationId);
+        String correlationIdString = correlationId.toString();
+
+        // Now simulate the late ack arriving after the latch was already removed
+        annotationController.processConfirmAck(MessageBuilder.withPayload("late-ack").setCorrelationId(correlationIdString).build());
+
+        // Verify no exceptions were thrown and the tracker is clean
+        assertTrue(getAnnotationAckTracker().isEmpty(), "no latch should remain after late ack");
+    }
+
+    @Test
+    public void testSendAnnotationMessage_AckDisabledSucceedsWithoutWaitingForAck() {
+        annotationProperties.setAnnotationAckEnabled(false);
+        when(annotationSink.send(any())).thenReturn(true);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+
+        assertTrue(result.isPresent());
+        assertTrue(getAnnotationAckTracker().isEmpty(), "no latch should be registered when acks are disabled");
+    }
+
+    @Test
+    public void testSendAnnotationMessage_AckDisabledSendFailureReturnsEmpty() {
+        annotationProperties.setAnnotationAckEnabled(false);
+        when(annotationSink.send(any())).thenReturn(false);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testSendAnnotationMessage_UnhealthyMessagingInfrastructureSkipsSendEntirely() {
+        HealthChecker healthChecker = mock(HealthChecker.class);
+        when(healthChecker.isHealthy()).thenReturn(false);
+        setHealthChecker(healthChecker);
+
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+
+        assertTrue(result.isEmpty(), "an unhealthy messaging infrastructure should short-circuit to failure");
+        verify(annotationSink, times(0)).send(any());
+        assertTrue(getAnnotationAckTracker().isEmpty(), "no latch should be registered when the send is skipped due to health");
+    }
+
+    @Test
+    public void testSendAnnotationMessage_HealthyMessagingInfrastructureSendsNormally() {
+        HealthChecker healthChecker = mock(HealthChecker.class);
+        when(healthChecker.isHealthy()).thenReturn(true);
+        setHealthChecker(healthChecker);
+        configureImmediateAck();
+
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+
+        assertTrue(result.isPresent());
+        verify(annotationSink, times(1)).send(any());
+    }
+
+    @Test
+    public void testSendAnnotationMessage_NoHealthCheckerConfiguredSendsNormally() {
+        // healthChecker is left unset (null), mirroring production when 'annotation.health.rabbit.enabled' is false
+        configureImmediateAck();
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<AnnotationMessage> result = annotationController.sendAnnotationMessage(buildMessage(annotation));
+
+        assertTrue(result.isPresent());
+        verify(annotationSink, times(1)).send(any());
+    }
+
+    @Test
+    public void testWriteAnnotation_UnhealthyMessagingInfrastructureRetriesThenFallsBackToFileWriter() throws Exception {
+        HealthChecker healthChecker = mock(HealthChecker.class);
+        when(healthChecker.isHealthy()).thenReturn(false);
+        setHealthChecker(healthChecker);
+
+        AnnotationWriter fileWriter = mock(AnnotationWriter.class);
+        setFileAnnotationWriter(fileWriter);
+
+        Annotation annotation = generateTestAnnotation();
+
+        Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isPresent(), "the file-writer fallback should still report success");
+        verify(annotationSink, times(0)).send(any());
+        verify(fileWriter, times(1)).write(any());
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // sendAnnotation(...) wrapper tests
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testSendAnnotation_SuccessReturnsTheAnnotationThatWasSent() {
+        configureImmediateAck();
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<Annotation> result = annotationController.sendAnnotation(annotation);
+
+        assertTrue(result.isPresent());
+        assertEquals(annotation.getAnnotationId(), result.get().getAnnotationId());
+        assertEquals(annotation, result.get());
+    }
+
+    @Test
+    public void testSendAnnotation_UsesDefaultSystemFrom() {
+        AnnotationProperties defaultProperties = new AnnotationProperties();
+        defaultProperties.setAnnotationAckEnabled(false);
+        AnnotationControllerV1 defaultController = new AnnotationControllerV1(connectionFactory, lookupService, defaultProperties, timestampTransformer,
+                        visibilityTransformer, annotationSink, mock(ExecutorService.class), new AnnotationAckTracker());
+        when(annotationSink.send(any())).thenReturn(true);
+
+        Optional<Annotation> result = defaultController.sendAnnotation(AnnotationUtils.injectAllHashes(generateTestAnnotation()));
+
+        assertTrue(result.isPresent());
+        ArgumentCaptor<Message<AnnotationMessage>> captor = ArgumentCaptor.forClass(Message.class);
+        verify(annotationSink).send(captor.capture());
+        assertEquals("datawave-annotation-service", captor.getValue().getPayload().getSource());
+    }
+
+    @Test
+    public void testSendAnnotation_FailurePropagatesEmpty() {
+        when(annotationSink.send(any())).thenReturn(false);
+        Annotation annotation = AnnotationUtils.injectAllHashes(generateTestAnnotation());
+
+        Optional<Annotation> result = annotationController.sendAnnotation(annotation);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // writeAnnotation(...) tests
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testWriteAnnotation_SucceedsOnFirstAttempt() {
+        configureImmediateAck();
+        Annotation annotation = generateTestAnnotation();
+
+        Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isPresent());
+        assertEquals(AnnotationUtils.calculateAnnotationHash(annotation), result.get().getAnnotationId());
+        verify(annotationSink, times(1)).send(any());
+    }
+
+    @Test
+    public void testWriteAnnotation_RetriesUntilSendSucceeds() {
+        // fail on the first two attempts, then succeed (with acknowledgement) on the third
+        Annotation annotation = generateTestAnnotation();
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            boolean succeeds = callCount.incrementAndGet() >= 3;
+            if (succeeds) {
+                Message<AnnotationMessage> sent = invocation.getArgument(0);
+                Object correlationId = sent.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+                assertNotNull(correlationId);
+                annotationController.processConfirmAck(MessageBuilder.withPayload("ack").setCorrelationId(correlationId).build());
+            }
+            return succeeds;
+        });
+
+        Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isPresent());
+        assertEquals(AnnotationUtils.calculateAnnotationHash(annotation), result.get().getAnnotationId());
+        verify(annotationSink, times(3)).send(any());
+    }
+
+    @Test
+    public void testWriteAnnotation_FallsBackToFileWriterWhenAllAttemptsFail() throws Exception {
+        when(annotationSink.send(any())).thenReturn(false);
+        AnnotationWriter fileWriter = mock(AnnotationWriter.class);
+        setFileAnnotationWriter(fileWriter);
+
+        Annotation annotation = generateTestAnnotation();
+        Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isPresent(), "should fall back to the file writer when all send attempts fail");
+        assertEquals(AnnotationUtils.calculateAnnotationHash(annotation), result.get().getAnnotationId());
+        verify(fileWriter, times(1)).write(any());
+        verify(annotationSink, times(annotationProperties.getRetry().getMaxAttempts())).send(any());
+    }
+
+    @Test
+    public void testWriteAnnotation_FailsWhenAllAttemptsFailAndNoFileWriterConfigured() {
+        when(annotationSink.send(any())).thenReturn(false);
+        setFileAnnotationWriter(null);
+
+        Annotation annotation = generateTestAnnotation();
+        Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isEmpty());
+        assertTrue(getAnnotationAckTracker().isEmpty(), "no latches should remain after exhausting retries");
+    }
+
+    @Test
+    public void testWriteAnnotation_FileWriterFailureAlsoResultsInEmpty() throws Exception {
+        when(annotationSink.send(any())).thenReturn(false);
+        AnnotationWriter fileWriter = mock(AnnotationWriter.class);
+        when(fileWriter.write(any())).thenThrow(new RuntimeException("simulating a disk full condition"));
+        setFileAnnotationWriter(fileWriter);
+
+        Annotation annotation = generateTestAnnotation();
+        Optional<Annotation> result = annotationController.writeAnnotation(annotation);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testWriteAnnotation_InterruptedDuringRetryBackoffStopsRetryingAndRestoresInterruptStatus() throws Exception {
+        // Use a long backoff interval so there's a comfortable window to interrupt the thread while it's sleeping between
+        // retry attempts, and a send that always fails so the loop actually reaches that backoff sleep.
+        AnnotationProperties longBackoffProperties = new AnnotationProperties();
+        longBackoffProperties.setSystemFrom("annotation");
+        longBackoffProperties.setAnnotationAckEnabled(true);
+        longBackoffProperties.setAnnotationAckTimeoutMillis(150L);
+        longBackoffProperties.getRetry().setMaxAttempts(5);
+        longBackoffProperties.getRetry().setBackoffIntervalMillis(TimeUnit.SECONDS.toMillis(30));
+        longBackoffProperties.getRetry().setFailTimeoutMillis(TimeUnit.SECONDS.toMillis(60));
+
+        AnnotationControllerV1 controller = new AnnotationControllerV1(connectionFactory, lookupService, longBackoffProperties, timestampTransformer,
+                        visibilityTransformer, annotationSink, Executors.newCachedThreadPool(), new AnnotationAckTracker());
+
+        CountDownLatch firstSendAttempted = new CountDownLatch(1);
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            firstSendAttempted.countDown();
+            return false;
+        });
+
+        Annotation annotation = generateTestAnnotation();
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            AtomicReference<Optional<Annotation>> resultRef = new AtomicReference<>();
+            AtomicBoolean interruptedStatusObservedAfterReturn = new AtomicBoolean(false);
+
+            long start = System.currentTimeMillis();
+            Future<?> future = executor.submit(() -> {
+                resultRef.set(controller.writeAnnotation(annotation));
+                // the interrupt status must be restored by the time writeAnnotation returns.
+                interruptedStatusObservedAfterReturn.set(Thread.currentThread().isInterrupted());
+            });
+
+            assertTrue(firstSendAttempted.await(5, TimeUnit.SECONDS), "the first send attempt should occur promptly");
+            // give the worker thread a moment to enter the backoff Thread.sleep(...) after its first failed attempt
+            Thread.sleep(50);
+            executor.shutdownNow();
+
+            future.get(5, TimeUnit.SECONDS);
+            long elapsed = System.currentTimeMillis() - start;
+
+            assertNotNull(resultRef.get());
+            assertTrue(resultRef.get().isEmpty(), "an interrupted retry backoff must be treated as a failed write (no file writer configured here)");
+            assertTrue(interruptedStatusObservedAfterReturn.get(), "the thread's interrupt status must be restored, not swallowed, by writeAnnotation");
+            assertTrue(elapsed < longBackoffProperties.getRetry().getBackoffIntervalMillis(),
+                            "interrupting the backoff sleep should abandon retrying promptly rather than waiting out the full backoff interval");
+            verify(annotationSink, times(1)).send(any());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+    // concurrency: two independent writes must not cross-satisfy each other's latches
+    // ----------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testConcurrentWriteAnnotationCallsDoNotCrossSatisfyLatches() throws Exception {
+        // each send only acknowledges its own correlation id, and does so after a small delay to encourage interleaving
+        Map<String,Integer> sendCounts = new ConcurrentHashMap<>();
+        when(annotationSink.send(any())).thenAnswer(invocation -> {
+            Message<AnnotationMessage> sent = invocation.getArgument(0);
+            Object correlationId = sent.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID);
+            sendCounts.merge(String.valueOf(correlationId), 1, Integer::sum);
+            Thread.sleep(10);
+            assertNotNull(correlationId);
+            annotationController.processConfirmAck(MessageBuilder.withPayload("ack").setCorrelationId(correlationId).build());
+            return true;
+        });
+
+        Annotation annotationOne = generateTestAnnotation();
+        Annotation annotationTwo = generateTestAnnotation().toBuilder().setAnnotationType("someOtherAnnotationType").build();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Optional<Annotation>> futureOne = executor.submit(() -> annotationController.writeAnnotation(annotationOne));
+            Future<Optional<Annotation>> futureTwo = executor.submit(() -> annotationController.writeAnnotation(annotationTwo));
+
+            Optional<Annotation> resultOne = futureOne.get(10, TimeUnit.SECONDS);
+            Optional<Annotation> resultTwo = futureTwo.get(10, TimeUnit.SECONDS);
+
+            assertTrue(resultOne.isPresent());
+            assertTrue(resultTwo.isPresent());
+            assertNotEquals(resultOne.get().getAnnotationId(), resultTwo.get().getAnnotationId());
+            assertTrue(getAnnotationAckTracker().isEmpty(), "no latches should remain once both concurrent writes complete");
+
+            // each write should have used its own distinct correlation id, and been sent exactly once (no unnecessary retries,
+            // and no cross-talk where one write's ack satisfies the other's latch)
+            assertEquals(2, sendCounts.size(), "expected two distinct correlation ids to have been used: " + sendCounts.keySet());
+            sendCounts.values().forEach(count -> assertEquals(1, count, "expected each correlation id to have been sent exactly once"));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/TestAnnotationControllerV1JsonErrors.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/TestAnnotationControllerV1JsonErrors.java
@@ -1,0 +1,68 @@
+package datawave.microservice.annotation.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Regression tests for {@link AnnotationControllerV1}'s error-response serialization. Previously {@code jsonNotFound}/{@code jsonError} built their JSON
+ * response bodies via raw string concatenation (e.g. {@code "{\"message\":\"" + message + "\"}"}), which produced malformed or unsafe JSON whenever
+ * {@code message} contained a quote, backslash, or other character requiring JSON escaping -- plausible, since messages interpolate exception text and
+ * user-supplied identifiers. Verifies that the current Jackson-based serialization (exposed package-private/{@code @VisibleForTesting} for exactly this
+ * purpose) always produces valid, parseable JSON, regardless of the message content.
+ */
+class TestAnnotationControllerV1JsonErrors {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void testJsonErrorEscapesQuotesAndBackslashes() throws Exception {
+        String message = "Internal error fetching annotation: could not parse \"foo\\bar\" identifier";
+
+        ResponseEntity<String> response = AnnotationControllerV1.jsonError(message);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        Map<String,Object> parsed = MAPPER.readValue(response.getBody(), Map.class);
+        assertEquals(message, parsed.get("message"), "the original message must round-trip exactly through JSON serialization");
+    }
+
+    @Test
+    void testJsonNotFoundEscapesQuotesAndBackslashes() throws Exception {
+        String message = "No internal identifier found for 'idType:some\"weird\\id'";
+
+        ResponseEntity<String> response = AnnotationControllerV1.jsonNotFound(message);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        Map<String,Object> parsed = MAPPER.readValue(response.getBody(), Map.class);
+        assertEquals(message, parsed.get("message"), "the original message must round-trip exactly through JSON serialization");
+    }
+
+    @Test
+    void testJsonErrorProducesValidJsonForControlCharactersAndNewlines() throws Exception {
+        String message = "line one\nline two\tend";
+
+        ResponseEntity<String> response = AnnotationControllerV1.jsonError(message);
+
+        // if the response body were not valid JSON (e.g. due to unescaped control characters), this parse would throw
+        Map<String,Object> parsed = MAPPER.readValue(response.getBody(), Map.class);
+        assertTrue(parsed.containsKey("message"));
+        assertEquals(message, parsed.get("message"));
+    }
+
+    @Test
+    void testToJsonMessageProducesValidJson() throws Exception {
+        String message = "simple message";
+
+        String json = AnnotationControllerV1.toJsonMessage(message);
+
+        Map<String,Object> parsed = MAPPER.readValue(json, Map.class);
+        assertEquals(message, parsed.get("message"));
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/config/TestAnnotationConfigParity.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/config/TestAnnotationConfigParity.java
@@ -1,0 +1,70 @@
+package datawave.microservice.annotation.service.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import datawave.query.config.annotation.AnnotationConfig;
+
+/**
+ * Cross-module parity assertion test.
+ * <p>
+ * Verifies that {@link AnnotationProperties} (microservice Spring config) carries the same default values as {@link AnnotationConfig} (legacy monolith config)
+ * for every shared read-path field. This guards against the microservice silently diverging from the legacy defaults as the codebase evolves.
+ * <p>
+ * Note: {@code visibilityTransformer} and {@code timestampTransformer} are injected via Spring DI (not part of the properties/config POJO) and are therefore
+ * excluded from this parity check.
+ */
+public class TestAnnotationConfigParity {
+
+    @Test
+    public void testAnnotationTableNameDefaultParity() {
+        AnnotationConfig legacy = new AnnotationConfig();
+        AnnotationProperties microservice = new AnnotationProperties();
+        assertEquals(legacy.getAnnotationTableName(), microservice.getAnnotationTableName(),
+                        "annotationTableName default must match between legacy and microservice configs");
+    }
+
+    @Test
+    public void testAnnotationSourceTableNameDefaultParity() {
+        AnnotationConfig legacy = new AnnotationConfig();
+        AnnotationProperties microservice = new AnnotationProperties();
+        assertEquals(legacy.getAnnotationSourceTableName(), microservice.getAnnotationSourceTableName(),
+                        "annotationSourceTableName default must match between legacy and microservice configs");
+    }
+
+    @Test
+    public void testTruthmarkTableNameDefaultParity() {
+        AnnotationConfig legacy = new AnnotationConfig();
+        AnnotationProperties microservice = new AnnotationProperties();
+        assertEquals("truthmark", legacy.getTruthmarkTableName(), "legacy truthmarkTableName should default to 'truthmark'");
+        assertEquals("truthmark", microservice.getTruthmarkTableName(), "microservice truthmarkTableName should default to 'truthmark'");
+        assertEquals(legacy.getTruthmarkTableName(), microservice.getTruthmarkTableName(),
+                        "truthmarkTableName default must match between legacy and microservice configs");
+    }
+
+    @Test
+    public void testTruthmarkSourceTableNameDefaultParity() {
+        AnnotationConfig legacy = new AnnotationConfig();
+        AnnotationProperties microservice = new AnnotationProperties();
+        assertEquals("truthmarkSource", legacy.getTruthmarkSourceTableName(), "legacy truthmarkSourceTableName should default to 'truthmarkSource'");
+        assertEquals("truthmarkSource", microservice.getTruthmarkSourceTableName(),
+                        "microservice truthmarkSourceTableName should default to 'truthmarkSource'");
+        assertEquals(legacy.getTruthmarkSourceTableName(), microservice.getTruthmarkSourceTableName(),
+                        "truthmarkSourceTableName default must match between legacy and microservice configs");
+    }
+
+    @Test
+    public void testMaskSourceMetadataDefaultParity() {
+        AnnotationConfig legacy = new AnnotationConfig();
+        AnnotationProperties microservice = new AnnotationProperties();
+        assertNotNull(legacy.getMaskSourceMetadata(), "legacy maskSourceMetadata should not be null");
+        assertNotNull(microservice.getMaskSourceMetadata(), "microservice maskSourceMetadata should not be null");
+        assertEquals(legacy.getMaskSourceMetadata(), microservice.getMaskSourceMetadata(),
+                        "maskSourceMetadata default must match between legacy and microservice configs");
+        assertEquals(List.of("visibility"), microservice.getMaskSourceMetadata(), "maskSourceMetadata should default to ['visibility']");
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/util/lookup/common/LookupRequestCookieIsolationTest.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/util/lookup/common/LookupRequestCookieIsolationTest.java
@@ -1,0 +1,121 @@
+package datawave.microservice.annotation.util.lookup.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+
+import datawave.microservice.annotation.util.lookup.config.LookupProperties;
+
+/**
+ * Regression test for T11: LookupRequest previously held a single, field-level BasicCookieStore that was reused across every lookupId() invocation for every
+ * caller/principal, since LookupRequest is a shared singleton bean. This is a real cross-principal cookie leakage vector: a session cookie set by the
+ * downstream DataWave query service in response to one caller's request could be resent on a completely unrelated caller's subsequent lookup.
+ * <p>
+ * This test drives two real HTTPS round trips (via a local, in-process HttpsServer) through the exact same LookupRequest instance, using the same TLS trust
+ * material as the rest of the module's test suite (ssl/host.p12 as the server's identity, ssl/rootCA.p12 as the trusted CA). The first response sets a
+ * Set-Cookie header; the test then asserts that the second, independent lookupId() call does NOT present that cookie back to the server - proving that
+ * LookupRequest.getHttpContext() creates a fresh, request-scoped cookie store per call rather than retaining state across calls.
+ */
+class LookupRequestCookieIsolationTest {
+
+    private static final String KEY_STORE_PASSWORD = "LetMeIn";
+
+    private HttpsServer server;
+    private final Map<Integer,String> cookieHeaderSeenByRequestNumber = new HashMap<>();
+    private final AtomicReference<Integer> requestCounter = new AtomicReference<>(0);
+
+    @BeforeEach
+    void startServer() throws Exception {
+        SSLContext serverSslContext = SSLContext.getInstance("TLS");
+        KeyStore serverKeyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("ssl/host.p12")) {
+            serverKeyStore.load(is, KEY_STORE_PASSWORD.toCharArray());
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(serverKeyStore, KEY_STORE_PASSWORD.toCharArray());
+        serverSslContext.init(kmf.getKeyManagers(), null, null);
+
+        server = HttpsServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.setHttpsConfigurator(new HttpsConfigurator(serverSslContext));
+        server.createContext("/DataWave/Annotations/v1/", exchange -> {
+            int requestNumber = requestCounter.updateAndGet(n -> n + 1);
+            cookieHeaderSeenByRequestNumber.put(requestNumber, exchange.getRequestHeaders().getFirst("Cookie"));
+
+            byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+            if (requestNumber == 1) {
+                // Simulate the downstream DataWave query service setting a session cookie on the first caller's response
+                exchange.getResponseHeaders().add("Set-Cookie", "JSESSIONID=principal-A-session; Path=/");
+            }
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void secondLookupDoesNotReceiveCookieSetDuringFirstLookup() throws Exception {
+        SSLContext clientSslContext = SSLContext.getInstance("TLS");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("ssl/rootCA.p12")) {
+            trustStore.load(is, KEY_STORE_PASSWORD.toCharArray());
+        }
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+        clientSslContext.init(null, tmf.getTrustManagers(), null);
+
+        // Mirror HttpClientConfig's production wiring (NoopHostnameVerifier is the intentional, discovery-compatible TLS policy - see
+        // HttpClientConfigTlsPolicyTest for a dedicated assertion of that behavior). Only the trust material differs here (test CA vs. production truststore).
+        CloseableHttpClient httpClient = HttpClientBuilder.create()
+                        .setSSLSocketFactory(new SSLConnectionSocketFactory(clientSslContext, NoopHostnameVerifier.INSTANCE)).build();
+
+        LookupProperties lookupProperties = new LookupProperties();
+        lookupProperties.setDatawaveQueryHost("localhost:" + server.getAddress().getPort());
+
+        LookupRequest lookupRequest = new LookupRequest(httpClient, lookupProperties);
+
+        // First lookup: server sets a session cookie in the response
+        ParsedResponse first = lookupRequest.lookupId(Lookup.MARKINGS, "1234", Collections.emptyMap(), "params", "test");
+        assertEquals(200, first.getCode());
+        assertNull(cookieHeaderSeenByRequestNumber.get(1), "the first request should not have sent any cookie");
+
+        // Second lookup on the SAME LookupRequest singleton instance: must not carry the cookie set during the first call
+        ParsedResponse second = lookupRequest.lookupId(Lookup.MARKINGS, "5678", Collections.emptyMap(), "params", "test");
+        assertEquals(200, second.getCode());
+        assertNotNull(cookieHeaderSeenByRequestNumber.containsKey(2));
+        assertNull(cookieHeaderSeenByRequestNumber.get(2), "cookie set during a prior lookup must not be retained/resent on a later, independent lookup call");
+    }
+}

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/util/lookup/config/HttpClientConfigTlsPolicyTest.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/util/lookup/config/HttpClientConfigTlsPolicyTest.java
@@ -1,0 +1,112 @@
+package datawave.microservice.annotation.util.lookup.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+
+/**
+ * Regression/documentation test for T11 (Q06, Option A): the annotation service's outbound HttpClient (wired up in {@link HttpClientConfig}) intentionally
+ * registers {@link org.apache.http.conn.ssl.NoopHostnameVerifier} for its "https" scheme, so that it can reach a downstream DataWave query host whose
+ * certificate's CN/SAN may not match the configured discovery hostname (a "discovery-compatible" TLS policy). This is a deliberate, retained decision - not a
+ * defect - but it was previously untested and undocumented in code. This test proves the policy is in effect by presenting a server certificate (ssl/host.p12,
+ * CN=test.testcorp.com) while connecting to a mismatched hostname ("localhost"), and asserting the handshake still succeeds because hostname verification is
+ * skipped. As a control, it also proves that a client configured with normal (non-Noop) hostname verification would reject the exact same mismatched
+ * connection, confirming the mismatch is real and the Noop verifier is doing meaningful work.
+ */
+class HttpClientConfigTlsPolicyTest {
+
+    private static final String KEY_STORE_PASSWORD = "LetMeIn";
+
+    private HttpsServer server;
+
+    @BeforeEach
+    void startServer() throws Exception {
+        SSLContext serverSslContext = SSLContext.getInstance("TLS");
+        KeyStore serverKeyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("ssl/host.p12")) {
+            serverKeyStore.load(is, KEY_STORE_PASSWORD.toCharArray());
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(serverKeyStore, KEY_STORE_PASSWORD.toCharArray());
+        serverSslContext.init(kmf.getKeyManagers(), null, null);
+
+        // The server's certificate (ssl/host.p12) has CN=test.testcorp.com, which will NOT match the "localhost" hostname used to connect below.
+        server = HttpsServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.setHttpsConfigurator(new HttpsConfigurator(serverSslContext));
+        server.createContext("/", exchange -> {
+            byte[] body = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    private SSLContext trustingClientSslContext() throws Exception {
+        SSLContext clientSslContext = SSLContext.getInstance("TLS");
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream("ssl/rootCA.p12")) {
+            trustStore.load(is, KEY_STORE_PASSWORD.toCharArray());
+        }
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trustStore);
+        clientSslContext.init(null, tmf.getTrustManagers(), null);
+        return clientSslContext;
+    }
+
+    @Test
+    void productionHttpClientAcceptsMismatchedHostnameByDesign() throws Exception {
+        // Exercise the actual production bean-building code, exactly as Spring would.
+        CloseableHttpClient httpClient = new HttpClientConfig().httpClient(trustingClientSslContext());
+
+        HttpGet get = new HttpGet("https://localhost:" + server.getAddress().getPort() + "/");
+        try (CloseableHttpResponse response = httpClient.execute(get)) {
+            assertEquals(200, response.getStatusLine().getStatusCode(),
+                            "the production HttpClient must accept a certificate whose CN doesn't match the connected hostname, "
+                                            + "per the intentional discovery-compatible TLS policy (Q06, Option A)");
+        }
+    }
+
+    @Test
+    void hostnameMismatchIsRealAndWouldBeRejectedByDefaultVerification() throws Exception {
+        // Control: build a client identical to the production one, EXCEPT using default (non-Noop) hostname verification, to prove the mismatch
+        // above is genuine and that NoopHostnameVerifier is the reason the production client tolerates it.
+        CloseableHttpClient strictHttpClient = HttpClientBuilder.create().setSSLContext(trustingClientSslContext()).build();
+
+        HttpGet get = new HttpGet("https://localhost:" + server.getAddress().getPort() + "/");
+        try (CloseableHttpResponse ignored = strictHttpClient.execute(get)) {
+            fail("expected hostname verification to reject a certificate whose CN doesn't match the connected hostname");
+        } catch (SSLHandshakeException | javax.net.ssl.SSLPeerUnverifiedException expected) {
+            // expected: default hostname verification rejects the CN=test.testcorp.com certificate for host "localhost"
+        }
+    }
+}

--- a/microservices/services/annotation/service/src/test/resources/data/annotation_baseline.ndjson
+++ b/microservices/services/annotation/service/src/test/resources/data/annotation_baseline.ndjson
@@ -1,0 +1,5679 @@
+{
+    "shard": "20250405_123",
+    "dataType": "annotation",
+    "uid": "l46b0b.l9xx93.-jsda4n",
+    "annotationId": "A7699117",
+    "documentId": "000000000001",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_123",
+    "dataType": "annotation",
+    "uid": "6tzt7u.-hm7g23.i1ueb4",
+    "annotationId": "175BF2E8",
+    "documentId": "000000000002",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_123",
+    "dataType": "annotation",
+    "uid": "-pp0vkp.3rzqnz.5q54vx",
+    "annotationId": "3D3AFEA0",
+    "documentId": "000000000003",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_123",
+    "dataType": "annotation",
+    "uid": "b4t1ky.gc96ur.2tlvy3",
+    "annotationId": "7B2FAF43",
+    "documentId": "000000000004",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_456",
+    "dataType": "annotation",
+    "uid": "ayu73v.3cwl0r.-4ptvm7",
+    "annotationId": "327C292F",
+    "documentId": "000000000005",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_456",
+    "dataType": "annotation",
+    "uid": "-6j7k0l.u7xkz5.-x8hpes",
+    "annotationId": "19C96CBC",
+    "documentId": "000000000006",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_456",
+    "dataType": "annotation",
+    "uid": "sr2ace.-4lv4w6.-begkwn",
+    "annotationId": "32F7C24E",
+    "documentId": "000000000007",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_456",
+    "dataType": "annotation",
+    "uid": "9eqwcm.-m86zhv.-mm55jh",
+    "annotationId": "CC2AA8C3",
+    "documentId": "000000000008",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_789",
+    "dataType": "annotation",
+    "uid": "j0cfzn.-4j53im.-d2w0tz",
+    "annotationId": "3FE49853",
+    "documentId": "000000000009",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_789",
+    "dataType": "annotation",
+    "uid": "-ngbobu.-c94tvj.8y2p8a",
+    "annotationId": "CD27BF6E",
+    "documentId": "000000000010",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_789",
+    "dataType": "annotation",
+    "uid": "pz3x7s.o7mcqn.-kj0cpa",
+    "annotationId": "53F057A7",
+    "documentId": "000000000011",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250405_789",
+    "dataType": "annotation",
+    "uid": "-3c0glg.-dedab7.mz17rd",
+    "annotationId": "FB541605",
+    "documentId": "000000000012",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250405"
+    }
+}
+{
+    "shard": "20250406_123",
+    "dataType": "annotation",
+    "uid": "-hyi367.-mgypqf.-fg916b",
+    "annotationId": "8C315CC7",
+    "documentId": "000000000013",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_123",
+    "dataType": "annotation",
+    "uid": "wb1pp4.-wwcije.7resun",
+    "annotationId": "227FDA0F",
+    "documentId": "000000000014",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_123",
+    "dataType": "annotation",
+    "uid": "-ihvcwi.-y2d5ue.-wce8xi",
+    "annotationId": "C4416601",
+    "documentId": "000000000015",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_123",
+    "dataType": "annotation",
+    "uid": "voa7p7.83zv2w.-mnif39",
+    "annotationId": "808E32FD",
+    "documentId": "000000000016",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_456",
+    "dataType": "annotation",
+    "uid": "-j9ketf.npng62.u4mw0y",
+    "annotationId": "05EB49D4",
+    "documentId": "000000000017",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_456",
+    "dataType": "annotation",
+    "uid": "aiddza.kdn85e.-wnbwkq",
+    "annotationId": "989FC696",
+    "documentId": "000000000018",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_456",
+    "dataType": "annotation",
+    "uid": "-dwa987.-nmx1jx.g2brsm",
+    "annotationId": "5353CC53",
+    "documentId": "000000000019",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_456",
+    "dataType": "annotation",
+    "uid": "-kqa6eu.-35corl.wo67ll",
+    "annotationId": "8C866D2F",
+    "documentId": "000000000020",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_789",
+    "dataType": "annotation",
+    "uid": "-29vx6c.-lwa23c.isbedx",
+    "annotationId": "B852D3DA",
+    "documentId": "000000000021",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_789",
+    "dataType": "annotation",
+    "uid": "ofv6g7.-cb3p6d.-ivgfo9",
+    "annotationId": "30587053",
+    "documentId": "000000000022",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_789",
+    "dataType": "annotation",
+    "uid": "va8jna.-hil636.-9lwvxz",
+    "annotationId": "A2CEF983",
+    "documentId": "000000000023",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250406_789",
+    "dataType": "annotation",
+    "uid": "-rh2s8d.-9zqxoc.-4nrkwu",
+    "annotationId": "966BD4C9",
+    "documentId": "000000000024",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250406"
+    }
+}
+{
+    "shard": "20250407_123",
+    "dataType": "annotation",
+    "uid": "16end8.-vn8vng.-khm2w8",
+    "annotationId": "1574E0B4",
+    "documentId": "000000000025",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_123",
+    "dataType": "annotation",
+    "uid": "-6g8vi5.-m6euyr.cc6sho",
+    "annotationId": "46B19D5A",
+    "documentId": "000000000026",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_123",
+    "dataType": "annotation",
+    "uid": "-hytjod.-nov8f8.-g5zapt",
+    "annotationId": "937738CC",
+    "documentId": "000000000027",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_123",
+    "dataType": "annotation",
+    "uid": "-73gdy7.ohlf1z.-wuqj8m",
+    "annotationId": "A9E095FB",
+    "documentId": "000000000028",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "123",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_456",
+    "dataType": "annotation",
+    "uid": "pa5nh.-njbvvg.-82pk6f",
+    "annotationId": "91F84ECA",
+    "documentId": "000000000029",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_456",
+    "dataType": "annotation",
+    "uid": "-rjrn67.fih94d.-w0pe6m",
+    "annotationId": "224923C3",
+    "documentId": "000000000030",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_456",
+    "dataType": "annotation",
+    "uid": "-kzyodx.s0n5gw.xn56uj",
+    "annotationId": "B113E121",
+    "documentId": "000000000031",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_456",
+    "dataType": "annotation",
+    "uid": "re8nbj.-7k3d0l.iewqfu",
+    "annotationId": "CB26B407",
+    "documentId": "000000000032",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "456",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_789",
+    "dataType": "annotation",
+    "uid": "-h8gcvv.2ngwd5.7bbswm",
+    "annotationId": "E997916D",
+    "documentId": "000000000033",
+    "annotationType": "tts",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "6BD6F28F",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 0,
+        "end": 5000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "71B06C7B",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 10000,
+        "end": 15000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "868C6413",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 20000,
+        "end": 25000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "941674A8",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 30000,
+        "end": 35000
+      },
+      "values": [{
+        "valueHash": "1F83A785",
+        "value": "on",
+        "score": 0.235
+      }, {
+        "valueHash": "017E7B4F",
+        "value": "\u003cunk\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "FA0FE295",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 40000,
+        "end": 45000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "2EB66E6D",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 50000,
+        "end": 55000
+      },
+      "values": [{
+        "valueHash": "76BEE44F",
+        "value": "mat",
+        "score": 0.235
+      }, {
+        "valueHash": "84962936",
+        "value": "gnat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "E103E6C3",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 60000,
+        "end": 65000
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.235
+      }, {
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "4FBF9992",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 70000,
+        "end": 75000
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.235
+      }, {
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "6DCE0993",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 80000,
+        "end": 85000
+      },
+      "values": [{
+        "valueHash": "2CE5103A",
+        "value": "cat",
+        "score": 0.235
+      }, {
+        "valueHash": "102EA958",
+        "value": "bat",
+        "score": 0.21
+      }]
+    }, {
+      "segmentHash": "0B2095B4",
+      "boundary": {
+        "boundaryType": "TIME_MILLI",
+        "start": 90000,
+        "end": 95000
+      },
+      "values": [{
+        "valueHash": "8E4C5C70",
+        "value": "sat",
+        "score": 0.235
+      }, {
+        "valueHash": "6B4F46BE",
+        "value": "ate",
+        "score": 0.21
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "audio",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_789",
+    "dataType": "annotation",
+    "uid": "cvf0v4.-ncjfen.-69rc5w",
+    "annotationId": "FA6A536F",
+    "documentId": "000000000034",
+    "annotationType": "tokens",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "C7B766B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 0,
+        "end": 3
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "3885607A",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 4,
+        "end": 9
+      },
+      "values": [{
+        "valueHash": "F596B9D2",
+        "value": "quick",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "4F6A58B9",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 10,
+        "end": 15
+      },
+      "values": [{
+        "valueHash": "7C1D823B",
+        "value": "brown",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "6FF09C09",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 16,
+        "end": 19
+      },
+      "values": [{
+        "valueHash": "29E9B80A",
+        "value": "fox",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "BBE2E40F",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 20,
+        "end": 26
+      },
+      "values": [{
+        "valueHash": "F4329C61",
+        "value": "caught",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "FA48289B",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 27,
+        "end": 30
+      },
+      "values": [{
+        "valueHash": "B578A0BB",
+        "value": "the",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "32443188",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 31,
+        "end": 37
+      },
+      "values": [{
+        "valueHash": "CB78DACF",
+        "value": "rabbit",
+        "score": 1.0
+      }]
+    }, {
+      "segmentHash": "7EBDA0EF",
+      "boundary": {
+        "boundaryType": "TEXT_CHAR",
+        "start": 38,
+        "end": 43
+      },
+      "values": [{
+        "valueHash": "80529ABB",
+        "value": "\u003ceos\u003e",
+        "score": 1.0
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "news",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_789",
+    "dataType": "annotation",
+    "uid": "-diuujx.-vthisr.-z7h545",
+    "annotationId": "947C4B3F",
+    "documentId": "000000000035",
+    "annotationType": "object",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "A95669D7",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 0,
+          "y": 0,
+          "label": "topLeft"
+        }, {
+          "x": 5,
+          "y": 12,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "A9D3B0A4",
+        "value": "bird",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "B29CBAE1",
+        "value": "crow",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }, {
+      "segmentHash": "FFF3BAA1",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 10,
+          "y": 15,
+          "label": "topLeft"
+        }, {
+          "x": 15,
+          "y": 18,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "C21AF472",
+        "value": "car",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "A1AECAE0",
+        "value": "truck",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "EB77E18D",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 20,
+          "y": 20,
+          "label": "topLeft"
+        }, {
+          "x": 28,
+          "y": 47,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "6A06AA42",
+        "value": "stairs",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }]
+    }, {
+      "segmentHash": "A665835E",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 30,
+          "y": 50,
+          "label": "topLeft"
+        }, {
+          "x": 36,
+          "y": 55,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E4C953FF",
+        "value": "motorcycle",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }, {
+        "valueHash": "2B1BA4EB",
+        "value": "bicycle",
+        "score": 0.86,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "A458EEBE",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 60,
+          "y": 70,
+          "label": "topLeft"
+        }, {
+          "x": 70,
+          "y": 78,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "E5A4D3D7",
+        "value": "flashlight",
+        "score": 0.97,
+        "extension": {
+          "version": "beta"
+        }
+      }]
+    }, {
+      "segmentHash": "C894D8DA",
+      "boundary": {
+        "boundaryType": "POINTS",
+        "points": [{
+          "x": 80,
+          "y": 90,
+          "label": "topLeft"
+        }, {
+          "x": 89,
+          "y": 95,
+          "label": "bottomRight"
+        }]
+      },
+      "values": [{
+        "valueHash": "0A82F7E9",
+        "value": "dog",
+        "score": 0.97,
+        "extension": {
+          "version": "alpha"
+        }
+      }, {
+        "valueHash": "EB8EC849",
+        "value": "pig",
+        "score": 0.86,
+        "extension": {
+          "version": "alpha"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "cars",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}
+{
+    "shard": "20250407_789",
+    "dataType": "annotation",
+    "uid": "wzfohu.-qkr270.jl6f8e",
+    "annotationId": "05E5F3B9",
+    "documentId": "000000000036",
+    "annotationType": "image",
+    "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+    "source": {
+      "analyticHash": "86226841",
+      "analyticSourceHash": "F1A0463C207B3778B472B506F3F8351A",
+      "engine": "inline v6",
+      "model": "GR Supra",
+      "configuration": {
+        "octane": "99",
+        "model_year": "2025"
+      },
+      "metadata": {
+        "visibility": "PUBLIC",
+        "created_date": "2025-10-01T00:00:00Z"
+      }
+    },
+    "segments": [{
+      "segmentHash": "B809141A",
+      "boundary": {
+        "boundaryType": "ALL"
+      },
+      "values": [{
+        "valueHash": "BB6D70D3",
+        "value": "landscape",
+        "score": 0.97,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "F3C97BE0",
+        "value": "underground",
+        "score": 0.86,
+        "extension": {
+          "version": "charlie"
+        }
+      }, {
+        "valueHash": "0CE17D26",
+        "value": "portrait",
+        "score": 0.97,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "E9416D45",
+        "value": "postcard",
+        "score": 0.86,
+        "extension": {
+          "version": "bravo"
+        }
+      }, {
+        "valueHash": "73A136DF",
+        "value": "scene",
+        "score": 0.97,
+        "extension": {
+          "version": "lima"
+        }
+      }, {
+        "valueHash": "F03AA692",
+        "value": "evening",
+        "score": 0.97,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C3186504",
+        "value": "afternoon",
+        "score": 0.86,
+        "extension": {
+          "version": "victor"
+        }
+      }, {
+        "valueHash": "C77BBB3D",
+        "value": "astral",
+        "score": 0.97,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "09AF7469",
+        "value": "ethereal",
+        "score": 0.86,
+        "extension": {
+          "version": "delta"
+        }
+      }, {
+        "valueHash": "1C80E5B8",
+        "value": "material",
+        "score": 0.97,
+        "extension": {
+          "version": "micro"
+        }
+      }, {
+        "valueHash": "500A9257",
+        "value": "fabric",
+        "score": 0.86,
+        "extension": {
+          "version": "micro"
+        }
+      }]
+    }],
+    "metadata": {
+      "visibility": "PUBLIC",
+      "datatype": "media",
+      "foo": "bar",
+      "plough": "plover",
+      "shard": "789",
+      "created_date": "2025-10-01T00:00:00Z",
+      "day": "20250407"
+    }
+}


### PR DESCRIPTION
## Summary

Adds the annotation REST API, lookup integration, authorization handling, and caller-facing delivery semantics.

See the [Datawave Annotation Microservice Review Guide](https://gist.github.com/drewfarris/26e97e780c96e4d9c367a656d68f3d97) for more details.

This is PR 3 of 4 replacing #3909. Review only the changes introduced on top of the persistence and messaging PR.

## Size note

This PR contains approximately 4,688 handwritten lines plus the 5,679-line generated `annotation_baseline.ndjson` compatibility fixture.

## Scope

- Add `AnnotationControllerV1` and `AnnotationAckTracker`.
- Add controller configuration and properties.
- Add metadata and authorization utilities.
- Add lookup request, TLS, and cookie-isolation support.
- Add controller exception and JSON error handling.
- Test create/update, read, lookup, authorization, health gating, timeout, retry, fallback, duplicate acknowledgment, and interrupted-request behavior.
- Add a Spring startup test with deployment integration absent.

The HTTP success contract confirms broker acceptance of the write request. It does not claim that Accumulo persistence has completed.

## Fixture provenance

`annotation_baseline.ndjson` was generated through code in `core/annotation`, which contains analogous serialization baselines under its test resources.

SHA-256:

```text
54b8eb8ae678ec1cfd1d33b963487fb4e197d094c733bd47ff50b3cc447a2472
```

## Excluded

- External deployment configuration
- Docker image support
- Production deployment or enablement

## Validation

Focused build:

```text
mvn -Dservices -pl microservices/services/annotation/service -am test
```

124 focused tests passed.

Full 127-module build:

```text
mvn -Ddocker-release -Dmicroservice-docker -Ddist -Dutils -Dservices -Dstarters clean install -T 1C
```

The full build passed.

## Production impact

None expected. The service is not added to production orchestration or enabled by default.