### PR TITLE
Remove static field caches from DefaultQueryPlanner

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/LookupUUIDTune.java
@@ -94,7 +94,6 @@ public class LookupUUIDTune implements Profile {
     public void configure(QueryPlanner planner) {
         if (planner instanceof DefaultQueryPlanner) {
             DefaultQueryPlanner dqp = DefaultQueryPlanner.class.cast(planner);
-            dqp.setCacheDataTypes(enableCaching);
 
             if (transforms != null) {
                 dqp.setTransformRules(transforms);

--- a/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
+++ b/warehouse/query-core/src/main/java/datawave/query/planner/DefaultQueryPlanner.java
@@ -34,8 +34,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
@@ -55,8 +53,6 @@ import org.apache.log4j.Logger;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -245,11 +241,6 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     protected boolean disableExpandIndexFunction = false;
 
     /**
-     * Allows developers to cache data types
-     */
-    protected boolean cacheDataTypes = false;
-
-    /**
      * The max number of child nodes that we will print with the PrintingVisitor. If trace is enabled, all nodes will be printed.
      */
     public static int maxChildNodesToPrint = 10;
@@ -257,21 +248,6 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     public static int maxTermsToPrint = 100;
 
     private final long maxRangesPerQueryPiece;
-
-    private static Cache<String,Set<String>> allFieldTypeMap = CacheBuilder.newBuilder().maximumSize(100).concurrencyLevel(100)
-                    .expireAfterAccess(24, TimeUnit.HOURS).build();
-
-    private static Cache<String,Multimap<String,Type<?>>> dataTypeMap = CacheBuilder.newBuilder().maximumSize(100).concurrencyLevel(100)
-                    .expireAfterAccess(24, TimeUnit.HOURS).build();
-
-    private static Multimap<String,Type<?>> queryFieldsAsDataTypeMap;
-
-    private static Multimap<String,Type<?>> normalizedFieldAsDataTypeMap;
-
-    // These are caches of the complete set of indexed and normalized fields
-    private static Set<String> cachedIndexedFields = null;
-    private static Set<String> cachedReverseIndexedFields = null;
-    private static Set<String> cachedNormalizedFields = null;
 
     protected List<PushDownRule> rules = Lists.newArrayList();
 
@@ -391,7 +367,6 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     protected DefaultQueryPlanner(DefaultQueryPlanner other) {
         this(other.maxRangesPerQueryPiece, other.limitScanners);
         setRangeStreamClass(other.getRangeStreamClass());
-        setCacheDataTypes(other.getCacheDataTypes());
         setDisableAnyFieldLookup(other.disableAnyFieldLookup);
         setDisableBoundedLookup(other.disableBoundedLookup);
         setDisableCompositeFields(other.disableCompositeFields);
@@ -1355,41 +1330,7 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
                     throws DatawaveQueryException {
         TraceStopwatch stopwatch = timers.newStartedStopwatch("DefaultQueryPlanner - " + stage);
         try {
-            Multimap<String,Type<?>> fieldToDatatypeMap = null;
-            if (cacheDataTypes) {
-                fieldToDatatypeMap = dataTypeMap.getIfPresent(String.valueOf(config.getDatatypeFilter().hashCode()));
-            }
-
-            if (null != fieldToDatatypeMap) {
-                Set<String> indexedFields = Sets.newHashSet();
-                Set<String> reverseIndexedFields = Sets.newHashSet();
-                Set<String> normalizedFields = Sets.newHashSet();
-
-                loadDataTypeMetadata(fieldToDatatypeMap, indexedFields, reverseIndexedFields, normalizedFields, false);
-
-                if (null == queryFieldsAsDataTypeMap) {
-                    queryFieldsAsDataTypeMap = HashMultimap.create(Multimaps.filterKeys(fieldToDatatypeMap, input -> !cachedNormalizedFields.contains(input)));
-                }
-
-                if (null == normalizedFieldAsDataTypeMap) {
-                    normalizedFieldAsDataTypeMap = HashMultimap
-                                    .create(Multimaps.filterKeys(fieldToDatatypeMap, input -> cachedNormalizedFields.contains(input)));
-                }
-
-                setCachedFields(indexedFields, reverseIndexedFields, queryFieldsAsDataTypeMap, normalizedFieldAsDataTypeMap, config);
-            } else {
-                fieldToDatatypeMap = configureIndexedAndNormalizedFields(metadataHelper, config, script);
-
-                if (cacheDataTypes) {
-                    loadDataTypeMetadata(null, null, null, null, true);
-
-                    dataTypeMap.put(String.valueOf(config.getDatatypeFilter().hashCode()), metadataHelper.getFieldsToDatatypes(config.getDatatypeFilter()));
-                }
-            }
-
-        } catch (InstantiationException | IllegalAccessException | AccumuloException | AccumuloSecurityException | TableNotFoundException
-                        | ExecutionException e) {
-            throw new DatawaveFatalQueryException(e);
+            configureIndexedAndNormalizedFields(metadataHelper, config, script);
         } finally {
             stopwatch.stop();
         }
@@ -2030,60 +1971,8 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
      */
 
     /**
-     * Load the metadata information.
-     *
-     * @param fieldToDatatypeMap
-     *            the field mapping
-     * @param indexedFields
-     *            set of indexed fields
-     * @param reverseIndexedFields
-     *            reverse indexed fields
-     * @param normalizedFields
-     *            the normalized fields
-     * @param reload
-     *            the reload flag
-     * @throws AccumuloException
-     *             for issues with accumulo
-     * @throws AccumuloSecurityException
-     *             for accumulo authentication issues
-     * @throws TableNotFoundException
-     *             if the table is not found
-     * @throws ExecutionException
-     *             for execuition errors
-     * @throws InstantiationException
-     *             for issues with instantiation
-     * @throws IllegalAccessException
-     *             for issues with access
-     */
-    private void loadDataTypeMetadata(Multimap<String,Type<?>> fieldToDatatypeMap, Set<String> indexedFields, Set<String> reverseIndexedFields,
-                    Set<String> normalizedFields, boolean reload) throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
-                    ExecutionException, InstantiationException, IllegalAccessException {
-        synchronized (dataTypeMap) {
-            if (!reload && (null != cachedIndexedFields && null != indexedFields) && (null != cachedNormalizedFields && null != normalizedFields)
-                            && (null != cachedReverseIndexedFields && null != reverseIndexedFields)) {
-                indexedFields.addAll(cachedIndexedFields);
-                reverseIndexedFields.addAll(cachedReverseIndexedFields);
-                normalizedFields.addAll(cachedNormalizedFields);
-
-                return;
-            }
-
-            cachedIndexedFields = metadataHelper.getIndexedFields(null);
-            cachedReverseIndexedFields = metadataHelper.getReverseIndexedFields(null);
-            cachedNormalizedFields = metadataHelper.getAllNormalized();
-
-            if ((null != cachedIndexedFields && null != indexedFields) && (null != cachedNormalizedFields && null != normalizedFields)
-                            && (null != cachedReverseIndexedFields && null != reverseIndexedFields)) {
-                indexedFields.addAll(cachedIndexedFields);
-                reverseIndexedFields.addAll(cachedReverseIndexedFields);
-                normalizedFields.addAll(cachedNormalizedFields);
-            }
-        }
-    }
-
-    /**
-     * Apply the query model to the given query script and query configuration, using the set of all fields cached in allFieldTypeMap if cacheDataTypes is true,
-     * or from {@link MetadataHelper#getAllFields(Set)} otherwise.
+     * Apply the query model to the given query script and query configuration, using the set of all fields from
+     * {@link MetadataHelper#getModelExpansionFields(Set)}.
      *
      * @param metadataHelper
      *            the metadata helper
@@ -2098,18 +1987,9 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
     protected ASTJexlScript applyQueryModel(MetadataHelper metadataHelper, ShardQueryConfiguration config, ASTJexlScript script, QueryModel queryModel) {
         // Establish the set of all fields to use when applying the query model.
         Set<String> dataTypes = config.getDatatypeFilter();
-        Set<String> allFields = null;
+        Set<String> allFields;
         try {
-            String dataTypeHash = String.valueOf(dataTypes.hashCode());
-            if (cacheDataTypes) {
-                allFields = allFieldTypeMap.getIfPresent(dataTypeHash);
-            }
-            if (null == allFields) {
-                allFields = metadataHelper.getModelExpansionFields(dataTypes);
-                if (cacheDataTypes) {
-                    allFieldTypeMap.put(dataTypeHash, allFields);
-                }
-            }
+            allFields = metadataHelper.getModelExpansionFields(dataTypes);
 
             if (log.isTraceEnabled()) {
                 StringBuilder builder = new StringBuilder();
@@ -3235,14 +3115,6 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
         this.disableCompositeFields = disableCompositeFields;
     }
 
-    public boolean getCacheDataTypes() {
-        return cacheDataTypes;
-    }
-
-    public void setCacheDataTypes(boolean cacheDataTypes) {
-        this.cacheDataTypes = cacheDataTypes;
-    }
-
     private Multimap<String,String> invertMultimap(Map<String,String> multi) {
         Multimap<String,String> inverse = HashMultimap.create();
         for (Entry<String,String> entry : multi.entrySet()) {
@@ -3349,14 +3221,6 @@ public class DefaultQueryPlanner extends QueryPlanner implements Cloneable {
             throw new DatawaveFatalQueryException(e);
         }
 
-    }
-
-    protected void setCachedFields(Set<String> indexedFields, Set<String> reverseIndexedFields, Multimap<String,Type<?>> queryFieldMap,
-                    Multimap<String,Type<?>> normalizedFieldMap, ShardQueryConfiguration config) {
-        config.setIndexedFields(indexedFields);
-        config.setReverseIndexedFields(reverseIndexedFields);
-        updateQueryFieldsDatatypes(config, queryFieldMap);
-        config.setNormalizedFieldsDatatypes(normalizedFieldMap);
     }
 
     protected Multimap<String,Type<?>> configureIndexedAndNormalizedFields(Multimap<String,Type<?>> fieldToDatatypeMap, Set<String> indexedFields,

--- a/warehouse/query-core/src/main/java/datawave/query/util/ShardQueryUtils.java
+++ b/warehouse/query-core/src/main/java/datawave/query/util/ShardQueryUtils.java
@@ -84,9 +84,8 @@ public class ShardQueryUtils {
     }
 
     /**
-     * Applies the query model to the given query script and query configuration. If cacheDataTypes is true and allFieldTypeMap is not null, allFieldTypeMap
-     * will be used to fetch the set of all fields seen for the set of datatype filters within the config, and will be updated as needed. If log is not null,
-     * messages documenting the field expansion changes will be logged at the trace level.
+     * Applies the query model to the given query script and query configuration. If log is not null, messages documenting the field expansion changes will be
+     * logged at the trace level.
      *
      * @param script
      *            the query script


### PR DESCRIPTION
The cached indexed, reverse indexed and normalized field sets were shared across every planner instance and never invalidated. MetadataHelper already caches these lookups, so the dataTypeMap and allFieldTypeMap shortcuts they gated are gone as well, along with the cacheDataTypes flag that had no remaining effect.