### PR TITLE
Add annotation microservice integration assets

### DIFF
--- a/microservices/services/annotation/README.md
+++ b/microservices/services/annotation/README.md
@@ -1,6 +1,156 @@
 ## Annotation Service
 
-The annotation service modules provide a microservice boundary for DATAWAVE annotation capabilities.
+[![Apache License][li]][ll]
 
-The `annotation-api` module currently exposes the released `datawave-core-annotation` artifact to
-microservice consumers. Service implementation and deployment support are added separately.
+The annotation service is a DATAWAVE microservice that provides annotation storage, retrieval,
+and update capabilities for the DATAWAVE ecosystem. The service supports federated reads across
+both `annotation` and `truthmark` table pairs, source-metadata masking, and an asynchronous
+ack/retry write pipeline with optional file-backup fallback.
+
+### Annotation Context
+
+*https://host:port/annotation/v1/*
+
+---
+
+### User API
+
+| Method   | Operation                                                | Description                                                                  | Path Params                                        | Request Body     |
+|:---------|:---------------------------------------------------------|:-----------------------------------------------------------------------------|:---------------------------------------------------|:-----------------|
+| `GET`    | /source/{analyticHash}                                    | Retrieves the annotation source for the given analytic hash                 | [AnalyticHash]                                     | N/A              |
+| `GET`    | /{idType}/{id}/types                                      | Lists the distinct annotation types for a document                          | [IdType], [Id]                                      | N/A              |
+| `GET`    | /{idType}/{id}                                            | Retrieves all annotations for a document                                    | [IdType], [Id]                                      | N/A              |
+| `GET`    | /{idType}/{id}/type/{annotationType}                      | Retrieves all annotations of a specific type for a document                 | [IdType], [Id], [AnnotationType]                   | N/A              |
+| `GET`    | /{idType}/{id}/annotation/{annotationId}                  | Retrieves a single annotation by annotation ID                              | [IdType], [Id], [AnnotationId]                     | N/A              |
+| `GET`    | /{idType}/{id}/annotation/{annotationId}/segment/{segmentHash} | Retrieves a single segment of an annotation                          | [IdType], [Id], [AnnotationId], [SegmentHash]      | N/A              |
+| `POST`   | /{idType}/{id}/annotation                                 | Adds a new annotation for a document                                        | [IdType], [Id]                                      | [Annotation]     |
+| `PUT`    | /{idType}/{id}/annotation/{annotationId}                  | Updates an existing annotation by linking a new version to the target       | [IdType], [Id], [AnnotationId]                     | [Annotation]     |
+
+Users must possess the **AnnotationWriter** role to access the `POST` and `PUT` endpoints.
+
+* See [AnnotationControllerV1] class for details
+
+### Architecture
+
+#### Read Path (Federated + Truthmark)
+
+Reads are performed via `FederatedAnnotationReader`, which fans out queries across
+both the `annotation`/`annotationSource` table pair and the
+`truthmark`/`truthmarkSource` table pair. This mirrors the legacy behavior in
+`AnnotationManagerBean.RequestContext`.
+
+The table names are configurable via `AnnotationProperties`:
+
+| Property (YAML)                        | Default          | Description                              |
+|:---------------------------------------|:-----------------|:-----------------------------------------|
+| `annotation.annotation-table-name`     | `annotation`     | Primary annotation table                 |
+| `annotation.annotation-source-table-name` | `annotationSource` | Primary annotation source table    |
+| `annotation.truthmark-table-name`      | `truthmark`      | Truthmark annotation table (writes here) |
+| `annotation.truthmark-source-table-name` | `truthmarkSource` | Truthmark annotation source table (writes here) |
+| `annotation.mask-source-metadata`      | `["visibility"]` | Metadata keys to mask from sources     |
+| `annotation.shard-table-name`          | `shard`          | Shard table for internal ID lookups     |
+
+#### Source-Metadata Masking
+
+When returning annotation sources injected into annotations, certain metadata
+fields (e.g., `visibility`) are masked based on the `maskSourceMetadata`
+configuration. This is applied **only** in `lookupAndInjectAnnotationSource`,
+never in the `getAnnotationSource` endpoint.
+
+#### Write Path (Microservice-Only)
+
+The annotation service is the sole writer for truthmark tables. The monolith
+ingest framework owns the `annotation`/`annotationSource` tables. Writes are
+asynchronous via a message sink (`AnnotationConsumer` → `AccumuloAnnotationWriter`),
+with configurable retry (`maxAttempts`, `failTimeoutMillis`,
+`backoffIntervalMillis`) and optional file-backup fallback
+(`fileAnnotationWriter`, injected as `@Autowired(required = false)`).
+
+#### Ack / Retry Protocol
+
+The `AnnotationAckTracker` singleton bean (replacing the static
+`correlationLatchMap`) tracks in-flight writes by correlation ID. The
+`processConfirmAck` handler counts down latches when acks arrive from the
+message broker. This protocol is microservice-only; the legacy
+`AnnotationManagerBean` has no write path.
+
+### Test Data
+
+The test suite includes sample annotation data for baseline testing:
+
+* `service/src/test/resources/data/annotation_baseline.ndjson` — generated
+  compatibility reference produced through the serialization code in
+  `core/annotation`. It is retained with the service test resources for
+  compatibility validation and is not currently loaded directly by the
+  annotation-service unit tests.
+
+### Test Certificates
+
+The test suite includes SSL certificates suitable for local testing:
+
+* `service/src/test/resources/ssl/host.p12` — Server certificate
+* `service/src/test/resources/ssl/rootCA.p12` — Root certificate authority
+
+### Roles
+
+Users must possess the **AnnotationWriter** role to add or update annotations.
+Query operations (`GET`) are available to any authenticated user.
+
+### Configuration
+
+Configuration is managed via `AnnotationProperties` (Spring `@ConfigurationProperties`
+with prefix `annotation`). See [AnnotationProperties] for the full set of options,
+including retry settings and ack timeout configuration.
+
+### Docker
+
+For local containerized integration testing, refer to the
+[DATAWAVE Docker Compose README][docker-compose] for instructions on building
+and running DATAWAVE microservices. The annotation service is opt-in through
+the Compose `annotation` profile; these repository assets do not enable a
+production deployment.
+
+[docker-compose]:../../../docker/README.md
+
+---
+
+### Getting Started
+
+1. Prepare the supporting services required by the selected configuration.
+   A typical development environment includes Config Server, authorization,
+   RabbitMQ, Accumulo, Hazelcast, and the DATAWAVE web service used for internal
+   identifier lookups. The [Docker Compose guide][docker-compose] is the
+   authoritative in-repository setup for the complete local environment.
+
+2. Make the annotation configuration available to Config Server. The checked-in
+   examples are `service/src/main/config/annotation.yml` and
+   `docker/config/annotation.yml`; select and adapt the one appropriate for the
+   development environment.
+
+3. Launch this service with the `remoteauth` profile to enable client-certificate
+   authentication:
+
+   ```
+   java -jar service/target/annotation-service*-exec.jar --spring.profiles.active=dev,remoteauth
+   ```
+
+4. Ensure that the repository's [testUser.p12][testUser] (password: *ChangeIt*) cert is
+   imported into your browser, and then visit any of the following:
+
+   * https://localhost:8643/annotation/v1/source/testAnalyticHash
+   * https://localhost:8643/annotation/v1/DOCUMENT/20250704_249:testDataType:abcde.fghij.klmno
+   * https://localhost:8643/annotation/v1/DOCUMENT/20250704_249:testDataType:abcde.fghij.klmno/annotation/testAnnotationId
+
+[AnnotationControllerV1]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[AnnotationProperties]:service/src/main/java/datawave/microservice/annotation/service/config/AnnotationProperties.java
+[testUser]:../../starters/datawave/src/main/resources/testUser.p12
+[analyticHash]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[idType]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[id]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[annotationId]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[segmentHash]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[annotationType]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+[annotation]:service/src/main/java/datawave/microservice/annotation/service/AnnotationControllerV1.java
+
+[li]: http://img.shields.io/badge/license-ASL-blue.svg
+[ll]: https://www.apache.org/licenses/LICENSE-2.0

--- a/microservices/services/annotation/service/pom.xml
+++ b/microservices/services/annotation/service/pom.xml
@@ -481,4 +481,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <activation>
+                <property>
+                    <name>microservice-docker</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>kubernetes-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/microservices/services/annotation/service/src/main/config/annotation.yml
+++ b/microservices/services/annotation/service/src/main/config/annotation.yml
@@ -98,7 +98,7 @@ annotation:
   priority: 'NORMAL'
   enableInternalIdLookup: 'true'
   lookup:
-    datawave-query-host: "webservice:8443"
+    datawave-query-host: "quickstart:8443"
     datawave-response-classes:
       - "datawave.webservice.result.GenericResponse"
       - "datawave.webservice.result.VoidResponse"
@@ -112,7 +112,7 @@ annotation:
       health:
         enabled: true
       accumuloConfig:
-        zookeepers: '${accumulo.zookeepers}'
+        zookeepers: "${accumulo.zookeepers}"
         instanceName: '${accumulo.instanceName}'
         username: '${accumulo.username}'
         password: '${accumulo.password}'
@@ -191,7 +191,7 @@ logging:
     root: INFO
     datawave.microservice.annotation: DEBUG
     datawave.microservice.annotation.health.rabbit: TRACE
-    org.apache.zookeeper: INFO
+    org.apache.zookeeper: ERROR
     org.apache.accumulo: ERROR
-    org.springframework.messaging: INFO
-    org.springframework.amqp: INFO
+    org.springframework.messaging: DEBUG
+    org.springframework.amqp: DEBUG

--- a/microservices/services/annotation/service/src/main/docker/Dockerfile
+++ b/microservices/services/annotation/service/src/main/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM azul/zulu-openjdk-alpine:11
+
+LABEL version=${project.version} \
+      run="docker run ${registry.namespace}${image.prefix}${project.artifactId}:${project.version}" \
+      pull="docker pull ${registry.namespace}${image.prefix}${project.artifactId}:${project.version}" \
+      description="${project.description}"
+
+ADD ${project.build.finalName}-exec.jar /app.jar
+RUN chmod 755 /app.jar
+RUN apk add libc6-compat curl
+
+EXPOSE 8443 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/microservices/services/annotation/service/src/main/resources/config/bootstrap.yml
+++ b/microservices/services/annotation/service/src/main/resources/config/bootstrap.yml
@@ -17,7 +17,7 @@ spring:
         bindings:
           annotationSource-out-0:
             producer:
-              # Note: This must match ANNOTATION_ACK_CHANNEL in AnnotationController.java or producer confirms will not work.
+              # Note: This must match ANNOTATION_ACK_CHANNEL in AnnotationControllerV1 or producer confirms will not work.
               confirmAckChannel: 'annotationAckChannel'
 management:
   health:
@@ -25,14 +25,6 @@ management:
       order: DOWN, OUT_OF_SERVICE, UNKNOWN, RABBITMQ_UNHEALTHY, UP
       http-mapping:
         RABBITMQ_UNHEALTHY: 200
-
-annotation:
-  writers:
-    accumulo:
-      # Bind the health checker's concurrency source to the actual accumuloAnnotationSink-in-0 consumer concurrency (see annotation.yml)
-      # so the "percent hung" calculation always reflects the real number of concurrent writer consumers, rather than drifting out of
-      # sync with a separately-configured value.
-      concurrency: "${spring.cloud.stream.bindings.accumuloAnnotationSink-in-0.consumer.concurrency:1}"
 
 annotation:
   system-from: "datawave-annotation-service"
@@ -67,7 +59,10 @@ annotation:
 
   writers:
     accumulo:
-      concurrency: "${spring.cloud.stream.bindings.accumuloAnnotationWriterSink.consumer.concurrency:1}"
+      # Bind the health checker's concurrency source to the actual accumuloAnnotationSink-in-0 consumer concurrency (see annotation.yml)
+      # so the "percent hung" calculation always reflects the real number of concurrent writer consumers, rather than drifting out of
+      # sync with a separately-configured value.
+      concurrency: "${spring.cloud.stream.bindings.accumuloAnnotationSink-in-0.consumer.concurrency:1}"
 
 datawave:
   table:

--- a/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/config/TestAnnotationConfigParity.java
+++ b/microservices/services/annotation/service/src/test/java/datawave/microservice/annotation/service/config/TestAnnotationConfigParity.java
@@ -2,10 +2,15 @@ package datawave.microservice.annotation.service.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.FileSystemResource;
 
 import datawave.query.config.annotation.AnnotationConfig;
 
@@ -19,6 +24,28 @@ import datawave.query.config.annotation.AnnotationConfig;
  * excluded from this parity check.
  */
 public class TestAnnotationConfigParity {
+
+    @Test
+    public void testPackagedBootstrapConfigurationLoads() throws Exception {
+        var propertySources = loadYaml("bootstrap", projectDirectory().resolve("src/main/resources/config/bootstrap.yml"));
+        assertEquals(4, propertySources.size(), "bootstrap.yml should contain its base, dev, consul, and nomessaging documents");
+    }
+
+    @Test
+    public void testExternalConfigurationParity() throws Exception {
+        PropertySource<?> serviceConfig = loadYaml("service-config", projectDirectory().resolve("src/main/config/annotation.yml")).get(0);
+        PropertySource<?> dockerConfig = loadYaml("docker-config", projectDirectory().resolve("../../../../docker/config/annotation.yml")).get(0);
+
+        assertEquals(serviceConfig.getProperty("spring.cloud.function.definition"), dockerConfig.getProperty("spring.cloud.function.definition"));
+        assertEquals(serviceConfig.getProperty("annotation.system-from"), dockerConfig.getProperty("annotation.system-from"));
+        assertEquals(serviceConfig.getProperty("annotation.writers.accumulo.enabled"), dockerConfig.getProperty("annotation.writers.accumulo.enabled"));
+        assertEquals(serviceConfig.getProperty("annotation.writers.accumulo.health.enabled"),
+                        dockerConfig.getProperty("annotation.writers.accumulo.health.enabled"));
+        assertNull(dockerConfig.getProperty("annotation.writers.accumulo.annotationTableName"),
+                        "the Accumulo writer uses truthmark table properties, not annotation read-table properties");
+        assertNull(dockerConfig.getProperty("annotation.writers.accumulo.annotationSourceTableName"),
+                        "the Accumulo writer uses truthmark source-table properties, not annotation read-table properties");
+    }
 
     @Test
     public void testAnnotationTableNameDefaultParity() {
@@ -66,5 +93,13 @@ public class TestAnnotationConfigParity {
         assertEquals(legacy.getMaskSourceMetadata(), microservice.getMaskSourceMetadata(),
                         "maskSourceMetadata default must match between legacy and microservice configs");
         assertEquals(List.of("visibility"), microservice.getMaskSourceMetadata(), "maskSourceMetadata should default to ['visibility']");
+    }
+
+    private static Path projectDirectory() {
+        return Path.of(System.getProperty("basedir")).toAbsolutePath().normalize();
+    }
+
+    private static List<PropertySource<?>> loadYaml(String name, Path path) throws Exception {
+        return new YamlPropertySourceLoader().load(name, new FileSystemResource(path));
     }
 }


### PR DESCRIPTION
## Summary

Adds the annotation service's integration configuration, Docker image support, and documentation.

See the [Datawave Annotation Microservice Review Guide](https://gist.github.com/drewfarris/26e97e780c96e4d9c367a656d68f3d97) for more details.

This is PR 4 of 4 replacing #3909. Review only the changes introduced on top of the HTTP API PR.

## Scope

- Add the external annotation configuration used for integration testing.
- Add the annotation Dockerfile and Maven Docker profile.
- Add the complete service README and local environment guidance.
- Add the Docker configuration `system-from` setting.
- Normalize shipped YAML files to mode `100644`.
- Correct packaged `bootstrap.yml` so it contains one top-level `annotation` block.
- Preserve the Accumulo consumer concurrency binding to `accumuloAnnotationSink-in-0`.
- Add regression coverage that loads the packaged bootstrap configuration through Spring's YAML loader.
- Align Accumulo writer health across the shipped external configurations and remove unused Docker writer table properties.
- Add parity coverage for the actual packaged bootstrap and both shipped external annotation configurations.

The packaged bootstrap correction differs intentionally from the archived #3909 branch. The archived form contains duplicate YAML keys and fails during packaged startup.

The dependency versions also intentionally use released artifacts:

- `datawave-microservice-parent:4.0.14`
- `datawave-core-annotation:8.0.0`

No external snapshot dependency exception is required.

## Validation

Focused build:

```text
mvn -Dservices -pl microservices/services/annotation/service -am test
```

126 focused tests passed.

Full 127-module build:

```text
mvn -Ddocker-release -Dmicroservice-docker -Ddist -Dutils -Dservices -Dstarters clean install -T 1C
```

The full build passed and produced:

```text
nationalsecurityagency/datawave/annotation-service:1.0.0-SNAPSHOT
```

The packaged image was also smoke-started with repository test certificates and external systems disabled. It reached `Started AnnotationService`, remained running for the test window, and shut down cleanly.

## Production impact

Production enablement is explicitly excluded. The checked-in YAML and Dockerfile support local integration testing. This PR does not add or alter production orchestration.

The repository's existing Docker Compose annotation service remains opt-in through the explicit `annotation` profi